### PR TITLE
fix: invalidate managed provider synchronously

### DIFF
--- a/src/rigplane/runtime/managed_tx_authority.py
+++ b/src/rigplane/runtime/managed_tx_authority.py
@@ -154,6 +154,7 @@ class ManagedTxAuthority:
         self._terminated = False
         self._shutdown_termination: asyncio.Event | None = None
         self._shutdown_task: asyncio.Task[ShutdownResult] | None = None
+        self._provider_unavailable_task: asyncio.Task[None] | None = None
         self._closing = False
         self._closed = False
         self._scheduler_task = asyncio.create_task(self._scheduler())
@@ -446,20 +447,34 @@ class ManagedTxAuthority:
                 self._provider_generation,
             )
 
+    def start_provider_unavailable(self) -> asyncio.Task[None]:
+        """Invalidate provider authority before returning and own cleanup."""
+        self._require_open_locked()
+        self._require_provider_change_locked()
+        task = self._provider_unavailable_task
+        if self._provider_generation is None and task is not None:
+            return task
+
+        self._provider_generation = None
+        self._retry_due = None
+        self._pending_abort_cleanup.append(self._abort_fence.force_off())
+        if self._state.release_required:
+            self._reduce_locked(ForceOff(None, self._attempt_id_locked()))
+        self._wakeup.wake()
+        self._start_abort_cleanup()
+
+        task = asyncio.create_task(self._finish_abort_cleanup())
+        self._provider_unavailable_task = task
+
+        def harvest(completion: asyncio.Task[None]) -> None:
+            if not completion.cancelled():
+                completion.exception()
+
+        task.add_done_callback(harvest)
+        return task
+
     async def provider_unavailable(self) -> None:
-        transition = None
-        async with self._lock:
-            self._require_open_locked()
-            self._require_provider_change_locked()
-            if self._provider_generation is None:
-                return
-            self._provider_generation = None
-            self._retry_due = None
-            if self._state.release_required:
-                transition = self._force_off_locked()
-            self._wakeup.wake()
-        if transition is not None:
-            await self._execute(transition.effects, full_force=True)
+        await asyncio.shield(self.start_provider_unavailable())
 
     async def provider_available(self, generation: int) -> None:
         transition = None

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -1,13 +1,7 @@
 import asyncio
-import hashlib
-import os
-import subprocess
-import sys
-import warnings
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
-from pathlib import Path
 
 import pytest
 
@@ -781,135 +775,6 @@ async def test_unavailable_start_after_clean_shutdown_barrier_does_not_mutate() 
     assert fence.calls == fence_calls_before
     allow_retirement.set()
     assert await asyncio.wait_for(shutdown, 0.2) is ShutdownResult.DRAINED
