### PR TITLE
test(MOR-2168): ready fixtures for managed TX callbacks

### DIFF
--- a/frontend/src/__tests__/app-global-host.component.test.ts
+++ b/frontend/src/__tests__/app-global-host.component.test.ts
@@ -61,6 +61,7 @@ vi.mock('$lib/runtime', async () => {
     },
     get scope() { return { hardwareScopeConnected: false }; },
     bootstrap: h.bootstrap,
+    onTxAudioDied: () => () => {},
   };
   return { runtime: h.runtime };
 });
@@ -78,7 +79,10 @@ vi.mock('../lib/runtime/frontend-runtime', async () => {
     },
   };
 });
-vi.mock('../lib/transport/ws-client', () => ({ onMessage: h.onMessage }));
+vi.mock('../lib/transport/ws-client', () => ({
+  onMessage: h.onMessage,
+  onCommandDelivery: () => () => {},
+}));
 vi.mock('$lib/i18n', () => ({
   t: (key: string) => key,
   messageFromReasonCode: (code: string) => code,

--- a/frontend/src/__tests__/design-language-activation.component.test.ts
+++ b/frontend/src/__tests__/design-language-activation.component.test.ts
@@ -62,6 +62,7 @@ vi.mock('../skins/registry', async (importOriginal) => {
 
 vi.mock('../lib/runtime/frontend-runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return { stateRevision: 1, freshnessRevision: 1, observationSeq: 1, ptt: false }; },
     get caps() { return { tx: true, capabilities: ['tx'] }; },
     bootstrap: h.bootstrap,

--- a/frontend/src/__tests__/lazy-presentation.component.test.ts
+++ b/frontend/src/__tests__/lazy-presentation.component.test.ts
@@ -49,6 +49,7 @@ vi.mock('../skins/registry', () => ({
 
 vi.mock('../lib/runtime/frontend-runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return { stateRevision: 1, freshnessRevision: 1, observationSeq: 1, ptt: false }; },
     get caps() { return { tx: true, capabilities: ['tx'] }; },
     bootstrap: h.bootstrap,

--- a/frontend/src/__tests__/presentation-switch-resources.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-resources.component.test.ts
@@ -81,6 +81,7 @@ vi.mock('$lib/transport/ws-client', () => ({
 }));
 vi.mock('$lib/audio/audio-manager', () => ({
   audioManager: {
+    onTxAudioDied: () => () => {},
     rxEnabled: false,
     startRx: vi.fn(),
     stopRx: vi.fn(),

--- a/frontend/src/components-v2/layout/__tests__/LcdLayout.autostep-lifecycle.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/LcdLayout.autostep-lifecycle.isolated.test.ts
@@ -70,6 +70,7 @@ const rt = vi.hoisted(() => ({ state: null as unknown }));
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return rt.state; },
     caps: null,
     connectionStatus: 'disconnected',

--- a/frontend/src/components-v2/layout/__tests__/LcdLayout.command-bus-migration.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/LcdLayout.command-bus-migration.isolated.test.ts
@@ -49,6 +49,7 @@ const rt = vi.hoisted(() => ({ state: null as unknown }));
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return rt.state; },
     caps: null,
     connectionStatus: 'disconnected',

--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.honesty.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.honesty.isolated.test.ts
@@ -96,7 +96,10 @@ vi.mock('$lib/stores/audio.svelte', () => ({
   })),
 }));
 vi.mock('$lib/audio/audio-manager', () => ({
-  audioManager: { start: vi.fn(), stop: vi.fn(), setVolume: vi.fn(), toggleMute: vi.fn() },
+  audioManager: {
+    onTxAudioDied: () => () => {},
+    start: vi.fn(), stop: vi.fn(), setVolume: vi.fn(), toggleMute: vi.fn(),
+  },
 }));
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   hasTx: vi.fn(() => true), hasDualReceiver: vi.fn(() => false), hasAnyScope: vi.fn(() => false),

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.command-bus-migration.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.command-bus-migration.isolated.test.ts
@@ -64,6 +64,7 @@ const rt = vi.hoisted(() => ({ state: null as unknown }));
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return rt.state; },
     caps: null,
     connectionStatus: 'disconnected',

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -28,6 +28,7 @@ const h = vi.hoisted(() => {
   return {
     ...box,
     runtime: {
+    onTxAudioDied: () => () => {},
       get state() { return h.state; },
       get caps() { return h.caps; },
       connectionStatus: 'disconnected',

--- a/frontend/src/components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts
@@ -103,6 +103,7 @@ const h = vi.hoisted(() => {
             source: null, available: false, resourceSelected: false, demand: 0,
             lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
           },
+          onTxAudioDied: () => () => {},
           bootstrap: async () => () => {},
         };
       })();

--- a/frontend/src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts
@@ -102,7 +102,10 @@ vi.mock('$lib/stores/audio.svelte', () => ({
   getAudioState: vi.fn(() => ({ volume: 50, muted: false, rxEnabled: false, txEnabled: false, micEnabled: false, bridgeRunning: false })),
 }));
 vi.mock('$lib/audio/audio-manager', () => ({
-  audioManager: { start: vi.fn(), stop: vi.fn(), setVolume: vi.fn(), toggleMute: vi.fn() },
+  audioManager: {
+    onTxAudioDied: () => () => {},
+    start: vi.fn(), stop: vi.fn(), setVolume: vi.fn(), toggleMute: vi.fn(),
+  },
 }));
 vi.mock('$lib/utils/tx-permit', () => ({ getTxPermit: vi.fn(() => 'allowed') }));
 vi.mock('$lib/stores/tuning.svelte', () => ({ applyModeDefault: vi.fn() }));

--- a/frontend/src/components-v2/layout/__tests__/tab-traversal.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/tab-traversal.isolated.test.ts
@@ -59,6 +59,7 @@ const rt = vi.hoisted(() => ({ state: null as unknown, caps: null as unknown }))
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return rt.state; },
     get caps() { return rt.caps; },
     connectionStatus: 'disconnected',

--- a/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.isolated.test.ts
@@ -31,6 +31,7 @@ vi.mock('../../../skins/registry', () => ({
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     state: null,
     caps: null,
     connectionStatus: 'disconnected',

--- a/frontend/src/components-v2/wiring/__tests__/cw-keyer-zone-lifecycle.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/cw-keyer-zone-lifecycle.component.test.ts
@@ -61,6 +61,7 @@ vi.mock('$lib/audio/audio-manager', () => ({
 }));
 vi.mock('$lib/runtime/frontend-runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
     get audio() { return h.audio; },

--- a/frontend/src/components-v2/wiring/__tests__/design-language-selector-reachability.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/design-language-selector-reachability.component.test.ts
@@ -105,6 +105,7 @@ const h = vi.hoisted(() => ({
 }));
 vi.mock('$lib/runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
     get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },

--- a/frontend/src/components-v2/wiring/__tests__/semantic-antenna-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-antenna-wiring.component.test.ts
@@ -67,6 +67,7 @@ vi.mock('$lib/audio/audio-manager', () => ({
 }));
 vi.mock('$lib/runtime/frontend-runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
     get audio() { return h.audio; },

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -73,6 +73,7 @@ vi.mock('$lib/audio/audio-manager', () => ({
 }));
 vi.mock('$lib/runtime/frontend-runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
     get audio() { return h.audio; },

--- a/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
@@ -78,6 +78,7 @@ vi.mock('$lib/audio/audio-manager', () => ({
 }));
 vi.mock('$lib/runtime/frontend-runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
     get audio() { return h.audio; },

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -44,6 +44,7 @@ const h = vi.hoisted(() => ({
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
     // MOR-1279 slice 3B: the wiring now also hands the adapter an App-owned

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -38,6 +38,7 @@ const h = vi.hoisted(() => ({
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
     // MOR-1279 slice 3B: the wiring now also hands the adapter an

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -59,6 +59,7 @@ const h = vi.hoisted(() => ({
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
     get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },

--- a/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
@@ -51,6 +51,7 @@ vi.mock('$lib/runtime/commands/radio-intents', async () => {
 });
 vi.mock('$lib/runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
     get audio() { return h.audio; },

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
@@ -83,6 +83,7 @@ vi.mock('$lib/audio/audio-manager', () => ({
 }));
 vi.mock('$lib/runtime/frontend-runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
     get audio() { return h.audio; },

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
@@ -50,6 +50,7 @@ vi.mock('$lib/runtime/commands/radio-intents', async () => {
 });
 vi.mock('$lib/runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
     get audio() { return h.audio; },

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
@@ -69,6 +69,7 @@ const h = vi.hoisted(() => ({
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
     get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -47,6 +47,7 @@ const h = vi.hoisted(() => ({
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
     // MOR-1279 slice 3B: the wiring now also hands the adapter an

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -15,6 +15,7 @@ const group = new Proxy({}, { get: () => h.noop });
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return h.state; }, get caps() { return h.caps; },
     get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
     get connectionAudio() { return false; },

--- a/frontend/src/components-v2/wiring/__tests__/single-receiver-active-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/single-receiver-active-wiring.component.test.ts
@@ -69,6 +69,7 @@ vi.mock('$lib/audio/audio-manager', () => ({
 }));
 vi.mock('$lib/runtime/frontend-runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
     get audio() { return { muted: false, rxEnabled: true, volume: 42 }; },

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -130,6 +130,7 @@ const runtimeHarness = vi.hoisted(() => {
   const runtime = {
     get state() { return state.currentState; },
     get caps() { return state.currentCaps; },
+    onTxAudioDied: () => () => {},
     scope: {
       get hardwareScopeConnected() { return state.mockScopeConnected; },
       subscribeHardware: vi.fn((handler: (frame: TestScopeFrame) => void) => {

--- a/frontend/src/lib/runtime/adapters/__tests__/semantic-surface-handler-binder.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/semantic-surface-handler-binder.isolated.test.ts
@@ -22,6 +22,7 @@ vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => ({
 }));
 vi.mock('$lib/runtime/frontend-runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return tuner.state; },
     get caps() { return tuner.caps; },
   },

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -40,6 +40,7 @@ const h = vi.hoisted(() => ({
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
     // MOR-1279 slice 3B: the wiring now also hands the adapter an App-owned

--- a/frontend/src/skins/lcd-peer-split/__tests__/LcdPeerSplitSkin.component.test.ts
+++ b/frontend/src/skins/lcd-peer-split/__tests__/LcdPeerSplitSkin.component.test.ts
@@ -49,6 +49,7 @@ const rt = vi.hoisted(() => ({ state: null as unknown }));
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return rt.state; },
     caps: null,
     connectionStatus: 'disconnected',

--- a/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
@@ -57,6 +57,7 @@ const h = vi.hoisted(() => ({
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
+    onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
     get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },


### PR DESCRIPTION
Adds required test-harness `onTxAudioDied` and `onCommandDelivery` unsubscribe stubs ahead of the managed TX cutover. Assertions and production code are unchanged.

Validation: changed-file ESLint; focused Vitest (33 files, 726 tests).