### PR TITLE
Fence local CW and tuner work

### DIFF
--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -15,6 +15,8 @@ from ...audio import AudioPacket
 from ...audio.lan_stream import SYNTHETIC_RX_IDENT
 from ...command_spec import CatCommandSpec
 from ...runtime.callable_support import supports_callable
+from ...runtime.local_tx_work import LocalTxWorkRunner
+from ...runtime.managed_tx_fence import TxAbortFence
 from ...runtime.managed_tx_state import (
     AbortOperation,
     ActuationOperation,
@@ -201,6 +203,7 @@ class YaesuCatRadio:
         tx_device: str | None = None,
         audio_sample_rate: int = 48000,
         audio_driver: UsbAudioDriver | None = None,
+        tx_abort_fence: TxAbortFence | None = None,
     ) -> None:
         """Create a YaesuCatRadio instance.
 
@@ -212,6 +215,8 @@ class YaesuCatRadio:
             tx_device: USB audio output device name for TX audio playback.
             audio_sample_rate: Audio sample rate in Hz (default 48000).
             audio_driver: Optional pre-constructed UsbAudioDriver (for testing).
+            tx_abort_fence: Runtime-owned fence for local CW/tuner work. Calls
+                remain unmanaged when omitted.
         """
         self._config: RigConfig = _load_config(profile)
         self._profile_cache: RadioProfile | None = None
@@ -223,6 +228,9 @@ class YaesuCatRadio:
         self._opus_rx_user_callback: Callable[[AudioPacket | None], None] | None = None
         self._pcm_rx_user_callback: Callable[[bytes | None], None] | None = None
         self._audio_sample_rate = audio_sample_rate
+        self._local_tx_work = (
+            LocalTxWorkRunner(tx_abort_fence) if tx_abort_fence is not None else None
+        )
         if audio_driver is None:
             # Lazy import: avoids pulling rigplane.audio.backend (PortAudio,
             # numpy DSP) into top-level package import. PR #1200 / #1194.
@@ -2266,7 +2274,14 @@ class YaesuCatRadio:
             msg_type: Message type character.
             mem: CW message text to send.
         """
-        await self._write("send_cw", type=msg_type, mem=mem)
+        if not mem or self._local_tx_work is None:
+            await self._write("send_cw", type=msg_type, mem=mem)
+            return
+
+        async def write(is_current: Callable[[], bool]) -> None:
+            await self._write("send_cw", type=msg_type, mem=mem, is_current=is_current)
+
+        await self._local_tx_work.run(write)
 
     async def read_break_in_delay(self) -> int:
         """Read CW break-in delay in ms (30–3000) without mutating legacy state."""
@@ -2539,7 +2554,15 @@ class YaesuCatRadio:
 
     async def set_tuner(self, state: int, src: int = 0, typ: int = 0) -> None:
         """Set antenna tuner (AC). state: 0=OFF, 1=ON, 2=tune."""
-        await self._write("set_tuner", src=str(src), type=str(typ), state=str(state))
+        params = {"src": str(src), "type": str(typ), "state": str(state)}
+        if state == 0 or self._local_tx_work is None:
+            await self._write("set_tuner", **params)
+            return
+
+        async def write(is_current: Callable[[], bool]) -> None:
+            await self._write("set_tuner", is_current=is_current, **params)
+
+        await self._local_tx_work.run(write)
 
     # -- Contour / S-DX (CO) -----------------------------------------------
 
@@ -2713,8 +2736,21 @@ class YaesuCatRadio:
             await self.send_cw(" ", "")
             return
         chunk_size = 24
-        for i in range(0, len(text), chunk_size):
-            await self.send_cw(" ", text[i : i + chunk_size])
+        if self._local_tx_work is None:
+            for i in range(0, len(text), chunk_size):
+                await self.send_cw(" ", text[i : i + chunk_size])
+            return
+
+        async def write_chunks(is_current: Callable[[], bool]) -> None:
+            for i in range(0, len(text), chunk_size):
+                await self._write(
+                    "send_cw",
+                    type=" ",
+                    mem=text[i : i + chunk_size],
+                    is_current=is_current,
+                )
+
+        await self._local_tx_work.run(write_chunks)
 
     async def stop_cw_text(self) -> None:
         """Stop CW sending by clearing the keyer buffer."""

--- a/src/rigplane/runtime/local_tx_work.py
+++ b/src/rigplane/runtime/local_tx_work.py
@@ -1,0 +1,50 @@
+"""Abort-fenced execution for local transmit-adjacent provider work."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from .managed_tx_fence import TxAbortFence
+
+__all__ = ["LocalTxWorkRunner"]
+
+
+_T = TypeVar("_T")
+CurrencyCheck = Callable[[], bool]
+LocalTxWork = Callable[[CurrencyCheck], Awaitable[_T]]
+
+
+class LocalTxWorkRunner:
+    """Register one caller-owned operation with an injected abort fence.
+
+    The runner owns no fence, queue, authority, task, or lifecycle.  It only
+    lends the operation a fence token and passes its live currency check down
+    to the provider's transport write.
+    """
+
+    def __init__(self, abort_fence: TxAbortFence) -> None:
+        self._abort_fence = abort_fence
+
+    async def run(self, work: LocalTxWork[_T]) -> _T:
+        task = asyncio.current_task()
+        if task is None:  # pragma: no cover - an async call always has a task
+            raise RuntimeError("local TX work requires an asyncio task")
+
+        token = self._abort_fence.issue()
+
+        def cancel() -> None:
+            task.cancel()
+
+        self._abort_fence.register(token, cancel)
+
+        def is_current() -> bool:
+            return self._abort_fence.is_current(token)
+
+        try:
+            if not is_current():
+                raise asyncio.CancelledError
+            return await work(is_current)
+        finally:
+            self._abort_fence.remove(token)

