### PR TITLE
fix(MOR-1984): distinguish CI-V response selectors

### DIFF
--- a/src/rigplane/core/civ.py
+++ b/src/rigplane/core/civ.py
@@ -47,6 +47,7 @@ class CivRequestKey:
     command: int
     sub: int | None
     receiver: int | None = None
+    data_prefix: bytes = b""
 
 
 @dataclass(slots=True)
@@ -79,6 +80,7 @@ def request_key_from_frame(frame: CivFrame) -> CivRequestKey:
         command=frame.command,
         sub=frame.sub,
         receiver=frame.receiver,
+        data_prefix=frame.data,
     )
 
 
@@ -422,5 +424,7 @@ class CivRequestTracker:
         if frame.sub != key.sub:
             return False
         if key.receiver is not None and frame.receiver != key.receiver:
+            return False
+        if key.data_prefix and not frame.data.startswith(key.data_prefix):
             return False
         return True

--- a/src/rigplane/core/civ.py
+++ b/src/rigplane/core/civ.py
@@ -11,6 +11,8 @@ from enum import StrEnum
 
 from .types import CivFrame
 
+_REQUEST_DATA_PREFIX_COMMANDS = frozenset({0x07, 0x25, 0x26})
+
 __all__ = [
     "CivEvent",
     "CivEventType",
@@ -80,7 +82,9 @@ def request_key_from_frame(frame: CivFrame) -> CivRequestKey:
         command=frame.command,
         sub=frame.sub,
         receiver=frame.receiver,
-        data_prefix=frame.data,
+        data_prefix=(
+            frame.data if frame.command in _REQUEST_DATA_PREFIX_COMMANDS else b""
+        ),
     )
 
 

--- a/tests/test_civ.py
+++ b/tests/test_civ.py
@@ -10,6 +10,7 @@ from rigplane.civ import (
     CivEventType,
     CivRequestKey,
     CivRequestTracker,
+    request_key_from_frame,
 )
 from rigplane.types import CivFrame
 
@@ -32,6 +33,67 @@ def _ack_frame_from(addr: int) -> CivFrame:
         sub=None,
         data=b"",
     )
+
+
+def _response_frame(command: int, data: bytes) -> CivFrame:
+    return CivFrame(
+        to_addr=0xE0,
+        from_addr=0x98,
+        command=command,
+        sub=None,
+        data=data,
+    )
+
+
+def test_request_key_preserves_outgoing_data_prefix() -> None:
+    frame = _response_frame(0x25, b"\x00")
+
+    assert request_key_from_frame(frame) == CivRequestKey(
+        command=0x25,
+        sub=None,
+        data_prefix=b"\x00",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "expected_prefix", "wrong_prefix"),
+    [
+        (0x25, b"\x00", b"\x01"),
+        (0x26, b"\x00", b"\x01"),
+        (0x07, b"\xc2", b"\xd2"),
+    ],
+)
+async def test_tracker_distinguishes_response_data_prefixes(
+    command: int,
+    expected_prefix: bytes,
+    wrong_prefix: bytes,
+) -> None:
+    tracker = CivRequestTracker()
+    pending = tracker.register_response(
+        CivRequestKey(command=command, sub=None, data_prefix=expected_prefix)
+    )
+
+    wrong = CivEvent(
+        type=CivEventType.RESPONSE,
+        frame=_response_frame(command, wrong_prefix + b"\xaa"),
+    )
+    assert tracker.resolve(wrong) is False
+    assert not pending.done()
+
+    expected = _response_frame(command, expected_prefix + b"\xbb")
+    assert tracker.resolve(CivEvent(type=CivEventType.RESPONSE, frame=expected)) is True
+    assert pending.result() == expected
+
+
+@pytest.mark.asyncio
+async def test_tracker_empty_data_prefix_preserves_legacy_matching() -> None:
+    tracker = CivRequestTracker()
+    pending = tracker.register_response(CivRequestKey(command=0x25, sub=None))
+    response = _response_frame(0x25, b"\x01\xaa")
+
+    assert tracker.resolve(CivEvent(type=CivEventType.RESPONSE, frame=response)) is True
+    assert pending.result() == response
 
 
 @pytest.mark.asyncio

