### PR TITLE
feat(MOR-2168): expose managed transmit HTTP ingress

### DIFF
--- a/src/rigplane/web/api_contract.py
+++ b/src/rigplane/web/api_contract.py
@@ -76,6 +76,24 @@ STABLE_HTTP_ENDPOINTS: Final[tuple[HttpEndpoint, ...]] = (
     },
     {
         "method": "GET",
+        "path": "/api/v1/managed-transmit",
+        "purpose": "managed transmit authority snapshot",
+        "auth": "bearer",
+    },
+    {
+        "method": "POST",
+        "path": "/api/v1/managed-transmit/command",
+        "purpose": "submit latched transmit or force-off intent",
+        "auth": "bearer",
+    },
+    {
+        "method": "PUT",
+        "path": "/api/v1/managed-transmit/tot",
+        "purpose": "update managed transmit time-out",
+        "auth": "bearer",
+    },
+    {
+        "method": "GET",
         "path": "/api/v1/bridge",
         "purpose": "audio bridge status",
         "auth": "bearer",
@@ -188,6 +206,25 @@ RESPONSE_FIELD_CONTRACTS: Final[dict[str, ResponseFieldContract]] = {
             "filters",
             "audioConfig",
             "webrtc",
+        )
+    },
+    "/api/v1/managed-transmit": {
+        "required": (
+            "schemaVersion",
+            "sampledAt",
+            "managedTransmit",
+            "txObservation",
+        )
+    },
+    "/api/v1/managed-transmit/command": {
+        "required": ("ok", "operation", "result")
+    },
+    "/api/v1/managed-transmit/tot": {
+        "required": (
+            "schemaVersion",
+            "sampledAt",
+            "managedTransmit",
+            "txObservation",
         )
     },
     "/api/v1/commands": {"required": ("ok", "name", "result")},

--- a/src/rigplane/web/api_contract.py
+++ b/src/rigplane/web/api_contract.py
@@ -216,9 +216,7 @@ RESPONSE_FIELD_CONTRACTS: Final[dict[str, ResponseFieldContract]] = {
             "txObservation",
         )
     },