--- a/tests/test_fenced_local_tx_providers.py
+++ b/tests/test_fenced_local_tx_providers.py
@@ -1,0 +1,140 @@
+"""Provider wiring for fenced local CW and tuner work."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from unittest.mock import AsyncMock
+
+import pytest
+
+from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
+from rigplane.backends.yaesu_cat.transport import CatTransportError
+from rigplane.runtime.managed_tx_fence import TxAbortFence
+from rigplane.runtime.managed_tx_state import (
+    ActuationOperation,
+    ActuationResult,
+    EffectToken,
+)
+
+
+def _fenced_radio(fence: TxAbortFence | None) -> YaesuCatRadio:
+    radio = YaesuCatRadio("/dev/null", tx_abort_fence=fence)
+    transport = radio._transport
+    transport._connected = True
+    transport.flush_rx = AsyncMock(return_value=0)
+    transport._drain_responses = AsyncMock(return_value=0)
+    transport._raw_write = AsyncMock()
+    return radio
+
+
+def _effect_token() -> EffectToken:
+    return EffectToken(1, 1, "force-off-test")
+
+
+async def _hold_transport(
+    radio: YaesuCatRadio,
+) -> tuple[asyncio.Event, asyncio.Task[None]]:
+    acquired = asyncio.Event()
+    release = asyncio.Event()
+
+    async def hold() -> None:
+        async with radio._transport._exchange_gate.exchange():
+            acquired.set()
+            await release.wait()
+
+    task = asyncio.create_task(hold())
+    await acquired.wait()
+    return release, task
+
+
+async def _force_receive(radio: YaesuCatRadio) -> ActuationResult:
+    return await radio.actuate(
+        _effect_token(),
+        ActuationOperation.FORCE_RECEIVE,
+        is_current=lambda: True,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "start_local_work",
+    [
+        pytest.param(lambda radio: radio.send_cw_text("CQ"), id="cw"),
+        pytest.param(lambda radio: radio.set_tuner_status(2), id="tuner"),
+    ],
+)
+async def test_force_receive_bypasses_queued_stale_local_work(
+    start_local_work: Callable[[YaesuCatRadio], Awaitable[None]],
+) -> None:
+    fence = TxAbortFence()
+    radio = _fenced_radio(fence)
+    release, holder = await _hold_transport(radio)
+    local = asyncio.create_task(start_local_work(radio))
+    await asyncio.sleep(0)
+
+    cleanup = fence.force_off()
+    force_receive = asyncio.create_task(_force_receive(radio))
+    await asyncio.sleep(0)
+    release.set()
+
+    assert await force_receive is ActuationResult.ACCEPTED
+    with pytest.raises(CatTransportError, match="no longer current"):
+        await local
+    await holder
+    await cleanup
+
+    radio._transport._raw_write.assert_awaited_once()
+    command = radio._transport._raw_write.await_args.args[0]
+    assert command.startswith("TX0")
+
+
+@pytest.mark.asyncio
+async def test_force_receive_suppresses_remaining_cw_chunks() -> None:
+    fence = TxAbortFence()
+    radio = _fenced_radio(fence)
+    first_drain_started = asyncio.Event()
+    release_first_drain = asyncio.Event()
+    drain_calls = 0
+
+    async def drain(_command: str) -> int:
+        nonlocal drain_calls
+        drain_calls += 1
+        if drain_calls == 1:
+            first_drain_started.set()
+            await release_first_drain.wait()
+        return 0
+
+    radio._transport._drain_responses = drain
+    local = asyncio.create_task(radio.send_cw_text("A" * 25))
+    await first_drain_started.wait()
+
+    cleanup = fence.force_off()
+    force_receive = asyncio.create_task(_force_receive(radio))
+    await asyncio.sleep(0)
+    release_first_drain.set()
+
+    assert await force_receive is ActuationResult.ACCEPTED
+    with pytest.raises(CatTransportError, match="no longer current"):
+        await local
+    await cleanup
+
+    wire_commands = [
+        call.args[0] for call in radio._transport._raw_write.await_args_list
+    ]
+    assert len(wire_commands) == 2
+    assert wire_commands[0].startswith("KY ")
+    assert wire_commands[1].startswith("TX0")
+
+
+@pytest.mark.asyncio
+async def test_unmanaged_calls_keep_the_direct_write_contract() -> None:
+    radio = _fenced_radio(None)
+    radio._transport.write = AsyncMock()
+
+    await radio.send_cw_text("CQ")
+    await radio.set_tuner_status(2)
+
+    assert [call.kwargs for call in radio._transport.write.await_args_list] == [{}, {}]
+    assert radio._transport.write.await_args_list[0].args[0].startswith("KY ")
+    assert radio._transport.write.await_args_list[1].args[0].startswith("AC")

--- a/tests/test_local_tx_work.py
+++ b/tests/test_local_tx_work.py
@@ -1,0 +1,79 @@
+"""Local transmit-adjacent work shares the runtime's abort fence."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+
+import pytest
+
+from rigplane.runtime.local_tx_work import LocalTxWorkRunner
+from rigplane.runtime.managed_tx_fence import TxAbortFence
+
+
+@pytest.mark.asyncio
+async def test_force_off_is_immediate_and_registered_cleanup_cancels_work() -> None:
+    fence = TxAbortFence()
+    runner = LocalTxWorkRunner(fence)
+    started = asyncio.Event()
+    held = asyncio.Event()
+
+    async def work(_is_current: Callable[[], bool]) -> None:
+        started.set()
+        await held.wait()
+
+    task = asyncio.create_task(runner.run(work))
+    await started.wait()
+
+    cleanup = fence.force_off()
+    assert fence.epoch == 1
+    assert not task.done()
+
+    result = await cleanup
+    assert result.failures == ()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, 0.1)
+
+
+@pytest.mark.asyncio
+async def test_work_currency_tracks_the_externally_owned_fence() -> None:
+    fence = TxAbortFence()
+    runner = LocalTxWorkRunner(fence)
+    started = asyncio.Event()
+    release = asyncio.Event()
+    observed: list[bool] = []
+
+    async def work(is_current: Callable[[], bool]) -> None:
+        observed.append(is_current())
+        started.set()
+        await release.wait()
+        observed.append(is_current())
+
+    task = asyncio.create_task(runner.run(work))
+    await started.wait()
+    cleanup = fence.force_off()
+    release.set()
+    await task
+    await cleanup
+
+    assert observed == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_external_task_cancellation_propagates_and_unregisters() -> None:
+    fence = TxAbortFence()
+    runner = LocalTxWorkRunner(fence)
+    started = asyncio.Event()
+
+    async def work(_is_current: Callable[[], bool]) -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(runner.run(work))
+    await started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    result = await fence.force_off()
+    assert result.failures == ()


