### PR TITLE
feat(MOR-2315): project managed transmit snapshot

### DIFF
--- a/src/rigplane/web/managed_tx_view.py
+++ b/src/rigplane/web/managed_tx_view.py
@@ -1,0 +1,83 @@
+"""Normalized read-only view of one managed-transmit authority snapshot."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from math import floor
+from typing import assert_never
+
+from rigplane.core.tx_observation import ObservedPtt
+from rigplane.runtime.managed_tx_authority import ManagedTxProjection
+from rigplane.runtime.managed_tx_state import ManagedTxIntent, ManagedTxIntentKind
+
+__all__ = ["build_managed_tx_view"]
+
+
+def build_managed_tx_view(
+    projection: ManagedTxProjection,
+    observed_ptt: ObservedPtt,
+    *,
+    sampled_at: datetime,
+) -> dict[str, object]:
+    """Serialize one authority snapshot and independent observed PTT evidence."""
+
+    state = projection.state
+    active = (
+        state.tot_deadline_monotonic is not None
+        and projection.remaining_tot_seconds is not None
+    )
+    remaining_ms = (
+        None
+        if not active
+        else max(0, floor(projection.remaining_tot_seconds * 1000))
+    )
+    sampled_at_text = _utc_milliseconds(sampled_at)
+    return {
+        "schemaVersion": 1,
+        "sampledAt": sampled_at_text,
+        "managedTransmit": {
+            "status": "available",
+            "intent": _intent_view(state.intent),
+            "releaseRequired": state.release_required,
+            "lastError": state.last_error,
+            "lastActuation": (
+                None
+                if state.last_actuation is None
+                else {
+                    "operation": state.last_actuation.operation.value,
+                    "result": state.last_actuation.result.value,
+                    "attemptId": state.last_actuation.attempt_id,
+                }
+            ),
+            "abortErrors": [
+                {"operation": error.operation.value, "error": error.error}
+                for error in state.abort_errors
+            ],
+            "tot": {
+                "configuredSeconds": projection.configured_tot_seconds,
+                "active": active,
+                "remainingMs": remaining_ms,
+                "expiresAt": (
+                    None
+                    if remaining_ms is None
+                    else _utc_milliseconds(sampled_at + timedelta(milliseconds=remaining_ms))
+                ),
+            },
+        },
+        "txObservation": {"observedPtt": observed_ptt.value},
+    }
+
+
+def _intent_view(intent: ManagedTxIntent) -> dict[str, str]:
+    if intent.kind is ManagedTxIntentKind.RX:
+        return {"kind": "rx"}
+    if intent.kind is ManagedTxIntentKind.TRANSMIT:
+        return {"kind": "transmit"}
+    if intent.kind is ManagedTxIntentKind.PTT:
+        assert intent.owner_token is not None
+        return {"kind": "ptt", "owner": intent.owner_token}
+    assert_never(intent.kind)
+
+
+def _utc_milliseconds(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")

--- a/src/rigplane/web/managed_tx_view.py
+++ b/src/rigplane/web/managed_tx_view.py
@@ -22,10 +22,11 @@ def build_managed_tx_view(
     """Serialize one authority snapshot and independent observed PTT evidence."""
 
     state = projection.state
-    active = (
-        state.tot_deadline_monotonic is not None
-        and projection.remaining_tot_seconds is not None
-    )
+    has_deadline = state.tot_deadline_monotonic is not None
+    has_remaining = projection.remaining_tot_seconds is not None
+    if has_deadline != has_remaining:
+        raise ValueError("TOT deadline and remaining time disagree")
+    active = has_deadline
     remaining_ms = (
         None if not active else max(0, floor(projection.remaining_tot_seconds * 1000))
     )
@@ -80,6 +81,8 @@ def _intent_view(intent: ManagedTxIntent) -> dict[str, str]:
 
 
 def _utc_milliseconds(value: datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("sampled_at must be timezone-aware")
     return (
         value.astimezone(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
     )

--- a/src/rigplane/web/managed_tx_view.py
+++ b/src/rigplane/web/managed_tx_view.py
@@ -27,9 +27,7 @@ def build_managed_tx_view(
         and projection.remaining_tot_seconds is not None
     )
     remaining_ms = (
-        None
-        if not active
-        else max(0, floor(projection.remaining_tot_seconds * 1000))
+        None if not active else max(0, floor(projection.remaining_tot_seconds * 1000))
     )
     sampled_at_text = _utc_milliseconds(sampled_at)
     return {
@@ -60,7 +58,9 @@ def build_managed_tx_view(
                 "expiresAt": (
                     None
                     if remaining_ms is None
-                    else _utc_milliseconds(sampled_at + timedelta(milliseconds=remaining_ms))
+                    else _utc_milliseconds(
+                        sampled_at + timedelta(milliseconds=remaining_ms)
+                    )
                 ),
             },
         },
@@ -80,4 +80,6 @@ def _intent_view(intent: ManagedTxIntent) -> dict[str, str]:
 
 
 def _utc_milliseconds(value: datetime) -> str:
-    return value.astimezone(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    return (
+        value.astimezone(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    )

--- a/tests/test_managed_tx_web_projection.py
+++ b/tests/test_managed_tx_web_projection.py
@@ -194,7 +194,7 @@ def test_mismatched_tot_deadline_and_remaining_time_are_rejected(
     [
         (0.0, 0, "2026-09-04T12:34:56.789Z"),
         (-0.0001, 0, "2026-09-04T12:34:56.789Z"),
-        (604800.9999, 604800999, "2026-09-11T12:34:56.788Z"),
+        (604800.9999, 604800999, "2026-09-11T12:34:57.788Z"),
     ],
 )
 def test_active_tot_clamps_expired_time_and_preserves_large_remaining_time(

--- a/tests/test_managed_tx_web_projection.py
+++ b/tests/test_managed_tx_web_projection.py
@@ -95,9 +95,7 @@ def test_rx_release_debt_is_not_inferred_from_observed_ptt() -> None:
 def test_observation_changes_only_the_diagnostic_block(
     observed_ptt: ObservedPtt,
 ) -> None:
-    view = build_managed_tx_view(
-        _projection(), observed_ptt, sampled_at=_SAMPLED_AT
-    )
+    view = build_managed_tx_view(_projection(), observed_ptt, sampled_at=_SAMPLED_AT)
 
     assert view["managedTransmit"] == {
         "status": "available",
@@ -162,4 +160,3 @@ def test_diagnostics_preserve_normalized_values_and_hide_internal_tokens() -> No
     }
     assert "providerGeneration" not in str(view)
     assert "effectEpoch" not in str(view)
-

--- a/tests/test_managed_tx_web_projection.py
+++ b/tests/test_managed_tx_web_projection.py
@@ -1,0 +1,165 @@
+"""Pure public projection for one managed-transmit authority snapshot."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from rigplane.core.tx_observation import ObservedPtt
+from rigplane.runtime.managed_tx_authority import ManagedTxProjection
+from rigplane.runtime.managed_tx_state import (
+    AbortError,
+    AbortOperation,
+    ActuationDiagnostic,
+    ActuationOperation,
+    ActuationResult,
+    ManagedTxIntent,
+    ManagedTxIntentKind,
+    ManagedTxState,
+    ReleasePlan,
+)
+from rigplane.web.managed_tx_view import build_managed_tx_view
+
+
+_SAMPLED_AT = datetime(2026, 9, 4, 12, 34, 56, 789_000, tzinfo=UTC)
+
+
+def _projection(
+    state: ManagedTxState | None = None,
+    *,
+    configured_tot_seconds: float | None = 180.0,
+    remaining_tot_seconds: float | None = None,
+) -> ManagedTxProjection:
+    return ManagedTxProjection(
+        state or ManagedTxState(),
+        configured_tot_seconds,
+        remaining_tot_seconds,
+        provider_generation=123,
+    )
+
+
+def test_ptt_snapshot_serializes_the_authority_state_and_separate_observation() -> None:
+    state = ManagedTxState(
+        intent=ManagedTxIntent.ptt("opaque-owner-token"),
+        release_plan=ReleasePlan.PTT_RELEASE,
+        tx_started_at_monotonic=10.0,
+        tot_deadline_monotonic=55.0,
+    )
+
+    assert build_managed_tx_view(
+        _projection(state, remaining_tot_seconds=42.5009),
+        ObservedPtt.UNKNOWN,
+        sampled_at=_SAMPLED_AT,
+    ) == {
+        "schemaVersion": 1,
+        "sampledAt": "2026-09-04T12:34:56.789Z",
+        "managedTransmit": {
+            "status": "available",
+            "intent": {"kind": "ptt", "owner": "opaque-owner-token"},
+            "releaseRequired": True,
+            "lastError": None,
+            "lastActuation": None,
+            "abortErrors": [],
+            "tot": {
+                "configuredSeconds": 180.0,
+                "active": True,
+                "remainingMs": 42500,
+                "expiresAt": "2026-09-04T12:35:39.289Z",
+            },
+        },
+        "txObservation": {"observedPtt": "unknown"},
+    }
+
+
+def test_rx_release_debt_is_not_inferred_from_observed_ptt() -> None:
+    state = ManagedTxState(release_plan=ReleasePlan.FORCE_RELEASE)
+
+    assert build_managed_tx_view(
+        _projection(state), ObservedPtt.OFF, sampled_at=_SAMPLED_AT
+    )["managedTransmit"] == {
+        "status": "available",
+        "intent": {"kind": "rx"},
+        "releaseRequired": True,
+        "lastError": None,
+        "lastActuation": None,
+        "abortErrors": [],
+        "tot": {
+            "configuredSeconds": 180.0,
+            "active": False,
+            "remainingMs": None,
+            "expiresAt": None,
+        },
+    }
+
+
+@pytest.mark.parametrize("observed_ptt", list(ObservedPtt))
+def test_observation_changes_only_the_diagnostic_block(
+    observed_ptt: ObservedPtt,
+) -> None:
+    view = build_managed_tx_view(
+        _projection(), observed_ptt, sampled_at=_SAMPLED_AT
+    )
+
+    assert view["managedTransmit"] == {
+        "status": "available",
+        "intent": {"kind": "rx"},
+        "releaseRequired": False,
+        "lastError": None,
+        "lastActuation": None,
+        "abortErrors": [],
+        "tot": {
+            "configuredSeconds": 180.0,
+            "active": False,
+            "remainingMs": None,
+            "expiresAt": None,
+        },
+    }
+    assert view["txObservation"] == {"observedPtt": observed_ptt.value}
+
+
+def test_diagnostics_preserve_normalized_values_and_hide_internal_tokens() -> None:
+    state = ManagedTxState(
+        intent=ManagedTxIntent(ManagedTxIntentKind.TRANSMIT),
+        release_plan=ReleasePlan.PTT_RELEASE,
+        tx_started_at_monotonic=10.0,
+        last_actuation=ActuationDiagnostic(
+            ActuationOperation.TRANSMIT_ON,
+            ActuationResult.UNCERTAIN,
+            "opaque-attempt-id",
+        ),
+        last_error="provider error text",
+        abort_errors=(
+            AbortError(AbortOperation.STOP_CW, "cw error"),
+            AbortError(AbortOperation.STOP_TUNE, "tune error"),
+        ),
+    )
+
+    view = build_managed_tx_view(
+        _projection(state, configured_tot_seconds=None),
+        ObservedPtt.ON,
+        sampled_at=_SAMPLED_AT,
+    )
+
+    assert view["managedTransmit"] == {
+        "status": "available",
+        "intent": {"kind": "transmit"},
+        "releaseRequired": True,
+        "lastError": "provider error text",
+        "lastActuation": {
+            "operation": "transmit_on",
+            "result": "uncertain",
+            "attemptId": "opaque-attempt-id",
+        },
+        "abortErrors": [
+            {"operation": "stop_cw", "error": "cw error"},
+            {"operation": "stop_tune", "error": "tune error"},
+        ],
+        "tot": {
+            "configuredSeconds": None,
+            "active": False,
+            "remainingMs": None,
+            "expiresAt": None,
+        },
+    }
+    assert "providerGeneration" not in str(view)
+    assert "effectEpoch" not in str(view)
+

