### PR TITLE
fix(MOR-2129): validate profile CTCSS domain in web poller

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -558,6 +558,16 @@ _POST_WRITE_READBACK_FIELDS: dict[type, Callable[[Any], tuple[FieldPath, ...]]] 
     SetFilterWidth: lambda cmd: (
         FieldPath.active(_post_write_receiver_id(cmd), "freq_mode", "filter_width"),
     ),
+    SetToneFreq: lambda cmd: (
+        FieldPath.receiver(
+            _post_write_receiver_id(cmd), "operator_controls", "tone_freq"
+        ),
+    ),
+    SetTsqlFreq: lambda cmd: (
+        FieldPath.receiver(
+            _post_write_receiver_id(cmd), "operator_controls", "tsql_freq"
+        ),
+    ),
     SetBreakInDelay: lambda cmd: (
         FieldPath.global_("operator_controls", "break_in_delay"),
     ),
@@ -1169,6 +1179,29 @@ class RadioPoller:
         raise NotImplementedError(
             "radio-poller unsupported: unknown profile-less radio"
         )
+
+    def _validated_ctcss_centihz(self, value: Any) -> int:
+        """Return one exact neutral CTCSS value from the active profile domain.
+
+        The profile loader remains the only owner of catalog resolution and
+        detailed CTCSS limits.  This runtime boundary deliberately performs
+        no model selection, unit conversion, or fallback: it only rejects a
+        profile object that does not carry the loader's immutable, ascending
+        integer-domain shape and rejects values outside that exact domain.
+        """
+
+        domain = self._profile.ctcss_tones_centihz
+        if (
+            type(value) is not int
+            or type(domain) is not tuple
+            or not domain
+            or any(type(candidate) is not int for candidate in domain)
+            or any(first >= second for first, second in zip(domain, domain[1:]))
+        ):
+            raise CommandError("invalid CTCSS profile domain or centiHz value")
+        if value not in domain:
+            raise CommandError("centiHz value is outside the CTCSS profile domain")
+        return value
 
     def _vfo_command_profile(self, command: str) -> RadioProfile:
         """Resolve the exact profile allowed to declare a VFO primitive."""
@@ -3179,6 +3212,7 @@ class RadioPoller:
                     await radio.set_compressor(on)
             case SetToneFreq(freq_hz=freq, receiver=rx):
                 self._ensure_receiver_supported(rx, operation="set_tone_freq")
+                freq = self._validated_ctcss_centihz(freq)
                 if CAP_REPEATER_TONE in self._caps:
                     await radio.set_tone_freq(freq, receiver=rx)
                 if self._radio_state:
@@ -3188,6 +3222,7 @@ class RadioPoller:
                     target.tone_freq = freq
             case SetTsqlFreq(freq_hz=freq, receiver=rx):
                 self._ensure_receiver_supported(rx, operation="set_tsql_freq")
+                freq = self._validated_ctcss_centihz(freq)
                 if CAP_TSQL in self._caps:
                     await radio.set_tsql_freq(freq, receiver=rx)
                 if self._radio_state:

