### PR TITLE
feat(MOR-2326): own scope frame lifecycle

### DIFF
--- a/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
+++ b/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
@@ -17,11 +17,14 @@ import type { ScopeFrame } from '../scope-controller.svelte';
 function makeMockChannel() {
   const binaryHandlers = new Set<(buf: ArrayBuffer) => void>();
   const stateHandlers = new Set<(state: string) => void>();
+  const sessionHandlers = new Set<(transition: { state: string; epoch: number }) => void>();
   const binaryHistory: Array<(buf: ArrayBuffer) => void> = [];
   const stateHistory: Array<(state: string) => void> = [];
   let state = 'disconnected';
+  let sessionEpoch = 1;
   return {
     get state() { return state; },
+    get sessionEpoch() { return sessionEpoch; },
     connect: vi.fn(),
     disconnect: vi.fn(),
     onBinary: vi.fn((handler: (buf: ArrayBuffer) => void) => {
@@ -34,17 +37,24 @@ function makeMockChannel() {
       stateHistory.push(handler);
       return () => { stateHandlers.delete(handler); };
     }),
+    onSessionTransition: vi.fn((handler: (transition: { state: string; epoch: number }) => void) => {
+      sessionHandlers.add(handler);
+      return () => { sessionHandlers.delete(handler); };
+    }),
     /** Fire a binary message to all registered handlers. */
     _fire(buf: ArrayBuffer) {
       for (const h of binaryHandlers) h(buf);
     },
     _setState(next: string) {
+      if (next === 'connected' && state !== 'connected') sessionEpoch += 1;
       state = next;
       for (const h of stateHandlers) h(next);
+      for (const h of sessionHandlers) h({ state: next, epoch: sessionEpoch });
     },
     _binaryHistory: binaryHistory, _stateHistory: stateHistory,
     _handlerCount() { return binaryHandlers.size; },
     _stateHandlerCount() { return stateHandlers.size; },
+    _sessionHandlerCount() { return sessionHandlers.size; },
   };
 }
 
@@ -58,6 +68,44 @@ function makeScopeFrameBuffer(pixelCount = 4): ArrayBuffer {
   view.setUint32(7, 14_200_000, true); // endFreq
   view.setUint16(14, pixelCount, true);
   return buf;
+}
+
+function makeTiming() {
+  let now = 0;
+  let nextId = 1;
+  const tasks = new Map<number, { at: number; callback: () => void; cancelled: boolean }>();
+  const timing = {
+    now: () => now,
+    setTimeout: (callback: () => void, delayMs: number) => {
+      const id = nextId++;
+      tasks.set(id, { at: now + delayMs, callback, cancelled: false });
+      return id as unknown as ReturnType<typeof setTimeout>;
+    },
+    clearTimeout: (handle: ReturnType<typeof setTimeout>) => {
+      const task = tasks.get(handle as unknown as number);
+      if (task) task.cancelled = true;
+    },
+  };
+  return {
+    timing,
+    advance(ms: number) {
+      now += ms;
+      let progressed = true;
+      while (progressed) {
+        progressed = false;
+        for (const [id, task] of [...tasks]) {
+          if (!task.cancelled && task.at <= now) {
+            tasks.delete(id);
+            task.callback();
+            progressed = true;
+          }
+        }
+      }
+    },
+    fireEvenIfCancelled(id: number) { tasks.get(id)?.callback(); },
+    ids: () => [...tasks.keys()],
+    activeCount: () => [...tasks.values()].filter((task) => !task.cancelled).length,
+  };
 }
 
 // ── Tests ──
@@ -566,5 +614,109 @@ describe('ScopeController', () => {
       demanded: false, transport: 'disconnected', frameSeen: false,
     });
     expect(audio.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['hardware', 'hardwareScopeDriver'],
+    ['audio_fft', 'audioFftDriver'],
+  ] as const)('owns a live %s receipt only below the exact 500 ms boundary', async (source, driverName) => {
+    const timed = makeTiming();
+    const local = makeMockChannel();
+    const controller = new ScopeController(() => local as any, timed.timing);
+    controller.setFrameAuthority({ source, receiver: 0, providerGeneration: 9 });
+    const driver = controller[driverName];
+    const handle = await driver.start();
+    local._setState('connected');
+    local._fire(makeScopeFrameBuffer());
+
+    const receipt = controller.snapshotFrameEvidence().envelope;
+    expect(receipt).toMatchObject({
+      source, receiver: 0, providerGeneration: 9,
+      transportEpoch: local.sessionEpoch, receivedAt: 0, acceptedSequence: 1,
+    });
+    expect(controller.snapshotHealth(source).frameSeen).toBe(true);
+    timed.advance(499);
+    expect(controller.snapshotHealth(source).frameSeen).toBe(true);
+    timed.advance(1);
+    expect(controller.snapshotHealth(source).frameSeen).toBe(false);
+    expect(controller.snapshotFrameEvidence().envelope).toBe(receipt);
+    await driver.stop(handle);
+  });
+
+  it('does not let a delayed older expiry callback clear a newer receipt', async () => {
+    const timed = makeTiming();
+    const local = makeMockChannel();
+    const controller = new ScopeController(() => local as any, timed.timing);
+    controller.setFrameAuthority({ source: 'hardware', receiver: 0, providerGeneration: 2 });
+    const handle = await controller.hardwareScopeDriver.start();
+    local._setState('connected');
+    local._fire(makeScopeFrameBuffer());
+    const oldTimer = timed.ids()[0];
+    timed.advance(100);
+    local._fire(makeScopeFrameBuffer());
+    const newer = controller.snapshotFrameEvidence().envelope;
+
+    timed.fireEvenIfCancelled(oldTimer);
+    expect(controller.snapshotFrameEvidence().envelope).toBe(newer);
+    expect(controller.snapshotHealth('hardware').frameSeen).toBe(true);
+    expect(newer?.acceptedSequence).toBe(2);
+    await controller.hardwareScopeDriver.stop(handle);
+  });
+
+  it('invalidates source, receiver, provider, transport, and demand boundaries immediately', async () => {
+    const timed = makeTiming();
+    const local = makeMockChannel();
+    const controller = new ScopeController(() => local as any, timed.timing);
+    controller.setFrameAuthority({ source: 'hardware', receiver: 0, providerGeneration: 3 });
+    let handle = await controller.hardwareScopeDriver.start();
+    local._setState('connected');
+    local._fire(makeScopeFrameBuffer());
+    expect(controller.snapshotFrameEvidence().envelope).not.toBeNull();
+
+    controller.setFrameAuthority({ source: 'audio_fft', receiver: 0, providerGeneration: 3 });
+    expect(controller.snapshotFrameEvidence().envelope).toBeNull();
+    controller.setFrameAuthority({ source: 'hardware', receiver: null, providerGeneration: 3 });
+    expect(controller.snapshotFrameEvidence().envelope).toBeNull();
+    controller.setFrameAuthority({ source: 'hardware', receiver: 0, providerGeneration: 4 });
+    expect(controller.snapshotFrameEvidence().envelope).toBeNull();
+
+    await controller.hardwareScopeDriver.stop(handle);
+    handle = await controller.hardwareScopeDriver.start();
+    local._setState('reconnecting');
+    local._setState('connected');
+    local._fire(makeScopeFrameBuffer());
+    expect(controller.snapshotFrameEvidence().envelope).not.toBeNull();
+    local._setState('reconnecting');
+    expect(controller.snapshotFrameEvidence().envelope).toBeNull();
+    expect(controller.snapshotHealth('hardware').frameSeen).toBe(false);
+
+    await controller.hardwareScopeDriver.stop(handle);
+    expect(controller.snapshotFrameEvidence().authority.demanded).toBe(false);
+    expect(timed.activeCount()).toBe(0);
+  });
+
+  it('rejects mismatched receivers and old provider callbacks without reviving or clearing current facts', async () => {
+    const timed = makeTiming();
+    const local = makeMockChannel();
+    const controller = new ScopeController(() => local as any, timed.timing);
+    controller.setFrameAuthority({ source: 'hardware', receiver: 1, providerGeneration: 5 });
+    const oldHandle = await controller.hardwareScopeDriver.start();
+    local._setState('connected');
+    local._fire(makeScopeFrameBuffer());
+    expect(controller.snapshotFrameEvidence().envelope).toBeNull();
+
+    await controller.hardwareScopeDriver.stop(oldHandle);
+    controller.setFrameAuthority({ source: 'hardware', receiver: 0, providerGeneration: 5 });
+    const currentHandle = await controller.hardwareScopeDriver.start();
+    const oldGenerationCallback = local._binaryHistory.at(-1)!;
+    local._setState('connected');
+    local._fire(makeScopeFrameBuffer());
+    expect(controller.snapshotFrameEvidence().envelope?.providerGeneration).toBe(5);
+    controller.setFrameAuthority({ source: 'hardware', receiver: 0, providerGeneration: 6 });
+    oldGenerationCallback(makeScopeFrameBuffer());
+    expect(controller.snapshotFrameEvidence().envelope).toBeNull();
+    await controller.hardwareScopeDriver.stop(currentHandle);
+    expect([local._handlerCount(), local._stateHandlerCount(), local._sessionHandlerCount()])
+      .toEqual([0, 0, 0]);
   });
 });

