### PR TITLE
MOR-2172: bypass legacy TX gates for managed ingress

### DIFF
--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -36,6 +36,7 @@ from rigplane.core.state_pipeline_contracts import CommandIntent, FieldPath
 from rigplane.core.tx_observation import OBSERVED_PTT_PATH
 from rigplane.core.tx_target import KnownTxTarget, UnknownTxTarget
 from rigplane.runtime._poller_types import (
+    PttOn,
     canonicalize_level_command,
     execute_command_queue_entry,
     execute_positive_tx_queue_entry,
@@ -707,26 +708,27 @@ class YaesuCatPoller:
         if self._command_queue is None:
             return
 
-        boundary = self._deferred_generation_change()
-        if boundary is not None:
-            self._cancel_deferred_entry(boundary)
-        now = time.monotonic()
-        transition = self._deferred_tx_lane.observe(
-            rf_state=self._current_rf_state(), now=now
-        )
         released: list[CommandQueueEntry] = []
-        if (
-            transition is not None
-            and transition.outcome is not TxInterlockDeferredOutcome.HELD
-        ):
-            entry, self._deferred_tx_entry = self._deferred_tx_entry, None
-            self._deferred_tx_generation = None
-            if entry is not None:
-                if transition.outcome is TxInterlockDeferredOutcome.RELEASED:
-                    if self._deferred_release_is_live(entry):
-                        released.append(entry)
-                else:
-                    self._finish_deferred_entry(entry, superseded=False)
+        if self._managed_tx_authority is None:
+            boundary = self._deferred_generation_change()
+            if boundary is not None:
+                self._cancel_deferred_entry(boundary)
+            now = time.monotonic()
+            transition = self._deferred_tx_lane.observe(
+                rf_state=self._current_rf_state(), now=now
+            )
+            if (
+                transition is not None
+                and transition.outcome is not TxInterlockDeferredOutcome.HELD
+            ):
+                entry, self._deferred_tx_entry = self._deferred_tx_entry, None
+                self._deferred_tx_generation = None
+                if entry is not None:
+                    if transition.outcome is TxInterlockDeferredOutcome.RELEASED:
+                        if self._deferred_release_is_live(entry):
+                            released.append(entry)
+                    else:
+                        self._finish_deferred_entry(entry, superseded=False)
 
         pending_count = self._command_queue.pending_count
 
@@ -783,13 +785,13 @@ class YaesuCatPoller:
 
         async def finish_entry(
             entry: CommandQueueEntry,
-            decision: TxInterlockDecision | Exception,
+            decision: TxInterlockDecision | Exception | None,
         ) -> None:
             cmd = entry.command
             try:
                 if isinstance(decision, BaseException):
                     raise decision
-                if (
+                if decision is not None and (
                     decision.disposition is TxInterlockDisposition.DEFER
                     and not decision.allowed
                 ):
@@ -839,8 +841,9 @@ class YaesuCatPoller:
                     exc_info=True,
                 )
                 return
-            decision = stage_entry(entry)
-            if decision is None:
+            bypass_legacy_policy = self._managed_tx_authority is not None
+            decision = None if bypass_legacy_policy else stage_entry(entry)
+            if decision is None and not bypass_legacy_policy:
                 return
             policy_error = isinstance(decision, BaseException)
             try:
@@ -1044,6 +1047,8 @@ class YaesuCatPoller:
         all command types; unsupported commands fail truthfully.
         """
         cmd = canonicalize_level_command(cmd, self._radio)
+        if self._managed_tx_authority is not None and isinstance(cmd, PttOn):
+            raise CommandError("managed PTT ON requires a positive TX queue submission")
         if isinstance(cmd, CommandIntent):
             await execute_command_intent(
                 self._radio,
@@ -1052,20 +1057,20 @@ class YaesuCatPoller:
                 validate_currency=validate_currency,
             )
             return
-        decision = evaluate_tx_interlock(
-            cmd,
-            rf_state=self._current_rf_state(),
-            disposition_overrides=self._tx_interlock_disposition_overrides(),
-        )
-        if not decision.allowed and (
-            decision.disposition is TxInterlockDisposition.BLOCK
-            or classify_tx_interlock(cmd) is TxInterlockDisposition.TX_SAFE
-        ):
-            raise CommandError(decision.reason)
+        if self._managed_tx_authority is None:
+            decision = evaluate_tx_interlock(
+                cmd,
+                rf_state=self._current_rf_state(),
+                disposition_overrides=self._tx_interlock_disposition_overrides(),
+            )
+            if not decision.allowed and (
+                decision.disposition is TxInterlockDisposition.BLOCK
+                or classify_tx_interlock(cmd) is TxInterlockDisposition.TX_SAFE
+            ):
+                raise CommandError(decision.reason)
 
         from ..._poller_types import (
             PttOff,
-            PttOn,
             SelectVfo,
             SetAgc,
             SetApf,

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -611,13 +611,15 @@ class _RigctldCommandExecutor:
         ):
             return await self._execute_managed_tuner(intent)
 
-        classification = _classify_rigctld_tx_intent(intent)
-        if (
-            classification.disposition is TxInterlockDisposition.BLOCK
-            and self.handler._has_canonical_state_store
-            and self.handler._resolve_rigctld_rf_state() is not tx_interlock.RfState.RX
-        ):
-            raise _RigctldCommandFailure(HamlibError.ERJCTED)
+        if not managed:
+            classification = _classify_rigctld_tx_intent(intent)
+            if (
+                classification.disposition is TxInterlockDisposition.BLOCK
+                and self.handler._has_canonical_state_store
+                and self.handler._resolve_rigctld_rf_state()
+                is not tx_interlock.RfState.RX
+            ):
+                raise _RigctldCommandFailure(HamlibError.ERJCTED)
         await self._wait_predecessor()
         params = intent.params
         if intent.name == "set_freq":
@@ -1646,9 +1648,10 @@ class RigctldHandler:
             command_id=f"rigctld-set-freq-{time.monotonic_ns()}",
             session_id=self._session_id(),
         )
-        dropped = self._defer_write_gate(intent)
-        if dropped is not None:
-            return dropped
+        if self._managed_tx_authority is None:
+            dropped = self._defer_write_gate(intent)
+            if dropped is not None:
+                return dropped
         await self._execute_write(intent)
         return _ok()
 
@@ -1815,9 +1818,10 @@ class RigctldHandler:
                 command_id=f"rigctld-set-mode-{time.monotonic_ns()}",
                 session_id=self._session_id(),
             )
-            dropped = self._defer_write_gate(intent)
-            if dropped is not None:
-                return dropped
+            if self._managed_tx_authority is None:
+                dropped = self._defer_write_gate(intent)
+                if dropped is not None:
+                    return dropped
             await self._execute_write(intent)
             # ``filter_width`` (the local var) is a filter NUMBER, so the
             # readback overlay belongs on ``filter_num`` — that is the key the
@@ -1847,9 +1851,10 @@ class RigctldHandler:
             command_id=f"rigctld-set-mode-{time.monotonic_ns()}",
             session_id=self._session_id(),
         )
-        dropped = self._defer_write_gate(intent)
-        if dropped is not None:
-            return dropped
+        if self._managed_tx_authority is None:
+            dropped = self._defer_write_gate(intent)
+            if dropped is not None:
+                return dropped
         await self._execute_write(intent)
         self._cache.update_mode(base_mode_str, filter_width)
         if requested_mode in packet_modes:
@@ -2370,9 +2375,10 @@ class RigctldHandler:
             command_id=f"rigctld-set-vfo-{time.monotonic_ns()}",
             session_id=self._session_id(),
         )
-        dropped = self._defer_write_gate(intent)
-        if dropped is not None:
-            return dropped
+        if self._managed_tx_authority is None:
+            dropped = self._defer_write_gate(intent)
+            if dropped is not None:
+                return dropped
         await self._execute_write(intent)
         return _ok()
 
@@ -2829,7 +2835,7 @@ class RigctldHandler:
             command_id=f"rigctld-set-func-{time.monotonic_ns()}",
             session_id=self._session_id(),
         )
-        if not (self._managed_tx_authority is not None and func == "TUNER"):
+        if self._managed_tx_authority is None:
             dropped = self._defer_write_gate(intent)
             if dropped is not None:
                 return dropped
@@ -2918,9 +2924,10 @@ class RigctldHandler:
             command_id=f"rigctld-set-split-vfo-{time.monotonic_ns()}",
             session_id=self._session_id(),
         )
-        dropped = self._defer_write_gate(intent)
-        if dropped is not None:
-            return dropped
+        if self._managed_tx_authority is None:
+            dropped = self._defer_write_gate(intent)
+            if dropped is not None:
+                return dropped
         await self._execute_write(intent)
         return _ok()
 
@@ -3065,9 +3072,10 @@ class RigctldHandler:
             command_id=f"rigctld-set-rit-{time.monotonic_ns()}",
             session_id=self._session_id(),
         )
-        dropped = self._defer_write_gate(intent)
-        if dropped is not None:
-            return dropped
+        if self._managed_tx_authority is None:
+            dropped = self._defer_write_gate(intent)
+            if dropped is not None:
+                return dropped
         await self._execute_write(intent)
         return _ok()
 
@@ -3096,9 +3104,10 @@ class RigctldHandler:
             command_id=f"rigctld-set-xit-{time.monotonic_ns()}",
             session_id=self._session_id(),
         )
-        dropped = self._defer_write_gate(intent)
-        if dropped is not None:
-            return dropped
+        if self._managed_tx_authority is None:
+            dropped = self._defer_write_gate(intent)
+            if dropped is not None:
+                return dropped
         await self._execute_write(intent)
         return _ok()
 

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -730,6 +730,10 @@ class RadioPoller:
         return RfState.TX if field.value else RfState.RX
 
     def _enforce_tx_interlock(self, cmd: Command) -> None:
+        if self._managed_tx_authority is not None and not isinstance(
+            cmd, (PttOn, PttOff)
+        ):
+            return
         metadata = get_tx_interlock_command_family_metadata(cmd)
         if metadata is None or (
             metadata.family not in _WEB_IMMEDIATE_BLOCK_FAMILIES
@@ -809,6 +813,8 @@ class RadioPoller:
         self, entries: list[CommandQueueEntry], *, advance_held: bool = True
     ) -> list[CommandQueueEntry]:
         """Stage DEFER entries before advancing the existing held slot."""
+        if self._managed_tx_authority is not None:
+            return entries
         has_defer = self._deferred_tx_lane.pending is not None or any(
             (metadata := get_tx_interlock_command_family_metadata(entry.command))
             is not None
@@ -2186,6 +2192,8 @@ class RadioPoller:
             source=source,
             session_id=session_id,
         )
+        if self._managed_tx_authority is not None and isinstance(cmd, PttOn):
+            raise CommandError("managed PTT ON requires a positive TX queue submission")
         if isinstance(cmd, CommandIntent):
             await execute_command_intent(
                 self._radio,

--- a/tests/test_radio_poller_tx_interlock.py
+++ b/tests/test_radio_poller_tx_interlock.py
@@ -331,6 +331,31 @@ def test_authority_approved_commands_do_not_inspect_observed_rf() -> None:
 
 
 @pytest.mark.asyncio
+async def test_managed_non_ptt_bypasses_legacy_observed_rf_and_deferred_lane() -> None:
+    radio, store, queue = _radio(), StateStore(), CommandQueue()
+    store.begin_provider_generation()
+    authority = SimpleNamespace(admit_managed_write=AsyncMock(return_value=True))
+    poller = RadioPoller(
+        radio,
+        queue,
+        state_store=store,
+        managed_tx_authority=authority,
+    )
+    poller._current_rf_state = lambda *_: pytest.fail(  # type: ignore[method-assign] # noqa: SLF001
+        "managed non-PTT dispatch inspected legacy RF state"
+    )
+    future = asyncio.get_running_loop().create_future()
+    entry = CommandQueueEntry(SetSplit(True), future=future)
+
+    assert poller._stage_tx_interlocked_entries([entry]) == [entry]  # noqa: SLF001
+    await poller._execute_queued_entry(entry)  # noqa: SLF001
+
+    assert future.result() is None
+    radio.set_split.assert_awaited_once_with(True)
+    assert poller._deferred_tx_lane.pending is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_descriptor_intent_uses_bound_authority_before_radio_write() -> None:
     radio, store, queue = _radio(), StateStore(), CommandQueue()
     store.begin_provider_generation()
@@ -713,6 +738,42 @@ async def test_ptt_on_dispatches_in_fresh_rx() -> None:
     await _dispatch(poller, PttOn())
 
     radio.set_ptt.assert_awaited_once_with(True)
+
+
+async def test_managed_typed_ptt_on_fails_before_raw_write_or_legacy_timer() -> None:
+    radio, store, queue = _radio(), StateStore(), CommandQueue()
+    store.begin_provider_generation()
+    _observe_ptt(store, False)
+    authority = SimpleNamespace(admit_managed_write=AsyncMock(return_value=True))
+    poller = RadioPoller(
+        radio,
+        queue,
+        state_store=store,
+        managed_tx_authority=authority,
+    )
+    poller._arm_max_key_down = MagicMock()  # type: ignore[method-assign] # noqa: SLF001
+
+    with pytest.raises(CommandError, match="positive TX queue submission"):
+        await poller._execute(PttOn())  # noqa: SLF001
+
+    radio.set_ptt.assert_not_awaited()
+    poller._arm_max_key_down.assert_not_called()  # type: ignore[attr-defined] # noqa: SLF001
+
+
+async def test_managed_typed_ptt_off_remains_unconditionally_attemptable() -> None:
+    radio, store, queue = _radio(), StateStore(), CommandQueue()
+    store.begin_provider_generation()
+    authority = SimpleNamespace(admit_managed_write=AsyncMock(return_value=True))
+    poller = RadioPoller(
+        radio,
+        queue,
+        state_store=store,
+        managed_tx_authority=authority,
+    )
+
+    await poller._execute(PttOff())  # noqa: SLF001
+
+    radio.set_ptt.assert_awaited_once_with(False)
 
 
 @pytest.mark.parametrize("ptt", (None, True), ids=("unknown", "tx"))

--- a/tests/test_rigctld_managed_context.py
+++ b/tests/test_rigctld_managed_context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
@@ -36,10 +37,28 @@ class _RecordingRadio(SerialMockRadio):
         super().__init__()
         self.state_store = store
         self.frequency_calls = []
+        self.write_calls = []
 
     async def set_freq(self, freq, receiver=0):
         self.frequency_calls.append((freq, receiver))
+        self.write_calls.append(("freq", freq, receiver))
         await super().set_freq(freq, receiver=receiver)
+
+    async def set_mode(self, mode, filter_width=None, receiver=0):
+        self.write_calls.append(("mode", mode, filter_width, receiver))
+        await super().set_mode(mode, filter_width=filter_width, receiver=receiver)
+
+    async def set_vfo(self, vfo):
+        self.write_calls.append(("vfo", vfo))
+        await super().set_vfo(vfo)
+
+    async def set_split(self, on):
+        self.write_calls.append(("split", on))
+        await super().set_split(on)
+
+    async def _send_civ_raw(self, frame):
+        self.write_calls.append(("raw", frame))
+        return None
 
 
 class _DefaultExecutor:
@@ -147,3 +166,41 @@ async def test_handler_leaf_preserves_shared_service_default(context):
         assert context.radio.frequency_calls == [(14_075_000, 0)]
     finally:
         unsubscribe()
+
+
+@pytest.mark.parametrize(
+    ("wire", "expected_family"),
+    [
+        (b"F 14075000", "freq"),
+        (b"M USB 2400", "mode"),
+        (b"V VFOB", "vfo"),
+        (b"S 0 VFOA", "split"),
+        (b"w FE FE 98 E0 03 FD", "raw"),
+    ],
+)
+async def test_managed_non_tuner_writes_bypass_legacy_rf_gates(
+    context, monkeypatch, wire, expected_family
+):
+    context.store.apply_current(
+        Observation(
+            path=FieldPath.global_("tx_state", "ptt"),
+            value=True,
+            source=SourceMetadata(source="test", provider="tests"),
+            timestamp_monotonic=asyncio.get_running_loop().time(),
+            max_age=1e9,
+        )
+    )
+    handler = RigctldHandler(context.radio, RigctldConfig(), **context.refs)
+    legacy_defer = Mock(side_effect=AssertionError("managed write used defer gate"))
+    legacy_rf = Mock(side_effect=AssertionError("managed write used observed RF gate"))
+    monkeypatch.setattr(handler, "_defer_write_gate", legacy_defer)
+    monkeypatch.setattr(handler, "_resolve_rigctld_rf_state", legacy_rf)
+
+    response = await handler.execute(parse_line(wire), session_id="client")
+
+    assert response.ok
+    assert len(context.radio.write_calls) == 1
+    assert context.radio.write_calls[0][0] == expected_family
+    legacy_defer.assert_not_called()
+    legacy_rf.assert_not_called()
+    assert handler._command_service.lifecycle_events()[-1].state == "acknowledged"  # noqa: SLF001

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -1701,6 +1701,48 @@ async def test_yaesu_authority_approved_commands_dispatch_during_observed_tx(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("active", (True, None), ids=("tx", "unknown"))
+async def test_yaesu_managed_queue_bypasses_legacy_deferred_policy(
+    active: bool | None,
+) -> None:
+    radio, queue = make_radio(), CommandQueue()
+    radio.set_split = AsyncMock()
+    authority = MagicMock()
+    authority.admit_managed_write = AsyncMock(return_value=True)
+    poller = YaesuCatPoller(radio, command_queue=queue)
+    poller.bind_managed_tx_authority(authority)
+    future = asyncio.get_running_loop().create_future()
+    queue.put_ordered(SetSplit(True), future=future)
+    if active is not None:
+        _set_fresh_ptt_observation(poller, active=active)
+
+    await poller._drain_commands()  # noqa: SLF001
+
+    assert future.result() is None
+    radio.set_split.assert_awaited_once_with(True)
+    assert poller._deferred_tx_lane.pending is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_yaesu_managed_non_ptt_execute_does_not_inspect_legacy_rf() -> None:
+    from rigplane.runtime._poller_types import SetPowerstat
+
+    radio = make_radio()
+    radio.set_powerstat = AsyncMock()
+    authority = MagicMock()
+    authority.admit_managed_write = AsyncMock(return_value=True)
+    poller = YaesuCatPoller(radio)
+    poller.bind_managed_tx_authority(authority)
+    poller._current_rf_state = MagicMock(  # type: ignore[method-assign] # noqa: SLF001
+        side_effect=AssertionError("managed non-PTT dispatch inspected legacy RF state")
+    )
+
+    await poller._execute_command(SetPowerstat(on=True))  # noqa: SLF001
+
+    radio.set_powerstat.assert_awaited_once_with(True)
+
+
+@pytest.mark.asyncio
 async def test_yaesu_descriptor_intent_uses_bound_authority_once() -> None:
     radio = make_radio()
     radio.set_civ_output_ant = AsyncMock()
@@ -1717,6 +1759,59 @@ async def test_yaesu_descriptor_intent_uses_bound_authority_once() -> None:
     radio.set_civ_output_ant.assert_awaited_once_with(on=True)
     with pytest.raises(RuntimeError, match="already bound"):
         poller.bind_managed_tx_authority(authority)
+
+
+@pytest.mark.asyncio
+async def test_yaesu_descriptor_refusal_occurs_once_at_bound_authority() -> None:
+    radio = make_radio()
+    radio.set_antenna_1 = AsyncMock()
+    authority = MagicMock()
+    authority.admit_managed_write = AsyncMock(return_value=False)
+    poller = YaesuCatPoller(radio)
+    poller.bind_managed_tx_authority(authority)
+    intent = bind_command_intent("set_antenna_1", {"on": True}, source="websocket")
+
+    with pytest.raises(CommandError, match="transmit authority"):
+        await poller._execute_command(intent)  # noqa: SLF001
+
+    authority.admit_managed_write.assert_awaited_once_with(intent)
+    radio.set_antenna_1.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_yaesu_managed_typed_ptt_on_fails_before_raw_write() -> None:
+    from rigplane.runtime._poller_types import PttOn
+
+    radio = make_radio()
+    radio.set_ptt = AsyncMock()
+    authority = MagicMock()
+    authority.admit_managed_write = AsyncMock(return_value=True)
+    poller = YaesuCatPoller(radio)
+    poller.bind_managed_tx_authority(authority)
+    _set_fresh_ptt_observation(poller, active=False)
+
+    with pytest.raises(CommandError, match="positive TX queue submission"):
+        await poller._execute_command(PttOn())  # noqa: SLF001
+
+    radio.set_ptt.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_yaesu_managed_typed_ptt_off_remains_unconditionally_attemptable() -> (
+    None
+):
+    from rigplane.runtime._poller_types import PttOff
+
+    radio = make_radio()
+    radio.set_ptt = AsyncMock()
+    authority = MagicMock()
+    authority.admit_managed_write = AsyncMock(return_value=True)
+    poller = YaesuCatPoller(radio)
+    poller.bind_managed_tx_authority(authority)
+
+    await poller._execute_command(PttOff())  # noqa: SLF001
+
+    radio.set_ptt.assert_awaited_once_with(False)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Managed Web, Yaesu, and embedded rigctld writes were still traversing legacy observed-RF/deferred gates after canonical managed admission. This change makes the managed composition bypass those legacy policy seats while preserving the existing standalone/unmanaged behavior.

Linear: https://linear.app/morozsm/issue/MOR-2172

## Behavior

- Web and Yaesu managed non-PTT commands proceed to the canonical descriptor/admission path without legacy RF observation or deferred-lane decisions.
- Managed typed `PttOn` fails closed before raw `set_ptt(True)`, the Web max-key timer, or the rigctld backstop; positive TX still requires the managed submission path.
- Managed embedded rigctld writes bypass all eight legacy `_defer_write_gate` call sites and the executor's legacy RF classification.
- `PttOff`/ForceOff remain urgent and attemptable.
- Unmanaged Web/Yaesu/standalone rigctld retain their legacy interlock, deferred lane, raw PTT, max-key timer, and key-down backstop behavior.

## Verification

- RED evidence on the common base: five managed rigctld bypass cases failed while two unmanaged preservation controls passed. The Web/Yaesu additions cover legacy RF/deferred interception, single canonical refusal, raw positive PTT prevention, and OFF preservation. The base RED was not repeated during integration.
- Combined focused Mac mini run from an isolated checkout: `364 passed in 15.77s` across `test_radio_poller_tx_interlock.py`, `test_yaesu_cat_poller.py`, `test_rigctld_managed_tx.py`, `test_rigctld_managed_context.py`, `test_rigctld_tx_interlock.py`, and `test_rigctld_key_down_backstop.py`.
- Changed-file Ruff check, Ruff format check, and `git diff --check`: PASS.
- Architecture census: one production `admit_managed_write` call; all eight rigctld defer calls are guarded by unmanaged mode.

## Boundaries

No managed authority, queue, abort fence, reconnect mechanism, F3 CW/tune behavior, public compatibility facade, or standalone rigctld mechanism is removed or replaced here.
