### PR TITLE
Add local CW/tune abort-fence foundation

### DIFF
--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -2737,9 +2737,7 @@ class YaesuCatRadio:
             return
         chunk_size = 24
         for i in range(0, len(text), chunk_size):
-            await self.send_cw(
-                " ", text[i : i + chunk_size], is_current=is_current
-            )
+            await self.send_cw(" ", text[i : i + chunk_size], is_current=is_current)
 
     async def stop_cw_text(self) -> None:
         """Stop CW sending by clearing the keyer buffer."""

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -2259,14 +2259,20 @@ class YaesuCatRadio:
         """Set CW spot tone state."""
         await self._write("set_cw_spot", state="1" if state else "0")
 
-    async def send_cw(self, msg_type: str, mem: str) -> None:
+    async def send_cw(
+        self,
+        msg_type: str,
+        mem: str,
+        *,
+        is_current: Callable[[], bool] | None = None,
+    ) -> None:
         """Send a CW message (KY command).
 
         Args:
             msg_type: Message type character.
             mem: CW message text to send.
         """
-        await self._write("send_cw", type=msg_type, mem=mem)
+        await self._write("send_cw", type=msg_type, mem=mem, is_current=is_current)
 
     async def read_break_in_delay(self) -> int:
         """Read CW break-in delay in ms (30–3000) without mutating legacy state."""
@@ -2537,9 +2543,22 @@ class YaesuCatRadio:
         """
         return await self.read_tuner()
 
-    async def set_tuner(self, state: int, src: int = 0, typ: int = 0) -> None:
+    async def set_tuner(
+        self,
+        state: int,
+        src: int = 0,
+        typ: int = 0,
+        *,
+        is_current: Callable[[], bool] | None = None,
+    ) -> None:
         """Set antenna tuner (AC). state: 0=OFF, 1=ON, 2=tune."""
-        await self._write("set_tuner", src=str(src), type=str(typ), state=str(state))
+        await self._write(
+            "set_tuner",
+            src=str(src),
+            type=str(typ),
+            state=str(state),
+            is_current=is_current,
+        )
 
     # -- Contour / S-DX (CO) -----------------------------------------------
 
@@ -2696,11 +2715,15 @@ class YaesuCatRadio:
         """AdvancedControlCapable alias. Returns tuner state (0=OFF, 1=ON, 2=tuning)."""
         return await self.get_tuner()
 
-    async def set_tuner_status(self, value: int) -> None:
+    async def set_tuner_status(
+        self, value: int, *, is_current: Callable[[], bool] | None = None
+    ) -> None:
         """AdvancedControlCapable alias."""
-        await self.set_tuner(value)
+        await self.set_tuner(value, is_current=is_current)
 
-    async def send_cw_text(self, text: str) -> None:
+    async def send_cw_text(
+        self, text: str, *, is_current: Callable[[], bool] | None = None
+    ) -> None:
         """Send CW text via keyer (KY command), split into 24-character chunks.
 
         Uses ``send_cw(" ", text)`` — the space is the P1 type parameter