-    "/api/v1/managed-transmit/command": {
-        "required": ("ok", "operation", "result")
-    },
+    "/api/v1/managed-transmit/command": {"required": ("ok", "operation", "result")},
     "/api/v1/managed-transmit/tot": {
         "required": (
             "schemaVersion",

--- a/src/rigplane/web/managed_tx_view.py
+++ b/src/rigplane/web/managed_tx_view.py
@@ -14,12 +14,24 @@ __all__ = ["build_managed_tx_view"]
 
 
 def build_managed_tx_view(
-    projection: ManagedTxProjection,
+    projection: ManagedTxProjection | None,
     observed_ptt: ObservedPtt,
     *,
     sampled_at: datetime,
 ) -> dict[str, object]:
     """Serialize one authority snapshot and independent observed PTT evidence."""
+
+    sampled_at_text = _utc_milliseconds(sampled_at)
+    if projection is None:
+        return {
+            "schemaVersion": 1,
+            "sampledAt": sampled_at_text,
+            "managedTransmit": {
+                "status": "unavailable",
+                "reason": "authority_not_composed",
+            },
+            "txObservation": {"observedPtt": observed_ptt.value},
+        }
 
     state = projection.state
     has_deadline = state.tot_deadline_monotonic is not None
@@ -30,7 +42,6 @@ def build_managed_tx_view(
     remaining_ms = (
         None if not active else max(0, floor(projection.remaining_tot_seconds * 1000))
     )
-    sampled_at_text = _utc_milliseconds(sampled_at)
     return {
         "schemaVersion": 1,
         "sampledAt": sampled_at_text,

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -35,6 +35,7 @@ import time
 import urllib.parse
 from collections.abc import Callable, Collection, Coroutine
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from inspect import getattr_static
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TextIO
 
@@ -67,6 +68,7 @@ from ..core.state_pipeline_contracts import (
     SourceMetadata,
 )
 from ..core.state_store import StateSnapshot, StateStore
+from ..core.tx_observation import project_observed_ptt
 from ..radio_state import RadioState
 from ..capabilities import CAP_AUDIO
 from ..exceptions import TimeoutError as RigplaneTimeoutError
@@ -91,6 +93,7 @@ from .handlers import (  # noqa: TID251
     ScopeHandler,
 )
 from .handlers.audio import browser_tx_audio_facts  # noqa: TID251
+from .managed_tx_view import build_managed_tx_view  # noqa: TID251
 from .transport.webrtc import webrtc_available  # noqa: TID251
 from .radio_poller import (  # noqa: TID251
     CommandQueue,
@@ -3970,6 +3973,126 @@ class WebServer:
             )
             return None
         return payload
+
+    def _managed_tx_authority(self) -> Any | None:
+        port = self._production_managed_tx_port
+        return None if port is None else getattr(port, "authority", None)
+
+    async def _managed_tx_document(self) -> dict[str, object]:
+        authority = self._managed_tx_authority()
+        projection = None if authority is None else await authority.snapshot()
+        observed_ptt = project_observed_ptt(self.command_state_store.snapshot())
+        return build_managed_tx_view(
+            projection,
+            observed_ptt,
+            sampled_at=datetime.now(UTC),
+        )
+
+    async def _managed_tx_unavailable(self, writer: asyncio.StreamWriter) -> None:
+        await self._send_json(
+            writer,
+            503,
+            "Service Unavailable",
+            {
+                "error": "managed_tx_unavailable",
+                "message": "Managed transmit authority unavailable",
+            },
+        )
+
+    async def _handle_http_managed_tx(
+        self,
+        path: str,
+        writer: asyncio.StreamWriter,
+        headers: dict[str, str] | None = None,
+        reader: asyncio.StreamReader | None = None,
+    ) -> None:
+        if path == "/api/v1/managed-transmit":
+            await self._send_json(writer, 200, "OK", await self._managed_tx_document())
+            return
+
+        authority = self._managed_tx_authority()
+        if authority is None:
+            await self._managed_tx_unavailable(writer)
+            return
+        payload = await self._read_json_object(writer, headers, reader)
+        if payload is None:
+            return
+
+        if path == "/api/v1/managed-transmit/command":
+            operation = payload.get("operation")
+            if (
+                set(payload) != {"operation"}
+                or type(operation) is not str
+                or operation not in {"transmit_on", "force_off"}
+            ):
+                await self._send_json(
+                    writer,
+                    400,
+                    "Bad Request",
+                    {
+                        "error": "invalid_request",
+                        "message": "operation must be transmit_on or force_off",
+                    },
+                )
+                return
+            if operation == "transmit_on" and self._config.read_only:
+                await self._send_json(
+                    writer,
+                    403,
+                    "Forbidden",
+                    {
+                        "error": "read_only",
+                        "message": "Server is in read-only mode",
+                    },
+                )
+                return
+            try:
+                submission = (
+                    await authority.submit_transmit_on()
+                    if operation == "transmit_on"
+                    else await authority.submit_force_off()
+                )
+            except RuntimeError:
+                await self._managed_tx_unavailable(writer)
+                return
+            accepted = submission.outcome.value == "accepted"
+            await self._send_json(
+                writer,
+                202 if accepted else 409,
+                "Accepted" if accepted else "Conflict",
+                {
+                    "ok": accepted,
+                    "operation": operation,
+                    "result": "accepted" if accepted else "rejected",
+                },
+            )
+            return
+
+        if set(payload) != {"configuredSeconds"}:
+            await self._send_json(
+                writer,
+                400,
+                "Bad Request",
+                {
+                    "error": "invalid_request",
+                    "message": "configuredSeconds is required",
+                },
+            )
+            return
+        try:
+            await authority.set_tot_seconds(payload["configuredSeconds"])
+        except ValueError as exc:
+            await self._send_json(
+                writer,
+                400,
+                "Bad Request",
+                {"error": "invalid_request", "message": str(exc)},
+            )
+            return
+        except RuntimeError:
+            await self._managed_tx_unavailable(writer)
+            return
+        await self._send_json(writer, 200, "OK", await self._managed_tx_document())
 
     def _control_handler_for(self, *, server: Any | None = None) -> ControlHandler:
         return ControlHandler(

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -4089,6 +4089,17 @@ class WebServer:
                 {"error": "invalid_request", "message": str(exc)},
             )
             return
+        except OSError:
+            await self._send_json(
+                writer,
+                500,
+                "Internal Server Error",
+                {
+                    "error": "managed_tx_config_error",
+                    "message": "Managed transmit TOT configuration could not be saved",
+                },
+            )
+            return
         except RuntimeError:
             await self._managed_tx_unavailable(writer)
             return

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -125,6 +125,7 @@ if TYPE_CHECKING:
 
     from ..profiles import RadioProfile
     from ..radio_protocol import Radio
+    from ..runtime.radio import ManagedTxCompositionPort
     from .transport.webrtc_session import WebRtcSessionManager  # noqa: TID251
 
 __all__ = ["WebConfig", "WebServer", "run_web_server"]
@@ -826,6 +827,7 @@ class WebServer:
         self._hardware_scope_available = _supports_scope(radio)
         # Gated WebRTC transport session manager (A2.3 / MOR-307). Lazily
         # constructed on first use so the import stays out of the no-extra path.
+        self._production_managed_tx_port: ManagedTxCompositionPort | None = None
         self._webrtc_sessions: WebRtcSessionManager | None = None
         # Audio FFT scope: available when radio has audio capability.
         # For non-hardware-scope radios, also feeds /api/v1/scope (legacy).

--- a/src/rigplane/web/web_routing.py
+++ b/src/rigplane/web/web_routing.py
@@ -82,6 +82,22 @@ async def dispatch_http_request(
         return
 
     # Routes that accept POST/DELETE
+    if path in (
+        "/api/v1/managed-transmit",
+        "/api/v1/managed-transmit/command",
+        "/api/v1/managed-transmit/tot",
+    ):
+        expected_methods = {
+            "/api/v1/managed-transmit": ("GET", "HEAD"),
+            "/api/v1/managed-transmit/command": ("POST",),
+            "/api/v1/managed-transmit/tot": ("PUT",),
+        }[path]
+        if method not in expected_methods:
+            await _send_response(writer, 405, "Method Not Allowed", b"", {})
+            return
+        await server._handle_http_managed_tx(path, writer, headers, reader)
+        return
+
     if path == "/api/v1/bridge":
         if method not in ("GET", "HEAD", "POST", "DELETE"):
             await _send_response(writer, 405, "Method Not Allowed", b"", {})

--- a/src/rigplane/web/web_routing.py
+++ b/src/rigplane/web/web_routing.py
@@ -88,7 +88,7 @@ async def dispatch_http_request(
         "/api/v1/managed-transmit/tot",
     ):
         expected_methods = {
-            "/api/v1/managed-transmit": ("GET", "HEAD"),
+            "/api/v1/managed-transmit": ("GET",),
             "/api/v1/managed-transmit/command": ("POST",),
             "/api/v1/managed-transmit/tot": ("PUT",),
         }[path]

--- a/tests/test_managed_tx_http_route.py
+++ b/tests/test_managed_tx_http_route.py
@@ -67,6 +67,7 @@ class _Authority:
         self.submissions: list[_Submission] = []
         self.configured_tot_seconds: float | None = 180.0
         self.next_outcome = ManagedTxOutcome.ACCEPTED
+        self.tot_error: OSError | None = None
 
     async def snapshot(self) -> ManagedTxProjection:
         self.calls.append("snapshot")
@@ -96,6 +97,8 @@ class _Authority:
 
     async def set_tot_seconds(self, value: object) -> ManagedTxTotConfig:
         self.calls.append(("set_tot_seconds", value))
+        if self.tot_error is not None:
+            raise self.tot_error
         if value == "invalid":
             raise ValueError("invalid TOT")
         self.configured_tot_seconds = None if value in (None, 0) else float(value)
@@ -285,6 +288,47 @@ async def test_tot_update_round_trips_through_the_authority_snapshot() -> None:
     assert isinstance(tot, dict)
     assert tot["configuredSeconds"] == 45.0
     assert authority.calls == [("set_tot_seconds", 45), "snapshot"]
+
+
+@pytest.mark.asyncio
+async def test_tot_persistence_failure_returns_stable_json_error() -> None:
+    authority = _Authority()
+    authority.tot_error = OSError("disk full")
+    server = _server(authority)
+    reader, headers = _reader({"configuredSeconds": 45})
+    writer = _Writer()
+
+    await server._handle_http(  # noqa: SLF001
+        writer,  # type: ignore[arg-type]
+        "PUT",
+        "/api/v1/managed-transmit/tot",
+        headers=headers,
+        reader=reader,
+    )
+
+    assert writer.status == 500
+    assert writer.payload == {
+        "error": "managed_tx_config_error",
+        "message": "Managed transmit TOT configuration could not be saved",
+    }
+    assert authority.calls == [("set_tot_seconds", 45)]
+
+
+@pytest.mark.asyncio
+async def test_managed_transmit_snapshot_rejects_head_instead_of_sending_json() -> None:
+    authority = _Authority()
+    server = _server(authority)
+    writer = _Writer()
+
+    await server._handle_http(  # noqa: SLF001
+        writer,  # type: ignore[arg-type]
+        "HEAD",
+        "/api/v1/managed-transmit",
+    )
+
+    assert writer.status == 405
+    assert writer.payload == {}
+    assert authority.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_managed_tx_http_route.py
+++ b/tests/test_managed_tx_http_route.py
@@ -1,0 +1,353 @@
+"""HTTP ingress contracts for the composed managed-transmit authority."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from dataclasses import dataclass
+
+import pytest
+
+from rigplane.core.state_pipeline_contracts import Observation, SourceMetadata
+from rigplane.core.tx_observation import OBSERVED_PTT_PATH, ObservedPtt
+from rigplane.runtime.managed_tx_authority import ManagedTxProjection
+from rigplane.runtime.managed_tx_config import ManagedTxTotConfig
+from rigplane.runtime.managed_tx_state import (
+    ManagedTxIntent,
+    ManagedTxIntentKind,
+    ManagedTxOutcome,
+    ManagedTxState,
+    ReleasePlan,
+)
+from rigplane.web.server import WebConfig, WebServer
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        return None
+
+    @property
+    def status(self) -> int:
+        return int(self.buffer.split(b" ", 2)[1])
+
+    @property
+    def payload(self) -> dict[str, object]:
+        body = self.buffer.split(b"\r\n\r\n", 1)[1]
+        return json.loads(body or b"{}")
+
+
+def _reader(payload: dict[str, object]) -> tuple[asyncio.StreamReader, dict[str, str]]:
+    body = json.dumps(payload).encode()
+    reader = asyncio.StreamReader()
+    reader.feed_data(body)
+    reader.feed_eof()
+    return reader, {"content-length": str(len(body))}
+
+
+@dataclass
+class _Submission:
+    outcome: ManagedTxOutcome
+    settlement_waits: int = 0
+
+    async def wait_settlement(self) -> None:
+        self.settlement_waits += 1
+        raise AssertionError("HTTP admission waited for provider settlement")
+
+
+class _Authority:
+    def __init__(self) -> None:
+        self.calls: list[object] = []
+        self.submissions: list[_Submission] = []
+        self.configured_tot_seconds: float | None = 180.0
+        self.next_outcome = ManagedTxOutcome.ACCEPTED
+
+    async def snapshot(self) -> ManagedTxProjection:
+        self.calls.append("snapshot")
+        return ManagedTxProjection(
+            ManagedTxState(
+                intent=ManagedTxIntent(ManagedTxIntentKind.TRANSMIT),
+                release_plan=ReleasePlan.PTT_RELEASE,
+                tx_started_at_monotonic=10.0,
+                tot_deadline_monotonic=20.0,
+            ),
+            self.configured_tot_seconds,
+            5.25,
+            provider_generation=7,
+        )
+
+    async def submit_transmit_on(self) -> _Submission:
+        self.calls.append("transmit_on")
+        submission = _Submission(self.next_outcome)
+        self.submissions.append(submission)
+        return submission
+
+    async def submit_force_off(self) -> _Submission:
+        self.calls.append("force_off")
+        submission = _Submission(self.next_outcome)
+        self.submissions.append(submission)
+        return submission
+
+    async def set_tot_seconds(self, value: object) -> ManagedTxTotConfig:
+        self.calls.append(("set_tot_seconds", value))
+        if value == "invalid":
+            raise ValueError("invalid TOT")
+        self.configured_tot_seconds = None if value in (None, 0) else float(value)
+        return ManagedTxTotConfig(self.configured_tot_seconds)
+
+
+def _server(
+    authority: _Authority | None,
+    *,
+    read_only: bool = False,
+) -> WebServer:
+    server = WebServer(
+        None,
+        WebConfig(host="127.0.0.1", port=0, read_only=read_only),
+    )
+    if authority is not None:
+        server._production_managed_tx_port = type(  # noqa: SLF001
+            "_Port", (), {"authority": authority}
+        )()
+    return server
+
+
+def _observe(server: WebServer, value: ObservedPtt) -> None:
+    now = time.monotonic()
+    server.command_state_store.apply_current(
+        Observation(
+            path=OBSERVED_PTT_PATH,
+            value=value,
+            source=SourceMetadata(source="poll_response", provider="test"),
+            timestamp_monotonic=now,
+            max_age=30.0,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_projects_one_authority_snapshot_and_separate_observation() -> None:
+    authority = _Authority()
+    server = _server(authority)
+    _observe(server, ObservedPtt.OFF)
+    writer = _Writer()
+
+    await server._handle_http(  # noqa: SLF001
+        writer,  # type: ignore[arg-type]
+        "GET",
+        "/api/v1/managed-transmit",
+    )
+
+    assert writer.status == 200
+    managed = writer.payload["managedTransmit"]
+    assert isinstance(managed, dict)
+    tot = managed["tot"]
+    assert isinstance(tot, dict)
+    expires_at = tot["expiresAt"]
+    assert isinstance(expires_at, str)
+    assert managed == {
+        "status": "available",
+        "intent": {"kind": "transmit"},
+        "releaseRequired": True,
+        "lastError": None,
+        "lastActuation": None,
+        "abortErrors": [],
+        "tot": {
+            "configuredSeconds": 180.0,
+            "active": True,
+            "remainingMs": 5250,
+            "expiresAt": expires_at,
+        },
+    }
+    assert writer.payload["txObservation"] == {"observedPtt": "off"}
+    assert authority.calls == ["snapshot"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("observed", (ObservedPtt.OFF, ObservedPtt.ON))
+async def test_transmit_on_returns_admission_without_observation_gating_or_settlement(
+    observed: ObservedPtt,
+) -> None:
+    authority = _Authority()
+    server = _server(authority)
+    _observe(server, observed)
+    reader, headers = _reader({"operation": "transmit_on"})
+    writer = _Writer()
+
+    await server._handle_http(  # noqa: SLF001
+        writer,  # type: ignore[arg-type]
+        "POST",
+        "/api/v1/managed-transmit/command",
+        headers=headers,
+        reader=reader,
+    )
+
+    assert writer.status == 202
+    assert writer.payload == {
+        "ok": True,
+        "operation": "transmit_on",
+        "result": "accepted",
+    }
+    assert authority.calls == ["transmit_on"]
+    assert authority.submissions[0].settlement_waits == 0
+
+
+@pytest.mark.asyncio
+async def test_rejected_transmit_admission_maps_to_conflict() -> None:
+    authority = _Authority()
+    authority.next_outcome = ManagedTxOutcome.REJECTED
+    server = _server(authority)
+    reader, headers = _reader({"operation": "transmit_on"})
+    writer = _Writer()
+
+    await server._handle_http(  # noqa: SLF001
+        writer,  # type: ignore[arg-type]
+        "POST",
+        "/api/v1/managed-transmit/command",
+        headers=headers,
+        reader=reader,
+    )
+
+    assert writer.status == 409
+    assert writer.payload == {
+        "ok": False,
+        "operation": "transmit_on",
+        "result": "rejected",
+    }
+    assert authority.submissions[0].settlement_waits == 0
+
+
+@pytest.mark.asyncio
+async def test_force_off_is_unconditional_even_for_read_only_observed_rx() -> None:
+    authority = _Authority()
+    server = _server(authority, read_only=True)
+    _observe(server, ObservedPtt.OFF)
+    reader, headers = _reader({"operation": "force_off"})
+    writer = _Writer()
+
+    await server._handle_http(  # noqa: SLF001
+        writer,  # type: ignore[arg-type]
+        "POST",
+        "/api/v1/managed-transmit/command",
+        headers=headers,
+        reader=reader,
+    )
+
+    assert writer.status == 202
+    assert authority.calls == ["force_off"]
+    assert authority.submissions[0].settlement_waits == 0
+
+
+@pytest.mark.asyncio
+async def test_read_only_refuses_transmit_on_before_authority_admission() -> None:
+    authority = _Authority()
+    server = _server(authority, read_only=True)
+    reader, headers = _reader({"operation": "transmit_on"})
+    writer = _Writer()
+
+    await server._handle_http(  # noqa: SLF001
+        writer,  # type: ignore[arg-type]
+        "POST",
+        "/api/v1/managed-transmit/command",
+        headers=headers,
+        reader=reader,
+    )
+
+    assert writer.status == 403
+    assert authority.calls == []
+
+
+@pytest.mark.asyncio
+async def test_tot_update_round_trips_through_the_authority_snapshot() -> None:
+    authority = _Authority()
+    server = _server(authority)
+    reader, headers = _reader({"configuredSeconds": 45})
+    writer = _Writer()
+
+    await server._handle_http(  # noqa: SLF001
+        writer,  # type: ignore[arg-type]
+        "PUT",
+        "/api/v1/managed-transmit/tot",
+        headers=headers,
+        reader=reader,
+    )
+
+    assert writer.status == 200
+    managed = writer.payload["managedTransmit"]
+    assert isinstance(managed, dict)
+    tot = managed["tot"]
+    assert isinstance(tot, dict)
+    assert tot["configuredSeconds"] == 45.0
+    assert authority.calls == [("set_tot_seconds", 45), "snapshot"]
+
+
+@pytest.mark.asyncio
+async def test_missing_composition_projects_unavailable_and_rejects_writes() -> None:
+    server = _server(None)
+    snapshot_writer = _Writer()
+
+    await server._handle_http(  # noqa: SLF001
+        snapshot_writer,  # type: ignore[arg-type]
+        "GET",
+        "/api/v1/managed-transmit",
+    )
+
+    assert snapshot_writer.status == 200
+    assert snapshot_writer.payload["managedTransmit"] == {
+        "status": "unavailable",
+        "reason": "authority_not_composed",
+    }
+    assert snapshot_writer.payload["txObservation"] == {"observedPtt": "unknown"}
+
+    for path, method, payload in (
+        ("/api/v1/managed-transmit/command", "POST", {"operation": "force_off"}),
+        ("/api/v1/managed-transmit/tot", "PUT", {"configuredSeconds": 45}),
+    ):
+        reader, headers = _reader(payload)
+        writer = _Writer()
+        await server._handle_http(  # noqa: SLF001
+            writer,  # type: ignore[arg-type]
+            method,
+            path,
+            headers=headers,
+            reader=reader,
+        )
+        assert writer.status == 503
+        assert writer.payload["error"] == "managed_tx_unavailable"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {"operation": "ptt_on"},
+        {"operation": ["force_off"]},
+        {"operation": "force_off", "observedPtt": "on"},
+        {},
+    ),
+)
+async def test_command_body_accepts_only_latched_transmit_and_force_off(
+    payload: dict[str, object],
+) -> None:
+    authority = _Authority()
+    server = _server(authority)
+    reader, headers = _reader(payload)
+    writer = _Writer()
+
+    await server._handle_http(  # noqa: SLF001
+        writer,  # type: ignore[arg-type]
+        "POST",
+        "/api/v1/managed-transmit/command",
+        headers=headers,
+        reader=reader,
+    )
+
+    assert writer.status == 400
+    assert writer.payload["error"] == "invalid_request"
+    assert authority.calls == []

--- a/tests/test_web_api_contract.py
+++ b/tests/test_web_api_contract.py
@@ -211,6 +211,9 @@ def test_pro_web_api_contract_lists_stable_surface() -> None:
     assert ("GET", "/api/v1/state") in http
     assert ("GET", "/api/v1/capabilities") in http
     assert ("GET", "/api/v1/audio/analysis") in http
+    assert ("GET", "/api/v1/managed-transmit") in http
+    assert ("POST", "/api/v1/managed-transmit/command") in http
+    assert ("PUT", "/api/v1/managed-transmit/tot") in http
     assert ("GET", "/api/v1/bridge") in http
     assert ("POST", "/api/v1/bridge") in http
     assert ("DELETE", "/api/v1/bridge") in http
@@ -241,6 +244,15 @@ def test_pro_web_api_contract_lists_stable_surface() -> None:
         "ok",
         "results",
     )
+    assert RESPONSE_FIELD_CONTRACTS["/api/v1/managed-transmit"]["required"] == (
+        "schemaVersion",
+        "sampledAt",
+        "managedTransmit",
+        "txObservation",
+    )
+    assert RESPONSE_FIELD_CONTRACTS["/api/v1/managed-transmit/command"][
+        "required"
+    ] == ("ok", "operation", "result")
 
 
 def test_command_batch_docs_use_numeric_data_mode_contract() -> None:

--- a/tests/test_web_api_contract.py
+++ b/tests/test_web_api_contract.py
@@ -250,9 +250,11 @@ def test_pro_web_api_contract_lists_stable_surface() -> None:
         "managedTransmit",
         "txObservation",
     )
-    assert RESPONSE_FIELD_CONTRACTS["/api/v1/managed-transmit/command"][
-        "required"
-    ] == ("ok", "operation", "result")
+    assert RESPONSE_FIELD_CONTRACTS["/api/v1/managed-transmit/command"]["required"] == (
+        "ok",
+        "operation",
+        "result",
+    )
 
 
 def test_command_batch_docs_use_numeric_data_mode_contract() -> None:


### PR DESCRIPTION
## Summary

- register the managed-transmit HTTP projection and mutation routes
- keep momentary PTT off HTTP while exposing latched `transmit_on`, unconditional `force_off`, and TOT configuration
- fail closed when managed composition is absent and return stable JSON for persistence failures
- add focused API and route contract coverage

Linear owner: MOR-2168.

## Safety contract

- HTTP does not accept momentary PTT
- `force_off` remains available even in read-only mode and does not trust observed PTT state
- `transmit_on` fails before admission when the managed composition is unavailable
- observed PTT remains diagnostic projection, not authority

## Verification

Independent review returned PASS for source head `0a9e7d02f4dc0b50d015b0fe3705d63742e36d83`. The delivery commits are patch-identical on current `main`: `git range-diff df1645f23564d802dcd83e0495816c1674ca62bd..0a9e7d02f4dc0b50d015b0fe3705d63742e36d83 origin/main..d69f6f32` reports both commits as `=`.

No local product suite or hardware test is claimed. The natural Ready-PR checks are the execution gate.

## Guardrail note

This PR changes 6 files and 611 lines, crossing the 600-line soft threshold by 11 lines while remaining below the hard ceilings. Route registration, API schema, fail-closed persistence behavior, and their executable contract tests form one HTTP boundary and are reviewed as one unit.