### PR TITLE
Route Web PTT through managed authority

### DIFF
--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -28,6 +28,7 @@ from ...core.state_pipeline_contracts import CommandIntent, CommandSource, Field
 from ...core.state_store import FreshnessState, StateStore
 from ...profiles import RadioProfile, resolve_radio_profile
 from ...runtime.tx_interlock import RfState, evaluate_tx_interlock
+from ...runtime.managed_tx_state import ManagedTxOutcome
 from ..protocol import (  # noqa: TID251
     decode_json,
     encode_json,
@@ -162,6 +163,7 @@ from ..websocket import WS_OP_TEXT  # noqa: TID251
 
 if TYPE_CHECKING:
     from ...radio_protocol import Radio
+    from ...runtime.managed_tx_authority import ManagedTxAuthority
 
 from ...capabilities import (
     CAP_AF_LEVEL,
@@ -483,6 +485,7 @@ class ControlHandler:
             "send_cw_text",
         }
     )
+    _MANAGED_PTT_COMMANDS: frozenset[str] = frozenset({"ptt", "ptt_on", "ptt_off"})
 
     # MOR-1499: SELECTOR commands — the param carries a discrete TARGET
     # (which filter/VFO/band), not a continuous magnitude — so the
@@ -510,6 +513,7 @@ class ControlHandler:
         server: Any = None,
         read_only: bool = False,
         session_id: str | None = None,
+        managed_tx_authority: "ManagedTxAuthority | None" = None,
     ) -> None:
         self._ws = ws
         self._radio = radio
@@ -520,6 +524,7 @@ class ControlHandler:
         self._session_id = (
             session_id if session_id is not None else f"websocket-{time.monotonic_ns()}"
         )
+        self._managed_tx_authority = managed_tx_authority
         self._subscribed_streams: set[str] = set()
         # MOR-624: (command_name, previous_source) armed by the frontend auto-LAN
         # feature at TX start. MOR-993 forbids replaying it on teardown; MOR-1013
@@ -616,19 +621,44 @@ class ControlHandler:
             # socket ``await event_task`` re-raises the sender's error and
             # unregister broadcasts, so either would skip the unkey on exactly
             # the abrupt drops that need it most. The release needs neither.
-            self._release_ptt_on_teardown()
+            disconnect_task = self._start_managed_ptt_disconnect()
+            deferred_cancel: asyncio.CancelledError | None = None
+            if disconnect_task is not None:
+                try:
+                    await asyncio.shield(disconnect_task)
+                except asyncio.CancelledError as exc:
+                    # The retained authority operation must outlive this
+                    # handler, but cancellation must not skip the synchronous
+                    # session cleanup below. Re-raise it once cleanup is done.
+                    deferred_cancel = exc
+                except Exception:
+                    logger.warning(
+                        "control: managed PTT owner disconnect failed",
+                        exc_info=True,
+                    )
             self._publish_session_liveness(live=False)
             self._clear_mod_input_restore_on_teardown()
             self._cancel_pending_command_flushes()
             event_task.cancel()
+            teardown_error: Exception | None = None
+            if self._server is not None:
+                try:
+                    self._server.unregister_control_event_queue(
+                        self._event_queue, session_id=self._session_id
+                    )
+                except Exception as exc:
+                    teardown_error = exc
             try:
                 await event_task
             except asyncio.CancelledError:
                 pass
-            if self._server is not None:
-                self._server.unregister_control_event_queue(
-                    self._event_queue, session_id=self._session_id
-                )
+            except Exception as exc:
+                if teardown_error is None:
+                    teardown_error = exc
+            if deferred_cancel is not None:
+                raise deferred_cancel
+            if teardown_error is not None:
+                raise teardown_error
 
     async def _event_sender_loop(self) -> None:
         """Drain event queue and forward events to WebSocket."""
@@ -1371,6 +1401,20 @@ class ControlHandler:
                 self._session_id,
             )
 
