### PR TITLE
Fence Icom local CW and tuner work

### DIFF
--- a/src/rigplane/runtime/local_tx_work.py
+++ b/src/rigplane/runtime/local_tx_work.py
@@ -16,35 +16,48 @@ CurrencyCheck = Callable[[], bool]
 LocalTxWork = Callable[[CurrencyCheck], Awaitable[_T]]
 
 
+async def _drain(task: asyncio.Task[object]) -> None:
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
 class LocalTxWorkRunner:
     """Register one caller-owned operation with an injected abort fence.
 
-    The runner owns no fence, queue, authority, task, or lifecycle.  It only
-    lends the operation a fence token and passes its live currency check down
-    to the provider's transport write.
+    The runner owns no fence, queue, authority, or lifecycle.  It owns and
+    drains the provider task for one call while lending it a fence token and
+    live currency check.
     """
 
     def __init__(self, abort_fence: TxAbortFence) -> None:
         self._abort_fence = abort_fence
 
     async def run(self, work: LocalTxWork[_T]) -> _T:
-        task = asyncio.current_task()
-        if task is None:  # pragma: no cover - an async call always has a task
-            raise RuntimeError("local TX work requires an asyncio task")
-
         token = self._abort_fence.issue()
 
-        def cancel() -> None:
-            task.cancel()
+        async def invoke() -> _T:
+            return await work(lambda: self._abort_fence.is_current(token))
 
-        self._abort_fence.register(token, cancel)
+        task = asyncio.create_task(invoke())
 
-        def is_current() -> bool:
-            return self._abort_fence.is_current(token)
+        def cancel_and_drain() -> Awaitable[None]:
+            if not task.done():
+                task.cancel()
+            return _drain(task)
+
+        self._abort_fence.register(token, cancel_and_drain)
 
         try:
-            if not is_current():
+            result = await task
+            if not self._abort_fence.is_current(token):
                 raise asyncio.CancelledError
-            return await work(is_current)
+            return result
+        except asyncio.CancelledError:
+            if not task.done():
+                task.cancel()
+            await _drain(task)
+            raise
         finally:
             self._abort_fence.remove(token)

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from rigplane._runtime_protocols import ControlPhaseHost
     from rigplane.core.acquisition_scheduler import RadioStateModelService
     from rigplane.core.tx_safety import ProviderPttObservation
+    from rigplane.runtime.local_tx_work import LocalTxWorkRunner
     from rigplane.runtime.managed_tx_composition import ManagedTxCompositionPort
 
     def _managed_tx_runtime_satisfies_supervisor(
@@ -673,6 +674,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         # NOT_READY, never back to ``None`` (see ``_arm_managed_tx``).
         self._managed_tx_runtime: ManagedRadioRuntime | None = None
         self._managed_tx_composition: ManagedTxCompositionPort | None = None
+        self._local_tx_work: LocalTxWorkRunner | None = None
         # CI-V epoch the last arming attempt was made against; ``None`` until
         # the first attempt.  Bounds arming to one attempt per epoch.
         self._managed_tx_armed_epoch: int | None = None
@@ -1626,6 +1628,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         key: str | None = None,
         dedupe: bool = False,
         timeout: float | None = None,
+        is_current: "Callable[[], bool] | None" = None,
     ) -> CivFrame:
         """Send a CIV frame and raise CommandError if no response."""
         resp = await self._send_civ_raw(
@@ -1634,6 +1637,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             key=key,
             dedupe=dedupe,
             timeout=timeout,
+            is_current=is_current,
         )
         if resp is None:
             raise CommandError(f"No response for {label}")
@@ -3755,7 +3759,18 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         """
         self._check_connected()
         civ = self._commands.set_tuner_status(value, to_addr=self._radio_addr)
-        await self._send_civ_raw(civ, wait_response=False)
+        if value == 0 or self._local_tx_work is None:
+            await self._send_civ_raw(civ, wait_response=False)
+            return
+
+        async def send(is_current: Callable[[], bool]) -> None:
+            await self._send_civ_raw(
+                civ,
+                wait_response=False,
+                is_current=is_current,
+            )
+
+        await self._local_tx_work.run(send)
 
     async def get_xfc_status(self) -> bool:
         """Read XFC (transmit frequency correction) status."""
@@ -5069,11 +5084,30 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         """
         self._check_connected()
         frames = self._commands.send_cw(text, to_addr=self._radio_addr)
