### PR TITLE
fix: keep interface navigation reachable in Dual SDR Face (MOR-2237)

### DIFF
--- a/frontend/src/skins/dual-sdr-face/DualSdrFaceSkin.svelte
+++ b/frontend/src/skins/dual-sdr-face/DualSdrFaceSkin.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { runtime } from '$lib/runtime/frontend-runtime';
+  import StatusBar from '../../components-v2/layout/StatusBar.svelte';
   import SemanticRadioSurfaces from '../../components-v2/wiring/SemanticRadioSurfaces.svelte';
   import type { RadioViewModel } from '../../semantic/radio-view-model';
   import DualSdrFace from './DualSdrFace.svelte';
@@ -26,4 +27,5 @@
   <DualSdrFace {view} scopeSource={hardwareScope} />
 {/snippet}
 
+<StatusBar />
 <SemanticRadioSurfaces {readonlyDisplay} />

--- a/frontend/src/skins/dual-sdr-face/__tests__/DualSdrFaceSkin.component.test.ts
+++ b/frontend/src/skins/dual-sdr-face/__tests__/DualSdrFaceSkin.component.test.ts
@@ -1,10 +1,28 @@
 import { readFileSync } from 'node:fs';
 import { mount, tick, unmount } from 'svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CANONICAL_LAYOUT_MODES, type CanonicalLayoutMode } from '../../../presentation/layout-mode';
 
 const lifecycle = vi.hoisted(() => ({
   acquire: vi.fn(() => ({ resource: 'hardware-scope', token: Symbol('lease') })),
   release: vi.fn(() => true),
+}));
+
+const navigation = vi.hoisted(() => ({
+  selections: [] as CanonicalLayoutMode[],
+  mount(anchor: Node) {
+    const select = document.createElement('select');
+    select.dataset.testid = 'skin-navigation-probe';
+    for (const mode of CANONICAL_LAYOUT_MODES) {
+      const option = document.createElement('option');
+      option.value = mode;
+      select.append(option);
+    }
+    select.addEventListener('change', () => {
+      navigation.selections.push(select.value as CanonicalLayoutMode);
+    });
+    anchor.parentNode?.insertBefore(select, anchor);
+  },
 }));
 
 vi.mock('$lib/runtime/frontend-runtime', () => ({
@@ -20,15 +38,23 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
 
 vi.mock('../../../components-v2/wiring/SemanticRadioSurfaces.svelte', () => ({ default: () => {} }));
 vi.mock('../DualSdrFace.svelte', () => ({ default: () => {} }));
+vi.mock('../../../components-v2/layout/StatusBar.svelte', () => ({ default: navigation.mount }));
+vi.mock('../../../components-v2/layout/RadioLayout.svelte', () => ({ default: navigation.mount }));
+vi.mock('../../../components-v2/layout/LcdLayout.svelte', () => ({ default: navigation.mount }));
 
 import DualSdrFaceSkin from '../DualSdrFaceSkin.svelte';
+import { loadSkin, resolveSkinId } from '../../registry';
 
 describe('DualSdrFaceSkin production entrypoint', () => {
   const source = readFileSync('src/skins/dual-sdr-face/DualSdrFaceSkin.svelte', 'utf8');
+  const statusBarSource = readFileSync('src/components-v2/layout/StatusBar.svelte', 'utf8');
+  const pickerModes = [...statusBarSource.matchAll(/\{ value: '([^']+)', label:/g)]
+    .map((match) => match[1] as CanonicalLayoutMode);
 
   beforeEach(() => {
     lifecycle.acquire.mockClear();
     lifecycle.release.mockClear();
+    navigation.selections.length = 0;
   });
 
   it('mounts the exact face through the canonical read-only semantic view', () => {
@@ -37,6 +63,38 @@ describe('DualSdrFaceSkin production entrypoint', () => {
     expect(source).toMatch(/<SemanticRadioSurfaces\s+\{readonlyDisplay\}\s*\/>/);
     expect(source).toMatch(/<DualSdrFace\s+\{view\}\s+scopeSource=\{hardwareScope\}\s*\/>/);
   });
+
+  it('keeps the picker options synchronized with the canonical layout vocabulary', () => {
+    expect(new Set(pickerModes)).toEqual(CANONICAL_LAYOUT_MODES);
+  });
+
+  it.each(pickerModes)(
+    'keeps a mounted selector path from picker-selectable mode %s',
+    async (layoutPreference) => {
+      const skinId = resolveSkinId({
+        capabilities: null,
+        layoutPreference,
+        isMobile: false,
+        hasAnyScope: true,
+      });
+      const Component = await loadSkin(skinId);
+      const target = document.createElement('div');
+      const mounted = mount(Component, { target });
+
+      const selector = target.querySelector<HTMLSelectElement>(
+        'select[data-testid="skin-navigation-probe"]',
+      );
+      expect(selector, `${layoutPreference} resolved to ${skinId} without navigation`).not.toBeNull();
+
+      const returnMode = layoutPreference === 'standard' ? 'lcd-cockpit' : 'standard';
+      selector!.value = returnMode;
+      selector!.dispatchEvent(new Event('change', { bubbles: true }));
+      expect(navigation.selections).toEqual([returnMode]);
+
+      unmount(mounted);
+      target.remove();
+    },
+  );
 
   it('uses the canonical hardware scope and grants no command callback', () => {
     expect(source).toContain('runtime.scope.subscribeHardware(listener)');


### PR DESCRIPTION
Selecting Dual SDR Face previously replaced the navigation shell with a passive display, leaving no normal way to choose another interface. Mount the existing StatusBar alongside that display so users can switch back.

The registry-driven regression check covers every currently selectable layout, including both SDR choices. It preserves the passive face behavior and does not introduce radio commands or another state/control path.

Linear: [MOR-2237](https://linear.app/morozsm/issue/MOR-2237/peer-split-skin-has-no-skin-selector-once-chosen-there-is-no-way-back).

Validation: focused mounted RED reproduced the missing navigation only for Dual SDR Face (1 failed, 11 passed); GREEN passed 13 tests. Changed-file ESLint, Svelte checks and diff checks passed. Natural applicable CI and one independent exact-head review run in parallel. Final operator acceptance remains separate.
