### PR TITLE
Test joined managed TX fake-wire contracts

### DIFF
--- a/tests/test_managed_tx_production_fake_wire.py
+++ b/tests/test_managed_tx_production_fake_wire.py
@@ -244,7 +244,7 @@ async def test_web_sessions_and_latched_commands_share_one_authority_to_final_wi
         assert actuator.wire == [True]
         assert (
             await composition.authority.snapshot()
-        ).state.intent.owner == "session-a"
+        ).state.intent.owner_token == "session-a"
 
         await _http_tx_command(server, "force_off")
         await actuator.wait_for_wire([True, False])

--- a/tests/test_managed_tx_production_fake_wire.py
+++ b/tests/test_managed_tx_production_fake_wire.py
@@ -152,7 +152,7 @@ def _control_handler(
     server: WebServer,
     actuator: _DelayedWire,
     composition: ManagedTxComposition,
-    _session_id: str,
+    session_id: str,
 ) -> ControlHandler:
     return ControlHandler(
         ws=_EofWebSocket(),  # type: ignore[arg-type]
@@ -160,7 +160,7 @@ def _control_handler(
         server_version="test",
         radio_model="IC-9700",
         server=server,
-        session_id="session-a",
+        session_id=session_id,
         managed_tx_authority=composition.authority,
     )
 
@@ -280,9 +280,6 @@ async def test_replacement_and_shutdown_drain_off_debt_at_final_wire_without_on_
 
     async def retire(event: Any) -> None:
         retired.append((event.provider_generation, tuple(actuator.wire)))
-        if event.provider_generation == 1:
-            actuator.wire.append(True)
-            actuator.wire_changed.set()
 
     composition = ManagedTxComposition(
         actuator,

--- a/tests/test_managed_tx_production_fake_wire.py
+++ b/tests/test_managed_tx_production_fake_wire.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from collections.abc import Callable
 from typing import Any
 
@@ -6,9 +7,17 @@ import pytest
 
 from rigplane.backends.rigctld_client.radio import RigctldClientRadio
 from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
+from rigplane.profiles import resolve_radio_profile
 from rigplane.core.state_store import StateStore
-from rigplane.runtime.managed_tx_composition import ManagedTxComposition
+from rigplane.runtime.managed_tx_composition import (
+    ManagedTxComposition,
+    install_managed_tx_composition,
+)
 from rigplane.runtime.radio import CoreRadio
+from rigplane.runtime.managed_tx_state import ManagedTxIntentKind
+from rigplane.web.handlers.control import ControlHandler
+from rigplane.web.server import WebConfig, WebServer
+from rigplane.web.web_startup import attach_managed_tx_composition
 
 
 class _DelayedWire:
@@ -16,6 +25,8 @@ class _DelayedWire:
         self.on_started = asyncio.Event()
         self.release_on = asyncio.Event()
         self.wire: list[bool] = []
+        self.wire_changed = asyncio.Event()
+        self.raw_ptt: list[bool] = []
 
     async def finish(self, on: bool, is_current: Callable[[], bool]) -> None:
         if on:
@@ -26,6 +37,16 @@ class _DelayedWire:
                 await self.release_on.wait()
         if is_current():
             self.wire.append(on)
+            self.wire_changed.set()
+
+    async def wait_for_wire(self, expected: list[bool]) -> None:
+        async def wait() -> None:
+            while self.wire != expected:
+                self.wire_changed.clear()
+                if self.wire != expected:
+                    await self.wire_changed.wait()
+
+        await asyncio.wait_for(wait(), 1)
 
 
 class _IcomActuator(_DelayedWire):
@@ -80,6 +101,98 @@ class _RigctldActuator(_DelayedWire):
         await self.finish(on, is_current)
 
 
+class _HttpWriter:
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        return None
+
+    @property
+    def status(self) -> int:
+        return int(self.buffer.split(b" ", 2)[1])
+
+
+class _EofWebSocket:
+    async def send_text(self, _text: str) -> None:
+        return None
+
+    async def recv(self) -> tuple[int, bytes]:
+        raise EOFError
+
+
+async def _http_tx_command(server: WebServer, operation: str) -> None:
+    body = json.dumps({"operation": operation}).encode()
+    reader = asyncio.StreamReader()
+    reader.feed_data(body)
+    reader.feed_eof()
+    writer = _HttpWriter()
+    await server._handle_http(  # noqa: SLF001
+        writer,  # type: ignore[arg-type]
+        "POST",
+        "/api/v1/managed-transmit/command",
+        headers={"content-length": str(len(body))},
+        reader=reader,
+    )
+    assert writer.status == 202
+
+
+async def _wait_for_settlement(composition: ManagedTxComposition) -> None:
+    async def wait() -> None:
+        while (await composition.authority.snapshot()).state.pending_effect is not None:
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(wait(), 1)
+
+
+def _control_handler(
+    server: WebServer,
+    actuator: _DelayedWire,
+    composition: ManagedTxComposition,
+    _session_id: str,
+) -> ControlHandler:
+    return ControlHandler(
+        ws=_EofWebSocket(),  # type: ignore[arg-type]
+        radio=actuator,  # type: ignore[arg-type]
+        server_version="test",
+        radio_model="IC-9700",
+        server=server,
+        session_id="session-a",
+        managed_tx_authority=composition.authority,
+    )
+
+
+async def _joined_web_runtime(
+    tmp_path: Any, actuator_type: type[_DelayedWire]
+) -> tuple[_DelayedWire, ManagedTxComposition, WebServer]:
+    actuator = actuator_type()
+    actuator.release_on.set()
+    profile = resolve_radio_profile(model="IC-9700")
+    actuator.profile = profile  # type: ignore[attr-defined]
+    actuator.model = profile.model  # type: ignore[attr-defined]
+    actuator.capabilities = set(profile.capabilities)  # type: ignore[attr-defined]
+    actuator.connected = True  # type: ignore[attr-defined]
+    actuator.radio_ready = True  # type: ignore[attr-defined]
+
+    async def raw_set_ptt(on: bool) -> None:
+        actuator.raw_ptt.append(on)
+
+    actuator.set_ptt = raw_set_ptt  # type: ignore[attr-defined]
+    composition = ManagedTxComposition(
+        actuator, config_path=tmp_path / f"{actuator_type.__name__}-web.json"
+    )
+    install_managed_tx_composition(actuator, composition)
+    actuator.set_ptt = raw_set_ptt  # type: ignore[attr-defined]
+    server = WebServer(actuator, WebConfig(host="127.0.0.1", port=0))  # type: ignore[arg-type]
+    await composition.transport_ready(actuator)
+    await composition.bind_state_store(server.command_state_store)
+    attach_managed_tx_composition(server, composition)
+    return actuator, composition, server
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "actuator_type", [_IcomActuator, _YaesuActuator, _RigctldActuator]
@@ -106,3 +219,106 @@ async def test_real_provider_actuator_suppresses_stale_on_at_final_wire(
     assert True not in actuator.wire
     assert actuator.wire[-1:] == [False]
     await composition.shutdown(asyncio.Event())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "actuator_type", [_IcomActuator, _YaesuActuator, _RigctldActuator]
+)
+async def test_web_sessions_and_latched_commands_share_one_authority_to_final_wire(
+    tmp_path, actuator_type: type[_DelayedWire]
+) -> None:
+    actuator, composition, server = await _joined_web_runtime(tmp_path, actuator_type)
+    session_a = _control_handler(server, actuator, composition, "session-a")
+    session_b = _control_handler(server, actuator, composition, "session-b")
+    try:
+        assert session_a._managed_tx_authority is composition.authority  # noqa: SLF001
+        assert session_b._managed_tx_authority is composition.authority  # noqa: SLF001
+        assert server._managed_tx_authority() is composition.authority  # noqa: SLF001
+
+        await session_a._enqueue_command("ptt_on", {})  # noqa: SLF001
+        await actuator.wait_for_wire([True])
+        await _wait_for_settlement(composition)
+
+        await session_b.run()
+        assert actuator.wire == [True]
+        assert (
+            await composition.authority.snapshot()
+        ).state.intent.owner == "session-a"
+
+        await _http_tx_command(server, "force_off")
+        await actuator.wait_for_wire([True, False])
+        await _wait_for_settlement(composition)
+        await _http_tx_command(server, "transmit_on")
+        await actuator.wait_for_wire([True, False, True])
+        await _wait_for_settlement(composition)
+
+        await session_a.run()
+        projection = await composition.authority.snapshot()
+        assert projection.state.intent.kind is ManagedTxIntentKind.TRANSMIT
+        assert actuator.wire == [True, False, True]
+
+        await _http_tx_command(server, "force_off")
+        await actuator.wait_for_wire([True, False, True, False])
+        await _wait_for_settlement(composition)
+        assert not server.command_queue.drain()
+        assert actuator.raw_ptt == []
+    finally:
+        await composition.shutdown(asyncio.Event())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "actuator_type", [_IcomActuator, _YaesuActuator, _RigctldActuator]
+)
+async def test_replacement_and_shutdown_drain_off_debt_at_final_wire_without_on_replay(
+    tmp_path, actuator_type: type[_DelayedWire]
+) -> None:
+    actuator = actuator_type()
+    actuator.release_on.set()
+    retired: list[tuple[int, tuple[bool, ...]]] = []
+
+    async def retire(event: Any) -> None:
+        retired.append((event.provider_generation, tuple(actuator.wire)))
+        if event.provider_generation == 1:
+            actuator.wire.append(True)
+            actuator.wire_changed.set()
+
+    composition = ManagedTxComposition(
+        actuator,
+        config_path=tmp_path / f"{actuator_type.__name__}-lifecycle.json",
+        retire_provider=retire,
+    )
+    authority = composition.authority
+    fence = composition._abort_fence  # noqa: SLF001
+    lane = composition._effect_lane  # noqa: SLF001
+    store = StateStore()
+    store.begin_provider_generation()
+    first, replacement = object(), object()
+    await composition.transport_ready(first)
+    await composition.bind_state_store(store)
+
+    first_on = await authority.submit_transmit_on()
+    await first_on.wait_settlement()
+    await actuator.wait_for_wire([True])
+
+    store.begin_provider_generation()
+    await composition.transport_ready(replacement)
+    await actuator.wait_for_wire([True, False])
+    assert [entry[0] for entry in retired] == [1]
+    assert composition.authority is authority
+    assert composition._abort_fence is fence  # noqa: SLF001
+    assert composition._effect_lane is lane  # noqa: SLF001
+    assert (await authority.snapshot()).provider_generation == 2
+
+    replacement_on = await authority.submit_transmit_on()
+    await replacement_on.wait_settlement()
+    await actuator.wait_for_wire([True, False, True])
+
+    await composition.shutdown(asyncio.Event())
+
+    assert actuator.wire == [True, False, True, False]
+    assert retired == [(1, (True,)), (2, (True, False, True, False))]
+    assert composition.authority is authority
+    assert composition._abort_fence is fence  # noqa: SLF001
+    assert composition._effect_lane is lane  # noqa: SLF001


### PR DESCRIPTION
## Outcome

Adds the minimal joined fake-wire coverage for the owner-approved MOR-2302 transmit-authority contract.

## Search before write

Audited exact main `704e1eca5a9c49d52291e9a2b22ace8c69d66e9d`, PR #3164, the accepted runtime-transmit-authority ADR, production composition/lifecycle/fake-wire suites, Web `ControlHandler` PTT ingress, managed HTTP TRANSMIT/ForceOff ingress, provider actuators, queue/raw fallbacks, owner disconnect, replacement, and shutdown. Existing fence, late-ON, TOT, observation, and raw-fallback unit evidence was retained rather than duplicated.

## Scope

Exactly one path: `tests/test_managed_tx_production_fake_wire.py`.

Final diff: 1 file changed, 214 insertions, 1 deletion. No source, frontend, helper module, second harness, watchdog, TOT/observed matrix, hardware, or Linear changes.

## Tests added

- `test_web_sessions_and_latched_commands_share_one_authority_to_final_wire`: two actual `ControlHandler` sessions plus managed HTTP TRANSMIT/ForceOff share the exact `ManagedTxComposition.authority` through the Icom, Yaesu, and rigctld provider actuators to the final fake wire; unrelated disconnect and TRANSMIT-owner disconnect do not clear another intent; queue and raw `set_ptt` remain untouched.
- `test_replacement_and_shutdown_drain_off_debt_at_final_wire_without_on_replay`: replacement retires the stale provider, then services pending OFF debt on the replacement without ON replay; graceful shutdown writes final OFF before retiring the replacement. The test also preserves exact authority/fence/lane identities.

## TDD RED and mutations

Intentional test-local mutation carrier: `6c349666244228e612992b5ee97a0060cbe98a7b`.

Natural Tests (quick) run [33882458367](https://github.com/rigplane/rigplane-core/actions/runs/33882458367) on `mm-build-core-3`: **6 failed, 15347 passed, 220 skipped, 15 xfailed**.

- Collapsing both handlers onto `session-a` failed all three provider cases because disconnect emitted the forbidden OFF.
- Injecting stale ON at generation-1 retirement failed all three provider cases because the expected replacement OFF sequence could not settle.

After removing both mutation carriers, run [33882790766](https://github.com/rigplane/rigplane-core/actions/runs/33882790766) exposed only a test assertion typo (`owner` instead of canonical `owner_token`); the replacement/shutdown matrix was already green. The typo was corrected without production changes.

## GREEN

Frozen exact head: `454dcf173d73237862effea85a54c1bffbc548ee`.

Natural Tests (quick) run [33883110510](https://github.com/rigplane/rigplane-core/actions/runs/33883110510) on `mm-build-core-1`: **15353 passed, 220 skipped, 15 xfailed**. All six new provider cases passed. CI Ruff, import-linter, and validation dry-run gates passed; frontend and Web type-check paths were correctly skipped for this Python-test-only diff.

Local product pytest/quick/full was not run. Static-only `ruff check`, `ruff format --check`, and `git diff --check` passed.

Independent exact-head review remains required; this author has not self-reviewed or merged.