-
-
-def test_provider_unavailable_consolidated_mutation_carrier(tmp_path: Path) -> None:
-    repo = Path(__file__).parents[1]
-    source = repo / "src/rigplane/runtime/managed_tx_authority.py"
-    original = source.read_bytes()
-    original_text = original.decode()
-    test_file = "tests/test_managed_tx_authority.py"
-    sync_test = (
-        f"{test_file}::"
-        "test_unavailable_start_is_synchronous_idempotent_and_generation_is_strict"
-    )
-    active_test = (
-        f"{test_file}::test_unavailable_start_invalidates_active_effect_before_return"
-    )
-    pending_test = (
-        f"{test_file}::"
-        "test_unavailable_start_blocks_pending_and_new_on_while_cleanup_waits"
-    )
-    cancellation_test = (
-        f"{test_file}::test_cancelled_unavailable_waiter_does_not_cancel_owned_cleanup"
-    )
-    force_release = (
-        "        if self._state.release_required:\n"
-        "            self._reduce_locked(ForceOff(None, self._attempt_id_locked()))\n"
-    )
-    mutants = (
-        (
-            "M1-defer-generation-invalidation",
-            sync_test,
-            (
-                (
-                    "        self._provider_generation = None\n",
-                    "        asyncio.get_running_loop().call_soon(\n"
-                    '            setattr, self, "_provider_generation", None\n'
-                    "        )\n",
-                ),
-            ),
-        ),
-        (
-            "M2-fence-only",
-            pending_test,
-            (
-                ("        self._provider_generation = None\n", "        pass\n"),
-                (force_release, "        pass\n"),
-            ),
-        ),
-        (
-            "M3-leave-active-intent",
-            active_test,
-            ((force_release, "        pass\n"),),
-        ),
-        (
-            "M4-omit-fence-advance",
-            pending_test,
-            (
-                (
-                    "        self._pending_abort_cleanup.append("
-                    "self._abort_fence.force_off())\n",
-                    "        pass\n",
-                ),
-            ),
-        ),
-        (
-            "M5-double-fence-advance",
-            active_test,
-            (
-                (
-                    "            self._reduce_locked("
-                    "ForceOff(None, self._attempt_id_locked()))\n",
-                    "            self._force_off_locked()\n",
-                ),
-            ),
-        ),
-        (
-            "M6-clean-rx-debt",
-            sync_test,
-            (("        if self._state.release_required:\n", "        if True:\n"),),
-        ),
-        (
-            "M7-caller-cancels-cleanup",
-            cancellation_test,
-            (
-                (
-                    "        await asyncio.shield(self.start_provider_unavailable())\n",
-                    "        await self.start_provider_unavailable()\n",
-                ),
-            ),
-        ),
-        (
-            "M8-accept-equal-generation",
-            sync_test,
-            (
-                (
-                    "            if generation <= self._generation_high_water:\n",
-                    "            if generation < self._generation_high_water:\n",
-                ),
-            ),
-        ),
-    )
-
-    for name, node, replacements in mutants:
-        mutated = original_text
-        for old, new in replacements:
-            assert old in mutated, f"{name}: mutation anchor missing"
-            mutated = mutated.replace(old, new, 1)
-        source.write_text(mutated)
-        env = os.environ.copy()
-        env["PYTHONPYCACHEPREFIX"] = str(tmp_path / name)
-        try:
-            result = subprocess.run(
-                [sys.executable, "-m", "pytest", "-q", node],
-                cwd=repo,
-                env=env,
-                capture_output=True,
-                encoding="utf-8",
-                timeout=20,
-                check=False,
-            )
-        finally:
-            source.write_bytes(original)
-        output = result.stdout + result.stderr
-        assert source.read_bytes() == original, f"{name}: source restoration failed"
-        assert result.returncode == 1, output
-        assert f"FAILED {node}" in output, output
-        warnings.warn(f"{name} KILLED by {node}", stacklevel=1)
-
-    digest = hashlib.sha256(original).hexdigest()
-    warnings.warn(f"source bytes restored sha256={digest}", stacklevel=1)
 
 
 @pytest.mark.asyncio

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -505,8 +505,9 @@ async def test_unavailable_start_is_synchronous_idempotent_and_generation_is_str
     assert not managed._state.release_required
     assert fence.calls == 1 and lane.effects == []
     await first
-    with pytest.raises(ValueError, match="increase"):
-        await managed.provider_available(6)
+    for stale_generation in (6, 7):
+        with pytest.raises(ValueError, match="increase"):
+            await managed.provider_available(stale_generation)
     await managed.provider_available(8)
     assert (await managed.snapshot()).provider_generation == 8
     with pytest.raises(RuntimeError, match="unavailable first"):