--- a/tests/test_managed_tx_web_projection.py
+++ b/tests/test_managed_tx_web_projection.py
@@ -1,6 +1,6 @@
 """Pure public projection for one managed-transmit authority snapshot."""
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
 
@@ -34,6 +34,15 @@ def _projection(
         configured_tot_seconds,
         remaining_tot_seconds,
         provider_generation=123,
+    )
+
+
+def _active_state() -> ManagedTxState:
+    return ManagedTxState(
+        intent=ManagedTxIntent(ManagedTxIntentKind.TRANSMIT),
+        release_plan=ReleasePlan.PTT_RELEASE,
+        tx_started_at_monotonic=10.0,
+        tot_deadline_monotonic=55.0,
     )
 
 
@@ -160,3 +169,75 @@ def test_diagnostics_preserve_normalized_values_and_hide_internal_tokens() -> No
     }
     assert "providerGeneration" not in str(view)
     assert "effectEpoch" not in str(view)
+
+
+@pytest.mark.parametrize(
+    ("state", "remaining_tot_seconds"),
+    [
+        (_active_state(), None),
+        (ManagedTxState(), 1.0),
+    ],
+)
+def test_mismatched_tot_deadline_and_remaining_time_are_rejected(
+    state: ManagedTxState, remaining_tot_seconds: float | None
+) -> None:
+    with pytest.raises(ValueError, match="TOT deadline and remaining time disagree"):
+        build_managed_tx_view(
+            _projection(state, remaining_tot_seconds=remaining_tot_seconds),
+            ObservedPtt.UNKNOWN,
+            sampled_at=_SAMPLED_AT,
+        )
+
+
+@pytest.mark.parametrize(
+    ("remaining_tot_seconds", "remaining_ms", "expires_at"),
+    [
+        (0.0, 0, "2026-09-04T12:34:56.789Z"),
+        (-0.0001, 0, "2026-09-04T12:34:56.789Z"),
+        (604800.9999, 604800999, "2026-09-11T12:34:56.788Z"),
+    ],
+)
+def test_active_tot_clamps_expired_time_and_preserves_large_remaining_time(
+    remaining_tot_seconds: float, remaining_ms: int, expires_at: str
+) -> None:
+    tot = build_managed_tx_view(
+        _projection(_active_state(), remaining_tot_seconds=remaining_tot_seconds),
+        ObservedPtt.UNKNOWN,
+        sampled_at=_SAMPLED_AT,
+    )["managedTransmit"]["tot"]  # type: ignore[index]
+
+    assert tot == {
+        "configuredSeconds": 180.0,
+        "active": True,
+        "remainingMs": remaining_ms,
+        "expiresAt": expires_at,
+    }
+
+
+def test_naive_sample_time_is_rejected() -> None:
+    with pytest.raises(ValueError, match="sampled_at must be timezone-aware"):
+        build_managed_tx_view(
+            _projection(),
+            ObservedPtt.UNKNOWN,
+            sampled_at=datetime(2026, 9, 4, 12, 34, 56, 789_000),
+        )
+
+
+def test_non_utc_sample_time_converts_sample_and_expiry_to_utc() -> None:
+    view = build_managed_tx_view(
+        _projection(_active_state(), remaining_tot_seconds=1.0),
+        ObservedPtt.UNKNOWN,
+        sampled_at=datetime(
+            2026,
+            9,
+            4,
+            8,
+            34,
+            56,
+            789_000,
+            tzinfo=timezone(-timedelta(hours=4)),
+        ),
+    )
+
+    assert view["sampledAt"] == "2026-09-04T12:34:56.789Z"
+    assert view["managedTransmit"]["tot"]["expiresAt"] == "2026-09-04T12:34:57.789Z"  # type: ignore[index]


### PR DESCRIPTION
## MOR-2315

https://linear.app/morozsm/issue/MOR-2315/tx-authority-pure-managed-transmit-web-snapshot-projection

## Scope

Pure, read-only projection of one supplied `ManagedTxProjection` plus separately supplied canonical observed PTT. It has no authority construction/calls, retained state, task, timer, queue, route, server, startup, persistence, or command behavior.

Exact lease: 2 files, +247 lines.

- `src/rigplane/web/managed_tx_view.py`
- `tests/test_managed_tx_web_projection.py`

## Evidence

- RED: focused Mac Mini run 33826071685 on `c81c3b20463d19d9ebc004b0d8320301926e4db2` failed as intended because the projection module did not yet exist.
- Final GREEN: focused Mac Mini run 33826767259 on `f36ab9b87bf49b58ecde374d0b424760a18214a5` passed the six leased projection tests and Ruff for both leased files.

No local project tests, hardware operation, or TX was performed.