### PR TITLE
MOR-2129: bind Icom CTCSS to active profile domain

### DIFF
--- a/src/rigplane/commands/tone.py
+++ b/src/rigplane/commands/tone.py
@@ -38,8 +38,47 @@ if TYPE_CHECKING:
     from ..types import CivFrame
 
 
-def _encode_tone_freq(freq_hz: float) -> bytes:
-    """Encode tone frequency (Hz) to 3-byte BCD.
+def _require_ctcss_domain(
+    ctcss_tones_centihz: tuple[int, ...] | None,
+) -> tuple[int, ...]:
+    """Validate the active profile's exact, ordered CTCSS domain."""
+    if not isinstance(ctcss_tones_centihz, tuple) or not ctcss_tones_centihz:
+        raise ValueError("CTCSS tone domain must be a non-empty tuple")
+
+    previous: int | None = None
+    for tone_centihz in ctcss_tones_centihz:
+        if type(tone_centihz) is not int:
+            raise ValueError("CTCSS tone domain entries must be exact ints in centiHz")
+        if tone_centihz % 10:
+            raise ValueError(
+                "CTCSS tone domain entries must be representable in 0.1 Hz CI-V BCD"
+            )
+        # Validate the CI-V representation without duplicating a profile catalog
+        # or assuming the standard-50 table below RadioProfile.
+        bcd_encode_value(tone_centihz // 10, byte_count=3)
+        if previous is not None and tone_centihz <= previous:
+            raise ValueError("CTCSS tone domain entries must be strictly ascending")
+        previous = tone_centihz
+    return ctcss_tones_centihz
+
+
+def _require_profile_tone(
+    freq_centihz: int,
+    ctcss_tones_centihz: tuple[int, ...] | None,
+) -> int:
+    """Admit one exact centiHz value through the active profile domain."""
+    if type(freq_centihz) is not int:
+        raise TypeError("Tone frequency must be an exact int in centiHz")
+    domain = _require_ctcss_domain(ctcss_tones_centihz)
+    if freq_centihz not in domain:
+        raise ValueError(
+            f"Tone frequency {freq_centihz} is not declared by the active profile"
+        )
+    return freq_centihz
+
+
+def _encode_tone_freq(freq_centihz: int) -> bytes:
+    """Encode exact centiHz to 3-byte CI-V BCD in 0.1 Hz units.
 
     Three bytes hold six packed BCD digits, read as a decimal integer of
     tenths of a Hz: ``[0][0][100Hz digit][10Hz digit][1Hz digit]
@@ -50,17 +89,18 @@ def _encode_tone_freq(freq_hz: float) -> bytes:
     ``tests/test_tone_tsql.py``'s ``_BCD_TABLE`` for the full manual and
     hardware-capture sourcing.
     """
-    if not 67.0 <= freq_hz <= 254.1:
-        raise ValueError(f"Tone frequency must be 67.0-254.1 Hz, got {freq_hz}")
-    total_tenths = round(freq_hz * 10)
-    return bcd_encode_value(total_tenths, byte_count=3)
+    if type(freq_centihz) is not int:
+        raise TypeError("Tone frequency must be an exact int in centiHz")
+    if freq_centihz % 10:
+        raise ValueError("Tone frequency must be representable in 0.1 Hz CI-V BCD")
+    return bcd_encode_value(freq_centihz // 10, byte_count=3)
 
 
-def _decode_tone_freq(data: bytes) -> float:
-    """Decode 3-byte BCD to tone frequency (Hz). Inverse of `_encode_tone_freq`."""
+def _decode_tone_freq(data: bytes) -> int:
+    """Decode 3-byte CI-V BCD in 0.1 Hz units to exact centiHz."""
     if len(data) < 3:
         raise ValueError(f"Expected 3 bytes for tone freq, got {len(data)}")
-    return _bcd_decode_value(data[:3]) / 10.0
+    return _bcd_decode_value(data[:3]) * 10
 
 
 @expose_command_key(lambda cmd_map: "get_repeater_tone")
@@ -164,8 +204,11 @@ def get_tone_freq(
     *,
     command29: bool = True,
     cmd_map: CommandMap,
+    ctcss_tones_centihz: tuple[int, ...] | None,
 ) -> bytes:
     """Build CI-V command to get tone frequency (0x1B 0x00)."""
+    cmd_map.get("get_tone_freq")
+    _require_ctcss_domain(ctcss_tones_centihz)
     return _build_from_map(
         cmd_map,
         "get_tone_freq",
@@ -179,15 +222,17 @@ def get_tone_freq(
 @expose_command_key(lambda cmd_map: "set_tone_freq")
 @require_cmd_map
 def set_tone_freq(
-    freq_hz: float,
+    freq_centihz: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     *,
     command29: bool = True,
     cmd_map: CommandMap,
+    ctcss_tones_centihz: tuple[int, ...] | None,
 ) -> bytes:
     """Build CI-V command to set tone frequency (0x1B 0x00)."""
+    cmd_map.get("set_tone_freq")
     return _build_from_map(
         cmd_map,
         "set_tone_freq",
@@ -195,7 +240,9 @@ def set_tone_freq(
         from_addr=from_addr,
         command29=command29,
         receiver=receiver,
-        data=_encode_tone_freq(freq_hz),
+        data=_encode_tone_freq(
+            _require_profile_tone(freq_centihz, ctcss_tones_centihz)
+        ),
     )
 
 
@@ -208,8 +255,11 @@ def get_tsql_freq(
     *,
     command29: bool = True,
     cmd_map: CommandMap,
+    ctcss_tones_centihz: tuple[int, ...] | None,
 ) -> bytes:
     """Build CI-V command to get TSQL frequency (0x1B 0x01)."""
+    cmd_map.get("get_tsql_freq")
+    _require_ctcss_domain(ctcss_tones_centihz)
     return _build_from_map(
         cmd_map,
         "get_tsql_freq",
@@ -223,15 +273,17 @@ def get_tsql_freq(
 @expose_command_key(lambda cmd_map: "set_tsql_freq")
 @require_cmd_map
 def set_tsql_freq(
-    freq_hz: float,
+    freq_centihz: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     *,
     command29: bool = True,
     cmd_map: CommandMap,
+    ctcss_tones_centihz: tuple[int, ...] | None,
 ) -> bytes:
     """Build CI-V command to set TSQL frequency (0x1B 0x01)."""
+    cmd_map.get("set_tsql_freq")
     return _build_from_map(
         cmd_map,
         "set_tsql_freq",
@@ -239,11 +291,17 @@ def set_tsql_freq(
         from_addr=from_addr,
         command29=command29,
         receiver=receiver,
-        data=_encode_tone_freq(freq_hz),
+        data=_encode_tone_freq(
+            _require_profile_tone(freq_centihz, ctcss_tones_centihz)
+        ),
     )
 
 
-def parse_tone_freq_response(frame: CivFrame) -> tuple[int | None, float]:
+def parse_tone_freq_response(
+    frame: CivFrame,
+    *,
+    ctcss_tones_centihz: tuple[int, ...] | None,
+) -> tuple[int | None, int]:
     """Parse tone frequency response (0x1B 0x00)."""
     if frame.command != _CMD_TONE or frame.sub != _SUB_TONE_FREQ:
         raise ValueError(
@@ -251,10 +309,17 @@ def parse_tone_freq_response(frame: CivFrame) -> tuple[int | None, float]:
         )
     if len(frame.data) < 3:
         raise ValueError(f"Expected 3 bytes for tone freq, got {len(frame.data)}")
-    return (frame.receiver, _decode_tone_freq(frame.data))
+    return (
+        frame.receiver,
+        _require_profile_tone(_decode_tone_freq(frame.data), ctcss_tones_centihz),
+    )
 
 
-def parse_tsql_freq_response(frame: CivFrame) -> tuple[int | None, float]:
+def parse_tsql_freq_response(
+    frame: CivFrame,
+    *,
+    ctcss_tones_centihz: tuple[int, ...] | None,
+) -> tuple[int | None, int]:
     """Parse TSQL frequency response (0x1B 0x01)."""
     if frame.command != _CMD_TONE or frame.sub != _SUB_TSQL_FREQ:
         raise ValueError(
@@ -262,4 +327,7 @@ def parse_tsql_freq_response(frame: CivFrame) -> tuple[int | None, float]:
         )
     if len(frame.data) < 3:
         raise ValueError(f"Expected 3 bytes for TSQL freq, got {len(frame.data)}")
-    return (frame.receiver, _decode_tone_freq(frame.data))
+    return (
+        frame.receiver,
+        _require_profile_tone(_decode_tone_freq(frame.data), ctcss_tones_centihz),
+    )

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -32,6 +32,8 @@ from rigplane.commands import (
     parse_level_response,
     parse_mode_response,
     parse_rit_frequency_response,
+    parse_tone_freq_response,
+    parse_tsql_freq_response,
     parse_scope_center_type_response,
     parse_scope_during_tx_response,
     parse_scope_edge_response,
@@ -2449,16 +2451,24 @@ class CivRuntime:
                 )
             )
         elif frame.command == 0x1B and len(frame.data) >= 3:
-            # Tone/TSQL freq: BCD freq → centiHz, reusing the exact decode of
-            # ``_handle_1b`` (``round(_decode_tone_freq(...) * 100)``) (MOR-451).
+            # Tone/TSQL freq: publish only exact centiHz values admitted by the
+            # active profile. Parser failures abort this frame before StateStore.
             mapping = _OBSERVABLE_CMD1B_FIELDS.get(frame.sub or 0)
             if mapping is not None:
-                from rigplane.commands import _decode_tone_freq
+                parser = (
+                    parse_tone_freq_response
+                    if frame.sub == 0x00
+                    else parse_tsql_freq_response
+                )
+                _, freq_centihz = parser(
+                    frame,
+                    ctcss_tones_centihz=self._host._profile.ctcss_tones_centihz,
+                )
 
                 observations.append(
                     self._observation(
                         self._field_path(mapping, receiver_id=receiver_id),
-                        round(_decode_tone_freq(frame.data) * 100),
+                        freq_centihz,
                         frame=frame,
                     )
                 )

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -4554,21 +4554,23 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             )
         )
 
-    async def get_tone_freq(self, receiver: int = 0) -> float:
-        """Read CTCSS tone frequency in Hz (0x1B 0x00)."""
+    async def get_tone_freq(self, receiver: int = 0) -> int:
+        """Read CTCSS tone frequency in exact centiHz (0x1B 0x00)."""
         self._check_connected()
         self._require_receiver(receiver, operation="get_tone_freq")
+        domain = self._profile.ctcss_tones_centihz
 
         if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(0x1B, 0x00):
+            civ = self._commands.get_tone_freq(
+                to_addr=self._radio_addr,
+                receiver=RECEIVER_MAIN,
+                command29=False,
+                ctcss_tones_centihz=domain,
+            )
 
-            async def _action() -> float:
-                civ = self._commands.get_tone_freq(
-                    to_addr=self._radio_addr,
-                    receiver=RECEIVER_MAIN,
-                    command29=False,
-                )
+            async def _action() -> int:
                 resp = await self._send_civ_expect(civ, label="get_tone_freq")
-                _, freq = parse_tone_freq_response(resp)
+                _, freq = parse_tone_freq_response(resp, ctcss_tones_centihz=domain)
                 return freq
 
             return await self._run_with_receiver_vfo_fallback(
@@ -4582,28 +4584,32 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
         cmd29 = self._profile.supports_cmd29(0x1B, 0x00)
         civ = self._commands.get_tone_freq(
-            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            to_addr=self._radio_addr,
+            receiver=receiver,
+            command29=cmd29,
+            ctcss_tones_centihz=domain,
         )
         resp = await self._send_civ_expect(civ, label="get_tone_freq")
-        _, freq = parse_tone_freq_response(resp)
+        _, freq = parse_tone_freq_response(resp, ctcss_tones_centihz=domain)
         return freq
 
-    async def set_tone_freq(self, freq_hz: float, receiver: int = 0) -> None:
-        """Set CTCSS tone frequency in Hz (0x1B 0x00)."""
+    async def set_tone_freq(self, freq_centihz: int, receiver: int = 0) -> None:
+        """Set CTCSS tone frequency in exact centiHz (0x1B 0x00)."""
         self._check_connected()
         self._require_receiver(receiver, operation="set_tone_freq")
+        domain = self._profile.ctcss_tones_centihz
 
         if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(0x1B, 0x00):
+            civ = self._commands.set_tone_freq(
+                freq_centihz,
+                to_addr=self._radio_addr,
+                receiver=RECEIVER_MAIN,
+                command29=False,
+                ctcss_tones_centihz=domain,
+            )
 
             async def _action() -> None:
-                await self._send_fire_and_forget(
-                    self._commands.set_tone_freq(
-                        freq_hz,
-                        to_addr=self._radio_addr,
-                        receiver=RECEIVER_MAIN,
-                        command29=False,
-                    )
-                )
+                await self._send_fire_and_forget(civ)
 
             await self._run_with_receiver_vfo_fallback(
                 receiver=receiver,
@@ -4618,25 +4624,31 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         cmd29 = self._profile.supports_cmd29(0x1B, 0x00)
         await self._send_fire_and_forget(
             self._commands.set_tone_freq(
-                freq_hz, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+                freq_centihz,
+                to_addr=self._radio_addr,
+                receiver=receiver,
+                command29=cmd29,
+                ctcss_tones_centihz=domain,
             )
         )
 
-    async def get_tsql_freq(self, receiver: int = 0) -> float:
-        """Read TSQL frequency in Hz (0x1B 0x01)."""
+    async def get_tsql_freq(self, receiver: int = 0) -> int:
+        """Read TSQL frequency in exact centiHz (0x1B 0x01)."""
         self._check_connected()
         self._require_receiver(receiver, operation="get_tsql_freq")
+        domain = self._profile.ctcss_tones_centihz
 
         if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(0x1B, 0x01):
+            civ = self._commands.get_tsql_freq(
+                to_addr=self._radio_addr,
+                receiver=RECEIVER_MAIN,
+                command29=False,
+                ctcss_tones_centihz=domain,
+            )
 
-            async def _action() -> float:
-                civ = self._commands.get_tsql_freq(
-                    to_addr=self._radio_addr,
-                    receiver=RECEIVER_MAIN,
-                    command29=False,
-                )
+            async def _action() -> int:
                 resp = await self._send_civ_expect(civ, label="get_tsql_freq")
-                _, freq = parse_tsql_freq_response(resp)
+                _, freq = parse_tsql_freq_response(resp, ctcss_tones_centihz=domain)
                 return freq
 
             return await self._run_with_receiver_vfo_fallback(
@@ -4650,28 +4662,32 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
         cmd29 = self._profile.supports_cmd29(0x1B, 0x01)
         civ = self._commands.get_tsql_freq(
-            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            to_addr=self._radio_addr,
+            receiver=receiver,
+            command29=cmd29,
+            ctcss_tones_centihz=domain,
         )
         resp = await self._send_civ_expect(civ, label="get_tsql_freq")
-        _, freq = parse_tsql_freq_response(resp)
+        _, freq = parse_tsql_freq_response(resp, ctcss_tones_centihz=domain)
         return freq
 
-    async def set_tsql_freq(self, freq_hz: float, receiver: int = 0) -> None:
-        """Set TSQL frequency in Hz (0x1B 0x01)."""
+    async def set_tsql_freq(self, freq_centihz: int, receiver: int = 0) -> None:
+        """Set TSQL frequency in exact centiHz (0x1B 0x01)."""
         self._check_connected()
         self._require_receiver(receiver, operation="set_tsql_freq")
+        domain = self._profile.ctcss_tones_centihz
 
         if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(0x1B, 0x01):
+            civ = self._commands.set_tsql_freq(
+                freq_centihz,
+                to_addr=self._radio_addr,
+                receiver=RECEIVER_MAIN,
+                command29=False,
+                ctcss_tones_centihz=domain,
+            )
 
             async def _action() -> None:
-                await self._send_fire_and_forget(
-                    self._commands.set_tsql_freq(
-                        freq_hz,
-                        to_addr=self._radio_addr,
-                        receiver=RECEIVER_MAIN,
-                        command29=False,
-                    )
-                )
+                await self._send_fire_and_forget(civ)
 
             await self._run_with_receiver_vfo_fallback(
                 receiver=receiver,
@@ -4686,7 +4702,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         cmd29 = self._profile.supports_cmd29(0x1B, 0x01)
         await self._send_fire_and_forget(
             self._commands.set_tsql_freq(
-                freq_hz, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+                freq_centihz,
+                to_addr=self._radio_addr,
+                receiver=receiver,
+                command29=cmd29,
+                ctcss_tones_centihz=domain,
             )
         )
 

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -1345,7 +1345,7 @@ async def _read_modify_verify_restore(
             evidence={
                 "original": original,
                 "reason": (
-                    "current value outside settable range; not mutated to "
+                    "current value outside active settable domain; not mutated to "
                     "keep the run non-destructive"
                 ),
             },
@@ -2214,6 +2214,34 @@ async def _check_xit_set(
 # Generic dispatch: value-rule map + _check_from_spec
 # ---------------------------------------------------------------------------
 
+
+def _declared_ctcss_tones_centihz(radio: Radio) -> tuple[int, ...]:
+    """Return the active profile's exact CTCSS domain, or fail closed."""
+    profile = getattr(radio, "profile", None)
+    tones = getattr(profile, "ctcss_tones_centihz", None)
+    if not isinstance(tones, tuple) or not tones:
+        return ()
+    if any(type(tone) is not int for tone in tones):
+        return ()
+    return tones
+
+
+def _ctcss_probe_value(radio: Radio, *, avoid: int) -> int:
+    """Choose a different tone from the active profile's exact domain."""
+    for tone in _declared_ctcss_tones_centihz(radio):
+        if tone != avoid:
+            return tone
+    raise ValueError("active profile has no alternate CTCSS tone")
+
+
+def _ctcss_original_is_restorable(radio: Radio, value: object) -> bool:
+    """Admit RMVR only when the original and an alternate are profile members."""
+    if type(value) is not int:
+        return False
+    domain = _declared_ctcss_tones_centihz(radio)
+    return value in domain and any(tone != value for tone in domain)
+
+
 # Standalone test value to SET for a write-only control (no original is readable).
 _WRITE_ONLY_TEST_VALUES: dict[str, Any] = {
     ValueRule.TOGGLE_BOOL: True,
@@ -2232,7 +2260,6 @@ _WRITE_ONLY_TEST_VALUES: dict[str, Any] = {
     # fallback happens to equal this same constant — a coincidence of the
     # chosen value, not a shared code path.
     ValueRule.AGC_FLIP: int(AgcMode.FAST),
-    ValueRule.TONE_FREQ_CYCLE: 88.5,
     ValueRule.VFO_AB_FLIP: "A",
     ValueRule.KEY_SPEED_WPM: 20,
     # T11 / MOR-646 — scope controls: index 1 and edge 1 are valid for every
@@ -2277,9 +2304,6 @@ _VALUE_RULE_FNS: dict[str, Callable[[Any], Any]] = {
         int(AgcMode.SLOW) if m != AgcMode.SLOW else int(AgcMode.FAST)
     ),
     ValueRule.BUMP_HZ: lambda v: v + 100,
-    # MOR-642..645 command-coverage families.
-    # Flip between two standard CTCSS tones (Hz).
-    ValueRule.TONE_FREQ_CYCLE: lambda f: 100.0 if float(f) == 88.5 else 88.5,
     # VFO slot select: "A" <-> "B".
     ValueRule.VFO_AB_FLIP: lambda s: "B" if str(s).upper() == "A" else "A",
     # CW keyer speed in WPM (real range 6-48): pick a DIFFERENT in-range value.
@@ -2310,13 +2334,9 @@ _VALUE_RULE_FNS: dict[str, Callable[[Any], Any]] = {
 }
 
 # Restore-safety predicates (MOR-659): when the CURRENT value of an RMVR
-# control is outside the encoder's settable band, the check must SKIP without
-# writing — a test value could never be restored from. Bounds mirror the real
-# encoder: ``commands/tone.py::_encode_tone_freq`` (67.0-254.1 Hz, shared by
-# ``set_tone_freq`` and ``set_tsql_freq``). The live IC-7610 read back 16.5 Hz
-# (tone not configured), which aborted an entire validation run.
+# control is outside its settable domain, the check must SKIP without writing
+# because a test value could never be restored from.
 _VALUE_RULE_RESTORABLE: dict[str, Callable[[Any], bool]] = {
-    ValueRule.TONE_FREQ_CYCLE: lambda v: 67.0 <= float(v) <= 254.1,
     # MOR-672 — only the valid ``CT`` SQL-type codes (0=off / 1=TONE / 2=TSQL)
     # are restorable; an out-of-range read must SKIP rather than write.
     ValueRule.SQL_TYPE_CYCLE: lambda v: 0 <= int(v) <= 2,
@@ -2355,6 +2375,9 @@ async def _set_and_observe(
         # classification does not inherit the same hazard MOR-1529 fixed for
         # the named RMVR handler.
         test_value = _agc_probe_value(radio, avoid=None)
+    elif spec.value_rule == ValueRule.TONE_FREQ_CYCLE:
+        domain = _declared_ctcss_tones_centihz(radio)
+        test_value = domain[0] if domain else None
     if test_value is None:
         return _base_result(
             entry,
@@ -2467,7 +2490,15 @@ async def _check_from_spec(
                 },
             )
         make_changed = _VALUE_RULE_FNS.get(spec.value_rule)
-        if make_changed is None:
+        restorable = _VALUE_RULE_RESTORABLE.get(spec.value_rule)
+        if spec.value_rule == ValueRule.TONE_FREQ_CYCLE:
+            make_changed = lambda current: _ctcss_probe_value(  # noqa: E731
+                radio, avoid=current
+            )
+            restorable = lambda value: _ctcss_original_is_restorable(  # noqa: E731
+                radio, value
+            )
+        elif make_changed is None:
             return _base_result(
                 entry,
                 CheckStatus.UNSUPPORTED,
@@ -2475,7 +2506,6 @@ async def _check_from_spec(
                     "reason": f"value_rule {spec.value_rule!r} not supported by generic handler"
                 },
             )
-        restorable = _VALUE_RULE_RESTORABLE.get(spec.value_rule)
         extra_evidence: dict[str, object] = {
             "handler": "generic",
             "value_rule": str(spec.value_rule),

--- a/tests/integration/test_tone_tsql_integration.py
+++ b/tests/integration/test_tone_tsql_integration.py
@@ -59,13 +59,13 @@ _SUB_REPEATER_TSQL = 0x43
 
 _SETTLE = 0.05  # seconds: wait after fire-and-forget SET before GET
 
-# Standard CTCSS test frequencies (Hz)
-_FREQ_MIN = 67.0
-_FREQ_DEFAULT = 88.5
-_FREQ_MID_LO = 110.9
-_FREQ_MID_HI = 136.5
-_FREQ_MID_2 = 167.9
-_FREQ_MAX = 254.1
+# Standard CTCSS test frequencies (exact centiHz)
+_FREQ_MIN = 6700
+_FREQ_DEFAULT = 8850
+_FREQ_MID_LO = 11090
+_FREQ_MID_HI = 13650
+_FREQ_MID_2 = 16790
+_FREQ_MAX = 25410
 
 
 # ---------------------------------------------------------------------------
@@ -83,8 +83,8 @@ def _bcd_byte_decode(b: int) -> int:
     return ((b >> 4) & 0x0F) * 10 + (b & 0x0F)
 
 
-def _encode_tone_freq(freq_hz: float) -> bytes:
-    """Encode a CTCSS tone frequency to 3-byte BCD.
+def _encode_tone_freq(freq_centihz: int) -> bytes:
+    """Encode an exact-centiHz CTCSS tone frequency to 3-byte BCD.
 
     MOR-2091: the radio packs six BCD digits as
     [0][0][100Hz digit][10Hz digit][1Hz digit][0.1Hz digit] -- not
@@ -94,15 +94,15 @@ def _encode_tone_freq(freq_hz: float) -> bytes:
     tenths=1109 -> byte[0]=0x00, byte[1]=_bcd_byte(11)=0x11,
     byte[2]=_bcd_byte(9)=0x09.
     """
-    total_tenths = int(round(freq_hz * 10))
+    total_tenths = freq_centihz // 10
     return bytes([0x00, _bcd_byte(total_tenths // 100), _bcd_byte(total_tenths % 100)])
 
 
-def _decode_tone_freq(data: bytes) -> float:
-    """Decode 3-byte BCD to a CTCSS tone frequency in Hz. Inverse of
+def _decode_tone_freq(data: bytes) -> int:
+    """Decode 3-byte BCD to exact centiHz. Inverse of
     `_encode_tone_freq` above."""
     total_tenths = _bcd_byte_decode(data[1]) * 100 + _bcd_byte_decode(data[2])
-    return round(total_tenths / 10.0, 1)
+    return total_tenths * 10
 
 
 # ---------------------------------------------------------------------------
@@ -145,8 +145,8 @@ class ToneMockRadio(MockIcomRadio):
         super().__init__(**kwargs)
         self._repeater_tone: int = 0  # 0 = off, 1 = on
         self._repeater_tsql: int = 0  # 0 = off, 1 = on
-        self._tone_freq_hz: float = _FREQ_DEFAULT
-        self._tsql_freq_hz: float = _FREQ_DEFAULT
+        self._tone_freq_centihz: int = _FREQ_DEFAULT
+        self._tsql_freq_centihz: int = _FREQ_DEFAULT
 
     # ------------------------------------------------------------------
     # CI-V dispatch override
@@ -242,14 +242,14 @@ class ToneMockRadio(MockIcomRadio):
         to = from_addr
         frm = self._radio_addr
         if len(rest) >= 3:  # SET (3-byte BCD payload)
-            self._tone_freq_hz = _decode_tone_freq(rest[:3])
+            self._tone_freq_centihz = _decode_tone_freq(rest[:3])
             return self._civ_ack(to, frm)
         return self._civ_frame(
             to,
             frm,
             _CMD_TONE,
             sub=_SUB_TONE_FREQ,
-            data=_encode_tone_freq(self._tone_freq_hz),
+            data=_encode_tone_freq(self._tone_freq_centihz),
         )
 
     def _handle_tsql_freq(self, rest: bytes, from_addr: int) -> bytes:
@@ -257,14 +257,14 @@ class ToneMockRadio(MockIcomRadio):
         to = from_addr
         frm = self._radio_addr
         if len(rest) >= 3:  # SET (3-byte BCD payload)
-            self._tsql_freq_hz = _decode_tone_freq(rest[:3])
+            self._tsql_freq_centihz = _decode_tone_freq(rest[:3])
             return self._civ_ack(to, frm)
         return self._civ_frame(
             to,
             frm,
             _CMD_TONE,
             sub=_SUB_TSQL_FREQ,
-            data=_encode_tone_freq(self._tsql_freq_hz),
+            data=_encode_tone_freq(self._tsql_freq_centihz),
         )
 
 
@@ -449,7 +449,7 @@ class TestToneFrequency:
 
         result = await tone_radio.get_tone_freq()
         assert result == _FREQ_MIN
-        assert tone_mock._tone_freq_hz == _FREQ_MIN
+        assert tone_mock._tone_freq_centihz == _FREQ_MIN
 
     async def test_set_110_9_hz(self, tone_radio: IcomRadio) -> None:
         """Set tone frequency to 110.9 Hz."""
@@ -468,7 +468,7 @@ class TestToneFrequency:
 
         result = await tone_radio.get_tone_freq()
         assert result == _FREQ_MAX
-        assert tone_mock._tone_freq_hz == _FREQ_MAX
+        assert tone_mock._tone_freq_centihz == _FREQ_MAX
 
     async def test_multiple_freq_changes(self, tone_radio: IcomRadio) -> None:
         """Change tone frequency through all standard test values."""
@@ -483,11 +483,11 @@ class TestToneFrequency:
             await tone_radio.set_tone_freq(freq)
             await asyncio.sleep(_SETTLE)
             result = await tone_radio.get_tone_freq()
-            assert result == freq, f"Expected {freq} Hz, got {result} Hz"
+            assert result == freq, f"Expected {freq} centiHz, got {result} centiHz"
 
     async def test_freq_roundtrip_precision(self, tone_radio: IcomRadio) -> None:
         """BCD encoding/decoding preserves single-decimal precision."""
-        for freq in (67.0, 77.0, 88.5, 100.0, 110.9, 127.3, 167.9, 203.5, 254.1):
+        for freq in (6700, 7700, 8850, 10000, 11090, 12730, 16790, 20350, 25410):
             await tone_radio.set_tone_freq(freq)
             await asyncio.sleep(_SETTLE)
             result = await tone_radio.get_tone_freq()
@@ -516,7 +516,7 @@ class TestTSQLFrequency:
 
         result = await tone_radio.get_tsql_freq()
         assert result == _FREQ_MIN
-        assert tone_mock._tsql_freq_hz == _FREQ_MIN
+        assert tone_mock._tsql_freq_centihz == _FREQ_MIN
 
     async def test_set_110_9_hz(self, tone_radio: IcomRadio) -> None:
         """Set TSQL frequency to 110.9 Hz."""
@@ -535,7 +535,7 @@ class TestTSQLFrequency:
 
         result = await tone_radio.get_tsql_freq()
         assert result == _FREQ_MAX
-        assert tone_mock._tsql_freq_hz == _FREQ_MAX
+        assert tone_mock._tsql_freq_centihz == _FREQ_MAX
 
     async def test_multiple_freq_changes(self, tone_radio: IcomRadio) -> None:
         """Change TSQL frequency through all standard test values."""
@@ -550,7 +550,7 @@ class TestTSQLFrequency:
             await tone_radio.set_tsql_freq(freq)
             await asyncio.sleep(_SETTLE)
             result = await tone_radio.get_tsql_freq()
-            assert result == freq, f"Expected {freq} Hz, got {result} Hz"
+            assert result == freq, f"Expected {freq} centiHz, got {result} centiHz"
 
     async def test_tone_and_tsql_freq_independent(self, tone_radio: IcomRadio) -> None:
         """Tone and TSQL frequencies are stored independently."""
@@ -565,7 +565,7 @@ class TestTSQLFrequency:
 
     async def test_freq_roundtrip_precision(self, tone_radio: IcomRadio) -> None:
         """BCD encoding/decoding preserves single-decimal precision for TSQL."""
-        for freq in (67.0, 77.0, 88.5, 100.0, 110.9, 127.3, 167.9, 203.5, 254.1):
+        for freq in (6700, 7700, 8850, 10000, 11090, 12730, 16790, 20350, 25410):
             await tone_radio.set_tsql_freq(freq)
             await asyncio.sleep(_SETTLE)
             result = await tone_radio.get_tsql_freq()
@@ -583,21 +583,21 @@ class TestBcdCodec:
     @pytest.mark.parametrize(
         "freq",
         [
-            67.0,
-            77.0,
-            88.5,
-            100.0,
-            110.9,
-            127.3,
-            136.5,
-            167.9,
-            203.5,
-            254.1,
+            6700,
+            7700,
+            8850,
+            10000,
+            11090,
+            12730,
+            13650,
+            16790,
+            20350,
+            25410,
         ],
     )
-    def test_encode_decode_roundtrip(self, freq: float) -> None:
+    def test_encode_decode_roundtrip(self, freq: int) -> None:
         """encode → decode must recover the original frequency."""
         encoded = _encode_tone_freq(freq)
         assert len(encoded) == 3
         decoded = _decode_tone_freq(encoded)
-        assert decoded == freq, f"Roundtrip failed for {freq} Hz: got {decoded}"
+        assert decoded == freq, f"Roundtrip failed for {freq} centiHz: got {decoded}"

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -2223,14 +2223,14 @@ _VALUE_CONTROL_CASES = (
     ),
     # 0x1B 0x00 tone_freq: BCD freq-encoded 88.5 Hz → 8850 centiHz (MOR-451).
     (
-        _make_frame(cmd=0x1B, sub=0x00, data=_encode_tone_freq(88.5), receiver=0x00),
+        _make_frame(cmd=0x1B, sub=0x00, data=_encode_tone_freq(8850), receiver=0x00),
         "receiver.0.operator_controls.tone_freq",
         "main.toneFreq",
         8850,
     ),
     # 0x1B 0x01 tsql_freq: BCD freq-encoded 88.5 Hz → 8850 centiHz (MOR-451).
     (
-        _make_frame(cmd=0x1B, sub=0x01, data=_encode_tone_freq(88.5), receiver=0x00),
+        _make_frame(cmd=0x1B, sub=0x01, data=_encode_tone_freq(8850), receiver=0x00),
         "receiver.0.operator_controls.tsql_freq",
         "main.tsqlFreq",
         8850,
@@ -2320,6 +2320,12 @@ def _expected_value_control_max_age(store_path: str) -> float | None:
     return None
 
 
+def _use_ctcss_fixture_profile(radio: IcomRadio, store_path: str) -> None:
+    """Use a tone-capable profile only for the two CTCSS observation cases."""
+    if store_path.endswith((".tone_freq", ".tsql_freq")):
+        radio._profile = resolve_radio_profile(model="IC-7300")  # noqa: SLF001
+
+
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("frame", "store_path", "public_path", "expected"),
     _VALUE_CONTROL_CASES,
@@ -2333,6 +2339,7 @@ def test_value_control_observation_value(
     expected: object,
 ) -> None:
     """MOR-437 (BE-2): level/value CI-V families emit the exact decoded value."""
+    _use_ctcss_fixture_profile(radio_with_state, store_path)
     # A real mode is required so the profile-dependent filter_width decode runs.
     radio_with_state._radio_state.main.mode = "USB"
     radio_with_state._civ_runtime._update_state_cache_from_frame(frame)
@@ -2356,6 +2363,7 @@ def test_value_control_survives_unrelated_poll_cycle(
     expected: object,
 ) -> None:
     """The observed value must not snap back when an unrelated frame arrives."""
+    _use_ctcss_fixture_profile(radio_with_state, store_path)
     radio_with_state._radio_state.main.mode = "USB"
     radio_with_state._civ_runtime._update_state_cache_from_frame(frame)
     # An unrelated S-meter poll on the next cycle must not disturb the value.
@@ -2385,6 +2393,7 @@ def test_value_control_projects_available(
         build_public_state_payload_from_snapshot,
     )
 
+    _use_ctcss_fixture_profile(radio_with_state, store_path)
     radio_with_state._radio_state.main.mode = "USB"
     radio_with_state._civ_runtime._update_state_cache_from_frame(frame)
     payload = build_public_state_payload_from_snapshot(
@@ -2915,6 +2924,7 @@ def test_tone_and_tsql_freq_observations_can_go_stale(
     still ``FRESH`` past the TTL ``rigs/ic7300.toml`` declares for it.
     """
 
+    radio._profile = resolve_radio_profile(model="IC-7300")  # noqa: SLF001
     stored = FieldPath.receiver("0", "operator_controls", name)
     # The TTL is not a literal here: it is read from the IC-7300 profile,
     # which is what declared this path observable (e0558fea).
@@ -2929,7 +2939,7 @@ def test_tone_and_tsql_freq_observations_can_go_stale(
     observed_at = 500.0
     with patch("rigplane.runtime._civ_rx.time.monotonic", return_value=observed_at):
         radio._civ_runtime._apply_state_store_observations(
-            _make_frame(cmd=0x1B, sub=sub, data=_encode_tone_freq(88.5), receiver=0x00)
+            _make_frame(cmd=0x1B, sub=sub, data=_encode_tone_freq(8850), receiver=0x00)
         )
     assert radio._state_store.snapshot().field(str(stored)).value == 8850
 
@@ -3819,8 +3829,9 @@ def test_update_radio_state_cmd1b_tone_freq_observation_backed(
     field: str,
 ) -> None:
     """MOR-451: cmd 0x1B/0x00-0x01 mirror removed; StateStore is source of truth."""
+    radio_with_state._profile = resolve_radio_profile(model="IC-7300")  # noqa: SLF001
     rs = radio_with_state._radio_state
-    frame = _make_frame(cmd=0x1B, sub=sub, data=_encode_tone_freq(88.5), receiver=0x01)
+    frame = _make_frame(cmd=0x1B, sub=sub, data=_encode_tone_freq(8850), receiver=0x01)
     radio_with_state._civ_runtime._update_state_cache_from_frame(frame)
     # Legacy ReceiverState mirror stays at its default 0; the store carries truth.
     assert getattr(rs.sub, field) == 0
@@ -3828,6 +3839,50 @@ def test_update_radio_state_cmd1b_tone_freq_observation_backed(
         f"receiver.1.operator_controls.{field}"
     )
     assert store_field.value == 8850
+
+
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    ("sub", "field"),
+    [(0x00, "tone_freq"), (0x01, "tsql_freq")],
+)
+@pytest.mark.parametrize(
+    ("domain", "rejected_data"),
+    [
+        (None, _encode_tone_freq(10000)),
+        ((), _encode_tone_freq(10000)),
+        ((8850.0,), _encode_tone_freq(10000)),
+        ((8851,), _encode_tone_freq(10000)),
+        ((10000, 8850), _encode_tone_freq(10000)),
+        ((6700, 8850), _encode_tone_freq(10000)),
+        ((6700, 8850), b"\x00\x0a\x00"),
+    ],
+)
+def test_cmd1b_rejected_profile_value_preserves_state_truth(
+    radio_with_state: IcomRadio,
+    sub: int,
+    field: str,
+    domain: tuple | None,
+    rejected_data: bytes,
+) -> None:
+    radio_with_state._profile = resolve_radio_profile(model="IC-7300")  # noqa: SLF001
+    path = f"receiver.1.operator_controls.{field}"
+    radio_with_state._civ_runtime._update_state_cache_from_frame(
+        _make_frame(cmd=0x1B, sub=sub, data=_encode_tone_freq(8850), receiver=0x01)
+    )
+    before = radio_with_state._state_store.snapshot()
+    assert before.field(path).value == 8850
+
+    radio_with_state._profile = dataclasses.replace(  # noqa: SLF001
+        radio_with_state._profile,
+        ctcss_tones_centihz=domain,
+    )
+    radio_with_state._civ_runtime._update_state_cache_from_frame(
+        _make_frame(cmd=0x1B, sub=sub, data=rejected_data, receiver=0x01)
+    )
+
+    after = radio_with_state._state_store.snapshot()
+    assert after.observation_seq == before.observation_seq
+    assert after.field(path) == before.field(path)
 
 
 def test_update_radio_state_cmd1a_agc_time_constant_observation_backed(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -43,6 +43,8 @@ from rigplane.types import (
 from _command_test_helpers import bind_default_addr_globals, bind_default_addr_module
 
 RIG_DIR = Path(__file__).resolve().parents[1] / "rigs"
+_CTCSS_DOMAIN = load_rig(RIG_DIR / "ic7300.toml").ctcss_tones_centihz
+assert _CTCSS_DOMAIN is not None
 
 # The eight Icom CI-V scope span presets (span code 0-7 -> Hz), copied
 # verbatim from the module constant `commands/scope.py` held at c23d8cbd
@@ -1884,59 +1886,61 @@ class TestToneTsqlCommands:
     def test_encode_tone_freq_88_5(self) -> None:
         from rigplane.commands import _encode_tone_freq
 
-        assert _encode_tone_freq(88.5) == bytes([0x00, 0x08, 0x85])
+        assert _encode_tone_freq(8850) == bytes([0x00, 0x08, 0x85])
 
     def test_encode_tone_freq_110_9(self) -> None:
         from rigplane.commands import _encode_tone_freq
 
-        assert _encode_tone_freq(110.9) == bytes([0x00, 0x11, 0x09])
+        assert _encode_tone_freq(11090) == bytes([0x00, 0x11, 0x09])
 
     def test_encode_tone_freq_100_0(self) -> None:
         from rigplane.commands import _encode_tone_freq
 
-        assert _encode_tone_freq(100.0) == bytes([0x00, 0x10, 0x00])
+        assert _encode_tone_freq(10000) == bytes([0x00, 0x10, 0x00])
 
     def test_encode_tone_freq_67_0(self) -> None:
         from rigplane.commands import _encode_tone_freq
 
-        assert _encode_tone_freq(67.0) == bytes([0x00, 0x06, 0x70])
+        assert _encode_tone_freq(6700) == bytes([0x00, 0x06, 0x70])
 
     def test_encode_tone_freq_254_1(self) -> None:
         from rigplane.commands import _encode_tone_freq
 
-        assert _encode_tone_freq(254.1) == bytes([0x00, 0x25, 0x41])
+        assert _encode_tone_freq(25410) == bytes([0x00, 0x25, 0x41])
 
     def test_encode_tone_freq_rejects_out_of_range(self) -> None:
         from rigplane.commands import _encode_tone_freq
 
-        with pytest.raises(ValueError, match="67.0-254.1"):
-            _encode_tone_freq(60.0)
-        with pytest.raises(ValueError, match="67.0-254.1"):
-            _encode_tone_freq(300.0)
+        with pytest.raises(ValueError, match="0.1 Hz"):
+            _encode_tone_freq(8851)
 
     def test_decode_tone_freq_88_5(self) -> None:
         from rigplane.commands import _decode_tone_freq
 
-        assert _decode_tone_freq(bytes([0x00, 0x08, 0x85])) == pytest.approx(88.5)
+        assert _decode_tone_freq(bytes([0x00, 0x08, 0x85])) == 8850
 
     def test_decode_tone_freq_110_9(self) -> None:
         from rigplane.commands import _decode_tone_freq
 
-        assert _decode_tone_freq(bytes([0x00, 0x11, 0x09])) == pytest.approx(110.9)
+        assert _decode_tone_freq(bytes([0x00, 0x11, 0x09])) == 11090
 
     def test_decode_tone_freq_roundtrip(self) -> None:
         from rigplane.commands import _decode_tone_freq, _encode_tone_freq
 
-        for freq in [67.0, 88.5, 100.0, 110.9, 127.3, 203.5, 254.1]:
+        for freq in [6700, 8850, 10000, 11090, 12730, 20350, 25410]:
             encoded = _encode_tone_freq(freq)
-            assert _decode_tone_freq(encoded) == pytest.approx(freq, abs=0.05)
+            assert _decode_tone_freq(encoded) == freq
 
     # --- Tone Frequency command (0x1B 0x00) ---
 
     def test_get_tone_freq_uses_cmd29(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, get_tone_freq
 
-        frame = get_tone_freq(receiver=RECEIVER_MAIN, cmd_map=cmd_map)
+        frame = get_tone_freq(
+            receiver=RECEIVER_MAIN,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
+        )
         assert frame[4] == 0x29
         assert frame[5] == RECEIVER_MAIN
         assert frame[6] == 0x1B
@@ -1945,7 +1949,12 @@ class TestToneTsqlCommands:
     def test_set_tone_freq_encodes_bcd(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, set_tone_freq
 
-        frame = set_tone_freq(88.5, receiver=RECEIVER_MAIN, cmd_map=cmd_map)
+        frame = set_tone_freq(
+            8850,
+            receiver=RECEIVER_MAIN,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
+        )
         assert frame[4] == 0x29
         assert frame[6] == 0x1B
         assert frame[7] == 0x00
@@ -1954,15 +1963,19 @@ class TestToneTsqlCommands:
     def test_set_tone_freq_rejects_out_of_range(self, cmd_map) -> None:
         from rigplane.commands import set_tone_freq
 
-        with pytest.raises(ValueError, match="67.0-254.1"):
-            set_tone_freq(50.0, cmd_map=cmd_map)
+        with pytest.raises(ValueError, match="not declared"):
+            set_tone_freq(5000, cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN)
 
     # --- TSQL Frequency command (0x1B 0x01) ---
 
     def test_get_tsql_freq_uses_cmd29(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_SUB, get_tsql_freq
 
-        frame = get_tsql_freq(receiver=RECEIVER_SUB, cmd_map=cmd_map)
+        frame = get_tsql_freq(
+            receiver=RECEIVER_SUB,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
+        )
         assert frame[4] == 0x29
         assert frame[5] == RECEIVER_SUB
         assert frame[6] == 0x1B
@@ -1971,7 +1984,12 @@ class TestToneTsqlCommands:
     def test_set_tsql_freq_encodes_bcd(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, set_tsql_freq
 
-        frame = set_tsql_freq(110.9, receiver=RECEIVER_MAIN, cmd_map=cmd_map)
+        frame = set_tsql_freq(
+            11090,
+            receiver=RECEIVER_MAIN,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
+        )
         assert frame[4] == 0x29
         assert frame[6] == 0x1B
         assert frame[7] == 0x01
@@ -1998,9 +2016,11 @@ class TestToneTsqlCommands:
             receiver=RECEIVER_MAIN,
         )
         frame = parse_civ_frame(civ)
-        receiver, freq = parse_tone_freq_response(frame)
+        receiver, freq = parse_tone_freq_response(
+            frame, ctcss_tones_centihz=_CTCSS_DOMAIN
+        )
         assert receiver == RECEIVER_MAIN
-        assert freq == pytest.approx(88.5)
+        assert freq == 8850
 
     def test_parse_tsql_freq_response(self) -> None:
         from rigplane import IC_7610_ADDR
@@ -2021,9 +2041,11 @@ class TestToneTsqlCommands:
             receiver=RECEIVER_SUB,
         )
         frame = parse_civ_frame(civ)
-        receiver, freq = parse_tsql_freq_response(frame)
+        receiver, freq = parse_tsql_freq_response(
+            frame, ctcss_tones_centihz=_CTCSS_DOMAIN
+        )
         assert receiver == RECEIVER_SUB
-        assert freq == pytest.approx(110.9)
+        assert freq == 11090
 
     def test_build_memory_mode_get(self) -> None:
         """get_memory_mode is PROVENANCE OPEN on every shipped Icom profile

--- a/tests/test_mor1517_cmd29_gating.py
+++ b/tests/test_mor1517_cmd29_gating.py
@@ -81,7 +81,10 @@ _IC705_ADDR = 0xA4
 # address, no divergence row for any of them), so the expected bytes below
 # are unchanged.
 RIG_DIR = Path(__file__).resolve().parents[1] / "rigs"
-_IC7300_CMD_MAP = load_rig(RIG_DIR / "ic7300.toml").to_command_map()
+_IC7300_RIG = load_rig(RIG_DIR / "ic7300.toml")
+_IC7300_CMD_MAP = _IC7300_RIG.to_command_map()
+_IC7300_CTCSS_DOMAIN = _IC7300_RIG.ctcss_tones_centihz
+assert _IC7300_CTCSS_DOMAIN is not None
 _IC7610_CMD_MAP = load_rig(RIG_DIR / "ic7610.toml").to_command_map()
 _IC705_CMD_MAP = load_rig(RIG_DIR / "ic705.toml").to_command_map()
 
@@ -758,13 +761,14 @@ class TestToneFreqGating:
     async def test_set_tone_freq_unwrapped_on_ic7300(self) -> None:
         radio = _connected_icom(model="IC-7300")
         mock = _mock_raw(radio)
-        await radio.set_tone_freq(100.0, receiver=0)
+        await radio.set_tone_freq(10000, receiver=0)
         expected = set_tone_freq(
-            100.0,
+            10000,
             to_addr=_IC7300_ADDR,
             receiver=0,
             command29=False,
             cmd_map=_IC7300_CMD_MAP,
+            ctcss_tones_centihz=_IC7300_CTCSS_DOMAIN,
         )
         assert _sent_civ(mock) == expected
 
@@ -779,7 +783,7 @@ class TestToneFreqGating:
         radio = _connected_icom(model="IC-7610")
         mock = _mock_raw(radio)
         with pytest.raises(CommandError, match="not supported by this radio"):
-            await radio.set_tone_freq(100.0, receiver=0)
+            await radio.set_tone_freq(10000, receiver=0)
         mock.assert_not_called()
 
     @pytest.mark.asyncio
@@ -795,10 +799,14 @@ class TestToneFreqGating:
         mock = _mock_expect(radio, response)
         value = await radio.get_tone_freq(receiver=0)
         expected = get_tone_freq(
-            to_addr=_IC7300_ADDR, receiver=0, command29=False, cmd_map=_IC7300_CMD_MAP
+            to_addr=_IC7300_ADDR,
+            receiver=0,
+            command29=False,
+            cmd_map=_IC7300_CMD_MAP,
+            ctcss_tones_centihz=_IC7300_CTCSS_DOMAIN,
         )
         assert _sent_civ(mock) == expected
-        assert value == 100.0
+        assert value == 10000
 
     @pytest.mark.asyncio
     async def test_get_tone_freq_refused_on_ic7610(self) -> None:
@@ -822,13 +830,14 @@ class TestTsqlFreqGating:
     async def test_set_tsql_freq_unwrapped_on_ic7300(self) -> None:
         radio = _connected_icom(model="IC-7300")
         mock = _mock_raw(radio)
-        await radio.set_tsql_freq(100.0, receiver=0)
+        await radio.set_tsql_freq(10000, receiver=0)
         expected = set_tsql_freq(
-            100.0,
+            10000,
             to_addr=_IC7300_ADDR,
             receiver=0,
             command29=False,
             cmd_map=_IC7300_CMD_MAP,
+            ctcss_tones_centihz=_IC7300_CTCSS_DOMAIN,
         )
         assert _sent_civ(mock) == expected
 
@@ -839,7 +848,7 @@ class TestTsqlFreqGating:
         radio = _connected_icom(model="IC-7610")
         mock = _mock_raw(radio)
         with pytest.raises(CommandError, match="not supported by this radio"):
-            await radio.set_tsql_freq(100.0, receiver=0)
+            await radio.set_tsql_freq(10000, receiver=0)
         mock.assert_not_called()
 
     @pytest.mark.asyncio
@@ -855,10 +864,14 @@ class TestTsqlFreqGating:
         mock = _mock_expect(radio, response)
         value = await radio.get_tsql_freq(receiver=0)
         expected = get_tsql_freq(
-            to_addr=_IC7300_ADDR, receiver=0, command29=False, cmd_map=_IC7300_CMD_MAP
+            to_addr=_IC7300_ADDR,
+            receiver=0,
+            command29=False,
+            cmd_map=_IC7300_CMD_MAP,
+            ctcss_tones_centihz=_IC7300_CTCSS_DOMAIN,
         )
         assert _sent_civ(mock) == expected
-        assert value == 100.0
+        assert value == 10000
 
     @pytest.mark.asyncio
     async def test_get_tsql_freq_refused_on_ic7610(self) -> None:

--- a/tests/test_profile_command_binding.py
+++ b/tests/test_profile_command_binding.py
@@ -358,6 +358,13 @@ _EXTRA_PROBE_KWARGS: dict[str, dict[str, Any]] = {
             band=1, register=1, frequency_hz=14_074_000, mode=1, filter=1
         )
     },
+    # Tone builders deliberately require the active profile's exact domain.
+    # Supply a synthetic domain here so this guard still reaches its map-key
+    # assertion without smuggling a fallback into production behavior.
+    "get_tone_freq": {"ctcss_tones_centihz": (8850, 10000)},
+    "set_tone_freq": {"freq_centihz": 8850, "ctcss_tones_centihz": (8850, 10000)},
+    "get_tsql_freq": {"ctcss_tones_centihz": (8850, 10000)},
+    "set_tsql_freq": {"freq_centihz": 8850, "ctcss_tones_centihz": (8850, 10000)},
 }
 
 
@@ -478,12 +485,21 @@ class TestExposedKeyDriftGuard:
         # routes through it, not just this batch's five.
         builders_module = sys.modules["rigplane.commands._builders"]
         monkeypatch.setattr(builders_module, "_build_from_map", _fake_build_from_map)
-        case_kwargs = self._synthesize_case(builder, cmd_map)
-        builder(to_addr=0x94, cmd_map=cmd_map, **case_kwargs)
+        target = inspect.unwrap(builder)
+        probe_map = cmd_map
+        if "ctcss_tones_centihz" in inspect.signature(target).parameters:
+            # Tone builders validate both their profile domain and their named
+            # command before reaching the patched frame builder.  Add only the
+            # builder's own placeholder command to this synthetic probe map.
+            probe_map = CommandMap(
+                {name: cmd_map.get(name) for name in cmd_map} | {_name: (0x1B, 0x00)}
+            )
+        case_kwargs = self._synthesize_case(builder, probe_map)
+        builder(to_addr=0x94, cmd_map=probe_map, **case_kwargs)
         assert "key" in captured, (
             f"{builder.__qualname__} did not call _build_from_map with cmd_map set"
         )
-        assert captured["key"] == builder.cmd_map_key(cmd_map)
+        assert captured["key"] == builder.cmd_map_key(probe_map)
 
 
 def test_ptt_off_is_also_covered_directly() -> None:

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import time
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -3760,7 +3761,7 @@ class TestToneTsqlParity:
             data=bytes([0x00, 0x08, 0x85]),
         )
         mock_transport.queue_response(_wrap_civ_in_udp(civ))
-        assert await radio.get_tone_freq() == pytest.approx(88.5)
+        assert await radio.get_tone_freq() == 8850
 
     @pytest.mark.asyncio
     async def test_get_tsql_freq(
@@ -3775,13 +3776,13 @@ class TestToneTsqlParity:
             data=bytes([0x00, 0x11, 0x09]),
         )
         mock_transport.queue_response(_wrap_civ_in_udp(civ))
-        assert await radio.get_tsql_freq() == pytest.approx(110.9)
+        assert await radio.get_tsql_freq() == 11090
 
     @pytest.mark.asyncio
     async def test_set_tone_freq(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
-        await radio.set_tone_freq(88.5)
+        await radio.set_tone_freq(8850)
         # plain (no cmd29 -- IC-7300 has none) + 0x1B + 0x00 + BCD(88.5) + FD
         assert mock_transport.sent_packets[-1].endswith(b"\x1b\x00\x00\x08\x85\xfd")
 
@@ -3789,8 +3790,32 @@ class TestToneTsqlParity:
     async def test_set_tsql_freq(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
-        await radio.set_tsql_freq(110.9)
+        await radio.set_tsql_freq(11090)
         assert mock_transport.sent_packets[-1].endswith(b"\x1b\x01\x00\x11\x09\xfd")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "sub"),
+        [("get_tone_freq", 0x00), ("get_tsql_freq", 0x01)],
+    )
+    async def test_get_tone_frequency_rejects_profile_nonmember(
+        self,
+        radio: IcomRadio,
+        mock_transport: MockTransport,
+        method_name: str,
+        sub: int,
+    ) -> None:
+        civ = build_civ_frame(
+            CONTROLLER_ADDR,
+            _IC_7300_ADDR,
+            0x1B,
+            sub=sub,
+            data=bytes([0x00, 0x08, 0x80]),
+        )
+        mock_transport.queue_response(_wrap_civ_in_udp(civ))
+
+        with pytest.raises(ValueError, match="not declared"):
+            await getattr(radio, method_name)()
 
 
 class TestToneTsqlDualRxCmd29Guard:
@@ -3852,7 +3877,7 @@ class TestToneTsqlDualRxCmd29Guard:
                 build_civ_frame(
                     CONTROLLER_ADDR, 0xA2, 0x1B, sub=0x00, data=b"\x00\x08\x85"
                 ),
-                88.5,
+                8850,
             ),
             (
                 "get_tsql_freq",
@@ -3860,7 +3885,7 @@ class TestToneTsqlDualRxCmd29Guard:
                 build_civ_frame(
                     CONTROLLER_ADDR, 0xA2, 0x1B, sub=0x01, data=b"\x00\x11\x09"
                 ),
-                110.9,
+                11090,
             ),
         ],
     )
@@ -3871,7 +3896,7 @@ class TestToneTsqlDualRxCmd29Guard:
         method_name: str,
         request_tail: bytes,
         response_civ: bytes,
-        expected: bool | float,
+        expected: bool | int,
     ) -> None:
         """MOR-1538: SUB GETs reach SUB via VFO-select instead of raising."""
         ack = _wrap_civ_in_udp(build_civ_frame(CONTROLLER_ADDR, 0xA2, _CMD_ACK))
@@ -3882,10 +3907,7 @@ class TestToneTsqlDualRxCmd29Guard:
         method = getattr(ic9700_radio, method_name)
         result = await method(receiver=1)
 
-        if isinstance(expected, float):
-            assert result == pytest.approx(expected)
-        else:
-            assert result is expected
+        assert result == expected
 
         frames = mock_transport.sent_packets
         assert frames[0].endswith(b"\x07\xd1\xfd")  # select SUB
@@ -3898,8 +3920,8 @@ class TestToneTsqlDualRxCmd29Guard:
         [
             ("set_repeater_tone", (True,), b"\x16\x42\x01\xfd"),
             ("set_repeater_tsql", (True,), b"\x16\x43\x01\xfd"),
-            ("set_tone_freq", (88.5,), b"\x1b\x00\x00\x08\x85\xfd"),
-            ("set_tsql_freq", (110.9,), b"\x1b\x01\x00\x11\x09\xfd"),
+            ("set_tone_freq", (8850,), b"\x1b\x00\x00\x08\x85\xfd"),
+            ("set_tsql_freq", (11090,), b"\x1b\x01\x00\x11\x09\xfd"),
         ],
     )
     async def test_sub_receiver_set_uses_vfo_select_fallback(
@@ -3936,8 +3958,8 @@ class TestToneTsqlDualRxCmd29Guard:
         [
             ("set_repeater_tone", (True,), b"\x16\x42\x01\xfd"),
             ("set_repeater_tsql", (True,), b"\x16\x43\x01\xfd"),
-            ("set_tone_freq", (88.5,), b"\x1b\x00\x00\x08\x85\xfd"),
-            ("set_tsql_freq", (110.9,), b"\x1b\x01\x00\x11\x09\xfd"),
+            ("set_tone_freq", (8850,), b"\x1b\x00\x00\x08\x85\xfd"),
+            ("set_tsql_freq", (11090,), b"\x1b\x01\x00\x11\x09\xfd"),
         ],
     )
     async def test_main_receiver_still_sends_direct_frame(
@@ -3960,6 +3982,60 @@ class TestToneTsqlDualRxCmd29Guard:
         mock_transport.queue_response(_wrap_civ_in_udp(civ))
         assert await ic9700_radio.get_repeater_tone(receiver=0) is True
         assert mock_transport.sent_packets[-1].endswith(b"\x16\x42\xfd")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "args"),
+        [
+            ("get_tone_freq", ()),
+            ("set_tone_freq", (8850,)),
+            ("get_tsql_freq", ()),
+            ("set_tsql_freq", (11090,)),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "domain",
+        [None, (), (8850.0,), (8851,), (10000, 8850)],
+    )
+    async def test_invalid_tone_domain_fails_before_sub_vfo_fallback(
+        self,
+        ic9700_radio: IcomRadio,
+        mock_transport: MockTransport,
+        method_name: str,
+        args: tuple,
+        domain: tuple | None,
+    ) -> None:
+        ic9700_radio._profile = replace(
+            ic9700_radio._profile,
+            ctcss_tones_centihz=domain,
+        )
+
+        with pytest.raises(ValueError, match="CTCSS tone domain"):
+            await getattr(ic9700_radio, method_name)(*args, receiver=1)
+
+        assert mock_transport.sent_packets == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("invalid", [True, 8850.0, "8850"])
+    async def test_non_int_tone_fails_before_sub_vfo_fallback(
+        self,
+        ic9700_radio: IcomRadio,
+        mock_transport: MockTransport,
+        invalid: object,
+    ) -> None:
+        with pytest.raises(TypeError, match="exact int in centiHz"):
+            await ic9700_radio.set_tone_freq(invalid, receiver=1)  # type: ignore[arg-type]
+
+        assert mock_transport.sent_packets == []
+
+    @pytest.mark.asyncio
+    async def test_nonmember_tone_fails_before_sub_vfo_fallback(
+        self, ic9700_radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        with pytest.raises(ValueError, match="not declared"):
+            await ic9700_radio.set_tsql_freq(8800, receiver=1)
+
+        assert mock_transport.sent_packets == []
 
 
 class TestRepeaterToneDedupeKeyReceiverScoped:
@@ -4135,9 +4211,9 @@ class TestRequireReceiverToneMethodsPin:
             ("get_repeater_tsql", ()),
             ("set_repeater_tsql", (True,)),
             ("get_tone_freq", ()),
-            ("set_tone_freq", (88.5,)),
+            ("set_tone_freq", (8850,)),
             ("get_tsql_freq", ()),
-            ("set_tsql_freq", (110.9,)),
+            ("set_tsql_freq", (11090,)),
         ],
     )
     async def test_single_rx_receiver_1_reports_accurate_receiver_count(

--- a/tests/test_tone_tsql.py
+++ b/tests/test_tone_tsql.py
@@ -41,6 +41,8 @@ from _command_test_helpers import bind_default_addr_globals
 bind_default_addr_globals(globals(), to_addr=IC_7610_ADDR)
 
 RIG_DIR = Path(__file__).resolve().parents[1] / "rigs"
+_CTCSS_DOMAIN = load_rig(RIG_DIR / "ic7300.toml").ctcss_tones_centihz
+assert _CTCSS_DOMAIN is not None
 
 
 @pytest.fixture()
@@ -176,7 +178,7 @@ def _tsql_freq_response(bcd: bytes, receiver: int | None = None) -> CivFrame:
 # BCD encoding reference values
 # ---------------------------------------------------------------------------
 
-# freq_hz → expected 3-byte BCD encoding.
+# freq_centihz → expected 3-byte BCD encoding.
 #
 # Layout: 3 bytes hold six packed BCD digits, read as a decimal integer of
 # tenths of a Hz -- [0][0][100Hz digit 0-2][10Hz digit][1Hz digit]
@@ -195,13 +197,13 @@ def _tsql_freq_response(bcd: bytes, receiver: int | None = None) -> CivFrame:
 # MOR-2091: this table previously held the output of the buggy encoder
 # itself (e.g. 88.5 Hz paired with 00 88 05), so it round-tripped against
 # the bug instead of catching it.
-_BCD_TABLE: list[tuple[float, bytes]] = [
-    (67.0, b"\x00\x06\x70"),
-    (88.5, b"\x00\x08\x85"),  # live capture -- see comment above
-    (110.9, b"\x00\x11\x09"),
-    (136.5, b"\x00\x13\x65"),
-    (167.9, b"\x00\x16\x79"),
-    (254.1, b"\x00\x25\x41"),
+_BCD_TABLE: list[tuple[int, bytes]] = [
+    (6700, b"\x00\x06\x70"),
+    (8850, b"\x00\x08\x85"),  # live capture -- see comment above
+    (11090, b"\x00\x11\x09"),
+    (13650, b"\x00\x13\x65"),
+    (16790, b"\x00\x16\x79"),
+    (25410, b"\x00\x25\x41"),
 ]
 
 
@@ -215,7 +217,62 @@ def test_decode_matches_bench_ic7300_capture() -> None:
       request fe fe 94 e0 1b 00 fd
       reply   fe fe e0 94 1b 00 00 08 85 fd   (data = 00 08 85)
     """
-    assert _decode_tone_freq(bytes([0x00, 0x08, 0x85])) == 88.5
+    assert _decode_tone_freq(bytes([0x00, 0x08, 0x85])) == 8850
+
+
+def test_all_profile_tones_round_trip_as_exact_centihz() -> None:
+    for freq_centihz in _CTCSS_DOMAIN:
+        decoded = _decode_tone_freq(commands._encode_tone_freq(freq_centihz))
+        assert type(decoded) is int
+        assert decoded == freq_centihz
+
+
+@pytest.mark.parametrize("invalid", [True, 8850.0, "8850"])
+def test_codec_rejects_non_int_centihz(invalid: object) -> None:
+    with pytest.raises(TypeError, match="exact int in centiHz"):
+        commands._encode_tone_freq(invalid)  # type: ignore[arg-type]
+
+
+def test_codec_rejects_non_tenth_centihz() -> None:
+    with pytest.raises(ValueError, match="representable in 0.1 Hz"):
+        commands._encode_tone_freq(8851)
+
+
+@pytest.mark.parametrize(
+    "domain",
+    [None, (), [8850], (True,), (8850.0,), (8851,), (10000, 8850)],
+)
+def test_tone_builders_reject_malformed_domain(domain, cmd_map) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        commands.set_tone_freq(
+            8850,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=domain,
+        )
+
+
+@pytest.mark.parametrize(
+    ("setter", "parser", "response"),
+    [
+        (commands.set_tone_freq, parse_tone_freq_response, _tone_freq_response),
+        (commands.set_tsql_freq, parse_tsql_freq_response, _tsql_freq_response),
+    ],
+)
+def test_tone_commands_and_parsers_reject_nonmember(
+    setter, parser, response, cmd_map
+) -> None:
+    synthetic_domain = (6700, 10000)
+    with pytest.raises(ValueError, match="not declared"):
+        setter(
+            8850,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=synthetic_domain,
+        )
+    with pytest.raises(ValueError, match="not declared"):
+        parser(
+            response(b"\x00\x08\x85"),
+            ctcss_tones_centihz=synthetic_domain,
+        )
 
 
 # ===========================================================================
@@ -376,33 +433,43 @@ class TestToneFreqBCDEncoding:
     """BCD encoding of CTCSS tone frequencies."""
 
     @pytest.mark.parametrize("freq, bcd", _BCD_TABLE)
-    def test_encode(self, freq: float, bcd: bytes, cmd_map) -> None:
-        frame = commands.set_tone_freq(freq, cmd_map=cmd_map)
+    def test_encode(self, freq: int, bcd: bytes, cmd_map) -> None:
+        frame = commands.set_tone_freq(
+            freq, cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+        )
         assert bcd in frame
 
     def test_rejects_below_minimum(self, cmd_map) -> None:
-        with pytest.raises(ValueError, match="67.0"):
-            commands.set_tone_freq(50.0, cmd_map=cmd_map)
+        with pytest.raises(ValueError, match="not declared"):
+            commands.set_tone_freq(
+                5000, cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+            )
 
     def test_rejects_above_maximum(self, cmd_map) -> None:
-        with pytest.raises(ValueError, match="254.1"):
-            commands.set_tone_freq(300.0, cmd_map=cmd_map)
+        with pytest.raises(ValueError, match="not declared"):
+            commands.set_tone_freq(
+                30000, cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+            )
 
     def test_accepts_boundary_low(self, cmd_map) -> None:
-        frame = commands.set_tone_freq(67.0, cmd_map=cmd_map)
+        frame = commands.set_tone_freq(
+            6700, cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+        )
         # 67.0 Hz -> 000670; see _BCD_TABLE's header comment for the layout
         # and manual sourcing.
         assert b"\x00\x06\x70" in frame
 
     def test_accepts_boundary_high(self, cmd_map) -> None:
-        frame = commands.set_tone_freq(254.1, cmd_map=cmd_map)
+        frame = commands.set_tone_freq(
+            25410, cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+        )
         # 254.1 Hz -> 002541; see _BCD_TABLE's header comment.
         assert b"\x00\x25\x41" in frame
 
     def test_requires_cmd_map(self) -> None:
         """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
         with pytest.raises(TypeError, match="MOR-2006"):
-            commands.set_tone_freq(88.5)  # type: ignore[call-arg]
+            commands.set_tone_freq(8850)  # type: ignore[call-arg]
 
 
 class TestGetToneFreq:
@@ -410,29 +477,46 @@ class TestGetToneFreq:
 
     def test_main_receiver(self, cmd_map) -> None:
         assert commands.get_tone_freq(
-            receiver=RECEIVER_MAIN, cmd_map=cmd_map
+            receiver=RECEIVER_MAIN,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
         ) == _cmd29_tone_get(_SUB_TONE_FREQ, RECEIVER_MAIN)
 
     def test_sub_receiver(self, cmd_map) -> None:
         assert commands.get_tone_freq(
-            receiver=RECEIVER_SUB, cmd_map=cmd_map
+            receiver=RECEIVER_SUB,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
         ) == _cmd29_tone_get(_SUB_TONE_FREQ, RECEIVER_SUB)
 
     def test_default_is_main(self, cmd_map) -> None:
-        assert commands.get_tone_freq(cmd_map=cmd_map) == commands.get_tone_freq(
-            receiver=RECEIVER_MAIN, cmd_map=cmd_map
+        assert commands.get_tone_freq(
+            cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+        ) == commands.get_tone_freq(
+            receiver=RECEIVER_MAIN,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
         )
 
     def test_uses_cmd29_prefix(self, cmd_map) -> None:
-        frame = commands.get_tone_freq(cmd_map=cmd_map)
+        frame = commands.get_tone_freq(
+            cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+        )
         assert frame[4] == _CMD_CMD29
 
     def test_contains_tone_command_and_sub(self, cmd_map) -> None:
-        frame = commands.get_tone_freq(cmd_map=cmd_map)
+        frame = commands.get_tone_freq(
+            cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+        )
         assert bytes([_CMD_TONE, _SUB_TONE_FREQ]) in frame
 
     def test_custom_addresses(self, cmd_map) -> None:
-        frame = commands.get_tone_freq(to_addr=0xA4, from_addr=0xE1, cmd_map=cmd_map)
+        frame = commands.get_tone_freq(
+            to_addr=0xA4,
+            from_addr=0xE1,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
+        )
         assert frame[2] == 0xA4
         assert frame[3] == 0xE1
 
@@ -441,21 +525,28 @@ class TestSetToneFreq:
     """Frame construction for set_tone_freq (0x1B 0x00)."""
 
     @pytest.mark.parametrize("freq, bcd", _BCD_TABLE)
-    def test_set_encodes_bcd(self, freq: float, bcd: bytes, cmd_map) -> None:
-        assert commands.set_tone_freq(freq, cmd_map=cmd_map) == _cmd29_tone_set(
-            _SUB_TONE_FREQ, bcd, RECEIVER_MAIN
-        )
+    def test_set_encodes_bcd(self, freq: int, bcd: bytes, cmd_map) -> None:
+        assert commands.set_tone_freq(
+            freq, cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+        ) == _cmd29_tone_set(_SUB_TONE_FREQ, bcd, RECEIVER_MAIN)
 
     def test_set_sub_receiver(self, cmd_map) -> None:
         assert commands.set_tone_freq(
-            88.5, receiver=RECEIVER_SUB, cmd_map=cmd_map
+            8850,
+            receiver=RECEIVER_SUB,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
         ) == _cmd29_tone_set(
             _SUB_TONE_FREQ, b"\x00\x08\x85", RECEIVER_SUB
         )  # 88.5 Hz, see _BCD_TABLE
 
     def test_set_custom_addresses(self, cmd_map) -> None:
         frame = commands.set_tone_freq(
-            88.5, to_addr=0xA4, from_addr=0xE1, cmd_map=cmd_map
+            8850,
+            to_addr=0xA4,
+            from_addr=0xE1,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
         )
         assert frame[2] == 0xA4
         assert frame[3] == 0xE1
@@ -465,25 +556,25 @@ class TestParseToneFreqResponse:
     """Parsing of tone frequency responses."""
 
     @pytest.mark.parametrize("freq, bcd", _BCD_TABLE)
-    def test_decode_main_receiver(self, freq: float, bcd: bytes) -> None:
+    def test_decode_main_receiver(self, freq: int, bcd: bytes) -> None:
         frame = _tone_freq_response(bcd, receiver=RECEIVER_MAIN)
-        rx, decoded = parse_tone_freq_response(frame)
+        rx, decoded = parse_tone_freq_response(frame, ctcss_tones_centihz=_CTCSS_DOMAIN)
         assert rx == RECEIVER_MAIN
-        assert decoded == pytest.approx(freq, abs=0.05)
+        assert decoded == freq
 
     @pytest.mark.parametrize("freq, bcd", _BCD_TABLE)
-    def test_decode_sub_receiver(self, freq: float, bcd: bytes) -> None:
+    def test_decode_sub_receiver(self, freq: int, bcd: bytes) -> None:
         frame = _tone_freq_response(bcd, receiver=RECEIVER_SUB)
-        rx, decoded = parse_tone_freq_response(frame)
+        rx, decoded = parse_tone_freq_response(frame, ctcss_tones_centihz=_CTCSS_DOMAIN)
         assert rx == RECEIVER_SUB
-        assert decoded == pytest.approx(freq, abs=0.05)
+        assert decoded == freq
 
     def test_decode_no_receiver(self) -> None:
         # 88.5 Hz, see _BCD_TABLE.
         frame = _tone_freq_response(b"\x00\x08\x85", receiver=None)
-        rx, freq = parse_tone_freq_response(frame)
+        rx, freq = parse_tone_freq_response(frame, ctcss_tones_centihz=_CTCSS_DOMAIN)
         assert rx is None
-        assert freq == pytest.approx(88.5)
+        assert freq == 8850
 
     def test_rejects_wrong_command(self) -> None:
         frame = CivFrame(
@@ -494,7 +585,7 @@ class TestParseToneFreqResponse:
             data=b"\x00\x88\x05",
         )
         with pytest.raises(ValueError):
-            parse_tone_freq_response(frame)
+            parse_tone_freq_response(frame, ctcss_tones_centihz=_CTCSS_DOMAIN)
 
     def test_rejects_wrong_sub(self) -> None:
         frame = CivFrame(
@@ -505,7 +596,7 @@ class TestParseToneFreqResponse:
             data=b"\x00\x88\x05",
         )
         with pytest.raises(ValueError):
-            parse_tone_freq_response(frame)
+            parse_tone_freq_response(frame, ctcss_tones_centihz=_CTCSS_DOMAIN)
 
     def test_rejects_short_data(self) -> None:
         frame = CivFrame(
@@ -516,7 +607,7 @@ class TestParseToneFreqResponse:
             data=b"\x00\x88",  # only 2 bytes
         )
         with pytest.raises(ValueError):
-            parse_tone_freq_response(frame)
+            parse_tone_freq_response(frame, ctcss_tones_centihz=_CTCSS_DOMAIN)
 
 
 # ===========================================================================
@@ -528,17 +619,23 @@ class TestTSQLFreqBCDEncoding:
     """BCD encoding of TSQL frequencies (shares codec with tone freq)."""
 
     @pytest.mark.parametrize("freq, bcd", _BCD_TABLE)
-    def test_encode(self, freq: float, bcd: bytes, cmd_map) -> None:
-        frame = commands.set_tsql_freq(freq, cmd_map=cmd_map)
+    def test_encode(self, freq: int, bcd: bytes, cmd_map) -> None:
+        frame = commands.set_tsql_freq(
+            freq, cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+        )
         assert bcd in frame
 
     def test_rejects_below_minimum(self, cmd_map) -> None:
-        with pytest.raises(ValueError, match="67.0"):
-            commands.set_tsql_freq(50.0, cmd_map=cmd_map)
+        with pytest.raises(ValueError, match="not declared"):
+            commands.set_tsql_freq(
+                5000, cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+            )
 
     def test_rejects_above_maximum(self, cmd_map) -> None:
-        with pytest.raises(ValueError, match="254.1"):
-            commands.set_tsql_freq(300.0, cmd_map=cmd_map)
+        with pytest.raises(ValueError, match="not declared"):
+            commands.set_tsql_freq(
+                30000, cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+            )
 
 
 class TestGetTSQLFreq:
@@ -546,25 +643,37 @@ class TestGetTSQLFreq:
 
     def test_main_receiver(self, cmd_map) -> None:
         assert commands.get_tsql_freq(
-            receiver=RECEIVER_MAIN, cmd_map=cmd_map
+            receiver=RECEIVER_MAIN,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
         ) == _cmd29_tone_get(_SUB_TSQL_FREQ, RECEIVER_MAIN)
 
     def test_sub_receiver(self, cmd_map) -> None:
         assert commands.get_tsql_freq(
-            receiver=RECEIVER_SUB, cmd_map=cmd_map
+            receiver=RECEIVER_SUB,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
         ) == _cmd29_tone_get(_SUB_TSQL_FREQ, RECEIVER_SUB)
 
     def test_default_is_main(self, cmd_map) -> None:
-        assert commands.get_tsql_freq(cmd_map=cmd_map) == commands.get_tsql_freq(
-            receiver=RECEIVER_MAIN, cmd_map=cmd_map
+        assert commands.get_tsql_freq(
+            cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+        ) == commands.get_tsql_freq(
+            receiver=RECEIVER_MAIN,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
         )
 
     def test_uses_cmd29_prefix(self, cmd_map) -> None:
-        frame = commands.get_tsql_freq(cmd_map=cmd_map)
+        frame = commands.get_tsql_freq(
+            cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+        )
         assert frame[4] == _CMD_CMD29
 
     def test_contains_tsql_sub(self, cmd_map) -> None:
-        frame = commands.get_tsql_freq(cmd_map=cmd_map)
+        frame = commands.get_tsql_freq(
+            cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+        )
         assert bytes([_CMD_TONE, _SUB_TSQL_FREQ]) in frame
 
 
@@ -572,14 +681,17 @@ class TestSetTSQLFreq:
     """Frame construction for set_tsql_freq (0x1B 0x01)."""
 
     @pytest.mark.parametrize("freq, bcd", _BCD_TABLE)
-    def test_set_encodes_bcd(self, freq: float, bcd: bytes, cmd_map) -> None:
-        assert commands.set_tsql_freq(freq, cmd_map=cmd_map) == _cmd29_tone_set(
-            _SUB_TSQL_FREQ, bcd, RECEIVER_MAIN
-        )
+    def test_set_encodes_bcd(self, freq: int, bcd: bytes, cmd_map) -> None:
+        assert commands.set_tsql_freq(
+            freq, cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+        ) == _cmd29_tone_set(_SUB_TSQL_FREQ, bcd, RECEIVER_MAIN)
 
     def test_set_sub_receiver(self, cmd_map) -> None:
         assert commands.set_tsql_freq(
-            88.5, receiver=RECEIVER_SUB, cmd_map=cmd_map
+            8850,
+            receiver=RECEIVER_SUB,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
         ) == _cmd29_tone_set(
             _SUB_TSQL_FREQ, b"\x00\x08\x85", RECEIVER_SUB
         )  # 88.5 Hz, see _BCD_TABLE
@@ -589,18 +701,18 @@ class TestParseTSQLFreqResponse:
     """Parsing of TSQL frequency responses."""
 
     @pytest.mark.parametrize("freq, bcd", _BCD_TABLE)
-    def test_decode_main_receiver(self, freq: float, bcd: bytes) -> None:
+    def test_decode_main_receiver(self, freq: int, bcd: bytes) -> None:
         frame = _tsql_freq_response(bcd, receiver=RECEIVER_MAIN)
-        rx, decoded = parse_tsql_freq_response(frame)
+        rx, decoded = parse_tsql_freq_response(frame, ctcss_tones_centihz=_CTCSS_DOMAIN)
         assert rx == RECEIVER_MAIN
-        assert decoded == pytest.approx(freq, abs=0.05)
+        assert decoded == freq
 
     def test_decode_no_receiver(self) -> None:
         # 88.5 Hz, see _BCD_TABLE.
         frame = _tsql_freq_response(b"\x00\x08\x85", receiver=None)
-        rx, freq = parse_tsql_freq_response(frame)
+        rx, freq = parse_tsql_freq_response(frame, ctcss_tones_centihz=_CTCSS_DOMAIN)
         assert rx is None
-        assert freq == pytest.approx(88.5)
+        assert freq == 8850
 
     def test_rejects_wrong_sub(self) -> None:
         frame = CivFrame(
@@ -611,7 +723,7 @@ class TestParseTSQLFreqResponse:
             data=b"\x00\x88\x05",
         )
         with pytest.raises(ValueError):
-            parse_tsql_freq_response(frame)
+            parse_tsql_freq_response(frame, ctcss_tones_centihz=_CTCSS_DOMAIN)
 
     def test_rejects_short_data(self) -> None:
         frame = CivFrame(
@@ -622,7 +734,7 @@ class TestParseTSQLFreqResponse:
             data=b"\x00\x88",
         )
         with pytest.raises(ValueError):
-            parse_tsql_freq_response(frame)
+            parse_tsql_freq_response(frame, ctcss_tones_centihz=_CTCSS_DOMAIN)
 
 
 # ===========================================================================
@@ -644,24 +756,38 @@ class TestCommandDistinctness:
         ) != commands.set_repeater_tsql(True, cmd_map=cmd_map)
 
     def test_tone_freq_vs_tsql_freq_get(self, cmd_map) -> None:
-        assert commands.get_tone_freq(cmd_map=cmd_map) != commands.get_tsql_freq(
-            cmd_map=cmd_map
-        )
+        assert commands.get_tone_freq(
+            cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+        ) != commands.get_tsql_freq(cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN)
 
     def test_tone_freq_vs_tsql_freq_set(self, cmd_map) -> None:
-        assert commands.set_tone_freq(88.5, cmd_map=cmd_map) != commands.set_tsql_freq(
-            88.5, cmd_map=cmd_map
+        assert commands.set_tone_freq(
+            8850, cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+        ) != commands.set_tsql_freq(
+            8850, cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
         )
 
     def test_tone_main_vs_sub_get(self, cmd_map) -> None:
         assert commands.get_tone_freq(
-            receiver=RECEIVER_MAIN, cmd_map=cmd_map
-        ) != commands.get_tone_freq(receiver=RECEIVER_SUB, cmd_map=cmd_map)
+            receiver=RECEIVER_MAIN,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
+        ) != commands.get_tone_freq(
+            receiver=RECEIVER_SUB,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
+        )
 
     def test_tsql_main_vs_sub_get(self, cmd_map) -> None:
         assert commands.get_tsql_freq(
-            receiver=RECEIVER_MAIN, cmd_map=cmd_map
-        ) != commands.get_tsql_freq(receiver=RECEIVER_SUB, cmd_map=cmd_map)
+            receiver=RECEIVER_MAIN,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
+        ) != commands.get_tsql_freq(
+            receiver=RECEIVER_SUB,
+            cmd_map=cmd_map,
+            ctcss_tones_centihz=_CTCSS_DOMAIN,
+        )
 
     def test_repeater_tone_main_vs_sub_get(self, cmd_map) -> None:
         assert commands.get_repeater_tone(
@@ -679,12 +805,14 @@ class TestCommandDistinctness:
         ) != commands.set_repeater_tsql(False, cmd_map=cmd_map)
 
     def test_different_tone_freqs(self, cmd_map) -> None:
-        assert commands.set_tone_freq(88.5, cmd_map=cmd_map) != commands.set_tone_freq(
-            110.9, cmd_map=cmd_map
+        assert commands.set_tone_freq(
+            8850, cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
+        ) != commands.set_tone_freq(
+            11090, cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
         )
 
     def test_repeater_tone_distinct_from_freq_cmd(self, cmd_map) -> None:
         """0x16 and 0x1B commands are fundamentally different."""
         assert commands.get_repeater_tone(cmd_map=cmd_map) != commands.get_tone_freq(
-            cmd_map=cmd_map
+            cmd_map=cmd_map, ctcss_tones_centihz=_CTCSS_DOMAIN
         )

--- a/tests/test_vox_tone_state.py
+++ b/tests/test_vox_tone_state.py
@@ -54,11 +54,11 @@ def _make_frame(
     )
 
 
-def _make_radio_with_state() -> IcomRadio:
+def _make_radio_with_state(*, model: str = "IC-7610") -> IcomRadio:
     """IcomRadio with RadioState wired up for _update_radio_state_from_frame tests."""
     from test_civ_rx_coverage import MockTransport  # type: ignore[import]
 
-    r = IcomRadio("192.168.1.100", model="IC-7610")
+    r = IcomRadio("192.168.1.100", model=model)
     r._civ_transport = MockTransport()
     r._ctrl_transport = r._civ_transport
     r._connected = True
@@ -223,7 +223,7 @@ def test_civ_rx_0x1b_0x00_sets_tone_freq_main(tmp_path: object) -> None:
     The legacy RadioState mirror was removed; the StateStore is the source of
     truth and the ReceiverState mirror stays at its default 0.
     """
-    r = _make_radio_with_state()
+    r = _make_radio_with_state(model="IC-9700")
     rs = r._radio_state
     # 88.5 Hz → [0x00, 0x08, 0x85]
     data = _bcd_tone_freq(0, 88, 5)
@@ -236,7 +236,7 @@ def test_civ_rx_0x1b_0x00_sets_tone_freq_main(tmp_path: object) -> None:
 
 def test_civ_rx_0x1b_0x01_sets_tsql_freq_sub(tmp_path: object) -> None:
     """0x1B 0x01 with receiver=1 observes sub tsql_freq in centihz (MOR-451)."""
-    r = _make_radio_with_state()
+    r = _make_radio_with_state(model="IC-9700")
     rs = r._radio_state
     # 100.0 Hz → [0x00, 0x10, 0x00]
     data = _bcd_tone_freq(1, 0, 0)

--- a/tests/validation/test_hardware_command_families.py
+++ b/tests/validation/test_hardware_command_families.py
@@ -12,6 +12,7 @@ soup), asserting:
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 from rigplane.core.radio_protocol import Radio
@@ -117,6 +118,12 @@ async def _run(
 # T7 / MOR-642 — tone / TSQL
 # ---------------------------------------------------------------------------
 
+_SYNTHETIC_CTCSS_DOMAIN = (7310, 9470, 16620)
+
+
+def _attach_ctcss_profile(radio, domain=_SYNTHETIC_CTCSS_DOMAIN) -> None:
+    radio.profile = SimpleNamespace(ctcss_tones_centihz=domain)
+
 
 async def test_repeater_tone_set_rmvr_roundtrip():
     radio, store = _stateful_value_radio(
@@ -145,33 +152,60 @@ async def test_tsql_set_rmvr_roundtrip():
     assert False in store["writes"]
 
 
-async def test_tone_freq_set_cycles_standard_ctcss_tone():
+async def test_tone_freq_set_cycles_active_profile_domain():
     radio, store = _stateful_value_radio(
         capability="repeater_tone",
         get_op="get_tone_freq",
         set_op="set_tone_freq",
-        start=88.5,
+        start=7310,
     )
+    radio.model = "SYNTHETIC-NONSTANDARD"
+    _attach_ctcss_profile(radio)
     result = await _run(radio, "tone_freq.set")
     assert result.status is CheckStatus.PASS
-    assert store["value"] == 88.5  # restored
-    # The mutated value must be a DIFFERENT standard CTCSS tone.
-    changed = [v for v in store["writes"] if v != 88.5]
-    assert changed and changed[0] == 100.0
+    assert store["value"] == 7310  # restored
+    assert store["writes"] == [9470, 7310]
 
 
-async def test_tsql_freq_set_cycles_standard_ctcss_tone():
+async def test_tsql_freq_set_cycles_active_profile_domain():
     radio, store = _stateful_value_radio(
         capability="tsql",
         get_op="get_tsql_freq",
         set_op="set_tsql_freq",
-        start=123.0,
+        start=9470,
     )
+    radio.model = "A-DIFFERENT-SYNTHETIC-MODEL"
+    _attach_ctcss_profile(radio)
     result = await _run(radio, "tsql_freq.set")
     assert result.status is CheckStatus.PASS
-    assert store["value"] == 123.0
-    changed = [v for v in store["writes"] if v != 123.0]
-    assert changed and changed[0] == 88.5
+    assert store["value"] == 9470
+    assert store["writes"] == [7310, 9470]
+
+
+async def test_tone_freq_set_rejects_nonmember_before_write():
+    radio, store = _stateful_value_radio(
+        capability="repeater_tone",
+        get_op="get_tone_freq",
+        set_op="set_tone_freq",
+        start=8850,
+    )
+    _attach_ctcss_profile(radio)
+    result = await _run(radio, "tone_freq.set")
+    assert result.status is CheckStatus.SKIP
+    assert store["writes"] == []
+
+
+async def test_tsql_freq_set_rejects_malformed_domain_before_write():
+    radio, store = _stateful_value_radio(
+        capability="tsql",
+        get_op="get_tsql_freq",
+        set_op="set_tsql_freq",
+        start=7310,
+    )
+    _attach_ctcss_profile(radio, (7310, True))
+    result = await _run(radio, "tsql_freq.set")
+    assert result.status is CheckStatus.SKIP
+    assert store["writes"] == []
 
 
 async def test_tone_check_unsupported_when_radio_lacks_op():

--- a/tests/validation/test_hardware_crash_containment.py
+++ b/tests/validation/test_hardware_crash_containment.py
@@ -1,10 +1,8 @@
 """Per-check crash containment for the hardware runner (MOR-659).
 
-The first live IC-7610 validation run crashed and discarded ALL results: the
-radio's repeater tone read back as 16.5 Hz (tone not configured), which is
-below the encoder's settable band (67.0-254.1 Hz, ``commands/tone.py``
-``_encode_tone_freq``), so the RMVR restore raised a bare ``ValueError`` that
-escaped ``_guard``, the restore ``finally`` and ``execute_hardware_checks``.
+The first live IC-7610 validation run crashed and discarded ALL results when
+the radio returned an unset tone value that could not be restored. The active
+profile domain is now the sole restore-safety authority for this path.
 
 These tests pin the four containment layers:
 
@@ -14,12 +12,13 @@ These tests pin the four containment layers:
 * ``execute_hardware_checks`` has a per-entry backstop so one raising check
   can never abort the matrix or lose the artifact;
 * ``tone_freq.set``/``tsql_freq.set`` SKIP without mutating when the current
-  value is outside the settable band (non-destructive harness).
+  exact centiHz value is outside the active profile domain.
 """
 
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 from unittest.mock import AsyncMock, MagicMock
 
@@ -44,13 +43,8 @@ from rigplane.validation.schema import (
     RadioTarget,
 )
 
-# Settable band of commands/tone.py::_encode_tone_freq (shared by
-# set_tone_freq and set_tsql_freq).
-_TONE_BAND_MIN = 67.0
-_TONE_BAND_MAX = 254.1
-
-# The IC-7610's readback when no repeater tone is configured: un-encodable.
-_UNENCODABLE_TONE = 16.5
+_SYNTHETIC_CTCSS_DOMAIN = (7310, 9470, 16620)
+_UNDECLARED_TONE = 1650
 
 
 def _flatten(levels):
@@ -80,37 +74,40 @@ def _template_for(*check_ids: str) -> MatrixTemplate:
     )
 
 
-def _encoder_guarded_setter(store: dict):
-    """A setter that raises like commands/tone.py::_encode_tone_freq."""
+def _profile_guarded_setter(store: dict):
+    """A setter that enforces the active profile's exact centiHz domain."""
 
-    async def _set(freq_hz: float, receiver: int = 0) -> None:
-        if not _TONE_BAND_MIN <= freq_hz <= _TONE_BAND_MAX:
-            raise ValueError(f"Tone frequency must be 67.0-254.1 Hz, got {freq_hz}")
-        store["value"] = freq_hz
-        store["writes"].append(freq_hz)
+    async def _set(freq_centihz: int, receiver: int = 0) -> None:
+        if type(freq_centihz) is not int or freq_centihz not in _SYNTHETIC_CTCSS_DOMAIN:
+            raise ValueError(
+                f"Tone frequency is not in the active profile: {freq_centihz}"
+            )
+        store["value"] = freq_centihz
+        store["writes"].append(freq_centihz)
 
     return _set
 
 
 def _unconfigured_tone_radio():
-    """A fake IC-7610 whose tone/TSQL frequencies read back un-encodable."""
+    """A fake radio whose tone/TSQL readbacks are outside its profile domain."""
     radio = MagicMock(spec=Radio)
     radio.connected = True
     radio.model = "IC-7610"
     radio.capabilities = {"repeater_tone", "tsql"}
-    tone_store: dict = {"value": _UNENCODABLE_TONE, "writes": []}
-    tsql_store: dict = {"value": _UNENCODABLE_TONE, "writes": []}
+    radio.profile = SimpleNamespace(ctcss_tones_centihz=_SYNTHETIC_CTCSS_DOMAIN)
+    tone_store: dict = {"value": _UNDECLARED_TONE, "writes": []}
+    tsql_store: dict = {"value": _UNDECLARED_TONE, "writes": []}
 
-    async def _get_tone(receiver: int = 0) -> float:
+    async def _get_tone(receiver: int = 0) -> int:
         return tone_store["value"]
 
-    async def _get_tsql(receiver: int = 0) -> float:
+    async def _get_tsql(receiver: int = 0) -> int:
         return tsql_store["value"]
 
     radio.get_tone_freq = AsyncMock(side_effect=_get_tone)
-    radio.set_tone_freq = AsyncMock(side_effect=_encoder_guarded_setter(tone_store))
+    radio.set_tone_freq = AsyncMock(side_effect=_profile_guarded_setter(tone_store))
     radio.get_tsql_freq = AsyncMock(side_effect=_get_tsql)
-    radio.set_tsql_freq = AsyncMock(side_effect=_encoder_guarded_setter(tsql_store))
+    radio.set_tsql_freq = AsyncMock(side_effect=_profile_guarded_setter(tsql_store))
 
     repeater_store: dict = {"value": False, "writes": []}
 
@@ -159,7 +156,7 @@ async def test_unencodable_tone_freq_never_crashes_the_run():
     for check_id in ("tone_freq.set", "tsql_freq.set"):
         result = results[check_id]
         assert result.status is CheckStatus.SKIP, check_id
-        assert result.evidence["original"] == _UNENCODABLE_TONE
+        assert result.evidence["original"] == _UNDECLARED_TONE
         assert "non-destructive" in str(result.evidence["reason"])
     # (d) the radio was NEVER mutated: no write reached either setter.
     assert tone_store["writes"] == []
@@ -170,9 +167,10 @@ async def test_unencodable_tone_freq_never_crashes_the_run():
 
 
 async def test_encodable_tone_freq_still_runs_rmvr():
-    """The restorable gate must not affect in-band values."""
+    """The restore gate admits members of a synthetic nonstandard domain."""
     radio, tone_store, _ = _unconfigured_tone_radio()
-    tone_store["value"] = 88.5
+    radio.model = "SYNTHETIC-NONSTANDARD"
+    tone_store["value"] = 7310
     levels = await execute_hardware_checks(
         radio,
         _template_for("tone_freq.set"),
@@ -181,8 +179,8 @@ async def test_encodable_tone_freq_still_runs_rmvr():
     )
     result = _flatten(levels)["tone_freq.set"]
     assert result.status is CheckStatus.PASS
-    assert tone_store["value"] == 88.5  # restored
-    assert 100.0 in tone_store["writes"]
+    assert tone_store["value"] == 7310  # restored
+    assert tone_store["writes"] == [9470, 7310]
 
 
 # ---------------------------------------------------------------------------
@@ -193,7 +191,7 @@ async def test_encodable_tone_freq_still_runs_rmvr():
 @pytest.mark.parametrize("exc_type", [ValueError, TypeError])
 async def test_guard_maps_bare_value_and_type_errors_to_fail(exc_type):
     async def _raises():
-        raise exc_type("Tone frequency must be 67.0-254.1 Hz, got 16.5")
+        raise exc_type("Tone frequency 1650 is not declared by the active profile")
 
     entry = _entry_for("tone_freq.set")
     value, failure = await _guard(_raises(), entry, per_check_timeout=1.0)
@@ -201,7 +199,7 @@ async def test_guard_maps_bare_value_and_type_errors_to_fail(exc_type):
     assert failure is not None
     assert failure.status is CheckStatus.FAIL
     assert failure.failure_domain is FailureDomain.COMMAND_EXECUTION
-    assert "16.5" in (failure.error or "")
+    assert "1650" in (failure.error or "")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Linear owner: MOR-2129.\n\nThis PR binds Icom CTCSS to the active RadioProfile domain:\n- tone codec and CI-V boundary use exact integer centiHz (wire conversion only at Icom boundary);\n- runtime admission/state ingress and hardware validation require active-profile membership;\n- invalid/missing/malformed/non-int/out-of-domain values fail closed before VFO selection, radio write, or state publication;\n- no fallback table, range surrogate, model/catalog lookup, or branching;\n- stale float-Hz callers were migrated to the integer-centiHz runtime/API contract.\n\nChanged scope (12 files): src/rigplane/commands/tone.py; src/rigplane/runtime/_civ_rx.py; src/rigplane/runtime/radio.py; src/rigplane/validation/hardware.py; tests/integration/test_tone_tsql_integration.py; tests/test_civ_rx_coverage.py; tests/test_commands.py; tests/test_mor1517_cmd29_gating.py; tests/test_radio.py; tests/test_tone_tsql.py; tests/validation/test_hardware_command_families.py; tests/validation/test_hardware_crash_containment.py.\n\nEvidence: focused pytest 1435 passed; validation subset 61 passed; Ruff check/format PASS; import-linter 5 kept, 0 broken; git diff --check clean.\n\nphysical IC-7300 bench proof: UNKNOWN\n\nNatural required CI was not manually dispatched. Independent exact-head review remains pending.