### PR TITLE
Route standalone rigctld through managed transmit

### DIFF
--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -1977,7 +1977,7 @@ async def _run(args: argparse.Namespace) -> int:
             return 1
 
     managed_tx_composition: ManagedTxCompositionPort | None = None
-    if args.command in ("web", "station"):
+    if args.command in ("web", "station", "serve"):
         candidate_composition: ManagedTxComposition | None = None
         try:
             import platformdirs
@@ -2120,7 +2120,12 @@ async def _run(args: argparse.Namespace) -> int:
             elif args.command == "scope":
                 return await _cmd_scope(radio, args)
             elif args.command == "serve":
-                return await _cmd_serve(radio, args)
+                assert managed_tx_composition is not None
+                return await _cmd_serve(
+                    radio,
+                    args,
+                    managed_tx_composition=managed_tx_composition,
+                )
             elif args.command == "audio":
                 if args.audio_command == "rx":
                     return await _cmd_audio_rx(radio, args)
@@ -3679,7 +3684,12 @@ def _print_startup_banner(
     print("\n".join(lines))
 
 
-async def _cmd_serve(radio: Radio, args: argparse.Namespace) -> int:
+async def _cmd_serve(
+    radio: Radio,
+    args: argparse.Namespace,
+    *,
+    managed_tx_composition: ManagedTxCompositionPort,
+) -> int:
     import logging as _logging
 
     from rigplane.rigctld.audit import AUDIT_LOGGER_NAME, RigctldAuditFormatter
@@ -3721,7 +3731,11 @@ async def _cmd_serve(radio: Radio, args: argparse.Namespace) -> int:
         rigctld_addr=f"{args.serve_host}:{args.serve_port}",
     )
     try:
-        await RigctldServer(radio, config).serve_forever()
+        await RigctldServer(
+            radio,
+            config,
+            managed_tx_composition=managed_tx_composition,
+        ).serve_forever()
     except asyncio.CancelledError:
         pass
     return 0

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -515,13 +515,15 @@ class _RigctldCommandExecutor:
         if managed and intent.name == "set_ptt":
             return await self._execute_managed_ptt(intent)
 
-        classification = _classify_rigctld_tx_intent(intent)
-        if (
-            classification.disposition is TxInterlockDisposition.BLOCK
-            and self.handler._has_canonical_state_store
-            and self.handler._resolve_rigctld_rf_state() is not tx_interlock.RfState.RX
-        ):
-            raise _RigctldCommandFailure(HamlibError.ERJCTED)
+        if not managed:
+            classification = _classify_rigctld_tx_intent(intent)
+            if (
+                classification.disposition is TxInterlockDisposition.BLOCK
+                and self.handler._has_canonical_state_store
+                and self.handler._resolve_rigctld_rf_state()
+                is not tx_interlock.RfState.RX
+            ):
+                raise _RigctldCommandFailure(HamlibError.ERJCTED)
         await self._wait_predecessor()
         params = intent.params
         if intent.name == "set_freq":
@@ -731,12 +733,18 @@ class RigctldHandler:
         managed_tx_authority: ManagedTxAuthority | None = None,
         command_queue: tx_commands.CommandQueue | None = None,
         command_service: CommandService | None = None,
+        build_local_managed_command_service: bool = False,
     ) -> None:
         supplied = (
             managed_tx_authority is not None,
             command_service is not None,
         )
-        if any(supplied) and not all(supplied):
+        if build_local_managed_command_service:
+            if managed_tx_authority is None or command_service is not None:
+                raise ValueError(
+                    "local managed service requires only a managed authority"
+                )
+        elif any(supplied) and not all(supplied):
             raise ValueError("managed authority and service must be supplied together")
         self._managed_tx_authority = managed_tx_authority
         self._radio = radio
