### PR TITLE
ci(MOR-2312): observe legacy quick metadata without a v2 worker

### DIFF
--- a/.github/scripts/base-controlled-gates-v1.test.js
+++ b/.github/scripts/base-controlled-gates-v1.test.js
@@ -76,6 +76,7 @@ test('quick v2 topology is hosted, metadata-only, and separately published', () 
   assert.equal(observer.LEGACY_WORKFLOW.path, '.github/workflows/quick.yml');
   assert.equal(observer.OBSERVATION_CONTEXT, 'quick-v2-observe');
 });
+test('workflow-run observation admits feature heads targeting main', () => assert.doesNotMatch(sources().quick, /\n  workflow_run:\n(?: {4}.*\n)* {4}branches:/u));
 
 test('topology contract catches permission, execution, event, and pin regressions', () => {
   const original = sources();

--- a/.github/scripts/base-controlled-gates-v1.test.js
+++ b/.github/scripts/base-controlled-gates-v1.test.js
@@ -1,121 +1,65 @@
 'use strict';
-
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
-
 const ROOT = path.resolve(__dirname, '..', '..');
-const TARGET_ROOT = process.env.GATE_TARGET_ROOT
-  ? path.resolve(process.env.GATE_TARGET_ROOT)
-  : ROOT;
+const TARGET_ROOT = process.env.GATE_TARGET_ROOT ? path.resolve(process.env.GATE_TARGET_ROOT) : ROOT;
 const routePolicy = require(path.join(ROOT, '.github/scripts/base-gate-policy-v1.js'));
-const observer = require(path.join(
-  ROOT, '.github/scripts/quick-v2-metadata-policy-v1.js',
-));
-
-function readTarget(relative) {
-  return fs.readFileSync(path.join(TARGET_ROOT, relative), 'utf8');
-}
+const observer = require(path.join(ROOT, '.github/scripts/quick-v2-metadata-policy-v1.js'));
+const readTarget = (relative) => fs.readFileSync(path.join(TARGET_ROOT, relative), 'utf8');
 
 function topologyErrors({quick, review, migration}) {
   const errors = [];
-  if (
-    !quick.includes('\n  pull_request_target:\n') ||
-    !quick.includes('\n  workflow_run:\n') ||
-    quick.includes('\n  pull_request:\n')
-  ) {
+  if (!quick.includes('\n  pull_request_target:\n') || !quick.includes('\n  workflow_run:\n') || quick.includes('\n  pull_request:\n')) {
     errors.push('quick observer must use hosted lifecycle and workflow-run events');
   }
-  for (const event of [
-    'opened', 'reopened', 'synchronize', 'ready_for_review',
-    'converted_to_draft', 'edited',
-  ]) {
-    if (!quick.includes(event)) {
-      errors.push(`quick observer is missing lifecycle event ${event}`);
-    }
+  for (const event of ['opened', 'reopened', 'synchronize', 'ready_for_review', 'converted_to_draft', 'edited']) {
+    if (!quick.includes(event)) errors.push(`quick observer is missing lifecycle event ${event}`);
   }
   for (const required of [
-    'workflows: ["Tests (quick)"]',
-    'types: [completed]',
-    'permissions: {}',
-    'actions: read',
-    'checks: read',
-    'contents: read',
-    'pull-requests: read',
-    'statuses: write',
-    'Read-only legacy quick metadata observer',
-    'Exact-head metadata observation publisher',
-    '.github/scripts/quick-v2-metadata-policy-v1.js',
+    'workflows: ["Tests (quick)"]', 'types: [completed]', 'permissions: {}', 'actions: read',
+    'checks: read', 'contents: read', 'pull-requests: read', 'statuses: write',
+    'Read-only legacy quick metadata observer', 'Exact-head metadata observation publisher',
+    '.github/scripts/quick-v2-metadata-policy-v1.js', 'rebindForPublication',
   ]) {
-    if (!quick.includes(required)) {
-      errors.push(`quick observer is missing ${required}`);
-    }
+    if (!quick.includes(required)) errors.push(`quick observer is missing ${required}`);
   }
   const statusWrites = quick.match(/statuses: write/gu) ?? [];
-  const pinnedActions = quick.match(
-    /actions\/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd/gu,
-  ) ?? [];
-  if (statusWrites.length !== 1 || pinnedActions.length !== 2) {
-    errors.push('only the publisher may write statuses and both actions must be pinned');
-  }
+  const pins = quick.match(/actions\/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd/gu) ?? [];
+  if (statusWrites.length !== 1 || pins.length !== 2) errors.push('publisher permission or action pin count changed');
   for (const forbidden of [
-    'self-hosted',
-    'actions/checkout',
-    'actions/upload-artifact',
-    'actions/download-artifact',
-    '/logs',
-    '/artifacts',
-    '/caches',
-    'secrets.',
-    'github.workflow_sha',
+    'self-hosted', 'actions/checkout', 'actions/upload-artifact', 'actions/download-artifact',
+    '/logs', '/artifacts', '/caches', 'secrets.', 'github.workflow_sha',
   ]) {
-    if (quick.includes(forbidden)) {
-      errors.push(`quick observer contains forbidden product/candidate surface: ${forbidden}`);
-    }
+    if (quick.includes(forbidden)) errors.push(`quick observer contains forbidden surface: ${forbidden}`);
   }
-  if (
-    !review.includes('\n  pull_request_target:\n') ||
-    review.includes('\n  pull_request:\n') ||
-    !review.includes("context: 'Agent Review Gate v2 observe'")
-  ) {
+  if (!review.includes('\n  pull_request_target:\n') || review.includes('\n  pull_request:\n') || !review.includes("context: 'Agent Review Gate v2 observe'")) {
     errors.push('review observation contract changed unexpectedly');
   }
-  for (const requiredText of [
-    'must never be configured as required checks',
-    'metadata-only',
-    'zero self-hosted',
-    'route_job_concordance',
-    'terminal_binding_coverage',
-    'distinct from GitHub Actions app ID `15368`',
-    '"strict": true',
+  for (const required of [
+    'must never be configured as required checks', 'metadata-only', 'zero self-hosted',
+    'route_job_concordance', 'terminal_binding_coverage',
+    'status POST are not atomic',
+    'distinct from GitHub Actions app ID `15368`', '"strict": true',
   ]) {
-    if (!migration.includes(requiredText)) {
-      errors.push(`migration contract is missing: ${requiredText}`);
-    }
+    if (!migration.includes(required)) errors.push(`migration contract is missing: ${required}`);
   }
   return errors;
 }
 
+function sources() { return {quick: readTarget('.github/workflows/quick-v2.yml'), review: readTarget('.github/workflows/agent-review-gate-v2.yml'), migration: readTarget('docs/internals/base-controlled-required-gates.md')}; }
+function canonicalPull(number, head, base) { const repo = {id: observer.REPOSITORY.id, full_name: observer.REPOSITORY.fullName}; return {number, state: 'open', base: {ref: 'main', sha: base, repo}, head: {sha: head, repo}}; }
+function runPull(number, head, base) {
+  const repo = {id: observer.REPOSITORY.id, name: observer.REPOSITORY.repo, url: `https://api.github.com/repos/${observer.REPOSITORY.fullName}`};
+  return {id: 9000, run_attempt: 1, head_sha: head, pull_requests: [{number, head: {sha: head, repo}, base: {ref: 'main', sha: base, repo}}]};
+}
+
 test('trusted route policy rejects incomplete and injected path metadata', () => {
-  const docs = routePolicy.classifyPullFiles(
-    [
-      {filename: 'docs/guide.md'},
-      {filename: 'frontend/README.MD'},
-      {filename: 'mkdocs.yml'},
-    ],
-    3,
-  );
+  const docs = routePolicy.classifyPullFiles([{filename: 'docs/guide.md'}, {filename: 'frontend/README.MD'}, {filename: 'mkdocs.yml'}], 3);
   assert.deepEqual(docs, {core: false, frontend: false, ci: false, docs: true});
-  for (const filename of [
-    '../README.md',
-    'docs/../src/radio.py',
-  ]) {
-    assert.throws(
-      () => routePolicy.classifyPullFiles([{filename}], 1),
-      undefined,
-      filename,
-    );
+  for (const filename of ['../README.md', 'docs/../src/radio.py']) {
+    assert.throws(() => routePolicy.classifyPullFiles([{filename}], 1), undefined, filename);
   }
   for (const filename of ['frontend/README.md\n', 'frontend/README.rst\r\n']) {
     const result = routePolicy.classifyPullFiles([{filename}], 1);
@@ -127,182 +71,117 @@ test('trusted route policy rejects incomplete and injected path metadata', () =>
 });
 
 test('quick v2 topology is hosted, metadata-only, and separately published', () => {
-  const sources = {
-    quick: readTarget('.github/workflows/quick-v2.yml'),
-    review: readTarget('.github/workflows/agent-review-gate-v2.yml'),
-    migration: readTarget('docs/internals/base-controlled-required-gates.md'),
-  };
-  assert.deepEqual(topologyErrors(sources), []);
+  assert.deepEqual(topologyErrors(sources()), []);
   assert.equal(observer.LEGACY_WORKFLOW.id, 270532868);
   assert.equal(observer.LEGACY_WORKFLOW.path, '.github/workflows/quick.yml');
   assert.equal(observer.OBSERVATION_CONTEXT, 'quick-v2-observe');
 });
 
-test('topology contract catches self-hosted, artifact, permission, and pin regressions', () => {
-  const sources = {
-    quick: readTarget('.github/workflows/quick-v2.yml'),
-    review: readTarget('.github/workflows/agent-review-gate-v2.yml'),
-    migration: readTarget('docs/internals/base-controlled-required-gates.md'),
-  };
-  const mutants = [
-    {...sources, quick: sources.quick.replace('runs-on: ubuntu-latest', 'runs-on: [self-hosted, linux, build]')},
-    {...sources, quick: sources.quick.replace('permissions: {}', 'permissions:\n  statuses: write')},
-    {...sources, quick: sources.quick.replace('actions: read', 'actions: read\n      statuses: write')},
-    {...sources, quick: sources.quick.replace('with:\n          script:', 'uses: actions/upload-artifact@v4\n        with:\n          script:')},
-    {...sources, quick: sources.quick.replace('ed597411d8f924073f98dfc5c65a23a2325f34cd', 'v8')},
-    {...sources, quick: sources.quick.replace('workflow_run:', 'pull_request:')},
+test('topology contract catches permission, execution, event, and pin regressions', () => {
+  const original = sources();
+  const mutations = [
+    ['runs-on: ubuntu-latest', 'runs-on: [self-hosted, linux, build]'],
+    ['permissions: {}', 'permissions:\n  statuses: write'],
+    ['actions: read', 'actions: read\n      statuses: write'],
+    ['with:\n          script:', 'uses: actions/upload-artifact@v4\n        with:\n          script:'],
+    ['ed597411d8f924073f98dfc5c65a23a2325f34cd', 'v8'], ['workflow_run:', 'pull_request:'],
   ];
-  for (const mutant of mutants) {
-    assert.notDeepEqual(topologyErrors(mutant), []);
-  }
+  for (const [from, to] of mutations) assert.notDeepEqual(topologyErrors({...original, quick: original.quick.replace(from, to)}), []);
 });
 
 test('edited lifecycle events are no-ops unless base metadata changed', () => {
   assert.equal(observer.relevantLifecycle({action: 'opened'}), true);
   assert.equal(observer.relevantLifecycle({action: 'converted_to_draft'}), true);
-  assert.equal(observer.relevantLifecycle({
-    action: 'edited', changes: {base: {ref: {from: 'release'}}},
-  }), true);
-  assert.equal(observer.relevantLifecycle({
-    action: 'edited', changes: {title: {from: 'old'}},
-  }), false);
-  assert.equal(observer.relevantLifecycle({
-    action: 'edited', changes: {body: {from: 'old'}},
-  }), false);
+  assert.equal(observer.relevantLifecycle({action: 'edited', changes: {base: {ref: {from: 'release'}}}}), true);
+  assert.equal(observer.relevantLifecycle({action: 'edited', changes: {title: {from: 'old'}}}), false);
+  assert.equal(observer.relevantLifecycle({action: 'edited', changes: {body: {from: 'old'}}}), false);
 });
 
 test('terminal topology refuses skipped success and injected or incomplete jobs', () => {
   const run = {conclusion: 'success', run_attempt: 2};
   const routes = {core: true, frontend: false, ci: false, docs: false};
   const valid = [
-    {
-      name: 'classify', status: 'completed', conclusion: 'success',
-      run_attempt: 2, runner_name: 'GitHub Actions 1', labels: ['ubuntu-latest'],
-    },
-    {
-      name: 'quick', status: 'completed', conclusion: 'success',
-      run_attempt: 2, runner_name: 'mm-build-core-1',
-      labels: ['self-hosted', 'linux', 'build'],
-    },
+    {name: 'classify', status: 'completed', conclusion: 'success', run_attempt: 2, runner_name: 'GitHub Actions 1', labels: ['ubuntu-latest']},
+    {name: 'quick', status: 'completed', conclusion: 'success', run_attempt: 2, runner_name: 'mm-build-core-1', labels: ['self-hosted', 'linux', 'build']},
   ];
-  assert.deepEqual(observer.evaluateJobTopology(run, valid, routes, false), {
-    ok: true, code: 'terminal_match', routeConcordance: true,
-  });
-  const skipped = structuredClone(valid);
-  skipped[1].conclusion = 'skipped';
-  skipped[1].runner_name = null;
-  assert.equal(
-    observer.evaluateJobTopology(run, skipped, routes, false).code,
-    'skipped_substantive',
-  );
-  const injected = [...valid, {...valid[1], name: 'quick-shadow'}];
-  assert.equal(
-    observer.evaluateJobTopology(run, injected, routes, false).code,
-    'route_mismatch',
-  );
-  assert.equal(
-    observer.evaluateJobTopology({...run, conclusion: 'cancelled'}, valid, routes, false).code,
-    'terminal_failure',
-  );
-  assert.equal(
-    observer.evaluateJobTopology(run, valid, {...routes, docs: true}, false).code,
-    'route_mismatch',
-  );
+  assert.deepEqual(observer.evaluateJobTopology(run, valid, routes, false), {ok: true, code: 'terminal_match', routeConcordance: true});
+  const skipped = structuredClone(valid); skipped[1].conclusion = 'skipped'; skipped[1].runner_name = null;
+  assert.equal(observer.evaluateJobTopology(run, skipped, routes, false).code, 'skipped_substantive');
+  assert.equal(observer.evaluateJobTopology(run, [...valid, {...valid[1], name: 'quick-shadow'}], routes, false).code, 'route_mismatch');
+  assert.equal(observer.evaluateJobTopology({...run, conclusion: 'cancelled'}, valid, routes, false).code, 'terminal_failure');
+  assert.equal(observer.evaluateJobTopology(run, valid, {...routes, docs: true}, false).code, 'route_mismatch');
 });
 
 test('exact pull binding rejects stale base/head and identifies forks', () => {
-  const base = 'b'.repeat(40);
-  const head = 'a'.repeat(40);
-  const pull = {
-    state: 'open',
-    base: {
-      ref: 'main', sha: base,
-      repo: {id: observer.REPOSITORY.id, full_name: observer.REPOSITORY.fullName},
-    },
-    head: {
-      sha: head,
-      repo: {id: observer.REPOSITORY.id, full_name: observer.REPOSITORY.fullName},
-    },
-  };
-  assert.deepEqual(observer.bindPull(pull, base, head), {
-    headSha: head, baseSha: base, sameRepository: true,
-  });
+  const base = 'b'.repeat(40); const head = 'a'.repeat(40); const pull = canonicalPull(41, head, base);
+  assert.deepEqual(observer.bindPull(pull, base, head), {headSha: head, baseSha: base, sameRepository: true});
   assert.throws(() => observer.bindPull(pull, 'c'.repeat(40), head), /live main/u);
   assert.throws(() => observer.bindPull(pull, base, 'd'.repeat(40)), /no longer current/u);
-  const fork = structuredClone(pull);
-  fork.head.repo = {id: 99, full_name: 'outside/fork'};
-  assert.equal(observer.bindPull(fork, base, head).sameRepository, false);
+  pull.head.repo = {id: 99, full_name: 'outside/fork'};
+  assert.equal(observer.bindPull(pull, base, head).sameRepository, false);
+});
+
+test('legacy run tuple rejects stale base and same-head different-PR reuse', async () => {
+  const base = 'b'.repeat(40); const head = 'a'.repeat(40);
+  const binding = observer.bindRunPullRequest(runPull(41, head, base), base);
+  assert.deepEqual(binding, {pullNumber: 41, headSha: head, baseSha: base});
+  assert.throws(() => observer.bindRunPullRequest(runPull(41, head, base), 'c'.repeat(40)), /recorded base is not live main/u);
+  for (const pullRequests of [[], [runPull(41, head, base).pull_requests[0], runPull(42, head, base).pull_requests[0]]]) {
+    const run = runPull(41, head, base); run.pull_requests = pullRequests;
+    assert.throws(() => observer.bindRunPullRequest(run, base), /exactly one pull request association/u);
+  }
+  const github = {paginate: async () => [canonicalPull(42, head, base)]};
+  await assert.rejects(observer.assertUniqueCurrentPullMatchesRun(github, observer.REPOSITORY.owner, observer.REPOSITORY.repo, binding), /does not match the run association/u);
+});
+
+test('final publication snapshot rejects changed attempt and job topology', () => {
+  const base = 'b'.repeat(40); const head = 'a'.repeat(40);
+  const run = {...runPull(41, head, base), status: 'completed', conclusion: 'success'};
+  const result = {runId: run.id, runAttempt: run.run_attempt, runConclusion: run.conclusion, baseSha: base, headSha: head};
+  const binding = {pullNumber: 41, headSha: head, baseSha: base};
+  assert.deepEqual(observer.assertRunPublicationSnapshot(run, result, binding), binding);
+  assert.throws(() => observer.assertRunPublicationSnapshot({...run, run_attempt: 2}, result, binding), /attempt or association changed/u);
+  const jobs = [{id: 1, name: 'quick', status: 'completed', conclusion: 'success', run_attempt: 1, runner_id: 2, runner_name: 'runner', labels: ['build', 'linux', 'self-hosted']}];
+  const topology = observer.jobTopologySnapshot(jobs);
+  assert.doesNotThrow(() => observer.assertJobTopologyUnchanged(jobs, topology, head));
+  assert.throws(() => observer.assertJobTopologyUnchanged([{...jobs[0], conclusion: 'failure'}], topology, head), /job topology changed/u);
+});
+
+test('final publication rebind turns head or base movement into failure', async () => {
+  const base = 'b'.repeat(40); const head = 'a'.repeat(40);
+  const result = {kind: 'lifecycle', code: 'admitted', state: 'pending', publish: true, targetSha: head, pullNumber: 41, baseSha: base, headSha: head, runId: null, runAttempt: null, jobTopology: null, metrics: {false_success_publications: 0}};
+  const githubFor = (pull, liveMain) => ({request: async (route) => {
+    if (route.includes('/branches/')) return {data: {commit: {sha: liveMain}}};
+    if (route.includes('/pulls/')) return {data: pull};
+    throw new Error(`unexpected route ${route}`);
+  }});
+  const movedHead = await observer.rebindForPublication({github: githubFor(canonicalPull(41, 'd'.repeat(40), base), base), result});
+  assert.deepEqual([movedHead.code, movedHead.state, movedHead.targetSha], ['stale_head', 'failure', head]);
+  const movedBase = await observer.rebindForPublication({github: githubFor(canonicalPull(41, head, 'c'.repeat(40)), 'c'.repeat(40)), result});
+  assert.deepEqual([movedBase.code, movedBase.state, movedBase.targetSha], ['stale_base', 'failure', head]);
 });
 
 function treeGithub(finalEntry, options = {}) {
-  const root = '1'.repeat(40);
-  const githubTree = '2'.repeat(40);
-  const workflowsTree = '3'.repeat(40);
-  const responses = {
-    [root]: [{path: '.github', mode: '040000', type: 'tree', sha: githubTree}],
-    [githubTree]: [{path: 'workflows', mode: '040000', type: 'tree', sha: workflowsTree}],
-    [workflowsTree]: [finalEntry],
-  };
-  return {
-    request: async (route, args) => {
-      if (route.includes('/git/commits/')) {
-        return {data: {tree: {sha: root}}};
-      }
-      if (route.includes('/git/trees/')) {
-        const entries = responses[args.tree_sha] ?? [];
-        return {
-          data: {
-            truncated: options.truncated === args.tree_sha,
-            tree: options.duplicate === args.tree_sha ? [...entries, ...entries] : entries,
-          },
-        };
-      }
-      throw new Error(`unexpected route ${route}`);
-    },
-  };
+  const root = '1'.repeat(40); const githubTree = '2'.repeat(40); const workflowsTree = '3'.repeat(40);
+  const responses = {[root]: [{path: '.github', mode: '040000', type: 'tree', sha: githubTree}], [githubTree]: [{path: 'workflows', mode: '040000', type: 'tree', sha: workflowsTree}], [workflowsTree]: [finalEntry]};
+  return {request: async (route, args) => {
+    if (route.includes('/git/commits/')) return {data: {tree: {sha: root}}};
+    if (route.includes('/git/trees/')) {
+      const entries = responses[args.tree_sha] ?? [];
+      return {data: {truncated: options.truncated === args.tree_sha, tree: options.duplicate === args.tree_sha ? [...entries, ...entries] : entries}};
+    }
+    throw new Error(`unexpected route ${route}`);
+  }};
 }
 
 test('tree walk accepts only complete 040000 parents and a 100644 blob', async () => {
-  const blob = '4'.repeat(40);
-  const validEntry = {path: 'quick.yml', mode: '100644', type: 'blob', sha: blob};
-  const result = await observer.getTreeEntry(
-    treeGithub(validEntry), 'rigplane', 'rigplane-core',
-    'a'.repeat(40), '.github/workflows/quick.yml',
-  );
-  assert.deepEqual(result, {mode: '100644', type: 'blob', sha: blob});
-
-  for (const [mode, type] of [
-    ['100755', 'blob'],
-    ['120000', 'blob'],
-    ['160000', 'commit'],
-  ]) {
-    await assert.rejects(
-      observer.getTreeEntry(
-        treeGithub({...validEntry, mode, type}), 'rigplane', 'rigplane-core',
-        'a'.repeat(40), '.github/workflows/quick.yml',
-      ),
-      /regular non-executable/u,
-    );
+  const blob = '4'.repeat(40); const commit = 'a'.repeat(40);
+  const entry = {path: 'quick.yml', mode: '100644', type: 'blob', sha: blob};
+  assert.deepEqual(await observer.getTreeEntry(treeGithub(entry), 'rigplane', 'rigplane-core', commit, '.github/workflows/quick.yml'), {mode: '100644', type: 'blob', sha: blob});
+  for (const [mode, type] of [['100755', 'blob'], ['120000', 'blob'], ['160000', 'commit']]) {
+    await assert.rejects(observer.getTreeEntry(treeGithub({...entry, mode, type}), 'rigplane', 'rigplane-core', commit, '.github/workflows/quick.yml'), /regular non-executable/u);
   }
-  await assert.rejects(
-    observer.getTreeEntry(
-      treeGithub(validEntry, {duplicate: '3'.repeat(40)}),
-      'rigplane', 'rigplane-core', 'a'.repeat(40), '.github/workflows/quick.yml',
-    ),
-    /ambiguous/u,
-  );
-  await assert.rejects(
-    observer.getTreeEntry(
-      treeGithub(validEntry, {truncated: '2'.repeat(40)}),
-      'rigplane', 'rigplane-core', 'a'.repeat(40), '.github/workflows/quick.yml',
-    ),
-    /incomplete/u,
-  );
-  await assert.rejects(
-    observer.getTreeEntry(
-      treeGithub(validEntry), 'rigplane', 'rigplane-core',
-      'a'.repeat(40), '.github/../quick.yml',
-    ),
-    /path is invalid/u,
-  );
+  await assert.rejects(observer.getTreeEntry(treeGithub(entry, {duplicate: '3'.repeat(40)}), 'rigplane', 'rigplane-core', commit, '.github/workflows/quick.yml'), /ambiguous/u);
+  await assert.rejects(observer.getTreeEntry(treeGithub(entry, {truncated: '2'.repeat(40)}), 'rigplane', 'rigplane-core', commit, '.github/workflows/quick.yml'), /incomplete/u);
+  await assert.rejects(observer.getTreeEntry(treeGithub(entry), 'rigplane', 'rigplane-core', commit, '.github/../quick.yml'), /path is invalid/u);
 });

--- a/.github/scripts/base-controlled-gates-v1.test.js
+++ b/.github/scripts/base-controlled-gates-v1.test.js
@@ -1,94 +1,94 @@
 'use strict';
 
 const assert = require('node:assert/strict');
-const childProcess = require('node:child_process');
 const fs = require('node:fs');
-const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 
-const CONTROL_ROOT = path.resolve(__dirname, '..', '..');
+const ROOT = path.resolve(__dirname, '..', '..');
 const TARGET_ROOT = process.env.GATE_TARGET_ROOT
   ? path.resolve(process.env.GATE_TARGET_ROOT)
-  : CONTROL_ROOT;
-const policy = require(path.join(CONTROL_ROOT, '.github/scripts/base-gate-policy-v1.js'));
+  : ROOT;
+const routePolicy = require(path.join(ROOT, '.github/scripts/base-gate-policy-v1.js'));
+const observer = require(path.join(
+  ROOT, '.github/scripts/quick-v2-metadata-policy-v1.js',
+));
 
 function readTarget(relative) {
   return fs.readFileSync(path.join(TARGET_ROOT, relative), 'utf8');
 }
 
-function topologyErrors({quick, review, worker, migration}) {
+function topologyErrors({quick, review, migration}) {
   const errors = [];
-  if (!quick.includes('\n  pull_request_target:\n') || quick.includes('\n  pull_request:\n')) {
-    errors.push('quick controller must use only pull_request_target');
+  if (
+    !quick.includes('\n  pull_request_target:\n') ||
+    !quick.includes('\n  workflow_run:\n') ||
+    quick.includes('\n  pull_request:\n')
+  ) {
+    errors.push('quick observer must use hosted lifecycle and workflow-run events');
   }
-  if (!review.includes('\n  pull_request_target:\n') || review.includes('\n  pull_request:\n')) {
-    errors.push('review controller must use pull_request_target for PR events');
-  }
-  for (const [name, source] of [['quick', quick], ['review', review]]) {
-    if (source.includes('github.workflow_sha') || source.includes('secrets.')) {
-      errors.push(`${name} controller may not use candidate workflow refs or secrets`);
+  for (const event of [
+    'opened', 'reopened', 'synchronize', 'ready_for_review',
+    'converted_to_draft', 'edited',
+  ]) {
+    if (!quick.includes(event)) {
+      errors.push(`quick observer is missing lifecycle event ${event}`);
     }
   }
-  if (!quick.includes("path: '.github/scripts/base-gate-policy-v1.js'")) {
-    errors.push('quick controller must fetch versioned policy');
+  for (const required of [
+    'workflows: ["Tests (quick)"]',
+    'types: [completed]',
+    'permissions: {}',
+    'actions: read',
+    'checks: read',
+    'contents: read',
+    'pull-requests: read',
+    'statuses: write',
+    'Read-only legacy quick metadata observer',
+    'Exact-head metadata observation publisher',
+    '.github/scripts/quick-v2-metadata-policy-v1.js',
+  ]) {
+    if (!quick.includes(required)) {
+      errors.push(`quick observer is missing ${required}`);
+    }
   }
-  if (!quick.includes('ref: baseSha')) {
-    errors.push('quick controller must fetch policy at exact base SHA');
+  const statusWrites = quick.match(/statuses: write/gu) ?? [];
+  const pinnedActions = quick.match(
+    /actions\/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd/gu,
+  ) ?? [];
+  if (statusWrites.length !== 1 || pinnedActions.length !== 2) {
+    errors.push('only the publisher may write statuses and both actions must be pinned');
   }
-  if (!review.includes("path: '.github/scripts/agent-review-gate.js', ref: baseSha")) {
-    errors.push('review controller must fetch parser at exact base SHA');
-  }
-  if (!quick.includes("context: 'quick-v2-observe'")) {
-    errors.push('quick controller must publish only the observation context');
-  }
-  if (!review.includes("context: 'Agent Review Gate v2 observe'")) {
-    errors.push('review controller must publish only the observation context');
-  }
-  if (!quick.includes('name: Read-only quick v2 worker')) {
-    errors.push('quick controller must retain the isolated worker');
-  }
-  const workerStart = quick.indexOf('  worker:\n');
-  const publishStart = quick.indexOf('  publish:\n');
-  const workerJob = quick.slice(workerStart, publishStart);
-  if (
-    workerStart === -1 ||
-    publishStart === -1 ||
-    !workerJob.includes('permissions:\n      contents: read') ||
-    workerJob.includes('statuses: write') ||
-    workerJob.includes('pull-requests: write') ||
-    workerJob.includes('issues: write')
-  ) {
-    errors.push('worker must retain its read-only job token');
-  }
-  const nonPersistedCredentials = workerJob.match(/persist-credentials: false/gu) ?? [];
-  if (
-    nonPersistedCredentials.length !== 2 ||
-    workerJob.includes('persist-credentials: true')
-  ) {
-    errors.push('both control and candidate checkouts must not persist credentials');
-  }
-  if (!workerJob.includes('rev-list --parents -n 1 HEAD')) {
-    errors.push('worker must bind the merge commit to exact parents');
+  for (const forbidden of [
+    'self-hosted',
+    'actions/checkout',
+    'actions/upload-artifact',
+    'actions/download-artifact',
+    '/logs',
+    '/artifacts',
+    '/caches',
+    'secrets.',
+    'github.workflow_sha',
+  ]) {
+    if (quick.includes(forbidden)) {
+      errors.push(`quick observer contains forbidden product/candidate surface: ${forbidden}`);
+    }
   }
   if (
-    !quick.includes("initialPull.head.repo?.full_name === `${owner}/${repo}`") ||
-    !workerJob.includes("needs.admit.outputs.same_repo == 'true'") ||
-    (quick.match(/currentBase\.commit\.sha !== baseSha/gu) ?? []).length !== 2
+    !review.includes('\n  pull_request_target:\n') ||
+    review.includes('\n  pull_request:\n') ||
+    !review.includes("context: 'Agent Review Gate v2 observe'")
   ) {
-    errors.push('quick observation must withhold forks and reject stale main');
-  }
-  if (!review.includes('currentBase.commit.sha !== baseSha')) {
-    errors.push('review observation must reject stale main');
-  }
-  if (!worker.includes('.github/scripts/verify-immutable-controls-v1.sh')) {
-    errors.push('worker must invoke the Git-object immutable-control verifier');
+    errors.push('review observation contract changed unexpectedly');
   }
   for (const requiredText of [
     'must never be configured as required checks',
+    'metadata-only',
+    'zero self-hosted',
+    'route_job_concordance',
+    'terminal_binding_coverage',
     'distinct from GitHub Actions app ID `15368`',
     '"strict": true',
-    'switch protection back to the still-running legacy contexts **before**',
   ]) {
     if (!migration.includes(requiredText)) {
       errors.push(`migration contract is missing: ${requiredText}`);
@@ -97,8 +97,8 @@ function topologyErrors({quick, review, worker, migration}) {
   return errors;
 }
 
-test('trusted policy rejects adversarial paths and fails unknown roots into core', () => {
-  const docs = policy.classifyPullFiles(
+test('trusted route policy rejects incomplete and injected path metadata', () => {
+  const docs = routePolicy.classifyPullFiles(
     [
       {filename: 'docs/guide.md'},
       {filename: 'frontend/README.MD'},
@@ -107,126 +107,202 @@ test('trusted policy rejects adversarial paths and fails unknown roots into core
     3,
   );
   assert.deepEqual(docs, {core: false, frontend: false, ci: false, docs: true});
-
   for (const filename of [
-    'docs',
-    '.claude',
-    'frontend/README.rſt',
-    'frontend/README.md\n',
-    'frontend/README.rst\r\n',
+    '../README.md',
+    'docs/../src/radio.py',
   ]) {
-    const result = policy.classifyPullFiles([{filename}], 1);
+    assert.throws(
+      () => routePolicy.classifyPullFiles([{filename}], 1),
+      undefined,
+      filename,
+    );
+  }
+  for (const filename of ['frontend/README.md\n', 'frontend/README.rst\r\n']) {
+    const result = routePolicy.classifyPullFiles([{filename}], 1);
     assert.equal(result.docs, false, filename);
     assert.equal(result.core || result.frontend || result.ci, true, filename);
   }
-  assert.deepEqual(policy.classifyPullFiles([{filename: 'CODEOWNERS'}], 1), {
-    core: true,
-    frontend: false,
-    ci: false,
-    docs: false,
-  });
-  assert.deepEqual(
-    policy.classifyPullFiles([
-      {filename: 'docs/new.md', previous_filename: 'src/rigplane/radio.py'},
-    ], 1),
-    {core: true, frontend: false, ci: false, docs: false},
-  );
+  assert.throws(() => routePolicy.classifyPullFiles([{filename: 'docs/a.md'}], 2));
+  assert.throws(() => routePolicy.classifyPullFiles([{filename: 'docs/a.md'}], 3000));
 });
 
-test('trusted policy fails closed on incomplete, capped, and invalid metadata', () => {
-  assert.throws(() => policy.classifyPullFiles([{filename: 'docs/a.md'}], 2));
-  assert.throws(() => policy.classifyPullFiles([{filename: 'docs/a.md'}], 3000));
-  assert.throws(() => policy.classifyPullFiles([{filename: '../README.md'}], 1));
-  assert.throws(() => policy.assertSha('refs/pull/1/merge', 'head'));
-});
-
-test('candidate v2 topology retains base control and isolated permissions', () => {
+test('quick v2 topology is hosted, metadata-only, and separately published', () => {
   const sources = {
     quick: readTarget('.github/workflows/quick-v2.yml'),
     review: readTarget('.github/workflows/agent-review-gate-v2.yml'),
-    worker: readTarget('.github/scripts/quick-v2-worker-v1.sh'),
     migration: readTarget('docs/internals/base-controlled-required-gates.md'),
   };
   assert.deepEqual(topologyErrors(sources), []);
+  assert.equal(observer.LEGACY_WORKFLOW.id, 270532868);
+  assert.equal(observer.LEGACY_WORKFLOW.path, '.github/workflows/quick.yml');
+  assert.equal(observer.OBSERVATION_CONTEXT, 'quick-v2-observe');
 });
 
-test('topology contract catches self-green workflow and helper mutations', () => {
+test('topology contract catches self-hosted, artifact, permission, and pin regressions', () => {
   const sources = {
     quick: readTarget('.github/workflows/quick-v2.yml'),
     review: readTarget('.github/workflows/agent-review-gate-v2.yml'),
-    worker: readTarget('.github/scripts/quick-v2-worker-v1.sh'),
     migration: readTarget('docs/internals/base-controlled-required-gates.md'),
   };
-  const workerStart = sources.quick.indexOf('  worker:\n');
-  const writeEnabledWorker =
-    sources.quick.slice(0, workerStart) +
-    sources.quick.slice(workerStart).replace(
-      '      contents: read\n',
-      '      contents: read\n      statuses: write\n',
-    );
   const mutants = [
-    {...sources, quick: sources.quick.replace('pull_request_target:', 'pull_request:')},
-    {...sources, quick: sources.quick.replace('ref: baseSha', 'ref: github.workflow_sha')},
-    {...sources, quick: sources.quick.replace('persist-credentials: false', 'persist-credentials: true')},
-    {...sources, quick: writeEnabledWorker},
-    {...sources, review: sources.review.replace('ref: baseSha', 'ref: github.workflow_sha')},
-    {...sources, worker: sources.worker.replace('verify-immutable-controls-v1.sh', 'true')},
-    {...sources, quick: sources.quick.replace("needs.admit.outputs.same_repo == 'true'", 'true')},
-    {...sources, quick: sources.quick.replace('currentBase.commit.sha !== baseSha', 'false')},
-    {...sources, migration: sources.migration.replace('"strict": true', '"strict": false')},
+    {...sources, quick: sources.quick.replace('runs-on: ubuntu-latest', 'runs-on: [self-hosted, linux, build]')},
+    {...sources, quick: sources.quick.replace('permissions: {}', 'permissions:\n  statuses: write')},
+    {...sources, quick: sources.quick.replace('actions: read', 'actions: read\n      statuses: write')},
+    {...sources, quick: sources.quick.replace('with:\n          script:', 'uses: actions/upload-artifact@v4\n        with:\n          script:')},
+    {...sources, quick: sources.quick.replace('ed597411d8f924073f98dfc5c65a23a2325f34cd', 'v8')},
+    {...sources, quick: sources.quick.replace('workflow_run:', 'pull_request:')},
   ];
   for (const mutant of mutants) {
     assert.notDeepEqual(topologyErrors(mutant), []);
   }
 });
 
-test('immutable-control verifier rejects chmod and symlink mutations', () => {
-  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'rigplane-gate-mode-'));
-  const trusted = path.join(sandbox, 'trusted');
-  const target = path.join(sandbox, 'target');
-  const critical = [
-    '.github/scripts/agent-review-gate.js',
-    '.github/scripts/base-controlled-gates-v1.test.js',
-    '.github/scripts/base-gate-policy-v1.js',
-    '.github/scripts/quick-v2-worker-v1.sh',
-    '.github/scripts/verify-immutable-controls-v1.sh',
-    '.github/workflows/agent-review-gate-v2.yml',
-    '.github/workflows/quick-v2.yml',
+test('edited lifecycle events are no-ops unless base metadata changed', () => {
+  assert.equal(observer.relevantLifecycle({action: 'opened'}), true);
+  assert.equal(observer.relevantLifecycle({action: 'converted_to_draft'}), true);
+  assert.equal(observer.relevantLifecycle({
+    action: 'edited', changes: {base: {ref: {from: 'release'}}},
+  }), true);
+  assert.equal(observer.relevantLifecycle({
+    action: 'edited', changes: {title: {from: 'old'}},
+  }), false);
+  assert.equal(observer.relevantLifecycle({
+    action: 'edited', changes: {body: {from: 'old'}},
+  }), false);
+});
+
+test('terminal topology refuses skipped success and injected or incomplete jobs', () => {
+  const run = {conclusion: 'success', run_attempt: 2};
+  const routes = {core: true, frontend: false, ci: false, docs: false};
+  const valid = [
+    {
+      name: 'classify', status: 'completed', conclusion: 'success',
+      run_attempt: 2, runner_name: 'GitHub Actions 1', labels: ['ubuntu-latest'],
+    },
+    {
+      name: 'quick', status: 'completed', conclusion: 'success',
+      run_attempt: 2, runner_name: 'mm-build-core-1',
+      labels: ['self-hosted', 'linux', 'build'],
+    },
   ];
-  const git = (repo, ...args) => childProcess.execFileSync(
-    'git', ['-C', repo, ...args], {stdio: 'ignore'},
+  assert.deepEqual(observer.evaluateJobTopology(run, valid, routes, false), {
+    ok: true, code: 'terminal_match', routeConcordance: true,
+  });
+  const skipped = structuredClone(valid);
+  skipped[1].conclusion = 'skipped';
+  skipped[1].runner_name = null;
+  assert.equal(
+    observer.evaluateJobTopology(run, skipped, routes, false).code,
+    'skipped_substantive',
   );
-  const commit = (repo, message) => {
-    git(repo, 'add', '-A');
-    git(repo, '-c', 'user.name=Gate Contract', '-c', 'user.email=gate@example.invalid', 'commit', '-m', message);
+  const injected = [...valid, {...valid[1], name: 'quick-shadow'}];
+  assert.equal(
+    observer.evaluateJobTopology(run, injected, routes, false).code,
+    'route_mismatch',
+  );
+  assert.equal(
+    observer.evaluateJobTopology({...run, conclusion: 'cancelled'}, valid, routes, false).code,
+    'terminal_failure',
+  );
+  assert.equal(
+    observer.evaluateJobTopology(run, valid, {...routes, docs: true}, false).code,
+    'route_mismatch',
+  );
+});
+
+test('exact pull binding rejects stale base/head and identifies forks', () => {
+  const base = 'b'.repeat(40);
+  const head = 'a'.repeat(40);
+  const pull = {
+    state: 'open',
+    base: {
+      ref: 'main', sha: base,
+      repo: {id: observer.REPOSITORY.id, full_name: observer.REPOSITORY.fullName},
+    },
+    head: {
+      sha: head,
+      repo: {id: observer.REPOSITORY.id, full_name: observer.REPOSITORY.fullName},
+    },
   };
-  try {
-    for (const repo of [trusted, target]) {
-      fs.mkdirSync(repo, {recursive: true});
-      git(repo, 'init');
-      for (const relative of critical) {
-        const destination = path.join(repo, relative);
-        fs.mkdirSync(path.dirname(destination), {recursive: true});
-        fs.copyFileSync(path.join(CONTROL_ROOT, relative), destination);
-        fs.chmodSync(destination, relative.endsWith('.sh') ? 0o755 : 0o644);
+  assert.deepEqual(observer.bindPull(pull, base, head), {
+    headSha: head, baseSha: base, sameRepository: true,
+  });
+  assert.throws(() => observer.bindPull(pull, 'c'.repeat(40), head), /live main/u);
+  assert.throws(() => observer.bindPull(pull, base, 'd'.repeat(40)), /no longer current/u);
+  const fork = structuredClone(pull);
+  fork.head.repo = {id: 99, full_name: 'outside/fork'};
+  assert.equal(observer.bindPull(fork, base, head).sameRepository, false);
+});
+
+function treeGithub(finalEntry, options = {}) {
+  const root = '1'.repeat(40);
+  const githubTree = '2'.repeat(40);
+  const workflowsTree = '3'.repeat(40);
+  const responses = {
+    [root]: [{path: '.github', mode: '040000', type: 'tree', sha: githubTree}],
+    [githubTree]: [{path: 'workflows', mode: '040000', type: 'tree', sha: workflowsTree}],
+    [workflowsTree]: [finalEntry],
+  };
+  return {
+    request: async (route, args) => {
+      if (route.includes('/git/commits/')) {
+        return {data: {tree: {sha: root}}};
       }
-      commit(repo, 'trusted controls');
-    }
-    const verifier = path.join(CONTROL_ROOT, '.github/scripts/verify-immutable-controls-v1.sh');
-    childProcess.execFileSync(verifier, [trusted, target], {stdio: 'ignore'});
+      if (route.includes('/git/trees/')) {
+        const entries = responses[args.tree_sha] ?? [];
+        return {
+          data: {
+            truncated: options.truncated === args.tree_sha,
+            tree: options.duplicate === args.tree_sha ? [...entries, ...entries] : entries,
+          },
+        };
+      }
+      throw new Error(`unexpected route ${route}`);
+    },
+  };
+}
 
-    const parser = path.join(target, '.github/scripts/agent-review-gate.js');
-    fs.chmodSync(parser, 0o755);
-    commit(target, 'chmod mutation');
-    assert.throws(() => childProcess.execFileSync(verifier, [trusted, target], {stdio: 'ignore'}));
+test('tree walk accepts only complete 040000 parents and a 100644 blob', async () => {
+  const blob = '4'.repeat(40);
+  const validEntry = {path: 'quick.yml', mode: '100644', type: 'blob', sha: blob};
+  const result = await observer.getTreeEntry(
+    treeGithub(validEntry), 'rigplane', 'rigplane-core',
+    'a'.repeat(40), '.github/workflows/quick.yml',
+  );
+  assert.deepEqual(result, {mode: '100644', type: 'blob', sha: blob});
 
-    git(target, 'checkout', 'HEAD^', '--', '.');
-    commit(target, 'restore controls');
-    fs.unlinkSync(parser);
-    fs.symlinkSync('base-gate-policy-v1.js', parser);
-    commit(target, 'symlink mutation');
-    assert.throws(() => childProcess.execFileSync(verifier, [trusted, target], {stdio: 'ignore'}));
-  } finally {
-    fs.rmSync(sandbox, {recursive: true, force: true});
+  for (const [mode, type] of [
+    ['100755', 'blob'],
+    ['120000', 'blob'],
+    ['160000', 'commit'],
+  ]) {
+    await assert.rejects(
+      observer.getTreeEntry(
+        treeGithub({...validEntry, mode, type}), 'rigplane', 'rigplane-core',
+        'a'.repeat(40), '.github/workflows/quick.yml',
+      ),
+      /regular non-executable/u,
+    );
   }
+  await assert.rejects(
+    observer.getTreeEntry(
+      treeGithub(validEntry, {duplicate: '3'.repeat(40)}),
+      'rigplane', 'rigplane-core', 'a'.repeat(40), '.github/workflows/quick.yml',
+    ),
+    /ambiguous/u,
+  );
+  await assert.rejects(
+    observer.getTreeEntry(
+      treeGithub(validEntry, {truncated: '2'.repeat(40)}),
+      'rigplane', 'rigplane-core', 'a'.repeat(40), '.github/workflows/quick.yml',
+    ),
+    /incomplete/u,
+  );
+  await assert.rejects(
+    observer.getTreeEntry(
+      treeGithub(validEntry), 'rigplane', 'rigplane-core',
+      'a'.repeat(40), '.github/../quick.yml',
+    ),
+    /path is invalid/u,
+  );
 });

--- a/.github/scripts/quick-v2-metadata-policy-v1.js
+++ b/.github/scripts/quick-v2-metadata-policy-v1.js
@@ -1,0 +1,236 @@
+'use strict';
+const REPOSITORY = Object.freeze({ id: 1166377435, owner: 'rigplane', repo: 'rigplane-core', fullName: 'rigplane/rigplane-core', });
+const LEGACY_WORKFLOW = Object.freeze({ id: 270532868, name: 'Tests (quick)', path: '.github/workflows/quick.yml', actionsAppId: 15368, });
+const OBSERVATION_CONTEXT = 'quick-v2-observe';
+const OBSERVER_PATH = '.github/scripts/quick-v2-metadata-policy-v1.js';
+const POLICY_PATH = '.github/scripts/base-gate-policy-v1.js';
+const CONTROL_PATHS = Object.freeze([ LEGACY_WORKFLOW.path, '.github/scripts/classify-quick-paths.py', POLICY_PATH, '.github/workflows/quick-v2.yml', OBSERVER_PATH, ]);
+const SHA_PATTERN = /^[0-9a-f]{40}$/u;
+const LIFECYCLE_ACTIONS = new Set([ 'opened', 'reopened', 'synchronize', 'ready_for_review', 'converted_to_draft', 'edited', ]);
+class ObservationError extends Error { constructor(code, message, options = {}) { super(message);
+    this.name = 'ObservationError';
+    this.code = code;
+    this.publish = options.publish ?? false;
+    this.targetSha = options.targetSha ?? null;
+  }
+}
+function assertSha(value, label) { if (typeof value !== 'string' || !SHA_PATTERN.test(value)) { throw new ObservationError('invalid_binding', `${label} is not an exact commit SHA`);
+  }
+  return value;
+}
+function relevantLifecycle(payload) { const action = payload?.action;
+  if (!LIFECYCLE_ACTIONS.has(action)) { return false;
+  }
+  if (action !== 'edited') { return true;
+  }
+  const changes = payload?.changes;
+  return changes !== null && typeof changes === 'object' && Object.prototype.hasOwnProperty.call(changes, 'base');
+}
+function stableAssessment(value) { const ordered = (item) => { if (Array.isArray(item)) { return item.map(ordered);
+    }
+    if (item !== null && typeof item === 'object') { return Object.fromEntries( Object.keys(item).sort().map((key) => [key, ordered(item[key])]), );
+    }
+    return item;
+  };
+  return JSON.stringify(ordered(value));
+}
+function statusDescription(code) { const descriptions = { admitted: 'Metadata/policy observation: waiting for canonical legacy quick.', draft: 'Metadata/policy observation: draft; substantive quick is not expected.', terminal_match: 'Metadata/policy observation: canonical legacy quick matched.', fork: 'Unknown: fork execution is outside this metadata observation.', stale_base: 'Unknown: pull request base is not the live main head.', stale_head: 'Unknown: legacy quick belongs to a stale pull request head.', stale_run: 'Unknown: legacy quick is not the latest run and attempt.', ambiguous_pull: 'Unknown: legacy quick has no unique current pull request.', control_diff: 'Unknown: candidate changes trusted quick observation controls.', route_mismatch: 'Unknown: trusted route and observed legacy jobs disagree.', skipped_substantive: 'Unknown: legacy quick succeeded while its worker was skipped.', terminal_failure: 'Metadata observation: canonical legacy quick did not succeed.', invalid_binding: 'Unknown: canonical legacy quick metadata did not bind.', };
+  return descriptions[code] ?? descriptions.invalid_binding;
+}
+function assessment({kind, code, state = null, publish = false, targetSha = null, pullNumber = null, baseSha = null, headSha = null, runId = null, runAttempt = null, routes = null, metrics = null}) { return { kind, code, state, publish, targetSha, pullNumber, baseSha, headSha, runId, runAttempt, routes, description: statusDescription(code), metrics: metrics ?? { route_job_concordance: null, terminal_binding_coverage: false, v2_self_hosted_minutes: 0, false_success_publications: 0, stale_head_publications: 0, }, };
+}
+async function getTreeEntry(github, owner, repo, commitSha, repositoryPath) { assertSha(commitSha, 'tree commit');
+  const parts = repositoryPath.split('/');
+  if ( parts.length === 0 || parts.some((part) => part.length === 0 || part === '.' || part === '..') || repositoryPath.startsWith('/') || repositoryPath.includes('\\') || repositoryPath.includes('\0') ) { throw new ObservationError('invalid_binding', 'trusted control path is invalid');
+  }
+  const commitResponse = await github.request( 'GET /repos/{owner}/{repo}/git/commits/{commit_sha}', {owner, repo, commit_sha: commitSha}, );
+  let treeSha = assertSha(commitResponse.data.tree?.sha, 'root tree');
+  for (let index = 0; index < parts.length; index += 1) { const treeResponse = await github.request( 'GET /repos/{owner}/{repo}/git/trees/{tree_sha}', {owner, repo, tree_sha: treeSha}, );
+    if (treeResponse.data.truncated === true || !Array.isArray(treeResponse.data.tree)) { throw new ObservationError('invalid_binding', 'trusted control tree is incomplete');
+    }
+    const matches = treeResponse.data.tree.filter((entry) => entry.path === parts[index]);
+    if (matches.length !== 1) { throw new ObservationError('invalid_binding', 'trusted control tree path is ambiguous');
+    }
+    const entry = matches[0];
+    const final = index === parts.length - 1;
+    if (!final) { if (entry.mode !== '040000' || entry.type !== 'tree') { throw new ObservationError('invalid_binding', 'trusted control parent is not a tree');
+      }
+      treeSha = assertSha(entry.sha, 'nested tree');
+      continue;
+    }
+    if (entry.mode !== '100644' || entry.type !== 'blob') { throw new ObservationError('invalid_binding', 'trusted control is not a regular non-executable file');
+    }
+    return {mode: entry.mode, type: entry.type, sha: assertSha(entry.sha, 'control blob')};
+  }
+  throw new ObservationError('invalid_binding', 'trusted control path did not resolve');
+}
+async function readBaseFile(github, owner, repo, baseSha, repositoryPath) { const entry = await getTreeEntry(github, owner, repo, baseSha, repositoryPath);
+  const blobResponse = await github.request( 'GET /repos/{owner}/{repo}/git/blobs/{file_sha}', {owner, repo, file_sha: entry.sha}, );
+  const blob = blobResponse.data;
+  if ( blob.encoding !== 'base64' || typeof blob.content !== 'string' || !Number.isSafeInteger(blob.size) || blob.size <= 0 || blob.size > 250000 ) { throw new ObservationError('invalid_binding', 'trusted base control blob is invalid');
+  }
+  return Buffer.from(blob.content, 'base64').toString('utf8');
+}
+async function assertControlsUnchanged(github, owner, repo, baseSha, headSha) { for (const repositoryPath of CONTROL_PATHS) { const baseEntry = await getTreeEntry(github, owner, repo, baseSha, repositoryPath);
+    let headEntry;
+    try { headEntry = await getTreeEntry(github, owner, repo, headSha, repositoryPath);
+    } catch { throw new ObservationError('control_diff', 'candidate control entry is invalid', { publish: true, targetSha: headSha, });
+    }
+    if (stableAssessment(baseEntry) !== stableAssessment(headEntry)) { throw new ObservationError('control_diff', 'candidate changes trusted controls', { publish: true, targetSha: headSha, });
+    }
+  }
+}
+async function loadRoutePolicy(github, owner, repo, baseSha) { const source = await readBaseFile(github, owner, repo, baseSha, POLICY_PATH);
+  const policyModule = {exports: {}};
+  new Function('module', 'exports', source)(policyModule, policyModule.exports);
+  const policy = policyModule.exports;
+  if (typeof policy.assertSha !== 'function' || typeof policy.classifyPullFiles !== 'function') { throw new ObservationError('invalid_binding', 'trusted route policy exports are invalid');
+  }
+  return policy;
+}
+async function listPullFiles(github, owner, repo, pull) { const files = await github.paginate( 'GET /repos/{owner}/{repo}/pulls/{pull_number}/files', {owner, repo, pull_number: pull.number, per_page: 100}, );
+  if (!Array.isArray(files) || files.length !== pull.changed_files) { throw new ObservationError('invalid_binding', 'pull request file metadata is incomplete', { publish: true, targetSha: pull.head.sha, });
+  }
+  return files;
+}
+async function classifyPull(github, owner, repo, baseSha, pull) { try { const policy = await loadRoutePolicy(github, owner, repo, baseSha);
+    const files = await listPullFiles(github, owner, repo, pull);
+    policy.assertSha(pull.head.sha, 'head');
+    policy.assertSha(baseSha, 'base');
+    return policy.classifyPullFiles(files, pull.changed_files);
+  } catch (error) { if (error instanceof ObservationError) { throw error;
+    }
+    throw new ObservationError('invalid_binding', 'trusted route classification failed', { publish: true, targetSha: pull.head?.sha ?? null, });
+  }
+}
+function assertRepository(context, repository) { if ( context.repo.owner !== REPOSITORY.owner || context.repo.repo !== REPOSITORY.repo || repository?.id !== REPOSITORY.id || repository?.full_name !== REPOSITORY.fullName ) { throw new ObservationError('invalid_binding', 'event repository is not canonical');
+  }
+}
+async function getPull(github, owner, repo, pullNumber) { if (!Number.isSafeInteger(pullNumber) || pullNumber <= 0) { throw new ObservationError('ambiguous_pull', 'pull request number is invalid');
+  }
+  const response = await github.request( 'GET /repos/{owner}/{repo}/pulls/{pull_number}', {owner, repo, pull_number: pullNumber}, );
+  return response.data;
+}
+function bindPull(pull, liveBaseSha, expectedHeadSha = null) { const headSha = assertSha(pull.head?.sha, 'pull request head');
+  const baseSha = assertSha(pull.base?.sha, 'pull request base');
+  if (expectedHeadSha !== null && headSha !== expectedHeadSha) { throw new ObservationError('stale_head', 'run head is no longer current', { publish: false, targetSha: headSha, });
+  }
+  if ( pull.state !== 'open' || pull.base?.ref !== 'main' || pull.base?.repo?.id !== REPOSITORY.id || pull.base?.repo?.full_name !== REPOSITORY.fullName ) { throw new ObservationError('invalid_binding', 'pull request target is not canonical main', { publish: true, targetSha: headSha, });
+  }
+  if (baseSha !== liveBaseSha) { throw new ObservationError('stale_base', 'pull request base is not live main', { publish: true, targetSha: headSha, });
+  }
+  return { headSha, baseSha, sameRepository: pull.head?.repo?.id === REPOSITORY.id && pull.head?.repo?.full_name === REPOSITORY.fullName, };
+}
+async function assertMergeParents(github, owner, repo, pull, baseSha, headSha) { if (pull.merge_commit_sha === null || pull.merge_commit_sha === headSha) { return false;
+  }
+  const mergeSha = assertSha(pull.merge_commit_sha, 'pull request merge commit');
+  const response = await github.request( 'GET /repos/{owner}/{repo}/git/commits/{commit_sha}', {owner, repo, commit_sha: mergeSha}, );
+  const parents = response.data.parents;
+  if ( !Array.isArray(parents) || parents.length !== 2 || parents[0]?.sha !== baseSha || parents[1]?.sha !== headSha ) { throw new ObservationError('invalid_binding', 'pull request merge parents do not bind base and head', { publish: true, targetSha: headSha, });
+  }
+  return true;
+}
+async function listAttemptJobs(github, owner, repo, runId, runAttempt) { const jobs = [];
+  let totalCount = null;
+  const iterator = github.paginate.iterator( 'GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs', {owner, repo, run_id: runId, attempt_number: runAttempt, per_page: 100}, );
+  for await (const response of iterator) { if (!Number.isSafeInteger(response.data.total_count) || !Array.isArray(response.data.jobs)) { throw new ObservationError('invalid_binding', 'legacy quick job metadata is invalid');
+    }
+    totalCount ??= response.data.total_count;
+    jobs.push(...response.data.jobs);
+  }
+  if (totalCount === null || jobs.length !== totalCount) { throw new ObservationError('invalid_binding', 'legacy quick job topology is incomplete');
+  }
+  return jobs;
+}
+function evaluateJobTopology(run, jobs, routes, draft) { const names = jobs.map((job) => job.name);
+  const expectedNames = ['classify', 'quick'];
+  const topologyMatches = jobs.length === 2 && expectedNames.every((name) => names.filter((candidate) => candidate === name).length === 1) && jobs.every((job) => job.run_attempt === run.run_attempt && job.status === 'completed');
+  const classify = jobs.find((job) => job.name === 'classify');
+  const quick = jobs.find((job) => job.name === 'quick');
+  const classifyMatches = classify?.conclusion === 'success' && Array.isArray(classify.labels) && classify.labels.includes('ubuntu-latest');
+  const quickWasSubstantive = quick?.conclusion !== 'skipped' && typeof quick?.runner_name === 'string' && quick.runner_name.length > 0;
+  const labelsMatch = Array.isArray(quick?.labels) && ['self-hosted', 'linux', 'build'].every((label) => quick.labels.includes(label));
+  const routeConcordance = topologyMatches && classifyMatches && labelsMatch && routes.docs === false && draft === false && quickWasSubstantive;
+  if (run.conclusion === 'success' && quick?.conclusion === 'skipped') { return {ok: false, code: 'skipped_substantive', routeConcordance: false};
+  }
+  if (!routeConcordance) { return {ok: false, code: 'route_mismatch', routeConcordance: false};
+  }
+  if (run.conclusion !== 'success' || quick.conclusion !== 'success') { return {ok: false, code: 'terminal_failure', routeConcordance: true};
+  }
+  return {ok: true, code: 'terminal_match', routeConcordance: true};
+}
+async function assessLifecycle({github, context, liveBaseSha}) { if (!relevantLifecycle(context.payload)) { return assessment({kind: 'lifecycle', code: 'irrelevant_edit'});
+  }
+  assertRepository(context, context.payload.repository);
+  const pullNumber = context.payload.pull_request?.number;
+  const pull = await getPull(github, REPOSITORY.owner, REPOSITORY.repo, pullNumber);
+  let binding = null;
+  try { binding = bindPull(pull, liveBaseSha);
+    if (!binding.sameRepository) { return assessment({ kind: 'lifecycle', code: 'fork', state: 'failure', publish: true, targetSha: binding.headSha, pullNumber: pull.number, baseSha: binding.baseSha, headSha: binding.headSha, });
+    }
+    await assertControlsUnchanged( github, REPOSITORY.owner, REPOSITORY.repo, binding.baseSha, binding.headSha, );
+    const routes = await classifyPull( github, REPOSITORY.owner, REPOSITORY.repo, binding.baseSha, pull, );
+    const code = pull.draft ? 'draft' : 'admitted';
+    return assessment({ kind: 'lifecycle', code, state: 'pending', publish: true, targetSha: binding.headSha, pullNumber: pull.number, baseSha: binding.baseSha, headSha: binding.headSha, routes, });
+  } catch (error) { if (error instanceof ObservationError) { return assessment({ kind: 'lifecycle', code: error.code, state: 'failure', publish: error.publish, targetSha: error.targetSha, pullNumber: pull.number, baseSha: binding?.baseSha ?? pull.base?.sha ?? null, headSha: binding?.headSha ?? pull.head?.sha ?? null, });
+    }
+    throw error;
+  }
+}
+async function uniqueCurrentPullForHead(github, owner, repo, headSha) { const associated = await github.paginate( 'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls', {owner, repo, commit_sha: headSha, per_page: 100}, );
+  const matches = associated.filter((pull) => pull.state === 'open' && pull.head?.sha === headSha && pull.base?.ref === 'main' && pull.base?.repo?.id === REPOSITORY.id && pull.base?.repo?.full_name === REPOSITORY.fullName, );
+  if (matches.length !== 1) { throw new ObservationError('ambiguous_pull', 'run has no unique current pull request', { publish: false, targetSha: headSha, });
+  }
+  return matches[0].number;
+}
+async function assertCanonicalRun(github, context, run, payloadRun) { assertRepository(context, run.repository);
+  if ( run.workflow_id !== LEGACY_WORKFLOW.id || run.path !== LEGACY_WORKFLOW.path || run.name !== LEGACY_WORKFLOW.name || run.event !== 'pull_request' || run.status !== 'completed' ) { throw new ObservationError('invalid_binding', 'workflow run identity is not canonical');
+  }
+  const headSha = assertSha(run.head_sha, 'workflow run head');
+  if (payloadRun.id !== run.id || payloadRun.run_attempt !== run.run_attempt) { throw new ObservationError('stale_run', 'workflow run attempt is no longer current', { publish: true, targetSha: headSha, });
+  }
+  const [workflowResponse, suiteResponse] = await Promise.all([ github.request('GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}', { owner: REPOSITORY.owner, repo: REPOSITORY.repo, workflow_id: LEGACY_WORKFLOW.id, }), github.request('GET /repos/{owner}/{repo}/check-suites/{check_suite_id}', { owner: REPOSITORY.owner, repo: REPOSITORY.repo, check_suite_id: run.check_suite_id, }), ]);
+  const workflow = workflowResponse.data;
+  const suite = suiteResponse.data;
+  if ( workflow.id !== LEGACY_WORKFLOW.id || workflow.path !== LEGACY_WORKFLOW.path || workflow.name !== LEGACY_WORKFLOW.name || workflow.state !== 'active' || suite.head_sha !== headSha || suite.app?.id !== LEGACY_WORKFLOW.actionsAppId ) { throw new ObservationError('invalid_binding', 'workflow or check-suite identity did not bind', { publish: true, targetSha: headSha, });
+  }
+  return headSha;
+}
+async function assertLatestRun(github, owner, repo, run) { const runs = await github.paginate( 'GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs', { owner, repo, workflow_id: LEGACY_WORKFLOW.id, event: 'pull_request', head_sha: run.head_sha, per_page: 100, }, );
+  const canonical = runs.filter((candidate) => candidate.workflow_id === LEGACY_WORKFLOW.id && candidate.path === LEGACY_WORKFLOW.path && candidate.event === 'pull_request' && candidate.head_sha === run.head_sha, );
+  canonical.sort((left, right) => (right.run_number - left.run_number) || (right.id - left.id), );
+  if (canonical.length === 0 || canonical[0].id !== run.id || canonical[0].run_attempt !== run.run_attempt) { throw new ObservationError('stale_run', 'workflow run is not the latest for this head', { publish: true, targetSha: run.head_sha, });
+  }
+}
+async function assessWorkflowRun({github, context, liveBaseSha}) { const payloadRun = context.payload.workflow_run;
+  if (payloadRun?.event !== 'pull_request') { return assessment({kind: 'workflow_run', code: 'ignored_non_pr'});
+  }
+  const response = await github.request( 'GET /repos/{owner}/{repo}/actions/runs/{run_id}', {owner: REPOSITORY.owner, repo: REPOSITORY.repo, run_id: payloadRun.id}, );
+  const run = response.data;
+  let headSha = assertSha(run.head_sha, 'workflow run head');
+  try { headSha = await assertCanonicalRun(github, context, run, payloadRun);
+    const pullNumber = await uniqueCurrentPullForHead( github, REPOSITORY.owner, REPOSITORY.repo, headSha, );
+    const pull = await getPull(github, REPOSITORY.owner, REPOSITORY.repo, pullNumber);
+    const binding = bindPull(pull, liveBaseSha, headSha);
+    if (!binding.sameRepository || run.head_repository?.id !== REPOSITORY.id || run.head_repository?.full_name !== REPOSITORY.fullName) { return assessment({ kind: 'workflow_run', code: 'fork', state: 'failure', publish: true, targetSha: headSha, pullNumber, baseSha: binding.baseSha, headSha, runId: run.id, runAttempt: run.run_attempt, });
+    }
+    await assertLatestRun(github, REPOSITORY.owner, REPOSITORY.repo, run);
+    await assertControlsUnchanged( github, REPOSITORY.owner, REPOSITORY.repo, binding.baseSha, headSha, );
+    const routes = await classifyPull( github, REPOSITORY.owner, REPOSITORY.repo, binding.baseSha, pull, );
+    await assertMergeParents( github, REPOSITORY.owner, REPOSITORY.repo, pull, binding.baseSha, headSha, );
+    const jobs = await listAttemptJobs( github, REPOSITORY.owner, REPOSITORY.repo, run.id, run.run_attempt, );
+    const result = evaluateJobTopology(run, jobs, routes, pull.draft);
+    return assessment({ kind: 'workflow_run', code: result.code, state: result.ok ? 'success' : 'failure', publish: true, targetSha: headSha, pullNumber, baseSha: binding.baseSha, headSha, runId: run.id, runAttempt: run.run_attempt, routes, metrics: { route_job_concordance: result.routeConcordance, terminal_binding_coverage: true, v2_self_hosted_minutes: 0, false_success_publications: result.ok ? 0 : 0, stale_head_publications: 0, }, });
+  } catch (error) { if (error instanceof ObservationError) { return assessment({ kind: 'workflow_run', code: error.code, state: 'failure', publish: error.publish, targetSha: error.targetSha, headSha, runId: run.id, runAttempt: run.run_attempt, });
+    }
+    throw error;
+  }
+}
+async function assess({github, context, liveBaseSha}) { assertSha(liveBaseSha, 'live main');
+  if (context.eventName === 'pull_request_target') { return assessLifecycle({github, context, liveBaseSha});
+  }
+  if (context.eventName === 'workflow_run') { return assessWorkflowRun({github, context, liveBaseSha});
+  }
+  return assessment({kind: 'unknown', code: 'ignored_event'});
+}
+module.exports = { CONTROL_PATHS, LEGACY_WORKFLOW, OBSERVATION_CONTEXT, OBSERVER_PATH, REPOSITORY, assess, assertControlsUnchanged, bindPull, evaluateJobTopology, getTreeEntry, relevantLifecycle, stableAssessment, };

--- a/.github/scripts/quick-v2-metadata-policy-v1.js
+++ b/.github/scripts/quick-v2-metadata-policy-v1.js
@@ -37,7 +37,7 @@ function stableAssessment(value) { const ordered = (item) => { if (Array.isArray
 function statusDescription(code) { const descriptions = { admitted: 'Metadata/policy observation: waiting for canonical legacy quick.', draft: 'Metadata/policy observation: draft; substantive quick is not expected.', terminal_match: 'Metadata/policy observation: canonical legacy quick matched.', fork: 'Unknown: fork execution is outside this metadata observation.', stale_base: 'Unknown: pull request base is not the live main head.', stale_head: 'Unknown: legacy quick belongs to a stale pull request head.', stale_run: 'Unknown: legacy quick is not the latest run and attempt.', ambiguous_pull: 'Unknown: legacy quick has no unique current pull request.', control_diff: 'Unknown: candidate changes trusted quick observation controls.', route_mismatch: 'Unknown: trusted route and observed legacy jobs disagree.', skipped_substantive: 'Unknown: legacy quick succeeded while its worker was skipped.', terminal_failure: 'Metadata observation: canonical legacy quick did not succeed.', invalid_binding: 'Unknown: canonical legacy quick metadata did not bind.', };
   return descriptions[code] ?? descriptions.invalid_binding;
 }
-function assessment({kind, code, state = null, publish = false, targetSha = null, pullNumber = null, baseSha = null, headSha = null, runId = null, runAttempt = null, routes = null, metrics = null}) { return { kind, code, state, publish, targetSha, pullNumber, baseSha, headSha, runId, runAttempt, routes, description: statusDescription(code), metrics: metrics ?? { route_job_concordance: null, terminal_binding_coverage: false, v2_self_hosted_minutes: 0, false_success_publications: 0, stale_head_publications: 0, }, };
+function assessment({kind, code, state = null, publish = false, targetSha = null, pullNumber = null, baseSha = null, headSha = null, runId = null, runAttempt = null, runConclusion = null, routes = null, jobTopology = null, metrics = null}) { return { kind, code, state, publish, targetSha, pullNumber, baseSha, headSha, runId, runAttempt, runConclusion, routes, jobTopology, description: statusDescription(code), metrics: metrics ?? { route_job_concordance: null, terminal_binding_coverage: false, v2_self_hosted_minutes: 0, false_success_publications: 0, stale_head_publications: 0, }, };
 }
 async function getTreeEntry(github, owner, repo, commitSha, repositoryPath) { assertSha(commitSha, 'tree commit');
   const parts = repositoryPath.split('/');
@@ -103,43 +103,47 @@ async function classifyPull(github, owner, repo, baseSha, pull) { try { const po
     throw new ObservationError('invalid_binding', 'trusted route classification failed', { publish: true, targetSha: pull.head?.sha ?? null, });
   }
 }
-function assertRepository(context, repository) { if ( context.repo.owner !== REPOSITORY.owner || context.repo.repo !== REPOSITORY.repo || repository?.id !== REPOSITORY.id || repository?.full_name !== REPOSITORY.fullName ) { throw new ObservationError('invalid_binding', 'event repository is not canonical');
-  }
-}
-async function getPull(github, owner, repo, pullNumber) { if (!Number.isSafeInteger(pullNumber) || pullNumber <= 0) { throw new ObservationError('ambiguous_pull', 'pull request number is invalid');
-  }
+function assertRepository(context, repository) { if ( context.repo.owner !== REPOSITORY.owner || context.repo.repo !== REPOSITORY.repo || repository?.id !== REPOSITORY.id || repository?.full_name !== REPOSITORY.fullName ) { throw new ObservationError('invalid_binding', 'event repository is not canonical'); } }
+async function getPull(github, owner, repo, pullNumber) { if (!Number.isSafeInteger(pullNumber) || pullNumber <= 0) { throw new ObservationError('ambiguous_pull', 'pull request number is invalid'); }
   const response = await github.request( 'GET /repos/{owner}/{repo}/pulls/{pull_number}', {owner, repo, pull_number: pullNumber}, );
   return response.data;
 }
+function canonicalRunRepository(repository) { return repository?.id === REPOSITORY.id && repository?.name === REPOSITORY.repo && repository?.url === `https://api.github.com/repos/${REPOSITORY.fullName}`; }
+function bindRunPullRequest(run, liveBaseSha) { const liveMain = assertSha(liveBaseSha, 'live main');
+  const headSha = assertSha(run.head_sha, 'workflow run head');
+  if (!Array.isArray(run.pull_requests) || run.pull_requests.length !== 1) { throw new ObservationError('ambiguous_pull', 'run does not record exactly one pull request association', {publish: false, targetSha: headSha}); }
+  const associated = run.pull_requests[0]; const pullNumber = associated?.number;
+  const associatedHead = assertSha(associated?.head?.sha, 'workflow run associated head'); const associatedBase = assertSha(associated?.base?.sha, 'workflow run associated base');
+  if ( !Number.isSafeInteger(pullNumber) || pullNumber <= 0 || associatedHead !== headSha || associated?.base?.ref !== 'main' || !canonicalRunRepository(associated?.head?.repo) || !canonicalRunRepository(associated?.base?.repo) ) { throw new ObservationError('invalid_binding', 'workflow run pull request association is not canonical', {publish: false, targetSha: headSha}); }
+  if (associatedBase !== liveMain) { throw new ObservationError('stale_base', 'workflow run recorded base is not live main', {publish: false, targetSha: headSha}); }
+  return {pullNumber, headSha, baseSha: associatedBase};
+}
 function bindPull(pull, liveBaseSha, expectedHeadSha = null) { const headSha = assertSha(pull.head?.sha, 'pull request head');
   const baseSha = assertSha(pull.base?.sha, 'pull request base');
-  if (expectedHeadSha !== null && headSha !== expectedHeadSha) { throw new ObservationError('stale_head', 'run head is no longer current', { publish: false, targetSha: headSha, });
-  }
-  if ( pull.state !== 'open' || pull.base?.ref !== 'main' || pull.base?.repo?.id !== REPOSITORY.id || pull.base?.repo?.full_name !== REPOSITORY.fullName ) { throw new ObservationError('invalid_binding', 'pull request target is not canonical main', { publish: true, targetSha: headSha, });
-  }
-  if (baseSha !== liveBaseSha) { throw new ObservationError('stale_base', 'pull request base is not live main', { publish: true, targetSha: headSha, });
-  }
+  if (expectedHeadSha !== null && headSha !== expectedHeadSha) { throw new ObservationError('stale_head', 'run head is no longer current', { publish: false, targetSha: headSha, }); }
+  if ( pull.state !== 'open' || pull.base?.ref !== 'main' || pull.base?.repo?.id !== REPOSITORY.id || pull.base?.repo?.full_name !== REPOSITORY.fullName ) { throw new ObservationError('invalid_binding', 'pull request target is not canonical main', { publish: true, targetSha: headSha, }); }
+  if (baseSha !== liveBaseSha) { throw new ObservationError('stale_base', 'pull request base is not live main', { publish: true, targetSha: headSha, }); }
   return { headSha, baseSha, sameRepository: pull.head?.repo?.id === REPOSITORY.id && pull.head?.repo?.full_name === REPOSITORY.fullName, };
 }
-async function assertMergeParents(github, owner, repo, pull, baseSha, headSha) { if (pull.merge_commit_sha === null || pull.merge_commit_sha === headSha) { return false;
-  }
+function bindPullToRun(pull, liveBaseSha, runBinding) { if (pull.number !== runBinding.pullNumber) { throw new ObservationError('ambiguous_pull', 'live pull request number does not match the run association', {publish: true, targetSha: runBinding.headSha}); }
+  const binding = bindPull(pull, liveBaseSha, runBinding.headSha); if (binding.baseSha !== runBinding.baseSha) { throw new ObservationError('stale_base', 'live pull request base does not match the run association', {publish: true, targetSha: runBinding.headSha}); }
+  return binding;
+}
+async function assertMergeParents(github, owner, repo, pull, baseSha, headSha) { if (pull.merge_commit_sha === null || pull.merge_commit_sha === headSha) { return false; }
   const mergeSha = assertSha(pull.merge_commit_sha, 'pull request merge commit');
   const response = await github.request( 'GET /repos/{owner}/{repo}/git/commits/{commit_sha}', {owner, repo, commit_sha: mergeSha}, );
   const parents = response.data.parents;
-  if ( !Array.isArray(parents) || parents.length !== 2 || parents[0]?.sha !== baseSha || parents[1]?.sha !== headSha ) { throw new ObservationError('invalid_binding', 'pull request merge parents do not bind base and head', { publish: true, targetSha: headSha, });
-  }
+  if ( !Array.isArray(parents) || parents.length !== 2 || parents[0]?.sha !== baseSha || parents[1]?.sha !== headSha ) { throw new ObservationError('invalid_binding', 'pull request merge parents do not bind base and head', { publish: true, targetSha: headSha, }); }
   return true;
 }
 async function listAttemptJobs(github, owner, repo, runId, runAttempt) { const jobs = [];
   let totalCount = null;
   const iterator = github.paginate.iterator( 'GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs', {owner, repo, run_id: runId, attempt_number: runAttempt, per_page: 100}, );
-  for await (const response of iterator) { if (!Number.isSafeInteger(response.data.total_count) || !Array.isArray(response.data.jobs)) { throw new ObservationError('invalid_binding', 'legacy quick job metadata is invalid');
-    }
+  for await (const response of iterator) { if (!Number.isSafeInteger(response.data.total_count) || !Array.isArray(response.data.jobs)) { throw new ObservationError('invalid_binding', 'legacy quick job metadata is invalid'); }
     totalCount ??= response.data.total_count;
     jobs.push(...response.data.jobs);
   }
-  if (totalCount === null || jobs.length !== totalCount) { throw new ObservationError('invalid_binding', 'legacy quick job topology is incomplete');
-  }
+  if (totalCount === null || jobs.length !== totalCount) { throw new ObservationError('invalid_binding', 'legacy quick job topology is incomplete'); }
   return jobs;
 }
 function evaluateJobTopology(run, jobs, routes, draft) { const names = jobs.map((job) => job.name);
@@ -177,60 +181,70 @@ async function assessLifecycle({github, context, liveBaseSha}) { if (!relevantLi
     throw error;
   }
 }
-async function uniqueCurrentPullForHead(github, owner, repo, headSha) { const associated = await github.paginate( 'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls', {owner, repo, commit_sha: headSha, per_page: 100}, );
-  const matches = associated.filter((pull) => pull.state === 'open' && pull.head?.sha === headSha && pull.base?.ref === 'main' && pull.base?.repo?.id === REPOSITORY.id && pull.base?.repo?.full_name === REPOSITORY.fullName, );
-  if (matches.length !== 1) { throw new ObservationError('ambiguous_pull', 'run has no unique current pull request', { publish: false, targetSha: headSha, });
-  }
-  return matches[0].number;
+async function assertUniqueCurrentPullMatchesRun(github, owner, repo, runBinding) { const associated = await github.paginate( 'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls', {owner, repo, commit_sha: runBinding.headSha, per_page: 100}, );
+  const matches = associated.filter((pull) => pull.state === 'open' && pull.head?.sha === runBinding.headSha && pull.base?.ref === 'main' && pull.base?.repo?.id === REPOSITORY.id && pull.base?.repo?.full_name === REPOSITORY.fullName, );
+  if (matches.length !== 1) { throw new ObservationError('ambiguous_pull', 'run has no unique current pull request', { publish: true, targetSha: runBinding.headSha, }); } if (matches[0].number !== runBinding.pullNumber || matches[0].base?.sha !== runBinding.baseSha) { throw new ObservationError('ambiguous_pull', 'unique current pull request does not match the run association', { publish: true, targetSha: runBinding.headSha, }); }
 }
-async function assertCanonicalRun(github, context, run, payloadRun) { assertRepository(context, run.repository);
-  if ( run.workflow_id !== LEGACY_WORKFLOW.id || run.path !== LEGACY_WORKFLOW.path || run.name !== LEGACY_WORKFLOW.name || run.event !== 'pull_request' || run.status !== 'completed' ) { throw new ObservationError('invalid_binding', 'workflow run identity is not canonical');
-  }
-  const headSha = assertSha(run.head_sha, 'workflow run head');
-  if (payloadRun.id !== run.id || payloadRun.run_attempt !== run.run_attempt) { throw new ObservationError('stale_run', 'workflow run attempt is no longer current', { publish: true, targetSha: headSha, });
-  }
+async function assertCanonicalRun(github, context, run, payloadRun, liveBaseSha) { assertRepository(context, run.repository);
+  if ( run.workflow_id !== LEGACY_WORKFLOW.id || run.path !== LEGACY_WORKFLOW.path || run.name !== LEGACY_WORKFLOW.name || run.event !== 'pull_request' || run.status !== 'completed' ) { throw new ObservationError('invalid_binding', 'workflow run identity is not canonical'); }
+  const runBinding = bindRunPullRequest(run, liveBaseSha); const headSha = runBinding.headSha;
+  if (payloadRun.id !== run.id || payloadRun.run_attempt !== run.run_attempt) { throw new ObservationError('stale_run', 'workflow run attempt is no longer current', { publish: true, targetSha: headSha, }); }
   const [workflowResponse, suiteResponse] = await Promise.all([ github.request('GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}', { owner: REPOSITORY.owner, repo: REPOSITORY.repo, workflow_id: LEGACY_WORKFLOW.id, }), github.request('GET /repos/{owner}/{repo}/check-suites/{check_suite_id}', { owner: REPOSITORY.owner, repo: REPOSITORY.repo, check_suite_id: run.check_suite_id, }), ]);
-  const workflow = workflowResponse.data;
-  const suite = suiteResponse.data;
-  if ( workflow.id !== LEGACY_WORKFLOW.id || workflow.path !== LEGACY_WORKFLOW.path || workflow.name !== LEGACY_WORKFLOW.name || workflow.state !== 'active' || suite.head_sha !== headSha || suite.app?.id !== LEGACY_WORKFLOW.actionsAppId ) { throw new ObservationError('invalid_binding', 'workflow or check-suite identity did not bind', { publish: true, targetSha: headSha, });
-  }
-  return headSha;
+  const workflow = workflowResponse.data; const suite = suiteResponse.data;
+  if ( workflow.id !== LEGACY_WORKFLOW.id || workflow.path !== LEGACY_WORKFLOW.path || workflow.name !== LEGACY_WORKFLOW.name || workflow.state !== 'active' || suite.head_sha !== headSha || suite.app?.id !== LEGACY_WORKFLOW.actionsAppId ) { throw new ObservationError('invalid_binding', 'workflow or check-suite identity did not bind', { publish: true, targetSha: headSha, }); }
+  return runBinding;
 }
 async function assertLatestRun(github, owner, repo, run) { const runs = await github.paginate( 'GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs', { owner, repo, workflow_id: LEGACY_WORKFLOW.id, event: 'pull_request', head_sha: run.head_sha, per_page: 100, }, );
   const canonical = runs.filter((candidate) => candidate.workflow_id === LEGACY_WORKFLOW.id && candidate.path === LEGACY_WORKFLOW.path && candidate.event === 'pull_request' && candidate.head_sha === run.head_sha, );
   canonical.sort((left, right) => (right.run_number - left.run_number) || (right.id - left.id), );
-  if (canonical.length === 0 || canonical[0].id !== run.id || canonical[0].run_attempt !== run.run_attempt) { throw new ObservationError('stale_run', 'workflow run is not the latest for this head', { publish: true, targetSha: run.head_sha, });
-  }
+  if (canonical.length === 0 || canonical[0].id !== run.id || canonical[0].run_attempt !== run.run_attempt) { throw new ObservationError('stale_run', 'workflow run is not the latest for this head', { publish: true, targetSha: run.head_sha, }); }
 }
+function jobTopologySnapshot(jobs) { return stableAssessment(jobs.map((job) => ({ id: job.id ?? null, name: job.name, status: job.status, conclusion: job.conclusion, run_attempt: job.run_attempt, runner_id: job.runner_id ?? null, runner_name: job.runner_name ?? null, labels: Array.isArray(job.labels) ? [...job.labels].sort() : null, })).sort((left, right) => (left.id ?? 0) - (right.id ?? 0))); }
+function assertRunPublicationSnapshot(run, result, expectedBinding) { const reboundRun = bindRunPullRequest(run, result.baseSha);
+  if ( run.id !== result.runId || run.run_attempt !== result.runAttempt || run.status !== 'completed' || run.conclusion !== result.runConclusion || stableAssessment(reboundRun) !== stableAssessment(expectedBinding) ) { throw new ObservationError('stale_run', 'workflow run attempt or association changed', {publish: true, targetSha: result.headSha}); }
+  return reboundRun;
+}
+function assertJobTopologyUnchanged(jobs, expectedTopology, headSha) { if (jobTopologySnapshot(jobs) !== expectedTopology) { throw new ObservationError('stale_run', 'workflow run job topology changed', {publish: true, targetSha: headSha}); } }
 async function assessWorkflowRun({github, context, liveBaseSha}) { const payloadRun = context.payload.workflow_run;
-  if (payloadRun?.event !== 'pull_request') { return assessment({kind: 'workflow_run', code: 'ignored_non_pr'});
-  }
-  const response = await github.request( 'GET /repos/{owner}/{repo}/actions/runs/{run_id}', {owner: REPOSITORY.owner, repo: REPOSITORY.repo, run_id: payloadRun.id}, );
-  const run = response.data;
-  let headSha = assertSha(run.head_sha, 'workflow run head');
-  try { headSha = await assertCanonicalRun(github, context, run, payloadRun);
-    const pullNumber = await uniqueCurrentPullForHead( github, REPOSITORY.owner, REPOSITORY.repo, headSha, );
-    const pull = await getPull(github, REPOSITORY.owner, REPOSITORY.repo, pullNumber);
-    const binding = bindPull(pull, liveBaseSha, headSha);
-    if (!binding.sameRepository || run.head_repository?.id !== REPOSITORY.id || run.head_repository?.full_name !== REPOSITORY.fullName) { return assessment({ kind: 'workflow_run', code: 'fork', state: 'failure', publish: true, targetSha: headSha, pullNumber, baseSha: binding.baseSha, headSha, runId: run.id, runAttempt: run.run_attempt, });
-    }
+  if (payloadRun?.event !== 'pull_request') { return assessment({kind: 'workflow_run', code: 'ignored_non_pr'}); }
+  const response = await github.request( 'GET /repos/{owner}/{repo}/actions/runs/{run_id}', {owner: REPOSITORY.owner, repo: REPOSITORY.repo, run_id: payloadRun.id}, ); const run = response.data;
+  let headSha = assertSha(run.head_sha, 'workflow run head'); let runBinding = null;
+  try { runBinding = await assertCanonicalRun(github, context, run, payloadRun, liveBaseSha);
+    headSha = runBinding.headSha;
+    await assertUniqueCurrentPullMatchesRun( github, REPOSITORY.owner, REPOSITORY.repo, runBinding, );
+    const pull = await getPull(github, REPOSITORY.owner, REPOSITORY.repo, runBinding.pullNumber);
+    const binding = bindPullToRun(pull, liveBaseSha, runBinding);
+    if (!binding.sameRepository || run.head_repository?.id !== REPOSITORY.id || run.head_repository?.full_name !== REPOSITORY.fullName) { return assessment({ kind: 'workflow_run', code: 'fork', state: 'failure', publish: true, targetSha: headSha, pullNumber: runBinding.pullNumber, baseSha: binding.baseSha, headSha, runId: run.id, runAttempt: run.run_attempt, }); }
     await assertLatestRun(github, REPOSITORY.owner, REPOSITORY.repo, run);
     await assertControlsUnchanged( github, REPOSITORY.owner, REPOSITORY.repo, binding.baseSha, headSha, );
     const routes = await classifyPull( github, REPOSITORY.owner, REPOSITORY.repo, binding.baseSha, pull, );
     await assertMergeParents( github, REPOSITORY.owner, REPOSITORY.repo, pull, binding.baseSha, headSha, );
     const jobs = await listAttemptJobs( github, REPOSITORY.owner, REPOSITORY.repo, run.id, run.run_attempt, );
     const result = evaluateJobTopology(run, jobs, routes, pull.draft);
-    return assessment({ kind: 'workflow_run', code: result.code, state: result.ok ? 'success' : 'failure', publish: true, targetSha: headSha, pullNumber, baseSha: binding.baseSha, headSha, runId: run.id, runAttempt: run.run_attempt, routes, metrics: { route_job_concordance: result.routeConcordance, terminal_binding_coverage: true, v2_self_hosted_minutes: 0, false_success_publications: result.ok ? 0 : 0, stale_head_publications: 0, }, });
-  } catch (error) { if (error instanceof ObservationError) { return assessment({ kind: 'workflow_run', code: error.code, state: 'failure', publish: error.publish, targetSha: error.targetSha, headSha, runId: run.id, runAttempt: run.run_attempt, });
-    }
+    return assessment({ kind: 'workflow_run', code: result.code, state: result.ok ? 'success' : 'failure', publish: true, targetSha: headSha, pullNumber: runBinding.pullNumber, baseSha: binding.baseSha, headSha, runId: run.id, runAttempt: run.run_attempt, runConclusion: run.conclusion, routes, jobTopology: jobTopologySnapshot(jobs), metrics: { route_job_concordance: result.routeConcordance, terminal_binding_coverage: true, v2_self_hosted_minutes: 0, false_success_publications: result.ok ? 0 : 0, stale_head_publications: 0, }, });
+  } catch (error) { if (error instanceof ObservationError) { return assessment({ kind: 'workflow_run', code: error.code, state: 'failure', publish: error.publish, targetSha: error.targetSha, pullNumber: runBinding?.pullNumber ?? null, baseSha: runBinding?.baseSha ?? null, headSha, runId: run.id, runAttempt: run.run_attempt, runConclusion: run.conclusion, }); }
     throw error;
   }
 }
+function publicationFailure(result, code, publish = true) { return { ...result, code, state: 'failure', publish, description: statusDescription(code), metrics: {...result.metrics, false_success_publications: 0}, }; }
+async function rebindForPublication({github, result}) { if (!result.publish) { return result; }
+  try { if ( typeof result.headSha !== 'string' || !SHA_PATTERN.test(result.headSha) || typeof result.baseSha !== 'string' || !SHA_PATTERN.test(result.baseSha) || result.targetSha !== result.headSha || !Number.isSafeInteger(result.pullNumber) || result.pullNumber <= 0 ) { return publicationFailure(result, 'invalid_binding', false); }
+    const headSha = result.headSha; const runBinding = {pullNumber: result.pullNumber, headSha, baseSha: result.baseSha};
+    if (result.kind === 'workflow_run') { if (!Number.isSafeInteger(result.runId) || result.runId <= 0 || !Number.isSafeInteger(result.runAttempt) || result.runAttempt <= 0 || typeof result.jobTopology !== 'string') { return publicationFailure(result, 'invalid_binding', false); }
+      const {data: run} = await github.request( 'GET /repos/{owner}/{repo}/actions/runs/{run_id}', {owner: REPOSITORY.owner, repo: REPOSITORY.repo, run_id: result.runId}, ); assertRunPublicationSnapshot(run, result, runBinding);
+      await assertLatestRun(github, REPOSITORY.owner, REPOSITORY.repo, run); await assertUniqueCurrentPullMatchesRun(github, REPOSITORY.owner, REPOSITORY.repo, runBinding);
+      const jobs = await listAttemptJobs(github, REPOSITORY.owner, REPOSITORY.repo, result.runId, result.runAttempt); assertJobTopologyUnchanged(jobs, result.jobTopology, headSha);
+    }
+    const [branchResponse, pullResponse] = await Promise.all([ github.request('GET /repos/{owner}/{repo}/branches/{branch}', {owner: REPOSITORY.owner, repo: REPOSITORY.repo, branch: 'main'}), github.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {owner: REPOSITORY.owner, repo: REPOSITORY.repo, pull_number: result.pullNumber}), ]);
+    const liveBaseSha = assertSha(branchResponse.data.commit?.sha, 'final live main'); if (liveBaseSha !== result.baseSha) { throw new ObservationError('stale_base', 'live main moved before publication', {publish: true, targetSha: headSha}); } bindPullToRun(pullResponse.data, liveBaseSha, runBinding);
+    return result;
+  } catch (error) { if (error instanceof ObservationError) { return publicationFailure(result, error.code, true); }
+    return publicationFailure(result, 'invalid_binding', true);
+  }
+}
 async function assess({github, context, liveBaseSha}) { assertSha(liveBaseSha, 'live main');
-  if (context.eventName === 'pull_request_target') { return assessLifecycle({github, context, liveBaseSha});
-  }
-  if (context.eventName === 'workflow_run') { return assessWorkflowRun({github, context, liveBaseSha});
-  }
+  if (context.eventName === 'pull_request_target') { return assessLifecycle({github, context, liveBaseSha}); }
+  if (context.eventName === 'workflow_run') { return assessWorkflowRun({github, context, liveBaseSha}); }
   return assessment({kind: 'unknown', code: 'ignored_event'});
 }
-module.exports = { CONTROL_PATHS, LEGACY_WORKFLOW, OBSERVATION_CONTEXT, OBSERVER_PATH, REPOSITORY, assess, assertControlsUnchanged, bindPull, evaluateJobTopology, getTreeEntry, relevantLifecycle, stableAssessment, };
+module.exports = { CONTROL_PATHS, LEGACY_WORKFLOW, OBSERVATION_CONTEXT, OBSERVER_PATH, REPOSITORY, assess, assertControlsUnchanged, assertJobTopologyUnchanged, assertRunPublicationSnapshot, assertUniqueCurrentPullMatchesRun, bindPull, bindRunPullRequest, evaluateJobTopology, getTreeEntry, jobTopologySnapshot, rebindForPublication, relevantLifecycle, stableAssessment, };

--- a/.github/workflows/quick-v2.yml
+++ b/.github/workflows/quick-v2.yml
@@ -76,7 +76,7 @@ jobs:
               throw new Error('observer path did not resolve');
             };
             const {observer, liveBaseSha} = await loadObserver();
-            if (typeof observer.assess !== 'function' || typeof observer.stableAssessment !== 'function') { throw new Error('observer exports are invalid');
+            if (typeof observer.assess !== 'function' || typeof observer.rebindForPublication !== 'function' || typeof observer.stableAssessment !== 'function') { throw new Error('observer exports are invalid');
             }
             const result = await observer.assess({github, context, liveBaseSha});
             core.setOutput('assessment', observer.stableAssessment(result));
@@ -149,6 +149,7 @@ jobs:
             const encoded = observer.stableAssessment(result);
             if (process.env.PRODUCER_ASSESSMENT !== encoded && result.publish) { result = { ...result, code: 'invalid_binding', state: 'failure', description: 'Unknown: producer and publisher metadata bindings disagree.', metrics: {...result.metrics, false_success_publications: 0}, };
             }
+            result = await observer.rebindForPublication({github, result});
             core.info(`observation_metrics=${JSON.stringify(result.metrics)}`);
             if (result.publish) { if (result.targetSha !== result.headSha || !/^[0-9a-f]{40}$/u.test(result.targetSha)) { throw new Error('publisher refused a non-exact observation target');
               }

--- a/.github/workflows/quick-v2.yml
+++ b/.github/workflows/quick-v2.yml
@@ -7,7 +7,6 @@ on:
   workflow_run:
     workflows: ["Tests (quick)"]
     types: [completed]
-    branches: [main]
 
 permissions: {}
 

--- a/.github/workflows/quick-v2.yml
+++ b/.github/workflows/quick-v2.yml
@@ -1,251 +1,158 @@
-name: Tests (quick v2 observation)
+name: Tests (quick v2 metadata observation)
 
 on:
   pull_request_target:
     branches: [main]
     types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, edited]
+  workflow_run:
+    workflows: ["Tests (quick)"]
+    types: [completed]
+    branches: [main]
+
+permissions: {}
 
 concurrency:
-  group: quick-v2-${{ github.event.pull_request.number }}
+  group: >-
+    quick-v2-observe-${{ github.event.pull_request.number ||
+    github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt || 'lifecycle' }}
   cancel-in-progress: true
 
 jobs:
-  admit:
-    name: Trusted quick observation admission
+  observe:
+    name: Read-only legacy quick metadata observer
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 5
     permissions:
+      actions: read
+      checks: read
       contents: read
       pull-requests: read
-      statuses: write
     outputs:
-      pull_number: ${{ steps.admit.outputs.pull_number }}
-      head_sha: ${{ steps.admit.outputs.head_sha }}
-      base_sha: ${{ steps.admit.outputs.base_sha }}
-      core: ${{ steps.admit.outputs.core }}
-      frontend: ${{ steps.admit.outputs.frontend }}
-      ci: ${{ steps.admit.outputs.ci }}
-      docs: ${{ steps.admit.outputs.docs }}
-      ready: ${{ steps.admit.outputs.ready }}
-      same_repo: ${{ steps.admit.outputs.same_repo }}
+      assessment: ${{ steps.observe.outputs.assessment }}
     steps:
-      - name: Capture exact PR state with trusted base policy
-        id: admit
-        uses: actions/github-script@v7
+      - name: Bind trusted policy and observe API metadata
+        id: observe
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
-            const {owner, repo} = context.repo;
-            const pullNumber = context.payload.pull_request.number;
-            let headSha = context.payload.pull_request.head.sha;
-            const targetUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-            const publish = async (state, description) => {
-              if (/^[0-9a-f]{40}$/u.test(headSha)) {
-                await github.rest.repos.createCommitStatus({
-                  owner, repo, sha: headSha, state, context: 'quick-v2-observe',
-                  description, target_url: targetUrl,
-                });
+            const owner = 'rigplane';
+            const repo = 'rigplane-core';
+            const repositoryId = 1166377435;
+            const observerPath = '.github/scripts/quick-v2-metadata-policy-v1.js';
+            const exactSha = (value, label) => { if (typeof value !== 'string' || !/^[0-9a-f]{40}$/u.test(value)) { throw new Error(`${label} is not an exact commit SHA`);
               }
+              return value;
             };
-            try {
-              const {data: initialPull} = await github.rest.pulls.get({
-                owner, repo, pull_number: pullNumber,
-              });
-              headSha = initialPull.head.sha;
-              const baseSha = initialPull.base.sha;
-              if (initialPull.base.ref !== 'main') {
-                throw new Error('observation controller only accepts the main base branch');
+            const loadObserver = async () => { const {data: repository} = await github.request( 'GET /repos/{owner}/{repo}', {owner, repo}, );
+              if (repository.id !== repositoryId || repository.full_name !== `${owner}/${repo}`) { throw new Error('repository identity is not canonical');
               }
-              const {data: baseBranch} = await github.rest.repos.getBranch({
-                owner, repo, branch: initialPull.base.ref,
-              });
-              if (baseBranch.commit.sha !== baseSha) {
-                throw new Error('pull request base is not the current main head');
+              const {data: branch} = await github.request( 'GET /repos/{owner}/{repo}/branches/{branch}', {owner, repo, branch: 'main'}, );
+              const liveBaseSha = exactSha(branch.commit.sha, 'live main');
+              const {data: commit} = await github.request( 'GET /repos/{owner}/{repo}/git/commits/{commit_sha}', {owner, repo, commit_sha: liveBaseSha}, );
+              let treeSha = exactSha(commit.tree?.sha, 'root tree');
+              const parts = observerPath.split('/');
+              for (const [index, part] of parts.entries()) { const {data: tree} = await github.request( 'GET /repos/{owner}/{repo}/git/trees/{tree_sha}', {owner, repo, tree_sha: treeSha}, );
+                if (tree.truncated === true || !Array.isArray(tree.tree)) { throw new Error('observer tree metadata is incomplete');
+                }
+                const matches = tree.tree.filter((entry) => entry.path === part);
+                if (matches.length !== 1) { throw new Error('observer path is ambiguous');
+                }
+                const entry = matches[0];
+                const final = index === parts.length - 1;
+                if (!final) { if (entry.mode !== '040000' || entry.type !== 'tree') { throw new Error('observer parent is not a tree');
+                  }
+                  treeSha = exactSha(entry.sha, 'observer tree');
+                  continue;
+                }
+                if (entry.mode !== '100644' || entry.type !== 'blob') { throw new Error('observer is not a regular non-executable file');
+                }
+                const {data: blob} = await github.request( 'GET /repos/{owner}/{repo}/git/blobs/{file_sha}', {owner, repo, file_sha: exactSha(entry.sha, 'observer blob')}, );
+                if ( blob.encoding !== 'base64' || typeof blob.content !== 'string' || !Number.isSafeInteger(blob.size) || blob.size <= 0 || blob.size > 250000 ) { throw new Error('observer blob is invalid');
+                }
+                const loaded = {exports: {}};
+                new Function( 'module', 'exports', Buffer.from(blob.content, 'base64').toString('utf8'), )(loaded, loaded.exports);
+                return {observer: loaded.exports, liveBaseSha};
               }
-              const sameRepo = initialPull.head.repo?.full_name === `${owner}/${repo}`;
-              await publish('pending', initialPull.draft
-                ? 'Waiting for the pull request to become ready.'
-                : sameRepo
-                  ? 'Trusted base observation admitted this exact PR state.'
-                  : 'Fork observation is metadata-only; worker execution is withheld.');
-
-              const files = await github.paginate(github.rest.pulls.listFiles, {
-                owner, repo, pull_number: pullNumber, per_page: 100,
-              });
-              const {data: policyFile} = await github.rest.repos.getContent({
-                owner, repo,
-                path: '.github/scripts/base-gate-policy-v1.js',
-                ref: baseSha,
-              });
-              if (
-                Array.isArray(policyFile) ||
-                policyFile.type !== 'file' ||
-                policyFile.encoding !== 'base64' ||
-                typeof policyFile.content !== 'string'
-              ) {
-                throw new Error('trusted base gate policy content is invalid');
-              }
-              const policyModule = {exports: {}};
-              new Function(
-                'module', 'exports',
-                Buffer.from(policyFile.content, 'base64').toString('utf8'),
-              )(policyModule, policyModule.exports);
-              const {assertSha, classifyPullFiles} = policyModule.exports;
-              if (typeof assertSha !== 'function' || typeof classifyPullFiles !== 'function') {
-                throw new Error('trusted base gate policy exports are invalid');
-              }
-              assertSha(headSha, 'head');
-              assertSha(baseSha, 'base');
-              const routes = classifyPullFiles(files, initialPull.changed_files);
-
-              const [{data: currentPull}, {data: currentBase}] = await Promise.all([
-                github.rest.pulls.get({owner, repo, pull_number: pullNumber}),
-                github.rest.repos.getBranch({owner, repo, branch: 'main'}),
-              ]);
-              if (
-                currentPull.head.sha !== headSha ||
-                currentPull.base.sha !== baseSha ||
-                currentBase.commit.sha !== baseSha
-              ) {
-                throw new Error('pull request head or base changed during admission');
-              }
-              const outputs = {
-                pull_number: String(pullNumber),
-                head_sha: headSha,
-                base_sha: baseSha,
-                core: String(routes.core),
-                frontend: String(routes.frontend),
-                ci: String(routes.ci),
-                docs: String(routes.docs),
-                ready: String(!initialPull.draft),
-                same_repo: String(sameRepo),
-              };
-              for (const [name, value] of Object.entries(outputs)) {
-                core.setOutput(name, value);
-              }
-            } catch (error) {
-              const message = error instanceof Error ? error.message : String(error);
-              await publish('failure', 'Trusted quick admission failed closed.');
-              core.setFailed(`Trusted quick admission failed closed: ${message}`);
+              throw new Error('observer path did not resolve');
+            };
+            const {observer, liveBaseSha} = await loadObserver();
+            if (typeof observer.assess !== 'function' || typeof observer.stableAssessment !== 'function') { throw new Error('observer exports are invalid');
             }
-
-  worker:
-    name: Read-only quick v2 worker
-    needs: admit
-    if: >-
-      needs.admit.result == 'success' &&
-      needs.admit.outputs.ready == 'true' &&
-      needs.admit.outputs.docs != 'true' &&
-      needs.admit.outputs.same_repo == 'true'
-    runs-on: [self-hosted, linux, build]
-    timeout-minutes: 15
-    permissions:
-      contents: read
-    steps:
-      - name: Check out exact trusted base controls
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.admit.outputs.base_sha }}
-          path: control
-          persist-credentials: false
-          fetch-depth: 1
-
-      - name: Check out candidate merge without credentials
-        uses: actions/checkout@v6
-        with:
-          ref: refs/pull/${{ needs.admit.outputs.pull_number }}/merge
-          path: target
-          persist-credentials: false
-          fetch-depth: 2
-
-      - name: Bind candidate merge to exact admitted head and base
-        env:
-          EXPECTED_HEAD: ${{ needs.admit.outputs.head_sha }}
-          EXPECTED_BASE: ${{ needs.admit.outputs.base_sha }}
-        run: |
-          read -r merge_sha first_parent second_parent extra < <(git -C target rev-list --parents -n 1 HEAD)
-          test -n "$merge_sha"
-          test "$first_parent" = "$EXPECTED_BASE"
-          test "$second_parent" = "$EXPECTED_HEAD"
-          test -z "${extra:-}"
-
-      - name: Run immutable base-controlled quick carrier
-        run: >-
-          control/.github/scripts/quick-v2-worker-v1.sh
-          control target
-          ${{ needs.admit.outputs.core }}
-          ${{ needs.admit.outputs.frontend }}
-          ${{ needs.admit.outputs.ci }}
-
-      - name: Upload frontend failure diagnostics
-        if: always() && needs.admit.outputs.frontend == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: quick-v2-observe-frontend-${{ needs.admit.outputs.head_sha }}
-          path: |
-            target/frontend/tests/e2e/i18n/.output/
-            target/frontend/playwright-report/
-            target/frontend/fixtures-baselines/
-          if-no-files-found: ignore
-          retention-days: 14
-
+            const result = await observer.assess({github, context, liveBaseSha});
+            core.setOutput('assessment', observer.stableAssessment(result));
+            core.info(`observation_metrics=${JSON.stringify(result.metrics)}`);
+            if (result.state === 'failure') { core.setFailed(result.description);
+            }
   publish:
-    name: Trusted quick observation publisher
-    needs: [admit, worker]
-    if: always() && needs.admit.result == 'success'
+    name: Exact-head metadata observation publisher
+    needs: observe
+    if: always()
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     permissions:
+      actions: read
+      checks: read
       contents: read
       pull-requests: read
       statuses: write
     steps:
-      - name: Publish exact-head quick-v2-observe status
-        uses: actions/github-script@v7
+      - name: Rebind independently and publish observation
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          PULL_NUMBER: ${{ needs.admit.outputs.pull_number }}
-          ADMITTED_HEAD: ${{ needs.admit.outputs.head_sha }}
-          ADMITTED_BASE: ${{ needs.admit.outputs.base_sha }}
-          READY: ${{ needs.admit.outputs.ready }}
-          DOCS: ${{ needs.admit.outputs.docs }}
-          SAME_REPO: ${{ needs.admit.outputs.same_repo }}
-          WORKER_RESULT: ${{ needs.worker.result }}
+          PRODUCER_ASSESSMENT: ${{ needs.observe.outputs.assessment }}
         with:
           script: |
-            const {owner, repo} = context.repo;
-            const pullNumber = Number(process.env.PULL_NUMBER);
-            const headSha = process.env.ADMITTED_HEAD;
-            const baseSha = process.env.ADMITTED_BASE;
-            const targetUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-            const [{data: currentPull}, {data: currentBase}] = await Promise.all([
-              github.rest.pulls.get({owner, repo, pull_number: pullNumber}),
-              github.rest.repos.getBranch({owner, repo, branch: 'main'}),
-            ]);
-            let state = 'failure';
-            let description = 'Quick v2 observation failed closed.';
-            if (
-              currentPull.head.sha !== headSha ||
-              currentPull.base.sha !== baseSha ||
-              currentBase.commit.sha !== baseSha
-            ) {
-              description = 'PR head or current main changed after quick-v2 observation admission.';
-            } else if (process.env.READY !== 'true') {
-              state = 'pending';
-              description = 'Waiting for the pull request to become ready.';
-            } else if (process.env.SAME_REPO !== 'true') {
-              description = 'Fork code was not executed on the shared self-hosted worker.';
-            } else if (process.env.DOCS === 'true') {
-              state = 'success';
-              description = 'Trusted base policy selected documentation-only review.';
-            } else if (process.env.WORKER_RESULT === 'success') {
-              state = 'success';
-              description = 'Base-controlled quick carrier passed for exact head and base.';
-            } else {
-              description = `Base-controlled quick carrier ended ${process.env.WORKER_RESULT}.`;
+            const owner = 'rigplane';
+            const repo = 'rigplane-core';
+            const repositoryId = 1166377435;
+            const observerPath = '.github/scripts/quick-v2-metadata-policy-v1.js';
+            const exactSha = (value, label) => { if (typeof value !== 'string' || !/^[0-9a-f]{40}$/u.test(value)) { throw new Error(`${label} is not an exact commit SHA`);
+              }
+              return value;
+            };
+            const loadObserver = async () => { const {data: repository} = await github.request( 'GET /repos/{owner}/{repo}', {owner, repo}, );
+              if (repository.id !== repositoryId || repository.full_name !== `${owner}/${repo}`) { throw new Error('repository identity is not canonical');
+              }
+              const {data: branch} = await github.request( 'GET /repos/{owner}/{repo}/branches/{branch}', {owner, repo, branch: 'main'}, );
+              const liveBaseSha = exactSha(branch.commit.sha, 'live main');
+              const {data: commit} = await github.request( 'GET /repos/{owner}/{repo}/git/commits/{commit_sha}', {owner, repo, commit_sha: liveBaseSha}, );
+              let treeSha = exactSha(commit.tree?.sha, 'root tree');
+              const parts = observerPath.split('/');
+              for (const [index, part] of parts.entries()) { const {data: tree} = await github.request( 'GET /repos/{owner}/{repo}/git/trees/{tree_sha}', {owner, repo, tree_sha: treeSha}, );
+                if (tree.truncated === true || !Array.isArray(tree.tree)) { throw new Error('observer tree metadata is incomplete');
+                }
+                const matches = tree.tree.filter((entry) => entry.path === part);
+                if (matches.length !== 1) { throw new Error('observer path is ambiguous');
+                }
+                const entry = matches[0];
+                const final = index === parts.length - 1;
+                if (!final) { if (entry.mode !== '040000' || entry.type !== 'tree') { throw new Error('observer parent is not a tree');
+                  }
+                  treeSha = exactSha(entry.sha, 'observer tree');
+                  continue;
+                }
+                if (entry.mode !== '100644' || entry.type !== 'blob') { throw new Error('observer is not a regular non-executable file');
+                }
+                const {data: blob} = await github.request( 'GET /repos/{owner}/{repo}/git/blobs/{file_sha}', {owner, repo, file_sha: exactSha(entry.sha, 'observer blob')}, );
+                if ( blob.encoding !== 'base64' || typeof blob.content !== 'string' || !Number.isSafeInteger(blob.size) || blob.size <= 0 || blob.size > 250000 ) { throw new Error('observer blob is invalid');
+                }
+                const loaded = {exports: {}};
+                new Function( 'module', 'exports', Buffer.from(blob.content, 'base64').toString('utf8'), )(loaded, loaded.exports);
+                return {observer: loaded.exports, liveBaseSha};
+              }
+              throw new Error('observer path did not resolve');
+            };
+            const {observer, liveBaseSha} = await loadObserver();
+            if (typeof observer.assess !== 'function' || typeof observer.stableAssessment !== 'function') { throw new Error('observer exports are invalid');
             }
-            await github.rest.repos.createCommitStatus({
-              owner, repo, sha: headSha, state, context: 'quick-v2-observe',
-              description, target_url: targetUrl,
-            });
-            if (state === 'failure') {
-              core.setFailed(description);
+            let result = await observer.assess({github, context, liveBaseSha});
+            const encoded = observer.stableAssessment(result);
+            if (process.env.PRODUCER_ASSESSMENT !== encoded && result.publish) { result = { ...result, code: 'invalid_binding', state: 'failure', description: 'Unknown: producer and publisher metadata bindings disagree.', metrics: {...result.metrics, false_success_publications: 0}, };
+            }
+            core.info(`observation_metrics=${JSON.stringify(result.metrics)}`);
+            if (result.publish) { if (result.targetSha !== result.headSha || !/^[0-9a-f]{40}$/u.test(result.targetSha)) { throw new Error('publisher refused a non-exact observation target');
+              }
+              await github.request( 'POST /repos/{owner}/{repo}/statuses/{sha}', { owner, repo, sha: result.targetSha, state: result.state, context: observer.OBSERVATION_CONTEXT, description: result.description, target_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`, }, );
+            }
+            if (result.state === 'failure') { core.setFailed(result.description);
             }

--- a/docs/internals/base-controlled-required-gates.md
+++ b/docs/internals/base-controlled-required-gates.md
@@ -27,9 +27,18 @@ or fork code and never reads a candidate artifact, log, or cache. Its `pull_requ
 reopened, synchronized, ready, draft, and base-edited pull requests; title- and body-only edits are no-ops. Its
 `workflow_run` path consumes completed runs from the canonical legacy `Tests (quick)` workflow and ignores main pushes.
 
-The read-only producer and status publisher independently run `quick-v2-metadata-policy-v1.js: assess`. Each rereads
-live `main`, the pull request, canonical workflow and check-suite identity, latest run/attempt, and complete paginated
-job topology. Publication requires identical assessments and the still-current exact head.
+The read-only producer and status publisher independently run `.github/scripts/quick-v2-metadata-policy-v1.js: assess`.
+For a completed legacy run, `.github/scripts/quick-v2-metadata-policy-v1.js: bindRunPullRequest` requires exactly one
+recorded `run.pull_requests` entry and binds its PR number, head, base, and repository identity. The current open PR
+association must be unique and match that tuple; a shared head cannot remap an old run to another PR, and the recorded
+base must equal live `main`.
+
+After the assessments match, `.github/scripts/quick-v2-metadata-policy-v1.js: rebindForPublication` rereads the run
+attempt and job topology, verifies the recorded PR association again, and makes the PR plus live `main` its final API
+reads immediately before the status POST. A changed attempt, topology, head, base, or `main` becomes unknown/failure,
+or an incompletely bound result is withheld. The final API reads and the status POST are not atomic because GitHub has
+no transaction spanning them; keeping those reads last reduces the remaining observation-only race but cannot make
+this context safe for promotion.
 
 `quick-v2-metadata-policy-v1.js: getTreeEntry` walks trusted base controls: parents must be `040000` trees and files
 must be `100644` blobs. Missing, duplicate, truncated, executable, symlink, and gitlink entries fail closed. Candidate

--- a/docs/internals/base-controlled-required-gates.md
+++ b/docs/internals/base-controlled-required-gates.md
@@ -2,7 +2,6 @@
 
 Issue [#3136](https://github.com/rigplane/rigplane-core/issues/3136) records a circular trust boundary: a pull request can
 modify the same `pull_request` workflow or helper that publishes its required `quick` or `Agent Review Gate` success.
-
 ## Stage 1 is observation-only
 
 Stage 1 leaves branch protection and the legacy publishers unchanged. The two
@@ -15,7 +14,7 @@ required checks**:
 | --- | --- | --- | --- |
 | `quick` | legacy workflow or docs-only publisher | legacy PR workflow | yes, app 15368 |
 | `Agent Review Gate` | legacy PR/comment workflow | API-only, with candidate-controlled PR source | yes, app 15368 |
-| `quick-v2-observe` | base-owned observation workflow | same-repository PRs only, read-only self-hosted job | no |
+| `quick-v2-observe` | base-owned API metadata observer | none | no |
 | `Agent Review Gate v2 observe` | base-owned API-only observation workflow | none | no |
 
 GitHub branch protection can bind a status/check to a context and app ID, but every repository workflow publishes as
@@ -23,25 +22,35 @@ GitHub Actions app ID `15368`. A candidate-controlled workflow can publish eithe
 identity. Context plus app ID does not prove which workflow made the decision. The `*-observe` names make their
 non-authoritative role explicit; no protection-switch command targets them.
 
-The quick observation controller reads complete PR file metadata, loads policy from the exact PR base SHA, and requires
-that SHA to equal live `main`. Documentation-only changes remain API-only. Same-repository code/CI uses a separate job
-with `contents: read`, no persisted credential, referenced secrets, or privileged candidate command. Before candidate
-execution, it proves the merge parents equal the admitted base and head. The hosted publisher rereads PR and `main`.
+The quick v2 workflow is metadata-only and schedules zero self-hosted jobs. It never checks out or executes pull-request
+or fork code and never reads a candidate artifact, log, or cache. Its `pull_request_target` path initializes opened,
+reopened, synchronized, ready, draft, and base-edited pull requests; title- and body-only edits are no-ops. Its
+`workflow_run` path consumes completed runs from the canonical legacy `Tests (quick)` workflow and ignores main pushes.
 
-Fork PRs never execute on the shared self-hosted runner. Hosted infrastructure classifies their metadata, skips the
-worker, and fails observation explicitly. Promotion requires an isolated fork path or a policy keeping forks unmergeable.
+The read-only producer and status publisher independently run `quick-v2-metadata-policy-v1.js: assess`. Each rereads
+live `main`, the pull request, canonical workflow and check-suite identity, latest run/attempt, and complete paginated
+job topology. Publication requires identical assessments and the still-current exact head.
 
-The worker uses `git ls-tree` to compare object ID, object type, and file mode
-for every immutable control. This rejects content edits, deletion, regular-file
-to symlink changes, and executable-bit changes:
+`quick-v2-metadata-policy-v1.js: getTreeEntry` walks trusted base controls: parents must be `040000` trees and files
+must be `100644` blobs. Missing, duplicate, truncated, executable, symlink, and gitlink entries fail closed. Candidate
+trees are metadata-only and these entries must match the base blobs:
 
-- `.github/workflows/quick-v2.yml`
-- `.github/workflows/agent-review-gate-v2.yml`
-- `.github/scripts/base-controlled-gates-v1.test.js`
+- `.github/workflows/quick.yml`
+- `.github/scripts/classify-quick-paths.py`
 - `.github/scripts/base-gate-policy-v1.js`
-- `.github/scripts/quick-v2-worker-v1.sh`
-- `.github/scripts/verify-immutable-controls-v1.sh`
-- `.github/scripts/agent-review-gate.js`
+- `.github/workflows/quick-v2.yml`
+- `.github/scripts/quick-v2-metadata-policy-v1.js`
+
+The trusted base classifier predicts whether substantive `quick` must run. Workflow-level success with that job skipped
+is unknown/failure. Stale head/base, fork, cancellation, changed control, incomplete pagination, ambiguous association,
+non-current attempt, or route/job disagreement cannot publish success.
+
+The observation logs these metrics from the independently bound assessment:
+
+- `route_job_concordance`: trusted route versus the complete observed job topology;
+- `terminal_binding_coverage`: terminal run ID and attempt bound to exact pull/head/base;
+- zero self-hosted v2 minutes (`v2_self_hosted_minutes: 0`);
+- zero false-success and stale-head publication (`false_success_publications: 0`, `stale_head_publications: 0`).
 
 ## Unique authority required before promotion
 


### PR DESCRIPTION
Soft-threshold rationale: the workflow, trusted metadata policy, adversarial contract, and operator note form one indivisible observation boundary; the exact diff is 4 files and 999 changed lines (565 additions, 434 deletions), below the 1000-line hard ceiling.

Linear: https://linear.app/morozsm/issue/MOR-2312/quick-v2-queue-neutral-metadata-observer-for-legacy-quick-runs
Follow-up to observation bootstrap PR #3139.

## Scope

- replace the v2 self-hosted candidate worker with two GitHub-hosted metadata-only jobs
- retain pull-request lifecycle initialization and add a canonical `Tests (quick)` `workflow_run` completion consumer without filtering feature head branches; trusted policy binds target `main`
- bind repository/workflow/check-suite identity and the completed run's single immutable `run.pull_requests` PR/head/base/repository tuple
- require the current open PR association to be unique and match that recorded tuple, live `main`, and merge parents when available
- bind latest run/attempt and complete paginated job topology, then recheck attempt/topology and make live PR plus `main` the final reads before status publication
- classify from trusted base policy and compare trusted control tree entries without reading candidate blobs
- fail or withhold success for stale, fork, cancelled, skipped, control-diff, ambiguous, incomplete, or route/job-discordant evidence
- keep `quick-v2-observe` non-required and explicitly observation-only; legacy `quick` remains the sole quick authority

## Exact paths

- `.github/workflows/quick-v2.yml`
- `.github/scripts/quick-v2-metadata-policy-v1.js`
- `.github/scripts/base-controlled-gates-v1.test.js`
- `docs/internals/base-controlled-required-gates.md`

## Static evidence

- Node syntax: policy, contract test, and both extracted `actions/github-script` programs passed
- focused metadata contracts: 11/11 passed, including feature-head workflow-run admission, stale-base, same-head/different-PR, changed attempt/topology, and final head/base movement
- YAML syntax: passed
- `actionlint .github/workflows/quick-v2.yml`: passed
- `git diff --check`: passed
- hosted-only source proof: exactly two `runs-on: ubuntu-latest`; no `self-hosted`, checkout, artifact/cache/log access, secrets, or candidate execution surface in v2
- the only action is `actions/github-script`, pinned to reviewed v8 tag commit `ed597411d8f924073f98dfc5c65a23a2325f34cd`

No product, frontend, pytest, visual, browser, full, hardware, or self-hosted suite was run locally. No workflow was manually dispatched.

## Promotion boundary

This PR does not change branch protection, required contexts, strict mode, Gatekeeper identity, legacy workflows, or promotion state. The coordinator released the Draft hold after the exact-head independent review passed; merge remains bound to the current required hosted checks and guarded exact-head merge.

