### PR TITLE
feat(MOR-2321): freeze LCD display-frame contract

### DIFF
--- a/frontend/src/skins/segmentline/__tests__/lcd-display-contract.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/lcd-display-contract.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveLcdSpectrumFrame,
+  type LcdSpectrumFrame,
+  type LcdSpectrumFrameExpectation,
+} from '../lcd-display-contract';
+
+const EXPECT_HARDWARE_MAIN: LcdSpectrumFrameExpectation = {
+  source: 'hardware',
+  receiver: 'MAIN',
+};
+
+function frame(overrides: Partial<LcdSpectrumFrame> = {}): LcdSpectrumFrame {
+  return {
+    source: 'hardware',
+    receiver: 'MAIN',
+    freshness: 'fresh',
+    startHz: 14_200_000,
+    endHz: 14_300_000,
+    normalizedBins: [0.1, 0.7, 0.3],
+    ...overrides,
+  };
+}
+
+describe('LCD display-frame contract', () => {
+  it.each(['hardware', 'audio-fft'] as const)(
+    'admits a valid, source-qualified %s frame without changing its samples',
+    (source) => {
+      const candidate = frame({ source });
+      const result = resolveLcdSpectrumFrame(candidate, { source, receiver: 'MAIN' });
+
+      expect(result).toEqual({ state: 'live', frame: candidate });
+      if (result.state === 'live') {
+        expect(result.frame).toBe(candidate);
+        expect(result.frame.normalizedBins).toBe(candidate.normalizedBins);
+      }
+    },
+  );
+
+  it.each([
+    ['source-mismatch', frame({ source: 'audio-fft' }), EXPECT_HARDWARE_MAIN],
+    ['receiver-mismatch', frame({ receiver: 'SUB' }), EXPECT_HARDWARE_MAIN],
+    ['stale', frame({ freshness: 'stale' }), EXPECT_HARDWARE_MAIN],
+    ['receiver-unknown', frame(), { source: 'hardware', receiver: null }],
+  ] as const)('fails a %s closed to ghost geometry', (reason, candidate, expectation) => {
+    expect(resolveLcdSpectrumFrame(candidate, expectation)).toEqual({ state: 'ghost', reason });
+  });
+
+  it.each([
+    undefined,
+    null,
+  ])('treats absent production input as missing, never as a zero frame', (candidate) => {
+    expect(resolveLcdSpectrumFrame(candidate, EXPECT_HARDWARE_MAIN))
+      .toEqual({ state: 'ghost', reason: 'missing' });
+  });
+
+  it.each([
+    {},
+    'unknown',
+    frame({ startHz: Number.NaN }),
+    frame({ endHz: Number.POSITIVE_INFINITY }),
+    frame({ startHz: 14_300_000, endHz: 14_300_000 }),
+    frame({ startHz: 14_300_000, endHz: 14_200_000 }),
+    frame({ normalizedBins: [] }),
+    frame({ normalizedBins: [0.5] }),
+    frame({ normalizedBins: [0, Number.NaN] }),
+    frame({ normalizedBins: [0, Number.POSITIVE_INFINITY] }),
+    frame({ normalizedBins: [-0.01, 0.5] }),
+    frame({ normalizedBins: [0.5, 1.01] }),
+    frame({ normalizedBins: Array(2) }),
+  ])('rejects malformed production input without fabricating renderable data', (candidate) => {
+    const result = resolveLcdSpectrumFrame(candidate, EXPECT_HARDWARE_MAIN);
+
+    expect(result).toEqual({ state: 'ghost', reason: 'invalid' });
+    expect(result).not.toHaveProperty('frame');
+  });
+
+  it('never borrows the other receiver when the requested receiver has no matching frame', () => {
+    const mainFrame = frame({ receiver: 'MAIN' });
+
+    expect(resolveLcdSpectrumFrame(mainFrame, { source: 'hardware', receiver: 'SUB' }))
+      .toEqual({ state: 'ghost', reason: 'receiver-mismatch' });
+  });
+});

