### PR TITLE
fix(MOR-2129): resolve Yaesu CN CTCSS through profile domain

### DIFF
--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -26,6 +26,7 @@ from .transport import CatCommandRejected, CatTimeoutError, CatTransportError
 
 if TYPE_CHECKING:
     from rigplane.core.types import BreakInMode
+    from rigplane.profiles import RadioProfile
 
 logger = logging.getLogger(__name__)
 
@@ -165,7 +166,7 @@ _MAIN_REPEATER_TSQL = FieldPath.receiver("main", "operator_toggles", "repeater_t
 # command (FTX-1_CAT_OM_ENG_2508-C) reports the MAIN tone as a 0-49 INDEX into
 # the standard 50-tone EIA chart (NOT an absolute frequency; cf. Icom 0x1B
 # BCD-Hz). The radio maps that index → Hz → centiHz (the index→Hz Tone Chart
-# is verbatim from the manual; see ``radio._CTCSS_TONE_CENTIHZ``). The neutral
+# is resolved by the active ``RadioProfile`` catalog). The neutral
 # value is centiHz = round(Hz * 100), matching the Icom MOR-451 convention
 # (``round(_decode_tone_freq(...) * 100)``) so consumers see one unit.
 # SINGLE-YAESU-TONE: unlike Icom (which can carry distinct TONE/TSQL freqs),
@@ -199,6 +200,9 @@ YAESU_PTT_PATH = _PTT
 
 
 class YaesuObservationRadio(Protocol):
+    @property
+    def profile(self) -> RadioProfile: ...
+
     @property
     def capabilities(self) -> set[str]: ...
 
@@ -908,8 +912,8 @@ class YaesuObservationAdapter:
         # ``operator_controls``, grouped with the CTCSS squelch-type toggles
         # above. A SINGLE ``read_ctcss_tone_index(0)`` CAT ``CN`` read
         # (FTX-1_CAT_OM_ENG_2508-C) yields the 0-49 standard-EIA tone-chart index,
-        # which ``_ctcss_index_to_centihz`` maps index → Hz → centiHz (the
-        # index→Hz Tone Chart is verbatim from the manual). The neutral unit is
+        # which ``_ctcss_index_to_centihz`` maps through the active profile's
+        # resolved catalog domain. The neutral unit is
         # centiHz = round(Hz * 100), matching the Icom MOR-451 convention so
         # consumers see one unit. SINGLE-YAESU-TONE: the FTX-1 has ONE CTCSS
         # tone frequency (CN P2=0) used for BOTH encode (TONE) and decode
@@ -927,23 +931,34 @@ class YaesuObservationAdapter:
                 "main.ctcss_tone_index", self.radio.read_ctcss_tone_index(0)
             )
             if ok and tone_index is not None:
-                tone_centihz = _ctcss_index_to_centihz(tone_index)
-                if self._can_poll(_MAIN_TONE_FREQ):
-                    observations.append(
-                        adapter.observation(
-                            _MAIN_TONE_FREQ,
-                            tone_centihz,
-                            native_id="read_ctcss_tone_index",
-                        )
+                try:
+                    tone_centihz = _ctcss_index_to_centihz(
+                        tone_index,
+                        domain=self.radio.profile.ctcss_tones_centihz,
                     )
-                if self._can_poll(_MAIN_TSQL_FREQ):
-                    observations.append(
-                        adapter.observation(
-                            _MAIN_TSQL_FREQ,
-                            tone_centihz,
-                            native_id="read_ctcss_tone_index",
-                        )
+                except ValueError as exc:
+                    logger.warning(
+                        "Skipping CTCSS observations for invalid profile domain: %s",
+                        exc,
                     )
+                    tone_centihz = None
+                if tone_centihz is not None:
+                    if self._can_poll(_MAIN_TONE_FREQ):
+                        observations.append(
+                            adapter.observation(
+                                _MAIN_TONE_FREQ,
+                                tone_centihz,
+                                native_id="read_ctcss_tone_index",
+                            )
+                        )
+                    if self._can_poll(_MAIN_TSQL_FREQ):
+                        observations.append(
+                            adapter.observation(
+                                _MAIN_TSQL_FREQ,
+                                tone_centihz,
+                                native_id="read_ctcss_tone_index",
+                            )
+                        )
         # Repeater shift direction (MOR-2111/MOR-2160). OS0 and OS1 are read
         # independently so one side's malformed/rejected answer never hides
         # or relabels the other side. P2 is already the neutral 0-3 value.

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -56,80 +56,24 @@ logger = logging.getLogger(__name__)
 # Path to rigs/ directory: src/rigplane/backends/yaesu_cat/radio.py → 4 levels up
 _RIGS_DIR = Path(__file__).parents[4] / "rigs"
 
-# CTCSS tone chart (MOR-458). The FTX-1 CAT ``CN`` "CTCSS TONE FREQUENCY"
-# command reports the tone as a 0-49 INDEX into the standard 50-tone EIA CTCSS
-# set, NOT as an absolute frequency (unlike the Icom 0x1B BCD-Hz encoding). The
-# index → Hz chart is verbatim from the official FTX-1 CAT manual
-# (``FTX-1_CAT_OM_ENG_2508-C``). Values are stored directly in centiHz
-# (round(Hz * 100)) so the neutral emission matches the Icom convention
-# (``round(_decode_tone_freq(...) * 100)``, MOR-451) with no float rounding
-# ambiguity at the call site. There is no shared cross-vendor CTCSS table in
-# the codebase (Icom decodes raw BCD Hz; the generic ``table_index_to_hz``
-# helper carries no table of its own), so this Yaesu-local table is the single
-# source of truth for the index → centiHz mapping.
-_CTCSS_TONE_CENTIHZ: tuple[int, ...] = (
-    6700,  # 000 = 67.0 Hz
-    6930,  # 001 = 69.3 Hz
-    7190,  # 002 = 71.9 Hz
-    7440,  # 003 = 74.4 Hz
-    7700,  # 004 = 77.0 Hz
-    7970,  # 005 = 79.7 Hz
-    8250,  # 006 = 82.5 Hz
-    8540,  # 007 = 85.4 Hz
-    8850,  # 008 = 88.5 Hz
-    9150,  # 009 = 91.5 Hz
-    9480,  # 010 = 94.8 Hz
-    9740,  # 011 = 97.4 Hz
-    10000,  # 012 = 100.0 Hz
-    10350,  # 013 = 103.5 Hz
-    10720,  # 014 = 107.2 Hz
-    11090,  # 015 = 110.9 Hz
-    11480,  # 016 = 114.8 Hz
-    11880,  # 017 = 118.8 Hz
-    12300,  # 018 = 123.0 Hz
-    12730,  # 019 = 127.3 Hz
-    13180,  # 020 = 131.8 Hz
-    13650,  # 021 = 136.5 Hz
-    14130,  # 022 = 141.3 Hz
-    14620,  # 023 = 146.2 Hz
-    15140,  # 024 = 151.4 Hz
-    15670,  # 025 = 156.7 Hz
-    15980,  # 026 = 159.8 Hz
-    16220,  # 027 = 162.2 Hz
-    16550,  # 028 = 165.5 Hz
-    16790,  # 029 = 167.9 Hz
-    17130,  # 030 = 171.3 Hz
-    17380,  # 031 = 173.8 Hz
-    17730,  # 032 = 177.3 Hz
-    17990,  # 033 = 179.9 Hz
-    18350,  # 034 = 183.5 Hz
-    18620,  # 035 = 186.2 Hz
-    18990,  # 036 = 189.9 Hz
-    19280,  # 037 = 192.8 Hz
-    19660,  # 038 = 196.6 Hz
-    19950,  # 039 = 199.5 Hz
-    20350,  # 040 = 203.5 Hz
-    20650,  # 041 = 206.5 Hz
-    21070,  # 042 = 210.7 Hz
-    21810,  # 043 = 218.1 Hz
-    22570,  # 044 = 225.7 Hz
-    22910,  # 045 = 229.1 Hz
-    23360,  # 046 = 233.6 Hz
-    24180,  # 047 = 241.8 Hz
-    25030,  # 048 = 250.3 Hz
-    25410,  # 049 = 254.1 Hz
-)
 
+def _ctcss_index_to_centihz(index: int, *, domain: tuple[int, ...] | None) -> int:
+    """Map a CAT ``CN`` index through a resolved profile CTCSS domain.
 
-def _ctcss_index_to_centihz(index: int) -> int:
-    """Map a CAT ``CN`` CTCSS tone-chart index (0-49) to centiHz.
-
-    Pure lookup into :data:`_CTCSS_TONE_CENTIHZ`, reusing the generic
-    :func:`table_index_to_hz` index-into-a-table helper. The result is in
-    centiHz (e.g. index 8 → 88.5 Hz → ``8850``) to match the Icom MOR-451
-    convention. Raises ``ValueError`` for out-of-range indices.
+    The profile catalog is the sole owner of selectable values. The Yaesu
+    provider only applies the device-reported index and fails closed when the
+    active profile has no valid resolved tuple or the index is out of range.
     """
-    return int(table_index_to_hz(index, table=_CTCSS_TONE_CENTIHZ))
+    if not isinstance(domain, tuple) or not domain:
+        raise ValueError("active profile has no resolved CTCSS tone domain")
+    if isinstance(index, bool) or not isinstance(index, int) or index < 0:
+        raise ValueError(f"invalid CTCSS tone index: {index!r}")
+    if any(
+        isinstance(value, bool) or not isinstance(value, int) or value <= 0
+        for value in domain
+    ):
+        raise ValueError("active profile has an invalid CTCSS tone domain")
+    return int(table_index_to_hz(index, table=domain))
 
 
 def _load_config(profile: Any) -> "RigConfig":
@@ -2418,7 +2362,10 @@ class YaesuCatRadio:
         MOR-451 convention. The FTX-1 has a single CTCSS tone (CN P2=0) shared
         by both TONE (encode) and TSQL (decode).
         """
-        return _ctcss_index_to_centihz(await self.read_ctcss_tone_index(receiver))
+        return _ctcss_index_to_centihz(
+            await self.read_ctcss_tone_index(receiver),
+            domain=self.profile.ctcss_tones_centihz,
+        )
 
     async def read_repeater_shift(self, receiver: int = 0) -> int:
         """Read one receiver's repeater shift direction — pure read.

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -1609,23 +1609,30 @@ async def test_read_repeater_shift_rejects_invalid_answer_direction(
     ],
 )
 def test_ctcss_index_to_centihz_matches_chart(index, expected_centihz):
-    """Spot-check the index -> Hz -> centiHz mapping against the tone chart.
+    """Spot-check CN mapping through the active profile's resolved domain.
 
-    The 50-tone EIA CTCSS chart is verbatim from FTX-1_CAT_OM_ENG_2507; the
-    centiHz emission matches the Icom convention (round(Hz * 100)).
+    The profile catalog owns the 50-tone EIA domain; the Yaesu provider only
+    applies the CAT CN index to that resolved tuple.
     """
     from rigplane.backends.yaesu_cat.radio import _ctcss_index_to_centihz
 
-    assert _ctcss_index_to_centihz(index) == expected_centihz
+    profile = load_rig(_RIGS_DIR / "ftx1.toml").to_profile()
+    assert (
+        _ctcss_index_to_centihz(index, domain=profile.ctcss_tones_centihz)
+        == expected_centihz
+    )
 
 
-def test_ctcss_table_has_50_standard_tones():
-    """The FTX-1 CTCSS chart is the standard 50-tone EIA set (indices 0-49)."""
-    from rigplane.backends.yaesu_cat.radio import _CTCSS_TONE_CENTIHZ
+@pytest.mark.asyncio
+async def test_get_ctcss_tone_uses_active_profile_domain(connected_radio):
+    """A provider/model-independent profile tuple controls CN index mapping."""
+    connected_radio._profile_cache = replace(
+        connected_radio.profile,
+        ctcss_tones_centihz=(1234, 5678),
+    )
+    connected_radio._transport.query = AsyncMock(return_value="CN00001")
 
-    assert len(_CTCSS_TONE_CENTIHZ) == 50
-    assert _CTCSS_TONE_CENTIHZ[0] == 6700
-    assert _CTCSS_TONE_CENTIHZ[49] == 25410
+    assert await connected_radio.get_ctcss_tone() == 5678
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -223,7 +223,10 @@ class _SideEffectingYaesuRadio:
     }
 
     def __init__(self) -> None:
-        self.profile = SimpleNamespace(max_watts=100)
+        self.profile = SimpleNamespace(
+            max_watts=100,
+            ctcss_tones_centihz=get_radio_profile("FTX-1").ctcss_tones_centihz,
+        )
         self.radio_state = RadioState()
         self.radio_state.main.freq = 1
         self.radio_state.main.mode = "INIT-MAIN"
@@ -1827,6 +1830,56 @@ async def test_ctcss_tone_freq_emits_both_paths_in_centihz(
     assert by_path["receiver.main.operator_controls.tone_freq"] == expected_centihz
     assert by_path["receiver.main.operator_controls.tsql_freq"] == expected_centihz
     # A SINGLE CN read feeds both emissions.
+    assert radio.read_ctcss_tone_index.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_ctcss_tone_freq_uses_active_profile_domain() -> None:
+    """A synthetic resolved tuple changes mapping without model branching."""
+    radio = _make_radio()
+    radio.profile = replace(radio.profile, ctcss_tones_centihz=(1234, 5678))
+    radio.read_ctcss_tone_index = AsyncMock(return_value=1)
+    adapter = YaesuObservationAdapter(
+        radio,
+        profile=_profile_state_acquisition(),
+        clock=_clock,
+    )
+
+    observations = await adapter.poll_slow_controls()
+    by_path = {str(item.path): item.value for item in observations}
+
+    assert by_path["receiver.main.operator_controls.tone_freq"] == 5678
+    assert by_path["receiver.main.operator_controls.tsql_freq"] == 5678
+
+
+@pytest.mark.parametrize(
+    ("domain", "index"),
+    [
+        (None, 0),
+        ((), 0),
+        ((6700,), 1),
+        ((6700, "invalid"), 0),
+    ],
+)
+@pytest.mark.asyncio
+async def test_ctcss_tone_freq_invalid_profile_domain_emits_nothing(
+    domain: object, index: int
+) -> None:
+    """Missing, malformed, or out-of-range profile domains fail closed."""
+    radio = _make_radio()
+    radio.profile = replace(radio.profile, ctcss_tones_centihz=domain)
+    radio.read_ctcss_tone_index = AsyncMock(return_value=index)
+    adapter = YaesuObservationAdapter(
+        radio,
+        profile=_profile_state_acquisition(),
+        clock=_clock,
+    )
+
+    observations = await adapter.poll_slow_controls()
+    paths = {str(item.path) for item in observations}
+
+    assert "receiver.main.operator_controls.tone_freq" not in paths
+    assert "receiver.main.operator_controls.tsql_freq" not in paths
     assert radio.read_ctcss_tone_index.await_count == 1
 
 


### PR DESCRIPTION
## MOR-2129 C1: make Yaesu CTCSS readback profile-backed

Moves the FTX-1 Yaesu CN CTCSS consumer off its backend-local 50-tone table and onto the active immutable RadioProfile.ctcss_tones_centihz tuple introduced by #3147.

### Scope

- Resolve Yaesu CN indices only at the provider boundary.
- Preserve canonical neutral integer centiHz values.
- Fail closed for missing, empty, malformed, or out-of-range profile-domain data.
- Preserve P2=0 one-read-to-tone-and-tsql semantics; leave DCS P2=1 unchanged.
- Does not add a Yaesu writer: no published CN CTCSS writer exists in this profile contract.

### Deliberately excluded

Icom/Web/public-write binding, validation, UI/PTT, profile schema/catalog work, factory selection, and hardware acceptance.

### Evidence

- Focused CTCSS tests: 19 passed.
- Full owned test files: 408 passed.
- Changed-scope Ruff, format, and git diff --check: PASS.
- Adversarial pass verified production adapter to YaesuCatRadio.profile reachability, no local CTCSS table or fallback, and fail-closed observation suppression.
- Independent exact-head code review: PASS.

Physical FTX-1 proof has not been run and remains UNKNOWN.