### PR TITLE
Compose production transmit authority

### DIFF
--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -40,7 +40,7 @@ from pathlib import Path
 import time
 import uuid
 import wave
-from typing import Any
+from typing import Any, cast
 
 logger = logging.getLogger(__name__)
 
@@ -108,6 +108,12 @@ from rigplane.core.radio_protocol import (  # noqa: E402
 )
 from rigplane.core.tx_safety import TxOutcome, TxOwner, TxSource  # noqa: E402
 from rigplane.core.types import Mode, get_audio_capabilities  # noqa: E402
+from rigplane.runtime.managed_tx_effect_lane import ManagedTxActuator  # noqa: E402
+from rigplane.runtime.managed_tx_composition import (  # noqa: E402
+    ManagedTxComposition,
+    ManagedTxCompositionPort,
+    install_managed_tx_composition,
+)
 
 _AUDIO_FRAME_MS = 20
 _PCM_SAMPLE_WIDTH_BYTES = 2
@@ -1869,6 +1875,51 @@ async def _cmd_list_audio_devices(args: argparse.Namespace) -> int:
     return 0
 
 
+async def _shutdown_managed_tx_composition(
+    composition: ManagedTxCompositionPort,
+) -> None:
+    termination = asyncio.Event()
+    shutdown = asyncio.create_task(composition.shutdown(termination))
+    try:
+        await asyncio.wait_for(asyncio.shield(shutdown), timeout=3.0)
+    except TimeoutError:
+        termination.set()
+        await asyncio.shield(shutdown)
+
+
+class _ManagedTxRadioSession:
+    def __init__(
+        self,
+        radio: Any,
+        composition: ManagedTxCompositionPort,
+    ) -> None:
+        self._radio = radio
+        self._composition = composition
+        self._shutdown_task: asyncio.Task[None] | None = None
+
+    async def __aenter__(self) -> Any:
+        entered = await self._radio.__aenter__()
+        await self._composition.transport_ready(entered)
+        return entered
+
+    async def shutdown(self) -> None:
+        task = self._shutdown_task
+        if task is None:
+            task = asyncio.create_task(
+                _shutdown_managed_tx_composition(self._composition)
+            )
+            self._shutdown_task = task
+        await asyncio.shield(task)
+
+    async def __aexit__(self, *exc: object) -> bool:
+        result = False
+        try:
+            await self.shutdown()
+        finally:
+            result = bool(await self._radio.__aexit__(*exc))
+        return result
+
+
 async def _run(args: argparse.Namespace) -> int:
     wants_stats = bool(getattr(args, "stats", False))
     if args.command == "audio" and args.audio_command == "caps" and not wants_stats:
@@ -1925,8 +1976,36 @@ async def _run(args: argparse.Namespace) -> int:
             print(f"Error: {exc}", file=sys.stderr)
             return 1
 
+    managed_tx_composition: ManagedTxCompositionPort | None = None
+    if args.command in ("web", "station"):
+        candidate_composition: ManagedTxComposition | None = None
+        try:
+            import platformdirs
+
+            from rigplane._platformdirs_migration import migrate_legacy_platformdirs
+
+            migrate_legacy_platformdirs()
+            candidate_composition = ManagedTxComposition(
+                cast(ManagedTxActuator, radio),
+                config_path=(
+                    Path(platformdirs.user_config_path("rigplane")) / "managed-tx.json"
+                ),
+            )
+            install_managed_tx_composition(radio, candidate_composition)
+            managed_tx_composition = candidate_composition
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            if candidate_composition is not None:
+                await _shutdown_managed_tx_composition(candidate_composition)
+            print(f"Error: managed TX composition unavailable: {exc}", file=sys.stderr)
+            return 1
+
+    session = (
+        radio
+        if managed_tx_composition is None
+        else _ManagedTxRadioSession(radio, managed_tx_composition)
+    )
     try:
-        async with radio:
+        async with session:
             if args.command == "audio" and args.audio_command == "caps":
                 if CAP_AUDIO not in radio.capabilities:
                     print(
@@ -2033,7 +2112,11 @@ async def _run(args: argparse.Namespace) -> int:
                     return 1
                 return await _cmd_levels(radio, args)
             elif args.command in ("web", "station"):
-                return await _cmd_web(radio, args)
+                return await _cmd_web(
+                    radio,
+                    args,
+                    managed_tx_composition=managed_tx_composition,
+                )
             elif args.command == "scope":
                 return await _cmd_scope(radio, args)
             elif args.command == "serve":
@@ -2075,6 +2158,9 @@ async def _run(args: argparse.Namespace) -> int:
         print(f"Error: {exc}", file=sys.stderr)
         logger.debug("Traceback:", exc_info=True)
         return 1
+    finally:
+        if isinstance(session, _ManagedTxRadioSession):
+            await session.shutdown()
 
 
 def _audio_frame_bytes(
@@ -3496,7 +3582,7 @@ async def _cmd_audio_bridge(radio: Radio, args: argparse.Namespace) -> int:
 
     try:
         bridge = AudioBridge(
-            radio,  # type: ignore[arg-type]
+            radio,
             device_name=args.device,
             tx_device_name=getattr(args, "tx_device", None),
             tx_enabled=not args.rx_only,
@@ -3641,7 +3727,12 @@ async def _cmd_serve(radio: Radio, args: argparse.Namespace) -> int:
     return 0
 
 
-async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
+async def _cmd_web(
+    radio: Radio,
+    args: argparse.Namespace,
+    *,
+    managed_tx_composition: ManagedTxCompositionPort | None = None,
+) -> int:
     import pathlib
 
     from rigplane.web.server import WebConfig, WebServer
@@ -3732,6 +3823,15 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
     config_kwargs["radio_model"] = getattr(radio, "model", "IC-7610")
     config = WebConfig(**config_kwargs)
     server = WebServer(radio, config)
+    if managed_tx_composition is not None:
+        from rigplane.web.web_startup import (
+            attach_managed_tx_composition,
+            prepare_managed_tx_observation_generation,
+        )
+
+        prepare_managed_tx_observation_generation(server)
+        await managed_tx_composition.bind_state_store(server.command_state_store)
+        attach_managed_tx_composition(server, managed_tx_composition)
     runtime_log_path = getattr(args, "runtime_log_path", None)
     if isinstance(runtime_log_path, str) and runtime_log_path:
         server._runtime_log_path = runtime_log_path
@@ -3841,7 +3941,15 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
             wsjtx_data_mode=wsjtx_data_mode,
             wsjtx_data_mod_input=wsjtx_data_mod_input,
         )
-        candidate = RigctldServer(radio, rigctld_config)
+        if managed_tx_composition is None:
+            candidate = RigctldServer(radio, rigctld_config)
+        else:
+            candidate = RigctldServer(
+                radio,
+                rigctld_config,
+                managed_tx_authority=managed_tx_composition.authority,
+                command_service=server.command_service,
+            )
         try:
             await candidate.start()
         except OSError as exc:
@@ -4041,7 +4149,7 @@ def _default_daemon_log_file(*, managed_runtime: bool) -> Path:
     from rigplane.diagnostics._log_paths import resolve_core_log_dir
 
     migrate_legacy_platformdirs()
-    return resolve_core_log_dir() / filename
+    return cast(Path, resolve_core_log_dir() / filename)
 
 
 def main() -> None:

--- a/src/rigplane/runtime/managed_tx_composition.py
+++ b/src/rigplane/runtime/managed_tx_composition.py
@@ -1,0 +1,389 @@
+"""Single production composition root for managed transmit."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from rigplane.core.radio_protocol import ManagedTxSupervisor
+from rigplane.core.state_store import StateStore
+from rigplane.core.tx_safety import (
+    RadioTx,
+    TxOutcome,
+    TxOwner,
+    TxPhase,
+    TxReleaseReason,
+    TxSafetySnapshot,
+    TxTransition,
+)
+from rigplane.runtime.local_tx_work import LocalTxWorkRunner
+from rigplane.runtime.managed_tx_authority import ManagedTxAuthority, ShutdownResult
+from rigplane.runtime.managed_tx_config import ManagedTxTotConfigStore
+from rigplane.runtime.managed_tx_effect_lane import (
+    ManagedTxActuator,
+    ManagedTxEffectLane,
+)
+from rigplane.runtime.managed_tx_fence import TxAbortFence
+from rigplane.runtime.managed_tx_state import ManagedTxIntentKind
+
+
+@dataclass(frozen=True, slots=True)
+class _ProviderEvent:
+    provider_generation: int
+    observation_generation: int
+    transport_identity: object
+
+
+_ProviderHook = Callable[[_ProviderEvent], Awaitable[None]]
+
+
+async def _no_provider_hook(_event: _ProviderEvent) -> None:
+    return None
+
+
+@runtime_checkable
+class ManagedTxCompositionPort(Protocol):
+    @property
+    def authority(self) -> ManagedTxAuthority: ...
+
+    @property
+    def local_tx_work_runner(self) -> LocalTxWorkRunner: ...
+
+    @property
+    def legacy_supervisor(self) -> ManagedTxSupervisor: ...
+
+    async def bind_state_store(self, store: StateStore) -> None: ...
+
+    async def transport_ready(self, identity: object) -> None: ...
+
+    async def transport_unavailable(self, identity: object) -> None: ...
+
+    def validate_state_store(self, store: StateStore) -> None: ...
+
+    async def shutdown(self, termination: asyncio.Event) -> ShutdownResult: ...
+
+
+class _LegacyManagedTxCutoverGate:
+    def __init__(self, authority: ManagedTxAuthority) -> None:
+        self._authority = authority
+
+    async def request_on(self, _owner: TxOwner) -> TxTransition:
+        raise RuntimeError("legacy PTT ON is blocked by production composition")
+
+    async def release_owner(
+        self, _owner: TxOwner, *, reason: TxReleaseReason
+    ) -> TxTransition:
+        del reason
+        submission = await self._authority.submit_force_off()
+        await submission.wait_settlement()
+        projection = await self._authority.snapshot()
+        active = projection.state.intent.kind is not ManagedTxIntentKind.RX
+        snapshot = TxSafetySnapshot(
+            phase=TxPhase.RELEASE_REQUIRED if active else TxPhase.IDLE,
+            radio_tx=RadioTx.UNKNOWN,
+            provider_generation=projection.provider_generation,
+            provider_ready=projection.provider_generation is not None,
+            lease_id=None,
+            owner=None,
+            release_reason=None,
+            terminal_release_reason=None,
+            release_attempt_count=0,
+            release_last_error=projection.state.last_error,
+            active_attempt=None,
+            watchdog_deadline_monotonic=None,
+            watchdog_enabled=False,
+            external_conflict=False,
+        )
+        return TxTransition(TxOutcome.IDEMPOTENT, snapshot)
+
+
+class ManagedTxComposition:
+    """Own the one authority graph and every production provider transition."""
+
+    def __init__(
+        self,
+        actuator: ManagedTxActuator,
+        *,
+        config_path: Path,
+        prepare_provider: _ProviderHook = _no_provider_hook,
+        retire_provider: _ProviderHook = _no_provider_hook,
+    ) -> None:
+        if not isinstance(actuator, ManagedTxActuator):
+            raise TypeError("production managed TX requires a normalized actuator")
+        self._prepare_provider = prepare_provider
+        self._retire_provider = retire_provider
+        self._abort_fence = TxAbortFence()
+        self._local_tx_work_runner = LocalTxWorkRunner(self._abort_fence)
+        self._tot_config_store = ManagedTxTotConfigStore(config_path)
+        self._effect_lane = ManagedTxEffectLane(
+            actuator, poison_generation=self._poison_tx_generation
+        )
+        self._authority = ManagedTxAuthority(
+            self._effect_lane,
+            self._tot_config_store,
+            self._abort_fence,
+            provider_generation=None,
+        )
+        self._legacy_supervisor = _LegacyManagedTxCutoverGate(self._authority)
+        self._state_store: StateStore | None = None
+        self._unsubscribe: Callable[[], None] | None = None
+        self._observation_generation: int | None = None
+        self._live_transport_identity: object | None = None
+        self._stale_transport_identities: list[object] = []
+        self._active_provider: _ProviderEvent | None = None
+        self._events: dict[int, _ProviderEvent] = {}
+        self._retired_generations: set[int] = set()
+        self._next_provider_generation = 0
+        self._transition_lock = asyncio.Lock()
+        self._transition_task: asyncio.Task[None] | None = None
+        self._shutdown_task: asyncio.Task[ShutdownResult] | None = None
+
+    @property
+    def authority(self) -> ManagedTxAuthority:
+        return self._authority
+
+    @property
+    def local_tx_work_runner(self) -> LocalTxWorkRunner:
+        return self._local_tx_work_runner
+
+    @property
+    def legacy_supervisor(self) -> ManagedTxSupervisor:
+        return self._legacy_supervisor
+
+    async def bind_state_store(self, store: StateStore) -> None:
+        if not isinstance(store, StateStore):
+            raise TypeError("managed TX requires the exact Web StateStore")
+        async with self._transition_lock:
+            if self._state_store is not None:
+                raise RuntimeError("managed TX StateStore is already bound")
+            self._state_store = store
+            self._observation_generation = int(store.provider_generation)
+            self._unsubscribe = store.subscribe_provider_generation(
+                self._provider_generation_changed
+            )
+            await self._ensure_current_locked()
+
+    def _provider_generation_changed(self, generation: int) -> None:
+        self._observation_generation = int(generation)
+        identity = self._live_transport_identity
+        if identity is not None:
+            self._stale_transport_identities.append(identity)
+        self._live_transport_identity = None
+        self._poison_active()
+
+    async def transport_ready(self, identity: object) -> None:
+        async with self._transition_lock:
+            if self._shutdown_task is not None:
+                return
+            if any(identity is stale for stale in self._stale_transport_identities):
+                return
+            if self._state_store is None and self._live_transport_identity is not None:
+                return
+            active = self._active_provider
+            if active is not None and active.transport_identity is not identity:
+                self._stale_transport_identities.append(active.transport_identity)
+                self._poison_active()
+            self._live_transport_identity = identity
+            await self._join_transition_locked()
+            await self._ensure_current_locked()
+
+    async def transport_unavailable(self, identity: object) -> None:
+        async with self._transition_lock:
+            if self._shutdown_task is not None:
+                return
+            if self._live_transport_identity is not identity:
+                return
+            self._stale_transport_identities.append(identity)
+            self._live_transport_identity = None
+            self._poison_active()
+            await self._join_transition_locked()
+
+    def validate_state_store(self, store: StateStore) -> None:
+        if self._state_store is not store:
+            raise RuntimeError("managed TX StateStore identity mismatch")
+        generation = int(store.provider_generation)
+        active = self._active_provider
+        if self._observation_generation != generation:
+            raise RuntimeError("managed TX observation generation mismatch")
+        if active is None or active.observation_generation != generation:
+            raise RuntimeError("managed TX provider is not current")
+
+    async def _ensure_current_locked(self) -> None:
+        store = self._state_store
+        identity = self._live_transport_identity
+        if store is None or identity is None or self._active_provider is not None:
+            return
+        observation_generation = int(store.provider_generation)
+        if observation_generation != self._observation_generation:
+            return
+        self._next_provider_generation += 1
+        event = _ProviderEvent(
+            self._next_provider_generation, observation_generation, identity
+        )
+        await self._prepare_provider(event)
+        if not self._candidate_is_current(event):
+            await self._retire_once(event)
+            return
+        try:
+            await self._authority.provider_available(event.provider_generation)
+        except BaseException:
+            await self._retire_once(event)
+            raise
+        if not self._candidate_is_current(event):
+            cleanup = self._authority.start_provider_unavailable()
+            await asyncio.shield(cleanup)
+            await self._retire_once(event)
+            return
+        self._events[event.provider_generation] = event
+        self._active_provider = event
+
+    def _candidate_is_current(self, event: _ProviderEvent) -> bool:
+        store = self._state_store
+        return (
+            self._shutdown_task is None
+            and store is not None
+            and self._live_transport_identity is event.transport_identity
+            and self._observation_generation == event.observation_generation
+            and int(store.provider_generation) == event.observation_generation
+        )
+
+    def _poison_active(self) -> None:
+        event = self._active_provider
+        if event is None:
+            return
+        cleanup = self._authority.start_provider_unavailable()
+        self._active_provider = None
+        previous = self._transition_task
+
+        async def finish() -> None:
+            if previous is not None:
+                await asyncio.shield(previous)
+            await asyncio.shield(cleanup)
+            await self._retire_once(event)
+
+        task = asyncio.create_task(finish())
+        task.add_done_callback(self._harvest)
+        self._transition_task = task
+
+    async def _poison_tx_generation(self, generation: int) -> None:
+        async with self._transition_lock:
+            active = self._active_provider
+            if active is None or active.provider_generation != generation:
+                return
+            identity = self._live_transport_identity
+            if identity is not None:
+                self._stale_transport_identities.append(identity)
+            self._live_transport_identity = None
+            self._poison_active()
+            await self._join_transition_locked()
+
+    async def _retire_once(self, event: _ProviderEvent) -> None:
+        if event.provider_generation in self._retired_generations:
+            return
+        await self._retire_provider(event)
+        self._retired_generations.add(event.provider_generation)
+
+    async def _join_transition_locked(self) -> None:
+        task = self._transition_task
+        if task is not None:
+            await asyncio.shield(task)
+            if self._transition_task is task:
+                self._transition_task = None
+
+    @staticmethod
+    def _harvest(task: asyncio.Task[None]) -> None:
+        if not task.cancelled():
+            task.exception()
+
+    async def shutdown(self, termination: asyncio.Event) -> ShutdownResult:
+        async with self._transition_lock:
+            task = self._shutdown_task
+            if task is None:
+                task = asyncio.create_task(self._complete_shutdown(termination))
+                self._shutdown_task = task
+        return await asyncio.shield(task)
+
+    async def _complete_shutdown(self, termination: asyncio.Event) -> ShutdownResult:
+        try:
+            task = self._transition_task
+            if task is not None:
+                await asyncio.shield(task)
+            if not self._events:
+                await self._authority.close()
+                return ShutdownResult.DRAINED
+            if self._active_provider is None:
+                try:
+                    await self._authority.close()
+                except RuntimeError:
+                    pass
+                else:
+                    return ShutdownResult.DRAINED
+
+            async def retire(generation: int) -> None:
+                event = self._events.get(generation)
+                if event is None:
+                    raise RuntimeError("managed TX retirement lost provider event")
+                await self._retire_once(event)
+
+            result = await self._authority.shutdown(
+                retire_provider=retire, termination=termination
+            )
+            terminal = self._active_provider
+            self._active_provider = None
+            self._live_transport_identity = None
+            if result is ShutdownResult.TERMINATED and terminal is not None:
+                await self._retire_once(terminal)
+            return result
+        finally:
+            unsubscribe, self._unsubscribe = self._unsubscribe, None
+            if unsubscribe is not None:
+                unsubscribe()
+
+
+def install_managed_tx_composition(
+    radio: object, composition: ManagedTxCompositionPort
+) -> None:
+    if getattr(radio, "_managed_tx_composition", None) is not None:
+        raise RuntimeError("managed TX composition is already installed")
+    try:
+        radio_namespace = vars(radio)
+    except TypeError:
+        radio_namespace = {}
+    has_local_tx_work = "_local_tx_work" in radio_namespace
+    prior_local_tx_work = radio_namespace.get("_local_tx_work")
+    if has_local_tx_work and prior_local_tx_work is not None:
+        raise RuntimeError("radio local TX work runner is already installed")
+    installer = getattr(radio, "install_managed_tx_composition", None)
+    raw_set_ptt = getattr(radio, "set_ptt", None)
+    if not callable(raw_set_ptt):
+        raise RuntimeError("radio cannot block raw PTT fallback")
+
+    async def guarded_set_ptt(on: bool) -> None:
+        if type(on) is not bool:
+            raise TypeError("PTT requires a bool")
+        if on:
+            raise RuntimeError("raw PTT ON is blocked by production composition")
+        submission = await composition.authority.submit_force_off()
+        await submission.wait_settlement()
+
+    try:
+        if has_local_tx_work:
+            setattr(radio, "_local_tx_work", composition.local_tx_work_runner)
+        setattr(radio, "set_ptt", guarded_set_ptt)
+        if callable(installer):
+            installer(composition)
+        else:
+            setattr(radio, "_managed_tx_composition", composition)
+            setattr(radio, "managed_tx", composition.legacy_supervisor)
+        if getattr(radio, "_managed_tx_composition", None) is not composition:
+            raise RuntimeError("radio did not retain the managed TX composition")
+    except BaseException:
+        setattr(radio, "set_ptt", raw_set_ptt)
+        if has_local_tx_work:
+            setattr(radio, "_local_tx_work", prior_local_tx_work)
+        if getattr(radio, "_managed_tx_composition", None) is composition:
+            setattr(radio, "_managed_tx_composition", None)
+        raise

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -17,15 +17,16 @@ import logging
 import os
 import socket as _socket
 import time
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Literal, cast
 
 if TYPE_CHECKING:
-    from typing import Any, Awaitable, Callable
+    from typing import Any
 
     from rigplane._runtime_protocols import ControlPhaseHost
     from rigplane.core.acquisition_scheduler import RadioStateModelService
-    from rigplane.core.radio_protocol import ManagedTxSupervisor
-    from rigplane.core.tx_safety import ProviderPttObservation, TxSafetySnapshot
+    from rigplane.core.tx_safety import ProviderPttObservation
+    from rigplane.runtime.managed_tx_composition import ManagedTxCompositionPort
 
     def _managed_tx_runtime_satisfies_supervisor(
         runtime: ManagedRadioRuntime,
@@ -173,13 +174,17 @@ from rigplane.commands import get_repeater_tone as _get_repeater_tone_cmd
 from rigplane.commands import get_repeater_tsql as _get_repeater_tsql_cmd
 from rigplane.core.env_config import get_managed_tx_enabled
 from rigplane.core.exceptions import CommandError, TimeoutError
+from rigplane.core.radio_protocol import ManagedTxSupervisor
 from rigplane.core.state_store import StateStore
 from rigplane.core.tx_observation import (
     RADIO_READBACK_SOURCES,
     TX_READ_DEADLINE_SECONDS,
     TxStateReading,
 )
-from rigplane.core.tx_safety import TxOutcome
+from rigplane.core.tx_safety import (
+    TxOutcome,
+    TxSafetySnapshot,
+)
 from rigplane.runtime.meter_cal import interpolate_swr
 from rigplane.commands.bound import BoundCommands
 from rigplane.commands.command_map import CommandMap
@@ -218,6 +223,7 @@ __all__ = [
 
 
 logger = logging.getLogger(__name__)
+
 
 _AUDIO_CAPABILITIES = get_audio_capabilities()
 _DEFAULT_AUDIO_CODEC = _AUDIO_CAPABILITIES.default_codec
@@ -666,6 +672,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         # non-None for the life of the radio: a failed arm degrades it to
         # NOT_READY, never back to ``None`` (see ``_arm_managed_tx``).
         self._managed_tx_runtime: ManagedRadioRuntime | None = None
+        self._managed_tx_composition: ManagedTxCompositionPort | None = None
         # CI-V epoch the last arming attempt was made against; ``None`` until
         # the first attempt.  Bounds arming to one attempt per epoch.
         self._managed_tx_armed_epoch: int | None = None
@@ -819,7 +826,25 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         a rig whose provider never came ready refuses keys with ``NOT_READY``
         rather than reverting to an unsupervised write (MOR-1193).
         """
-        return self._managed_tx_runtime
+        composition = self._managed_tx_composition
+        return (
+            composition.legacy_supervisor
+            if composition is not None
+            else self._managed_tx_runtime
+        )
+
+    def install_managed_tx_composition(
+        self, composition: ManagedTxCompositionPort
+    ) -> None:
+        if self._managed_tx_composition is not None:
+            raise RuntimeError("managed TX composition is already installed")
+        if self._managed_tx_runtime is not None or self._conn_state is not (
+            RadioConnectionState.DISCONNECTED
+        ):
+            raise RuntimeError(
+                "managed TX composition must be installed before connect"
+            )
+        self._managed_tx_composition = composition
 
     @property
     def tx_snapshot(self) -> "TxSafetySnapshot | None":
@@ -945,6 +970,13 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         worse answer than the honest ``None``. Only ``connect()`` brings a
         runtime back.
         """
+        composition = self._managed_tx_composition
+        if composition is not None:
+            async with self._managed_tx_arm_lock:
+                transport = self._civ_transport
+                if transport is not None:
+                    await composition.transport_ready(transport)
+            return
         if self._civ_transport is None or self._managed_tx_binding_is_live():
             return
         async with self._managed_tx_arm_lock:
@@ -975,6 +1007,13 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         to do with managed TX. ``RIGPLANE_MANAGED_TX`` is the only managed-TX
         switch; neither reads the other.
         """
+        composition = self._managed_tx_composition
+        if composition is not None:
+            async with self._managed_tx_arm_lock:
+                transport = self._civ_transport
+                if transport is not None:
+                    await composition.transport_ready(transport)
+            return
         async with self._managed_tx_arm_lock:
             if self._managed_tx_armed_epoch != self._civ_epoch:
                 await self._run_managed_tx_arm()
@@ -1120,6 +1159,13 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         Ordered inside the ``finally`` with the members it belongs to, so a
         shutdown that timed out or raised still leaves a connectable radio.
         """
+        composition = self._managed_tx_composition
+        if composition is not None:
+            async with self._managed_tx_arm_lock:
+                transport = self._civ_transport
+                if transport is not None:
+                    await composition.transport_unavailable(transport)
+            return
         runtime = self._managed_tx_runtime
         if runtime is None:
             return
@@ -1164,6 +1210,13 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         Bounded and fail-soft: a gate that will not shut is not a reason to
         refuse to tear down the path it guards.
         """
+        composition = self._managed_tx_composition
+        if composition is not None:
+            async with self._managed_tx_arm_lock:
+                transport = self._civ_transport
+                if transport is not None:
+                    await composition.transport_unavailable(transport)
+            return
         runtime = self._managed_tx_runtime
         if runtime is None:
             return

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -37,7 +37,7 @@ from collections.abc import Callable, Collection, Coroutine
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from inspect import getattr_static
-from typing import TYPE_CHECKING, Any, Literal, Protocol, TextIO
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TextIO, cast
 
 from .. import __version__
 from .._bounded_queue import BoundedQueue
@@ -125,7 +125,7 @@ if TYPE_CHECKING:
 
     from ..profiles import RadioProfile
     from ..radio_protocol import Radio
-    from ..runtime.radio import ManagedTxCompositionPort
+    from ..runtime.managed_tx_composition import ManagedTxCompositionPort
     from .transport.webrtc_session import WebRtcSessionManager  # noqa: TID251
 
 __all__ = ["WebConfig", "WebServer", "run_web_server"]
@@ -1012,8 +1012,9 @@ class WebServer:
     def _projected_runtime_capabilities(self) -> set[str]:
         """Return runtime tags with VFO primitives trusted only from a profile."""
         caps = _runtime_capabilities(self._radio) - VFO_CAPABILITY_TAGS
-        return caps | projected_vfo_capability_tags(
-            self._radio, self._config.radio_model
+        return cast(
+            set[str],
+            caps | projected_vfo_capability_tags(self._radio, self._config.radio_model),
         )
 
     def _bootstrap_state_acquisition(self) -> None:

--- a/src/rigplane/web/web_startup.py
+++ b/src/rigplane/web/web_startup.py
@@ -25,13 +25,68 @@ from .radio_poller import RadioPoller  # noqa: TID251
 from .runtime_helpers import runtime_capabilities  # noqa: TID251
 
 if TYPE_CHECKING:
+    from ..runtime.managed_tx_composition import ManagedTxCompositionPort
     from .server import WebServer  # noqa: TID251
 
-__all__ = ["start_web_server", "stop_web_server"]
+__all__ = [
+    "attach_managed_tx_composition",
+    "prepare_managed_tx_observation_generation",
+    "start_web_server",
+    "stop_web_server",
+]
 
 logger = logging.getLogger(__name__)
 
 _SHUTDOWN_SCOPE_RESTORE_TIMEOUT_S = 1.0
+_MANAGED_TX_FALLBACK_ADVANCED_ATTR = "_production_managed_tx_fallback_advanced"
+
+
+def _installed_managed_tx_composition(radio: object) -> object | None:
+    try:
+        namespace = vars(radio)
+    except TypeError:
+        return None
+    return namespace.get("_managed_tx_composition")
+
+
+def prepare_managed_tx_observation_generation(server: WebServer) -> int:
+    radio = server._radio
+    if isinstance(radio, ObservationPollable):
+        shared_store = isinstance(radio, StateStoreCapable) and (
+            radio.state_store is server.command_state_store
+        )
+        if not shared_store:
+            generation = int(server.command_state_store.begin_provider_generation())
+            setattr(server, _MANAGED_TX_FALLBACK_ADVANCED_ATTR, True)
+            return generation
+    return int(server.command_state_store.provider_generation)
+
+
+def attach_managed_tx_composition(
+    server: WebServer,
+    port: ManagedTxCompositionPort,
+) -> None:
+    installed = _installed_managed_tx_composition(server._radio)
+    if installed is not port:
+        raise RuntimeError("managed TX composition identity does not match the radio")
+    if vars(server).get("_production_managed_tx_port") is not None:
+        raise RuntimeError("managed TX composition is already attached")
+    server._production_managed_tx_port = port
+
+
+def _validate_managed_tx(server: WebServer) -> None:
+    installed = _installed_managed_tx_composition(server._radio)
+    server_namespace = vars(server)
+    attached = server_namespace.get("_production_managed_tx_port")
+    if installed is None:
+        if attached is not None:
+            raise RuntimeError("managed TX composition is not installed on the radio")
+        return
+    if attached is None:
+        raise RuntimeError("managed TX composition is not attached to Web")
+    if attached is not installed:
+        raise RuntimeError("managed TX composition identity mismatch")
+    attached.validate_state_store(server.command_state_store)
 
 
 def _supports_scope_local(server: WebServer) -> bool:
@@ -39,6 +94,11 @@ def _supports_scope_local(server: WebServer) -> bool:
 
 
 async def start_web_server(server: WebServer) -> None:
+    _validate_managed_tx(server)
+    await _start_web_server(server)
+
+
+async def _start_web_server(server: WebServer) -> None:
     """Start the HTTP/WS listener and RadioPoller (if radio is connected).
 
     Mirrors the original :meth:`WebServer.start` body verbatim — the method
@@ -152,7 +212,9 @@ async def start_web_server(server: WebServer) -> None:
                 "_uses_fallback_provider_generation",
                 fallback_store,
             )
-            if fallback_store:
+            if fallback_store and not getattr(
+                server, _MANAGED_TX_FALLBACK_ADVANCED_ATTR, False
+            ):
                 server.command_state_store.begin_provider_generation()
             server._spawn(server._state_poller.start())
             logger.info("observation poller started")
@@ -181,7 +243,8 @@ async def start_web_server(server: WebServer) -> None:
                 # Register callback so CI-V RX stream can notify us of state changes.
                 server._radio.set_state_change_callback(server._on_radio_state_change)
                 # Re-enable scope after soft_reconnect (CI-V stream reset loses scope state)
-                server._radio.set_reconnect_callback(server._on_radio_reconnect)
+                if _installed_managed_tx_composition(server._radio) is None:
+                    server._radio.set_reconnect_callback(server._on_radio_reconnect)
             server._radio_poller = RadioPoller(
                 server._radio,
                 server._command_queue,
@@ -250,6 +313,10 @@ async def start_web_server(server: WebServer) -> None:
 
 
 async def stop_web_server(server: WebServer) -> None:
+    await _stop_web_server(server)
+
+
+async def _stop_web_server(server: WebServer) -> None:
     """Close the listener, stop RadioPoller, disconnect radio, cancel tasks.
 
     Mirrors the original :meth:`WebServer.stop` body verbatim — the method

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1066,6 +1066,97 @@ class TestWebRigctldDefault:
         assert "rigctld:" in out
         assert "4532" in out
 
+    @pytest.mark.asyncio
+    async def test_cli_web_managed_rigctld_receives_exact_authority_and_service(
+        self,
+    ) -> None:
+        import asyncio
+
+        from rigplane.cli import _cmd_web
+
+        authority = object()
+        command_service = object()
+        composition = MagicMock(authority=authority)
+        composition.bind_state_store = AsyncMock()
+        captured: dict[str, object] = {}
+        web_stores: list[object] = []
+
+        class FakeWebServer:
+            def __init__(self, _radio, _cfg):
+                self.command_service = command_service
+                self.command_state_store = object()
+                web_stores.append(self.command_state_store)
+
+            async def serve_forever(self):
+                raise asyncio.CancelledError
+
+        class FakeRigctldServer:
+            def __init__(self, _radio, _cfg, **kwargs):
+                captured.update(kwargs)
+
+            async def start(self):
+                pass
+
+            async def stop(self):
+                pass
+
+        args = _build_parser().parse_args(["--host", "1.2.3.4", "web"])
+        args.web_bridge = None
+        with (
+            patch("rigplane.web.server.WebServer", FakeWebServer),
+            patch("rigplane.rigctld.server.RigctldServer", FakeRigctldServer),
+            patch(
+                "rigplane.web.web_startup.prepare_managed_tx_observation_generation",
+                return_value=3,
+            ),
+            patch("rigplane.web.web_startup.attach_managed_tx_composition"),
+            patch("rigplane.cli._detect_loopback_hint", return_value=None),
+        ):
+            assert (
+                await _cmd_web(AsyncMock(), args, managed_tx_composition=composition)
+                == 0
+            )
+
+        assert captured == {
+            "managed_tx_authority": authority,
+            "command_service": command_service,
+        }
+        composition.bind_state_store.assert_awaited_once_with(web_stores[0])
+
+    @pytest.mark.asyncio
+    async def test_cli_web_managed_rigctld_does_not_retry_legacy_constructor(
+        self,
+    ) -> None:
+        from rigplane.cli import _cmd_web
+
+        composition = MagicMock(authority=object())
+        composition.bind_state_store = AsyncMock()
+
+        class FakeWebServer:
+            command_service = object()
+
+            def __init__(self, _radio, _cfg):
+                self.command_state_store = object()
+
+        class LegacyOnlyRigctldServer:
+            def __init__(self, _radio, _cfg):
+                pass
+
+        args = _build_parser().parse_args(["--host", "1.2.3.4", "web"])
+        args.web_bridge = None
+        with (
+            patch("rigplane.web.server.WebServer", FakeWebServer),
+            patch("rigplane.rigctld.server.RigctldServer", LegacyOnlyRigctldServer),
+            patch(
+                "rigplane.web.web_startup.prepare_managed_tx_observation_generation",
+                return_value=3,
+            ),
+            patch("rigplane.web.web_startup.attach_managed_tx_composition"),
+            patch("rigplane.cli._detect_loopback_hint", return_value=None),
+        ):
+            with pytest.raises(TypeError, match="managed_tx_authority"):
+                await _cmd_web(AsyncMock(), args, managed_tx_composition=composition)
+
     async def test_cli_web_direct_lan_wsjtx_configures_data2_lan(self, capsys):
         """Direct Icom LAN backend maps WSJT-X packet mode to DATA2/LAN."""
         import asyncio
@@ -1758,6 +1849,153 @@ class TestCheckPortsAvailable:
         assert str(occupied_rigctld_port) in captured.err
         assert "lsof" in captured.err.lower()
 
+
+class TestProductionManagedTxComposition:
+    class _Radio:
+        capabilities: set[str] = set()
+
+        def __init__(self) -> None:
+            self.entered = False
+            self._managed_tx_composition = None
+
+        async def __aenter__(self):
+            self.entered = True
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def actuate(self, _token, _operation, *, is_current):
+            from rigplane.runtime.managed_tx_state import ActuationResult
+
+            return (
+                ActuationResult.ACCEPTED if is_current() else ActuationResult.REJECTED
+            )
+
+        async def set_ptt(self, _on: bool) -> None:
+            raise AssertionError("raw PTT must be replaced before connect")
+
+        def install_managed_tx_composition(self, composition) -> None:
+            self._managed_tx_composition = composition
+
+    @pytest.mark.asyncio
+    async def test_web_passes_the_exact_preconnect_composition_to_cmd_web(self) -> None:
+        from rigplane.cli import _run
+
+        args = _build_parser().parse_args(["--host", "1.2.3.4", "web", "--no-rigctld"])
+        radio = self._Radio()
+        with (
+            patch("rigplane.cli.create_radio", return_value=radio),
+            patch("rigplane.cli.check_ports_available"),
+            patch("rigplane.cli._cmd_web", new_callable=AsyncMock) as command,
+        ):
+            command.return_value = 0
+            result = await _run(args)
+
+        assert result == 0
+        assert radio.entered
+        composition = radio._managed_tx_composition
+        assert composition is not None
+        command.assert_awaited_once_with(
+            radio, args, managed_tx_composition=composition
+        )
+
+    @pytest.mark.asyncio
+    async def test_install_failure_closes_candidate_before_radio_connect(
+        self, capsys
+    ) -> None:
+        from rigplane.cli import _run
+
+        args = _build_parser().parse_args(["--host", "1.2.3.4", "web", "--no-rigctld"])
+        radio = self._Radio()
+        candidate = MagicMock()
+        candidate.shutdown = AsyncMock()
+
+        def fail_install(_composition) -> None:
+            raise RuntimeError("identity install failed")
+
+        radio.install_managed_tx_composition = fail_install  # type: ignore[method-assign]
+        with (
+            patch("rigplane.cli.create_radio", return_value=radio),
+            patch("rigplane.cli.check_ports_available"),
+            patch("rigplane.cli.ManagedTxComposition", return_value=candidate),
+        ):
+            result = await _run(args)
+
+        assert result == 1
+        assert not radio.entered
+        candidate.shutdown.assert_awaited_once()
+        assert "managed TX composition unavailable" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_cli_is_sole_ordered_joinable_shutdown_owner(self) -> None:
+        import asyncio
+
+        from rigplane.cli import _ManagedTxRadioSession
+
+        events: list[str] = []
+        started, release = asyncio.Event(), asyncio.Event()
+        radio = MagicMock()
+
+        async def exit_radio(*_args):
+            events.append("radio-exit")
+            return False
+
+        async def shutdown(_termination):
+            events.append("tx-start")
+            started.set()
+            await release.wait()
+            events.append("tx-stop")
+
+        radio.__aexit__ = AsyncMock(side_effect=exit_radio)
+        candidate = MagicMock()
+        candidate.shutdown = AsyncMock(side_effect=shutdown)
+        session = _ManagedTxRadioSession(radio, candidate)
+
+        cancelled = asyncio.create_task(session.shutdown())
+        await started.wait()
+        cancelled.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled
+        joining = asyncio.create_task(session.shutdown())
+        exiting = asyncio.create_task(session.__aexit__(None, None, None))
+        await asyncio.sleep(0)
+        assert not joining.done() and not exiting.done()
+        shared = session._shutdown_task
+        assert shared is not None and session._shutdown_task is shared
+        radio.__aexit__.assert_not_awaited()
+
+        release.set()
+        await asyncio.gather(joining, exiting)
+        await session.shutdown()
+
+        assert events == ["tx-start", "tx-stop", "radio-exit"]
+        candidate.shutdown.assert_awaited_once()
+        radio.__aexit__.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cli_shutdowns_once_when_radio_enter_fails(self) -> None:
+        from rigplane.cli import _run
+
+        args = _build_parser().parse_args(["--host", "1.2.3.4", "web", "--no-rigctld"])
+        radio = self._Radio()
+        radio.__aenter__ = AsyncMock(side_effect=RuntimeError("connect failed"))  # type: ignore[method-assign]
+        radio.__aexit__ = AsyncMock(return_value=False)  # type: ignore[method-assign]
+        candidate = MagicMock()
+        candidate.transport_ready = AsyncMock()
+        candidate.shutdown = AsyncMock()
+        with (
+            patch("rigplane.cli.create_radio", return_value=radio),
+            patch("rigplane.cli.check_ports_available"),
+            patch("rigplane.cli.ManagedTxComposition", return_value=candidate),
+        ):
+            assert await _run(args) == 1
+
+        candidate.shutdown.assert_awaited_once()
+        radio.__aexit__.assert_not_awaited()
+
+
+class TestRemainingPortPreflight:
     def test_no_rigctld_flag_skips_busy_rigctld_port_preflight(self):
         """MOR-1437: --no-rigctld opts out of the rigctld port check entirely —
         a busy rigctld port must not block a clean web-only start.
@@ -1791,6 +2029,12 @@ class TestCheckPortsAvailable:
             )
 
             mock_radio = MagicMock()
+            mock_radio._managed_tx_composition = None
+            mock_radio.actuate = AsyncMock()
+            mock_radio.set_ptt = AsyncMock()
+            mock_radio.install_managed_tx_composition.side_effect = lambda value: (
+                setattr(mock_radio, "_managed_tx_composition", value)
+            )
             mock_radio.__aenter__ = AsyncMock(return_value=mock_radio)
             mock_radio.__aexit__ = AsyncMock(return_value=False)
             with (
@@ -1802,7 +2046,12 @@ class TestCheckPortsAvailable:
 
         assert result == 0
         mock_radio.__aenter__.assert_called_once()
-        cmd_web.assert_awaited_once_with(mock_radio, args)
+        assert cmd_web.await_args is not None
+        assert cmd_web.await_args.args == (mock_radio, args)
+        assert (
+            cmd_web.await_args.kwargs["managed_tx_composition"]
+            is mock_radio._managed_tx_composition
+        )
 
     def test_station_preflight_blocks_on_occupied_rigctld_port_at_managed_host(
         self, capsys

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -142,6 +142,19 @@ def _mock_radio_ctx() -> tuple[MagicMock, _CapableRadio]:
     return radio_cls, radio
 
 
+def _add_managed_tx_surface(radio: _CapableRadio) -> None:
+    async def actuate(_token, _operation, *, is_current):
+        from rigplane.runtime.managed_tx_state import ActuationResult
+
+        return ActuationResult.ACCEPTED if is_current() else ActuationResult.REJECTED
+
+    async def set_ptt(_on: bool) -> None:
+        pass
+
+    radio.actuate = actuate
+    radio.set_ptt = set_ptt
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("command", "handler_name"),
@@ -193,6 +206,8 @@ async def test_run_dispatches_non_audio_commands(
         args.rate_limit = None
 
     _, radio = _mock_radio_ctx()
+    if command == "web":
+        _add_managed_tx_surface(radio)
     with (
         patch("rigplane.cli.create_radio", return_value=radio),
         patch("rigplane.cli.check_ports_available"),
@@ -202,7 +217,14 @@ async def test_run_dispatches_non_audio_commands(
         rc = await _run(args)
 
     assert rc == 7
-    handler.assert_awaited_once_with(radio, args)
+    if command == "web":
+        handler.assert_awaited_once_with(
+            radio,
+            args,
+            managed_tx_composition=radio._managed_tx_composition,
+        )
+    else:
+        handler.assert_awaited_once_with(radio, args)
 
 
 @pytest.mark.asyncio
@@ -226,6 +248,7 @@ async def test_run_web_uses_serial_backend_factory_config() -> None:
         callsign=None,
     )
     _, radio = _mock_radio_ctx()
+    _add_managed_tx_surface(radio)
     with (
         patch("rigplane.cli.create_radio", return_value=radio) as create_radio,
         patch("rigplane.cli.check_ports_available"),
@@ -245,7 +268,11 @@ async def test_run_web_uses_serial_backend_factory_config() -> None:
             ptt_mode="civ",
         )
     )
-    cmd_web.assert_awaited_once_with(radio, args)
+    cmd_web.assert_awaited_once_with(
+        radio,
+        args,
+        managed_tx_composition=radio._managed_tx_composition,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_managed_tx_production_composition.py
+++ b/tests/test_managed_tx_production_composition.py
@@ -1,0 +1,298 @@
+import asyncio
+from collections.abc import Callable
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from rigplane.core.radio_protocol import ManagedTxApi
+from rigplane.core.state_store import StateStore
+from rigplane.core.tx_safety import TxOutcome, TxOwner, TxSource
+from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
+from rigplane.runtime.managed_tx_effect_lane import ManagedTxActuator
+from rigplane.runtime.managed_tx_state import (
+    AbortOperation,
+    ActuationOperation,
+    ActuationResult,
+    EffectToken,
+)
+from rigplane.runtime.managed_tx_composition import (
+    ManagedTxComposition,
+    ManagedTxCompositionPort,
+    install_managed_tx_composition,
+)
+from rigplane.web.web_startup import (
+    attach_managed_tx_composition,
+    start_web_server,
+)
+
+
+class RecordingActuator:
+    def __init__(self) -> None:
+        self.operations: list[ActuationOperation | AbortOperation] = []
+
+    async def actuate(
+        self,
+        _token: EffectToken,
+        operation: ActuationOperation | AbortOperation,
+        *,
+        is_current: Callable[[], bool],
+    ) -> ActuationResult:
+        if not is_current():
+            return ActuationResult.REJECTED
+        self.operations.append(operation)
+        return ActuationResult.ACCEPTED
+
+
+class LegacyRadio:
+    def __init__(self) -> None:
+        self.raw_writes: list[bool] = []
+
+    async def set_ptt(self, on: bool) -> None:
+        self.raw_writes.append(on)
+
+
+@pytest.mark.asyncio
+async def test_one_identity_graph_is_installed_and_shared(tmp_path) -> None:
+    actuator = RecordingActuator()
+    composition = ManagedTxComposition(
+        actuator, config_path=tmp_path / "managed-tx.json"
+    )
+
+    assert isinstance(actuator, ManagedTxActuator)
+    assert isinstance(composition, ManagedTxCompositionPort)
+    assert composition.authority._lane is composition._effect_lane
+    assert composition.authority._abort_fence is composition._abort_fence
+    assert composition.authority._config_store is composition._tot_config_store
+    assert composition._effect_lane._actuator is actuator
+    assert composition.local_tx_work_runner._abort_fence is composition._abort_fence
+
+    radio = LegacyRadio()
+    install_managed_tx_composition(radio, composition)
+    assert radio._managed_tx_composition is composition
+    assert radio.managed_tx is composition.legacy_supervisor
+
+    store = StateStore()
+    store.begin_provider_generation()
+    await composition.transport_ready(radio)
+    await composition.bind_state_store(store)
+    server = SimpleNamespace(
+        _radio=radio,
+        _production_managed_tx_port=None,
+        command_state_store=store,
+    )
+    attach_managed_tx_composition(server, composition)
+    assert server._production_managed_tx_port is composition
+    await composition.shutdown(asyncio.Event())
+
+
+@pytest.mark.asyncio
+async def test_yaesu_install_shares_runner_and_poison_suppresses_queued_cw_chunks(
+    tmp_path,
+) -> None:
+    radio = object.__new__(YaesuCatRadio)
+    radio._local_tx_work = None
+
+    async def raw_set_ptt(_on: bool) -> None:
+        raise AssertionError("raw PTT must be replaced")
+
+    radio.set_ptt = raw_set_ptt
+    queued = asyncio.Event()
+    release = asyncio.Event()
+    pending: list[tuple[str, Callable[[], bool] | None]] = []
+    wire: list[str] = []
+
+    async def delayed_write(
+        _command: str,
+        *,
+        is_current: Callable[[], bool] | None = None,
+        **params: str,
+    ) -> None:
+        pending.append((params["mem"], is_current))
+        queued.set()
+        await release.wait()
+        if is_current is None or is_current():
+            wire.append(params["mem"])
+
+    radio._write = delayed_write
+    composition = ManagedTxComposition(radio, config_path=tmp_path / "managed-tx.json")
+    install_managed_tx_composition(radio, composition)
+
+    assert radio._local_tx_work is composition.local_tx_work_runner
+    assert radio._local_tx_work._abort_fence is composition._abort_fence
+    with pytest.raises(RuntimeError, match="already installed"):
+        install_managed_tx_composition(radio, composition)
+
+    mismatched = object.__new__(YaesuCatRadio)
+    mismatched._local_tx_work = object()
+    mismatched.set_ptt = raw_set_ptt
+    with pytest.raises(RuntimeError, match="local TX work runner"):
+        install_managed_tx_composition(mismatched, composition)
+    assert mismatched._local_tx_work is not composition.local_tx_work_runner
+
+    store = StateStore()
+    store.begin_provider_generation()
+    await composition.transport_ready(radio)
+    await composition.bind_state_store(store)
+    sending = asyncio.create_task(radio.send_cw_text("A" * 48))
+    await queued.wait()
+    await composition.transport_unavailable(radio)
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await sending
+    assert len(pending) == 1
+    assert pending[0][0] == "A" * 24
+    assert pending[0][1] is not None
+    assert wire == []
+    await composition.shutdown(asyncio.Event())
+
+
+@pytest.mark.asyncio
+async def test_legacy_on_fails_before_wire_but_off_uses_canonical_force_receive(
+    tmp_path,
+) -> None:
+    actuator = RecordingActuator()
+    radio = LegacyRadio()
+    composition = ManagedTxComposition(
+        actuator, config_path=tmp_path / "managed-tx.json"
+    )
+    install_managed_tx_composition(radio, composition)
+    store = StateStore()
+    store.begin_provider_generation()
+    await composition.transport_ready(radio)
+    await composition.bind_state_store(store)
+    api = ManagedTxApi.bind(radio, TxOwner(TxSource.SDK, "legacy-cutover"))
+    assert api is not None
+
+    with pytest.raises(RuntimeError, match="legacy PTT ON is blocked"):
+        await api.set_ptt(True)
+    with pytest.raises(RuntimeError, match="raw PTT ON is blocked"):
+        await radio.set_ptt(True)
+    first = await api.set_ptt(False)
+    await radio.set_ptt(False)
+    second = await api.set_ptt(False)
+
+    assert first.outcome is TxOutcome.IDEMPOTENT
+    assert second.outcome is TxOutcome.IDEMPOTENT
+    assert radio.raw_writes == []
+    assert actuator.operations.count(ActuationOperation.FORCE_RECEIVE) == 3
+    await composition.shutdown(asyncio.Event())
+
+
+@pytest.mark.asyncio
+async def test_installed_radio_requires_exact_port_and_active_event_before_listener(
+    tmp_path,
+) -> None:
+    composition = ManagedTxComposition(
+        RecordingActuator(), config_path=tmp_path / "managed-tx.json"
+    )
+    radio = LegacyRadio()
+    install_managed_tx_composition(radio, composition)
+    store = StateStore()
+    store.begin_provider_generation()
+    server = SimpleNamespace(
+        _radio=radio,
+        _production_managed_tx_port=None,
+        command_state_store=store,
+    )
+
+    with patch("asyncio.start_server", new_callable=AsyncMock) as listener:
+        with pytest.raises(RuntimeError, match="not attached"):
+            await start_web_server(server)
+    listener.assert_not_awaited()
+
+    await composition.bind_state_store(store)
+    attach_managed_tx_composition(server, composition)
+    with patch("asyncio.start_server", new_callable=AsyncMock) as listener:
+        with pytest.raises(RuntimeError, match="not current"):
+            await start_web_server(server)
+    listener.assert_not_awaited()
+    await composition.shutdown(asyncio.Event())
+
+
+@pytest.mark.asyncio
+async def test_unmanaged_web_ignores_dynamic_mock_attrs_but_rejects_attachments() -> (
+    None
+):
+    class SlotOnlyRadio:
+        __slots__ = ()
+
+    with patch(
+        "rigplane.web.web_startup._start_web_server", new_callable=AsyncMock
+    ) as start:
+        for radio in (MagicMock(), SlotOnlyRadio(), None):
+            unmanaged = SimpleNamespace(_radio=radio)
+            await start_web_server(unmanaged)
+    assert start.await_count == 3
+
+    attached_without_marker = SimpleNamespace(
+        _radio=LegacyRadio(),
+        _production_managed_tx_port=object(),
+    )
+    with pytest.raises(RuntimeError, match="not installed"):
+        await start_web_server(attached_without_marker)
+
+
+@pytest.mark.asyncio
+async def test_web_only_validates_and_never_owns_composition_lifecycle() -> None:
+    port = MagicMock()
+    port.validate_state_store = MagicMock()
+    port.shutdown = AsyncMock(side_effect=AssertionError("Web must not shut down TX"))
+    radio = LegacyRadio()
+    radio._managed_tx_composition = port
+    store = StateStore()
+    server = SimpleNamespace(
+        _radio=radio,
+        _production_managed_tx_port=None,
+        command_state_store=store,
+    )
+    attach_managed_tx_composition(server, port)
+
+    with (
+        patch(
+            "rigplane.web.web_startup._start_web_server", new_callable=AsyncMock
+        ) as start,
+        patch(
+            "rigplane.web.web_startup._stop_web_server", new_callable=AsyncMock
+        ) as stop,
+    ):
+        await start_web_server(server)
+        from rigplane.web.web_startup import stop_web_server
+
+        await stop_web_server(server)
+
+    port.validate_state_store.assert_called_once_with(store)
+    port.shutdown.assert_not_awaited()
+    assert port.method_calls == [call.validate_state_store(store)]
+    start.assert_awaited_once_with(server)
+    stop.assert_awaited_once_with(server)
+
+
+@pytest.mark.asyncio
+async def test_observation_generation_drift_poisons_before_listener(tmp_path) -> None:
+    composition = ManagedTxComposition(
+        RecordingActuator(), config_path=tmp_path / "managed-tx.json"
+    )
+    radio = LegacyRadio()
+    install_managed_tx_composition(radio, composition)
+    store = StateStore()
+    for _ in range(4):
+        store.begin_provider_generation()
+    await composition.transport_ready(radio)
+    await composition.bind_state_store(store)
+    server = SimpleNamespace(
+        _radio=radio,
+        _production_managed_tx_port=None,
+        command_state_store=store,
+    )
+    attach_managed_tx_composition(server, composition)
+    store.begin_provider_generation()
+
+    with patch("asyncio.start_server", new_callable=AsyncMock) as listener:
+        with pytest.raises(RuntimeError, match="provider is not current"):
+            await start_web_server(server)
+
+    listener.assert_not_awaited()
+    assert composition._active_provider is None
+    await composition.shutdown(asyncio.Event())

--- a/tests/test_managed_tx_production_fake_wire.py
+++ b/tests/test_managed_tx_production_fake_wire.py
@@ -1,0 +1,108 @@
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from rigplane.backends.rigctld_client.radio import RigctldClientRadio
+from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
+from rigplane.core.state_store import StateStore
+from rigplane.runtime.managed_tx_composition import ManagedTxComposition
+from rigplane.runtime.radio import CoreRadio
+
+
+class _DelayedWire:
+    def __init__(self) -> None:
+        self.on_started = asyncio.Event()
+        self.release_on = asyncio.Event()
+        self.wire: list[bool] = []
+
+    async def finish(self, on: bool, is_current: Callable[[], bool]) -> None:
+        if on:
+            self.on_started.set()
+            try:
+                await self.release_on.wait()
+            except asyncio.CancelledError:
+                await self.release_on.wait()
+        if is_current():
+            self.wire.append(on)
+
+
+class _IcomActuator(_DelayedWire):
+    actuate = CoreRadio.actuate
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._commands = type(
+            "Commands",
+            (),
+            {
+                "ptt_on": staticmethod(lambda **_kw: b"ON"),
+                "ptt_off": staticmethod(lambda **_kw: b"OFF"),
+                "stop_cw": staticmethod(lambda **_kw: b"CW-OFF"),
+                "set_tuner_status": staticmethod(lambda *_a, **_kw: b"TUNE-OFF"),
+            },
+        )()
+        self._radio_addr = 0x94
+
+    async def _send_civ_raw(
+        self, frame: bytes, *, is_current: Callable[[], bool], **_kw: Any
+    ) -> None:
+        if frame in (b"ON", b"OFF"):
+            await self.finish(frame == b"ON", is_current)
+
+
+class _YaesuActuator(_DelayedWire):
+    actuate = YaesuCatRadio.actuate
+
+    async def _write(
+        self,
+        command: str,
+        *,
+        is_current: Callable[[], bool],
+        **params: Any,
+    ) -> None:
+        if command == "set_ptt":
+            await self.finish(params["state"] == "1", is_current)
+
+
+class _RigctldActuator(_DelayedWire):
+    actuate = RigctldClientRadio.actuate
+
+    async def _set_ptt(
+        self,
+        on: bool,
+        *,
+        is_current: Callable[[], bool],
+        urgent: bool,
+    ) -> None:
+        del urgent
+        await self.finish(on, is_current)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "actuator_type", [_IcomActuator, _YaesuActuator, _RigctldActuator]
+)
+async def test_real_provider_actuator_suppresses_stale_on_at_final_wire(
+    tmp_path, actuator_type: type[_DelayedWire]
+) -> None:
+    actuator = actuator_type()
+    composition = ManagedTxComposition(
+        actuator, config_path=tmp_path / f"{actuator_type.__name__}.json"
+    )
+    store = StateStore()
+    store.begin_provider_generation()
+    await composition.transport_ready(actuator)
+    await composition.bind_state_store(store)
+
+    submission = await composition.authority.submit_ptt(True, "provider-owner")
+    await asyncio.wait_for(actuator.on_started.wait(), 0.2)
+    store.begin_provider_generation()
+    actuator.release_on.set()
+    await submission.wait_settlement()
+    await composition.transport_ready(object())
+
+    assert True not in actuator.wire
+    assert actuator.wire[-1:] == [False]
+    await composition.shutdown(asyncio.Event())

--- a/tests/test_managed_tx_production_lifecycle.py
+++ b/tests/test_managed_tx_production_lifecycle.py
@@ -1,0 +1,313 @@
+import asyncio
+from collections.abc import Callable
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from rigplane.core.state_store import StateStore
+from rigplane.runtime.managed_tx_composition import ManagedTxComposition
+from rigplane.runtime.managed_tx_authority import ShutdownResult
+from rigplane.runtime.radio import CoreRadio, RadioConnectionState
+from rigplane.runtime.managed_tx_state import (
+    AbortOperation,
+    ActuationOperation,
+    ActuationResult,
+    EffectToken,
+)
+
+
+class RecordingActuator:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    async def actuate(
+        self,
+        _token: EffectToken,
+        operation: ActuationOperation | AbortOperation,
+        *,
+        is_current: Callable[[], bool],
+    ) -> ActuationResult:
+        if not is_current():
+            return ActuationResult.REJECTED
+        self.events.append(operation.value)
+        return ActuationResult.ACCEPTED
+
+
+class BlockingActuator(RecordingActuator):
+    def __init__(self, events: list[str], generation: int) -> None:
+        super().__init__(events)
+        self.generation = generation
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def actuate(
+        self,
+        token: EffectToken,
+        operation: ActuationOperation | AbortOperation,
+        *,
+        is_current: Callable[[], bool],
+    ) -> ActuationResult:
+        if (
+            operation is ActuationOperation.FORCE_RECEIVE
+            and token.provider_generation == self.generation
+        ):
+            self.started.set()
+            await self.release.wait()
+        return await super().actuate(token, operation, is_current=is_current)
+
+
+@pytest.mark.asyncio
+async def test_initial_transport_ready_is_latched_until_exact_store_bind(
+    tmp_path,
+) -> None:
+    composition = ManagedTxComposition(
+        RecordingActuator([]), config_path=tmp_path / "managed-tx.json"
+    )
+    transport = object()
+    store = StateStore()
+    store.begin_provider_generation()
+
+    await composition.transport_ready(transport)
+    assert composition._active_provider is None
+    await composition.bind_state_store(store)
+
+    assert composition._active_provider is not None
+    assert composition._active_provider.transport_identity is transport
+    assert composition._active_provider.provider_generation == 1
+    assert composition._active_provider.observation_generation == 1
+    await composition.shutdown(asyncio.Event())
+
+
+@pytest.mark.asyncio
+async def test_full_reconnect_retires_then_services_pending_off_debt(tmp_path) -> None:
+    events: list[str] = []
+    retired: list[int] = []
+
+    async def retire(event) -> None:
+        retired.append(event.provider_generation)
+
+    composition = ManagedTxComposition(
+        RecordingActuator(events),
+        config_path=tmp_path / "managed-tx.json",
+        retire_provider=retire,
+    )
+    store = StateStore()
+    store.begin_provider_generation()
+    first_transport, second_transport = object(), object()
+    radio = object.__new__(CoreRadio)
+    radio._managed_tx_composition = composition
+    radio._managed_tx_arm_lock = asyncio.Lock()
+    radio._civ_transport = first_transport
+    radio._session_lifecycle = SimpleNamespace(connect=AsyncMock())
+    radio._fetch_initial_state = AsyncMock()
+    radio._reset_external_cat_session = lambda: None
+    await radio.connect()
+    await composition.bind_state_store(store)
+    await composition.authority.transmit_on()
+
+    store.begin_provider_generation()
+    radio._civ_transport = second_transport
+    await radio.connect()
+
+    assert retired == [1]
+    assert events[-1] == "force_receive"
+    assert composition._active_provider.provider_generation == 2
+    assert composition._active_provider.transport_identity is second_transport
+    await composition.shutdown(asyncio.Event())
+
+
+@pytest.mark.asyncio
+async def test_two_replacements_use_monotonic_tx_generations_and_one_graph(
+    tmp_path,
+) -> None:
+    composition = ManagedTxComposition(
+        RecordingActuator([]), config_path=tmp_path / "managed-tx.json"
+    )
+    store = StateStore()
+    store.begin_provider_generation()
+    authority = composition.authority
+    fence, lane = composition._abort_fence, composition._effect_lane
+    transports = [object(), object(), object()]
+    await composition.transport_ready(transports[0])
+    await composition.bind_state_store(store)
+    generations = [composition._active_provider.provider_generation]
+
+    for transport in transports[1:]:
+        store.begin_provider_generation()
+        await composition.transport_ready(transport)
+        generations.append(composition._active_provider.provider_generation)
+
+    assert generations == [1, 2, 3]
+    assert composition.authority is authority
+    assert (composition._abort_fence, composition._effect_lane) == (fence, lane)
+    await composition.shutdown(asyncio.Event())
+
+
+@pytest.mark.asyncio
+async def test_concurrent_duplicate_and_stale_transport_signals_are_idempotent(
+    tmp_path,
+) -> None:
+    composition = ManagedTxComposition(
+        RecordingActuator([]), config_path=tmp_path / "managed-tx.json"
+    )
+    store = StateStore()
+    store.begin_provider_generation()
+    first, second = object(), object()
+    radio = object.__new__(CoreRadio)
+    radio._managed_tx_composition = composition
+    radio._managed_tx_arm_lock = asyncio.Lock()
+    radio._civ_transport = first
+    await radio._arm_managed_tx()
+    await composition.bind_state_store(store)
+    await radio._park_managed_tx()
+    store.begin_provider_generation()
+    radio._civ_transport = second
+
+    await asyncio.gather(
+        radio.rearm_managed_tx(),
+        radio.rearm_managed_tx(),
+        composition.transport_unavailable(first),
+    )
+
+    assert composition._active_provider.provider_generation == 2
+    assert composition._active_provider.transport_identity is second
+    await composition.shutdown(asyncio.Event())
+
+
+@pytest.mark.asyncio
+async def test_generation_drift_without_live_transport_poisons_without_activation(
+    tmp_path,
+) -> None:
+    composition = ManagedTxComposition(
+        RecordingActuator([]), config_path=tmp_path / "managed-tx.json"
+    )
+    store = StateStore()
+    store.begin_provider_generation()
+    transport = object()
+    await composition.transport_ready(transport)
+    await composition.bind_state_store(store)
+    await composition.transport_unavailable(transport)
+
+    store.begin_provider_generation()
+    async with composition._transition_lock:
+        await composition._join_transition_locked()
+
+    assert composition._active_provider is None
+    assert composition._observation_generation == 2
+    await composition.shutdown(asyncio.Event())
+
+
+@pytest.mark.asyncio
+async def test_generation_drift_during_debt_replay_cannot_publish_stale_candidate(
+    tmp_path,
+) -> None:
+    events: list[str] = []
+    retired: list[int] = []
+    actuator = BlockingActuator(events, generation=2)
+
+    async def retire(event) -> None:
+        retired.append(event.provider_generation)
+
+    composition = ManagedTxComposition(
+        actuator,
+        config_path=tmp_path / "managed-tx.json",
+        retire_provider=retire,
+    )
+    store = StateStore()
+    store.begin_provider_generation()
+    first, candidate = object(), object()
+    await composition.transport_ready(first)
+    await composition.bind_state_store(store)
+    await composition.authority.transmit_on()
+    store.begin_provider_generation()
+
+    replacement = asyncio.create_task(composition.transport_ready(candidate))
+    await actuator.started.wait()
+    store.begin_provider_generation()
+    actuator.release.set()
+    await replacement
+
+    assert composition._active_provider is None
+    assert (await composition.authority.snapshot()).provider_generation is None
+    assert retired == [1, 2]
+    assert events.count("transmit_on") == 1
+    await composition.shutdown(asyncio.Event())
+
+
+@pytest.mark.asyncio
+async def test_terminal_shutdown_then_actual_core_disconnect_is_idempotent(
+    tmp_path,
+) -> None:
+    actuator = BlockingActuator([], generation=1)
+    retired: list[int] = []
+
+    async def retire(event) -> None:
+        retired.append(event.provider_generation)
+
+    composition = ManagedTxComposition(
+        actuator,
+        config_path=tmp_path / "managed-tx.json",
+        retire_provider=retire,
+    )
+    store = StateStore()
+    store.begin_provider_generation()
+    transport = object()
+    await composition.transport_ready(transport)
+    await composition.bind_state_store(store)
+    await composition.authority.transmit_on()
+    termination = asyncio.Event()
+    termination.set()
+
+    result = await composition.shutdown(termination)
+    await composition.transport_ready(object())
+
+    radio = object.__new__(CoreRadio)
+    radio._managed_tx_composition = composition
+    radio._managed_tx_arm_lock = asyncio.Lock()
+    radio._civ_transport = transport
+    radio._session_lifecycle = SimpleNamespace(disconnect=AsyncMock())
+    radio._conn_state = RadioConnectionState.DISCONNECTED
+    await radio.disconnect()
+
+    assert result is ShutdownResult.TERMINATED
+    assert composition._active_provider is None
+    assert retired == [1]
+    radio._session_lifecycle.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_is_ordered_joinable_and_retires_once(tmp_path) -> None:
+    events: list[str] = []
+    retired: list[int] = []
+
+    async def retire(event) -> None:
+        retired.append(event.provider_generation)
+
+    composition = ManagedTxComposition(
+        RecordingActuator(events),
+        config_path=tmp_path / "managed-tx.json",
+        retire_provider=retire,
+    )
+    store = StateStore()
+    store.begin_provider_generation()
+    await composition.transport_ready(object())
+    await composition.bind_state_store(store)
+    assert len(store._provider_generation_subscribers) == 1
+    await composition.authority.transmit_on()
+
+    first, second, third = await asyncio.gather(
+        composition.shutdown(asyncio.Event()),
+        composition.shutdown(asyncio.Event()),
+        composition.shutdown(asyncio.Event()),
+    )
+
+    assert first is second is third
+    assert events == [
+        "transmit_on",
+        "force_receive",
+        "stop_cw",
+        "stop_tune",
+    ]
+    assert retired == [1]
+    assert store._provider_generation_subscribers == []


### PR DESCRIPTION
## Summary

- make one `ManagedTxComposition` the sole production owner of the authority, abort fence, effect lane, TOT store, local runner, provider lifecycle, and durable OFF debt
- move the composition into its own runtime module and expose only transport-ready/unavailable, exact StateStore bind/validation, ingress authority, and joinable shutdown
- have Core signal transport identity only, CLI own construction/bind/shutdown, and Web perform validation/ingress only
- preserve the shared Yaesu runner, fail-closed legacy/raw ON, canonical ForceReceive OFF, fake-wire suppression, and truly unmanaged Web behavior

## Topology and ownership

- Search-before-write completed before edits. Linear owner/topology: MOR-2307, atomic composition after the local-fence foundation.
- Prerequisite exact merge SHA and this commit's exact parent: `6e0f9b49711c81ba05d962ce6612081941e37e86`.
- The branch is materialized directly on that exact `origin/main` merge commit.
- Option C ruling: composition owns observation subscription and all provider transitions; Core emits transport identity; CLI is the sole production root; Web owns no managed-TX lifecycle.

## Manifest and cap

Exactly 10 approved paths, 1,635 additions and 22 deletions (1,657 total changed lines; cap 1,700):

- `src/rigplane/runtime/managed_tx_composition.py` (+389/-0)
- `src/rigplane/runtime/radio.py` (+58/-5)
- `src/rigplane/cli/__init__.py` (+115/-7)
- `src/rigplane/web/web_startup.py` (+70/-3)
- `src/rigplane/web/server.py` (+5/-4)
- `tests/test_cli.py` (+250/-1)
- `tests/test_cli_coverage.py` (+29/-2)
- `tests/test_managed_tx_production_composition.py` (+298/-0)
- `tests/test_managed_tx_production_fake_wire.py` (+108/-0)
- `tests/test_managed_tx_production_lifecycle.py` (+313/-0)

## TDD and mutation discriminators

Behavior-specific RED was captured against exact prior head `3c5c5267bf03c2c87a6a9e4bcd68784126ab9aa4` after adding only an importable lifecycle shell:

1. initial ready/bind: provider lacked the latched transport identity;
2. full reconnect/debt: retirement was `[]`, not `[1]`, so pending OFF debt was not serviced;
3. two replacements: internal TX generations were `[1, 1, 1]`, not `[1, 2, 3]`;
4. concurrent duplicate/stale signals: the current provider remained generation 1 instead of exactly one generation-2 provider;
5. no-live drift: the old provider remained active after observation generation changed;
6. Web ownership sentinel: the old Web attach/lifecycle contract required an externally constructed event and invoked provider invalidation/shutdown;
7. CLI ownership: the old session and outer `finally` both invoked composition shutdown and `_cmd_web` did not bind the exact Web StateStore;
8. existing fake-wire, blocked legacy/raw ON, and canonical defensive OFF nodes remained the regression discriminators.

Fresh lifecycle-review RED against exact prior head `f9aae82c8d6cec4b6dd92285698f907a01abf9db`:

- generation advanced while generation-2 debt replay was blocked, then the stale candidate was incorrectly published active;
- after `ShutdownResult.TERMINATED`, actual `CoreRadio.disconnect()` raised `managed TX authority runtime has terminated` before session cleanup.

Mutation proof after the fixes:

- removing only post-`provider_available` revalidation made only the stale-activation race fail; terminal cleanup passed;
- removing terminal clear/retire and the post-shutdown unavailable guard made only terminal cleanup fail with the terminated-authority error; stale activation passed.

Fresh CLI cancellation RED against exact prior head `d17cb4c20044052a5dbbf7b0ccf87fccbb0d29ca`: after cancelling the first shielded shutdown waiter, a second `session.shutdown()` was already complete while the composition's OFF/shutdown remained blocked. Mutation restoring the boolean guard made only this cancellation discriminator fail; the enter/connect-failure shutdown regression remained green.

GREEN, exact owned run: **221 passed in 1.29s**:

- `tests/test_managed_tx_production_lifecycle.py::test_initial_transport_ready_is_latched_until_exact_store_bind`
- `tests/test_managed_tx_production_lifecycle.py::test_full_reconnect_retires_then_services_pending_off_debt`
- `tests/test_managed_tx_production_lifecycle.py::test_two_replacements_use_monotonic_tx_generations_and_one_graph`
- `tests/test_managed_tx_production_lifecycle.py::test_concurrent_duplicate_and_stale_transport_signals_are_idempotent`
- `tests/test_managed_tx_production_lifecycle.py::test_generation_drift_without_live_transport_poisons_without_activation`
- `tests/test_managed_tx_production_lifecycle.py::test_generation_drift_during_debt_replay_cannot_publish_stale_candidate`
- `tests/test_managed_tx_production_lifecycle.py::test_terminal_shutdown_then_actual_core_disconnect_is_idempotent`
- `tests/test_managed_tx_production_lifecycle.py::test_shutdown_is_ordered_joinable_and_retires_once`
- `tests/test_managed_tx_production_composition.py::test_one_identity_graph_is_installed_and_shared`
- `tests/test_managed_tx_production_composition.py::test_yaesu_install_shares_runner_and_poison_suppresses_queued_cw_chunks`
- `tests/test_managed_tx_production_composition.py::test_legacy_on_fails_before_wire_but_off_uses_canonical_force_receive`
- `tests/test_managed_tx_production_composition.py::test_installed_radio_requires_exact_port_and_active_event_before_listener`
- `tests/test_managed_tx_production_composition.py::test_unmanaged_web_ignores_dynamic_mock_attrs_but_rejects_attachments`
- `tests/test_managed_tx_production_composition.py::test_web_only_validates_and_never_owns_composition_lifecycle`
- `tests/test_managed_tx_production_composition.py::test_observation_generation_drift_poisons_before_listener`
- `tests/test_managed_tx_production_fake_wire.py::test_real_provider_actuator_suppresses_stale_on_at_final_wire[_IcomActuator]`
- `tests/test_managed_tx_production_fake_wire.py::test_real_provider_actuator_suppresses_stale_on_at_final_wire[_YaesuActuator]`
- `tests/test_managed_tx_production_fake_wire.py::test_real_provider_actuator_suppresses_stale_on_at_final_wire[_RigctldActuator]`
- `tests/test_cli.py::TestProductionManagedTxComposition::test_web_passes_the_exact_preconnect_composition_to_cmd_web`
- `tests/test_cli.py::TestProductionManagedTxComposition::test_install_failure_closes_candidate_before_radio_connect`
- `tests/test_cli.py::TestProductionManagedTxComposition::test_cli_is_sole_ordered_joinable_shutdown_owner`
- `tests/test_cli.py::TestProductionManagedTxComposition::test_cli_shutdowns_once_when_radio_enter_fails`
- `tests/test_cli.py::TestWebRigctldDefault::test_cli_web_managed_rigctld_receives_exact_authority_and_service`
- `tests/test_cli.py::TestWebRigctldDefault::test_cli_web_managed_rigctld_does_not_retry_legacy_constructor`

Static evidence:

- Ruff format check, exact 10 paths: PASS
- Ruff check, exact 10 paths: PASS
- strict mypy, 5 touched source paths: PASS
- `git diff --check`: PASS

Natural quick `33868826469` on prior head `a50c476315bff4b715547171f0b0b6c1d9154c28` failed only at strict Web mypy: `src/rigplane/web/server.py:3988: Redundant cast to "dict[str, object]"`. The behavior-neutral correction removes only that redundant cast. Exact local reproduction was RED with that single diagnostic, then `uv run mypy --strict src/rigplane/web` passed all 27 source files; touched-file Ruff format/check and diff-check also passed.

No local quick/full/product suite was run. The 221-test run is limited to the five owned test files.

## Generation and ordering proof

- CLI installs the composition before connect. Core's initial `connect()` emits the live CI-V transport identity, which the composition latches until CLI constructs Web, prepares the observation store, and binds that exact `WebServer.command_state_store` once.
- The composition's synchronous StateStore callback poisons authority and fence before returning, clears live-transport proof, and chains retirement. It cannot reactivate until a later live transport signal.
- Full reconnect advances the canonical StateStore observation generation, then `CoreRadio.connect()` signals the replacement transport. Soft reconnect parks the exact old transport and uses the same `_managed_tx_arm_lock` for the later ready signal.
- Under the composition's one transition lock, replacement waits for poison/retirement, increments its private TX provider counter, then calls `provider_available`; the authority services durable OFF debt before readiness returns. Tests prove private TX generations 1 -> 2 -> 3 while observation generation remains a distinct store token.
- Candidate activation revalidates observation generation and exact live identity after every await. A drift during debt replay synchronously invalidates the candidate; after replay returns, the candidate is poisoned and retired without publication.
- Duplicate ready and stale unavailable signals serialize without raising or creating a second current provider.
- After joinable shutdown, ready/unavailable signals are fail-closed idempotent no-ops. TERMINATED shutdown clears and retires the terminal event before later Core transport cleanup.

## Constructor/writer/lifecycle census

- One production constructor each for `TxAbortFence`, `LocalTxWorkRunner`, `ManagedTxTotConfigStore`, `ManagedTxEffectLane`, and `ManagedTxAuthority`: `ManagedTxComposition.__init__`.
- One production composition construction/install site: CLI pre-connect setup.
- One production managed-TX observation-generation subscription: the composition; it unsubscribes in shutdown `finally`.
- Production transport writers are Core initial/rearm/unavailable hooks plus the CLI's generic initial fallback. Core never constructs or inspects provider events or generations.
- `_ProviderEvent` is private to the composition. The consumer port exposes no `active_provider`, `activate_provider`, or `start_provider_unavailable`; whole-tree grep found no remaining external consumer.
- Whole-tree census also found no production consumer of the temporary `join_transitions` method or `runtime.radio` composition re-exports; both were removed, leaving only the composition-port typing import in radio.
- Web attaches and validates the exact installed composition/store only. It has no generation subscription, poison/reactivation callback, provider event, unsubscribe, or composition shutdown. Installed composition also suppresses Web's legacy reconnect lifecycle callback.
- CLI's session owner caches one shared shutdown task. Every waiter uses `asyncio.shield` on that exact task, so waiter cancellation cannot cancel it or let radio exit overtake durable OFF/retirement; outer cleanup and repeated normal shutdown join the same task.
- Embedded rigctld receives the exact composition authority and command service through the explicit managed constructor branch; unmanaged construction remains the historical two positional arguments.

## Evidence boundary

Fake-wire tests invoke the real Icom/Core, Yaesu CAT, and rigctld-client actuator methods and prove stale ON suppression at the final fake transport. They are not real-provider or hardware proof. No radio was connected, no observed RF was used for admission, and no TX was emitted. Hardware/owner-present acceptance remains separate.