--- a/tests/test_civ.py
+++ b/tests/test_civ.py
@@ -55,6 +55,21 @@ def test_request_key_preserves_outgoing_data_prefix() -> None:
     )
 
 
+def test_request_key_ignores_data_for_non_selector_commands() -> None:
+    frame = CivFrame(
+        to_addr=0xE0,
+        from_addr=0x98,
+        command=0x27,
+        sub=0x1F,
+        data=b"\x00",
+    )
+
+    assert request_key_from_frame(frame) == CivRequestKey(
+        command=0x27,
+        sub=0x1F,
+    )
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("command", "expected_prefix", "wrong_prefix"),

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, call, patch
 
 import pytest
 
-from rigplane.commands._frame import build_civ_frame, decode_wire_tuple
+from rigplane.commands._frame import build_civ_frame, decode_wire_tuple, parse_civ_frame
 from rigplane.commands.bound import BoundCommands
 from rigplane.commands.command_map import CommandMap
 from rigplane.commands.commander import Priority
@@ -20,6 +20,7 @@ from rigplane.commands.scope import (
     SCOPE_SELECTOR_MAIN,
 )
 from rigplane.core.acquisition_scheduler import IcomCivAcquisitionExecutor
+from rigplane.core.civ import request_key_from_frame
 from rigplane.core.state_pipeline_contracts import FieldPath
 from rigplane.exceptions import CommandError
 from rigplane.profiles import resolve_radio_profile
@@ -514,6 +515,27 @@ class TestBuildStateQueries:
         assert len(queries) > 0
         for query in queries:
             civ_frame_parts(query)
+
+    @pytest.mark.parametrize("model", _shipped_civ_models())
+    def test_every_state_query_has_a_unique_response_key(self, model: str) -> None:
+        profile = resolve_radio_profile(model=model)
+        queries = build_state_queries(profile)
+        keys = []
+        for query in queries:
+            command, sub, data = wire_parts_for_query(query, SCOPE_SELECTOR_MAIN)
+            frame = parse_civ_frame(
+                build_civ_frame(
+                    profile.civ_addr,
+                    0xE0,
+                    command,
+                    sub=sub,
+                    data=data,
+                )
+            )
+            keys.append(request_key_from_frame(frame))
+
+        collisions = {key: count for key, count in Counter(keys).items() if count > 1}
+        assert len(set(keys)) == len(queries), f"{model}: {collisions}"
 
     def test_ic7610_includes_dual_receiver_queries(self) -> None:
         """IC-7610 has 2 receivers — freq/mode must appear for rx 0 and rx 1."""


### PR DESCRIPTION
Linear: [MOR-1984](https://linear.app/morozsm/issue/MOR-1984/civrequestkey-cannot-tell-two-reads-apart-65-sweep-queries-produce-63)

## Summary
- retain outgoing discriminator data for the collision-bearing 0x07, 0x25, and 0x26 read families as a default-compatible response-key prefix
- require nonempty prefixes to match the start of response data while leaving non-selector command payloads out of the key
- cover the current 0x25, 0x26, and 0x07 selector collisions and legacy empty-prefix matching
- assert response-key uniqueness across every shipped CI-V profile

## Verification
- `uv run --isolated --no-project ruff format src/rigplane/core/civ.py tests/test_civ.py tests/test_state_queries.py`
- `uv run --isolated --no-project ruff check src/rigplane/core/civ.py tests/test_civ.py tests/test_state_queries.py`
- `uv run --isolated --no-project python -m py_compile src/rigplane/core/civ.py tests/test_civ.py tests/test_state_queries.py`
- `git diff --check`

The first candidate quick-v2 observation (run 33821085112) found three deterministic scope timeouts because scope request payloads are not response prefixes. The corrected head limits prefix discrimination to the three collision-bearing command families and adds an explicit non-selector regression. Per repository cadence, no local pytest/product suite was run; the corrected immutable ready head receives its natural required `quick` run.