@@ -744,6 +745,36 @@ async def test_unavailable_start_and_shutdown_overlap_drains_new_generation(
     assert await asyncio.wait_for(shutdown, 0.2) is ShutdownResult.DRAINED
     assert retired == [8]
     assert not managed._state.release_required
+
+
+@pytest.mark.asyncio
+async def test_unavailable_start_after_clean_shutdown_barrier_does_not_mutate() -> None:
+    managed, _, _, _, fence, _ = authority(generation=7)
+    retirement_started, allow_retirement = asyncio.Event(), asyncio.Event()
+
+    async def retire_provider(_generation: int) -> None:
+        retirement_started.set()
+        await allow_retirement.wait()
+
+    shutdown = asyncio.create_task(
+        managed.shutdown(
+            retire_provider=retire_provider,
+            termination=asyncio.Event(),
+        )
+    )
+    await asyncio.wait_for(retirement_started.wait(), 0.2)
+    state_before = managed._state
+    generation_before = managed._provider_generation
+    fence_calls_before = fence.calls
+
+    with pytest.raises(RuntimeError, match="shutdown drain is complete"):
+        managed.start_provider_unavailable()
+
+    assert managed._state is state_before
+    assert managed._provider_generation == generation_before
+    assert fence.calls == fence_calls_before
+    allow_retirement.set()
+    assert await asyncio.wait_for(shutdown, 0.2) is ShutdownResult.DRAINED
 
 
 @pytest.mark.asyncio

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -492,17 +492,140 @@ async def test_repeated_force_off_is_accepted_and_advances_epoch() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generation_is_monotonic_and_wakes_debt() -> None:
+async def test_unavailable_start_is_synchronous_idempotent_and_generation_is_strict() -> (
+    None
+):
     managed, _, _, _, fence, lane = authority(generation=7)
-    await managed.provider_unavailable()
-    await managed.provider_unavailable()
-    assert fence.calls == 0 and lane.effects == []
+    first = managed.start_provider_unavailable()
+    second = managed.start_provider_unavailable()
+
+    assert first is second
+    assert managed._provider_generation is None
+    assert managed._state.intent.kind is ManagedTxIntentKind.RX
+    assert not managed._state.release_required
+    assert fence.calls == 1 and lane.effects == []
+    await first
     with pytest.raises(ValueError, match="increase"):
         await managed.provider_available(6)
     await managed.provider_available(8)
     assert (await managed.snapshot()).provider_generation == 8
     with pytest.raises(RuntimeError, match="unavailable first"):
         await managed.provider_available(9)
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_fence_only_then_scheduled_unavailable_can_admit_old_ptt() -> None:
+    managed, _, _, _, fence, lane = authority(generation=7)
+    cleanup = fence.force_off()
+    allow_unavailable = asyncio.Event()
+
+    async def delayed_unavailable() -> None:
+        await allow_unavailable.wait()
+        await managed.provider_unavailable()
+
+    unavailable = asyncio.create_task(delayed_unavailable())
+    submission = managed.start_ptt_submission(True, "owner")
+    accepted = await submission
+
+    assert accepted.outcome is ManagedTxOutcome.ACCEPTED
+    assert lane.effects[0].token.provider_generation == 7
+    allow_unavailable.set()
+    await unavailable
+    await cleanup
+    await managed.provider_available(8)
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_unavailable_start_invalidates_active_effect_before_return() -> None:
+    managed, _, _, _, fence, lane = authority(generation=7)
+    allow_old_on = lane.block_next()
+    old_on = asyncio.create_task(managed.transmit_on())
+    effect = await asyncio.wait_for(lane.started.get(), 0.2)
+    guard = lane.guards[-1]
+    assert effect.operation is ActuationOperation.TRANSMIT_ON
+    assert callable(guard) and guard()
+
+    completion = managed.start_provider_unavailable()
+
+    assert managed._provider_generation is None
+    assert managed._state.intent.kind is ManagedTxIntentKind.RX
+    assert managed._state.release_plan is ReleasePlan.FORCE_RELEASE
+    assert managed._state.pending_effect is None
+    assert fence.calls == 1
+    assert callable(guard) and not guard()
+
+    await completion
+    await managed.provider_available(8)
+    allow_old_on.set()
+    assert await old_on is ManagedTxOutcome.ACCEPTED
+    assert [item.operation for item in lane.effects] == [
+        ActuationOperation.TRANSMIT_ON,
+        ActuationOperation.FORCE_RECEIVE,
+    ]
+    assert lane.effects[-1].token.provider_generation == 8
+    assert not managed._state.release_required
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_unavailable_start_blocks_pending_and_new_on_while_cleanup_waits() -> (
+    None
+):
+    managed, _, _, _, fence, lane = authority(generation=7)
+    cleanup_started, allow_cleanup = asyncio.Event(), asyncio.Event()
+
+    async def cleanup() -> None:
+        cleanup_started.set()
+        await allow_cleanup.wait()
+
+    fence.register(fence.issue(), cleanup)
+    ready = asyncio.get_running_loop().create_future()
+    pending = managed.start_ptt_submission(True, "pending", ready=ready)
+
+    completion = managed.start_provider_unavailable()
+    after = managed.start_ptt_submission(True, "after")
+    transmit = asyncio.create_task(managed.submit_transmit_on())
+    after_receipt, transmit_receipt = await asyncio.gather(after, transmit)
+
+    await asyncio.wait_for(cleanup_started.wait(), 0.2)
+    await asyncio.wait_for(asyncio.gather(pending, return_exceptions=True), timeout=0.2)
+    assert cleanup_started.is_set()
+    assert not completion.done()
+    assert after_receipt.outcome is ManagedTxOutcome.REJECTED
+    assert transmit_receipt.outcome is ManagedTxOutcome.REJECTED
+    assert lane.effects == []
+    assert pending.cancelled()
+
+    allow_cleanup.set()
+    await completion
+    await managed.provider_available(8)
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_unavailable_waiter_does_not_cancel_owned_cleanup() -> None:
+    managed, _, _, _, fence, _ = authority(generation=7)
+    cleanup_started, allow_cleanup = asyncio.Event(), asyncio.Event()
+
+    async def cleanup() -> None:
+        cleanup_started.set()
+        await allow_cleanup.wait()
+
+    fence.register(fence.issue(), cleanup)
+    completion = managed.start_provider_unavailable()
+    waiter = asyncio.create_task(managed.provider_unavailable())
+    await asyncio.wait_for(cleanup_started.wait(), 0.2)
+
+    waiter.cancel()
+    await asyncio.gather(waiter, return_exceptions=True)
+    assert not completion.cancelled() and not completion.done()
+    assert managed.start_provider_unavailable() is completion
+
+    allow_cleanup.set()
+    await completion
+    await managed.provider_available(8)
     await managed.close()
 
 
@@ -579,6 +702,48 @@ async def test_active_replacement_never_replays_on(
     assert not (await managed.snapshot()).state.release_required
     if not shutdown:
         await managed.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "replacement_first", [True, False], ids=["replacement-first", "shutdown-first"]
+)
+async def test_unavailable_start_and_shutdown_overlap_drains_new_generation(
+    replacement_first: bool,
+) -> None:
+    managed, _, _, _, _, lane = authority(generation=7)
+    retired: list[int] = []
+    old_gate: asyncio.Event | None = None
+
+    if replacement_first:
+        await managed.start_provider_unavailable()
+        shutdown = asyncio.create_task(
+            managed.shutdown(
+                retire_provider=lambda generation: _append_async(retired, generation),
+                termination=asyncio.Event(),
+            )
+        )
+        while not managed._shutting_down:
+            await asyncio.sleep(0)
+    else:
+        old_gate = lane.block_next()
+        shutdown = asyncio.create_task(
+            managed.shutdown(
+                retire_provider=lambda generation: _append_async(retired, generation),
+                termination=asyncio.Event(),
+            )
+        )
+        old_release = await asyncio.wait_for(lane.started.get(), 0.2)
+        assert old_release.token.provider_generation == 7
+        await managed.start_provider_unavailable()
+        assert lane.guards[-1]() is False
+
+    await managed.provider_available(8)
+    if old_gate is not None:
+        old_gate.set()
+    assert await asyncio.wait_for(shutdown, 0.2) is ShutdownResult.DRAINED
+    assert retired == [8]
+    assert not managed._state.release_required
 
 
 @pytest.mark.asyncio

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -1,7 +1,13 @@
 import asyncio
+import hashlib
+import os
+import subprocess
+import sys
+import warnings
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 
 import pytest
 
@@ -775,6 +781,135 @@ async def test_unavailable_start_after_clean_shutdown_barrier_does_not_mutate() 
     assert fence.calls == fence_calls_before
     allow_retirement.set()
     assert await asyncio.wait_for(shutdown, 0.2) is ShutdownResult.DRAINED
+
+
+def test_provider_unavailable_consolidated_mutation_carrier(tmp_path: Path) -> None:
+    repo = Path(__file__).parents[1]
+    source = repo / "src/rigplane/runtime/managed_tx_authority.py"
+    original = source.read_bytes()
+    original_text = original.decode()
+    test_file = "tests/test_managed_tx_authority.py"
+    sync_test = (
+        f"{test_file}::"
+        "test_unavailable_start_is_synchronous_idempotent_and_generation_is_strict"
+    )
+    active_test = (
+        f"{test_file}::test_unavailable_start_invalidates_active_effect_before_return"
+    )
+    pending_test = (
+        f"{test_file}::"
+        "test_unavailable_start_blocks_pending_and_new_on_while_cleanup_waits"
+    )
+    cancellation_test = (
+        f"{test_file}::test_cancelled_unavailable_waiter_does_not_cancel_owned_cleanup"
+    )
+    force_release = (
+        "        if self._state.release_required:\n"
+        "            self._reduce_locked(ForceOff(None, self._attempt_id_locked()))\n"
+    )
+    mutants = (
+        (
+            "M1-defer-generation-invalidation",
+            sync_test,
+            (
+                (
+                    "        self._provider_generation = None\n",
+                    "        asyncio.get_running_loop().call_soon(\n"
+                    '            setattr, self, "_provider_generation", None\n'
+                    "        )\n",
+                ),
+            ),
+        ),
+        (
+            "M2-fence-only",
+            pending_test,
+            (
+                ("        self._provider_generation = None\n", "        pass\n"),
+                (force_release, "        pass\n"),
+            ),
+        ),
+        (
+            "M3-leave-active-intent",
+            active_test,
+            ((force_release, "        pass\n"),),
+        ),
+        (
+            "M4-omit-fence-advance",
+            pending_test,
+            (
+                (
+                    "        self._pending_abort_cleanup.append("
+                    "self._abort_fence.force_off())\n",
+                    "        pass\n",
+                ),
+            ),
+        ),
+        (
+            "M5-double-fence-advance",
+            active_test,
+            (
+                (
+                    "            self._reduce_locked("
+                    "ForceOff(None, self._attempt_id_locked()))\n",
+                    "            self._force_off_locked()\n",
+                ),
+            ),
+        ),
+        (
+            "M6-clean-rx-debt",
+            sync_test,
+            (("        if self._state.release_required:\n", "        if True:\n"),),
+        ),
+        (
+            "M7-caller-cancels-cleanup",
+            cancellation_test,
+            (
+                (
+                    "        await asyncio.shield(self.start_provider_unavailable())\n",
+                    "        await self.start_provider_unavailable()\n",
+                ),
+            ),
+        ),
+        (
+            "M8-accept-equal-generation",
+            sync_test,
+            (
+                (
+                    "            if generation <= self._generation_high_water:\n",
+                    "            if generation < self._generation_high_water:\n",
+                ),
+            ),
+        ),
+    )
+
+    for name, node, replacements in mutants:
+        mutated = original_text
+        for old, new in replacements:
+            assert old in mutated, f"{name}: mutation anchor missing"
+            mutated = mutated.replace(old, new, 1)
+        source.write_text(mutated)
+        env = os.environ.copy()
+        env["PYTHONPYCACHEPREFIX"] = str(tmp_path / name)
+        try:
+            result = subprocess.run(
+                [sys.executable, "-m", "pytest", "-q", node],
+                cwd=repo,
+                env=env,
+                capture_output=True,
+                encoding="utf-8",
+                timeout=20,
+                check=False,
+            )
+        finally:
+            source.write_bytes(original)
+        output = result.stdout + result.stderr
+        assert source.read_bytes() == original, f"{name}: source restoration failed"
+        assert result.returncode == 1, output
+        assert f"FAILED {node}" in output, output
+        warnings.warn(f"{name} KILLED by {node}", stacklevel=1)
+
+    digest = hashlib.sha256(original).hexdigest()
+    warnings.warn(f"source bytes restored sha256={digest}", stacklevel=1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `ManagedTxAuthority.start_provider_unavailable()` so provider generation, effect currency, retry state, active intent, and the sole abort fence are invalidated before the call returns
- retain one authority-owned cleanup task and keep `provider_unavailable()` as a cancellation-shielded compatibility wrapper
- preserve the existing reducer, fence, effect lane, scheduler, and strict authority-generation high-water rules; no second queue, epoch, registry, watchdog, or lifecycle state machine

Linear owner: MOR-2313

## Focused evidence
- RED `33821030692` at `d3cf41ca60c86023dd87a120fa719fbdf37e9771`: 57 existing tests passed; six new contract tests failed only because the API was absent; the fence-only unsafe-window witness passed. Artifact `9918422733`.
- GREEN `33821643256` at product head `98884d306e407f7d355e76fff472baca203b2a88`: 63 passed; Ruff and formatting passed. Artifact `9918656927`.
- consolidated mutation run `33822443775` at temporary carrier `937b010c80c7ad985451cc28757f4c8b4e014e26`: M1-M8 all killed in one run; source restored SHA-256 `812ca2a07927206ca7abd3228d3b26128442609a93b90b30dd3285e2e73f438d`. Artifact `9918898719`.
- temporary mutation carrier reverted; final tree `e96fa4a6431d1b9093fd367cb2a4699bf3cb9009` exactly equals the pre-carrier tree.
- final exact-head GREEN `33822995808` at `92810d0a9548f53da42ecfbb282f92406d20dc14`: 64 passed; Ruff and formatting passed. Artifact `9918995611`.
- natural required quick run `33823046717` completed SUCCESS on the exact final head.

## Contract cases
- clean RX stays clean and advances the fence once
- active or pending ON is synchronously reduced to RX/ForceRelease with stale effect guards before return
- pending ready PTT, new PTT, and TRANSMIT cannot bind the old generation while cleanup is blocked
- repeated unavailable starts return one retained completion; wrapper cancellation cannot cancel owned cleanup
- equal/lower authority generations remain rejected independently of StateStore tokens
- both provider-replacement/shutdown orderings drain and retire only the new generation; the clean shutdown barrier rejects without mutation

## Scope
Only `src/rigplane/runtime/managed_tx_authority.py` and `tests/test_managed_tx_authority.py` are changed. No hardware, sockets, TX, composition, StateStore, effect-lane, provider, ingress, frontend, interlock, or legacy runtime paths were touched.