### PR TITLE
fix: enforce rigctld read-only for raw commands (MOR-1894)

### DIFF
--- a/docs/api/rigctld.md
+++ b/docs/api/rigctld.md
@@ -54,7 +54,7 @@ Options:
 |------|---------|-------------|
 | `--host HOST` | `0.0.0.0` | Listen address |
 | `--port PORT` | `4532` | TCP port |
-| `--read-only` | off | Reject all set commands |
+| `--read-only` | off | Reject all set commands and all raw `w` / `send_raw` frames (including reads) with `RPRT -22` |
 | `--max-clients N` | `10` | Maximum concurrent clients |
 | `--cache-ttl S` | `0.2` | Frequency/mode cache TTL (seconds) |
 | `--wsjtx-compat` | off | Auto-enable DATA mode on first client connect |
@@ -194,7 +194,7 @@ RigctldConfig(
 |-------|------|---------|-------------|
 | `host` | `str` | `"0.0.0.0"` | TCP listen address |
 | `port` | `int` | `4532` | TCP port |
-| `read_only` | `bool` | `False` | Reject all set commands with `RPRT -22` |
+| `read_only` | `bool` | `False` | Reject all set commands and all raw `w` / `send_raw` frames (including reads) with `RPRT -22` |
 | `max_clients` | `int` | `10` | Maximum concurrent TCP connections |
 | `client_timeout` | `float` | `300.0` | Seconds of inactivity before idle disconnect |
 | `command_timeout` | `float` | `2.0` | Per-command CI-V timeout in seconds |
@@ -241,8 +241,8 @@ async def execute(self, cmd: RigctldCommand) -> RigctldResponse
 
 Execute a parsed rigctld command and return the response.
 
-Applies the read-only gate for set commands, looks up the handler in the
-dispatch table, and translates exceptions:
+Applies the read-only gate for set commands and all `send_raw` frames, looks up
+the handler in the dispatch table, and translates exceptions:
 
 | Exception | Hamlib code |
 |-----------|-------------|
@@ -311,6 +311,11 @@ dispatch table, and translates exceptions:
 ### `w` / `send_raw` passthrough
 
 Send raw CI-V bytes and return raw response bytes (space-separated uppercase hex).
+
+With `--read-only`, all `w` / `send_raw` frames are refused with `RPRT -22`,
+including raw read requests; use structured read commands instead. The gate in
+`src/rigplane/rigctld/handler.py: RigctldHandler.execute` does not inspect frame
+contents. Covered by `tests/test_rigctld_handler.py: test_read_only_raw_passthrough`.
 
 Accepted input formats:
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -721,7 +721,7 @@ rigplane serve --wsjtx-compat
 |--------|---------|-------------|
 | `--host` | `0.0.0.0` | Server listen address |
 | `--port` | `4532` | Server TCP port |
-| `--read-only` | off | Reject all set commands; allow only reads |
+| `--read-only` | off | Reject all set commands and all raw `w` / `send_raw` frames (including reads) with `RPRT -22`; allow structured reads |
 | `--max-clients` | `10` | Maximum concurrent TCP clients |
 | `--cache-ttl` | `0.2` | How long (seconds) to cache radio state before re-querying |
 | `--wsjtx-compat` | off | Pre-warm for WSJT-X: auto-enable DATA mode on first client connect |
@@ -1006,7 +1006,7 @@ rigplane --model IC-7300 --backend serial --serial-port /dev/cu.usbserial-XXX st
 | `--log-level LEVEL` | `serve` | `INFO` | Log verbosity: `DEBUG` `INFO` `WARNING` `ERROR` `CRITICAL` |
 | `--max-clients N` | `serve` | `10` | Maximum concurrent TCP clients |
 | `--rate-limit N` | `serve` | *(unlimited)* | Max commands per second per client; excess are dropped |
-| `--read-only` | `serve` | off | Reject all set (write) commands; allow reads only |
+| `--read-only` | `serve` | off | Reject all set commands and all raw `w` / `send_raw` frames (including reads) with `RPRT -22`; allow structured reads |
 | `--wsjtx-compat` | `serve` | off | Auto-enable DATA mode on first client connect (WSJT-X pre-warm) |
 | `--preset NAME` | `serve` | *(none)* | Apply a named preset: `hamradio`, `digimode`, `serial`, `headless` |
 

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -1485,8 +1485,8 @@ class RigctldHandler:
         ready_token = _RIGCTLD_PTT_READY.set(ptt_ready)
         # Read-only gate
         try:
-            if self._config.read_only and cmd.is_set:
-                logger.debug("read-only: rejecting set command %s", cmd.long_cmd)
+            if self._config.read_only and (cmd.is_set or cmd.long_cmd == "send_raw"):
+                logger.debug("read-only: rejecting command %s", cmd.long_cmd)
                 return _err(HamlibError.EACCESS)
 
             handler_fn = self._DISPATCH.get(cmd.long_cmd)

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -31,8 +31,14 @@ from rigplane.core.state_pipeline_contracts import (
 )
 from rigplane.core.state_store import StateStore
 from rigplane.radio_state import RadioState
-from rigplane.rigctld.contract import HamlibError, RigctldCommand, RigctldConfig
+from rigplane.rigctld.contract import (
+    ClientSession,
+    HamlibError,
+    RigctldCommand,
+    RigctldConfig,
+)
 from rigplane.rigctld.handler import RigctldHandler
+from rigplane.rigctld.protocol import format_response, parse_line
 from rigplane.types import CivFrame, Mode
 
 # ---------------------------------------------------------------------------
@@ -2376,6 +2382,38 @@ async def test_read_only_allows_get_mode(mock_radio: AsyncMock) -> None:
     mock_radio.get_mode_info.return_value = (Mode.USB, None)
     resp = await h.execute(get_cmd("get_mode"))
     assert resp.ok
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("read_only", [True, False])
+@pytest.mark.parametrize("command", ["w", r"\send_raw"])
+@pytest.mark.parametrize(
+    "frame",
+    ["FE FE 98 E0 00 00 40 07 14 FD", "FE FE 98 E0 03 FD"],
+    ids=["raw-write", "raw-read"],
+)
+async def test_read_only_raw_passthrough(
+    mock_radio: AsyncMock, read_only: bool, command: str, frame: str
+) -> None:
+    store = StateStore()
+    _seed_known_rx(store)
+    h = RigctldHandler(
+        mock_radio, RigctldConfig(read_only=read_only), state_store=store
+    )
+    mock_radio._send_civ_raw = AsyncMock(return_value=None)
+    cmd = parse_line(f"{command} {frame}".encode("ascii"))
+    assert isinstance(cmd, RigctldCommand)
+    assert not cmd.is_set
+
+    resp = await h.execute(cmd)
+
+    if read_only:
+        assert resp.error == HamlibError.EACCESS
+        assert format_response(cmd, resp, ClientSession()) == b"RPRT -22\n"
+        mock_radio._send_civ_raw.assert_not_called()
+    else:
+        assert resp.ok
+        mock_radio._send_civ_raw.assert_awaited_once_with(bytes.fromhex(frame))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
When rigctld runs with `--read-only`, raw `w`/`send_raw` frames previously bypassed the write guard because the command is not classified as a structured setter. Reject raw passthrough with `RPRT -22` before provider dispatch, and align the CLI/API documentation.

This deliberately rejects raw read frames as well as raw writes in read-only mode; callers should use structured read commands. Writable raw passthrough and the independent TX policy remain unchanged.

Linear: [MOR-1894](https://linear.app/morozsm/issue/MOR-1894/rigctld-read-only-does-not-stop-a-raw-ci-v-write-through-w).

Validation: isolated focused RED reproduced all four alias/payload combinations (4 failed, 6 passed); focused GREEN passed 23 tests including read-only, writable raw and structured reads. Changed-file Ruff, formatting and diff checks passed. Independent exact-head review and natural required CI run in parallel after PR creation.
