### PR TITLE
MOR-2328/MOR-2329: LCD live-frame cutover

### DIFF
--- a/frontend/fixtures/stubs/runtime.ts
+++ b/frontend/fixtures/stubs/runtime.ts
@@ -25,6 +25,29 @@ const DEFAULT_SCOPE_STATUS = {
   lifecycle: 'inactive' as const, transport: 'disconnected' as const, frameSeen: false,
 };
 
+type FixturePresentationResource = 'hardware-scope' | 'audio-fft';
+type FixturePresentationLease = Readonly<{
+  resource: FixturePresentationResource;
+  sessionEpoch: 'fixture';
+}>;
+const fixturePresentationLeases = new Set<FixturePresentationLease>();
+
+/**
+ * Fixture-only compatibility seam for explicitly selected LCD frame sources.
+ * It records lease identity for balanced release but intentionally owns no
+ * producer, controller, channel, or transport.
+ */
+export const presentationResources = Object.freeze({
+  acquire(resource: FixturePresentationResource, _consumer: string): FixturePresentationLease {
+    const lease = Object.freeze({ resource, sessionEpoch: 'fixture' as const });
+    fixturePresentationLeases.add(lease);
+    return lease;
+  },
+  release(lease: FixturePresentationLease): boolean {
+    return fixturePresentationLeases.delete(lease);
+  },
+});
+
 export const runtime = {
   get state() { return harness.state; },
   get caps() { return harness.caps; },

--- a/frontend/src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts
@@ -21,6 +21,7 @@ import { readFileSync } from 'node:fs';
 import { mount, unmount, flushSync } from 'svelte';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
 import type { ManagedTxState } from '$lib/runtime/tx-controller/managed-state';
+import { presentationResources } from '$lib/runtime';
 
 // -- Child components the shell mounts that are irrelevant here -------------
 vi.mock('../../../components/spectrum/SpectrumPanel.svelte', async () => {
@@ -369,16 +370,37 @@ describe('orientation change preserves App authority (MOR-1086 doctrine)', () =>
     expect(tx.transmitOn).toHaveBeenCalledTimes(1);
   });
 
-  // Kills: the semantic subtree taking its own App resource demand. It is
-  // destroyed and rebuilt on every rotation, so any demand it held would
-  // bounce the mobile hardware-scope stream (the MOR-1092 mutation, applied
-  // to mobile). Demand belongs to SpectrumPanel via the skin resource plan.
-  it('leaves App resource demand entirely outside the semantic subtree', () => {
-    const wiringSource = readFileSync('src/components-v2/wiring/SemanticRadioSurfaces.svelte', 'utf8');
-    for (const source of [mobileLayoutSource, wiringSource]) {
-      expect(source).not.toContain('presentationResources');
-      expect(source).not.toContain('resource-demand');
-    }
+  // Kills: treating every semantic mount as selected LCD demand. Explicit
+  // LCD faces may lease their selected source at the shared wiring host, but
+  // mobile passes no displayFrameSource. Its destroy/rebuild on rotation must
+  // therefore never bounce either canonical App resource.
+  it('keeps undefined-source mobile mount, rotation, rebuild, and destroy at zero demand', () => {
+    const acquire = vi.spyOn(presentationResources, 'acquire');
+    const release = vi.spyOn(presentationResources, 'release');
+    const t = mountMobile();
+    expect(t.querySelectorAll('[data-testid="semantic-radio-surfaces"]')).toHaveLength(1);
+    expect(acquire).not.toHaveBeenCalled();
+    expect(release).not.toHaveBeenCalled();
+
+    rotate(true);
+    expect(t.querySelectorAll('[data-testid="semantic-radio-surfaces"]')).toHaveLength(0);
+    expect(acquire).not.toHaveBeenCalled();
+    expect(release).not.toHaveBeenCalled();
+
+    rotate(false);
+    expect(t.querySelectorAll('[data-testid="semantic-radio-surfaces"]')).toHaveLength(1);
+    expect(acquire).not.toHaveBeenCalled();
+    expect(release).not.toHaveBeenCalled();
+
+    const mounted = components.splice(0);
+    mounted.forEach((component) => unmount(component));
+    flushSync();
+    expect(acquire).not.toHaveBeenCalled();
+    expect(release).not.toHaveBeenCalled();
+
+    expect(mobileLayoutSource).not.toContain('presentationResources');
+    expect(mobileLayoutSource).not.toContain('resource-demand');
+    expect(mobileLayoutSource).not.toContain('displayFrameSource');
     // The plan still names hardware-scope for mobile, owned by SpectrumPanel.
     const registrySource = readFileSync('src/skins/registry.ts', 'utf8');
     expect(registrySource).toContain("'mobile': ['hardware-scope']");

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -14,7 +14,8 @@
 <script lang="ts">
   import { onDestroy, untrack, type Snippet } from 'svelte';
   import { t } from '$lib/i18n';
-  import { runtime } from '$lib/runtime';
+  import { presentationResources, runtime } from '$lib/runtime';
+  import { ScopeFrameHost } from '$lib/runtime/scope-frame-host';
   import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
   import {
     EMPTY_PBT_PRESENTATION, projectPbtPresentation, type PbtField,
@@ -61,6 +62,9 @@
     forReceiver, receiversOf, isActiveStrip, isOperationalStrip,
   } from './dual-receiver-strips';
   import { guardRadioViewModel } from './radio-view-model-guard';
+  import type {
+    LcdSpectrumFrame, LcdSpectrumFrameResolution, LcdSpectrumSource,
+  } from '../../skins/segmentline/lcd-display-contract';
 
   /**
    * `'single'` (default) is the pre-MOR-1067 composition, wrapped per zone
@@ -82,7 +86,8 @@
     strips?: 'single' | 'dual';
     regions?: boolean;
     regionContent?: Snippet;
-    readonlyDisplay?: Snippet<[RadioViewModel]>;
+    displayFrameSource?: LcdSpectrumSource;
+    readonlyDisplay?: Snippet<[RadioViewModel, LcdSpectrumFrame?]>;
   }
   /**
    * MOR-2231 — `regions` routes `vfo`/`rxTx` through the generic `zoned()`
@@ -104,7 +109,9 @@
    * question: `desktop-v2` and `sdr-test` declare the same two zone ids, so
    * `zoneOwning()` returns non-null on both faces.
    */
-  let { strips = 'single', regions = false, regionContent, readonlyDisplay }: Props = $props();
+  let {
+    strips = 'single', regions = false, regionContent, displayFrameSource, readonlyDisplay,
+  }: Props = $props();
 
   /**
    * MOR-1082 — the workspace's per-zone `visibleSurfaces`/`zoneOrder`, resolved
@@ -474,6 +481,69 @@
       toRadioViewModel(runtime.state, runtime.caps, txState, rxAudioSnapshot, scopeDisplaySnapshot),
     ),
   );
+  let selectedDisplayFrame = $state.raw<LcdSpectrumFrame | undefined>(undefined);
+  let scopeFrameHost: ScopeFrameHost | null = null;
+  let stopWatchingScopeFrameHost: (() => void) | null = null;
+
+  function acceptDisplayFrameResolution(resolution: LcdSpectrumFrameResolution): void {
+    selectedDisplayFrame = resolution.state === 'live' ? resolution.frame : undefined;
+  }
+
+  function ensureScopeFrameHost(): ScopeFrameHost {
+    if (scopeFrameHost !== null) return scopeFrameHost;
+    scopeFrameHost = new ScopeFrameHost(runtime.scope);
+    stopWatchingScopeFrameHost = scopeFrameHost.subscribe(acceptDisplayFrameResolution);
+    return scopeFrameHost;
+  }
+
+  $effect(() => {
+    const source = displayFrameSource;
+    if (source === undefined) {
+      scopeFrameHost?.updateAuthority(null);
+      selectedDisplayFrame = undefined;
+      return;
+    }
+
+    const host = ensureScopeFrameHost();
+    const stateGeneration = runtime.state?.providerGeneration;
+    const capsGeneration = runtime.caps?.providerGeneration;
+    const receiver = canonicalView?.activeReceiver;
+    const authority = receiver?.status === 'known'
+      && typeof stateGeneration === 'number'
+      && Number.isSafeInteger(stateGeneration)
+      && stateGeneration >= 0
+      && typeof capsGeneration === 'number'
+      && Number.isSafeInteger(capsGeneration)
+      && capsGeneration >= 0
+      && stateGeneration === capsGeneration
+      ? { source, receiver: receiver.receiver, providerGeneration: stateGeneration }
+      : null;
+    host.updateAuthority(authority);
+    acceptDisplayFrameResolution(host.snapshot());
+  });
+
+  $effect(() => {
+    const source = displayFrameSource;
+    if (source === undefined) return;
+    ensureScopeFrameHost();
+    const resource = source === 'audio-fft' ? 'audio-fft' : 'hardware-scope';
+    const lease = presentationResources.acquire(resource, 'SemanticRadioSurfaces.readonlyDisplay');
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+      presentationResources.release(lease);
+    };
+  });
+
+  onDestroy(() => {
+    const stop = stopWatchingScopeFrameHost;
+    const host = scopeFrameHost;
+    stopWatchingScopeFrameHost = null;
+    scopeFrameHost = null;
+    try { stop?.(); } finally { host?.dispose(); }
+  });
+
   let pbtPresentation: PbtPresentationState = $state(EMPTY_PBT_PRESENTATION);
   // A disconnect makes every currently-held PBT observation prior-session
   // evidence. Floors are per provider/receiver/field: monotonic markers are
@@ -688,7 +758,7 @@
 
 <div class="semantic-surfaces" data-testid="semantic-radio-surfaces">
   {#if readonlyDisplay}
-    {#if view}{@render readonlyDisplay(view)}{/if}
+    {#if view}{@render readonlyDisplay(view, selectedDisplayFrame)}{/if}
   {:else}
   {#if view}
     {#if strips === 'dual'}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-lcd-display-frame-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-lcd-display-frame-wiring.component.test.ts
@@ -1,0 +1,340 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createRawSnippet, flushSync, type Snippet,
+} from 'svelte';
+import { createClassComponent } from 'svelte/legacy';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import type { RadioViewModel } from '../../../semantic/radio-view-model';
+import type {
+  LcdSpectrumFrame, LcdSpectrumFrameResolution, LcdSpectrumSource,
+} from '../../../skins/segmentline/lcd-display-contract';
+
+type Authority = Readonly<{
+  source: LcdSpectrumSource;
+  receiver: 'MAIN' | 'SUB' | null;
+  providerGeneration: number | null;
+}>;
+
+const h = vi.hoisted(() => ({
+  events: [] as string[],
+  hostInstances: [] as Array<{
+    authorities: Array<Authority | null>;
+    emit: (resolution: LcdSpectrumFrameResolution) => void;
+    dispose: () => void;
+  }>,
+  acquire: vi.fn((resource: string) => {
+    h.events.push(`acquire:${resource}`);
+    return Object.freeze({ resource, id: h.events.length });
+  }),
+  release: vi.fn((lease: { resource: string }) => {
+    h.events.push(`release:${lease.resource}`);
+    return true;
+  }),
+  subscribeCount: 0,
+  unsubscribeCount: 0,
+  disposeCount: 0,
+  frameGetter: null as null | (() => unknown),
+  viewGetter: null as null | (() => unknown),
+  renderCount: 0,
+  rawAudioFrame: Object.freeze({ pixels: new Uint8Array([255, 0]), startFreq: 1, endFreq: 2 }),
+  rawHardwareFrame: Object.freeze({ pixels: new Uint8Array([0, 255]), startFreq: 3, endFreq: 4 }),
+  txController: null as unknown,
+}));
+
+vi.mock('$lib/runtime/scope-frame-host', () => ({
+  ScopeFrameHost: class FakeScopeFrameHost {
+    readonly authorities: Array<Authority | null> = [];
+    private resolution: LcdSpectrumFrameResolution = { state: 'ghost', reason: 'missing' };
+    private listener: ((resolution: LcdSpectrumFrameResolution) => void) | null = null;
+    private disposed = false;
+
+    constructor(_scope: unknown) {
+      h.hostInstances.push(this);
+    }
+
+    updateAuthority(authority: Authority | null): void {
+      this.authorities.push(authority);
+      this.resolution = { state: 'ghost', reason: authority ? 'missing' : 'receiver-unknown' };
+      this.listener?.(this.resolution);
+    }
+
+    snapshot(): LcdSpectrumFrameResolution {
+      return this.resolution;
+    }
+
+    subscribe(listener: (resolution: LcdSpectrumFrameResolution) => void): () => void {
+      this.listener = listener;
+      h.subscribeCount += 1;
+      let active = true;
+      return () => {
+        if (!active) return;
+        active = false;
+        this.listener = null;
+        h.unsubscribeCount += 1;
+      };
+    }
+
+    emit(resolution: LcdSpectrumFrameResolution): void {
+      this.resolution = resolution;
+      this.listener?.(resolution);
+    }
+
+    dispose(): void {
+      if (this.disposed) return;
+      this.disposed = true;
+      h.disposeCount += 1;
+      this.listener = null;
+    }
+  },
+}));
+
+vi.mock('$lib/runtime', async () => {
+  const { radio } = await import('$lib/stores/radio.svelte');
+  const { getCapabilities } = await import('$lib/stores/capabilities.svelte');
+  return {
+    presentationResources: {
+      acquire: h.acquire,
+      release: h.release,
+    },
+    runtime: {
+      onTxAudioDied: () => () => {},
+      get state() { return radio.current; },
+      get caps() { return getCapabilities(); },
+      get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
+      get connectionAudio() { return false; },
+      get defaultScopeStatus() {
+        return {
+          source: null, available: false, resourceSelected: false, demand: 0,
+          lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+        };
+      },
+      get radioPowerOn() { return null; },
+      get scope() {
+        return {
+          hardwareScopeConnected: false,
+          audioScopeFrame: h.rawAudioFrame,
+          scopeFrame: h.rawHardwareFrame,
+        };
+      },
+    },
+  };
+});
+
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: null }),
+  getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+}));
+vi.mock('$lib/runtime/tx-controller/managed-app-host', () => ({
+  getManagedAppTxController: () => {
+    if (h.txController === null) throw new Error('managed TX harness is not installed');
+    return h.txController;
+  },
+}));
+
+import { radio, resetRadioState } from '$lib/stores/radio.svelte';
+import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
+import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
+
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
+
+function liveState(providerGeneration = 7, active: 'MAIN' | 'SUB' = 'MAIN'): ServerState {
+  const paths = ['active', 'split', 'dualWatch', 'txTarget'];
+  for (const rx of ['main', 'sub']) {
+    paths.push(`${rx}.freqHz`, `${rx}.mode`, `${rx}.filter`, `${rx}.activeSlot`);
+    for (const vfo of ['vfoA', 'vfoB']) {
+      paths.push(`${rx}.${vfo}.freqHz`, `${rx}.${vfo}.mode`, `${rx}.${vfo}.filterNum`);
+    }
+  }
+  const receiver = (frequency: number) => ({
+    ...slot(frequency), vfoA: slot(frequency), vfoB: slot(frequency + 50_000),
+    activeSlot: 'A', filter: 1,
+  });
+  return {
+    providerGeneration, active, split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: active, slot: 'A', frequencyHz: 14_250_000 },
+    main: receiver(14_250_000), sub: receiver(14_300_000),
+    fieldStatus: Object.fromEntries(paths.map((path) => [path, fresh])),
+  } as unknown as ServerState;
+}
+
+function liveCaps(providerGeneration = 7): Capabilities {
+  return {
+    stateContractVersion: 1, providerGeneration,
+    model: 'fixture', scope: true, audio: true, tx: true,
+    capabilities: ['audio', 'scope', 'tx', 'dual_rx'],
+    receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48_000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false }, txBands: [],
+    scopeSource: 'hardware', audioFftAvailable: true,
+  } as Capabilities;
+}
+
+const readonlyDisplay = createRawSnippet<[RadioViewModel, LcdSpectrumFrame?]>(
+  (view, frame) => {
+    h.viewGetter = view;
+    h.frameGetter = frame ?? (() => undefined);
+    h.renderCount += 1;
+    return { render: () => '<output data-testid="lcd-display"></output>' };
+  },
+) as Snippet<[RadioViewModel, LcdSpectrumFrame?]>;
+
+const audioFrame: LcdSpectrumFrame = Object.freeze({
+  source: 'audio-fft', receiver: 'MAIN', freshness: 'fresh',
+  startHz: 14_000_000, endHz: 14_100_000, normalizedBins: Object.freeze([0, 0.5, 1]),
+});
+const hardwareFrame: LcdSpectrumFrame = Object.freeze({
+  source: 'hardware', receiver: 'SUB', freshness: 'fresh',
+  startHz: 7_000_000, endHz: 7_100_000, normalizedBins: Object.freeze([1, 0.5, 0]),
+});
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof createClassComponent> | null = null;
+let txHarness: ManagedAppTxHarness;
+
+function render(
+  source?: LcdSpectrumSource,
+  strips: 'single' | 'dual' = 'single',
+): ReturnType<typeof createClassComponent> {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = createClassComponent({
+    component: SemanticRadioSurfaces,
+    target,
+    props: { strips, readonlyDisplay, displayFrameSource: source },
+  });
+  flushSync();
+  return component;
+}
+
+beforeEach(() => {
+  txHarness = new ManagedAppTxHarness();
+  h.txController = txHarness.controller;
+  radio.current = liveState();
+  expect(setCapabilities(liveCaps())).toBe(true);
+  h.events.length = 0;
+  h.hostInstances.length = 0;
+  h.acquire.mockClear();
+  h.release.mockClear();
+  h.subscribeCount = 0;
+  h.unsubscribeCount = 0;
+  h.disposeCount = 0;
+  h.frameGetter = null;
+  h.viewGetter = null;
+  h.renderCount = 0;
+});
+
+afterEach(() => {
+  component?.$destroy();
+  component = null;
+  flushSync();
+  resetRadioState();
+  clearCapabilities();
+  vi.restoreAllMocks();
+  document.body.innerHTML = '';
+});
+
+describe('MOR-2329 semantic LCD display-frame binding', () => {
+  it('owns one selected-source lease, preserves live identity, and switches sources without fallback', () => {
+    render('audio-fft');
+
+    expect(h.hostInstances).toHaveLength(1);
+    const host = h.hostInstances[0];
+    expect(host.authorities.at(-1)).toEqual({
+      source: 'audio-fft', receiver: 'MAIN', providerGeneration: 7,
+    });
+    expect(h.events).toEqual(['acquire:audio-fft']);
+    expect(h.frameGetter?.()).toBeUndefined();
+
+    host.emit({ state: 'live', frame: audioFrame });
+    flushSync();
+    expect(h.frameGetter?.()).toBe(audioFrame);
+
+    host.emit({ state: 'ghost', reason: 'stale' });
+    flushSync();
+    expect(h.frameGetter?.()).toBeUndefined();
+    expect(h.events).toEqual(['acquire:audio-fft']);
+
+    component?.$set({ displayFrameSource: 'hardware' });
+    flushSync();
+    expect(h.events).toEqual([
+      'acquire:audio-fft', 'release:audio-fft', 'acquire:hardware-scope',
+    ]);
+    expect(h.hostInstances).toHaveLength(1);
+    expect(host.authorities.at(-1)).toEqual({
+      source: 'hardware', receiver: 'MAIN', providerGeneration: 7,
+    });
+    expect(h.frameGetter?.()).toBeUndefined();
+
+    host.emit({ state: 'live', frame: hardwareFrame });
+    flushSync();
+    expect(h.frameGetter?.()).toBe(hardwareFrame);
+    expect(h.acquire.mock.calls.map(([resource]) => resource)).toEqual([
+      'audio-fft', 'hardware-scope',
+    ]);
+  });
+
+  it('updates canonical authority without reacquiring demand and fails closed on disagreement', () => {
+    render('hardware');
+    const host = h.hostInstances[0];
+    expect(h.events).toEqual(['acquire:hardware-scope']);
+
+    radio.current = liveState(8, 'SUB');
+    flushSync();
+    expect(host.authorities.at(-1)).toBeNull();
+    expect(h.events).toEqual(['acquire:hardware-scope']);
+
+    expect(setCapabilities(liveCaps(8))).toBe(true);
+    flushSync();
+    expect(host.authorities.at(-1)).toEqual({
+      source: 'hardware', receiver: 'SUB', providerGeneration: 8,
+    });
+    expect(h.events).toEqual(['acquire:hardware-scope']);
+
+    for (const reason of ['receiver-mismatch', 'source-mismatch', 'stale', 'missing'] as const) {
+      host.emit({ state: 'ghost', reason });
+      flushSync();
+      expect(h.frameGetter?.()).toBeUndefined();
+      expect(h.events).toEqual(['acquire:hardware-scope']);
+    }
+  });
+
+  it('acquires no source for the shared readonly path and tears a defined source down exactly once', () => {
+    render();
+    expect(h.hostInstances).toHaveLength(0);
+    expect(h.events).toEqual([]);
+    expect(h.frameGetter?.()).toBeUndefined();
+
+    component?.$destroy();
+    component = null;
+    const dualComponent = render(undefined, 'dual');
+    expect(h.hostInstances).toHaveLength(0);
+    expect(h.events).toEqual([]);
+
+    dualComponent.$set({ displayFrameSource: 'audio-fft' });
+    flushSync();
+    expect(h.hostInstances).toHaveLength(1);
+    expect(h.events).toEqual(['acquire:audio-fft']);
+
+    dualComponent.$destroy();
+    component = null;
+    flushSync();
+    expect(h.events).toEqual(['acquire:audio-fft', 'release:audio-fft']);
+    expect(h.subscribeCount).toBe(1);
+    expect(h.unsubscribeCount).toBe(1);
+    expect(h.disposeCount).toBe(1);
+  });
+
+  it('contains no raw-frame bypass or transport/channel authority', () => {
+    const source = readFileSync(resolve(
+      process.cwd(), 'src/components-v2/wiring/SemanticRadioSurfaces.svelte',
+    ), 'utf8');
+    expect(source).not.toMatch(/audioScopeFrame|scopeFrame\b|\$lib\/transport|getChannel|onBinary/);
+    expect(source.match(/new ScopeFrameHost\(/g)).toHaveLength(1);
+    expect(source).toContain("resolution.state === 'live' ? resolution.frame : undefined");
+  });
+});

--- a/frontend/src/lib/runtime/index.ts
+++ b/frontend/src/lib/runtime/index.ts
@@ -1,3 +1,3 @@
-export { runtime } from './frontend-runtime';
+export { presentationResources, runtime } from './frontend-runtime';
 export type { ConnectionSnapshot, ControlSessionSnapshot, ControlSessionSubscriber } from './frontend-runtime';
 export type { EibiStation, EibiResult } from './system-controller';

--- a/frontend/src/skins/segmentline/CenterstageDisplay.svelte
+++ b/frontend/src/skins/segmentline/CenterstageDisplay.svelte
@@ -7,11 +7,12 @@
   import LcdFilterScope from './LcdFilterScope.svelte';
   import LcdFrequencyReadout from './LcdFrequencyReadout.svelte';
   import LcdLinearSMeter from './LcdLinearSMeter.svelte';
+  import { resolveLcdSpectrumFrame } from './lcd-display-contract';
   import { stateText, telemetryText } from './lcd-display-helpers';
 
   interface Props {
     model: PeerSplitDisplayModel;
-    normalizedFftBins?: Partial<Record<'MAIN' | 'SUB', readonly number[]>>;
+    audioFftFrame?: unknown;
   }
 
   interface OrbitItem {
@@ -19,7 +20,7 @@
     readonly field: DisplayValue<number | string>;
   }
 
-  let { model, normalizedFftBins = {} }: Props = $props();
+  let { model, audioFftFrame }: Props = $props();
 
   const ghostReceiver: PeerSplitReceiverDisplay = {
     receiver: 'MAIN',
@@ -71,8 +72,14 @@
     { label: 'BAND', field: active.band },
     { label: 'AGC', field: active.dsp.agc },
   ]);
+  const activeAudioFft = $derived(
+    resolveLcdSpectrumFrame(audioFftFrame, {
+      source: 'audio-fft',
+      receiver: model.activeReceiver?.receiver ?? null,
+    }),
+  );
   const activeFftBins = $derived(
-    model.activeReceiver ? normalizedFftBins[model.activeReceiver.receiver] : undefined,
+    activeAudioFft.state === 'live' ? activeAudioFft.frame.normalizedBins : undefined,
   );
   const telemetry = $derived([
     { label: 'VD', field: model.telemetry.drainVoltage },

--- a/frontend/src/skins/segmentline/DominantUnifiedDisplay.svelte
+++ b/frontend/src/skins/segmentline/DominantUnifiedDisplay.svelte
@@ -10,17 +10,25 @@
   import LcdLinearSMeter from './LcdLinearSMeter.svelte';
   import LcdOffsetRail from './LcdOffsetRail.svelte';
   import LcdTelemetryRail from './LcdTelemetryRail.svelte';
+  import { resolveLcdSpectrumFrame } from './lcd-display-contract';
   import { notchIndicators, stateText } from './lcd-display-helpers';
 
   interface Props {
     model: PeerSplitDisplayModel;
-    normalizedFftBins?: Partial<Record<'MAIN' | 'SUB', readonly number[]>>;
+    spectrumFrame?: unknown;
   }
 
-  let { model, normalizedFftBins = {} }: Props = $props();
+  let { model, spectrumFrame }: Props = $props();
 
   const main = $derived(model.receivers[0]);
   const sub = $derived(model.receivers[1]);
+  const spectrumResolution = $derived(resolveLcdSpectrumFrame(spectrumFrame, {
+    source: 'audio-fft',
+    receiver: model.activeReceiver?.receiver ?? null,
+  }));
+  const activeSpectrumBins = $derived(
+    spectrumResolution.state === 'live' ? spectrumResolution.frame.normalizedBins : undefined,
+  );
 
   const activeDsp = $derived(model.activeReceiver?.dsp ?? {
     agc: { state: 'unknown' } as DisplayValue<number | string>,
@@ -202,7 +210,7 @@
       {#if model.activeReceiver}
         <LcdFilterScope
           receiver={model.activeReceiver}
-          normalizedBins={normalizedFftBins[model.activeReceiver.receiver]}
+          normalizedBins={activeSpectrumBins}
         />
       {:else}
         <div

--- a/frontend/src/skins/segmentline/LcdRfPanadapter.svelte
+++ b/frontend/src/skins/segmentline/LcdRfPanadapter.svelte
@@ -1,73 +1,166 @@
 <script module lang="ts">
-  import type { PeerSplitReceiverDisplay } from '../../semantic/radio-display-model';
+  import type { LcdSpectrumFrame } from './lcd-display-contract';
 
-  export interface LcdRfPanadapterFrame {
-    readonly receiver: PeerSplitReceiverDisplay['receiver'];
-    readonly freshness: 'fresh' | 'stale';
-    readonly normalizedBins: readonly number[];
+  export type LcdRfPanadapterFrame = LcdSpectrumFrame;
+
+  export interface LcdRfPanadapterPassband {
+    readonly mode: string;
+    readonly widthHz: number;
+    readonly shiftHz: number;
   }
 </script>
 
 <script lang="ts">
+  import { getPassbandGeometry } from '../../components/spectrum/passband-geometry';
+  import type { PeerSplitReceiverDisplay } from '../../semantic/radio-display-model';
+  import { resolveLcdSpectrumFrame } from './lcd-display-contract';
+
   interface Props {
     receiver: PeerSplitReceiverDisplay['receiver'] | null;
-    frame?: LcdRfPanadapterFrame;
+    frame?: unknown;
+    carrierHz?: number;
+    passband?: LcdRfPanadapterPassband;
   }
 
-  let { receiver, frame }: Props = $props();
+  interface AxisTick {
+    readonly frequencyHz: number;
+    readonly x: number;
+    readonly label: string;
+  }
 
-  type FrameReason = 'live' | 'missing' | 'stale' | 'receiver-unknown'
-    | 'receiver-mismatch' | 'invalid';
+  const PLOT_WIDTH = 600;
+  const PLOT_TOP = 18;
+  const PLOT_BOTTOM = 116;
+  const PLOT_HEIGHT = PLOT_BOTTOM - PLOT_TOP;
 
-  const frameReason: FrameReason = $derived.by(() => {
-    if (receiver === null) return 'receiver-unknown';
-    if (frame === undefined) return 'missing';
-    if (frame.freshness !== 'fresh') return 'stale';
-    if (frame.receiver !== receiver) return 'receiver-mismatch';
-    if (frame.normalizedBins.length < 2
-      || !frame.normalizedBins.every((sample) => (
-        Number.isFinite(sample) && sample >= 0 && sample <= 1
-      ))) return 'invalid';
-    return 'live';
+  let { receiver, frame, carrierHz, passband }: Props = $props();
+
+  function formatFrequency(hz: number): string {
+    const mhz = hz / 1_000_000;
+    return mhz >= 1 ? mhz.toFixed(3) : `${Math.round(hz / 1_000)}k`;
+  }
+
+  const resolution = $derived(resolveLcdSpectrumFrame(frame, {
+    source: 'hardware',
+    receiver,
+  }));
+  const liveFrame = $derived(resolution.state === 'live' ? resolution.frame : null);
+  const frameReason = $derived(resolution.state === 'live' ? 'live' : resolution.reason);
+  const spanHz = $derived(liveFrame === null ? 0 : liveFrame.endHz - liveFrame.startHz);
+  const renderBins = $derived(liveFrame?.normalizedBins ?? []);
+  const axisTicks: readonly AxisTick[] = $derived.by(() => {
+    if (liveFrame === null) return [];
+    return [0, 0.25, 0.5, 0.75, 1].map((ratio) => {
+      const frequencyHz = liveFrame.startHz + spanHz * ratio;
+      return { frequencyHz, x: PLOT_WIDTH * ratio, label: formatFrequency(frequencyHz) };
+    });
   });
-
-  const renderBins = $derived(frameReason === 'live' ? frame!.normalizedBins : []);
+  const carrierX = $derived.by(() => {
+    if (liveFrame === null || carrierHz === undefined || !Number.isFinite(carrierHz)
+      || carrierHz < liveFrame.startHz || carrierHz > liveFrame.endHz) return null;
+    return ((carrierHz - liveFrame.startHz) / spanHz) * PLOT_WIDTH;
+  });
+  const passbandGeometry = $derived.by(() => {
+    if (carrierX === null || passband === undefined
+      || !Number.isFinite(passband.widthHz) || passband.widthHz <= 0
+      || !Number.isFinite(passband.shiftHz)) return null;
+    return getPassbandGeometry(
+      passband.mode,
+      passband.widthHz,
+      passband.shiftHz,
+      spanHz,
+      PLOT_WIDTH,
+      carrierX,
+    );
+  });
 </script>
 
 <svg
   data-testid="lcd-rf-panadapter"
-  data-rf-mode={frameReason === 'live' ? 'live' : 'ghost'}
+  data-rf-mode={liveFrame === null ? 'ghost' : 'live'}
   data-frame-reason={frameReason}
-  viewBox="0 0 600 120"
+  data-start-hz={liveFrame?.startHz}
+  data-end-hz={liveFrame?.endHz}
+  viewBox="0 0 600 132"
   preserveAspectRatio="none"
   aria-hidden="true"
 >
-  <rect class="rf-frame" x="0.5" y="0.5" width="599" height="119" />
-  {#each [20, 40, 60, 80, 100] as y}
-    <line class="rf-grid" x1="0" x2="600" y1={y} y2={y} />
-  {/each}
-  {#each [60, 120, 180, 240, 300, 360, 420, 480, 540] as x}
-    <line class="rf-grid" x1={x} x2={x} y1="0" y2="120" />
-  {/each}
-  {#each renderBins as sample, index}
-    {@const binWidth = 600 / renderBins.length}
-    {@const binHeight = sample * 108}
-    <rect
-      class="rf-bin"
-      data-rf-bin={index}
-      data-rf-sample={sample}
-      x={index * binWidth}
-      y={116 - binHeight}
-      width={Math.max(0.5, binWidth - 0.5)}
-      height={binHeight}
-    />
-  {/each}
+  <rect class="rf-frame" x="0.5" y="0.5" width="599" height="131" />
+  {#if liveFrame !== null}
+    {#each axisTicks as tick}
+      <g class="rf-axis" data-axis-frequency={tick.frequencyHz}>
+        <line class="rf-grid" x1={tick.x} x2={tick.x} y1={PLOT_TOP} y2={PLOT_BOTTOM} />
+        <text
+          class="rf-axis-label"
+          x={tick.x}
+          y="12"
+          text-anchor={tick.x === 0 ? 'start' : tick.x === PLOT_WIDTH ? 'end' : 'middle'}
+        >{tick.label}</text>
+      </g>
+    {/each}
+    {#each [0.25, 0.5, 0.75] as ratio}
+      <line
+        class="rf-grid"
+        x1="0"
+        x2={PLOT_WIDTH}
+        y1={PLOT_TOP + PLOT_HEIGHT * ratio}
+        y2={PLOT_TOP + PLOT_HEIGHT * ratio}
+      />
+    {/each}
+    {#if passbandGeometry !== null && passbandGeometry.widthPx > 0}
+      <rect
+        class="rf-passband"
+        data-passband-mode={passband?.mode}
+        data-passband-width-hz={passband?.widthHz}
+        data-passband-shift-hz={passband?.shiftHz}
+        x={passbandGeometry.leftPx}
+        y={PLOT_TOP}
+        width={passbandGeometry.widthPx}
+        height={PLOT_HEIGHT}
+      />
+    {/if}
+    {#each renderBins as sample, index}
+      {@const binWidth = PLOT_WIDTH / renderBins.length}
+      {@const binHeight = sample * (PLOT_HEIGHT - 4)}
+      <rect
+        class="rf-bin"
+        data-rf-bin={index}
+        data-rf-sample={sample}
+        x={index * binWidth}
+        y={PLOT_BOTTOM - binHeight}
+        width={Math.max(0.5, binWidth - 0.5)}
+        height={binHeight}
+      />
+    {/each}
+    {#if carrierX !== null}
+      <line
+        class="rf-carrier"
+        data-carrier-hz={carrierHz}
+        x1={carrierX}
+        x2={carrierX}
+        y1={PLOT_TOP}
+        y2={PLOT_BOTTOM}
+      />
+    {/if}
+  {/if}
 </svg>
 
 <style>
   svg { display: block; width: 100%; height: 100%; min-height: 0; }
   .rf-frame { fill: none; stroke: var(--ink-soft); stroke-width: 1; }
   .rf-grid { stroke: var(--ink-ghost); stroke-width: 0.5; vector-effect: non-scaling-stroke; }
+  .rf-axis-label {
+    fill: var(--ink-mid);
+    font-family: 'Share Tech Mono', ui-monospace, monospace;
+    font-size: 8px;
+    font-variant-numeric: tabular-nums;
+  }
+  .rf-passband { fill: var(--ink-soft); opacity: 0.22; }
   .rf-bin { fill: var(--ink-mid); opacity: 0.86; }
-  svg[data-rf-mode='ghost'] .rf-grid { stroke: var(--ink-ghost); opacity: 0.55; }
+  .rf-carrier {
+    stroke: var(--ink-strong);
+    stroke-width: 1.25;
+    vector-effect: non-scaling-stroke;
+  }
+  svg[data-rf-mode='ghost'] .rf-frame { stroke: var(--ink-ghost); opacity: 0.55; }
 </style>

--- a/frontend/src/skins/segmentline/PanadapterDisplay.svelte
+++ b/frontend/src/skins/segmentline/PanadapterDisplay.svelte
@@ -5,14 +5,14 @@
   import LcdFrequencyReadout from './LcdFrequencyReadout.svelte';
   import LcdLinearSMeter from './LcdLinearSMeter.svelte';
   import LcdRfPanadapter, {
-    type LcdRfPanadapterFrame,
+    type LcdRfPanadapterPassband,
   } from './LcdRfPanadapter.svelte';
   import { stateText, telemetryText } from './lcd-display-helpers';
 
   interface Props {
     model: PeerSplitDisplayModel;
     normalizedFftBins?: Partial<Record<'MAIN' | 'SUB', readonly number[]>>;
-    rfFrame?: LcdRfPanadapterFrame;
+    rfFrame?: unknown;
   }
 
   let { model, normalizedFftBins = {}, rfFrame }: Props = $props();
@@ -21,6 +21,19 @@
   const activeAfBins = $derived(
     activeReceiver === null ? undefined : normalizedFftBins[activeReceiver.receiver],
   );
+  const activeCarrierHz = $derived(
+    activeReceiver?.frequency.state === 'known' ? activeReceiver.frequency.value : undefined,
+  );
+  const activePassband: LcdRfPanadapterPassband | undefined = $derived.by(() => {
+    if (activeReceiver?.mode.state !== 'known'
+      || activeReceiver.bandwidthHz.state !== 'known'
+      || activeReceiver.ifShiftHz.state !== 'known') return undefined;
+    return {
+      mode: activeReceiver.mode.value,
+      widthHz: activeReceiver.bandwidthHz.value,
+      shiftHz: activeReceiver.ifShiftHz.value,
+    };
+  });
   const telemetryItems = $derived([
     { label: 'VD', field: model.telemetry.drainVoltage },
     { label: 'ID', field: model.telemetry.drainCurrent },
@@ -31,7 +44,12 @@
   ]);
 </script>
 
-<div class="panadapter-display" data-testid="panadapter-display" data-rf-state={model.rfState}>
+<div
+  class="panadapter-display"
+  data-testid="panadapter-display"
+  data-native-stage="1280x594"
+  data-rf-state={model.rfState}
+>
   <div class="frequency-deck">
     {#each model.receivers as receiver (receiver.receiver)}
       <section
@@ -62,7 +80,12 @@
         {#if activeReceiver !== null}<small>{activeReceiver.label}</small>{/if}
       </div>
       <div class="rf-plot">
-        <LcdRfPanadapter receiver={activeReceiver?.receiver ?? null} frame={rfFrame} />
+        <LcdRfPanadapter
+          receiver={activeReceiver?.receiver ?? null}
+          frame={rfFrame}
+          carrierHz={activeCarrierHz}
+          passband={activePassband}
+        />
       </div>
     </section>
 

--- a/frontend/src/skins/segmentline/PeerSplitLayout.svelte
+++ b/frontend/src/skins/segmentline/PeerSplitLayout.svelte
@@ -23,6 +23,7 @@
   import CenterstageDisplay from './CenterstageDisplay.svelte';
   import DominantUnifiedDisplay from './DominantUnifiedDisplay.svelte';
   import LcdDisplayVariant, { type LcdDisplayVariantId } from './LcdDisplayVariant.svelte';
+  import type { LcdSpectrumFrame, LcdSpectrumSource } from './lcd-display-contract';
   import PanadapterDisplay from './PanadapterDisplay.svelte';
   import PeerSplitDisplay from './PeerSplitDisplay.svelte';
 
@@ -44,14 +45,27 @@
     displayVariant?: LcdDisplayVariantId;
   }
   let { canvasW, canvasH, minScale, displayVariant = 'peer' }: Props = $props();
+
+  /**
+   * The selected face declares exactly one potential LCD producer. The
+   * semantic host owns lifecycle and validates the resulting frame; this
+   * layout only selects the display's required source.
+   */
+  const displayFrameSource: LcdSpectrumSource | undefined = $derived(
+    displayVariant === 'dominant' || displayVariant === 'centerstage'
+      ? 'audio-fft'
+      : displayVariant === 'panadapter'
+        ? 'hardware'
+        : undefined,
+  );
 </script>
 
-{#snippet readonlyDisplay(view: RadioViewModel)}
+{#snippet readonlyDisplay(view: RadioViewModel, selectedFrame?: LcdSpectrumFrame)}
   {@const model = projectPeerSplitDisplay(view)}
   {#snippet peer()}<PeerSplitDisplay {model} />{/snippet}
-  {#snippet dominant()}<DominantUnifiedDisplay {model} />{/snippet}
-  {#snippet centerstage()}<CenterstageDisplay {model} />{/snippet}
-  {#snippet panadapter()}<PanadapterDisplay {model} />{/snippet}
+  {#snippet dominant()}<DominantUnifiedDisplay {model} spectrumFrame={selectedFrame} />{/snippet}
+  {#snippet centerstage()}<CenterstageDisplay {model} audioFftFrame={selectedFrame} />{/snippet}
+  {#snippet panadapter()}<PanadapterDisplay {model} rfFrame={selectedFrame} />{/snippet}
   <LcdDisplayVariant
     variant={displayVariant}
     {peer}
@@ -64,7 +78,7 @@
 <div class="peer-split-holder">
   <ScaledStage nativeW={canvasW} nativeH={canvasH} {minScale}>
     <div class="peer-split-glass" data-testid="peer-split-glass">
-      <SemanticRadioSurfaces strips="dual" {readonlyDisplay} />
+      <SemanticRadioSurfaces strips="dual" {displayFrameSource} {readonlyDisplay} />
     </div>
   </ScaledStage>
 </div>

--- a/frontend/src/skins/segmentline/__tests__/CenterstageDisplay.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/CenterstageDisplay.component.test.ts
@@ -4,6 +4,7 @@ import type {
   PeerSplitDisplayModel,
   PeerSplitReceiverDisplay,
 } from '../../../semantic/radio-display-model';
+import type { LcdSpectrumFrame } from '../lcd-display-contract';
 import CenterstageDisplay from '../CenterstageDisplay.svelte';
 
 const known = <T>(value: T) => ({ state: 'known' as const, value });
@@ -77,15 +78,27 @@ afterEach(() => {
 
 function render(
   displayModel: PeerSplitDisplayModel = model,
-  normalizedFftBins?: Partial<Record<'MAIN' | 'SUB', readonly number[]>>,
+  audioFftFrame?: unknown,
 ) {
   const target = document.createElement('div');
   document.body.appendChild(target);
   component = mount(CenterstageDisplay, {
     target,
-    props: { model: displayModel, normalizedFftBins },
+    props: { model: displayModel, audioFftFrame },
   });
   return target;
+}
+
+function audioFftFrame(overrides: Partial<LcdSpectrumFrame> = {}): LcdSpectrumFrame {
+  return {
+    source: 'audio-fft',
+    receiver: 'MAIN',
+    freshness: 'fresh',
+    startHz: 0,
+    endHz: 4_000,
+    normalizedBins: [0, 0.5, 1],
+    ...overrides,
+  };
 }
 
 function withActive(id: 'MAIN' | 'SUB'): PeerSplitDisplayModel {
@@ -101,7 +114,7 @@ function withActive(id: 'MAIN' | 'SUB'): PeerSplitDisplayModel {
 
 describe('CenterstageDisplay', () => {
   it('is passive and renders exactly one active-receiver meter and scope', () => {
-    const target = render(model, { MAIN: [0, 0.5, 1], SUB: [1, 0.5, 0] });
+    const target = render(model, audioFftFrame());
 
     expect(target.querySelectorAll('button,input,select,a[href],[tabindex],[role="button"],[role="switch"]')).toHaveLength(0);
     expect(target.innerHTML).not.toMatch(/onclick|onpointer|onwheel/i);
@@ -134,6 +147,18 @@ describe('CenterstageDisplay', () => {
     expect(hero.textContent).not.toContain('14.250.000');
     expect(target.querySelector('[data-testid="centerstage-secondary"]')?.textContent).toContain('14.195.500');
     expect(target.querySelector('[data-testid="centerstage-meter"]')?.getAttribute('data-state')).toBe('unknown');
+    expect(target.querySelector('[data-testid="lcd-af-fft"]')?.getAttribute('data-fft-mode')).toBe('safe-empty');
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['stale', audioFftFrame({ freshness: 'stale' })],
+    ['malformed', { source: 'audio-fft', receiver: 'MAIN', freshness: 'fresh', normalizedBins: [0] }],
+    ['source mismatch', audioFftFrame({ source: 'hardware' })],
+    ['receiver mismatch', audioFftFrame({ receiver: 'SUB' })],
+  ])('fails the audio FFT closed for a %s frame', (_case, frame) => {
+    const target = render(model, frame);
+
     expect(target.querySelector('[data-testid="lcd-af-fft"]')?.getAttribute('data-fft-mode')).toBe('safe-empty');
   });
 

--- a/frontend/src/skins/segmentline/__tests__/DominantUnifiedDisplay.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/DominantUnifiedDisplay.component.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { afterEach, describe, expect, it } from 'vitest';
 import { mount, unmount } from 'svelte';
 import type { PeerSplitDisplayModel } from '../../../semantic/radio-display-model';
+import type { LcdSpectrumFrame } from '../lcd-display-contract';
 import DominantUnifiedDisplay from '../DominantUnifiedDisplay.svelte';
 
 const known = <T>(value: T) => ({ state: 'known' as const, value });
@@ -69,14 +70,26 @@ afterEach(() => {
 
 function render(
   displayModel: PeerSplitDisplayModel = model,
-  normalizedFftBins?: Partial<Record<'MAIN' | 'SUB', readonly number[]>>,
+  spectrumFrame?: unknown,
 ) {
   const target = document.createElement('div');
   document.body.appendChild(target);
   component = mount(DominantUnifiedDisplay, {
-    target, props: { model: displayModel, normalizedFftBins },
+    target, props: { model: displayModel, spectrumFrame },
   });
   return target;
+}
+
+function audioFrame(overrides: Partial<LcdSpectrumFrame> = {}): LcdSpectrumFrame {
+  return {
+    source: 'audio-fft',
+    receiver: 'MAIN',
+    freshness: 'fresh',
+    startHz: 0,
+    endHz: 24_000,
+    normalizedBins: [0, 0.5, 1],
+    ...overrides,
+  };
 }
 
 describe('DominantUnifiedDisplay', () => {
@@ -102,7 +115,7 @@ describe('DominantUnifiedDisplay', () => {
   });
 
   it('uses exactly one unified AF FFT/filter scope for the active receiver', () => {
-    const target = render(model, { MAIN: [0, 0.5, 1], SUB: [1, 0.5, 0] });
+    const target = render(model, audioFrame());
 
     expect(target.querySelectorAll('[data-testid="lcd-af-fft"]')).toHaveLength(1);
     expect(target.querySelector('[data-testid="lcd-af-fft"]')?.getAttribute('data-fft-mode')).toBe('live');
@@ -117,7 +130,7 @@ describe('DominantUnifiedDisplay', () => {
     ];
     const target = render({
       ...model, receivers: subActiveReceivers, activeReceiver: subActiveReceivers[1],
-    }, { MAIN: [0, 0, 0], SUB: [0, 0.5, 1] });
+    }, audioFrame({ receiver: 'SUB', normalizedBins: [0, 0.5, 1] }));
 
     expect(target.querySelector('[data-testid="lcd-dominant-main"]')?.getAttribute('data-receiver-activity')).toBe('inactive');
     expect(target.querySelector('[data-testid="lcd-dominant-sub"]')?.getAttribute('data-receiver-activity')).toBe('active');
@@ -133,7 +146,8 @@ describe('DominantUnifiedDisplay', () => {
       { ...receivers[1], activity: 'unknown' },
     ];
     const target = render({ ...model, receivers: unknownReceivers, activeReceiver: null }, {
-      MAIN: [1, 0.5, 0], SUB: [0, 0.5, 1],
+      source: 'audio-fft', receiver: 'MAIN', freshness: 'fresh',
+      startHz: 0, endHz: 24_000, normalizedBins: [1, 0.5, 0],
     });
 
     expect(target.querySelector('[data-testid="lcd-dominant-scope-unknown"]')).not.toBeNull();
@@ -178,5 +192,26 @@ describe('DominantUnifiedDisplay', () => {
     expect(style).toContain('grid-template-rows: 132px 56px 52px minmax(0, 1fr);');
     expect(style).toContain(".fact[data-state='unsupported'] { visibility: hidden; }");
     expect(style).toContain(".fact[data-state='unknown'] { color: var(--ink-soft); }");
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['stale', audioFrame({ freshness: 'stale' })],
+    ['source mismatch', audioFrame({ source: 'hardware' })],
+    ['receiver mismatch', audioFrame({ receiver: 'SUB' })],
+    ['malformed', { source: 'audio-fft', receiver: 'MAIN', freshness: 'fresh', startHz: 0, endHz: 0, normalizedBins: [0] }],
+  ])('fails closed to an empty AF trace for %s input', (_label, spectrumFrame) => {
+    const target = render(model, spectrumFrame);
+
+    expect(target.querySelector('[data-testid="lcd-af-fft"]')?.getAttribute('data-fft-mode'))
+      .toBe('safe-empty');
+  });
+
+  it('uses the frozen source-qualified spectrum resolver', () => {
+    const source = readFileSync('src/skins/segmentline/DominantUnifiedDisplay.svelte', 'utf8');
+
+    expect(source).toContain("import { resolveLcdSpectrumFrame } from './lcd-display-contract';");
+    expect(source).toContain("source: 'audio-fft'");
+    expect(source).toContain("spectrumResolution.state === 'live'");
   });
 });

--- a/frontend/src/skins/segmentline/__tests__/LcdRfPanadapter.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/LcdRfPanadapter.component.test.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from 'node:fs';
 import { afterEach, describe, expect, it } from 'vitest';
 import { mount, unmount } from 'svelte';
+import type { LcdSpectrumFrame } from '../lcd-display-contract';
 import LcdRfPanadapter, {
-  type LcdRfPanadapterFrame,
+  type LcdRfPanadapterPassband,
 } from '../LcdRfPanadapter.svelte';
 
 let component: ReturnType<typeof mount> | null = null;
@@ -13,67 +14,153 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
+function hardwareFrame(overrides: Partial<LcdSpectrumFrame> = {}): LcdSpectrumFrame {
+  return {
+    source: 'hardware',
+    receiver: 'MAIN',
+    freshness: 'fresh',
+    startHz: 14_200_000,
+    endHz: 14_300_000,
+    normalizedBins: [0.15, 0.7, 0.35],
+    ...overrides,
+  };
+}
+
 function render(
-  frame?: LcdRfPanadapterFrame,
+  frame?: unknown,
   receiver: 'MAIN' | 'SUB' | null = 'MAIN',
+  carrierHz?: number,
+  passband?: LcdRfPanadapterPassband,
 ): HTMLElement {
   const target = document.createElement('div');
   document.body.appendChild(target);
-  component = mount(LcdRfPanadapter, { target, props: { receiver, frame } });
+  component = mount(LcdRfPanadapter, {
+    target, props: { receiver, frame, carrierHz, passband },
+  });
   return target;
 }
 
+function numberAttribute(target: Element, selector: string, attribute: string): number {
+  const value = target.querySelector(selector)?.getAttribute(attribute);
+  if (value === null || value === undefined) throw new Error(`${selector} lacks ${attribute}`);
+  return Number(value);
+}
+
 describe('LcdRfPanadapter', () => {
-  it('renders grid-only ghost geometry when no frame is supplied', () => {
+  it('renders frame-only ghost geometry when no hardware frame is supplied', () => {
     const target = render();
     const scope = target.querySelector('[data-testid="lcd-rf-panadapter"]');
 
     expect(scope?.getAttribute('data-rf-mode')).toBe('ghost');
     expect(scope?.getAttribute('data-frame-reason')).toBe('missing');
-    expect(target.querySelectorAll('[data-rf-bin]')).toHaveLength(0);
-    expect(target.querySelectorAll('.rf-grid')).not.toHaveLength(0);
-    expect(target.querySelector('.rf-trace')).toBeNull();
+    expect(target.querySelectorAll(
+      '[data-rf-bin],.rf-axis,.rf-grid,.rf-carrier,.rf-passband',
+    )).toHaveLength(0);
+    expect(target.querySelector('.rf-frame')).not.toBeNull();
   });
 
   it.each([
-    ['stale', { receiver: 'MAIN', freshness: 'stale', normalizedBins: [0.1, 0.8] }],
-    ['receiver-mismatch', { receiver: 'SUB', freshness: 'fresh', normalizedBins: [0.1, 0.8] }],
-    ['invalid', { receiver: 'MAIN', freshness: 'fresh', normalizedBins: [0.1, Number.NaN] }],
+    ['stale', hardwareFrame({ freshness: 'stale' })],
+    ['source-mismatch', hardwareFrame({ source: 'audio-fft' })],
+    ['receiver-mismatch', hardwareFrame({ receiver: 'SUB' })],
+    ['invalid', hardwareFrame({ endHz: 14_200_000 })],
+    ['invalid', hardwareFrame({ normalizedBins: [0.1, Number.NaN] })],
+    ['invalid', { state: 'unsupported' }],
   ] as const)('fails closed for a %s frame', (reason, frame) => {
-    const target = render(frame);
+    const target = render(frame, 'MAIN', 14_250_000, {
+      mode: 'USB', widthHz: 2_400, shiftHz: 0,
+    });
     const scope = target.querySelector('[data-testid="lcd-rf-panadapter"]');
 
     expect(scope?.getAttribute('data-rf-mode')).toBe('ghost');
     expect(scope?.getAttribute('data-frame-reason')).toBe(reason);
-    expect(target.querySelectorAll('[data-rf-bin]')).toHaveLength(0);
+    expect(target.querySelectorAll(
+      '[data-rf-bin],.rf-axis,.rf-grid,.rf-carrier,.rf-passband',
+    )).toHaveLength(0);
   });
 
   it('fails closed when receiver identity is unavailable', () => {
-    const target = render({
-      receiver: 'MAIN', freshness: 'fresh', normalizedBins: [0.1, 0.8],
-    }, null);
+    const target = render(hardwareFrame(), null, 14_250_000);
 
     expect(target.querySelector('[data-testid="lcd-rf-panadapter"]')
       ?.getAttribute('data-frame-reason')).toBe('receiver-unknown');
-    expect(target.querySelectorAll('[data-rf-bin]')).toHaveLength(0);
+    expect(target.querySelectorAll('[data-rf-bin],.rf-axis,.rf-carrier')).toHaveLength(0);
   });
 
-  it('renders exactly the finite samples supplied by a fresh matching frame', () => {
-    const bins = [0.15, 0.7, 0.35];
-    const target = render({ receiver: 'MAIN', freshness: 'fresh', normalizedBins: bins });
-    const renderedBins = target.querySelectorAll('[data-rf-bin]');
+  it('takes RF bins and the absolute frequency axis only from the live frame', () => {
+    const bins = [0.15, 0.7, 0.35, 0.9];
+    const target = render(hardwareFrame({
+      startHz: 7_000_000,
+      endHz: 7_200_000,
+      normalizedBins: bins,
+    }));
+    const scope = target.querySelector('[data-testid="lcd-rf-panadapter"]');
 
-    expect(target.querySelector('[data-testid="lcd-rf-panadapter"]')
-      ?.getAttribute('data-rf-mode')).toBe('live');
-    expect(renderedBins).toHaveLength(bins.length);
-    expect([...renderedBins].map((node) => Number(node.getAttribute('data-rf-sample'))))
-      .toEqual(bins);
+    expect(scope?.getAttribute('data-rf-mode')).toBe('live');
+    expect(scope?.getAttribute('data-start-hz')).toBe('7000000');
+    expect(scope?.getAttribute('data-end-hz')).toBe('7200000');
+    expect([...target.querySelectorAll('[data-axis-frequency]')]
+      .map((node) => Number(node.getAttribute('data-axis-frequency'))))
+      .toEqual([7_000_000, 7_050_000, 7_100_000, 7_150_000, 7_200_000]);
+    expect([...target.querySelectorAll('[data-rf-bin]')]
+      .map((node) => Number(node.getAttribute('data-rf-sample')))).toEqual(bins);
+  });
+
+  it.each([
+    ['fixed/off-centre', hardwareFrame(), 14_240_000, 240],
+    ['scrolling/centred', hardwareFrame({ startHz: 14_245_000, endHz: 14_255_000 }), 14_250_000, 300],
+  ] as const)('places a real carrier for a %s frame', (_label, frame, frequencyHz, expectedX) => {
+    const target = render(frame, 'MAIN', frequencyHz);
+
+    expect(numberAttribute(target, '.rf-carrier', 'x1')).toBeCloseTo(expectedX, 6);
+    expect(numberAttribute(target, '.rf-carrier', 'data-carrier-hz')).toBe(frequencyHz);
+  });
+
+  it('does not clamp an out-of-frame carrier into a false edge marker', () => {
+    const target = render(hardwareFrame(), 'MAIN', 14_350_000, {
+      mode: 'USB', widthHz: 2_400, shiftHz: 0,
+    });
+
+    expect(target.querySelector('.rf-carrier')).toBeNull();
+    expect(target.querySelector('.rf-passband')).toBeNull();
+  });
+
+  it.each([
+    ['USB', 300, 14.4],
+    ['LSB', 285.6, 14.4],
+    ['AM', 292.8, 14.4],
+    ['FM', 292.8, 14.4],
+  ] as const)('uses canonical %s passband geometry', (mode, expectedX, expectedWidth) => {
+    const target = render(hardwareFrame(), 'MAIN', 14_250_000, {
+      mode, widthHz: 2_400, shiftHz: 0,
+    });
+
+    expect(numberAttribute(target, '.rf-passband', 'x')).toBeCloseTo(expectedX, 6);
+    expect(numberAttribute(target, '.rf-passband', 'width')).toBeCloseTo(expectedWidth, 6);
+  });
+
+  it('applies a known passband shift on the live frame scale', () => {
+    const target = render(hardwareFrame(), 'MAIN', 14_250_000, {
+      mode: 'USB', widthHz: 2_400, shiftHz: 1_000,
+    });
+
+    expect(numberAttribute(target, '.rf-passband', 'x')).toBeCloseTo(306, 6);
+    expect(numberAttribute(target, '.rf-passband', 'width')).toBeCloseTo(14.4, 6);
+  });
+
+  it.each([
+    undefined,
+    { mode: 'USB', widthHz: Number.NaN, shiftHz: 0 },
+    { mode: 'USB', widthHz: 2_400, shiftHz: Number.NaN },
+  ])('shows no passband without completely known finite geometry', (passband) => {
+    const target = render(hardwareFrame(), 'MAIN', 14_250_000, passband);
+
+    expect(target.querySelector('.rf-carrier')).not.toBeNull();
+    expect(target.querySelector('.rf-passband')).toBeNull();
   });
 
   it('is passive and keeps resource ownership outside the renderer', () => {
-    const target = render({
-      receiver: 'MAIN', freshness: 'fresh', normalizedBins: [0.1, 0.8],
-    });
+    const target = render(hardwareFrame(), 'MAIN', 14_250_000);
     const source = readFileSync('src/skins/segmentline/LcdRfPanadapter.svelte', 'utf8');
 
     expect(target.querySelectorAll(

--- a/frontend/src/skins/segmentline/__tests__/PanadapterDisplay.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/PanadapterDisplay.component.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { afterEach, describe, expect, it } from 'vitest';
 import { mount, unmount } from 'svelte';
 import type { PeerSplitDisplayModel } from '../../../semantic/radio-display-model';
-import type { LcdRfPanadapterFrame } from '../LcdRfPanadapter.svelte';
+import type { LcdSpectrumFrame } from '../lcd-display-contract';
 import PanadapterDisplay from '../PanadapterDisplay.svelte';
 
 const known = <T>(value: T) => ({ state: 'known' as const, value });
@@ -59,6 +59,18 @@ const model: PeerSplitDisplayModel = {
   },
 };
 
+function hardwareFrame(overrides: Partial<LcdSpectrumFrame> = {}): LcdSpectrumFrame {
+  return {
+    source: 'hardware',
+    receiver: 'MAIN',
+    freshness: 'fresh',
+    startHz: 14_200_000,
+    endHz: 14_300_000,
+    normalizedBins: [0.1, 0.6, 0.25, 0.8],
+    ...overrides,
+  };
+}
+
 let component: ReturnType<typeof mount> | null = null;
 
 afterEach(() => {
@@ -70,7 +82,7 @@ afterEach(() => {
 function render(
   displayModel: PeerSplitDisplayModel = model,
   normalizedFftBins?: Partial<Record<'MAIN' | 'SUB', readonly number[]>>,
-  rfFrame?: LcdRfPanadapterFrame,
+  rfFrame?: unknown,
 ): HTMLElement {
   const target = document.createElement('div');
   document.body.appendChild(target);
@@ -81,6 +93,11 @@ function render(
 }
 
 describe('PanadapterDisplay', () => {
+  it('declares Direction D native instrument geometry', () => {
+    expect(render().querySelector('[data-testid="panadapter-display"]')
+      ?.getAttribute('data-native-stage')).toBe('1280x594');
+  });
+
   it('keeps two equal frequency columns truthful', () => {
     const target = render();
     const columns = target.querySelectorAll('[data-testid="panadapter-frequency-column"]');
@@ -132,28 +149,63 @@ describe('PanadapterDisplay', () => {
     expect(target.querySelector('[data-testid="lcd-rf-panadapter"]')
       ?.getAttribute('data-rf-mode')).toBe('ghost');
     expect(target.querySelectorAll('[data-rf-bin]')).toHaveLength(0);
+    expect(target.querySelectorAll('.rf-axis,.rf-carrier,.rf-passband')).toHaveLength(0);
     expect(target.querySelectorAll('[data-rf-peak],.rf-history,.band-edge')).toHaveLength(0);
   });
 
-  it('passes a valid matching RF frame through without adding samples', () => {
-    const bins = [0.1, 0.6, 0.25, 0.8];
-    const target = render(model, undefined, {
-      receiver: 'MAIN', freshness: 'fresh', normalizedBins: bins,
-    });
+  it('passes a source-qualified matching hardware frame through without adding samples', () => {
+    const frame = hardwareFrame();
+    const target = render(model, undefined, frame);
 
-    expect(target.querySelectorAll('[data-rf-bin]')).toHaveLength(bins.length);
+    expect(target.querySelectorAll('[data-rf-bin]')).toHaveLength(frame.normalizedBins.length);
     expect([...target.querySelectorAll('[data-rf-bin]')]
-      .map((node) => Number(node.getAttribute('data-rf-sample')))).toEqual(bins);
+      .map((node) => Number(node.getAttribute('data-rf-sample'))))
+      .toEqual(frame.normalizedBins);
+    expect(target.querySelector('.rf-carrier')?.getAttribute('data-carrier-hz'))
+      .toBe('14250000');
+    expect(target.querySelector('.rf-passband')?.getAttribute('data-passband-mode'))
+      .toBe('USB');
   });
 
   it('fails RF receiver mismatch closed at the active-receiver boundary', () => {
-    const target = render(model, undefined, {
-      receiver: 'SUB', freshness: 'fresh', normalizedBins: [0.2, 0.9],
-    });
+    const target = render(model, undefined, hardwareFrame({ receiver: 'SUB' }));
 
     expect(target.querySelector('[data-testid="lcd-rf-panadapter"]')
       ?.getAttribute('data-frame-reason')).toBe('receiver-mismatch');
     expect(target.querySelectorAll('[data-rf-bin]')).toHaveLength(0);
+    expect(target.querySelectorAll('.rf-axis,.rf-carrier,.rf-passband')).toHaveLength(0);
+  });
+
+  it('fails a non-hardware frame closed instead of borrowing AF samples', () => {
+    const target = render(model, undefined, hardwareFrame({ source: 'audio-fft' }));
+
+    expect(target.querySelector('[data-testid="lcd-rf-panadapter"]')
+      ?.getAttribute('data-frame-reason')).toBe('source-mismatch');
+    expect(target.querySelectorAll('[data-rf-bin],.rf-axis,.rf-carrier,.rf-passband'))
+      .toHaveLength(0);
+  });
+
+  it('requires known frequency, mode, width, and shift before showing overlays', () => {
+    const guardedReceivers: PeerSplitDisplayModel['receivers'] = [
+      {
+        ...model.receivers[0],
+        frequency: { state: 'unknown' },
+        mode: { state: 'unknown' },
+        bandwidthHz: { state: 'unknown' },
+        ifShiftHz: { state: 'unsupported' },
+      },
+      model.receivers[1],
+    ];
+    const target = render({
+      ...model,
+      receivers: guardedReceivers,
+      activeReceiver: guardedReceivers[0],
+    }, undefined, hardwareFrame());
+
+    expect(target.querySelectorAll('[data-rf-bin]')).toHaveLength(4);
+    expect(target.querySelectorAll('.rf-axis')).toHaveLength(5);
+    expect(target.querySelector('.rf-carrier')).toBeNull();
+    expect(target.querySelector('.rf-passband')).toBeNull();
   });
 
   it('preserves LcdAfFft safe-empty semantics in the active-receiver inset', () => {

--- a/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
@@ -32,10 +32,21 @@ const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
   noop: vi.fn(),
+  resourceEvents: [] as string[],
   modInputGuard: { visible: false, sourceLabel: null } as { visible: boolean; sourceLabel: string | null },
 }));
 
 vi.mock('$lib/runtime', () => ({
+  presentationResources: {
+    acquire: (resource: string) => {
+      h.resourceEvents.push(`acquire:${resource}`);
+      return Object.freeze({ resource, id: h.resourceEvents.length });
+    },
+    release: (lease: { resource: string }) => {
+      h.resourceEvents.push(`release:${lease.resource}`);
+      return true;
+    },
+  },
   runtime: {
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
@@ -49,7 +60,14 @@ vi.mock('$lib/runtime', () => ({
       };
     },
     get radioPowerOn() { return null; },
-    get scope() { return { hardwareScopeConnected: false }; },
+    get scope() {
+      return {
+        hardwareScopeConnected: false,
+        subscribeFrameEvidence: () => () => {},
+        setFrameAuthority: () => {},
+        snapshotFrameEvidence: () => ({ envelope: null, authority: null }),
+      };
+    },
   },
 }));
 vi.mock('$lib/runtime/tx-controller/managed-app-host', () => ({
@@ -174,6 +192,7 @@ beforeEach(() => {
   h.state = abSharedState();
   h.caps = liveCaps();
   h.noop.mockReset();
+  h.resourceEvents.length = 0;
   h.modInputGuard = { visible: false, sourceLabel: null };
 });
 
@@ -224,6 +243,10 @@ describe('the peer-split chassis mounts', () => {
       '[data-testid="peer-split-display"], [data-testid="dominant-unified-display"], '
       + '[data-testid="centerstage-display"], [data-testid="panadapter-display"]',
     )).toHaveLength(1);
+    const expectedResource = displayVariant === 'panadapter'
+      ? 'hardware-scope'
+      : displayVariant === 'peer' ? null : 'audio-fft';
+    expect(h.resourceEvents).toEqual(expectedResource === null ? [] : [`acquire:${expectedResource}`]);
   });
 
   // NOT ASSERTED HERE: that `.semantic-surfaces` actually receives
@@ -333,5 +356,35 @@ describe('the glass forwards the shell-resolved scale floor to its stage (MOR-22
     const tag = markup.match(/<ScaledStage[^>]*>/)?.[0];
     expect(tag, 'no <ScaledStage ...> tag found in PeerSplitLayout.svelte markup').toBeDefined();
     expect(tag).toMatch(/\{minScale\}|minScale=/);
+  });
+});
+
+describe('the selected segmentline face owns exactly one LCD source declaration (MOR-2328)', () => {
+  const source = readFileSync('src/skins/segmentline/PeerSplitLayout.svelte', 'utf8');
+  const markup = source.replace(/<script[\s\S]*?<\/script>/, '').replace(/<style>[\s\S]*?<\/style>/, '');
+
+  it('maps the four display variants to the host-owned source contract', () => {
+    expect(source).toMatch(/displayVariant === 'dominant'\s*\|\|\s*displayVariant === 'centerstage'\s*\?\s*'audio-fft'/);
+    expect(source).toMatch(/displayVariant === 'panadapter'\s*\?\s*'hardware'/);
+    expect(source).toMatch(/:\s*undefined/);
+
+    const host = markup.match(/<SemanticRadioSurfaces[^>]*\/>/)?.[0];
+    expect(host, 'no SemanticRadioSurfaces host found').toBeDefined();
+    expect(host).toMatch(/\{displayFrameSource\}/);
+    expect(host).toMatch(/\{readonlyDisplay\}/);
+  });
+
+  it('keeps frame authority at the semantic host and forwards its one selected object unchanged', () => {
+    expect(source).toContain("import type { LcdSpectrumFrame, LcdSpectrumSource } from './lcd-display-contract';");
+    expect(source).toMatch(/\{#snippet readonlyDisplay\(view: RadioViewModel, selectedFrame\?: LcdSpectrumFrame\)\}/);
+    expect(source).toMatch(/<DominantUnifiedDisplay\s+\{model\}\s+spectrumFrame=\{selectedFrame\}\s*\/>/);
+    expect(source).toMatch(/<CenterstageDisplay\s+\{model\}\s+audioFftFrame=\{selectedFrame\}\s*\/>/);
+    expect(source).toMatch(/<PanadapterDisplay\s+\{model\}\s+rfFrame=\{selectedFrame\}\s*\/>/);
+    expect(source).toMatch(/\{#snippet peer\(\)\}<PeerSplitDisplay \{model\} \/>\{\/snippet\}/);
+
+    // This selector must never grow a second producer, frame resolver, or
+    // demand lease. Those are host lifecycle concerns, not face heuristics.
+    expect(source).not.toMatch(/from ['"](?:\$lib\/runtime|.*\/runtime)['"]/);
+    expect(source).not.toMatch(/resolveLcdSpectrumFrame|audioFftDemand|requestAudioFft/);
   });
 });


### PR DESCRIPTION
## Scope

Delivery batch for Linear MOR-2328 and MOR-2329. It replays the safe LCD renderer prerequisites MOR-2322, MOR-2323, and MOR-2324; parent/residual scope remains MOR-2325.

The canonical mapping is dominant/centerstage = audio-fft, panadapter = hardware, peer = no source. `ScopeFrameHost.live.frame` identity is passed as one optional selected frame. One ScopeFrameHost owns source demand. Panadapter's selected live RF frame remains hardware-only; its existing AF inset remains present/tested and does not receive the selected RF frame or create an extra selected-source/fallback authority. There is no raw-frame bypass or fallback.

Exactly 15 paths are changed. Local evidence: Vitest 10 files / 153 tests PASS; ESLint 13 paths PASS; `npm run check` 0 errors / 0 warnings; diff-check and allowlist PASS.

The rejected #3161 approach / commit `78194edd` is not used. Remaining MOR-2325 registration and visual scope are excluded from this batch.