### PR TITLE
feat: add managed antenna descriptor admission

### DIFF
--- a/src/rigplane/core/command_dispatch.py
+++ b/src/rigplane/core/command_dispatch.py
@@ -512,7 +512,7 @@ def bind_command_intent(
     target = descriptor.target(normalized)
     return CommandIntent(
         id=command_id or f"{source}-{time.monotonic_ns()}",
-        name=descriptor.method_name,
+        name=descriptor.name,
         params=normalized,
         source=source,
         target=target,

--- a/src/rigplane/core/command_dispatch.py
+++ b/src/rigplane/core/command_dispatch.py
@@ -80,6 +80,7 @@ class ManagedWriteAdmission(Protocol):
 Binder = Callable[[Mapping[str, Any]], dict[str, Any]]
 TargetBuilder = Callable[[Mapping[str, Any]], FieldPath]
 ExpectationProjector = Callable[[Any, Mapping[str, Any]], dict[str, Any]]
+MethodNameResolver = Callable[[Mapping[str, Any]], str]
 
 
 class DescriptorTxPolicy(StrEnum):
@@ -95,19 +96,29 @@ class CommandDescriptor:
     """One operation's backend-neutral execution mechanics."""
 
     name: str
-    method_name: str
+    method_name: str | MethodNameResolver
     bind: Binder
     target: TargetBuilder
     argument_names: tuple[str, ...]
     tx_policy: DescriptorTxPolicy
     public_names: tuple[str, ...]
+    result_names: tuple[str, ...] | None = None
     timeout: float = 10.0
     queue_policy: Literal["ordered", "coalesced"] = "ordered"
     receiver_aware: bool = False
     project_expectation: ExpectationProjector | None = None
 
+    def resolve_method_name(self, params: Mapping[str, Any]) -> str:
+        method_name = (
+            self.method_name(params) if callable(self.method_name) else self.method_name
+        )
+        if not method_name:
+            raise CommandError(f"descriptor {self.name!r} resolved no Radio method")
+        return method_name
+
     def result(self, intent: CommandIntent) -> dict[str, Any]:
-        return {name: intent.params[name] for name in self.argument_names}
+        names = self.argument_names if self.result_names is None else self.result_names
+        return {name: intent.params[name] for name in names}
 
 
 def _bind_repeater_shift(params: Mapping[str, Any]) -> dict[str, Any]:
@@ -235,11 +246,28 @@ def _bind_boolean(field: str, params: Mapping[str, Any]) -> dict[str, Any]:
     value = params["on"] if "on" in params else params["enabled"]
     if type(value) is not bool:
         raise ValueError(f"{field} must be a bool")
-    return {"enabled": value, "on": value, field: value}
+    return {"on": value, field: value}
+
+
+def _bind_rx_antenna(params: Mapping[str, Any]) -> dict[str, Any]:
+    antenna = params["antenna"]
+    if isinstance(antenna, bool) or not isinstance(antenna, int):
+        raise ValueError("antenna must be 1 or 2")
+    if antenna not in (1, 2):
+        raise ValueError("antenna must be 1 or 2")
+    return {"antenna": antenna, **_bind_boolean(f"rx_antenna_{antenna}", params)}
 
 
 def _global_slow_state_target(field: str, _params: Mapping[str, Any]) -> FieldPath:
     return FieldPath.global_("slow_state", field)
+
+
+def _rx_antenna_target(params: Mapping[str, Any]) -> FieldPath:
+    return _global_slow_state_target(f"rx_antenna_{params['antenna']}", params)
+
+
+def _rx_antenna_method(params: Mapping[str, Any]) -> str:
+    return f"set_rx_antenna_ant{params['antenna']}"
 
 
 _COMMAND_DESCRIPTORS: Mapping[str, CommandDescriptor] = MappingProxyType(
@@ -303,7 +331,7 @@ _COMMAND_DESCRIPTORS: Mapping[str, CommandDescriptor] = MappingProxyType(
             method_name="set_antenna_1",
             bind=partial(_bind_boolean, "rx_antenna_1"),
             target=partial(_global_slow_state_target, "rx_antenna_1"),
-            argument_names=("enabled",),
+            argument_names=("on",),
             tx_policy=DescriptorTxPolicy.ANTENNA_SWITCH,
             public_names=("set_antenna", "set_antenna_1"),
         ),
@@ -312,25 +340,35 @@ _COMMAND_DESCRIPTORS: Mapping[str, CommandDescriptor] = MappingProxyType(
             method_name="set_antenna_2",
             bind=partial(_bind_boolean, "rx_antenna_2"),
             target=partial(_global_slow_state_target, "rx_antenna_2"),
-            argument_names=("enabled",),
+            argument_names=("on",),
             tx_policy=DescriptorTxPolicy.ANTENNA_SWITCH,
             public_names=("set_antenna_2",),
+        ),
+        "set_rx_antenna": CommandDescriptor(
+            name="set_rx_antenna",
+            method_name=_rx_antenna_method,
+            bind=_bind_rx_antenna,
+            target=_rx_antenna_target,
+            argument_names=("on",),
+            result_names=("antenna", "on"),
+            tx_policy=DescriptorTxPolicy.ANTENNA_SWITCH,
+            public_names=("set_rx_antenna",),
         ),
         "set_rx_antenna_ant1": CommandDescriptor(
             name="set_rx_antenna_ant1",
             method_name="set_rx_antenna_ant1",
             bind=partial(_bind_boolean, "rx_antenna_1"),
             target=partial(_global_slow_state_target, "rx_antenna_1"),
-            argument_names=("enabled",),
+            argument_names=("on",),
             tx_policy=DescriptorTxPolicy.ANTENNA_SWITCH,
-            public_names=("set_rx_antenna", "set_rx_antenna_ant1"),
+            public_names=("set_rx_antenna_ant1",),
         ),
         "set_rx_antenna_ant2": CommandDescriptor(
             name="set_rx_antenna_ant2",
             method_name="set_rx_antenna_ant2",
             bind=partial(_bind_boolean, "rx_antenna_2"),
             target=partial(_global_slow_state_target, "rx_antenna_2"),
-            argument_names=("enabled",),
+            argument_names=("on",),
             tx_policy=DescriptorTxPolicy.ANTENNA_SWITCH,
             public_names=("set_rx_antenna_ant2",),
         ),
@@ -339,7 +377,7 @@ _COMMAND_DESCRIPTORS: Mapping[str, CommandDescriptor] = MappingProxyType(
             method_name="set_civ_output_ant",
             bind=partial(_bind_boolean, "civ_output_ant"),
             target=partial(_global_slow_state_target, "civ_output_ant"),
-            argument_names=("enabled",),
+            argument_names=("on",),
             tx_policy=DescriptorTxPolicy.TX_SAFE,
             public_names=("set_civ_output_ant",),
         ),
@@ -388,7 +426,11 @@ def command_descriptor(name: str) -> CommandDescriptor | None:
             (
                 descriptor
                 for descriptor in _COMMAND_DESCRIPTORS.values()
-                if name in descriptor.public_names or name == descriptor.method_name
+                if name in descriptor.public_names
+                or (
+                    isinstance(descriptor.method_name, str)
+                    and name == descriptor.method_name
+                )
             ),
             None,
         )
@@ -501,16 +543,15 @@ def prepare_command_intent(
         session_id=session_id,
         timeout=descriptor.timeout,
     )
+    method_name = descriptor.resolve_method_name(intent.params)
     supported = (
-        radio.supports_command(
-            descriptor.method_name, receiver=intent.params["receiver"]
-        )
+        radio.supports_command(method_name, receiver=intent.params["receiver"])
         if descriptor.receiver_aware
-        else radio.supports_command(descriptor.method_name)
+        else radio.supports_command(method_name)
     )
     if not supported:
         raise CommandUnsupportedError(
-            f"command {descriptor.method_name!r} is not supported by active profile"
+            f"command {method_name!r} is not supported by active profile"
         )
     if descriptor.project_expectation is not None:
         intent = replace(
@@ -532,7 +573,7 @@ async def execute_command_intent(
     if descriptor is None:
         raise CommandError(f"no command descriptor for {intent.name!r}")
     _require_descriptor_policy_seat(descriptor)
-    method = getattr(radio, descriptor.method_name)
+    method = getattr(radio, descriptor.resolve_method_name(intent.params))
     if (
         managed_tx_authority is not None
         and not await managed_tx_authority.admit_managed_write(intent)

--- a/src/rigplane/core/command_dispatch.py
+++ b/src/rigplane/core/command_dispatch.py
@@ -30,6 +30,7 @@ __all__ = [
     "CommandDescriptor",
     "CommandUnsupportedError",
     "DescriptorTxPolicy",
+    "ManagedWriteAdmission",
     "bind_command_intent",
     "command_descriptor",
     "command_descriptors",
@@ -72,6 +73,10 @@ class DispatchQueue(Protocol):
     ) -> object: ...
 
 
+class ManagedWriteAdmission(Protocol):
+    async def admit_managed_write(self, intent: CommandIntent) -> bool: ...
+
+
 Binder = Callable[[Mapping[str, Any]], dict[str, Any]]
 TargetBuilder = Callable[[Mapping[str, Any]], FieldPath]
 ExpectationProjector = Callable[[Any, Mapping[str, Any]], dict[str, Any]]
@@ -82,6 +87,7 @@ class DescriptorTxPolicy(StrEnum):
 
     ALWAYS_PASS = "always_pass"
     TX_SAFE = "tx_safe"
+    ANTENNA_SWITCH = "antenna_switch"
 
 
 @dataclass(frozen=True, slots=True)
@@ -225,6 +231,17 @@ def _project_attenuator_expectation(
     return normalized
 
 
+def _bind_boolean(field: str, params: Mapping[str, Any]) -> dict[str, Any]:
+    value = params["on"] if "on" in params else params["enabled"]
+    if type(value) is not bool:
+        raise ValueError(f"{field} must be a bool")
+    return {"enabled": value, "on": value, field: value}
+
+
+def _global_slow_state_target(field: str, _params: Mapping[str, Any]) -> FieldPath:
+    return FieldPath.global_("slow_state", field)
+
+
 _COMMAND_DESCRIPTORS: Mapping[str, CommandDescriptor] = MappingProxyType(
     {
         "set_repeater_shift": CommandDescriptor(
@@ -281,6 +298,51 @@ _COMMAND_DESCRIPTORS: Mapping[str, CommandDescriptor] = MappingProxyType(
             receiver_aware=True,
             project_expectation=_project_attenuator_expectation,
         ),
+        "set_antenna_1": CommandDescriptor(
+            name="set_antenna_1",
+            method_name="set_antenna_1",
+            bind=partial(_bind_boolean, "rx_antenna_1"),
+            target=partial(_global_slow_state_target, "rx_antenna_1"),
+            argument_names=("enabled",),
+            tx_policy=DescriptorTxPolicy.ANTENNA_SWITCH,
+            public_names=("set_antenna", "set_antenna_1"),
+        ),
+        "set_antenna_2": CommandDescriptor(
+            name="set_antenna_2",
+            method_name="set_antenna_2",
+            bind=partial(_bind_boolean, "rx_antenna_2"),
+            target=partial(_global_slow_state_target, "rx_antenna_2"),
+            argument_names=("enabled",),
+            tx_policy=DescriptorTxPolicy.ANTENNA_SWITCH,
+            public_names=("set_antenna_2",),
+        ),
+        "set_rx_antenna_ant1": CommandDescriptor(
+            name="set_rx_antenna_ant1",
+            method_name="set_rx_antenna_ant1",
+            bind=partial(_bind_boolean, "rx_antenna_1"),
+            target=partial(_global_slow_state_target, "rx_antenna_1"),
+            argument_names=("enabled",),
+            tx_policy=DescriptorTxPolicy.ANTENNA_SWITCH,
+            public_names=("set_rx_antenna", "set_rx_antenna_ant1"),
+        ),
+        "set_rx_antenna_ant2": CommandDescriptor(
+            name="set_rx_antenna_ant2",
+            method_name="set_rx_antenna_ant2",
+            bind=partial(_bind_boolean, "rx_antenna_2"),
+            target=partial(_global_slow_state_target, "rx_antenna_2"),
+            argument_names=("enabled",),
+            tx_policy=DescriptorTxPolicy.ANTENNA_SWITCH,
+            public_names=("set_rx_antenna_ant2",),
+        ),
+        "set_civ_output_ant": CommandDescriptor(
+            name="set_civ_output_ant",
+            method_name="set_civ_output_ant",
+            bind=partial(_bind_boolean, "civ_output_ant"),
+            target=partial(_global_slow_state_target, "civ_output_ant"),
+            argument_names=("enabled",),
+            tx_policy=DescriptorTxPolicy.TX_SAFE,
+            public_names=("set_civ_output_ant",),
+        ),
     }
 )
 
@@ -289,6 +351,7 @@ _ADMITTED_DESCRIPTOR_TX_POLICIES = frozenset(
     {
         DescriptorTxPolicy.ALWAYS_PASS,
         DescriptorTxPolicy.TX_SAFE,
+        DescriptorTxPolicy.ANTENNA_SWITCH,
     }
 )
 
@@ -305,22 +368,33 @@ def _require_descriptor_policy_seat(descriptor: CommandDescriptor) -> None:
         )
 
 
+def _validate_descriptor_table() -> None:
+    for descriptor in _COMMAND_DESCRIPTORS.values():
+        _require_descriptor_policy_seat(descriptor)
+
+
+_validate_descriptor_table()
+
+
 def command_descriptors() -> Mapping[str, CommandDescriptor]:
+    _validate_descriptor_table()
     return _COMMAND_DESCRIPTORS
 
 
 def command_descriptor(name: str) -> CommandDescriptor | None:
     descriptor = _COMMAND_DESCRIPTORS.get(name)
+    if descriptor is None:
+        descriptor = next(
+            (
+                descriptor
+                for descriptor in _COMMAND_DESCRIPTORS.values()
+                if name in descriptor.public_names or name == descriptor.method_name
+            ),
+            None,
+        )
     if descriptor is not None:
-        return descriptor
-    return next(
-        (
-            descriptor
-            for descriptor in _COMMAND_DESCRIPTORS.values()
-            if name in descriptor.public_names or name == descriptor.method_name
-        ),
-        None,
-    )
+        _require_descriptor_policy_seat(descriptor)
+    return descriptor
 
 
 def enqueue_command_intent(
@@ -446,7 +520,12 @@ def prepare_command_intent(
     return intent
 
 
-async def execute_command_intent(radio: Any, intent: CommandIntent) -> None:
+async def execute_command_intent(
+    radio: Any,
+    intent: CommandIntent,
+    *,
+    managed_tx_authority: ManagedWriteAdmission | None = None,
+) -> None:
     """Invoke the reviewed Radio method for a descriptor-built intent."""
 
     descriptor = command_descriptor(intent.name)
@@ -454,4 +533,11 @@ async def execute_command_intent(radio: Any, intent: CommandIntent) -> None:
         raise CommandError(f"no command descriptor for {intent.name!r}")
     _require_descriptor_policy_seat(descriptor)
     method = getattr(radio, descriptor.method_name)
+    if (
+        managed_tx_authority is not None
+        and not await managed_tx_authority.admit_managed_write(intent)
+    ):
+        raise CommandError(
+            f"managed transmit authority refused command {descriptor.name!r}"
+        )
     await method(**{name: intent.params[name] for name in descriptor.argument_names})

--- a/src/rigplane/runtime/managed_tx_authority.py
+++ b/src/rigplane/runtime/managed_tx_authority.py
@@ -9,6 +9,7 @@ from enum import StrEnum
 from functools import partial
 from typing import Any, Protocol
 
+from rigplane.core.command_dispatch import DescriptorTxPolicy, command_descriptor
 from rigplane.core.state_pipeline_contracts import CommandIntent
 from rigplane.runtime.managed_tx_config import (
     ManagedTxTotConfig,
@@ -105,10 +106,6 @@ class ShutdownResult(StrEnum):
 
 
 _ProviderRetirement = Callable[[int], Awaitable[None]]
-
-_ANTENNA_WRITE_NAMES = frozenset(
-    {"set_antenna", "set_antenna_1", "set_antenna_2", "set_rx_antenna"}
-)
 
 
 class ManagedTxAuthority:
@@ -376,12 +373,13 @@ class ManagedTxAuthority:
         """Apply the sole managed-intent relay policy without altering ``intent``."""
         if not isinstance(intent, CommandIntent):
             raise TypeError("managed write admission requires a CommandIntent")
+        descriptor = command_descriptor(intent.name)
         async with self._lock:
             managed_tx = self._state.intent.kind is not ManagedTxIntentKind.RX
             if not managed_tx:
                 return True
-            if intent.name in _ANTENNA_WRITE_NAMES:
-                return False
+            if descriptor is not None:
+                return descriptor.tx_policy is not DescriptorTxPolicy.ANTENNA_SWITCH
             if intent.name == "set_tuner_status":
                 return intent.params.get("value") == 0
             if intent.name == "set_func" and intent.params.get("func") == "TUNER":

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -1,10 +1,12 @@
 import asyncio
 from collections import deque
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from typing import Any, cast
 
 import pytest
 
+from rigplane.core.exceptions import CommandError
 from rigplane.runtime.managed_tx_authority import ManagedTxAuthority, ShutdownResult
 from rigplane.runtime.managed_tx_config import ManagedTxTotConfig
 from rigplane.runtime.managed_tx_effect_lane import ManagedTxEffectLane
@@ -1105,6 +1107,28 @@ async def test_ten_thousand_idempotent_commands_keep_one_scheduler() -> None:
     assert not hasattr(managed, "observed_ptt")
     await managed.force_off()
     await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_managed_admission_fails_closed_for_unrepresentable_descriptor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from rigplane.core import command_dispatch
+    from rigplane.core.state_pipeline_contracts import CommandIntent
+
+    descriptor = command_dispatch.command_descriptor("set_repeater_shift")
+    assert descriptor is not None
+    invalid = replace(descriptor, tx_policy=cast(Any, "relay-ish"))
+    monkeypatch.setattr(
+        command_dispatch, "_COMMAND_DESCRIPTORS", {invalid.name: invalid}
+    )
+    managed, _, _, _, _, _ = authority()
+    command = CommandIntent("unsafe", invalid.name, {"direction": 1}, "test")
+    try:
+        with pytest.raises(CommandError, match="is not admitted"):
+            await managed.admit_managed_write(command)
+    finally:
+        await managed.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_managed_tx_submission_contract.py
+++ b/tests/test_managed_tx_submission_contract.py
@@ -2,7 +2,7 @@ import asyncio
 import gc
 import inspect
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -382,6 +382,25 @@ async def test_managed_antenna_alias_policy_uses_one_descriptor_lookup(
         ) as lookup:
             assert not await managed.admit_managed_write(command)
         lookup.assert_called_once_with(name)
+    finally:
+        await finish(managed)
+
+
+@pytest.mark.asyncio
+async def test_civ_output_executes_unchanged_during_managed_transmit() -> None:
+    from rigplane.core.command_dispatch import (
+        bind_command_intent,
+        execute_command_intent,
+    )
+
+    managed, _, _, _, _, _ = authority()
+    radio = MagicMock()
+    radio.set_civ_output_ant = AsyncMock()
+    command = bind_command_intent("set_civ_output_ant", {"on": True}, source="test")
+    try:
+        assert await managed.transmit_on() is ManagedTxOutcome.ACCEPTED
+        await execute_command_intent(radio, command, managed_tx_authority=managed)
+        radio.set_civ_output_ant.assert_awaited_once_with(enabled=True)
     finally:
         await finish(managed)
 

--- a/tests/test_managed_tx_submission_contract.py
+++ b/tests/test_managed_tx_submission_contract.py
@@ -2,7 +2,7 @@ import asyncio
 import gc
 import inspect
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import create_autospec, patch
 
 import pytest
 
@@ -394,13 +394,16 @@ async def test_civ_output_executes_unchanged_during_managed_transmit() -> None:
     )
 
     managed, _, _, _, _, _ = authority()
-    radio = MagicMock()
-    radio.set_civ_output_ant = AsyncMock()
+
+    class CivOutputRadio:
+        async def set_civ_output_ant(self, on: bool) -> None: ...
+
+    radio = create_autospec(CivOutputRadio, instance=True)
     command = bind_command_intent("set_civ_output_ant", {"on": True}, source="test")
     try:
         assert await managed.transmit_on() is ManagedTxOutcome.ACCEPTED
         await execute_command_intent(radio, command, managed_tx_authority=managed)
-        radio.set_civ_output_ant.assert_awaited_once_with(enabled=True)
+        radio.set_civ_output_ant.assert_awaited_once_with(on=True)
     finally:
         await finish(managed)
 
@@ -416,10 +419,10 @@ async def test_civ_output_executes_unchanged_during_managed_transmit() -> None:
         (intent("set_split_vfo", on=True, tx_vfo="VFOB"), True),
         (intent("set_antenna_1", on=True), False),
         (intent("set_antenna_2", on=False), False),
-        (intent("set_rx_antenna", enabled=True), False),
-        (intent("set_rx_antenna_ant1", enabled=True), False),
-        (intent("set_rx_antenna_ant2", enabled=False), False),
-        (intent("set_civ_output_ant", enabled=True), True),
+        (intent("set_rx_antenna", antenna=2, on=True), False),
+        (intent("set_rx_antenna_ant1", on=True), False),
+        (intent("set_rx_antenna_ant2", on=False), False),
+        (intent("set_civ_output_ant", on=True), True),
         (intent("set_tuner_status", value=1), False),
         (intent("set_tuner_status", value=2), False),
         (intent("set_tuner_status", value=0), True),

--- a/tests/test_managed_tx_submission_contract.py
+++ b/tests/test_managed_tx_submission_contract.py
@@ -2,6 +2,7 @@ import asyncio
 import gc
 import inspect
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -356,6 +357,37 @@ async def test_managed_write_policy_uses_intent_not_observed_ptt() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "name",
+    [
+        "set_antenna",
+        "set_antenna_1",
+        "set_antenna_2",
+        "set_rx_antenna",
+        "set_rx_antenna_ant1",
+        "set_rx_antenna_ant2",
+    ],
+)
+async def test_managed_antenna_alias_policy_uses_one_descriptor_lookup(
+    name: str,
+) -> None:
+    from rigplane.core.command_dispatch import command_descriptor
+
+    managed, _, _, _, _, _ = authority()
+    command = intent(name, enabled=True)
+    try:
+        assert await managed.transmit_on() is ManagedTxOutcome.ACCEPTED
+        with patch(
+            "rigplane.runtime.managed_tx_authority.command_descriptor",
+            wraps=command_descriptor,
+        ) as lookup:
+            assert not await managed.admit_managed_write(command)
+        lookup.assert_called_once_with(name)
+    finally:
+        await finish(managed)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("command", "admitted"),
     [
         (intent("set_band", band="20m"), True),
@@ -366,6 +398,9 @@ async def test_managed_write_policy_uses_intent_not_observed_ptt() -> None:
         (intent("set_antenna_1", on=True), False),
         (intent("set_antenna_2", on=False), False),
         (intent("set_rx_antenna", enabled=True), False),
+        (intent("set_rx_antenna_ant1", enabled=True), False),
+        (intent("set_rx_antenna_ant2", enabled=False), False),
+        (intent("set_civ_output_ant", enabled=True), True),
         (intent("set_tuner_status", value=1), False),
         (intent("set_tuner_status", value=2), False),
         (intent("set_tuner_status", value=0), True),

--- a/tests/test_mor2161_command_dispatch.py
+++ b/tests/test_mor2161_command_dispatch.py
@@ -18,8 +18,8 @@ from rigplane.backends.yaesu_cat.poller import YaesuCatPoller
 from rigplane.core.acquisition_scheduler import AcquisitionScheduler
 from rigplane.core.exceptions import CommandError, CommandRejectedError
 from rigplane.core.exceptions import TimeoutError as RigplaneTimeoutError
-from rigplane.core.state_pipeline_contracts import CommandIntent
 from rigplane.core.command_dispatch import DescriptorTxPolicy
+from rigplane.core.state_pipeline_contracts import CommandIntent
 from rigplane.profiles import resolve_radio_profile
 from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.radio_poller import RadioPoller
@@ -598,6 +598,11 @@ def test_descriptor_is_the_only_migrated_name_source() -> None:
         "set_rf_gain",
         "set_squelch",
         "set_att",
+        "set_antenna_1",
+        "set_antenna_2",
+        "set_rx_antenna_ant1",
+        "set_rx_antenna_ant2",
+        "set_civ_output_ant",
     }
     descriptor = command_descriptors()["set_repeater_shift"]
     assert descriptor.tx_policy is DescriptorTxPolicy.TX_SAFE
@@ -624,6 +629,144 @@ def test_descriptor_is_the_only_migrated_name_source() -> None:
     assert not hasattr(runtime_types, "SetRepeaterShift")
     assert not hasattr(_poller_types, "SetRepeaterShift")
     assert not hasattr(radio_poller, "SetRepeaterShift")
+
+
+@pytest.mark.parametrize(
+    ("name", "method_name", "target"),
+    [
+        ("set_antenna", "set_antenna_1", "global.slow_state.rx_antenna_1"),
+        ("set_antenna_1", "set_antenna_1", "global.slow_state.rx_antenna_1"),
+        ("set_antenna_2", "set_antenna_2", "global.slow_state.rx_antenna_2"),
+        (
+            "set_rx_antenna",
+            "set_rx_antenna_ant1",
+            "global.slow_state.rx_antenna_1",
+        ),
+        (
+            "set_rx_antenna_ant1",
+            "set_rx_antenna_ant1",
+            "global.slow_state.rx_antenna_1",
+        ),
+        (
+            "set_rx_antenna_ant2",
+            "set_rx_antenna_ant2",
+            "global.slow_state.rx_antenna_2",
+        ),
+    ],
+)
+def test_antenna_aliases_share_canonical_descriptor_policy(
+    name: str, method_name: str, target: str
+) -> None:
+    from rigplane.core.command_dispatch import (
+        bind_command_intent,
+        command_descriptor,
+    )
+
+    descriptor = command_descriptor(name)
+    assert descriptor is not None
+    assert descriptor.tx_policy is DescriptorTxPolicy.ANTENNA_SWITCH
+
+    command = bind_command_intent(name, {"on": True}, source="test")
+    assert command.name == method_name
+    assert command.params["on"] is True
+    assert command.params["enabled"] is True
+    assert str(command.target) == target
+
+
+def test_civ_output_ant_is_descriptor_tx_safe() -> None:
+    from rigplane.core.command_dispatch import (
+        bind_command_intent,
+        command_descriptor,
+    )
+
+    descriptor = command_descriptor("set_civ_output_ant")
+    assert descriptor is not None
+    assert descriptor.tx_policy is DescriptorTxPolicy.TX_SAFE
+    command = bind_command_intent(
+        "set_civ_output_ant", {"enabled": False}, source="test"
+    )
+    assert command.name == "set_civ_output_ant"
+    assert command.params["on"] is False
+    assert command.params["enabled"] is False
+
+
+def test_descriptor_lookup_rejects_unrepresentable_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from rigplane.core import command_dispatch
+
+    descriptor = command_dispatch.command_descriptor("set_repeater_shift")
+    assert descriptor is not None
+    invalid = replace(descriptor, tx_policy=cast(Any, "antenna-ish"))
+    monkeypatch.setattr(
+        command_dispatch, "_COMMAND_DESCRIPTORS", {invalid.name: invalid}
+    )
+
+    with pytest.raises(CommandError, match="is not admitted"):
+        command_dispatch.command_descriptor(invalid.name)
+    with pytest.raises(CommandError, match="is not admitted"):
+        command_dispatch.command_descriptors()
+
+
+@pytest.mark.asyncio
+async def test_managed_shared_leaf_admits_exactly_once_before_execution() -> None:
+    from rigplane.core.command_dispatch import (
+        bind_command_intent,
+        execute_command_intent,
+    )
+
+    radio = MagicMock()
+    radio.set_rx_antenna_ant1 = AsyncMock()
+    managed = MagicMock()
+    managed.admit_managed_write = AsyncMock(return_value=True)
+    command = bind_command_intent(
+        "set_rx_antenna_ant1", {"on": True}, source="test"
+    )
+
+    await execute_command_intent(radio, command, managed_tx_authority=managed)
+
+    managed.admit_managed_write.assert_awaited_once_with(command)
+    radio.set_rx_antenna_ant1.assert_awaited_once_with(enabled=True)
+
+
+@pytest.mark.asyncio
+async def test_managed_shared_leaf_refusal_is_immediate_and_not_deferred() -> None:
+    from rigplane.core.command_dispatch import (
+        bind_command_intent,
+        execute_command_intent,
+    )
+
+    radio = MagicMock()
+    radio.set_rx_antenna_ant2 = AsyncMock()
+    managed = MagicMock()
+    managed.admit_managed_write = AsyncMock(return_value=False)
+    command = bind_command_intent(
+        "set_rx_antenna_ant2", {"enabled": False}, source="test"
+    )
+
+    with pytest.raises(CommandError, match="transmit authority"):
+        await execute_command_intent(radio, command, managed_tx_authority=managed)
+
+    managed.admit_managed_write.assert_awaited_once_with(command)
+    radio.set_rx_antenna_ant2.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unmanaged_shared_leaf_remains_direct() -> None:
+    from rigplane.core.command_dispatch import (
+        bind_command_intent,
+        execute_command_intent,
+    )
+
+    radio = MagicMock()
+    radio.set_rx_antenna_ant1 = AsyncMock()
+    command = bind_command_intent(
+        "set_rx_antenna_ant1", {"enabled": True}, source="public_api"
+    )
+
+    await execute_command_intent(radio, command)
+
+    radio.set_rx_antenna_ant1.assert_awaited_once_with(enabled=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mor2161_command_dispatch.py
+++ b/tests/test_mor2161_command_dispatch.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 from dataclasses import replace
 from typing import Any, cast
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, create_autospec
 
 import pytest
 
@@ -600,6 +600,7 @@ def test_descriptor_is_the_only_migrated_name_source() -> None:
         "set_att",
         "set_antenna_1",
         "set_antenna_2",
+        "set_rx_antenna",
         "set_rx_antenna_ant1",
         "set_rx_antenna_ant2",
         "set_civ_output_ant",
@@ -638,11 +639,6 @@ def test_descriptor_is_the_only_migrated_name_source() -> None:
         ("set_antenna_1", "set_antenna_1", "global.slow_state.rx_antenna_1"),
         ("set_antenna_2", "set_antenna_2", "global.slow_state.rx_antenna_2"),
         (
-            "set_rx_antenna",
-            "set_rx_antenna_ant1",
-            "global.slow_state.rx_antenna_1",
-        ),
-        (
             "set_rx_antenna_ant1",
             "set_rx_antenna_ant1",
             "global.slow_state.rx_antenna_1",
@@ -669,8 +665,29 @@ def test_antenna_aliases_share_canonical_descriptor_policy(
     command = bind_command_intent(name, {"on": True}, source="test")
     assert command.name == method_name
     assert command.params["on"] is True
-    assert command.params["enabled"] is True
     assert str(command.target) == target
+
+
+def test_rx_antenna_selector_preserves_antenna_and_public_result_shape() -> None:
+    from rigplane.core.command_dispatch import (
+        bind_command_intent,
+        command_descriptor,
+    )
+
+    descriptor = command_descriptor("set_rx_antenna")
+    assert descriptor is not None
+    assert descriptor.name == "set_rx_antenna"
+    assert descriptor.tx_policy is DescriptorTxPolicy.ANTENNA_SWITCH
+
+    command = bind_command_intent(
+        "set_rx_antenna", {"antenna": 2, "on": True}, source="test"
+    )
+
+    assert command.name == "set_rx_antenna"
+    assert command.params["antenna"] == 2
+    assert command.params["on"] is True
+    assert str(command.target) == "global.slow_state.rx_antenna_2"
+    assert descriptor.result(command) == {"antenna": 2, "on": True}
 
 
 def test_civ_output_ant_is_descriptor_tx_safe() -> None:
@@ -687,7 +704,7 @@ def test_civ_output_ant_is_descriptor_tx_safe() -> None:
     )
     assert command.name == "set_civ_output_ant"
     assert command.params["on"] is False
-    assert command.params["enabled"] is False
+    assert descriptor.result(command) == {"on": False}
 
 
 def test_descriptor_lookup_rejects_unrepresentable_policy(
@@ -715,8 +732,9 @@ async def test_managed_shared_leaf_admits_exactly_once_before_execution() -> Non
         execute_command_intent,
     )
 
-    radio = MagicMock()
-    radio.set_rx_antenna_ant1 = AsyncMock()
+    from rigplane.core.radio_protocol import AntennaControlCapable
+
+    radio = create_autospec(AntennaControlCapable, instance=True)
     managed = MagicMock()
     managed.admit_managed_write = AsyncMock(return_value=True)
     command = bind_command_intent("set_rx_antenna_ant1", {"on": True}, source="test")
@@ -724,7 +742,7 @@ async def test_managed_shared_leaf_admits_exactly_once_before_execution() -> Non
     await execute_command_intent(radio, command, managed_tx_authority=managed)
 
     managed.admit_managed_write.assert_awaited_once_with(command)
-    radio.set_rx_antenna_ant1.assert_awaited_once_with(enabled=True)
+    radio.set_rx_antenna_ant1.assert_awaited_once_with(on=True)
 
 
 @pytest.mark.asyncio
@@ -756,15 +774,46 @@ async def test_unmanaged_shared_leaf_remains_direct() -> None:
         execute_command_intent,
     )
 
-    radio = MagicMock()
-    radio.set_rx_antenna_ant1 = AsyncMock()
+    from rigplane.core.radio_protocol import AntennaControlCapable
+
+    radio = create_autospec(AntennaControlCapable, instance=True)
     command = bind_command_intent(
         "set_rx_antenna_ant1", {"enabled": True}, source="public_api"
     )
 
     await execute_command_intent(radio, command)
 
-    radio.set_rx_antenna_ant1.assert_awaited_once_with(enabled=True)
+    radio.set_rx_antenna_ant1.assert_awaited_once_with(on=True)
+
+
+@pytest.mark.asyncio
+async def test_web_rx_antenna_selector_two_reaches_ant2_and_preserves_ack() -> None:
+    radio = _radio()
+    radio.set_rx_antenna_ant1 = AsyncMock()
+    radio.set_rx_antenna_ant2 = AsyncMock()
+    server = WebServer(radio, WebConfig())
+    ws = _Ws()
+    handler = ControlHandler(ws, radio, "test", "FTX-1", server=server)  # type: ignore[arg-type]
+
+    request = asyncio.create_task(
+        handler._dispatch_command(  # noqa: SLF001
+            "rx-ant", "set_rx_antenna", {"antenna": 2, "on": True}
+        )
+    )
+    await asyncio.sleep(0)
+    assert not request.done()
+
+    await _drain_yaesu(server, radio)
+    await request
+
+    radio.set_rx_antenna_ant1.assert_not_awaited()
+    radio.set_rx_antenna_ant2.assert_awaited_once_with(on=True)
+    assert ws.messages[-1] == {
+        "type": "response",
+        "id": "rx-ant",
+        "ok": True,
+        "result": {"antenna": 2, "on": True},
+    }
 
 
 def test_antenna_descriptor_preflight_preserves_profile_rejection() -> None:

--- a/tests/test_mor2161_command_dispatch.py
+++ b/tests/test_mor2161_command_dispatch.py
@@ -719,9 +719,7 @@ async def test_managed_shared_leaf_admits_exactly_once_before_execution() -> Non
     radio.set_rx_antenna_ant1 = AsyncMock()
     managed = MagicMock()
     managed.admit_managed_write = AsyncMock(return_value=True)
-    command = bind_command_intent(
-        "set_rx_antenna_ant1", {"on": True}, source="test"
-    )
+    command = bind_command_intent("set_rx_antenna_ant1", {"on": True}, source="test")
 
     await execute_command_intent(radio, command, managed_tx_authority=managed)
 
@@ -767,6 +765,24 @@ async def test_unmanaged_shared_leaf_remains_direct() -> None:
     await execute_command_intent(radio, command)
 
     radio.set_rx_antenna_ant1.assert_awaited_once_with(enabled=True)
+
+
+def test_antenna_descriptor_preflight_preserves_profile_rejection() -> None:
+    from rigplane.core.command_dispatch import (
+        CommandUnsupportedError,
+        prepare_command_intent,
+    )
+
+    radio = _radio(supported=False)
+    radio.set_rx_antenna_ant1 = AsyncMock()
+
+    with pytest.raises(CommandUnsupportedError, match="active profile"):
+        prepare_command_intent(
+            radio, "set_rx_antenna_ant1", {"on": True}, source="test"
+        )
+
+    radio.supports_command.assert_called_once_with("set_rx_antenna_ant1")
+    radio.set_rx_antenna_ant1.assert_not_awaited()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mor2161_command_dispatch.py
+++ b/tests/test_mor2161_command_dispatch.py
@@ -746,6 +746,28 @@ async def test_managed_shared_leaf_admits_exactly_once_before_execution() -> Non
 
 
 @pytest.mark.asyncio
+async def test_managed_selector_admission_uses_stable_descriptor_intent_name() -> None:
+    from rigplane.core.command_dispatch import (
+        bind_command_intent,
+        execute_command_intent,
+    )
+    from rigplane.core.radio_protocol import AntennaControlCapable
+
+    radio = create_autospec(AntennaControlCapable, instance=True)
+    managed = MagicMock()
+    managed.admit_managed_write = AsyncMock(return_value=True)
+    command = bind_command_intent(
+        "set_rx_antenna", {"antenna": 2, "on": True}, source="test"
+    )
+
+    assert command.name == "set_rx_antenna"
+    await execute_command_intent(radio, command, managed_tx_authority=managed)
+
+    managed.admit_managed_write.assert_awaited_once_with(command)
+    radio.set_rx_antenna_ant2.assert_awaited_once_with(on=True)
+
+
+@pytest.mark.asyncio
 async def test_managed_shared_leaf_refusal_is_immediate_and_not_deferred() -> None:
     from rigplane.core.command_dispatch import (
         bind_command_intent,


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-2306

## Summary

- add one `ANTENNA_SWITCH` descriptor policy for exact RX antenna operations and their public aliases
- preserve the selector form `set_rx_antenna {antenna, on}` as a distinct descriptor that resolves Ant1/Ant2 without losing its public result shape
- classify `set_civ_output_ant` as `TX_SAFE`
- inject optional managed-TX admission once at the shared execution leaf and fail closed for invalid descriptor policies

## Compatibility

- direct unmanaged callers remain direct when no authority is injected
- provider/profile support validation remains before execution
- no provider, profile, Web, CLI, composition, or fake-wire changes
- no hardware or TX validation

## Verification

- RED: focused run 33826813242 at `abe6bc8751f00262afcbe363f3c9e416694303e1` — 21 failed, 129 passed as expected
- Prior-head GREEN: focused run 33827912833 at `0a7b049b27766cd4f7dd2bcd34f65b105db73cf7` — successful, but stale after independent-review corrections
- Review correction head: `79eb528db42356009bb6d811ab07769d9300dfa4` — discriminating RED tests added first; selector intent identity is stable through shared admission; Ruff check and format check passed across all five leased files
- No new project test run or CI dispatch on the correction head while runner operations are unavailable, per coordinator instruction

## Activation dependency

**Do not merge or activate this PR alone.** Registering these descriptors makes the generic consumer path recognize the operations, while the dependent consumer change must inject this same `ManagedTxAuthority` at the shared leaf. Integrate with the consumer wiring so no fail-open intermediate is deployed.

Fake-wire work and retirement of the superseded TX interlock remain separate follow-ups.