--- a/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
+++ b/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
@@ -467,6 +467,39 @@ describe('ScopeController', () => {
     await defaultController.audioFftDriver.stop(handle);
   });
 
+  it.each(['audioFftDriver', 'hardwareScopeDriver'] as const)(
+    'keeps %s startup compatible with pre-session-transition channel doubles',
+    async (driverName) => {
+      const legacy = makeMockChannel();
+      Reflect.deleteProperty(legacy, 'onSessionTransition');
+      const controller = new ScopeController(() => legacy as any);
+      const driver = controller[driverName];
+
+      const handle = await driver.start();
+      expect(legacy.connect).toHaveBeenCalledTimes(1);
+      await driver.stop(handle);
+      expect(legacy.disconnect).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('preserves raw delivery but keeps display evidence closed without a public session epoch', async () => {
+    const legacy = makeMockChannel();
+    Reflect.deleteProperty(legacy, 'onSessionTransition');
+    Reflect.deleteProperty(legacy, 'sessionEpoch');
+    const controller = new ScopeController(() => legacy as any);
+    const subscriber = vi.fn();
+    controller.subscribeHardware(subscriber);
+    controller.setFrameAuthority({ source: 'hardware', receiver: 0, providerGeneration: 1 });
+    const handle = await controller.hardwareScopeDriver.start();
+
+    legacy._setState('connected');
+    legacy._fire(makeScopeFrameBuffer());
+    expect(subscriber).toHaveBeenCalledTimes(1);
+    expect(controller.snapshotHealth('hardware').frameSeen).toBe(true);
+    expect(controller.snapshotFrameEvidence().envelope).toBeNull();
+    await controller.hardwareScopeDriver.stop(handle);
+  });
+
   it('owns hardware first/shared/last demand without claiming frame liveness', async () => {
     const channels = { scope: makeMockChannel(), 'audio-scope': makeMockChannel() };
     const lookup = vi.fn((name: string) => channels[name as keyof typeof channels] as any);

--- a/frontend/src/lib/runtime/__tests__/scope-frame-host.test.ts
+++ b/frontend/src/lib/runtime/__tests__/scope-frame-host.test.ts
@@ -1,0 +1,210 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { ScopeController } from '../scope-controller.svelte';
+import { ScopeFrameHost } from '../scope-frame-host';
+
+function channel() {
+  const binary = new Set<(buffer: ArrayBuffer) => void>();
+  const states = new Set<(state: string) => void>();
+  const sessions = new Set<(value: { state: string; epoch: number }) => void>();
+  let state = 'disconnected';
+  let epoch = 0;
+  return {
+    get state() { return state; },
+    get sessionEpoch() { return epoch; },
+    connect: vi.fn(), disconnect: vi.fn(),
+    onBinary(handler: (buffer: ArrayBuffer) => void) {
+      binary.add(handler); return () => { binary.delete(handler); };
+    },
+    onStateChange(handler: (value: string) => void) {
+      states.add(handler); return () => { states.delete(handler); };
+    },
+    onSessionTransition(handler: (value: { state: string; epoch: number }) => void) {
+      sessions.add(handler); return () => { sessions.delete(handler); };
+    },
+    fire(buffer: ArrayBuffer) { for (const handler of [...binary]) handler(buffer); },
+    transition(next: string) {
+      if (next === 'connected' && state !== 'connected') epoch += 1;
+      state = next;
+      for (const handler of [...states]) handler(next);
+      for (const handler of [...sessions]) handler({ state: next, epoch });
+    },
+    counts: () => [binary.size, states.size, sessions.size],
+  };
+}
+
+function frame(receiver: 0 | 1 = 0, pixels = [0, 128, 255], wireSequence = 17): ArrayBuffer {
+  const buffer = new ArrayBuffer(16 + pixels.length);
+  const view = new DataView(buffer);
+  view.setUint8(0, 0x01);
+  view.setUint8(1, receiver);
+  view.setUint32(3, 14_000_000, true);
+  view.setUint32(7, 14_100_000, true);
+  view.setUint16(12, wireSequence, true);
+  view.setUint16(14, pixels.length, true);
+  pixels.forEach((sample, index) => view.setUint8(16 + index, sample));
+  return buffer;
+}
+
+function clock() {
+  let now = 0;
+  let id = 0;
+  const timers = new Map<number, { at: number; callback: () => void; cancelled: boolean }>();
+  return {
+    timing: {
+      now: () => now,
+      setTimeout(callback: () => void, delay: number) {
+        const token = ++id;
+        timers.set(token, { at: now + delay, callback, cancelled: false });
+        return token as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimeout(token: ReturnType<typeof setTimeout>) {
+        const timer = timers.get(token as unknown as number);
+        if (timer) timer.cancelled = true;
+      },
+    },
+    advance(ms: number) {
+      now += ms;
+      for (const [token, timer] of [...timers]) {
+        if (!timer.cancelled && timer.at <= now) {
+          timers.delete(token);
+          timer.callback();
+        }
+      }
+    },
+    active: () => [...timers.values()].filter((timer) => !timer.cancelled).length,
+  };
+}
+
+function rig() {
+  const time = clock();
+  const channels = { scope: channel(), 'audio-scope': channel() };
+  const controller = new ScopeController(
+    (name) => channels[name as keyof typeof channels] as never,
+    time.timing,
+  );
+  const host = new ScopeFrameHost(controller);
+  return { time, channels, controller, host };
+}
+
+describe('ScopeFrameHost MOR-2326 lifecycle', () => {
+  it.each([
+    ['hardware', 'hardwareScopeDriver', 'scope'],
+    ['audio-fft', 'audioFftDriver', 'audio-scope'],
+  ] as const)('resolves a nominal %s frame below 500 ms', async (source, driverName, channelName) => {
+    const { time, channels, controller, host } = rig();
+    host.updateAuthority({ source, receiver: 'MAIN', providerGeneration: 12 });
+    const driver = controller[driverName];
+    const handle = await driver.start();
+    const transport = channels[channelName];
+    transport.transition('connected');
+    transport.fire(frame());
+    time.advance(499);
+
+    expect(host.snapshot()).toEqual({
+      state: 'live',
+      frame: {
+        source, receiver: 'MAIN', freshness: 'fresh',
+        startHz: 14_000_000, endHz: 14_100_000,
+        normalizedBins: [0, 128 / 255, 1],
+      },
+    });
+    await driver.stop(handle);
+    host.dispose();
+  });
+
+  it('turns the exact 500 ms silence boundary into stale ghost geometry', async () => {
+    const { time, channels, controller, host } = rig();
+    const updates = vi.fn();
+    host.updateAuthority({ source: 'hardware', receiver: 'MAIN', providerGeneration: 1 });
+    host.subscribe(updates);
+    const handle = await controller.hardwareScopeDriver.start();
+    channels.scope.transition('connected');
+    channels.scope.fire(frame());
+    expect(host.snapshot().state).toBe('live');
+
+    time.advance(500);
+    expect(host.snapshot()).toEqual({ state: 'ghost', reason: 'stale' });
+    expect(updates).toHaveBeenLastCalledWith({ state: 'ghost', reason: 'stale' });
+    await controller.hardwareScopeDriver.stop(handle);
+    expect(time.active()).toBe(0);
+    host.dispose();
+  });
+
+  it('invalidates provider, receiver, source, transport epoch, and demand boundaries synchronously', async () => {
+    const { channels, controller, host } = rig();
+    host.updateAuthority({ source: 'hardware', receiver: 'MAIN', providerGeneration: 4 });
+    let handle = await controller.hardwareScopeDriver.start();
+    channels.scope.transition('connected');
+    channels.scope.fire(frame());
+    expect(host.snapshot().state).toBe('live');
+
+    host.updateAuthority({ source: 'hardware', receiver: 'MAIN', providerGeneration: 5 });
+    expect(host.snapshot().state).toBe('ghost');
+    channels.scope.fire(frame());
+    expect(host.snapshot().state).toBe('ghost');
+
+    host.updateAuthority({ source: 'hardware', receiver: null, providerGeneration: 5 });
+    expect(host.snapshot()).toEqual({ state: 'ghost', reason: 'receiver-unknown' });
+    host.updateAuthority({ source: 'audio-fft', receiver: 'MAIN', providerGeneration: 5 });
+    expect(host.snapshot().state).toBe('ghost');
+
+    await controller.hardwareScopeDriver.stop(handle);
+    host.updateAuthority({ source: 'hardware', receiver: 'MAIN', providerGeneration: 5 });
+    handle = await controller.hardwareScopeDriver.start();
+    channels.scope.transition('reconnecting');
+    channels.scope.transition('connected');
+    channels.scope.fire(frame());
+    expect(host.snapshot().state).toBe('live');
+    channels.scope.transition('reconnecting');
+    expect(host.snapshot().state).toBe('ghost');
+    await controller.hardwareScopeDriver.stop(handle);
+    expect(host.snapshot().state).toBe('ghost');
+    host.dispose();
+  });
+
+  it('fails malformed and mismatched frames closed without fallback or zero bins', async () => {
+    const { channels, controller, host } = rig();
+    host.updateAuthority({ source: 'hardware', receiver: 'MAIN', providerGeneration: 2 });
+    const handle = await controller.hardwareScopeDriver.start();
+    channels.scope.transition('connected');
+    channels.scope.fire(frame());
+    expect(host.snapshot().state).toBe('live');
+
+    channels.scope.fire(frame(1));
+    expect(host.snapshot()).toEqual({ state: 'ghost', reason: 'missing' });
+    channels.scope.fire(new ArrayBuffer(16));
+    const malformed = host.snapshot();
+    expect(malformed.state).toBe('ghost');
+    expect(malformed).not.toHaveProperty('frame');
+    await controller.hardwareScopeDriver.stop(handle);
+    host.dispose();
+  });
+
+  it('removes host and channel subscriptions and isolates a throwing observer', async () => {
+    const { channels, controller, host, time } = rig();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    host.updateAuthority({ source: 'audio-fft', receiver: 'MAIN', providerGeneration: 3 });
+    host.subscribe(() => { throw new Error('observer'); });
+    const healthy = vi.fn();
+    host.subscribe(healthy);
+    const handle = await controller.audioFftDriver.start();
+    channels['audio-scope'].transition('connected');
+    channels['audio-scope'].fire(frame());
+    expect(healthy).toHaveBeenCalledWith(expect.objectContaining({ state: 'live' }));
+    expect(warn).toHaveBeenCalledWith('Scope frame host subscriber failed', expect.any(Error));
+
+    await controller.audioFftDriver.stop(handle);
+    host.dispose();
+    expect(channels['audio-scope'].counts()).toEqual([0, 0, 0]);
+    expect(time.active()).toBe(0);
+  });
+
+  it('keeps timers, transport, wall clock, freshness inputs, and fallback out of the host', () => {
+    const source = readFileSync(resolve('src/lib/runtime/scope-frame-host.ts'), 'utf8');
+    expect(source).not.toMatch(/setTimeout|setInterval|requestAnimationFrame|Date\.now/);
+    expect(source).not.toMatch(/5_000|10_000|freshness\s*:|zero.?fill|fallback/i);
+    expect(source).not.toMatch(/getChannel|connect\(|disconnect\(/);
+  });
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/scope-adapter.authority.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scope-adapter.authority.isolated.test.ts
@@ -22,7 +22,11 @@ vi.mock('../radio-view-model-adapter', async (importOriginal) => {
 });
 
 import {
-  parseScopeFrame, snapSpectrumFilterWidth, toSpectrumAuthority,
+  parseScopeFrame, SCOPE_FRAME_SILENCE_MS, snapSpectrumFilterWidth,
+  qualifyScopeFrameEnvelope, toScopeDisplayFrame, toSpectrumAuthority,
+} from '../scope-adapter';
+import type {
+  QualifiedScopeFrameEnvelope, ScopeFrameProjectionAuthority,
 } from '../scope-adapter';
 import { toRadioViewModel } from '../radio-view-model-adapter';
 import { deriveIfShift, pbtRawToHz } from '$lib/radio/filter-controls';
@@ -463,5 +467,95 @@ describe('MOR-1409 A06a1 decoder and purity boundary', () => {
     const selector = source.slice(source.indexOf('export function toSpectrumAuthority'));
     expect(selector).toMatch(/toSpectrumAuthority\(\s*state[^,]*,\s*caps/);
     expect(selector).not.toMatch(/ScopeFrame|pixels|Uint8Array|FrontendRuntime|radio\.svelte|transport|sendCommand/);
+  });
+});
+
+describe('MOR-2326 pure scope display-frame projection', () => {
+  const envelope = (
+    overrides: Partial<QualifiedScopeFrameEnvelope> = {},
+  ): QualifiedScopeFrameEnvelope => ({
+    source: 'hardware', receiver: 0, providerGeneration: 7, transportEpoch: 3,
+    receivedAt: 1_000, acceptedSequence: 1, wireSequence: 65_535,
+    frame: Object.freeze({
+      receiver: 0, mode: 1, startFreq: 14_000_000, endFreq: 14_100_000,
+      pixels: new Uint8Array([0, 128, 255]),
+    }),
+    ...overrides,
+  });
+  const authority = (
+    overrides: Partial<ScopeFrameProjectionAuthority> = {},
+  ): ScopeFrameProjectionAuthority => ({
+    source: 'hardware', receiver: 0, providerGeneration: 7, transportEpoch: 3,
+    demanded: true, transport: 'connected', nowMonotonic: 1_499,
+    ...overrides,
+  });
+
+  it.each([
+    ['hardware', 'hardware'], ['audio_fft', 'audio-fft'],
+  ] as const)('projects nominal %s bins without fabricating samples', (source, displaySource) => {
+    const result = toScopeDisplayFrame(envelope({ source }), authority({ source }));
+    expect(result).toEqual({
+      source: displaySource, receiver: 'MAIN', freshness: 'fresh',
+      startHz: 14_000_000, endHz: 14_100_000,
+      normalizedBins: [0, 128 / 255, 1],
+    });
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result?.normalizedBins)).toBe(true);
+  });
+
+  it('uses monotonic age with an exclusive 500 ms live interval', () => {
+    expect(SCOPE_FRAME_SILENCE_MS).toBe(500);
+    expect(toScopeDisplayFrame(envelope(), authority({ nowMonotonic: 1_499 }))?.freshness)
+      .toBe('fresh');
+    expect(toScopeDisplayFrame(envelope(), authority({ nowMonotonic: 1_500 }))?.freshness)
+      .toBe('stale');
+  });
+
+  it.each([
+    ['source', envelope({ source: 'audio_fft' }), authority()],
+    ['receiver', envelope({ receiver: 1 }), authority()],
+    ['provider', envelope({ providerGeneration: 8 }), authority()],
+    ['transport epoch', envelope({ transportEpoch: 4 }), authority()],
+    ['demand', envelope(), authority({ demanded: false })],
+    ['transport state', envelope(), authority({ transport: 'reconnecting' })],
+    ['unknown receiver', envelope(), authority({ receiver: null })],
+    ['unknown provider', envelope(), authority({ providerGeneration: null })],
+  ] as const)('fails a %s authority boundary closed', (_label, candidate, current) => {
+    expect(toScopeDisplayFrame(candidate, current)).toBeNull();
+  });
+
+  it.each([
+    envelope({ acceptedSequence: 0 }),
+    envelope({ receivedAt: Number.NaN }),
+    envelope({ frame: { ...envelope().frame, receiver: 1 } }),
+    envelope({ frame: { ...envelope().frame, endFreq: 14_000_000 } }),
+    envelope({ frame: { ...envelope().frame, pixels: new Uint8Array([1]) } }),
+  ])('rejects malformed receipts and geometry instead of zero-filling', (candidate) => {
+    expect(toScopeDisplayFrame(candidate, authority())).toBeNull();
+  });
+
+  it('keeps the uint16 wire sequence diagnostic rather than generation authority', () => {
+    expect(toScopeDisplayFrame(envelope({ wireSequence: 0 }), authority())).not.toBeNull();
+    expect(toScopeDisplayFrame(envelope({ wireSequence: 65_535 }), authority())).not.toBeNull();
+  });
+
+  it('retains exact accepted bytes independently of mutable raw subscribers', () => {
+    const raw = envelope().frame;
+    const qualified = qualifyScopeFrameEnvelope(raw, {
+      source: 'hardware', receiver: 0, providerGeneration: 7, transportEpoch: 3,
+      receivedAt: 1_000, acceptedSequence: 1,
+    }, 17)!;
+    raw.pixels[0] = 255;
+    expect(qualified.frame.pixels).toEqual(new Uint8Array([0, 128, 255]));
+    expect(qualified.frame.pixels).not.toBe(raw.pixels);
+  });
+
+  it('contains no wall clock, caller freshness, fallback, or long stale threshold', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/lib/runtime/adapters/scope-adapter.ts'), 'utf8');
+    const start = source.indexOf('export function toScopeDisplayFrame');
+    const end = source.indexOf("\n\nimport type { Capabilities", start);
+    const implementation = source.slice(start, end);
+    expect(implementation).not.toMatch(/Date\.now|freshness\s*:\s*authority|5_000|10_000|fallback/i);
+    expect(implementation).not.toMatch(/new Uint8Array\([^)]*length/);
   });
 });

--- a/frontend/src/lib/runtime/adapters/scope-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/scope-adapter.ts
@@ -26,6 +26,107 @@ export function parseScopeFrame(buf: ArrayBuffer): ScopeFrame | null {
   });
 }
 
+/** The one LCD/SDR silence boundary. A frame is stale at this exact age. */
+export const SCOPE_FRAME_SILENCE_MS = 500;
+
+export type QualifiedScopeSource = 'hardware' | 'audio_fft';
+
+/**
+ * Runtime-qualified receipt. `wireSequence` is diagnostic continuity only;
+ * the locally accepted sequence and the three authority epochs are the
+ * lifecycle identity.
+ */
+export interface QualifiedScopeFrameEnvelope {
+  readonly source: QualifiedScopeSource;
+  readonly receiver: 0 | 1;
+  readonly providerGeneration: number;
+  readonly transportEpoch: number;
+  readonly receivedAt: number;
+  readonly acceptedSequence: number;
+  readonly wireSequence: number;
+  readonly frame: ScopeFrame;
+}
+
+export type ScopeFrameReceiptIdentity = Omit<QualifiedScopeFrameEnvelope, 'frame' | 'wireSequence'>;
+
+export interface ScopeFrameProjectionAuthority {
+  readonly source: QualifiedScopeSource;
+  readonly receiver: 0 | 1 | null;
+  readonly providerGeneration: number | null;
+  readonly transportEpoch: number | null;
+  readonly demanded: boolean;
+  readonly transport: 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
+  readonly nowMonotonic: number;
+}
+
+/** Structural match for the MOR-2321 LCD display-frame model. */
+export interface ScopeDisplayFrameCandidate {
+  readonly source: 'hardware' | 'audio-fft';
+  readonly receiver: 'MAIN' | 'SUB';
+  readonly freshness: 'fresh' | 'stale';
+  readonly startHz: number;
+  readonly endHz: number;
+  readonly normalizedBins: readonly number[];
+}
+
+const safeNonnegativeInteger = (value: unknown): value is number =>
+  Number.isSafeInteger(value) && (value as number) >= 0;
+const safePositiveInteger = (value: unknown): value is number =>
+  Number.isSafeInteger(value) && (value as number) > 0;
+
+export function qualifyScopeFrameEnvelope(
+  frame: ScopeFrame,
+  identity: ScopeFrameReceiptIdentity,
+  wireSequence: number,
+): QualifiedScopeFrameEnvelope | null {
+  if ((frame.receiver !== 0 && frame.receiver !== 1) || frame.receiver !== identity.receiver
+    || !safeNonnegativeInteger(identity.providerGeneration)
+    || !safePositiveInteger(identity.transportEpoch)
+    || !Number.isFinite(identity.receivedAt) || identity.receivedAt < 0
+    || !safePositiveInteger(identity.acceptedSequence)
+    || !safeNonnegativeInteger(wireSequence) || wireSequence > 0xffff) return null;
+  const retainedFrame = Object.freeze({ ...frame, pixels: new Uint8Array(frame.pixels) });
+  return Object.freeze({ ...identity, wireSequence, frame: retainedFrame });
+}
+
+/**
+ * Pure projection only: no store, clock, timer, transport, or alternate-source read.
+ * The caller supplies one monotonic snapshot from the controller's domain.
+ */
+export function toScopeDisplayFrame(
+  envelope: QualifiedScopeFrameEnvelope | null,
+  authority: ScopeFrameProjectionAuthority,
+): ScopeDisplayFrameCandidate | null {
+  if (!envelope || !authority.demanded || authority.transport !== 'connected'
+    || authority.receiver === null || !safeNonnegativeInteger(authority.providerGeneration)
+    || !safePositiveInteger(authority.transportEpoch)
+    || envelope.source !== authority.source || envelope.receiver !== authority.receiver
+    || envelope.providerGeneration !== authority.providerGeneration
+    || envelope.transportEpoch !== authority.transportEpoch
+    || !safeNonnegativeInteger(envelope.providerGeneration)
+    || !safePositiveInteger(envelope.transportEpoch)
+    || !safePositiveInteger(envelope.acceptedSequence)
+    || !safeNonnegativeInteger(envelope.wireSequence)
+    || !Number.isFinite(envelope.receivedAt) || envelope.receivedAt < 0
+    || !Number.isFinite(authority.nowMonotonic)) return null;
+
+  const age = authority.nowMonotonic - envelope.receivedAt;
+  const { frame } = envelope;
+  if (age < 0 || !(frame.pixels instanceof Uint8Array) || frame.pixels.length < 2
+    || frame.receiver !== envelope.receiver || !Number.isFinite(frame.startFreq)
+    || !Number.isFinite(frame.endFreq) || frame.endFreq <= frame.startFreq) return null;
+
+  const normalizedBins = Object.freeze(Array.from(frame.pixels, (sample) => sample / 255));
+  return Object.freeze({
+    source: envelope.source === 'audio_fft' ? 'audio-fft' : 'hardware',
+    receiver: envelope.receiver === 0 ? 'MAIN' : 'SUB',
+    freshness: age < SCOPE_FRAME_SILENCE_MS ? 'fresh' : 'stale',
+    startHz: frame.startFreq,
+    endHz: frame.endFreq,
+    normalizedBins,
+  });
+}
+
 import type { Capabilities, FilterModeConfig, FilterSegmentConfig } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import type { ScopeControlsViewModel } from '../../../semantic/radio-view-model';

--- a/frontend/src/lib/runtime/scope-controller.svelte.ts
+++ b/frontend/src/lib/runtime/scope-controller.svelte.ts
@@ -246,7 +246,7 @@ export class ScopeController {
           frameSeen: state === 'connected' && this._arrivalIsLive('audio_fft'),
         });
       });