@@ -878,6 +886,11 @@ class RigctldHandler:
           before this design and from what BLOCK-classified families still
           do inside the executor.
         """
+        # Managed ingress has one admission seat: ManagedTxAuthority.  The
+        # retiring observed-RF interlock remains only for the compatible
+        # unmanaged SDK constructor until its separate deletion cutover.
+        if self._managed_tx_authority is not None:
+            return None
         classification = _classify_rigctld_tx_intent(intent)
         if (
             classification.disposition is not TxInterlockDisposition.DEFER
@@ -940,6 +953,10 @@ class RigctldHandler:
         routing rigctld writes through the correlated queue without holding
         the socket — post-beta work, tracked separately.
         """
+        authority = self._managed_tx_authority
+        if authority is not None and intent.name != "set_ptt":
+            if not await authority.admit_managed_write(intent):
+                raise _RigctldCommandFailure(HamlibError.ERJCTED)
         try:
             result = await self._command_service.execute(
                 intent,

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
     from ..core.command_service import CommandService
     from ..radio_protocol import Radio
     from ..runtime.managed_tx_authority import ManagedTxAuthority
+    from ..runtime.managed_tx_composition import ManagedTxCompositionPort
 
 logger = logging.getLogger(__name__)
 
@@ -161,6 +162,7 @@ class RigctldServer:
         radio: "Radio",
         config: RigctldConfig | None = None,
         *,
+        managed_tx_composition: ManagedTxCompositionPort | None = None,
         managed_tx_authority: ManagedTxAuthority | None = None,
         command_service: CommandService | None = None,
         _protocol: Any = None,
@@ -175,7 +177,18 @@ class RigctldServer:
             raise ValueError("managed authority and service must be supplied together")
         if all(supplied) and _handler is not None:
             raise ValueError("managed references cannot be combined with _handler")
-        self._managed_tx_authority = managed_tx_authority
+        if managed_tx_composition is not None and (
+            any(supplied) or _handler is not None
+        ):
+            raise ValueError(
+                "managed composition is exclusive with injected references"
+            )
+        self._managed_tx_composition = managed_tx_composition
+        self._managed_tx_authority = (
+            managed_tx_composition.authority
+            if managed_tx_composition is not None
+            else managed_tx_authority
+        )
         self._command_service = command_service
         self._radio = radio
         self._config = config or RigctldConfig()
@@ -191,6 +204,8 @@ class RigctldServer:
         self._state_store: StateStore | None = None
         self._uses_fallback_state_store = False
         self._fallback_state_store_attached = False
+        self._managed_tx_bound_store: StateStore | None = None
+        self._unmanaged_warning_emitted = False
         self._acquisition_scheduler: AcquisitionScheduler | None = None
         self._state_model_service: StateModelService | None = None
         self._state_freshness_service: StateFreshnessService | None = None
@@ -759,9 +774,33 @@ class RigctldServer:
         if self._state_store is None:
             self._bootstrap_state_acquisition()
 
+        store = self._state_store
+        if store is not None:
+            if (
+                self._uses_fallback_state_store
+                and not self._fallback_state_store_attached
+            ):
+                store.begin_provider_generation()
+                self._fallback_state_store_attached = True
+
+            composition = self._managed_tx_composition
+            if composition is not None:
+                namespace = getattr(self._radio, "__dict__", {})
+                if namespace.get("_managed_tx_composition") is not composition:
+                    raise RuntimeError("managed TX composition identity mismatch")
+                if self._managed_tx_bound_store is None:
+                    await composition.bind_state_store(store)
+                    self._managed_tx_bound_store = store
+                elif self._managed_tx_bound_store is not store:
+                    raise RuntimeError("managed TX composition store mismatch")
+                composition.validate_state_store(store)
+
         if self._rig_handler is None:
             from . import handler as _handler_mod  # noqa: PLC0415, TID251
 
+            handler_kwargs: dict[str, Any] = {}
+            if self._managed_tx_composition is not None:
+                handler_kwargs["build_local_managed_command_service"] = True
             self._rig_handler = _handler_mod.RigctldHandler(
                 self._radio,
                 self._config,
@@ -770,21 +809,26 @@ class RigctldServer:
                 managed_tx_authority=self._managed_tx_authority,
                 command_queue=None,
                 command_service=self._command_service,
+                **handler_kwargs,
             )
 
-        store = self._state_store
         if store is not None:
             bind_provider_generation = getattr(
                 self._rig_handler, "bind_provider_generation", None
             )
             if callable(bind_provider_generation):
                 bind_provider_generation(lambda: store.provider_generation)
-            if (
-                self._uses_fallback_state_store
-                and not self._fallback_state_store_attached
-            ):
-                store.begin_provider_generation()
-                self._fallback_state_store_attached = True
+
+        if (
+            self._managed_tx_authority is None
+            and not self._config.read_only
+            and not self._unmanaged_warning_emitted
+        ):
+            logger.warning(
+                "writable unmanaged rigctld: Managed TX authority, ForceOff, "
+                "and software TOT are inactive"
+            )
+            self._unmanaged_warning_emitted = True
 
         self._server = await asyncio.start_server(
             self._accept_client,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1901,6 +1901,29 @@ class TestProductionManagedTxComposition:
         )
 
     @pytest.mark.asyncio
+    async def test_serve_passes_the_exact_preconnect_composition_to_cmd_serve(
+        self,
+    ) -> None:
+        from rigplane.cli import _run
+
+        args = _build_parser().parse_args(["--host", "1.2.3.4", "serve"])
+        radio = self._Radio()
+        with (
+            patch("rigplane.cli.create_radio", return_value=radio),
+            patch("rigplane.cli.check_ports_available"),
+            patch("rigplane.cli._cmd_serve", new_callable=AsyncMock) as command,
+        ):
+            command.return_value = 0
+            result = await _run(args)
+
+        assert result == 0
+        composition = radio._managed_tx_composition
+        assert radio.entered and composition is not None
+        command.assert_awaited_once_with(
+            radio, args, managed_tx_composition=composition
+        )
+
+    @pytest.mark.asyncio
     async def test_install_failure_closes_candidate_before_radio_connect(
         self, capsys
     ) -> None:

--- a/tests/test_rigctld_managed_write_admission.py
+++ b/tests/test_rigctld_managed_write_admission.py
@@ -1,0 +1,173 @@
+"""Managed rigctld writes enter the composition authority before delivery."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from rigplane.capabilities import CAP_RIT
+from rigplane.core.command_service import CommandExecutionResult, CommandService
+from rigplane.core.state_pipeline_contracts import CommandIntent
+from rigplane.core.state_store import StateStore
+from rigplane.rigctld.contract import HamlibError, RigctldConfig, RigctldResponse
+from rigplane.rigctld.handler import RigctldHandler, _RigctldCommandFailure
+from rigplane.rigctld.protocol import parse_line
+from rigplane.runtime import tx_interlock
+from rigplane.runtime.managed_tx_state import ManagedTxOutcome
+
+
+class _DefaultExecutor:
+    async def execute(self, _intent: object) -> CommandExecutionResult:
+        raise AssertionError("RigctldHandler must provide the write executor")
+
+
+def _handler(*, admitted: bool) -> tuple[RigctldHandler, AsyncMock, AsyncMock]:
+    store = StateStore()
+    radio = AsyncMock()
+    radio.capabilities = {CAP_RIT}
+    radio.state_store = store
+    routing = Mock()
+    routing.set_func = AsyncMock(return_value=RigctldResponse())
+    radio.rigctld_routing = Mock(return_value=routing)
+    authority = SimpleNamespace(
+        admit_managed_write=AsyncMock(return_value=admitted),
+        submit_ptt=AsyncMock(
+            return_value=SimpleNamespace(outcome=ManagedTxOutcome.ACCEPTED)
+        ),
+    )
+    service = CommandService(executor=_DefaultExecutor(), state_store=store)
+    return (
+        RigctldHandler(
+            radio,
+            RigctldConfig(),
+            state_store=store,
+            managed_tx_authority=authority,
+            command_service=service,
+        ),
+        radio,
+        authority.admit_managed_write,
+    )
+
+
+@pytest.mark.asyncio
+async def test_rejected_managed_write_never_reaches_overlay_or_provider() -> None:
+    handler, radio, admission = _handler(admitted=False)
+
+    response = await handler.execute(parse_line(b"F 14074000"))
+
+    assert response.error is HamlibError.ERJCTED
+    admission.assert_awaited_once()
+    assert admission.await_args.args[0].name == "set_freq"
+    radio.set_freq.assert_not_awaited()
+    assert handler._command_service.lifecycle_events() == ()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "rf_state", [tx_interlock.RfState.TX, tx_interlock.RfState.UNKNOWN]
+)
+@pytest.mark.parametrize("wire", [b"F 14074000", b"M USB 2400", b"V VFOA", b"S 1 VFOB"])
+async def test_approved_managed_write_ignores_observed_rf(
+    monkeypatch: pytest.MonkeyPatch, rf_state: tx_interlock.RfState, wire: bytes
+) -> None:
+    handler, radio, admission = _handler(admitted=True)
+    monkeypatch.setattr(handler, "_resolve_rigctld_rf_state", lambda: rf_state)
+
+    response = await handler.execute(parse_line(wire))
+
+    assert response.ok
+    admission.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_managed_tuner_on_is_refused_before_provider_but_off_passes() -> None:
+    handler, radio, admission = _handler(admitted=False)
+
+    blocked = await handler.execute(parse_line(b"U TUNER 1"))
+    assert blocked.error is HamlibError.ERJCTED
+    radio.rigctld_routing.return_value.set_func.assert_not_awaited()
+
+    admission.return_value = True
+    passed = await handler.execute(parse_line(b"U TUNER 0"))
+    assert passed.ok
+    radio.rigctld_routing.return_value.set_func.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_managed_authority_is_the_only_tuner_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler, radio, admission = _handler(admitted=True)
+    monkeypatch.setattr(
+        handler, "_resolve_rigctld_rf_state", lambda: tx_interlock.RfState.TX
+    )
+
+    response = await handler.execute(parse_line(b"U TUNER 1"))
+
+    assert response.ok
+    admission.assert_awaited_once()
+    radio.rigctld_routing.return_value.set_func.assert_awaited_once()
+
+
+def test_managed_defer_family_has_no_observed_rf_seat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler, _radio, _admission = _handler(admitted=True)
+    monkeypatch.setattr(
+        handler, "_resolve_rigctld_rf_state", lambda: tx_interlock.RfState.TX
+    )
+    intent = CommandIntent(
+        id="split",
+        name="set_split_vfo",
+        params={"on": True, "tx_vfo": "VFOB"},
+        source="rigctld",
+    )
+
+    assert handler._defer_write_gate(intent) is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_managed_antenna_intent_is_refused_before_delivery() -> None:
+    handler, _radio, admission = _handler(admitted=False)
+    intent = CommandIntent(
+        id="antenna",
+        name="set_antenna_1",
+        params={"on": True},
+        source="rigctld",
+    )
+
+    with pytest.raises(_RigctldCommandFailure):
+        await handler._execute_write(intent)  # noqa: SLF001
+
+    admission.assert_awaited_once_with(intent)
+    assert handler._command_service.lifecycle_events() == ()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_managed_ptt_does_not_double_admit_as_a_write() -> None:
+    handler, _radio, admission = _handler(admitted=True)
+    response = await handler.execute(parse_line(b"T 0"), session_id="client")
+    assert response.ok
+    admission.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unmanaged_rigctld_keeps_legacy_observed_rf_interlock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = StateStore()
+    radio = AsyncMock()
+    radio.capabilities = {CAP_RIT}
+    radio.state_store = store
+    routing = Mock()
+    routing.set_func = AsyncMock(return_value=RigctldResponse())
+    radio.rigctld_routing = Mock(return_value=routing)
+    handler = RigctldHandler(radio, RigctldConfig(), state_store=store)
+    monkeypatch.setattr(
+        handler, "_resolve_rigctld_rf_state", lambda: tx_interlock.RfState.TX
+    )
+
+    response = await handler.execute(parse_line(b"U TUNER 1"))
+
+    assert response.error is HamlibError.ERJCTED
+    routing.set_func.assert_not_awaited()

--- a/tests/test_rigctld_production_composition.py
+++ b/tests/test_rigctld_production_composition.py
@@ -1,0 +1,238 @@
+"""Standalone rigctld installs the one production managed-TX graph."""
+
+import asyncio
+import logging
+from collections.abc import Callable
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from rigplane.rigctld.contract import RigctldConfig
+from rigplane.rigctld.server import RigctldServer
+from rigplane.runtime.managed_tx_composition import (
+    ManagedTxComposition,
+    install_managed_tx_composition,
+)
+from rigplane.runtime.managed_tx_state import (
+    AbortOperation,
+    ActuationOperation,
+    ActuationResult,
+    EffectToken,
+)
+from serial_stub import SerialMockRadio
+
+
+class _Actuator:
+    def __init__(self) -> None:
+        self.operations: list[ActuationOperation | AbortOperation] = []
+
+    async def actuate(
+        self,
+        _token: EffectToken,
+        operation: ActuationOperation | AbortOperation,
+        *,
+        is_current: Callable[[], bool],
+    ) -> ActuationResult:
+        if not is_current():
+            return ActuationResult.REJECTED
+        self.operations.append(operation)
+        return ActuationResult.ACCEPTED
+
+
+async def _settle(predicate: Callable[[], bool]) -> None:
+    for _ in range(100):
+        if predicate():
+            return
+        await asyncio.sleep(0.005)
+    raise AssertionError("managed effect did not settle")
+
+
+@pytest.mark.asyncio
+async def test_standalone_binds_exact_store_before_listener_and_uses_local_service(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    radio = SerialMockRadio()
+    await radio.connect()
+    composition = ManagedTxComposition(
+        _Actuator(), config_path=tmp_path / "managed-tx.json"
+    )
+    install_managed_tx_composition(radio, composition)
+    await composition.transport_ready(radio)
+    server = RigctldServer(
+        radio,
+        RigctldConfig(host="127.0.0.1", port=0),
+        managed_tx_composition=composition,
+    )
+    order: list[str] = []
+    real_bind = composition.bind_state_store
+    real_validate = composition.validate_state_store
+
+    async def bind(store) -> None:
+        order.append(f"bind:{store.provider_generation}")
+        await real_bind(store)
+
+    def validate(store) -> None:
+        order.append("validate")
+        real_validate(store)
+
+    composition.bind_state_store = bind  # type: ignore[method-assign]
+    composition.validate_state_store = validate  # type: ignore[method-assign]
+    listener = SimpleNamespace(
+        sockets=[SimpleNamespace(getsockname=lambda: ("127.0.0.1", 4532))],
+        close=lambda: None,
+        wait_closed=AsyncMock(),
+    )
+
+    async def start_listener(*_args, **_kwargs):
+        order.append("listener")
+        return listener
+
+    monkeypatch.setattr(asyncio, "start_server", start_listener)
+    try:
+        await server.start()
+        store = server._state_store  # noqa: SLF001
+        assert store is not None and store.provider_generation == 1
+        composition.validate_state_store(store)
+        assert server._managed_tx_bound_store is store  # noqa: SLF001
+        assert server._rig_handler._state_store is store  # noqa: SLF001
+        assert server._rig_handler._command_service._state_store is store  # noqa: SLF001
+        assert order == ["bind:1", "validate", "listener", "validate"]
+    finally:
+        await server.stop()
+        await composition.shutdown(asyncio.Event())
+        await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_real_socket_t1_t0_routes_only_through_composition(tmp_path) -> None:
+    radio = SerialMockRadio()
+    await radio.connect()
+    actuator = _Actuator()
+    composition = ManagedTxComposition(
+        actuator, config_path=tmp_path / "managed-tx.json"
+    )
+    install_managed_tx_composition(radio, composition)
+    await composition.transport_ready(radio)
+    server = RigctldServer(
+        radio,
+        RigctldConfig(host="127.0.0.1", port=0),
+        managed_tx_composition=composition,
+    )
+    await server.start()
+    port = int(server._server.sockets[0].getsockname()[1])  # noqa: SLF001
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    try:
+        writer.write(b"T 1\n")
+        await writer.drain()
+        assert await reader.readline() == b"RPRT 0\n"
+        await _settle(lambda: actuator.operations == [ActuationOperation.PTT_ON])
+        writer.write(b"T 0\n")
+        await writer.drain()
+        assert await reader.readline() == b"RPRT 0\n"
+        await _settle(lambda: len(actuator.operations) == 2)
+        assert actuator.operations == [
+            ActuationOperation.PTT_ON,
+            ActuationOperation.FORCE_RECEIVE,
+        ]
+        assert radio._ptt is False  # noqa: SLF001
+    finally:
+        writer.close()
+        await writer.wait_closed()
+        await server.stop()
+        await composition.shutdown(asyncio.Event())
+        await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_foreign_t0_is_wire_success_without_force_off(tmp_path) -> None:
+    radio = SerialMockRadio()
+    await radio.connect()
+    actuator = _Actuator()
+    composition = ManagedTxComposition(
+        actuator, config_path=tmp_path / "managed-tx.json"
+    )
+    install_managed_tx_composition(radio, composition)
+    await composition.transport_ready(radio)
+    server = RigctldServer(
+        radio,
+        RigctldConfig(host="127.0.0.1", port=0),
+        managed_tx_composition=composition,
+    )
+    await server.start()
+    port = int(server._server.sockets[0].getsockname()[1])  # noqa: SLF001
+    first_r, first_w = await asyncio.open_connection("127.0.0.1", port)
+    second_r, second_w = await asyncio.open_connection("127.0.0.1", port)
+    try:
+        first_w.write(b"T 1\n")
+        await first_w.drain()
+        assert await first_r.readline() == b"RPRT 0\n"
+        await _settle(lambda: actuator.operations == [ActuationOperation.PTT_ON])
+
+        second_w.write(b"T 0\n")
+        await second_w.drain()
+        assert await second_r.readline() == b"RPRT 0\n"
+        await asyncio.sleep(0)
+        assert actuator.operations == [ActuationOperation.PTT_ON]
+    finally:
+        first_w.close()
+        second_w.close()
+        await asyncio.gather(first_w.wait_closed(), second_w.wait_closed())
+        await server.stop()
+        await composition.shutdown(asyncio.Event())
+        await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_composition_identity_mismatch_fails_before_listener(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    radio = SerialMockRadio()
+    await radio.connect()
+    installed = ManagedTxComposition(
+        _Actuator(), config_path=tmp_path / "installed.json"
+    )
+    other = ManagedTxComposition(_Actuator(), config_path=tmp_path / "other.json")
+    install_managed_tx_composition(radio, installed)
+    await other.transport_ready(radio)
+    listener = AsyncMock()
+    monkeypatch.setattr(asyncio, "start_server", listener)
+    try:
+        server = RigctldServer(radio, managed_tx_composition=other)
+        with pytest.raises(RuntimeError, match="identity mismatch"):
+            await server.start()
+        listener.assert_not_awaited()
+    finally:
+        await installed.shutdown(asyncio.Event())
+        await other.shutdown(asyncio.Event())
+        await radio.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("read_only,warned", [(False, True), (True, False)])
+async def test_unmanaged_warning_boundary(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    read_only: bool,
+    warned: bool,
+) -> None:
+    radio = SerialMockRadio()
+    await radio.connect()
+    server = RigctldServer(
+        radio,
+        RigctldConfig(host="127.0.0.1", port=0, read_only=read_only),
+    )
+    listener = SimpleNamespace(
+        sockets=[SimpleNamespace(getsockname=lambda: ("127.0.0.1", 4532))],
+        close=lambda: None,
+        wait_closed=AsyncMock(),
+    )
+    monkeypatch.setattr(asyncio, "start_server", AsyncMock(return_value=listener))
+    try:
+        with caplog.at_level(logging.WARNING):
+            await server.start()
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("Managed TX authority" in message for message in messages) is warned
+    finally:
+        await server.stop()
+        await radio.disconnect()


### PR DESCRIPTION
## Outcome

Standalone `rigplane serve` now installs and reuses the same production `ManagedTxComposition` as Web/station. Before the listener opens, the server seeds its single fallback observation generation, binds and validates the exact installed composition against that `StateStore`, then constructs one handler-local `CommandService` using the same store and injects the exact authority.

Managed non-PTT writes now enter `ManagedTxAuthority.admit_managed_write` before overlays/provider delivery. Observed RF no longer admits or blocks managed frequency/mode/VFO/split/relay writes. The compatible unmanaged SDK constructor retains the legacy interlock until its separate retirement; writable unmanaged startup emits one warning, while read-only startup stays silent.

Wire behavior is unchanged: `T 1` is owner PTT down; same-owner `T 0` is PTT up; foreign/stale `T 0` remains `RPRT 0` without a write. No ForceOff/TRANSMIT/TOT wire extension, second authority, fence, runner, watchdog, or timer was added. `RigctldServer.stop()` does not own composition/provider shutdown; the existing CLI session remains the sole ordered shutdown owner.

## Search before write

Searched CLI composition branches, every `RigctldServer` construction, rigctld `set_ptt` ingress/release paths, managed-write classification/admission, external rigctld-client actuation, StateStore generation/bootstrap, and existing disconnect/wire tests before editing. The external client remains the canonical `T 1`/urgent `T 0` actuator and is unchanged.

## TDD and focused evidence

Clean test-only worktree at exact base `893af0f08230bb36a2b8d162dea4cba0e3171610` produced behavior-specific RED:

- serve exact-composition node: installed composition was `None`;
- standalone composition nodes: no composition constructor branch;
- rejected managed write returned `RPRT 0` and never called authority;
- observed TX/UNKNOWN managed writes never called authority;
- writable unmanaged warning was absent.

Current head focused non-socket GREEN: `20 passed, 2 deselected` (the two deselected tests are real-loopback-socket tests reserved for natural Mini CI). Ruff check PASS; Ruff format check PASS. Strict mypy reports the same 9 pre-existing errors on base and head, with only shifted line numbers.

Mutation discriminators captured:

- remove composition from serve -> `test_serve_passes_the_exact_preconnect_composition_to_cmd_serve` fails;
- open listener early -> `test_standalone_binds_exact_store_before_listener_and_uses_local_service` fails with listener first;
- bind before fallback seed -> same node fails provider-current validation;
- remove `admit_managed_write` -> `test_rejected_managed_write_never_reaches_overlay_or_provider` fails OK vs ERJCTED;
- restore observed-RF DEFER seat -> `test_managed_defer_family_has_no_observed_rf_seat` fails;
- restore observed-RF BLOCK seat -> `test_managed_authority_is_the_only_tuner_gate` fails ERJCTED;
- remove identity check -> `test_composition_identity_mismatch_fails_before_listener` fails (no RuntimeError);
- remove warning -> writable case of `test_unmanaged_warning_boundary` fails.

The dangerous `T0 -> ForceOff` mutation was not reintroduced into production source after the safety guard rejected it; the existing discriminator is `test_a_declined_unkey_reports_ok_and_writes_nothing`. Disconnect release remains pinned by the existing six-path `test_every_way_a_session_ends_hands_the_lease_back_exactly_once`; both run in natural Mini CI.

## Mechanism audit

Cardinality on this head: one production `ManagedTxComposition` constructor in CLI, one `ManagedTxAuthority` constructor inside composition, one managed-write policy owner and one rigctld admission call. The old rigctld key-down backstop and raw `Radio.set_ptt` remain reachable only through the explicitly compatible unmanaged branch. No managed path added a second timer, resolver, shutdown owner, or direct radio PTT call.

## Scope and verification boundary

Exactly 6 files, 529 insertions / 20 deletions. No Web/frontend/composition/StateStore/reconnect/backend-client edits. No hardware or TX was used. Full/quick is not run locally; natural PR CI on the Mini is the required gate. Independent exact-head review and green exact-head CI remain required before merge.
