### PR TITLE
fix(MOR-2168): expose landscape Force Off

### DIFF
--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -561,6 +561,13 @@
       <span class="m-ls-filter">{mainVfo.filter}</span>
       {#if txCapable}
         <button
+          type="button"
+          class="m-ls-unkey"
+          aria-label="Unkey transmitter"
+          title="Unkey transmitter"
+          onclick={() => txCtl.forceOff()}
+        >UNKEY</button>
+        <button
           class="m-ls-ptt"
           class:m-ptt-held={owned && !latched}
           class:m-ptt-latched={latched}
@@ -1140,6 +1147,26 @@
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
     transition: background 0.15s, color 0.15s;
+  }
+
+  .m-ls-unkey {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 10px;
+    font-weight: 700;
+    min-width: 58px;
+    min-height: 44px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    border: 2px solid #facc15;
+    background: rgba(250, 204, 21, 0.14);
+    color: #facc15;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .m-ls-unkey:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
   }
 
   .m-ls-ptt.m-ptt-held {

--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
@@ -586,6 +586,7 @@ describe('mobile PTT via the App TX controller (MOR-1012)', () => {
 
   const fabEl = (t: HTMLElement) => t.querySelector<HTMLButtonElement>('.ptt-fab')!;
   const stripEl = (t: HTMLElement) => t.querySelector<HTMLButtonElement>('.m-ls-ptt')!;
+  const landscapeUnkeyEl = (t: HTMLElement) => t.querySelector<HTMLButtonElement>('.m-ls-unkey')!;
   function pointer(el: Element, type: string, init: PointerEventInit = {}) {
     el.dispatchEvent(new PointerEvent(type, {
       bubbles: true, pointerId: 1, clientX: 0, clientY: 0, ...init,
@@ -654,6 +655,33 @@ describe('mobile PTT via the App TX controller (MOR-1012)', () => {
     const t = mountMobile();
     pointer(fabEl(t), 'pointerdown');
     expect(tx.trace()).toEqual([{ transport: 'http', operation: 'force_off' }]);
+  });
+
+  it.each([
+    ['RX', { intent: 'rx', observedPtt: 'off', releaseRequired: false }],
+    ['PTT', { intent: 'ptt', observedPtt: 'on', releaseRequired: true }],
+    ['TRANSMIT', { intent: 'transmit', observedPtt: 'on', releaseRequired: true }],
+    ['failed', { intent: 'rx', observedPtt: 'unknown', releaseRequired: true, lastError: 'release failed' }],
+    ['stale', { intent: 'rx', observedPtt: 'unknown', releaseRequired: true, stale: true }],
+  ] as const)('landscape exposes unconditional HTTP ForceOFF while canonical state is %s', (_name, snapshot) => {
+    tx.emitServerSnapshot(snapshot);
+    const t = mountLandscape();
+    const unkey = landscapeUnkeyEl(t);
+
+    expect(unkey).not.toBeNull();
+    expect(unkey.disabled).toBe(false);
+    expect(unkey.tabIndex).toBe(0);
+    unkey.focus();
+    expect(document.activeElement).toBe(unkey);
+
+    unkey.click();
+    expect(tx.trace()).toEqual([{ transport: 'http', operation: 'force_off' }]);
+  });
+
+  it('keeps the landscape-only Unkey control out of portrait presentation', () => {
+    const t = mountMobile();
+    expect(t.querySelector('.m-ls-unkey')).toBeNull();
+    expect(t.querySelector('.m-semantic-deck')).not.toBeNull();
   });
 
   it('unavailable double tap emits no transmit_on and releases the WS PTT', () => {


### PR DESCRIPTION
Follow-up to [MOR-2168](https://linear.app/morozsm/issue/MOR-2168/tx-authority-atomic-webruntime-composition-and-shutdown-cutover).

Mobile landscape did not mount the semantic RX/TX deck, so a stale or failed managed snapshot left no explicit Force Off route. The landscape control strip now exposes a visible, focusable, always-enabled `UNKEY` button that calls the existing App-root managed TX facade's HTTP `forceOff()` operation directly. The gesture PTT path, controller ownership, and portrait presentation remain unchanged.

Validation:

- `npx vitest run src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts` — 44/44 PASS, including RX/PTT/TRANSMIT/failed/stale Force Off routing and portrait preservation
- `npm run check` — 0 errors, 0 warnings
- changed-file ESLint — PASS
- `git diff --check` — PASS

No hardware, radio TX, PTT, tune, or CW execution was performed.