+    def _start_managed_ptt_disconnect(self) -> asyncio.Task[ManagedTxOutcome] | None:
+        authority = self._managed_tx_authority
+        if authority is None:
+            return None
+        release = authority.owner_disconnect(self._session_id)
+        server = self._server
+        spawn = None if server is None else getattr(type(server), "_spawn", None)
+        if callable(spawn):
+            return cast(asyncio.Task[ManagedTxOutcome], spawn(server, release))
+        explicit_spawn = None if server is None else vars(server).get("_spawn")
+        if callable(explicit_spawn):
+            return cast(asyncio.Task[ManagedTxOutcome], explicit_spawn(release))
+        return asyncio.create_task(release)
+
     def _publish_session_liveness(self, *, live: bool) -> None:
         """Publish this session's liveness on the queue the poller drains.
 
@@ -1408,6 +1452,8 @@ class ControlHandler:
         command_id: str | None = None,
         source: CommandSource = "websocket",
     ) -> dict[str, Any]:
+        if name in self._MANAGED_PTT_COMMANDS:
+            return await self._enqueue_managed_ptt(name, params, source=source)
         intent_params = dict(params)
         if self._server is not None:
             intent_params["_control_server"] = self._server
@@ -1448,6 +1494,39 @@ class ControlHandler:
         )
         result = await self._command_service.execute(intent, executor=executor)
         return dict(result.executor_result.details or {})
+
+    async def _enqueue_managed_ptt(
+        self,
+        name: str,
+        params: dict[str, Any],
+        *,
+        source: CommandSource,
+    ) -> dict[str, Any]:
+        if self._read_only:
+            raise PermissionError(f"read-only mode: {name} rejected")
+        if source != "websocket":
+            raise CommandUnsupportedError(
+                "momentary PTT requires a stable WebSocket owner; "
+                "use managed force_off for unconditional release"
+            )
+        authority = self._managed_tx_authority
+        if authority is None:
+            raise CommandRejectedError("managed transmit authority unavailable")
+        if name == "ptt":
+            on = params.get("state")
+            if type(on) is not bool:
+                raise ValueError("PTT state must be a boolean")
+        else:
+            on = name == "ptt_on"
+        try:
+            submission = await authority.submit_ptt(on, self._session_id)
+        except RuntimeError as exc:
+            raise CommandRejectedError(
+                "managed transmit authority unavailable"
+            ) from exc
+        if submission.outcome is not ManagedTxOutcome.ACCEPTED:
+            raise CommandRejectedError("managed PTT admission rejected")
+        return {"state": on} if name == "ptt" else {}
 
     async def _execute_intent(
         self, intent: CommandIntent, *, wait_for_completion: bool = True

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -4116,6 +4116,7 @@ class WebServer:
             self._config.radio_model,
             server=server if server is not None else self,
             read_only=self._config.read_only,
+            managed_tx_authority=self._managed_tx_authority(),
         )
 
     async def _handle_http_commands(
@@ -5237,6 +5238,7 @@ class WebServer:
                     self._config.radio_model,
                     server=self,
                     read_only=self._config.read_only,
+                    managed_tx_authority=self._managed_tx_authority(),
                 )
                 resp = await handler._enqueue_command(  # noqa: SLF001
                     "send_cw_text",
@@ -5250,6 +5252,7 @@ class WebServer:
                     self._config.radio_model,
                     server=self,
                     read_only=self._config.read_only,
+                    managed_tx_authority=self._managed_tx_authority(),
                 )
                 resp = await handler._enqueue_command(  # noqa: SLF001
                     "stop_cw_text",
@@ -5937,6 +5940,7 @@ class WebServer:
                 model,
                 server=self,
                 read_only=self._config.read_only,
+                managed_tx_authority=self._managed_tx_authority(),
             )
         elif path == "/api/v1/scope":
             handler = ScopeHandler(ws, self._radio, server=self)

--- a/src/rigplane/web/transport/webrtc_session.py
+++ b/src/rigplane/web/transport/webrtc_session.py
@@ -247,6 +247,11 @@ class WebRtcSessionManager:
                     if self._server is not None
                     else False
                 ),
+                managed_tx_authority=(
+                    self._server._managed_tx_authority()  # noqa: SLF001
+                    if self._server is not None
+                    else None
+                ),
             )
         elif label == _SCOPE:
             handler = ScopeHandler(conn, self._radio, server=self._server)

--- a/tests/test_canonical_receiver_levels.py
+++ b/tests/test_canonical_receiver_levels.py
@@ -21,7 +21,8 @@ from rigplane.core.command_dispatch import CommandUnsupportedError
 from rigplane.core.command_service import command_intent_from_request
 from rigplane.core.exceptions import CommandError
 from rigplane.core.state_pipeline_contracts import CommandIntent, FieldPath
-from rigplane.runtime._poller_types import PttOff, SetAfLevel, SetRfGain, SetSquelch
+from rigplane.runtime._poller_types import SetAfLevel, SetRfGain, SetSquelch
+from rigplane.runtime.managed_tx_state import ManagedTxOutcome
 from rigplane.runtime.radio import CoreRadio
 from rigplane.web import radio_poller as icom_poller
 from rigplane.web.handlers.control import ControlHandler
@@ -413,6 +414,14 @@ async def test_canonical_readback_waits_for_successful_write(
 async def test_control_run_admits_next_off_while_level_write_is_unsettled(path):
     incoming = asyncio.Queue()
     entered, release, off_ack = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    authority = SimpleNamespace(
+        submit_ptt=AsyncMock(
+            return_value=SimpleNamespace(outcome=ManagedTxOutcome.ACCEPTED)
+        ),
+        owner_disconnect=AsyncMock(return_value=ManagedTxOutcome.REJECTED),
+    )
+    path.server._production_managed_tx_port = SimpleNamespace(authority=authority)
+    path.handler._managed_tx_authority = path.server._managed_tx_authority()
 
     async def send_text(payload):
         message = json.loads(payload)
@@ -443,9 +452,8 @@ async def test_control_run_admits_next_off_while_level_write_is_unsettled(path):
         off = b'{"type":"cmd","id":"off","name":"ptt_off","params":{}}'
         await incoming.put((WS_OP_TEXT, off))
         await asyncio.wait_for(off_ack.wait(), timeout=1.0)
-        [entry] = path.server.command_queue.drain_entries()
-        assert isinstance(entry.command, PttOff) and entry.command_id == "off"
-        assert entry.source == "websocket" and entry.session_id == "levels-session"
+        assert path.server.command_queue.drain_entries() == []
+        authority.submit_ptt.assert_awaited_once_with(False, "levels-session")
         assert ws.recv.await_count >= 2 and not drain.done()
         path.write.assert_awaited_once_with("AG0073;")
     finally:

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -25,6 +25,7 @@ from rigplane.core.state_pipeline_contracts import (
 )
 from rigplane.core.state_store import StateStore
 from rigplane.runtime.radio import IcomRadio
+from rigplane.runtime.managed_tx_state import ManagedTxOutcome
 from rigplane.scope import ScopeFrame
 from rigplane.types import AudioCodec
 from rigplane.web import server as server_module
@@ -46,8 +47,6 @@ from rigplane.web.protocol import (
     encode_json,
 )
 from rigplane.web.radio_poller import (
-    PttOff,
-    PttOn,
     QuickDwTrigger,
     QuickSplitTrigger,
     SelectVfo,
@@ -413,6 +412,9 @@ def _control_handler(
         "IC-7610",
         server=server,
         session_id=session_id,
+        managed_tx_authority=(
+            None if server is None else vars(server).get("managed_tx_authority")
+        ),
     )
 
 
@@ -526,8 +528,6 @@ def _scope_frame() -> ScopeFrame:
             {"shape": 1, "receiver": 1},
             {"shape": 1, "receiver": 1},
         ),
-        ("ptt", {"state": True}, PttOn, {}, {"state": True}),
-        ("ptt", {"state": False}, PttOff, {}, {"state": False}),
         (
             # MOR-1579: set_rf_power's wire contract is a normalized 0.0-1.0
             # float (frontend ValueControl min=0/max=1/step=0.01) — 0.4 is
@@ -781,8 +781,6 @@ def _scope_frame() -> ScopeFrame:
         ("set_split", {"on": True}, SetSplit, {"on": True}, {"on": True}),
         ("set_split", {"on": False}, SetSplit, {"on": False}, {"on": False}),
         ("set_vfo", {"vfo": "SUB"}, SelectVfo, {"vfo": "SUB"}, {"vfo": "SUB"}),
-        ("ptt_on", {}, PttOn, {}, {}),
-        ("ptt_off", {}, PttOff, {}, {}),
         ("vfo_swap", {}, VfoSwap, {}, {}),
         ("vfo_equalize", {}, VfoEqualize, {}, {}),
         (
@@ -2988,13 +2986,18 @@ async def test_event_sender_loop_forwards_notifications_without_subscription() -
 
 
 def _degraded_server() -> SimpleNamespace:
-    return SimpleNamespace(command_queue=_QueueRecorder())
+    authority = SimpleNamespace(
+        submit_ptt=AsyncMock(
+            return_value=SimpleNamespace(outcome=ManagedTxOutcome.ACCEPTED)
+        )
+    )
+    return SimpleNamespace(
+        command_queue=_QueueRecorder(), managed_tx_authority=authority
+    )
 
 
 @pytest.mark.asyncio
-async def test_ptt_on_rejected_when_radio_not_ready() -> None:
-    """connected:true + radio_ready:false (degraded LAN session) must not
-    silently ACK a PTT ON the radio will never execute (MOR-620)."""
+async def test_ptt_on_uses_authority_when_radio_not_ready() -> None:
     ws = SimpleNamespace(send_text=AsyncMock())
     server = _degraded_server()
     radio = _capable_radio()
@@ -3007,14 +3010,15 @@ async def test_ptt_on_rejected_when_radio_not_ready() -> None:
     )
 
     msg = decode_json(ws.send_text.await_args_list[-1].args[0])
-    assert msg["ok"] is False
-    assert msg["error"] == "radio_not_ready"
+    assert msg["ok"] is True
+    server.managed_tx_authority.submit_ptt.assert_awaited_once_with(
+        True, handler._session_id
+    )
     assert server.command_queue.items == []
 
 
 @pytest.mark.asyncio
-async def test_ptt_on_alias_rejected_when_radio_not_ready() -> None:
-    """The bare ptt_on command honors the same degraded-session gate."""
+async def test_ptt_on_alias_uses_authority_when_radio_not_ready() -> None:
     ws = SimpleNamespace(send_text=AsyncMock())
     server = _degraded_server()
     radio = _capable_radio()
@@ -3025,14 +3029,15 @@ async def test_ptt_on_alias_rejected_when_radio_not_ready() -> None:
     await handler._handle_command({"id": "p2", "name": "ptt_on", "params": {}})
 
     msg = decode_json(ws.send_text.await_args_list[-1].args[0])
-    assert msg["ok"] is False
-    assert msg["error"] == "radio_not_ready"
+    assert msg["ok"] is True
+    server.managed_tx_authority.submit_ptt.assert_awaited_once_with(
+        True, handler._session_id
+    )
     assert server.command_queue.items == []
 
 
 @pytest.mark.asyncio
-async def test_ptt_on_rejected_while_backend_reconnecting() -> None:
-    """A reconnect cycle in flight (conn_state=reconnecting) blocks PTT ON."""
+async def test_ptt_on_uses_authority_while_backend_reconnecting() -> None:
     ws = SimpleNamespace(send_text=AsyncMock())
     server = _degraded_server()
     radio = _capable_radio()
@@ -3044,8 +3049,10 @@ async def test_ptt_on_rejected_while_backend_reconnecting() -> None:
     )
 
     msg = decode_json(ws.send_text.await_args_list[-1].args[0])
-    assert msg["ok"] is False
-    assert msg["error"] == "radio_not_ready"
+    assert msg["ok"] is True
+    server.managed_tx_authority.submit_ptt.assert_awaited_once_with(
+        True, handler._session_id
+    )
     assert server.command_queue.items == []
 
 
@@ -3065,12 +3072,17 @@ async def test_ptt_off_allowed_when_radio_not_ready() -> None:
     )
     msg = decode_json(ws.send_text.await_args_list[-1].args[0])
     assert msg["ok"] is True
-    assert isinstance(server.command_queue.items[-1], PttOff)
 
     await handler._handle_command({"id": "p5", "name": "ptt_off", "params": {}})
     msg = decode_json(ws.send_text.await_args_list[-1].args[0])
     assert msg["ok"] is True
-    assert isinstance(server.command_queue.items[-1], PttOff)
+    assert [
+        call.args for call in server.managed_tx_authority.submit_ptt.await_args_list
+    ] == [
+        (False, handler._session_id),
+        (False, handler._session_id),
+    ]
+    assert server.command_queue.items == []
 
 
 @pytest.mark.asyncio
@@ -3090,4 +3102,7 @@ async def test_ptt_on_allowed_when_radio_ready() -> None:
     msg = decode_json(ws.send_text.await_args_list[-1].args[0])
     assert msg["ok"] is True
     assert msg["result"] == {"state": True}
-    assert isinstance(server.command_queue.items[-1], PttOn)
+    server.managed_tx_authority.submit_ptt.assert_awaited_once_with(
+        True, handler._session_id
+    )
+    assert server.command_queue.items == []

--- a/tests/test_mor1427_rate_limiter_coalesce.py
+++ b/tests/test_mor1427_rate_limiter_coalesce.py
@@ -27,6 +27,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from rigplane.runtime.managed_tx_state import ManagedTxOutcome
 from rigplane.web.handlers import ControlHandler
 from rigplane.web.protocol import decode_json
 from rigplane.web.radio_poller import PttOff, SetFilterWidth, SetFreq, SetMode
@@ -49,6 +50,7 @@ def _control_handler(
     radio: object | None = None,
     server: object | None = None,
     session_id: str | None = None,
+    managed_tx_authority: object | None = None,
 ) -> ControlHandler:
     if ws is None:
         ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
@@ -59,6 +61,7 @@ def _control_handler(
         "IC-7610",
         server=server,
         session_id=session_id,
+        managed_tx_authority=managed_tx_authority,  # type: ignore[arg-type]
     )
 
 
@@ -221,10 +224,16 @@ async def test_slower_than_window_commands_are_unaffected() -> None:
 async def test_ptt_off_bursts_are_never_rate_limited_or_coalesced() -> None:
     ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
     queue = _QueueRecorder()
+    authority = SimpleNamespace(
+        submit_ptt=AsyncMock(
+            return_value=SimpleNamespace(outcome=ManagedTxOutcome.ACCEPTED)
+        )
+    )
     handler = _control_handler(
         ws=ws,
         radio=SimpleNamespace(connected=True),
         server=SimpleNamespace(command_queue=queue),
+        managed_tx_authority=authority,
     )
 
     n = 5
@@ -233,10 +242,12 @@ async def test_ptt_off_bursts_are_never_rate_limited_or_coalesced() -> None:
             {"id": f"ptt-{i}", "name": "ptt_off", "params": {}}
         )
 
-    # Every single PTT OFF physically enqueues immediately — no coalescing,
-    # no pending state, regardless of how tightly they are spaced.
-    assert len(queue.items) == n
-    assert all(isinstance(item, PttOff) for item in queue.items)
+    assert authority.submit_ptt.await_count == n
+    assert all(
+        call.args == (False, handler._session_id)
+        for call in authority.submit_ptt.await_args_list
+    )
+    assert queue.items == []
     assert "ptt_off" not in handler._cmd_pending  # noqa: SLF001
     assert "ptt_off" not in handler._cmd_flush_tasks  # noqa: SLF001
 

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -119,6 +119,7 @@ from rigplane.core.tx_safety import (
     TxOwner,
     TxSource,
 )
+from rigplane.runtime.managed_tx_state import ManagedTxOutcome
 from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.runtime_helpers import build_public_state_payload_from_snapshot
 from rigplane.web.web_startup import stop_web_server
@@ -5384,7 +5385,7 @@ async def test_shutdown_drain_abandons_the_wait_not_the_write_on_timeout(
     assert radio.calls == ["set_ptt(False)", *_TEARDOWN]
 
 
-def _writable_control_session(queue: CommandQueue) -> ControlHandler:
+def _writable_control_session(queue: CommandQueue, authority: object) -> ControlHandler:
     """A writable control session whose ``run()`` ends only when cancelled —
     which is exactly when ``stop_web_server`` cancels its client tasks."""
 
@@ -5403,6 +5404,7 @@ def _writable_control_session(queue: CommandQueue) -> ControlHandler:
             unregister_control_event_queue=MagicMock(),
             build_state_update_envelope=MagicMock(return_value={}),
         ),
+        managed_tx_authority=authority,  # type: ignore[arg-type]
     )
 
 
@@ -5438,17 +5440,17 @@ def _shutdown_server(
 
 
 @pytest.mark.asyncio
-async def test_server_shutdown_delivers_the_unkey_its_client_enqueues_late() -> None:
-    """MOR-1181's production case, and why the drain alone is not enough:
-    ``stop_web_server`` cancels the poller at step 1, but the teardown PttOff
-    does not exist until ``ControlHandler.run()``'s finally runs at step 6. The
-    poller's own CancelledError handler therefore finds an empty queue every
-    time, deterministically — only the awaited final drain delivers the unkey."""
+async def test_server_shutdown_releases_via_authority_without_late_queue_off() -> None:
+    """Shutdown keeps provider teardown after Web owner release without a
+    late legacy queue fallback."""
     supervisor = _Supervisor()
     radio = _Radio(supervisor)
     queue = CommandQueue()
     poller = RadioPoller(radio, queue)  # type: ignore[arg-type]
-    handler = _writable_control_session(queue)
+    authority = SimpleNamespace(
+        owner_disconnect=AsyncMock(return_value=ManagedTxOutcome.ACCEPTED)
+    )
+    handler = _writable_control_session(queue, authority)
     client: asyncio.Task[None] = asyncio.create_task(handler.run())
     await asyncio.sleep(0.01)  # run() reaches the recv loop and publishes itself
     await poller._execute(PttOn(), session_id=handler._session_id)  # noqa: SLF001
@@ -5458,10 +5460,12 @@ async def test_server_shutdown_delivers_the_unkey_its_client_enqueues_late() -> 
     await stop_web_server(_shutdown_server(poller, [client]))  # type: ignore[arg-type]
 
     owner = TxOwner(TxSource.WEBSOCKET, handler._session_id)
-    assert supervisor.entries == [(True, owner), (False, owner)]
+    assert supervisor.entries == [(True, owner)]
     assert supervisor.outcomes[-1] is TxOutcome.ACCEPTED
-    assert radio.calls == ["start_tx", *_TEARDOWN]
+    authority.owner_disconnect.assert_awaited_once_with(handler._session_id)
+    assert radio.calls == ["start_tx"]
     assert queue.has_commands is False
+    assert poller.running is False and client.done()
 
 
 def _scope_shutdown_poller(

--- a/tests/test_web_managed_tx_ingress.py
+++ b/tests/test_web_managed_tx_ingress.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import inspect
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rigplane.core.command_dispatch import CommandUnsupportedError
+from rigplane.core.exceptions import CommandRejectedError
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import FreshnessClock, StateStore
+from rigplane.profiles import resolve_radio_profile
+from rigplane.runtime.managed_tx_state import ManagedTxOutcome
+from rigplane.web import handlers as web_handlers
+from rigplane.web.handlers.control import ControlHandler
+from rigplane.web.protocol import decode_json
+from rigplane.web.radio_poller import CommandQueue
+from rigplane.web.server import WebConfig, WebServer
+from rigplane.web.transport.webrtc_session import WebRtcSessionManager
+from test_managed_tx_http_route import _Writer, _reader
+
+
+@dataclass
+class _Submission:
+    outcome: ManagedTxOutcome
+
+    async def wait_settlement(self) -> None:
+        raise AssertionError("Web PTT admission waited for provider settlement")
+
+
+class _Authority:
+    def __init__(self) -> None:
+        self.calls: list[tuple[bool, str]] = []
+        self.next_outcome = ManagedTxOutcome.ACCEPTED
+        self.force_off_calls = 0
+        self.disconnect_calls: list[str] = []
+        self.intent: str = "rx"
+        self.tot_deadline = 120.0
+        self.disconnect_started = asyncio.Event()
+        self.disconnect_gate: asyncio.Event | None = None
+
+    async def submit_ptt(self, on: bool, owner: str) -> _Submission:
+        self.calls.append((on, owner))
+        submission = _Submission(self.next_outcome)
+        if submission.outcome is ManagedTxOutcome.ACCEPTED:
+            self.intent = f"ptt:{owner}" if on else "rx"
+        return submission
+
+    async def submit_force_off(self) -> _Submission:
+        self.force_off_calls += 1
+        return _Submission(self.next_outcome)
+
+    async def owner_disconnect(self, owner: str) -> ManagedTxOutcome:
+        self.disconnect_calls.append(owner)
+        self.disconnect_started.set()
+        if self.disconnect_gate is not None:
+            await self.disconnect_gate.wait()
+        outcome = (
+            ManagedTxOutcome.ACCEPTED
+            if self.intent == f"ptt:{owner}"
+            else ManagedTxOutcome.REJECTED
+        )
+        if outcome is ManagedTxOutcome.ACCEPTED:
+            self.intent = "rx"
+        return outcome
+
+
+def _radio() -> MagicMock:
+    profile = resolve_radio_profile(model="IC-9700")
+    radio = MagicMock()
+    radio.profile = profile
+    radio.model = profile.model
+    radio.capabilities = set(profile.capabilities)
+    radio.connected = True
+    radio.radio_ready = True
+    radio.set_ptt = AsyncMock()
+    return radio
+
+
+def _state_store(observed: object = None, *, stale: bool = False) -> StateStore:
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    if observed is not None:
+        store.apply(
+            Observation(
+                path=FieldPath.global_("tx_state", "ptt"),
+                value=observed,
+                source=SourceMetadata(source="poll_response", provider="test"),
+                timestamp_monotonic=clock.now(),
+                max_age=1.0,
+            )
+        )
+        if stale:
+            store.mark_stale_due(now=12.0)
+    return store
+
+
+def _handler(
+    authority: _Authority | None,
+    *,
+    read_only: bool = False,
+    observed: object = None,
+    stale: bool = False,
+    ws: Any | None = None,
+) -> tuple[ControlHandler, SimpleNamespace, MagicMock]:
+    queue = MagicMock()
+    retained: set[asyncio.Task[Any]] = set()
+
+    def spawn(coro: Any) -> asyncio.Task[Any]:
+        task = asyncio.create_task(coro)
+        retained.add(task)
+        task.add_done_callback(retained.discard)
+        return task
+
+    server = SimpleNamespace(
+        command_queue=queue,
+        command_state_store=_state_store(observed, stale=stale),
+        register_control_event_queue=MagicMock(return_value={}),
+        unregister_control_event_queue=MagicMock(),
+        build_state_update_envelope=MagicMock(return_value={}),
+        _managed_tx_authority=lambda: authority,
+        _spawn=spawn,
+        retained=retained,
+    )
+    radio = _radio()
+    handler = ControlHandler(
+        ws=ws or MagicMock(),
+        radio=radio,
+        server_version="test",
+        radio_model="IC-9700",
+        server=server,
+        read_only=read_only,
+        session_id="websocket-test",
+        managed_tx_authority=authority,
+    )
+    return handler, server, radio
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("name", "params", "on", "result"),
+    (
+        ("ptt", {"state": True}, True, {"state": True}),
+        ("ptt", {"state": False}, False, {"state": False}),
+        ("ptt_on", {}, True, {}),
+        ("ptt_off", {}, False, {}),
+    ),
+)
+async def test_ws_ptt_aliases_submit_exact_owner_without_queue_or_raw_fallback(
+    name: str, params: dict[str, Any], on: bool, result: dict[str, Any]
+) -> None:
+    authority = _Authority()
+    handler, server, radio = _handler(authority)
+    assert await handler._enqueue_command(name, params) == result
+    assert authority.calls == [(on, "websocket-test")]
+    assert authority.force_off_calls == 0
+    server.command_queue.put.assert_not_called()
+    server.command_queue.put_ordered.assert_not_called()
+    radio.set_ptt.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", (1, "false", {}), ids=("integer", "string", "object"))
+async def test_ws_ptt_rejects_non_boolean_state_before_authority(state: object) -> None:
+    authority = _Authority()
+    handler, server, radio = _handler(authority)
+    with pytest.raises(ValueError, match="state must be a boolean"):
+        await handler._enqueue_command("ptt", {"state": state})
+    assert authority.calls == []
+    server.command_queue.put.assert_not_called()
+    radio.set_ptt.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rejected_admission_is_a_terminal_ws_error() -> None:
+    authority = _Authority()
+    authority.next_outcome = ManagedTxOutcome.REJECTED
+    ws = SimpleNamespace(send_text=AsyncMock())
+    handler, _, _ = _handler(authority, ws=ws)
+    await handler._dispatch_command("command-1", "ptt_on", {})
+    response = decode_json(ws.send_text.await_args.args[0])
+    assert response["ok"] is False
+    assert response["id"] == "command-1"
+    assert authority.calls == [(True, "websocket-test")]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("observed", "stale"),
+    ((False, False), (True, False), (None, False), (True, True)),
+    ids=("rx", "tx", "unknown", "stale"),
+)
+async def test_observed_rf_never_changes_ptt_admission(
+    observed: object, stale: bool
+) -> None:
+    authority = _Authority()
+    handler, server, _ = _handler(authority, observed=observed, stale=stale)
+    await handler._enqueue_command("ptt_on", {})
+    assert authority.calls == [(True, "websocket-test")]
+    server.command_queue.put.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_authority_and_ownerless_http_ptt_fail_closed() -> None:
+    handler, server, radio = _handler(None)
+    with pytest.raises(CommandRejectedError, match="authority unavailable"):
+        await handler._enqueue_command("ptt_on", {})
+    with pytest.raises(CommandUnsupportedError, match="WebSocket owner"):
+        await handler._enqueue_command("ptt_off", {}, source="http")
+    server.command_queue.put.assert_not_called()
+    radio.set_ptt.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_provider_rejection_fails_before_wire() -> None:
+    authority = _Authority()
+    authority.next_outcome = ManagedTxOutcome.REJECTED
+    handler, server, radio = _handler(authority)
+    with pytest.raises(CommandRejectedError):
+        await handler._enqueue_command("ptt_on", {})
+    server.command_queue.put.assert_not_called()
+    radio.set_ptt.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_repeat_ptt_on_does_not_mutate_tot_or_wait_for_settlement() -> None:
+    authority = _Authority()
+    handler, _, _ = _handler(authority)
+    await handler._enqueue_command("ptt_on", {})
+    await handler._enqueue_command("ptt_on", {})
+    assert authority.calls == [
+        (True, "websocket-test"),
+        (True, "websocket-test"),
+    ]
+    assert authority.tot_deadline == 120.0
+
+
+def _eof_ws() -> SimpleNamespace:
+    async def recv() -> tuple[int, bytes]:
+        raise EOFError
+
+    return SimpleNamespace(send_text=AsyncMock(), recv=recv)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("intent", "expected"),
+    (
+        ("ptt:websocket-test", "rx"),
+        ("ptt:websocket-other", "ptt:websocket-other"),
+        ("transmit", "transmit"),
+    ),
+    ids=("matching-owner", "unrelated-owner", "transmit-latch"),
+)
+async def test_disconnect_is_owner_scoped_and_preserves_transmit(
+    intent: str, expected: str
+) -> None:
+    authority = _Authority()
+    authority.intent = intent
+    handler, server, _ = _handler(authority, ws=_eof_ws())
+    await handler.run()
+    assert authority.disconnect_calls == ["websocket-test"]
+    assert authority.intent == expected
+    assert authority.force_off_calls == 0
+    server.command_queue.put.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_handler_finishes_cleanup_and_retains_disconnect_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authority = _Authority()
+    authority.intent = "ptt:websocket-test"
+    authority.disconnect_gate = asyncio.Event()
+    recv_gate = asyncio.Event()
+    recv_started = asyncio.Event()
+    sender_cancelled = asyncio.Event()
+
+    async def recv() -> tuple[int, bytes]:
+        recv_started.set()
+        await recv_gate.wait()
+        raise EOFError
+
+    async def event_sender() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            sender_cancelled.set()
+            raise
+
+    handler, server, _ = _handler(
+        authority, ws=SimpleNamespace(send_text=AsyncMock(), recv=recv)
+    )
+    queue = CommandQueue()
+    server.command_queue = queue
+    server.unregister_control_event_queue.side_effect = RuntimeError(
+        "unregister failed"
+    )
+    monkeypatch.setattr(handler, "_event_sender_loop", event_sender)
+    pending_flush = asyncio.create_task(asyncio.Event().wait())
+    handler._cmd_flush_tasks["pending"] = pending_flush  # noqa: SLF001
+    handler._cmd_pending["pending"] = ("id", "set_freq", {})  # noqa: SLF001
+    task = asyncio.create_task(handler.run())
+    try:
+        await recv_started.wait()
+        assert queue.session_is_live("websocket-test")
+        task.cancel()
+        await authority.disconnect_started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert not queue.session_is_live("websocket-test")
+        server.unregister_control_event_queue.assert_called_once_with(
+            handler._event_queue,  # noqa: SLF001
+            session_id="websocket-test",
+        )
+        assert sender_cancelled.is_set()
+        assert not handler._cmd_flush_tasks  # noqa: SLF001
+        assert not handler._cmd_pending  # noqa: SLF001
+        assert pending_flush.cancelling()
+        assert server.retained
+        release_task = next(iter(server.retained))
+        assert not release_task.cancelled()
+        authority.disconnect_gate.set()
+        await release_task
+        assert authority.disconnect_calls == ["websocket-test"]
+        assert authority.intent == "rx"
+    finally:
+        authority.disconnect_gate.set()
+        task.cancel()
+        pending_flush.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        with contextlib.suppress(asyncio.CancelledError):
+            await pending_flush
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "payload", "status"),
+    (
+        ("/api/v1/commands", {"name": "ptt_on", "params": {}}, 409),
+        (
+            "/api/v1/commands/batch",
+            {"steps": [{"name": "ptt_off", "params": {}}]},
+            200,
+        ),
+    ),
+    ids=("single", "batch"),
+)
+async def test_generic_http_ptt_is_rejected_before_queue(
+    path: str, payload: dict[str, Any], status: int
+) -> None:
+    server = WebServer(_radio(), WebConfig(host="127.0.0.1", port=0))
+    reader, headers = _reader(payload)
+    writer = _Writer()
+
+    await server._handle_http(  # noqa: SLF001
+        writer,  # type: ignore[arg-type]
+        "POST",
+        path,
+        headers=headers,
+        reader=reader,
+    )
+
+    assert writer.status == status
+    assert writer.payload["ok"] is False
+    assert not server.command_queue.drain()
+
+
+@pytest.mark.asyncio
+async def test_managed_force_off_remains_available_while_generic_ptt_is_closed() -> (
+    None
+):
+    authority = _Authority()
+    server = WebServer(_radio(), WebConfig(host="127.0.0.1", port=0, read_only=True))
+    server._production_managed_tx_port = SimpleNamespace(authority=authority)  # noqa: SLF001
+    reader, headers = _reader({"operation": "force_off"})
+    writer = _Writer()
+
+    await server._handle_http(  # noqa: SLF001
+        writer,  # type: ignore[arg-type]
+        "POST",
+        "/api/v1/managed-transmit/command",
+        headers=headers,
+        reader=reader,
+    )
+
+    assert writer.status == 202
+    assert authority.force_off_calls == 1
+    assert not server.command_queue.drain()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_server", (True, False), ids=("server", "serverless"))
+async def test_webrtc_control_handler_receives_explicit_exact_authority(
+    monkeypatch: pytest.MonkeyPatch, with_server: bool
+) -> None:
+    authority = _Authority()
+    server = None
+    if with_server:
+        server = WebServer(_radio(), WebConfig(host="127.0.0.1", port=0))
+        server._production_managed_tx_port = SimpleNamespace(  # noqa: SLF001
+            authority=authority
+        )
+    captured: dict[str, Any] = {}
+
+    class _Handler:
+        def __init__(self, *_args: Any, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        async def run(self) -> None:
+            return None
+
+    monkeypatch.setattr(web_handlers, "ControlHandler", _Handler)
+    manager = WebRtcSessionManager(_radio(), server, "IC-9700")
+    session = SimpleNamespace(pc=MagicMock(), tasks=[])
+    channel = SimpleNamespace(label="control", on=MagicMock())
+
+    manager._dispatch_channel(session, channel)  # noqa: SLF001
+    await session.tasks[0]
+
+    assert captured.get("managed_tx_authority") is (authority if with_server else None)
+
+
+def test_managed_web_ptt_cannot_reach_legacy_control_producers() -> None:
+    run_source = inspect.getsource(ControlHandler.run)
+    enqueue_source = inspect.getsource(ControlHandler._enqueue_command)
+
+    assert "_release_ptt_on_teardown" not in run_source
+    assert enqueue_source.index("_MANAGED_PTT_COMMANDS") < enqueue_source.index(
+        "_command_service.execute"
+    )
+
+
+def test_state_projection_keeps_authority_separate_from_observed_rf() -> None:
+    source = inspect.getsource(WebServer._managed_tx_document)
+
+    assert "authority.snapshot" in source
+    assert "project_observed_ptt" in source
+    assert "observed_ptt" not in inspect.getsource(ControlHandler._enqueue_command)

--- a/tests/test_web_managed_tx_owner.py
+++ b/tests/test_web_managed_tx_owner.py
@@ -50,7 +50,6 @@ from rigplane.core.capabilities import CAP_AUDIO
 from rigplane.core.exceptions import CommandError
 from rigplane.core.radio_protocol import ManagedTxApi, PrivilegedTxApi
 from rigplane.core.tx_safety import (
-    ProviderAttemptKind,
     ProviderPttObservation,
     RadioTx,
     TxOutcome,
@@ -177,19 +176,6 @@ def _run_handler(
     ), queue
 
 
-def _wired(
-    supervisor: _Supervisor | None,
-) -> tuple[ControlHandler, RadioPoller, _Radio]:
-    """One control session and one poller over the queue the server shares."""
-    handler, queue = _run_handler()
-    radio = _Radio(supervisor)
-    return handler, RadioPoller(radio, queue), radio  # type: ignore[arg-type]
-
-
-def _owner(handler: ControlHandler) -> TxOwner:
-    return TxOwner(TxSource.WEBSOCKET, handler._session_id)
-
-
 async def _drain(poller: RadioPoller) -> None:
     """Execute queued entries exactly as ``_run``'s drain does — including its
     default of ``source="websocket"`` for an entry that carries no source."""
@@ -201,29 +187,6 @@ async def _drain(poller: RadioPoller) -> None:
             session_id=entry.session_id,
             command_service=entry.command_service,
         )
-
-
-def _settle_release(supervisor: _Supervisor) -> list[ProviderAttemptKind]:
-    """Drive the started de-key to completion and report the provider work.
-
-    The policy is pure: ``release_owner`` only STARTS the release. Undriven, the
-    lease sits in RELEASE_PENDING and the next session is refused for a reason
-    that is not BUSY but is still a refusal, which would prove nothing. Every
-    attempt this settles belongs to the de-key, so observing the rig OFF after
-    each one is what the runtime's effect service sees on a rig that obeyed.
-    """
-    kinds: list[ProviderAttemptKind] = []
-    seq = 1
-    while (attempt := supervisor.inner.snapshot.active_attempt) is not None:
-        kinds.append(attempt.kind)
-        supervisor.inner.settle_attempt(
-            attempt.id, attempt.provider_generation, succeeded=True
-        )
-        seq += 1
-        supervisor.inner.observe_ptt(
-            ProviderPttObservation(RadioTx.OFF, 0, seq, time.monotonic())
-        )
-    return kinds
 
 
 async def test_unmanaged_radio_keeps_the_legacy_write_and_ordering() -> None:
@@ -510,217 +473,6 @@ async def test_teardown_marks_the_session_gone_through_a_dead_egress_socket() ->
         await handler.run()
 
     assert not queue.session_is_live(handler._session_id)
-
-
-async def test_a_disconnect_releases_the_lease_it_took_not_just_the_rig() -> None:
-    """MOR-1185, acceptance 1 and 2: the next session keys without waiting.
-
-    The teardown OFF used to go onto the RAW server queue, so it reached the
-    drain sourceless and session-less, took the legacy write, and left the lease
-    with a session that no longer exists. MOR-1191's watchdog clears that after
-    ``watchdog_seconds`` — a backstop, not a fix: three minutes of denied TX
-    after every disconnect. A real supervisor drives this, so an owner that did
-    not match would answer STALE here rather than quietly passing.
-
-    Consequence C rides along: the finally unregisters the session immediately
-    after enqueuing the unkey, so the entry is always drained on behalf of an
-    author already gone. ``_refuse_key_from_gone_session`` covers ``PttOn`` only
-    and must keep to it — an OFF refused for being late strands a transmitter.
-    """
-    supervisor = _Supervisor()
-    handler, poller, radio = _wired(supervisor)
-    handler._publish_session_liveness(live=True)
-
-    await handler._enqueue_command("ptt_on", {})
-    await _drain(poller)
-    await handler.run()  # EOF on the first recv: the session disconnects
-    assert not poller._queue.session_is_live(handler._session_id)
-    await _drain(poller)
-
-    assert supervisor.entries == [(True, _owner(handler)), (False, _owner(handler))]
-    assert supervisor.outcomes == [TxOutcome.ACCEPTED, TxOutcome.ACCEPTED]
-    # The de-key is the supervisor's own WRITE_OFF, not a raw defensive write.
-    assert _settle_release(supervisor) == [
-        ProviderAttemptKind.WRITE_ON,  # the key attempt, cancelled by the release
-        ProviderAttemptKind.WRITE_OFF,
-    ]
-    assert "set_ptt(False)" not in radio.calls
-
-    second, _ = _run_handler(poller._queue)
-    second._publish_session_liveness(live=True)
-    await second._enqueue_command("ptt_on", {})
-    await _drain(poller)
-
-    # ACCEPTED, not BUSY and not RELEASE_PENDING: the lease is genuinely gone.
-    assert supervisor.entries[-1] == (True, _owner(second))
-    assert supervisor.outcomes[-1] is TxOutcome.ACCEPTED
-
-
-async def test_the_lease_is_released_through_a_dead_egress_socket() -> None:
-    """Acceptance 3: slice 2's guarantee, now with a lease behind it.
-
-    ``await event_task`` re-raises the sender's error and skips everything
-    behind it, which is why the release is the FIRST statement of the finally.
-    """
-    supervisor = _Supervisor()
-    handler, poller, radio = _wired(supervisor)
-    handler._publish_session_liveness(live=True)
-    await handler._enqueue_command("ptt_on", {})
-    await _drain(poller)
-    handler._ws.send_text = AsyncMock(
-        side_effect=[None, None, ConnectionResetError("egress socket closed")]
-    )
-    handler._event_queue.put_nowait({"type": "state_update"})
-
-    with pytest.raises(ConnectionResetError):
-        await handler.run()
-    await _drain(poller)
-
-    assert supervisor.entries[-1] == (False, _owner(handler))
-    assert supervisor.outcomes[-1] is TxOutcome.ACCEPTED
-
-
-async def test_a_session_that_never_keyed_writes_nothing_to_a_managed_rig() -> None:
-    """Consequence A, stated: this REMOVES a defensive write that fires today.
-
-    ``release_owner`` on a session holding no lease answers STALE and emits no
-    WRITE_OFF, so nothing reaches the rig. Correct when it is idle, and required
-    when it is not: under management the lease is the authority on who is on the
-    air, and one session's disconnect must not de-key another's transmission.
-    The rig keyed by something outside the supervisor's knowledge
-    (``TxPhase.EXTERNAL_UNOWNED``, still without consumers) stays MOR-1175's to
-    close — a per-session blind write is not the instrument for it.
-    """
-    supervisor = _Supervisor()
-    handler, poller, radio = _wired(supervisor)
-
-    await handler.run()
-    await _drain(poller)
-
-    assert supervisor.entries == [(False, _owner(handler))]
-    assert supervisor.outcomes == [TxOutcome.STALE]
-    assert _settle_release(supervisor) == []  # no provider write of any kind
-    assert radio.calls == _TEARDOWN
-
-
-async def test_an_unmanaged_teardown_still_writes_the_unconditional_unkey() -> None:
-    """Acceptance 4, corrected for MOR-1179.
-
-    This docstring used to say "no shipped backend assembles a managed runtime
-    until MOR-1016" — that is stale. MOR-1016 has merged and managed TX is ON
-    by default (``RIGPLANE_MANAGED_TX`` is an opt-out, ``core/env_config.py``),
-    so this is no longer what production's common case does. What it still
-    pins is the LEGACY residual behind the kill switch: with no supervisor
-    published (``RIGPLANE_MANAGED_TX=0``, or a backend that assembles none),
-    teardown keeps the unconditional legacy OFF, unchanged. See the two-session
-    tests below for the managed-path counterpart this residual sits next to.
-    """
-    handler, poller, radio = _wired(None)
-
-    await handler.run()
-    await _drain(poller)
-
-    assert radio.calls == ["set_ptt(False)", *_TEARDOWN]
-
-
-async def test_a_second_session_teardown_does_not_de_key_a_live_first_session() -> None:
-    """MOR-1179: a closing session must not de-key another session's live TX.
-
-    The acceptance gap this closes: the merged evidence
-    (``test_a_session_that_never_keyed_writes_nothing_to_a_managed_rig``, above)
-    only shows a closer holding NO lease leaves an idle rig alone. MOR-1179
-    wants the case where session A actually IS transmitting when session B — a
-    second writable session sharing the same queue — disconnects. Doctrine: one
-    session's disconnect must not de-key another session's live transmission;
-    ownership arbitration is the managed lease (``release_owner`` matching on
-    ``TxOwner``), not the queue B's teardown entry happens to share with A.
-
-    Structurally this is a straight read of ``release_owner``
-    (``core/tx_safety.py``): it answers STALE on any owner mismatch and emits
-    no effect, so B's teardown never reaches the provider. Confirmed live here,
-    not just asserted from the policy: a real ``TxSafetySupervisor`` drives it,
-    and A's lease is proven to still be live afterwards (a repeat key from A is
-    IDEMPOTENT; a key from a third owner is BUSY), not merely "not released".
-    """
-    supervisor = _Supervisor()
-    handler_a, poller, radio = _wired(supervisor)
-    handler_a._publish_session_liveness(live=True)
-    await handler_a._enqueue_command("ptt_on", {})
-    await _drain(poller)  # A is keyed, ACCEPTED
-
-    assert supervisor.outcomes[-1] is TxOutcome.ACCEPTED
-    assert "set_ptt(False)" not in radio.calls
-    a_write_on = supervisor.inner.snapshot.active_attempt  # A's own, still unsettled
-
-    handler_b, _ = _run_handler(poller._queue)  # second writable session, SAME queue
-    handler_b._publish_session_liveness(live=True)
-    await handler_b.run()  # EOF on first recv -> B tears down, enqueues its own PttOff
-    await _drain(poller)
-
-    assert supervisor.entries[-1] == (False, _owner(handler_b))
-    assert supervisor.outcomes[-1] is TxOutcome.STALE
-    # The load-bearing pair is the STALE outcome above plus release_reason
-    # below — NOT the identity check that follows on its own. A genuine,
-    # owner-matched release also leaves ``active_attempt`` as the same object:
-    # ``_release_current`` cancels it via ``_cancel()`` (``core/tx_safety.py``),
-    # which records a ``CancelProviderAttempt`` effect but never clears or
-    # replaces ``self._active``. So identity alone cannot tell "STALE, nothing
-    # happened" apart from "a real release just started". ``release_reason``
-    # can: it is set only by ``_begin_release``, which STALE's early return
-    # never reaches, so it stays ``None`` here and would flip to the release's
-    # reason the moment ownership resolution let a mismatched release through.
-    # (``radio.calls`` alone cannot prove any of this either: this harness's
-    # ``_Supervisor`` never calls ``radio.set_ptt`` on the managed path at
-    # all, so "set_ptt(False) not in radio.calls" would hold regardless of
-    # whether the release actually touched anything.)
-    assert supervisor.inner.snapshot.active_attempt is a_write_on
-    assert supervisor.inner.snapshot.release_reason is None
-    # A's transmission survives: no de-key reaches the provider. The leg is
-    # only ever disarmed defensively behind the refusal, never keyed off.
-    assert "set_ptt(False)" not in radio.calls
-    assert radio.calls == ["start_tx", *_TEARDOWN]
-
-    # A's lease is still live, proven two ways: a repeat key from A answers
-    # IDEMPOTENT (already-yours acceptance, not a fresh grant)...
-    await handler_a._enqueue_command("ptt_on", {})
-    await _drain(poller)
-    assert supervisor.entries[-1] == (True, _owner(handler_a))
-    assert supervisor.outcomes[-1] is TxOutcome.IDEMPOTENT
-
-    # ...and a third owner attempting to key while A holds the lease is BUSY,
-    # not refused as gone (the queue is authoritative once any session has
-    # registered, so the third owner must register too).
-    poller._queue.register_session("ws-third")
-    with pytest.raises(CommandError, match=TxOutcome.BUSY):
-        await poller._execute(PttOn(), command_id="c-third", session_id="ws-third")
-    assert supervisor.entries[-1] == (True, TxOwner(TxSource.WEBSOCKET, "ws-third"))
-    assert supervisor.outcomes[-1] is TxOutcome.BUSY
-
-
-async def test_a_second_sessions_teardown_still_de_keys_on_the_legacy_path() -> None:
-    """MOR-1179 legacy counterpart: pins the residual behind the kill switch.
-
-    Same two-session shape as the managed test above, but with
-    ``_wired(None)`` — no supervisor published, so ``PttOff`` always takes the
-    unconditional legacy write regardless of which session's teardown enqueued
-    it. This is the documented residual exposure MOR-1179's decision leaves in
-    place deliberately (interim legacy-path mitigation was explicitly declined,
-    to keep the kill switch's "no lease, no owner" contract honest): with
-    ``RIGPLANE_MANAGED_TX=0``, session B's disconnect DOES de-key session A.
-    """
-    handler_a, poller, radio = _wired(None)
-    handler_a._publish_session_liveness(live=True)
-    await handler_a._enqueue_command("ptt_on", {})
-    await _drain(poller)  # A is keyed via the raw legacy write
-
-    handler_b, _ = _run_handler(poller._queue)  # second writable session, SAME queue
-    handler_b._publish_session_liveness(live=True)
-    await handler_b.run()  # EOF on first recv -> B tears down, enqueues its own PttOff
-    await _drain(poller)
-
-    # The residual, pinned rather than latent: B's teardown de-keys A.
-    assert "set_ptt(False)" in radio.calls
-    assert radio.calls == [*_KEY, "set_ptt(False)", *_TEARDOWN]
 
 
 # --- the ingress gate itself (rigplane.runtime.managed_tx_ingress) ----------

--- a/tests/test_web_mod_input_restore.py
+++ b/tests/test_web_mod_input_restore.py
@@ -338,17 +338,16 @@ class TestTeardownPttRelease:
 
 
 class TestRunTeardownWiring:
-    """run()'s finally must reach the release before any step that can raise."""
+    """A handler without managed authority cannot invent a teardown release."""
 
     @pytest.mark.asyncio
-    async def test_run_releases_ptt_on_disconnect_without_arm(self) -> None:
+    async def test_run_without_authority_enqueues_no_disconnect_ptt(self) -> None:
         handler, q = _make_run_handler()
         await handler.run()
-        assert q.drain() == [PttOff()]
+        assert q.drain() == []
 
     @pytest.mark.asyncio
-    async def test_release_survives_dead_egress_socket(self) -> None:
-        """A dead egress socket kills the sender; ``await event_task`` re-raises."""
+    async def test_dead_egress_does_not_add_a_legacy_release(self) -> None:
         handler, q = _make_run_handler()
         handler._ws.send_text = AsyncMock(
             side_effect=[None, None, ConnectionResetError("egress socket closed")]
@@ -357,16 +356,15 @@ class TestRunTeardownWiring:
         handler._event_queue.put_nowait({"type": "state_update"})
         with pytest.raises(ConnectionResetError):
             await handler.run()
-        assert q.drain() == [PttOn(), PttOff()]
+        assert q.drain() == [PttOn()]
 
     @pytest.mark.asyncio
-    async def test_release_survives_unregister_failure(self) -> None:
-        """``unregister_control_event_queue`` broadcasts; it is not raise-free."""
+    async def test_unregister_failure_does_not_add_a_legacy_release(self) -> None:
         handler, q = _make_run_handler(unregister=MagicMock(side_effect=RuntimeError))
         handler._enqueue_rc_power("ptt_on", {}, q, handler._radio)
         with pytest.raises(RuntimeError):
             await handler.run()
-        assert q.drain() == [PttOn(), PttOff()]
+        assert q.drain() == [PttOn()]
 
 
 class TestCommandRouting:

--- a/tests/test_web_ptt_readonly.py
+++ b/tests/test_web_ptt_readonly.py
@@ -18,6 +18,7 @@ from rigplane.core.state_pipeline_contracts import (
     SourceMetadata,
 )
 from rigplane.core.state_store import FreshnessClock, StateStore
+from rigplane.runtime.managed_tx_state import ManagedTxOutcome
 from rigplane.web import server as web_server
 from rigplane.web.protocol import decode_json
 from rigplane.web.radio_poller import SetTunerStatus
@@ -32,6 +33,7 @@ def _make_handler(
     radio: Any = None,
     ptt: object = False,
     stale: bool = False,
+    authority: Any = None,
 ) -> tuple[ControlHandler, Queue[Any]]:
     """Build a ControlHandler with a fake server and return (handler, command_queue)."""
     ws = MagicMock()
@@ -72,6 +74,7 @@ def _make_handler(
         radio_model="IC-7610",
         server=server,
         read_only=read_only,
+        managed_tx_authority=authority,
     )
     return handler, command_queue
 
@@ -111,33 +114,48 @@ class TestWebPttReadOnly:
 
     @pytest.mark.asyncio
     async def test_ptt_allowed_when_not_read_only(self) -> None:
-        """ptt command dispatches normally when read_only=False."""
-        handler, q = _make_handler(read_only=False)
+        authority = SimpleNamespace(
+            submit_ptt=AsyncMock(
+                return_value=SimpleNamespace(outcome=ManagedTxOutcome.ACCEPTED)
+            )
+        )
+        handler, q = _make_handler(read_only=False, authority=authority)
 
         result = await handler._enqueue_command("ptt", {"state": True})
 
         assert result == {"state": True}
-        assert not q.empty(), "PttOn must be enqueued"
+        authority.submit_ptt.assert_awaited_once_with(True, handler._session_id)
+        assert q.empty()
 
     @pytest.mark.asyncio
     async def test_ptt_on_allowed_when_not_read_only(self) -> None:
-        """ptt_on command dispatches normally when read_only=False."""
-        handler, q = _make_handler(read_only=False)
+        authority = SimpleNamespace(
+            submit_ptt=AsyncMock(
+                return_value=SimpleNamespace(outcome=ManagedTxOutcome.ACCEPTED)
+            )
+        )
+        handler, q = _make_handler(read_only=False, authority=authority)
 
         result = await handler._enqueue_command("ptt_on", {})
 
         assert result == {}
-        assert not q.empty(), "PttOn must be enqueued"
+        authority.submit_ptt.assert_awaited_once_with(True, handler._session_id)
+        assert q.empty()
 
     @pytest.mark.asyncio
     async def test_ptt_off_allowed_when_not_read_only(self) -> None:
-        """ptt_off command dispatches normally when read_only=False."""
-        handler, q = _make_handler(read_only=False)
+        authority = SimpleNamespace(
+            submit_ptt=AsyncMock(
+                return_value=SimpleNamespace(outcome=ManagedTxOutcome.ACCEPTED)
+            )
+        )
+        handler, q = _make_handler(read_only=False, authority=authority)
 
         result = await handler._enqueue_command("ptt_off", {})
 
         assert result == {}
-        assert not q.empty(), "PttOff must be enqueued"
+        authority.submit_ptt.assert_awaited_once_with(False, handler._session_id)
+        assert q.empty()
 
 
 class TestWebCwReadOnly:

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -923,9 +923,6 @@ class TestControlChannel:
             await _close_ws(writer)
 
     async def test_command_ptt(self, server: WebServer, mock_radio: MagicMock) -> None:
-        # MOR-1879: keying now passes the server RF gate, so the scenario's
-        # premise — a rig observed in RX — is stated explicitly.
-        _seed_fresh_rx(server.command_state_store)
         host, port = _addr(server)
         reader, writer, _ = await _ws_connect(host, port, "/api/v1/ws")
         try:
@@ -939,10 +936,9 @@ class TestControlChannel:
             await _ws_send_text(writer, json.dumps(cmd))
             _, payload = await _ws_recv_frame(reader)
             resp = json.loads(payload)
-            assert resp["ok"] is True
-            # PTT goes through command queue; wait for poller to drain it
-            await asyncio.sleep(0.05)
-            mock_radio.set_ptt.assert_awaited_once_with(True)
+            assert resp["ok"] is False
+            assert resp["error"] == "radio_nak"
+            mock_radio.set_ptt.assert_not_awaited()
         finally:
             await _close_ws(writer)
 
@@ -2414,9 +2410,7 @@ class TestHalfOpenWsReaper:
         mock_radio: MagicMock,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """A stale (pong-timed-out) control session must be reaped within
-        one zombie-reaper pass: task completes, PTT OFF teardown ran, and
-        the disconnect is logged -- without the peer ever sending a FIN."""
+        """A stale control session is reaped without inventing a legacy OFF."""
         host, port = _addr(server)
         reader, writer, _ = await _ws_connect(host, port, "/api/v1/ws")
         try:
@@ -2451,12 +2445,10 @@ class TestHalfOpenWsReaper:
 
             assert len(server._client_tasks) == before - 1  # noqa: SLF001
 
-            # The exact PTT-OFF teardown log line pinned by MOR-1013/MOR-1429:
-            # a session must not disconnect (by any path) without this.
-            assert any(
+            assert not any(
                 "requested PTT OFF on control session teardown" in r.message
                 for r in caplog.records
-            ), "reaped session must have run the unconditional PTT OFF teardown"
+            )
             assert any("ws disconnect" in r.message for r in caplog.records)
         finally:
             writer.close()
@@ -2469,8 +2461,7 @@ class TestHalfOpenWsReaper:
         mock_radio: MagicMock,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """A normal client-initiated close must still run the exact same
-        teardown sequence -- the reaping fix must not disturb it."""
+        """A cooperative close also invents no legacy PTT OFF."""
         host, port = _addr(server)
         reader, writer, _ = await _ws_connect(host, port, "/api/v1/ws")
         await _ws_skip_handshake(reader)
@@ -2483,7 +2474,7 @@ class TestHalfOpenWsReaper:
             )
 
         assert len(server._client_tasks) == before - 1  # noqa: SLF001
-        assert any(
+        assert not any(
             "requested PTT OFF on control session teardown" in r.message
             for r in caplog.records
         )


### PR DESCRIPTION
## Outcome

Routes every managed Web momentary PTT ingress through the single installed ManagedTxAuthority. Web remains validation and ingress only: it neither constructs nor shuts down composition state.

Linear owner: MOR-2308.

## Search before write

Searched all production ControlHandler constructors, WebSocket and HTTP PTT aliases, teardown release paths, WebRTC dispatch, CommandService drains, Radio.set_ptt, tx_interlock, observed RF admission, wait_settlement, ForceOff, poller watchdog, and session-liveness cleanup before editing.

Dependencies already merged:
- browser thin client PR #3156: 2b1c4a7bab821be9b9321003e31c99d165efc5db
- managed composition PR #3159: 893af0f08230bb36a2b8d162dea4cba0e3171610
- exact base: 7ca58df0daf9b9e6a11dc43cab0bd649b6eb1af7
- exact head: f5a8199baa66bc3584c6c80e563a799f5cdace9a

## Contract

- ptt, ptt_on, and ptt_off are intercepted before CommandService and queue routing.
- WebSocket operations submit authority.submit_ptt with the immutable session owner; ACK is admission-only and never waits for provider settlement.
- missing authority and ownerless HTTP PTT fail closed.
- all five production ControlHandler constructors, including WebRTC, pass the exact authority explicitly; serverless WebRTC passes None and therefore fails closed.
- disconnect retains owner_disconnect, completes liveness, pending-flush, sender, and unregister cleanup under cancellation, then re-raises cancellation.
- owner disconnect is owner-local; it never substitutes global ForceOff and does not clear TRANSMIT.
- ForceOff, TRANSMIT, and TOT managed APIs remain unchanged.

Owner correction: legacy ControlHandler PttOn/PttOff definitions, poller/backstop state, and later-retirement tests remain for MOR-2172. They are unreachable from managed Web ingress and teardown in this PR. Standalone rigctld remains unmanaged for beta under MOR-2173.

## Scope

12 paths, 664 insertions, 329 deletions, 993 changed lines. Production changes are limited to control.py, server.py, and transport/webrtc_session.py. No CLI, rigctld, frontend, profile, RadioPoller production, web_startup, runtime authority/composition, or hardware changes.

## TDD

Initial RED before production cutover: 21 collected, 19 failed and 2 passed. Failures discriminated missing authority injection, queue/raw fallback, and ownerless HTTP acceptance.

Final production-gap RED before the last production edits: 4 collected, 3 failed and 1 passed:
- cancellation plus raising unregister propagated RuntimeError before sender cleanup and cancellation
- WebRTC omitted the exact authority
- legacy teardown producer remained reachable by structural contract

Review and terminal-integration RED additionally discriminated malformed truthy non-bool state, ordinary OFF escalation to ForceOff, canonical receiver-level legacy admission, and the late shutdown queue/unkey expectation.

GREEN, 80 focused tests total:
- managed ingress: 26 passed
- read-only PTT: 38 passed
- handler, degraded-radio, rate-limit, owner, and teardown group: 11 passed
- real loopback WebSocket PTT, reaper, and cooperative close: 3 passed
- terminal stale-contract nodes: 2 passed
- Ruff check: PASS on all 12 changed paths
- Ruff format check: PASS on all 12 changed paths
- strict mypy src/rigplane/web: PASS, 27 files
- git diff --check: PASS

No local quick, full, visual, product-wide suite, manual CI rerun, or hardware run.

## Mutation evidence

Prior safe mutations against this cutover produced the intended discriminators:
- remove managed intercept: all four alias nodes fail
- replace owner OFF with global ForceOff: both OFF alias nodes fail
- wait for settlement: repeat-PTT admission node fails
- use wrong owner: all four alias nodes fail
- add observed-RF gate: TX, UNKNOWN, and stale nodes fail while RX passes
- add raw fallback when authority is absent: fail-closed node fails
- unconditional ForceOff on disconnect: matching, unrelated, and TRANSMIT owner cases fail

Unsafe missing-disconnect and lost-retention mutations were not executed. Their discriminators are green: owner-scoped disconnect cases and test_cancelled_handler_finishes_cleanup_and_retains_disconnect_release.

## Census

Production constructors: 5 ControlHandler calls; explicit managed_tx_authority arguments: 5.

Managed Web PTT method calls only authority.submit_ptt. It contains no wait_settlement, queue put, PttOn/PttOff, Radio.set_ptt, raw protocol, evaluate_tx_interlock, observed RF, submit_force_off, or ForceOff call. ControlHandler.run contains no call to the legacy _release_ptt_on_teardown producer.

## Hardware boundary

No radio was keyed. Owner-present IC-7300 and FTX-1 acceptance and atomic legacy deletion remain later gates owned outside this PR.