--- a/tests/test_mor2129_profile_tone_parity.py
+++ b/tests/test_mor2129_profile_tone_parity.py
@@ -1,0 +1,112 @@
+"""Focused profile-domain parity tests for neutral tone/TSQL writes (MOR-2129)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rigplane.capabilities import CAP_REPEATER_TONE, CAP_TSQL
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionPriority,
+    AcquisitionScheduler,
+)
+from rigplane.core.state_pipeline_contracts import FieldPath
+from rigplane.exceptions import CommandError
+from rigplane.profiles import RadioProfile, resolve_radio_profile
+from rigplane.radio_state import RadioState
+from rigplane.web.radio_poller import (
+    CommandQueue,
+    RadioPoller,
+    SetToneFreq,
+    SetTsqlFreq,
+)
+
+pytestmark = pytest.mark.usefixtures("observed_rx_dispatch_premise")
+
+
+def _poller(
+    *, domain: Any = (8850, 10000)
+) -> tuple[RadioPoller, MagicMock, RadioState, AcquisitionScheduler]:
+    base = resolve_radio_profile(model="IC-7300")
+    profile: RadioProfile = replace(base, ctcss_tones_centihz=domain)
+    assert profile.state_acquisition is not None
+
+    radio = MagicMock()
+    radio.profile = profile
+    radio.model = profile.model
+    radio.capabilities = {CAP_REPEATER_TONE, CAP_TSQL}
+    radio._radio_state = SimpleNamespace(active="MAIN")
+    radio.set_tone_freq = AsyncMock()
+    radio.set_tsql_freq = AsyncMock()
+    scheduler = AcquisitionScheduler(profile=profile.state_acquisition)
+    radio._acquisition_scheduler = scheduler
+
+    state = RadioState()
+    state.main.tone_freq = 7770
+    state.main.tsql_freq = 7780
+    return (
+        RadioPoller(radio, CommandQueue(), radio_state=state),
+        radio,
+        state,
+        scheduler,
+    )
+
+
+@pytest.mark.asyncio
+async def test_valid_profile_member_stays_centihz_and_schedules_both_readbacks() -> (
+    None
+):
+    poller, radio, state, scheduler = _poller()
+
+    await poller._execute(SetToneFreq(freq_hz=8850, receiver=0))  # noqa: SLF001
+    await poller._execute(SetTsqlFreq(freq_hz=8850, receiver=0))  # noqa: SLF001
+
+    radio.set_tone_freq.assert_awaited_once_with(8850, receiver=0)
+    radio.set_tsql_freq.assert_awaited_once_with(8850, receiver=0)
+    assert type(state.main.tone_freq) is int
+    assert type(state.main.tsql_freq) is int
+    assert state.main.tone_freq == 8850
+    assert state.main.tsql_freq == 8850
+
+    pending = scheduler.pending_requests()
+    assert {path for request in pending for path in request.paths} == {
+        FieldPath.receiver("main", "operator_controls", "tone_freq"),
+        FieldPath.receiver("main", "operator_controls", "tsql_freq"),
+    }
+    assert {request.priority for request in pending} == {AcquisitionPriority.USER}
+    assert {request.reason for request in pending} == {"post_write_readback"}
+
+
+@pytest.mark.parametrize("command_type", [SetToneFreq, SetTsqlFreq])
+@pytest.mark.parametrize(
+    ("domain", "value"),
+    [
+        (None, 8850),
+        ((), 8850),
+        ((8850, True), 8850),
+        ((10000, 8850), 8850),
+        ((8850, 10000), 12340),
+        ((8850, 10000), True),
+        ((8850, 10000), 88.5),
+    ],
+)
+@pytest.mark.asyncio
+async def test_invalid_profile_or_value_fails_before_setter_mirror_or_readback(
+    command_type: type[SetToneFreq] | type[SetTsqlFreq],
+    domain: Any,
+    value: Any,
+) -> None:
+    poller, radio, state, scheduler = _poller(domain=domain)
+
+    with pytest.raises(CommandError, match="CTCSS profile domain"):
+        await poller._execute(command_type(freq_hz=value, receiver=0))  # type: ignore[arg-type]  # noqa: SLF001
+
+    radio.set_tone_freq.assert_not_awaited()
+    radio.set_tsql_freq.assert_not_awaited()
+    assert state.main.tone_freq == 7770
+    assert state.main.tsql_freq == 7780
+    assert scheduler.pending_requests() == ()

--- a/tests/test_vox_tone_state.py
+++ b/tests/test_vox_tone_state.py
@@ -66,8 +66,10 @@ def _make_radio_with_state() -> IcomRadio:
     return r
 
 
-def _make_poller(*, with_state: bool = True) -> tuple[RadioPoller, RadioState]:
-    profile = resolve_radio_profile(model="IC-7610")
+def _make_poller(
+    *, with_state: bool = True, model: str = "IC-7610"
+) -> tuple[RadioPoller, RadioState]:
+    profile = resolve_radio_profile(model=model)
     radio = MagicMock()
     radio.profile = profile
     radio.model = profile.model
@@ -429,28 +431,28 @@ async def test_execute_set_repeater_tsql_updates_sub_state() -> None:
 
 @pytest.mark.asyncio
 async def test_execute_set_tone_freq_updates_main_state() -> None:
-    poller, state = _make_poller()
+    poller, state = _make_poller(model="IC-9700")
     await poller._execute(SetToneFreq(freq_hz=8850, receiver=0))  # noqa: SLF001
     assert state.main.tone_freq == 8850
 
 
 @pytest.mark.asyncio
 async def test_execute_set_tone_freq_updates_sub_state() -> None:
-    poller, state = _make_poller()
-    await poller._execute(SetToneFreq(freq_hz=9700, receiver=1))  # noqa: SLF001
-    assert state.sub.tone_freq == 9700
+    poller, state = _make_poller(model="IC-9700")
+    await poller._execute(SetToneFreq(freq_hz=9740, receiver=1))  # noqa: SLF001
+    assert state.sub.tone_freq == 9740
 
 
 @pytest.mark.asyncio
 async def test_execute_set_tsql_freq_updates_main_state() -> None:
-    poller, state = _make_poller()
+    poller, state = _make_poller(model="IC-9700")
     await poller._execute(SetTsqlFreq(freq_hz=10000, receiver=0))  # noqa: SLF001
     assert state.main.tsql_freq == 10000
 
 
 @pytest.mark.asyncio
 async def test_execute_set_tsql_freq_updates_sub_state() -> None:
-    poller, state = _make_poller()
+    poller, state = _make_poller(model="IC-9700")
     await poller._execute(SetTsqlFreq(freq_hz=8850, receiver=1))  # noqa: SLF001
     assert state.sub.tsql_freq == 8850
 


### PR DESCRIPTION
## MOR-2129 Profiles B: fail closed in the neutral poller path

Makes the reachable Web queue/poller segment enforce the active profile CTCSS domain before a tone or TSQL write can call the neutral backend, mirror state, or schedule post-write confirmation.

### Scope

- Require exact integer centiHz values; bool and float are rejected.
- Require a nonempty, well-formed, strictly ascending active profile domain and membership.
- Preserve valid 8850 unchanged through both neutral setters and mirrors.
- Schedule confirmed post-write readback for both canonical tone and TSQL paths.
- Retarget four legacy successful dispatch tests to a tone-capable profile; IC-7610 remains without CTCSS.

### Explicit boundaries

This intentionally does not claim full MOR-2129 closure:

- Icom runtime/codec centiHz-to-Hz conversion and provider membership binding remain C2.
- Web ingress validation and public legal-choice projection remain in PTT-leased handlers/server paths.
- No Icom, Yaesu, UI, PTT authority, catalog/schema, ControlDomainSpec, or hardware change is included.

### Evidence

- New focused parity plus full VOX tone state tests: 45 passed.
- Changed-scope Ruff, format, strict web mypy, and git diff --check: PASS.
- Adversarial pass proved validation occurs before setter/mirror/readback and has no fallback, conversion, or model branch.
- Independent exact-head review: PASS.

Physical radio proof remains UNKNOWN.