--- a/frontend/src/skins/segmentline/lcd-display-contract.ts
+++ b/frontend/src/skins/segmentline/lcd-display-contract.ts
@@ -1,0 +1,73 @@
+export type LcdSpectrumSource = 'audio-fft' | 'hardware';
+export type LcdSpectrumReceiver = 'MAIN' | 'SUB';
+export type LcdSpectrumFreshness = 'fresh' | 'stale';
+
+export interface LcdSpectrumFrame {
+  readonly source: LcdSpectrumSource;
+  readonly receiver: LcdSpectrumReceiver;
+  readonly freshness: LcdSpectrumFreshness;
+  readonly startHz: number;
+  readonly endHz: number;
+  readonly normalizedBins: readonly number[];
+}
+
+export interface LcdSpectrumFrameExpectation {
+  readonly source: LcdSpectrumSource;
+  readonly receiver: LcdSpectrumReceiver | null;
+}
+
+export type LcdSpectrumFrameGhostReason =
+  | 'missing'
+  | 'stale'
+  | 'source-mismatch'
+  | 'receiver-unknown'
+  | 'receiver-mismatch'
+  | 'invalid';
+
+export type LcdSpectrumFrameResolution =
+  | { readonly state: 'live'; readonly frame: LcdSpectrumFrame }
+  | { readonly state: 'ghost'; readonly reason: LcdSpectrumFrameGhostReason };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasKnownQualifiers(value: Record<string, unknown>): boolean {
+  return (value.source === 'audio-fft' || value.source === 'hardware')
+    && (value.receiver === 'MAIN' || value.receiver === 'SUB')
+    && (value.freshness === 'fresh' || value.freshness === 'stale');
+}
+
+function hasValidGeometry(value: Record<string, unknown>): boolean {
+  if (typeof value.startHz !== 'number' || !Number.isFinite(value.startHz)
+    || typeof value.endHz !== 'number' || !Number.isFinite(value.endHz)
+    || value.endHz <= value.startHz
+    || !Array.isArray(value.normalizedBins)
+    || value.normalizedBins.length < 2) return false;
+
+  for (const sample of value.normalizedBins) {
+    if (typeof sample !== 'number' || !Number.isFinite(sample) || sample < 0 || sample > 1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function resolveLcdSpectrumFrame(
+  input: unknown,
+  expectation: LcdSpectrumFrameExpectation,
+): LcdSpectrumFrameResolution {
+  if (expectation.receiver === null) return { state: 'ghost', reason: 'receiver-unknown' };
+  if (input === undefined || input === null) return { state: 'ghost', reason: 'missing' };
+  if (!isRecord(input) || !hasKnownQualifiers(input)) {
+    return { state: 'ghost', reason: 'invalid' };
+  }
+  if (input.source !== expectation.source) return { state: 'ghost', reason: 'source-mismatch' };
+  if (input.receiver !== expectation.receiver) {
+    return { state: 'ghost', reason: 'receiver-mismatch' };
+  }
+  if (input.freshness !== 'fresh') return { state: 'ghost', reason: 'stale' };
+  if (!hasValidGeometry(input)) return { state: 'ghost', reason: 'invalid' };
+
+  return { state: 'live', frame: input as unknown as LcdSpectrumFrame };
+}


### PR DESCRIPTION
Linear: MOR-2321

## Summary
- add the source-qualified LCD spectrum frame presentation contract
- fail closed on missing, unknown, stale, mismatched, or invalid frames
- add focused contract coverage without sample synthesis or mode/passband tables

## Verification
- `npx vitest run src/skins/segmentline/__tests__/lcd-display-contract.test.ts` (22 passed)
- `npx eslint src/skins/segmentline/lcd-display-contract.ts src/skins/segmentline/__tests__/lcd-display-contract.test.ts`
- `git diff --check`
- exact two-file allowlist check