@@ -2710,11 +2733,13 @@ class YaesuCatRadio:
             text: CW text to send (A-Z, 0-9, punctuation).
         """
         if not text:
-            await self.send_cw(" ", "")
+            await self.send_cw(" ", "", is_current=is_current)
             return
         chunk_size = 24
         for i in range(0, len(text), chunk_size):
-            await self.send_cw(" ", text[i : i + chunk_size])
+            await self.send_cw(
+                " ", text[i : i + chunk_size], is_current=is_current
+            )
 
     async def stop_cw_text(self) -> None:
         """Stop CW sending by clearing the keyer buffer."""

--- a/src/rigplane/runtime/local_tx_work.py
+++ b/src/rigplane/runtime/local_tx_work.py
@@ -25,7 +25,10 @@ class GuardedTunerCapable(Protocol):
 
 
 async def _drain(task: asyncio.Task[object]) -> None:
-    await asyncio.gather(task, return_exceptions=True)
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
 
 
 class LocalTxWorkRunner:
@@ -47,7 +50,10 @@ class LocalTxWorkRunner:
 
         self._fence.register(token, cancel_and_drain, scope=None)
         try:
-            return await task
+            result = await task
+            if not self._fence.is_current(token):
+                raise asyncio.CancelledError
+            return result
         except asyncio.CancelledError:
             if not task.done():
                 task.cancel()

--- a/src/rigplane/runtime/local_tx_work.py
+++ b/src/rigplane/runtime/local_tx_work.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Protocol, TypeVar
+
+from .managed_tx_fence import TxAbortFence
+
+
+Currency = Callable[[], bool]
+T = TypeVar("T")
+LocalTxOperation = Callable[[Currency], Awaitable[T]]
+
+
+class GuardedCwCapable(Protocol):
+    async def send_cw_text(
+        self, text: str, *, is_current: Currency | None = None
+    ) -> None: ...
+
+
+class GuardedTunerCapable(Protocol):
+    async def set_tuner_status(
+        self, value: int, *, is_current: Currency | None = None
+    ) -> None: ...
+
+
+async def _drain(task: asyncio.Task[object]) -> None:
+    await asyncio.gather(task, return_exceptions=True)
+
+
+class LocalTxWorkRunner:
+    def __init__(self, fence: TxAbortFence) -> None:
+        self._fence = fence
+
+    async def run(self, operation: LocalTxOperation[T]) -> T:
+        token = self._fence.issue()
+
+        async def invoke() -> T:
+            return await operation(lambda: self._fence.is_current(token))
+
+        task = asyncio.create_task(invoke())
+
+        def cancel_and_drain() -> Awaitable[None]:
+            if not task.done():
+                task.cancel()
+            return _drain(task)
+
+        self._fence.register(token, cancel_and_drain, scope=None)
+        try:
+            return await task
+        except asyncio.CancelledError:
+            if not task.done():
+                task.cancel()
+            await _drain(task)
+            raise
+        finally:
+            self._fence.remove(token)

--- a/tests/test_fenced_local_tx_providers.py
+++ b/tests/test_fenced_local_tx_providers.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
+from rigplane.backends.yaesu_cat.transport import CatTransportError
+from rigplane.runtime.managed_tx_fence import TxAbortFence
+from rigplane.rig_loader import load_rig
+
+
+_RIGS_DIR = Path(__file__).parents[1] / "rigs"
+
+
+class FakeStreamReader:
+    async def readuntil(self, separator: bytes) -> bytes:
+        del separator
+        raise asyncio.TimeoutError("no responses")
+
+
+class FakeStreamWriter:
+    def __init__(self) -> None:
+        self.written: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        self.written.append(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    async def wait_closed(self) -> None:
+        return None
+
+
+class BlockingFirstDrainWriter(FakeStreamWriter):
+    def __init__(self) -> None:
+        super().__init__()
+        self.first_drain_entered = asyncio.Event()
+        self.release_first_drain = asyncio.Event()
+        self._drain_count = 0
+
+    async def drain(self) -> None:
+        self._drain_count += 1
+        if self._drain_count == 1:
+            self.first_drain_entered.set()
+            await self.release_first_drain.wait()
+
+
+async def _connected_radio(
+    monkeypatch: pytest.MonkeyPatch, writer: FakeStreamWriter
+) -> YaesuCatRadio:
+    serial_asyncio = MagicMock()
+    serial_asyncio.open_serial_connection = AsyncMock(
+        return_value=(FakeStreamReader(), writer)
+    )
+    monkeypatch.setitem(sys.modules, "serial_asyncio", serial_asyncio)
+    config = load_rig(_RIGS_DIR / "ftx1.toml")
+    radio = YaesuCatRadio("/dev/test", profile=config, audio_driver=MagicMock())
+    await radio._transport.connect()
+    radio._transport._drain_responses = AsyncMock(return_value=0)
+    return radio
+
+
+@pytest.mark.asyncio
+async def test_yaesu_cw_suppresses_second_chunk_after_fence_poison(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    writer = FakeStreamWriter()
+    radio = await _connected_radio(monkeypatch, writer)
+    fence = TxAbortFence()
+    token = fence.issue()
+    drains = 0
+
+    async def poison_after_first_write(command: str) -> int:
+        nonlocal drains
+        del command
+        drains += 1
+        if drains == 1:
+            await fence.force_off()
+        return 0
+
+    radio._transport._drain_responses = poison_after_first_write  # type: ignore[method-assign]
+
+    with pytest.raises(CatTransportError, match="no longer current"):
+        await radio.send_cw_text("A" * 25, is_current=lambda: fence.is_current(token))
+
+    assert writer.written == [b"KY " + b"A" * 24 + b";"]
+
+
+@pytest.mark.asyncio
+async def test_yaesu_tuner_start_is_suppressed_after_queued_fence_poison(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    writer = BlockingFirstDrainWriter()
+    radio = await _connected_radio(monkeypatch, writer)
+    fence = TxAbortFence()
+    token = fence.issue()
+
+    blocker = asyncio.create_task(radio._transport.write("FA000000001;"))
+    await writer.first_drain_entered.wait()
+    tuner = asyncio.create_task(
+        radio.set_tuner_status(1, is_current=lambda: fence.is_current(token))
+    )
+    await asyncio.sleep(0)
+    await fence.force_off()
+    writer.release_first_drain.set()
+
+    await blocker
+    with pytest.raises(CatTransportError, match="no longer current"):
+        await tuner
+    assert writer.written == [b"FA000000001;"]
+
+
+@pytest.mark.asyncio
+async def test_yaesu_direct_cw_and_tuner_calls_remain_unguarded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    writer = FakeStreamWriter()
+    radio = await _connected_radio(monkeypatch, writer)
+
+    await radio.send_cw_text("B" * 25)
+    await radio.set_tuner_status(1)
+
+    assert writer.written == [
+        b"KY " + b"B" * 24 + b";",
+        b"KY B;",
+        b"AC001;",
+    ]

--- a/tests/test_local_tx_work.py
+++ b/tests/test_local_tx_work.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import ast
+import asyncio
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+import pytest
+
+from rigplane.runtime import local_tx_work
+from rigplane.runtime.local_tx_work import LocalTxWorkRunner
+from rigplane.runtime.managed_tx_fence import (
+    Cancellation,
+    TxAbortFence,
+    TxAbortToken,
+)
+
+
+class RecordingFence(TxAbortFence):
+    def __init__(self) -> None:
+        super().__init__()
+        self.registered = False
+        self.last_token: TxAbortToken | None = None
+        self.cancellation_calls = 0
+
+    def register(
+        self,
+        token: TxAbortToken,
+        cancellation: Cancellation,
+        *,
+        scope: str | None = None,
+    ) -> None:
+        self.registered = True
+        self.last_token = token
+
+        def counted_cancellation() -> Awaitable[None] | None:
+            self.cancellation_calls += 1
+            return cancellation()
+
+        super().register(token, counted_cancellation, scope=scope)
+
+
+@pytest.mark.asyncio
+async def test_runner_registers_before_operation_gets_first_turn() -> None:
+    fence = RecordingFence()
+    runner = LocalTxWorkRunner(fence)
+
+    async def operation(is_current: Callable[[], bool]) -> str:
+        assert fence.registered
+        assert is_current()
+        return "done"
+
+    assert await runner.run(operation) == "done"
+
+
+@pytest.mark.asyncio
+async def test_force_off_poisons_predicate_before_cancellation_runs() -> None:
+    fence = TxAbortFence()
+    runner = LocalTxWorkRunner(fence)
+    started = asyncio.Event()
+    predicates: list[Callable[[], bool]] = []
+
+    async def operation(is_current: Callable[[], bool]) -> None:
+        predicates.append(is_current)
+        started.set()
+        await asyncio.Event().wait()
+
+    work = asyncio.create_task(runner.run(operation))
+    await started.wait()
+
+    cleanup = fence.force_off()
+    assert predicates[0]() is False
+    assert not work.done()
+
+    result = await cleanup
+    assert result.failures == ()
+    with pytest.raises(asyncio.CancelledError):
+        await work
+
+
+@pytest.mark.asyncio
+async def test_blocked_local_cleanup_does_not_block_separate_urgent_off() -> None:
+    fence = TxAbortFence()
+    runner = LocalTxWorkRunner(fence)
+    started = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+    events: list[str] = []
+
+    async def operation(is_current: Callable[[], bool]) -> None:
+        del is_current
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cleanup_started.set()
+            await release_cleanup.wait()
+            raise
+
+    work = asyncio.create_task(runner.run(operation))
+    await started.wait()
+    cleanup = asyncio.create_task(fence.force_off())
+    await cleanup_started.wait()
+
+    events.append("urgent_off_submitted")
+    assert events == ["urgent_off_submitted"]
+    assert not cleanup.done()
+
+    release_cleanup.set()
+    result = await cleanup
+    assert result.failures == ()
+    with pytest.raises(asyncio.CancelledError):
+        await work
+
+
+@pytest.mark.asyncio
+async def test_force_off_cancels_and_drains_active_operation_once() -> None:
+    fence = TxAbortFence()
+    runner = LocalTxWorkRunner(fence)
+    started = asyncio.Event()
+    cancellations = 0
+
+    async def operation(is_current: Callable[[], bool]) -> None:
+        nonlocal cancellations
+        del is_current
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancellations += 1
+            raise
+
+    work = asyncio.create_task(runner.run(operation))
+    await started.wait()
+
+    first = await fence.force_off()
+    second = await fence.force_off()
+
+    assert first.failures == second.failures == ()
+    assert cancellations == 1
+    with pytest.raises(asyncio.CancelledError):
+        await work
+
+
+@pytest.mark.asyncio
+async def test_ordinary_completion_removes_registration() -> None:
+    fence = RecordingFence()
+    runner = LocalTxWorkRunner(fence)
+
+    async def operation(is_current: Callable[[], bool]) -> int:
+        assert is_current()
+        return 7
+
+    assert await runner.run(operation) == 7
+    assert fence.last_token is not None
+    assert fence.remove(fence.last_token) is False
+    result = await fence.force_off()
+
+    assert result.failures == ()
+    assert fence.cancellation_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_provider_error_propagates_and_removes_registration() -> None:
+    fence = TxAbortFence()
+    runner = LocalTxWorkRunner(fence)
+
+    async def operation(is_current: Callable[[], bool]) -> None:
+        assert is_current()
+        raise RuntimeError("provider failed")
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        await runner.run(operation)
+
+    assert (await fence.force_off()).failures == ()
+
+
+@pytest.mark.asyncio
+async def test_caller_cancellation_drains_provider_before_returning() -> None:
+    fence = TxAbortFence()
+    runner = LocalTxWorkRunner(fence)
+    started = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    async def operation(is_current: Callable[[], bool]) -> None:
+        del is_current
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cleanup_started.set()
+            await release_cleanup.wait()
+            raise
+
+    work = asyncio.create_task(runner.run(operation))
+    await started.wait()
+    work.cancel()
+    await cleanup_started.wait()
+    assert not work.done()
+
+    release_cleanup.set()
+    with pytest.raises(asyncio.CancelledError):
+        await work
+    assert (await fence.force_off()).failures == ()
+
+
+def test_local_runner_never_constructs_an_abort_fence() -> None:
+    source = Path(local_tx_work.__file__).read_text()
+    tree = ast.parse(source)
+
+    constructions = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "TxAbortFence"
+    ]
+
+    assert constructions == []

--- a/tests/test_local_tx_work.py
+++ b/tests/test_local_tx_work.py
@@ -79,6 +79,32 @@ async def test_force_off_poisons_predicate_before_cancellation_runs() -> None:
 
 
 @pytest.mark.asyncio
+async def test_poisoned_operation_cannot_return_stale_success_before_cleanup() -> None:
+    fence = TxAbortFence()
+    runner = LocalTxWorkRunner(fence)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def operation(is_current: Callable[[], bool]) -> str:
+        assert is_current()
+        started.set()
+        await release.wait()
+        return "stale success"
+
+    work = asyncio.create_task(runner.run(operation))
+    await started.wait()
+    cleanup = fence.force_off()
+    try:
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await work
+    finally:
+        result = await cleanup
+
+    assert result.failures == ()
+
+
+@pytest.mark.asyncio
 async def test_blocked_local_cleanup_does_not_block_separate_urgent_off() -> None:
     fence = TxAbortFence()
     runner = LocalTxWorkRunner(fence)
@@ -139,6 +165,30 @@ async def test_force_off_cancels_and_drains_active_operation_once() -> None:
     assert first.failures == second.failures == ()
     assert cancellations == 1
     with pytest.raises(asyncio.CancelledError):
+        await work
+
+
+@pytest.mark.asyncio
+async def test_force_off_reports_provider_cancellation_cleanup_failure() -> None:
+    fence = TxAbortFence()
+    runner = LocalTxWorkRunner(fence)
+    started = asyncio.Event()
+
+    async def operation(is_current: Callable[[], bool]) -> None:
+        del is_current
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raise RuntimeError("provider cancellation cleanup failed")
+
+    work = asyncio.create_task(runner.run(operation))
+    await started.wait()
+    result = await fence.force_off()
+
+    assert len(result.failures) == 1
+    assert result.failures[0].error.args == ("provider cancellation cleanup failed",)
+    with pytest.raises(RuntimeError, match="provider cancellation cleanup failed"):
         await work
 
 


### PR DESCRIPTION
## Bounded salvage after #3158

PR #3158 merged the shared `LocalTxWorkRunner`, Yaesu CW/tuner participation, composition activation, and provider/runner coverage now present on current `main` (`704e1eca5a9c49d52291e9a2b22ace8c69d66e9d`).

This draft remains open only for the non-overlapping runner-hardening evidence at exact head `3a5134520cca1189df77f837b8d0cba187359fdd`:

- `src/rigplane/runtime/local_tx_work.py:LocalTxWorkRunner.run` and `_drain`: recheck token currency after provider completion so a poisoned operation cannot return stale success; cancel and drain the owned provider task so non-cancellation cleanup failures reach `TxAbortResult.failures`.
- `tests/test_local_tx_work.py:test_poisoned_operation_cannot_return_stale_success_before_cleanup`.
- `tests/test_local_tx_work.py:test_force_off_reports_provider_cancellation_cleanup_failure`.
- Unique source commits: `7f96ea02809f70870833f7badcdd505ad7aa53af` and `3a5134520cca1189df77f837b8d0cba187359fdd`.

Superseded/excluded from this PR: its Yaesu signature/predicate changes, provider tests, and initial runner foundation in `d79fe149`, `c71c7487`, and `3eaa4ff1`; #3158 already merged a different production-activated design.

The current branch is behind/diverged and must not be marked ready or merged as-is. Rebuild it on current `main` with only the exact runner hardening/tests above. Icom `CoreRadio.send_cw_text` / tuner participation is tracked separately in MOR-2314 and is not silently added to this draft.