-      unsubscribeSession = ch.onSessionTransition((transition) => {
+      unsubscribeSession = this._subscribeSession(ch, (transition) => {
         this._sessionTransition('audio_fft', handle, transition);
       });
       unsubscribeBinary = ch.onBinary((buf: ArrayBuffer) => {
@@ -344,7 +344,7 @@ export class ScopeController {
           frameSeen: state === 'connected' && this._arrivalIsLive('hardware'),
         });
       });
-      unsubscribeSession = channel.onSessionTransition((transition) => {
+      unsubscribeSession = this._subscribeSession(channel, (transition) => {
         this._sessionTransition('hardware', handle, transition);
       });
       this._hardwareBindings.set(handle, {
@@ -411,6 +411,14 @@ export class ScopeController {
     }
   }
 
+  private _subscribeSession(
+    channel: WsChannel,
+    handler: (transition: ControlSessionTransition) => void,
+  ): () => void {
+    return typeof channel.onSessionTransition === 'function'
+      ? channel.onSessionTransition(handler) : () => {};
+  }
+
   private _acceptFrame(
     source: ScopeSource,
     channel: WsChannel,
@@ -420,8 +428,7 @@ export class ScopeController {
   ): boolean {
     const receivedAt = this._timing.now();
     const transportEpoch = channel.sessionEpoch;
-    if (!Number.isFinite(receivedAt) || receivedAt < 0
-      || !Number.isSafeInteger(transportEpoch) || transportEpoch <= 0) {
+    if (!Number.isFinite(receivedAt) || receivedAt < 0) {
       this._invalidateSource(source, authorityRevision === this._authorityRevision);
       return false;
     }
@@ -436,6 +443,11 @@ export class ScopeController {
 
     const authority = this._frameAuthority;
     if (authorityRevision !== this._authorityRevision || authority?.source !== source) return true;
+    if (!Number.isSafeInteger(transportEpoch) || transportEpoch <= 0) {
+      this._frameEnvelope = null;
+      this._notifyEvidence();
+      return true;
+    }
     if ((authority.receiver !== 0 && authority.receiver !== 1)
       || !Number.isSafeInteger(authority.providerGeneration)
       || (authority.providerGeneration as number) < 0) {

--- a/frontend/src/lib/runtime/scope-controller.svelte.ts
+++ b/frontend/src/lib/runtime/scope-controller.svelte.ts
@@ -14,10 +14,22 @@
 
 import { getChannel } from '$lib/transport/ws-client';
 import { markScopeFrame } from '$lib/stores/connection.svelte';
-import { parseScopeFrame } from '$lib/runtime/adapters/scope-adapter';
+import {
+  parseScopeFrame,
+  qualifyScopeFrameEnvelope,
+  SCOPE_FRAME_SILENCE_MS,
+} from '$lib/runtime/adapters/scope-adapter';
 import { untrack } from 'svelte';
-import type { ScopeFrame } from '$lib/runtime/adapters/scope-adapter';
-import type { ConnectionState, WsChannel } from '$lib/transport/ws-client';
+import type {
+  QualifiedScopeFrameEnvelope,
+  ScopeFrameProjectionAuthority,
+  ScopeFrame,
+} from '$lib/runtime/adapters/scope-adapter';
+import type {
+  ConnectionState,
+  ControlSessionTransition,
+  WsChannel,
+} from '$lib/transport/ws-client';
 import type { PresentationResourceDriver, PresentationResourceHost } from './resource-host';
 
 export type { ScopeFrame };
@@ -29,11 +41,37 @@ export type ScopeHealth = Readonly<{
   demanded: boolean; transport: ConnectionState; frameSeen: boolean;
 }>;
 type HealthHandler = (source: ScopeSource, health: ScopeHealth) => void;
+type EvidenceHandler = () => void;
 type AudioFftHandle = Readonly<{ token: symbol }>;
 type ChannelBinding = {
-  channel: WsChannel; unsubscribeBinary: () => void; unsubscribeState: () => void;
+  channel: WsChannel;
+  authorityRevision: number;
+  unsubscribeBinary: () => void;
+  unsubscribeState: () => void;
+  unsubscribeSession: () => void;
 };
 type HardwareHandle = Readonly<{ generation: number }>;
+type TimerHandle = ReturnType<typeof setTimeout>;
+export type ScopeFrameCanonicalAuthority = Readonly<{
+  source: ScopeSource;
+  receiver: 0 | 1 | null;
+  providerGeneration: number | null;
+}>;
+export type ScopeFrameEvidence = Readonly<{
+  envelope: QualifiedScopeFrameEnvelope | null;
+  authority: ScopeFrameProjectionAuthority;
+}>;
+export interface ScopeFrameTiming {
+  now(): number;
+  setTimeout(callback: () => void, delayMs: number): TimerHandle;
+  clearTimeout(handle: TimerHandle): void;
+}
+
+const DEFAULT_TIMING: ScopeFrameTiming = {
+  now: () => performance.now(),
+  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+  clearTimeout: (handle) => clearTimeout(handle),
+};
 
 export class ScopeController {
   /** Latest parsed audio-scope frame (Svelte 5 reactive). */
@@ -51,18 +89,30 @@ export class ScopeController {
   private _subscribers = new Map<number, FrameHandler>();
   private _hardwareSubscribers = new Map<number, FrameHandler>();
   private _healthSubscribers = new Map<number, HealthHandler>();
+  private _evidenceSubscribers = new Map<number, EvidenceHandler>();
   private _nextId = 0;
   private _bindings = new Map<AudioFftHandle, ChannelBinding>();
   private _activeHandle: AudioFftHandle | null = null;
   private _hardwareBindings = new Map<HardwareHandle, ChannelBinding>();
   private _activeHardwareHandle: HardwareHandle | null = null;
   private _hardwareGeneration = 0;
+  private _authorityRevision = 0;
+  private _frameAuthority: ScopeFrameCanonicalAuthority | null = null;
+  private _frameEnvelope: QualifiedScopeFrameEnvelope | null = null;
+  private _acceptedSequence = 0;
+  private _arrivals: Record<ScopeSource, Readonly<{
+    receivedAt: number; acceptedSequence: number;
+  }> | null> = { hardware: null, audio_fft: null };
+  private _expiryTimers: Record<ScopeSource, TimerHandle | null> = {
+    hardware: null, audio_fft: null,
+  };
   private _registeredHosts = new WeakSet<object>();
   private _health: Record<ScopeSource, ScopeHealth> = $state({
     hardware: { demanded: false, transport: 'disconnected', frameSeen: false },
     audio_fft: { demanded: false, transport: 'disconnected', frameSeen: false },
   });
   private _getChannel: ChannelFactory;
+  private _timing: ScopeFrameTiming;
   readonly audioFftDriver: PresentationResourceDriver<unknown> = {
     start: () => this._connect(),
     stop: (handle) => this._disconnect(handle as AudioFftHandle),
@@ -74,8 +124,12 @@ export class ScopeController {
     dispose: (handle) => this._disconnectHardware(handle as HardwareHandle),
   };
 
-  constructor(channelFactory: ChannelFactory = (name) => getChannel(name)) {
+  constructor(
+    channelFactory: ChannelFactory = (name) => getChannel(name),
+    timing: ScopeFrameTiming = DEFAULT_TIMING,
+  ) {
     this._getChannel = channelFactory;
+    this._timing = timing;
   }
 
   /**
@@ -104,6 +158,60 @@ export class ScopeController {
     return () => { this._healthSubscribers.delete(id); };
   }
 
+  /**
+   * Installs the one canonical display identity. Changing any identity member
+   * retires the prior envelope synchronously. A provider-generation change
+   * also retires the channel revision: its callbacks may still serve legacy
+   * raw subscribers but cannot revive display facts under the new provider.
+   */
+  setFrameAuthority(authority: ScopeFrameCanonicalAuthority | null): void {
+    const normalized = authority
+      && (authority.source === 'hardware' || authority.source === 'audio_fft')
+      && (authority.receiver === null || authority.receiver === 0 || authority.receiver === 1)
+      && (authority.providerGeneration === null
+        || (Number.isSafeInteger(authority.providerGeneration) && authority.providerGeneration >= 0))
+      ? Object.freeze({ ...authority }) : null;
+    const current = this._frameAuthority;
+    if (current?.source === normalized?.source
+      && current?.receiver === normalized?.receiver
+      && current?.providerGeneration === normalized?.providerGeneration) return;
+    if (current?.providerGeneration !== normalized?.providerGeneration) {
+      this._authorityRevision += 1;
+    }
+    this._frameAuthority = normalized;
+    this._frameEnvelope = null;
+    this._notifyEvidence();
+  }
+
+  snapshotFrameEvidence(): ScopeFrameEvidence {
+    const authority = this._frameAuthority;
+    const source = authority?.source ?? 'hardware';
+    const health = this._readHealth(source);
+    const binding = source === 'hardware'
+      ? this._activeHardwareHandle && this._hardwareBindings.get(this._activeHardwareHandle)
+      : this._activeHandle && this._bindings.get(this._activeHandle);
+    const epoch = binding?.channel.sessionEpoch;
+    return Object.freeze({
+      envelope: this._frameEnvelope,
+      authority: Object.freeze({
+        source,
+        receiver: authority?.receiver ?? null,
+        providerGeneration: authority?.providerGeneration ?? null,
+        transportEpoch: Number.isSafeInteger(epoch) && (epoch as number) > 0
+          ? epoch as number : null,
+        demanded: authority !== null && health.demanded,
+        transport: health.transport,
+        nowMonotonic: this._timing.now(),
+      }),
+    });
+  }
+
+  subscribeFrameEvidence(handler: EvidenceHandler): () => void {
+    const id = this._nextId++;
+    this._evidenceSubscribers.set(id, handler);
+    return () => { this._evidenceSubscribers.delete(id); };
+  }
+
   registerPresentationDriver(
     host: Pick<PresentationResourceHost<unknown>, 'configure'>,
     initialConfig?: { available: boolean; selected: boolean },
@@ -122,41 +230,49 @@ export class ScopeController {
   private _connect(): AudioFftHandle {
     const ch = this._getChannel('audio-scope');
     const handle = Object.freeze({ token: Symbol('audio-fft') });
-    let unsubscribeBinary = () => {}, unsubscribeState = () => {};
+    const authorityRevision = this._authorityRevision;
+    let unsubscribeBinary = () => {}, unsubscribeState = () => {}, unsubscribeSession = () => {};
     this._activeHandle = handle;
-    this.audioScopeFrame = null;
+    this._invalidateSource('audio_fft');
     this._setHealth('audio_fft', {
       demanded: true, transport: ch.state, frameSeen: false,
     });
     try {
       unsubscribeState = ch.onStateChange((state) => {
         if (this._activeHandle !== handle) return;
-        if (state !== 'connected') this.audioScopeFrame = null;
+        if (state !== 'connected') this._invalidateSource('audio_fft');
         this._setHealth('audio_fft', {
           demanded: true, transport: state,
-          frameSeen: state === 'connected' && this._readHealth('audio_fft').frameSeen,
+          frameSeen: state === 'connected' && this._arrivalIsLive('audio_fft'),
         });
+      });
+      unsubscribeSession = ch.onSessionTransition((transition) => {
+        this._sessionTransition('audio_fft', handle, transition);
       });
       unsubscribeBinary = ch.onBinary((buf: ArrayBuffer) => {
         if (this._activeHandle !== handle || this._readHealth('audio_fft').transport !== 'connected') return;
         const frame = parseScopeFrame(buf);
-        if (frame) {
-          markScopeFrame();
-          this.audioScopeFrame = frame;
-          this._setHealth('audio_fft', { ...this._readHealth('audio_fft'), frameSeen: true });
-          for (const h of this._subscribers.values()) {
-            h(frame);
-          }
+        if (!frame) {
+          this._invalidateSource('audio_fft', authorityRevision === this._authorityRevision);
+          return;
+        }
+        if (this._acceptFrame('audio_fft', ch, authorityRevision, frame, buf)) {
+          for (const h of this._subscribers.values()) h(frame);
         }
       });
-      this._bindings.set(handle, { channel: ch, unsubscribeBinary, unsubscribeState });
+      this._bindings.set(handle, {
+        channel: ch, authorityRevision, unsubscribeBinary, unsubscribeState, unsubscribeSession,
+      });
       ch.connect('/api/v1/audio-scope');
       return handle;
     } catch (error) {
       this._bindings.delete(handle);
-      try { unsubscribeBinary(); } finally { unsubscribeState(); }
+      try { unsubscribeBinary(); } finally {
+        try { unsubscribeState(); } finally { unsubscribeSession(); }
+      }
       if (this._activeHandle === handle) {
         this._activeHandle = null;
+        this._invalidateSource('audio_fft');
         this._setHealth('audio_fft', {
           demanded: false, transport: 'disconnected', frameSeen: false,
         });
@@ -177,7 +293,7 @@ export class ScopeController {
     );
     if (this._activeHandle === handle) {
       this._activeHandle = null;
-      this.audioScopeFrame = null;
+      this._invalidateSource('audio_fft');
       this._setHealth('audio_fft', {
         demanded: false, transport: 'disconnected', frameSeen: false,
       });
@@ -188,7 +304,9 @@ export class ScopeController {
       try {
         binding.unsubscribeState();
       } finally {
-        if (!shared) binding.channel.disconnect();
+        try { binding.unsubscribeSession(); } finally {
+          if (!shared) binding.channel.disconnect();
+        }
       }
     }
   }
@@ -196,9 +314,10 @@ export class ScopeController {
   private _connectHardware(): HardwareHandle {
     const channel = this._getChannel('scope');
     const handle = Object.freeze({ generation: ++this._hardwareGeneration });
-    let unsubscribeBinary = () => {}, unsubscribeState = () => {};
+    const authorityRevision = this._authorityRevision;
+    let unsubscribeBinary = () => {}, unsubscribeState = () => {}, unsubscribeSession = () => {};
     this._activeHardwareHandle = handle;
-    this.scopeFrame = null;
+    this._invalidateSource('hardware');
     this._setHealth('hardware', {
       demanded: true, transport: channel.state, frameSeen: false,
     });
@@ -209,27 +328,37 @@ export class ScopeController {
           || this._readHealth('hardware').transport !== 'connected'
         ) return;
         const frame = parseScopeFrame(buf);
-        if (!frame) return;
-        markScopeFrame();
-        this.scopeFrame = frame;
-        this._setHealth('hardware', { ...this._readHealth('hardware'), frameSeen: true });
-        for (const subscriber of this._hardwareSubscribers.values()) subscriber(frame);
+        if (!frame) {
+          this._invalidateSource('hardware', authorityRevision === this._authorityRevision);
+          return;
+        }
+        if (this._acceptFrame('hardware', channel, authorityRevision, frame, buf)) {
+          for (const subscriber of this._hardwareSubscribers.values()) subscriber(frame);
+        }
       });
       unsubscribeState = channel.onStateChange((state: ConnectionState) => {
         if (this._activeHardwareHandle !== handle) return;
-        if (state !== 'connected') this.scopeFrame = null;
+        if (state !== 'connected') this._invalidateSource('hardware');
         this._setHealth('hardware', {
           demanded: true, transport: state,
-          frameSeen: state === 'connected' && this._readHealth('hardware').frameSeen,
+          frameSeen: state === 'connected' && this._arrivalIsLive('hardware'),
         });
       });
-      this._hardwareBindings.set(handle, { channel, unsubscribeBinary, unsubscribeState });
+      unsubscribeSession = channel.onSessionTransition((transition) => {
+        this._sessionTransition('hardware', handle, transition);
+      });
+      this._hardwareBindings.set(handle, {
+        channel, authorityRevision, unsubscribeBinary, unsubscribeState, unsubscribeSession,
+      });
       channel.connect('/api/v1/scope');
     } catch (error) {
       this._hardwareBindings.delete(handle);
-      try { unsubscribeBinary(); } finally { unsubscribeState(); }
+      try { unsubscribeBinary(); } finally {
+        try { unsubscribeState(); } finally { unsubscribeSession(); }
+      }
       if (this._activeHardwareHandle === handle) {
         this._activeHardwareHandle = null;
+        this._invalidateSource('hardware');
         this._setHealth('hardware', {
           demanded: false, transport: 'disconnected', frameSeen: false,
         });
@@ -248,7 +377,7 @@ export class ScopeController {
     this._hardwareBindings.delete(handle);
     if (this._activeHardwareHandle === handle) {
       this._activeHardwareHandle = null;
-      this.scopeFrame = null;
+      this._invalidateSource('hardware');
       this._setHealth('hardware', {
         demanded: false, transport: 'disconnected', frameSeen: false,
       });
@@ -257,9 +386,133 @@ export class ScopeController {
       binding.unsubscribeBinary();
     } finally {
       try { binding.unsubscribeState(); } finally {
-        if (![...this._hardwareBindings.values()].some((item) => item.channel === binding.channel)) {
-          binding.channel.disconnect();
+        try { binding.unsubscribeSession(); } finally {
+          if (![...this._hardwareBindings.values()].some((item) => item.channel === binding.channel)) {
+            binding.channel.disconnect();
+          }
         }
+      }
+    }
+  }
+
+  private _sessionTransition(
+    source: ScopeSource,
+    handle: AudioFftHandle | HardwareHandle,
+    transition: ControlSessionTransition,
+  ): void {
+    const active = source === 'hardware' ? this._activeHardwareHandle : this._activeHandle;
+    if (active !== handle) return;
+    const envelope = this._frameEnvelope;
+    if (transition.state !== 'connected'
+      || (envelope?.source === source && envelope.transportEpoch !== transition.epoch)) {
+      this._invalidateSource(source);
+    } else {
+      this._notifyEvidence();
+    }
+  }
+
+  private _acceptFrame(
+    source: ScopeSource,
+    channel: WsChannel,
+    authorityRevision: number,
+    frame: ScopeFrame,
+    buffer: ArrayBuffer,
+  ): boolean {
+    const receivedAt = this._timing.now();
+    const transportEpoch = channel.sessionEpoch;
+    if (!Number.isFinite(receivedAt) || receivedAt < 0
+      || !Number.isSafeInteger(transportEpoch) || transportEpoch <= 0) {
+      this._invalidateSource(source, authorityRevision === this._authorityRevision);
+      return false;
+    }
+    const acceptedSequence = ++this._acceptedSequence;
+    const arrival = Object.freeze({ receivedAt, acceptedSequence });
+    this._arrivals[source] = arrival;
+    if (source === 'hardware') this.scopeFrame = frame;
+    else this.audioScopeFrame = frame;
+    markScopeFrame();
+    this._setHealth(source, { ...this._readHealth(source), frameSeen: true });
+    this._armExpiry(source, arrival);
+
+    const authority = this._frameAuthority;
+    if (authorityRevision !== this._authorityRevision || authority?.source !== source) return true;
+    if ((authority.receiver !== 0 && authority.receiver !== 1)
+      || !Number.isSafeInteger(authority.providerGeneration)
+      || (authority.providerGeneration as number) < 0) {
+      this._frameEnvelope = null;
+      this._notifyEvidence();
+      return true;
+    }
+    const view = new DataView(buffer);
+    this._frameEnvelope = qualifyScopeFrameEnvelope(frame, {
+      source,
+      receiver: authority.receiver,
+      providerGeneration: authority.providerGeneration as number,
+      transportEpoch,
+      receivedAt,
+      acceptedSequence,
+    }, view.getUint16(12, true));
+    this._notifyEvidence();
+    return true;
+  }
+
+  private _armExpiry(
+    source: ScopeSource,
+    arrival: Readonly<{ receivedAt: number; acceptedSequence: number }>,
+  ): void {
+    this._clearExpiry(source);
+    const wake = () => {
+      const current = this._arrivals[source];
+      if (!current || current.acceptedSequence !== arrival.acceptedSequence) return;
+      const age = this._timing.now() - arrival.receivedAt;
+      if (!Number.isFinite(age) || age < 0 || age >= SCOPE_FRAME_SILENCE_MS) {
+        this._expiryTimers[source] = null;
+        if (source === 'hardware') this.scopeFrame = null;
+        else this.audioScopeFrame = null;
+        this._setHealth(source, { ...this._readHealth(source), frameSeen: false });
+        if (this._frameEnvelope?.source === source
+          && this._frameEnvelope.acceptedSequence === arrival.acceptedSequence) {
+          this._notifyEvidence();
+        }
+        return;
+      }
+      this._expiryTimers[source] = this._timing.setTimeout(
+        wake, SCOPE_FRAME_SILENCE_MS - age,
+      );
+    };
+    this._expiryTimers[source] = this._timing.setTimeout(wake, SCOPE_FRAME_SILENCE_MS);
+  }
+
+  private _clearExpiry(source: ScopeSource): void {
+    const timer = this._expiryTimers[source];
+    if (timer !== null) this._timing.clearTimeout(timer);
+    this._expiryTimers[source] = null;
+  }
+
+  private _invalidateSource(source: ScopeSource, clearEnvelope = true): void {
+    this._clearExpiry(source);
+    this._arrivals[source] = null;
+    if (source === 'hardware') this.scopeFrame = null;
+    else this.audioScopeFrame = null;
+    if (clearEnvelope && this._frameEnvelope?.source === source) this._frameEnvelope = null;
+    const current = this._readHealth(source);
+    if (current.frameSeen) this._setHealth(source, { ...current, frameSeen: false });
+    this._notifyEvidence();
+  }
+
+  private _arrivalIsLive(source: ScopeSource): boolean {
+    const arrival = this._arrivals[source];
+    if (!arrival) return false;
+    const age = this._timing.now() - arrival.receivedAt;
+    return Number.isFinite(age) && age >= 0 && age < SCOPE_FRAME_SILENCE_MS;
+  }
+
+  private _notifyEvidence(): void {
+    for (const listener of [...this._evidenceSubscribers.values()]) {
+      try {
+        listener();
+      } catch (error) {
+        console.warn('Scope frame evidence subscriber failed', error);
       }
     }
   }

--- a/frontend/src/lib/runtime/scope-frame-host.ts
+++ b/frontend/src/lib/runtime/scope-frame-host.ts
@@ -1,0 +1,91 @@
+import { toScopeDisplayFrame } from './adapters/scope-adapter';
+import type { ScopeController } from './scope-controller.svelte';
+import {
+  resolveLcdSpectrumFrame,
+  type LcdSpectrumFrameResolution,
+  type LcdSpectrumReceiver,
+  type LcdSpectrumSource,
+} from '../../skins/segmentline/lcd-display-contract';
+
+export interface ScopeFrameHostAuthority {
+  readonly source: LcdSpectrumSource;
+  readonly receiver: LcdSpectrumReceiver | null;
+  readonly providerGeneration: number | null;
+}
+
+type ResolutionHandler = (resolution: LcdSpectrumFrameResolution) => void;
+
+/**
+ * Runtime-side owner of the MOR-2321 display-frame resolution. Wiring supplies
+ * canonical provider/receiver/source authority; the controller supplies
+ * demand, transport epoch, receipt envelope, clock, and expiry notifications.
+ */
+export class ScopeFrameHost {
+  private readonly listeners = new Map<number, ResolutionHandler>();
+  private nextId = 0;
+  private authority: ScopeFrameHostAuthority | null = null;
+  private unsubscribeEvidence: () => void;
+  private disposed = false;
+
+  constructor(private readonly controller: ScopeController) {
+    this.unsubscribeEvidence = controller.subscribeFrameEvidence(() => this.publish());
+  }
+
+  updateAuthority(authority: ScopeFrameHostAuthority | null): void {
+    if (this.disposed) return;
+    const normalized = authority ? Object.freeze({ ...authority }) : null;
+    if (this.authority?.source === normalized?.source
+      && this.authority?.receiver === normalized?.receiver
+      && this.authority?.providerGeneration === normalized?.providerGeneration) return;
+    this.authority = normalized;
+    this.controller.setFrameAuthority(normalized ? {
+      source: normalized.source === 'audio-fft' ? 'audio_fft' : 'hardware',
+      receiver: normalized.receiver === null ? null : normalized.receiver === 'MAIN' ? 0 : 1,
+      providerGeneration: normalized.providerGeneration,
+    } : null);
+  }
+
+  snapshot(): LcdSpectrumFrameResolution {
+    return this.resolve();
+  }
+
+  subscribe(handler: ResolutionHandler): () => void {
+    if (this.disposed) return () => {};
+    const id = this.nextId++;
+    this.listeners.set(id, handler);
+    return () => { this.listeners.delete(id); };
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.unsubscribeEvidence();
+    this.controller.setFrameAuthority(null);
+    this.listeners.clear();
+  }
+
+  private resolve(): LcdSpectrumFrameResolution {
+    const authority = this.authority;
+    if (!authority) {
+      return resolveLcdSpectrumFrame(null, { source: 'hardware', receiver: null });
+    }
+    const evidence = this.controller.snapshotFrameEvidence();
+    const candidate = toScopeDisplayFrame(evidence.envelope, evidence.authority);
+    return resolveLcdSpectrumFrame(candidate, {
+      source: authority.source,
+      receiver: authority.receiver,
+    });
+  }
+
+  private publish(): void {
+    if (this.disposed) return;
+    const resolution = this.resolve();
+    for (const listener of [...this.listeners.values()]) {
+      try {
+        listener(resolution);
+      } catch (error) {
+        console.warn('Scope frame host subscriber failed', error);
+      }
+    }
+  }
+}

--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -305,6 +305,26 @@ describe('WsChannel', () => {
     expect(received[0].type).toBe('ack');
   });
 
+  it('drops binary frames from a replaced socket while delivering the current socket', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    const received: ArrayBuffer[] = [];
+    ch.onBinary((frame) => received.push(frame));
+
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+    instances[0].simulateClose();
+    vi.advanceTimersByTime(1_300);
+    instances[1].simulateOpen();
+
+    const staleFrame = new ArrayBuffer(1);
+    const currentFrame = new ArrayBuffer(2);
+    instances[0].simulateMessage(staleFrame);
+    instances[1].simulateMessage(currentFrame);
+
+    expect(received).toEqual([currentFrame]);
+  });
+
   it('emits correlated PTT delivery events without fabricating RF state', async () => {
     const { WsChannel } = await import('../ws-client');
     const ch = new WsChannel();

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -258,6 +258,7 @@ export class WsChannel {
     ws.onmessage = (event: MessageEvent) => {
       if (this.ws === ws) this._resetHeartbeat();
       if (event.data instanceof ArrayBuffer) {
+        if (this.ws !== ws) return;
         this.binaryHandlers.forEach((h) => h(event.data as ArrayBuffer));
       } else {
         try {


### PR DESCRIPTION
Linear: MOR-2326

## Summary
- add the runtime-only LCD/SDR display-frame lifecycle owner and MOR-2321 resolver host
- treat frames as live only while monotonic age is below 500 ms; at exactly 500 ms they resolve stale/ghost
- qualify receipts by source, receiver, provider generation, and the public WsChannel.sessionEpoch without duplicating transport epoch authority
- invalidate immediately across source, receiver, provider-generation, transport-epoch, and demand boundaries
- retain wire uint16 sequence only as diagnostic continuity and preserve the raw ScopeFrame decoder/subscribers

## Boundary
- runtime-only delivery; this PR does not perform the live LCD cutover
- MOR-2325 owns SemanticRadioSurfaces and audio-demand integration
- no renderer timer, transport connection, fallback source, or fabricated zero bins are added

## Verification
- focused Vitest: 3 files passed, 102 tests passed
- ESLint: exact six-file changed-scope set passed
- npm run check: 0 errors, 0 warnings
- git diff --check passed
- exact six-file allowlist passed