### PR DESCRIPTION
## Scope

Search-before-write: rg -n "TxAbortFence|LocalTxWorkRunner|send_cw_text|set_tuner_status" src tests found the existing shared TxAbortFence and provider write-currency mechanism; no LocalTxWorkRunner existed.

Topology / owner: PR0 local-fence foundation owned by MOR-2307, based on current main 21a2a83fc71ee1c3aa7a4f855e4ba076de985c9f. Exact head: baf63015b304c422f38c4e967c6c545d2bba4d1a. This PR is the base for the later atomic-composition PR and subsequent A/B work.

Exact manifest:
- src/rigplane/runtime/local_tx_work.py
- src/rigplane/backends/yaesu_cat/radio.py
- tests/test_local_tx_work.py
- tests/test_fenced_local_tx_providers.py

Limits: 4 of 4 allowed files; 313 changed lines (309 additions, 4 deletions) of the 550-line cap.

## Behavior

LocalTxWorkRunner borrows an externally injected TxAbortFence. It owns no authority, fence, queue, task, or lifecycle. Fenced Yaesu local CW/tuner writes pass live currency to the existing transport gate; unmanaged calls retain their direct write behavior. ForceOff invalidates synchronously and remains independent of later cleanup.

## Evidence

- Static: ruff check passed on all four files; ruff format --check passed on all four files; git diff --cached --check passed before commit.
- TDD mutation discrimination (test design, not executed locally): removing fence registration makes test_force_off_is_immediate_and_registered_cleanup_cancels_work fail at its bounded cancellation wait. Removing is_current propagation into provider writes makes test_force_receive_bypasses_queued_stale_local_work and test_force_receive_suppresses_remaining_cw_chunks observe forbidden stale fake-wire writes.
- No local product test suite was run, per the explicit constraint. No hardware, radio, PTT, TX, tune, or CW operation was performed.
- Only the natural GitHub Mini quick run from this non-draft PR is requested; no manual rerun or cancellation.

## Declared non-closure

This does not close Web CW/tune ingress, runtime atomic composition, provider replacement, legacy retirement, rigctld behavior, physical-radio behavior, provider proof, hardware proof, or owner-present TX acceptance. It does not recreate or replace the existing authority, fence, or effect lane.