-        for frame in frames:
-            resp = await self._send_civ_expect(frame, label="send_cw_text")
-            ack = parse_ack_nak(resp)
-            if ack is False:
-                raise CommandError("Radio rejected CW text")
+
+        async def send_frames(
+            is_current: Callable[[], bool] | None = None,
+        ) -> None:
+            for frame in frames:
+                if is_current is None:
+                    resp = await self._send_civ_expect(
+                        frame,
+                        label="send_cw_text",
+                    )
+                else:
+                    resp = await self._send_civ_expect(
+                        frame,
+                        label="send_cw_text",
+                        is_current=is_current,
+                    )
+                ack = parse_ack_nak(resp)
+                if ack is False:
+                    raise CommandError("Radio rejected CW text")
+
+        if not frames or self._local_tx_work is None:
+            await send_frames()
+            return
+        await self._local_tx_work.run(send_frames)
 
     async def stop_cw_text(self) -> None:
         """Stop CW sending."""

--- a/tests/test_fenced_local_tx_providers.py
+++ b/tests/test_fenced_local_tx_providers.py
@@ -158,7 +158,8 @@ def _ack() -> CivFrame:
     return CivFrame(to_addr=0xE0, from_addr=0x94, command=0xFB)
 
 
-def test_icom_composition_injects_its_exact_runner_fence_and_authority(
+@pytest.mark.asyncio
+async def test_icom_composition_injects_its_exact_runner_fence_and_authority(
     tmp_path,
 ) -> None:
     radio = _icom_radio()
@@ -170,6 +171,7 @@ def test_icom_composition_injects_its_exact_runner_fence_and_authority(
     assert radio._local_tx_work is composition.local_tx_work_runner
     assert radio._local_tx_work._abort_fence is composition._abort_fence
     assert composition.authority._abort_fence is composition._abort_fence
+    await composition.shutdown(asyncio.Event())
 
 
 @pytest.mark.asyncio
@@ -201,6 +203,7 @@ async def test_icom_managed_cw_uses_one_operation_and_guards_every_chunk(
     assert predicates[0] is predicates[1]
     assert predicates[0] is not None
     assert predicates[0]() is True
+    await composition.shutdown(asyncio.Event())
 
 
 @pytest.mark.asyncio
@@ -248,6 +251,7 @@ async def test_icom_force_off_suppresses_late_cw_write_and_remaining_chunks(
     assert predicates[0] is not None
     assert predicates[0]() is False
     assert wire == []
+    await composition.shutdown(asyncio.Event())
 
 
 @pytest.mark.asyncio
@@ -295,6 +299,7 @@ async def test_icom_force_off_suppresses_late_tuner_write(
     assert predicates[0] is not None
     assert predicates[0]() is False
     assert wire == []
+    await composition.shutdown(asyncio.Event())
 
 
 @pytest.mark.asyncio
@@ -318,6 +323,7 @@ async def test_icom_managed_empty_cw_stop_and_tuner_off_remain_direct(
         "priority": Priority.IMMEDIATE
     }
     assert radio._send_civ_raw.await_args_list[1].kwargs == {"wait_response": False}
+    await composition.shutdown(asyncio.Event())
 
 
 @pytest.mark.asyncio

--- a/tests/test_fenced_local_tx_providers.py
+++ b/tests/test_fenced_local_tx_providers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 from collections.abc import Awaitable, Callable
 from unittest.mock import AsyncMock
 
@@ -10,12 +11,19 @@ import pytest
 
 from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
 from rigplane.backends.yaesu_cat.transport import CatTransportError
+from rigplane.commands.commander import Priority
+from rigplane.core.types import CivFrame
+from rigplane.runtime.managed_tx_composition import (
+    ManagedTxComposition,
+    install_managed_tx_composition,
+)
 from rigplane.runtime.managed_tx_fence import TxAbortFence
 from rigplane.runtime.managed_tx_state import (
     ActuationOperation,
     ActuationResult,
     EffectToken,
 )
+from rigplane.runtime.radio import CoreRadio
 
 
 def _fenced_radio(fence: TxAbortFence | None) -> YaesuCatRadio:
@@ -138,3 +146,191 @@ async def test_unmanaged_calls_keep_the_direct_write_contract() -> None:
     assert [call.kwargs for call in radio._transport.write.await_args_list] == [{}, {}]
     assert radio._transport.write.await_args_list[0].args[0].startswith("KY ")
     assert radio._transport.write.await_args_list[1].args[0].startswith("AC")
+
+
+def _icom_radio() -> CoreRadio:
+    radio = CoreRadio("127.0.0.1", model="IC-7300")
+    radio._check_connected = lambda: None
+    return radio
+
+
+def _ack() -> CivFrame:
+    return CivFrame(to_addr=0xE0, from_addr=0x94, command=0xFB)
+
+
+def test_icom_composition_injects_its_exact_runner_fence_and_authority(
+    tmp_path,
+) -> None:
+    radio = _icom_radio()
+    assert radio._local_tx_work is None
+    composition = ManagedTxComposition(radio, config_path=tmp_path / "managed-tx.json")
+
+    install_managed_tx_composition(radio, composition)
+
+    assert radio._local_tx_work is composition.local_tx_work_runner
+    assert radio._local_tx_work._abort_fence is composition._abort_fence
+    assert composition.authority._abort_fence is composition._abort_fence
+
+
+@pytest.mark.asyncio
+async def test_icom_managed_cw_uses_one_operation_and_guards_every_chunk(
+    tmp_path,
+) -> None:
+    radio = _icom_radio()
+    composition = ManagedTxComposition(radio, config_path=tmp_path / "managed-tx.json")
+    install_managed_tx_composition(radio, composition)
+    runner = composition.local_tx_work_runner
+    original_run = runner.run
+    runner.run = AsyncMock(wraps=original_run)
+    predicates: list[Callable[[], bool] | None] = []
+
+    async def send_raw(
+        _frame: bytes,
+        **kwargs: object,
+    ) -> CivFrame:
+        predicate = kwargs.get("is_current")
+        assert predicate is None or callable(predicate)
+        predicates.append(predicate)
+        return _ack()
+
+    radio._send_civ_raw = send_raw
+    await radio.send_cw_text("A" * 31)
+
+    runner.run.assert_awaited_once()
+    assert len(predicates) == 2
+    assert predicates[0] is predicates[1]
+    assert predicates[0] is not None
+    assert predicates[0]() is True
+
+
+@pytest.mark.asyncio
+async def test_icom_force_off_suppresses_late_cw_write_and_remaining_chunks(
+    tmp_path,
+) -> None:
+    radio = _icom_radio()
+    composition = ManagedTxComposition(radio, config_path=tmp_path / "managed-tx.json")
+    install_managed_tx_composition(radio, composition)
+    runner = composition.local_tx_work_runner
+    original_run = runner.run
+    runner.run = AsyncMock(wraps=original_run)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    wire: list[bytes] = []
+    predicates: list[Callable[[], bool] | None] = []
+
+    async def delayed_send_raw(
+        frame: bytes,
+        **kwargs: object,
+    ) -> CivFrame:
+        predicate = kwargs.get("is_current")
+        assert predicate is None or callable(predicate)
+        predicates.append(predicate)
+        entered.set()
+        await release.wait()
+        if predicate is None or predicate():
+            wire.append(frame)
+        return _ack()
+
+    radio._send_civ_raw = delayed_send_raw
+    sending = asyncio.create_task(radio.send_cw_text("A" * 31))
+    await entered.wait()
+
+    cleanup = composition._abort_fence.force_off()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await sending
+    result = await cleanup
+
+    runner.run.assert_awaited_once()
+    assert result.failures == ()
+    assert len(predicates) == 2
+    assert predicates[0] is predicates[1]
+    assert predicates[0] is not None
+    assert predicates[0]() is False
+    assert wire == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", [1, 2])
+async def test_icom_force_off_suppresses_late_tuner_write(
+    tmp_path,
+    value: int,
+) -> None:
+    radio = _icom_radio()
+    composition = ManagedTxComposition(radio, config_path=tmp_path / "managed-tx.json")
+    install_managed_tx_composition(radio, composition)
+    runner = composition.local_tx_work_runner
+    original_run = runner.run
+    runner.run = AsyncMock(wraps=original_run)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    wire: list[bytes] = []
+    predicates: list[Callable[[], bool] | None] = []
+
+    async def delayed_send_raw(
+        frame: bytes,
+        **kwargs: object,
+    ) -> None:
+        predicate = kwargs.get("is_current")
+        assert predicate is None or callable(predicate)
+        predicates.append(predicate)
+        entered.set()
+        await release.wait()
+        if predicate is None or predicate():
+            wire.append(frame)
+
+    radio._send_civ_raw = delayed_send_raw
+    tuning = asyncio.create_task(radio.set_tuner_status(value))
+    await entered.wait()
+
+    cleanup = composition._abort_fence.force_off()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await tuning
+    result = await cleanup
+
+    runner.run.assert_awaited_once()
+    assert result.failures == ()
+    assert len(predicates) == 1
+    assert predicates[0] is not None
+    assert predicates[0]() is False
+    assert wire == []
+
+
+@pytest.mark.asyncio
+async def test_icom_managed_empty_cw_stop_and_tuner_off_remain_direct(
+    tmp_path,
+) -> None:
+    radio = _icom_radio()
+    composition = ManagedTxComposition(radio, config_path=tmp_path / "managed-tx.json")
+    install_managed_tx_composition(radio, composition)
+    runner = composition.local_tx_work_runner
+    original_run = runner.run
+    runner.run = AsyncMock(wraps=original_run)
+    radio._send_civ_raw = AsyncMock(return_value=None)
+
+    await radio.send_cw_text("")
+    await radio.stop_cw_text()
+    await radio.set_tuner_status(0)
+
+    runner.run.assert_not_awaited()
+    assert radio._send_civ_raw.await_args_list[0].kwargs == {
+        "priority": Priority.IMMEDIATE
+    }
+    assert radio._send_civ_raw.await_args_list[1].kwargs == {"wait_response": False}
+
+
+@pytest.mark.asyncio
+async def test_icom_unmanaged_calls_and_public_signatures_stay_direct() -> None:
+    radio = _icom_radio()
+    radio._send_civ_expect = AsyncMock(return_value=_ack())
+    radio._send_civ_raw = AsyncMock(return_value=None)
+
+    await radio.send_cw_text("CQ")
+    await radio.set_tuner_status(2)
+
+    assert radio._send_civ_expect.await_args.kwargs == {"label": "send_cw_text"}
+    assert radio._send_civ_raw.await_args.kwargs == {"wait_response": False}
+    assert "is_current" not in inspect.signature(CoreRadio.send_cw_text).parameters
+    assert "is_current" not in inspect.signature(CoreRadio.stop_cw_text).parameters
+    assert "is_current" not in inspect.signature(CoreRadio.set_tuner_status).parameters

--- a/tests/test_local_tx_work.py
+++ b/tests/test_local_tx_work.py
@@ -53,10 +53,60 @@ async def test_work_currency_tracks_the_externally_owned_fence() -> None:
     await started.wait()
     cleanup = fence.force_off()
     release.set()
-    await task
+    with pytest.raises(asyncio.CancelledError):
+        await task
     await cleanup
 
     assert observed == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_poisoned_operation_cannot_return_stale_success_before_cleanup() -> None:
+    fence = TxAbortFence()
+    runner = LocalTxWorkRunner(fence)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def work(is_current: Callable[[], bool]) -> str:
+        assert is_current()
+        started.set()
+        await release.wait()
+        return "stale success"
+
+    task = asyncio.create_task(runner.run(work))
+    await started.wait()
+    cleanup = fence.force_off()
+    try:
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        result = await cleanup
+
+    assert result.failures == ()
+
+
+@pytest.mark.asyncio
+async def test_force_off_reports_provider_cancellation_cleanup_failure() -> None:
+    fence = TxAbortFence()
+    runner = LocalTxWorkRunner(fence)
+    started = asyncio.Event()
+
+    async def work(_is_current: Callable[[], bool]) -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raise RuntimeError("provider cancellation cleanup failed")
+
+    task = asyncio.create_task(runner.run(work))
+    await started.wait()
+    result = await fence.force_off()
+
+    assert len(result.failures) == 1
+    assert result.failures[0].error.args == ("provider cancellation cleanup failed",)
+    with pytest.raises(RuntimeError, match="provider cancellation cleanup failed"):
+        await task
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- harden `LocalTxWorkRunner` so one owned provider task is cancelled and drained, cleanup failures reach `TxAbortResult.failures`, and a poisoned operation cannot return stale success after provider completion;
- let `CoreRadio` accept the production composition's exact local-TX runner and pass its live currency check through every managed Icom CW chunk and tuner-on/tune final write;
- retain direct behavior for empty CW, CW stop, tuner off, and every unmanaged call.

## Boundary

- Public `send_cw_text`, `stop_cw_text`, and `set_tuner_status` signatures are unchanged. The only signature extension is the private `_send_civ_expect(..., is_current=None)` seam, forwarded to the already-guarded `_send_civ_raw` path.
- Production additions contain no `LocalTxWorkRunner(...)` or `TxAbortFence(...)` construction. `CoreRadio` only predeclares the private injection seat used by `install_managed_tx_composition`, so the runner, fence, and authority retain one exact composition identity.
- No queue, watchdog, timer, authority, public API, or observed-RF mechanism was added.

## Search before write

Before the first push, `git ls-remote --heads origin refs/heads/codex/icom-local-tx-fence` returned no branch and `gh pr list --state all --head codex/icom-local-tx-fence` returned `[]`.

## Exact packet

- base: `55b87c8a8d5b40ac8b058a7e58157d330cb7407c`
- base tree: `a0782e30706baa0623623f7752a2b7f0860d0e56`
- head: `1b00884115ea5f3acc4ba9aa0adebd99e2d23df4`
- head tree: `5e110e664c2e45cb030b7da50418eaf2abcd9636`
- scope: 4 files, +320/-21

| Path | Additions | Deletions |
| --- | ---: | ---: |
| `src/rigplane/runtime/local_tx_work.py` | 27 | 14 |
| `src/rigplane/runtime/radio.py` | 40 | 6 |
| `tests/test_fenced_local_tx_providers.py` | 202 | 0 |
| `tests/test_local_tx_work.py` | 51 | 1 |

The two intervening main commits changed none of these four paths; the final-base rebuild applied without overlap.

## Mac Mini TDD evidence

- RED test-only `1fda823af9f168269cbdf679ca4bf663c6af57be`: [focused run 33887232647](https://github.com/rigplane/rigplane-core/actions/runs/33887232647), [job](https://github.com/rigplane/rigplane-core/actions/runs/33887232647/job/101069909823) — 16 collected, 8 expected discriminator failures and 8 passes; Ruff passed and all four files were formatted.
- Initial GREEN candidate `6d8a8495606d69ee7878a630fb7dfa28a8d958f1`: [focused run 33887410182](https://github.com/rigplane/rigplane-core/actions/runs/33887410182) — 15/16 passed; the only failure was a synchronous test fixture constructing the async composition without a running loop. No production code changed in the correction.
- Final GREEN exact head: [focused run 33887591539](https://github.com/rigplane/rigplane-core/actions/runs/33887591539), [job](https://github.com/rigplane/rigplane-core/actions/runs/33887591539/job/101071094104) — SUCCESS, 16/16 focused tests plus Ruff check and Ruff format check.

No product pytest was run locally. Local checks were limited to Ruff check, Ruff format check, and `git diff --check`.

## Isolated mutation evidence

Each mutation was committed away from the final branch and checked through the focused workflow. Every run kept Ruff check and format check green while the named discriminator failed.

| Mutated invariant | Mutant | Focused evidence | Expected kill |
| --- | --- | --- | --- |
| post-provider currency recheck removed | `e5c84bec1cdbe1a9649e65ffdd9b635d63dc99a4` | [33888682410](https://github.com/rigplane/rigplane-core/actions/runs/33888682410) | stale success did not raise `CancelledError` |
| cancellation cleanup exceptions swallowed | `e976db51a3509e97de47cd29d74db0930f620104` | [33888739361](https://github.com/rigplane/rigplane-core/actions/runs/33888739361) | cleanup failure disappeared from `TxAbortResult.failures` |
| `CoreRadio` runner injection seat removed | `f04cce794f76f4633b47c1aeec8dcbb43f160cc1` | [33888800786](https://github.com/rigplane/rigplane-core/actions/runs/33888800786) | exact composition identity test failed |
| CW final-write currency dropped | `79ba3d7deb36118fee514b61aef296f2137fb431` | [33888876497](https://github.com/rigplane/rigplane-core/actions/runs/33888876497) | chunk predicate became `None` |
| tuner values 1 and 2 sent directly | `e3a61f74e20b5e2b5d96e281ddfc775ccb567360` | [33888941817](https://github.com/rigplane/rigplane-core/actions/runs/33888941817) | both parameter rows failed to cancel/suppress the stale write |
