### PR TITLE
fix: complete managed provider readiness and queue integration

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/fixture-capture-root-cwd.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/fixture-capture-root-cwd.isolated.test.ts
@@ -2,6 +2,9 @@ import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
+// MOR-2080 measured this full-build subprocess at 18.22 s under load.
+const PREFLIGHT_TIMEOUT_MS = 30_000;
+
 describe('fixture capture repository-root invocation (MOR-1409 A04a)', () => {
   it('anchors its Vite preflight at the frontend app root', () => {
     const repoRoot = resolve(import.meta.dirname, '../../../../..');
@@ -12,5 +15,5 @@ describe('fixture capture repository-root invocation (MOR-1409 A04a)', () => {
     );
 
     expect(output).toContain('PASS fixture build preflight');
-  }, 15_000);
+  }, PREFLIGHT_TIMEOUT_MS);
 });

--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 from ...exceptions import CommandError
 from ...exceptions import TimeoutError as RadioTimeoutError
-from ...core.command_dispatch import execute_command_intent
+from ...core.command_dispatch import ManagedWriteAdmission, execute_command_intent
 from ...core.radio_protocol import (
     PhysicalWriteReadbackResult,
     PhysicalWriteReadbackStatus,
@@ -28,6 +28,8 @@ from ...radio_state import RadioState
 from ...runtime._poller_types import (
     canonicalize_level_command,
     execute_command_queue_entry,
+    execute_positive_tx_queue_entry,
+    validate_command_queue_entry_currency,
 )
 from ...runtime.callable_support import supports_explicit_callable
 from ...runtime.managed_tx_state import (
@@ -104,6 +106,27 @@ class RigctldClientObservationPoller:
         self._pending_readback_entries: list[_ReadbackCorrelation] = []
         self._capture_provider_generation: Callable[[], int] | None = None
         self._clock = clock
+        self._managed_tx_authority: ManagedWriteAdmission | None = None
+        self._connection_generation_capture = self._current_connection_generation
+        self._connection_generation_bound = False
+        self._bind_connection_generation()
+
+    def bind_managed_tx_authority(self, authority: ManagedWriteAdmission) -> None:
+        if self._managed_tx_authority is not None:
+            raise RuntimeError("managed transmit authority is already bound")
+        self._managed_tx_authority = authority
+
+    def _current_connection_generation(self) -> object | None:
+        transport = self._radio._transport
+        return transport._writer if transport.connected else None
+
+    def _bind_connection_generation(self) -> None:
+        if self._command_queue is None or self._connection_generation_bound:
+            return
+        self._command_queue.bind_connection_generation(
+            self._connection_generation_capture
+        )
+        self._connection_generation_bound = True
 
     def bind_provider_generation(
         self,
@@ -139,6 +162,7 @@ class RigctldClientObservationPoller:
     async def start(self) -> None:
         if self._tasks:
             return
+        self._bind_connection_generation()
         loop = asyncio.get_running_loop()
         self._tasks = [
             loop.create_task(self._run_loop(self._poll_medium, self._medium_interval)),
@@ -151,6 +175,11 @@ class RigctldClientObservationPoller:
         if self._tasks:
             await asyncio.gather(*self._tasks, return_exceptions=True)
         self._tasks.clear()
+        if self._command_queue is not None and self._connection_generation_bound:
+            self._command_queue.unbind_connection_generation(
+                self._connection_generation_capture
+            )
+            self._connection_generation_bound = False
         self._finish_readbacks(self._pending_readback_entries, "cancelled")
 
     async def _run_loop(
@@ -238,6 +267,24 @@ class RigctldClientObservationPoller:
 
         successful: list["CommandQueueEntry"] = []
 
+        def validate_currency(entry: "CommandQueueEntry") -> None:
+            assert self._command_queue is not None
+            capture = self._capture_provider_generation
+            validate_command_queue_entry_currency(
+                entry,
+                now=self._clock(),
+                provider_generation=None if capture is None else capture(),
+                connection_generation=self._current_connection_generation(),
+                session_is_live=self._command_queue.session_is_live,
+                require_connection_generation=(
+                    self._managed_tx_authority is not None
+                    and (
+                        entry.positive_tx_submission is not None
+                        or isinstance(entry.command, CommandIntent)
+                    )
+                ),
+            )
+
         async def execute_entry(entry: "CommandQueueEntry") -> None:
             cmd = entry.command
             capture = self._capture_provider_generation
@@ -247,7 +294,13 @@ class RigctldClientObservationPoller:
                 provider_generation=None if capture is None else capture(),
             )
             try:
-                await self._execute_command(cmd)
+                validate_currency(entry)
+                if entry.positive_tx_submission is not None:
+                    await execute_positive_tx_queue_entry(entry)
+                    return
+                await self._execute_command(
+                    cmd, validate_currency=lambda: validate_currency(entry)
+                )
             except Exception as exc:
                 if correlation is not None:
                     self._finish_readbacks((correlation,), "rejected")
@@ -358,10 +411,17 @@ class RigctldClientObservationPoller:
                 self._finish_readbacks((entry,), "mismatched", mismatch)
         return tuple(annotated)
 
-    async def _execute_command(self, cmd: Any) -> None:
+    async def _execute_command(
+        self, cmd: Any, *, validate_currency: Callable[[], None] | None = None
+    ) -> None:
         cmd = canonicalize_level_command(cmd, self._radio)
         if isinstance(cmd, CommandIntent):
-            await execute_command_intent(self._radio, cmd)
+            await execute_command_intent(
+                self._radio,
+                cmd,
+                managed_tx_authority=self._managed_tx_authority,
+                validate_currency=validate_currency,
+            )
             return
         from ..._poller_types import (
             PttOff,
@@ -385,6 +445,10 @@ class RigctldClientObservationPoller:
                     receiver=rx,
                 )
             case PttOn():
+                if self._managed_tx_authority is not None:
+                    raise CommandError(
+                        "managed PTT ON requires a positive TX queue submission"
+                    )
                 await self._radio.set_ptt(True)
             case PttOff():
                 await self._radio.set_ptt(False)

--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -631,12 +631,25 @@ class YaesuCatPoller:
         self._cancel_deferred_entry("serial reconnect")
         advance = self._advance_provider_generation
         provider_generation = None if advance is None else advance()
+        reconnect_generation = self._captured_provider_generation()
+        previous_writer = getattr(transport, "_writer", None)
         try:
             logger.warning("YaesuCatPoller: triggering auto-reconnect")
             self._invalidate_ptt_observation()
             self._invalidate_tx_target(provider_generation=provider_generation)
             self._publish_unknown_ptt(provider_generation)
             await transport.reconnect()
+            composition = getattr(self._radio, "_managed_tx_composition", None)
+            writer = getattr(transport, "_writer", None)
+            if (
+                composition is not None
+                and transport is getattr(self._radio, "_transport", None)
+                and getattr(transport, "connected", False) is True
+                and writer is not None
+                and writer is not previous_writer
+                and self._provider_generation_is_current(reconnect_generation)
+            ):
+                await composition.transport_ready(writer)
             logger.info("YaesuCatPoller: reconnected successfully")
         except Exception:
             logger.error("YaesuCatPoller: reconnect failed", exc_info=True)

--- a/tests/test_lifecycle_diagnostics.py
+++ b/tests/test_lifecycle_diagnostics.py
@@ -49,9 +49,15 @@ def test_radio_gc_when_disconnected_does_not_log_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """When a Radio is collected after disconnect, no WARN is emitted."""
-    # Collect cyclic garbage from prior tests before caplog starts observing this
-    # test's warning boundary.
+    foreign_radio = IcomRadio("192.168.1.2", model="IC-7610")
+    foreign_radio._conn_state = RadioConnectionState.CONNECTED
+    foreign_radio._gc_cycle = foreign_radio  # type: ignore[attr-defined]
+    del foreign_radio
+
+    # Model cyclic garbage from an unrelated test, then exclude its diagnostics
+    # from this instance's warning boundary.
     gc.collect()
+    caplog.clear()
     with caplog.at_level(logging.WARNING, logger="rigplane.runtime.radio"):
         radio = IcomRadio("192.168.1.1", model="IC-7610")
         assert radio._conn_state == RadioConnectionState.DISCONNECTED

--- a/tests/test_mor2161_command_dispatch.py
+++ b/tests/test_mor2161_command_dispatch.py
@@ -253,10 +253,9 @@ async def test_all_three_drains_execute_the_same_neutral_intent() -> None:
             poller._managed_tx_authority = None  # noqa: SLF001
             await poller._execute_command(intent)  # noqa: SLF001
         else:
-            poller = RigctldClientObservationPoller.__new__(
-                RigctldClientObservationPoller
+            poller = RigctldClientObservationPoller(
+                radio, callback=lambda _: None, medium_interval=1.0, slow_interval=1.0
             )
-            poller._radio = radio  # type: ignore[attr-defined]
             await poller._execute_command(intent)  # noqa: SLF001
         radio.set_repeater_shift.assert_awaited_once_with(direction=3, receiver=1)
 
@@ -388,8 +387,9 @@ async def test_rigctld_drain_rejects_non_admitted_policy_before_radio_invocation
         radio, "set_repeater_shift", {"direction": 3}, source="http"
     )
     _install_non_admitted_descriptor(monkeypatch)
-    poller = RigctldClientObservationPoller.__new__(RigctldClientObservationPoller)
-    poller._radio = radio  # type: ignore[attr-defined]
+    poller = RigctldClientObservationPoller(
+        radio, callback=lambda _: None, medium_interval=1.0, slow_interval=1.0
+    )
 
     with pytest.raises(CommandError, match="is not admitted"):
         await poller._execute_command(intent)  # noqa: SLF001

--- a/tests/test_rigctld_client_managed_poller.py
+++ b/tests/test_rigctld_client_managed_poller.py
@@ -1,0 +1,262 @@
+"""External provider polling through the production managed composition."""
+
+import asyncio
+
+from fake_rigctld import FakeRigctldServer
+from rigplane.backends.rigctld_client.radio import RigctldClientRadio
+from rigplane.runtime.managed_tx_composition import (
+    ManagedTxComposition,
+    install_managed_tx_composition,
+)
+from rigplane.web.server import WebConfig, WebServer
+from rigplane.web.web_startup import (
+    attach_managed_tx_composition,
+    prepare_managed_tx_observation_generation,
+)
+
+
+import time
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from rigplane.backends.rigctld_client import radio as provider_module
+from rigplane.core.command_dispatch import (
+    enqueue_command_intent,
+    prepare_command_intent,
+)
+from rigplane.exceptions import CommandError
+from rigplane.runtime._poller_types import CommandQueue, PttOff, PttOn
+from rigplane.runtime.managed_tx_state import ManagedTxOutcome
+
+
+async def test_external_provider_managed_web_startup(tmp_path):
+    async with FakeRigctldServer() as fake:
+        radio = RigctldClientRadio(host=fake.host, port=fake.port)
+        composition = ManagedTxComposition(radio, config_path=tmp_path / "tx.json")
+        install_managed_tx_composition(radio, composition)
+        await radio.connect()
+        server = WebServer(radio, WebConfig(host="127.0.0.1", port=0, discovery=False))
+        prepare_managed_tx_observation_generation(server)
+        await composition.transport_ready(radio)
+        await composition.bind_state_store(server.command_state_store)
+        attach_managed_tx_composition(server, composition)
+        try:
+            await server.start()
+            assert server._state_poller._managed_tx_authority is composition.authority
+            assert (
+                server.command_queue.capture_connection_generation()
+                is radio._transport._writer
+            )
+        finally:
+            await composition.shutdown(asyncio.Event())
+            await server.stop()
+            await radio.disconnect()
+
+
+@pytest.fixture
+async def managed(tmp_path):
+    async with FakeRigctldServer() as fake:
+        radio = RigctldClientRadio(host=fake.host, port=fake.port)
+        composition = ManagedTxComposition(radio, config_path=tmp_path / "tx.json")
+        install_managed_tx_composition(radio, composition)
+        await radio.connect()
+        server = WebServer(radio, WebConfig(host="127.0.0.1", port=0, discovery=False))
+        prepare_managed_tx_observation_generation(server)
+        await composition.transport_ready(radio)
+        await composition.bind_state_store(server.command_state_store)
+        attach_managed_tx_composition(server, composition)
+        queue = server.command_queue
+        queue.register_session("operator")
+        poller = radio.create_observation_poller(
+            callback=lambda _: None, command_queue=queue
+        )
+        poller.bind_managed_tx_authority(composition.authority)
+        poller.bind_provider_generation(
+            capture=lambda: server.command_state_store.provider_generation
+        )
+        rig = SimpleNamespace(
+            fake=fake,
+            radio=radio,
+            composition=composition,
+            authority=composition.authority,
+            server=server,
+            queue=queue,
+            poller=poller,
+        )
+        try:
+            yield rig
+        finally:
+            await composition.shutdown(asyncio.Event())
+            await poller.stop()
+            await radio.disconnect()
+
+
+def _enqueue_intent(rig):
+    intent = replace(
+        prepare_command_intent(
+            rig.radio,
+            "set_af_level",
+            {"level": 128, "receiver": 0},
+            source="websocket",
+            command_id="rich-envelope",
+            session_id="operator",
+        ),
+        timeout=10.0,
+    )
+    reply = asyncio.get_running_loop().create_future()
+    enqueue_command_intent(
+        rig.queue,
+        intent,
+        future=reply,
+        command_id=intent.id,
+        source=intent.source,
+        session_id="operator",
+        command_service=rig.server.command_service,
+        timeout=intent.timeout,
+        expires_at_monotonic=time.monotonic() + 10,
+        provider_generation=rig.server.command_state_store.provider_generation,
+        connection_generation=rig.queue.capture_connection_generation(),
+    )
+    return intent, reply
+
+
+@pytest.mark.parametrize(
+    "change", ["none", "deny", "provider", "connection", "session", "expiry"]
+)
+async def test_rich_intent_shared_leaf_rechecks_currency(managed, monkeypatch, change):
+    rig = managed
+    intent, reply = _enqueue_intent(rig)
+    seen = []
+    leaf = provider_module.execute_command_intent
+    admit = rig.authority.admit_managed_write
+
+    async def admission(received):
+        assert received is intent
+        if change == "provider":
+            rig.server.command_state_store.begin_provider_generation()
+        elif change == "connection":
+            await rig.radio.disconnect()
+            await rig.radio.connect()
+        elif change == "session":
+            rig.queue.unregister_session("operator")
+        elif change == "expiry":
+            rig.poller._clock = lambda: time.monotonic() + 20
+        return False if change == "deny" else await admit(received)
+
+    async def observed_leaf(radio, received, **kwargs):
+        seen.append((radio, received, kwargs))
+        await leaf(radio, received, **kwargs)
+
+    monkeypatch.setattr(rig.authority, "admit_managed_write", admission)
+    monkeypatch.setattr(provider_module, "execute_command_intent", observed_leaf)
+    await rig.poller._drain_commands()
+    if change == "none":
+        await reply
+        assert (
+            len([cmd for cmd in rig.fake.commands_seen if cmd.startswith("L AF ")]) == 1
+        )
+    else:
+        with pytest.raises(CommandError):
+            await reply
+        assert not any(cmd.startswith("L AF ") for cmd in rig.fake.commands_seen)
+    assert len(seen) == 1
+    assert seen[0][0] is rig.radio and seen[0][1] is intent
+    assert seen[0][2]["managed_tx_authority"] is rig.authority
+    assert callable(seen[0][2]["validate_currency"])
+
+
+@pytest.mark.parametrize(
+    "change", ["none", "provider", "connection", "session", "expiry", "poison"]
+)
+async def test_positive_submission_uses_current_shared_executor(managed, change):
+    rig = managed
+    loop = asyncio.get_running_loop()
+    ready = loop.create_future()
+    expiry = loop.time() + 10
+    submission = rig.authority.start_ptt_submission(
+        True, "operator", ready=ready, expires_at_monotonic=expiry
+    )
+    joined = asyncio.create_task(
+        rig.server.enqueue_managed_positive_tx(
+            ready=ready,
+            submission=submission,
+            source="websocket",
+            session_id="operator",
+            expires_at_monotonic=expiry,
+            connection_generation=rig.queue.capture_connection_generation(),
+        )
+    )
+    await rig.queue.wait(1)
+    if change == "provider":
+        rig.server.command_state_store.begin_provider_generation()
+    elif change == "connection":
+        await rig.radio.disconnect()
+        await rig.radio.connect()
+    elif change == "session":
+        rig.queue.unregister_session("operator")
+    elif change == "expiry":
+        rig.poller._clock = lambda: time.monotonic() + 20
+    elif change == "poison":
+        await rig.authority.provider_unavailable()
+        await rig.composition.transport_unavailable(rig.radio)
+        await rig.composition.transport_ready(object())
+    await rig.poller._drain_commands()
+    await rig.poller._drain_commands()
+    if change == "none":
+        receipt = await joined
+        assert receipt.outcome is ManagedTxOutcome.ACCEPTED
+        assert rig.fake.commands_seen.count("T 1") == 1
+        off = await rig.authority.submit_ptt(False, "operator")
+        await off.wait_settlement()
+        assert rig.fake.commands_seen.count("T 0") == 1
+        await rig.composition.shutdown(asyncio.Event())
+        assert rig.fake.commands_seen.count("T 0") == 2
+    else:
+        with pytest.raises((CommandError, asyncio.CancelledError)):
+            await joined
+        assert "T 1" not in rig.fake.commands_seen
+    assert submission.done()
+
+
+async def test_managed_legacy_on_denied_and_off_reachable(managed):
+    rig = managed
+    with pytest.raises(RuntimeError, match="already bound"):
+        rig.poller.bind_managed_tx_authority(rig.authority)
+    on, off = (asyncio.get_running_loop().create_future() for _ in range(2))
+    rig.queue.put_ordered(PttOn(), future=on)
+    rig.queue.put_ordered(PttOff(), future=off)
+    await rig.poller._drain_commands()
+    with pytest.raises(CommandError, match="positive TX queue submission"):
+        await on
+    await off
+    assert "T 1" not in rig.fake.commands_seen
+    assert "T 0" in rig.fake.commands_seen
+
+
+async def test_unmanaged_provider_ptt_and_connection_binding_lifecycle():
+    async with FakeRigctldServer() as fake:
+        radio = RigctldClientRadio(host=fake.host, port=fake.port)
+        await radio.connect()
+        queue = CommandQueue()
+        poller = radio.create_observation_poller(
+            callback=lambda _: None, command_queue=queue
+        )
+        try:
+            assert queue.capture_connection_generation() is radio._transport._writer
+            queue.put_ordered(PttOn())
+            queue.put_ordered(PttOff())
+            await poller._drain_commands()
+            assert [cmd for cmd in fake.commands_seen if cmd.startswith("T ")] == [
+                "T 1",
+                "T 0",
+            ]
+            await poller.stop()
+            with pytest.raises(RuntimeError, match="not bound"):
+                queue.capture_connection_generation()
+            await poller.start()
+            assert queue.capture_connection_generation() is radio._transport._writer
+        finally:
+            await poller.stop()
+            await radio.disconnect()

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import time
 from collections.abc import Callable, Sequence
 from dataclasses import replace
 from pathlib import Path
@@ -44,6 +45,18 @@ from rigplane.backends.yaesu_cat.transport import (
 )
 from rigplane.profiles import get_radio_profile
 from rigplane.radio_state import RadioState
+from rigplane.runtime.managed_tx_composition import (
+    ManagedTxComposition,
+    install_managed_tx_composition,
+)
+from rigplane.runtime.managed_tx_state import (
+    AbortOperation,
+    ActuationOperation,
+    ActuationResult,
+    EffectToken,
+    ManagedTxIntentKind,
+    ManagedTxOutcome,
+)
 from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.radio_poller import (
     CommandQueue,
@@ -60,6 +73,167 @@ from rigplane.web.radio_poller import (
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+class _ReconnectActuator:
+    def __init__(self) -> None:
+        self.operations: list[
+            tuple[EffectToken, ActuationOperation | AbortOperation]
+        ] = []
+        self.currency: list[Callable[[], bool]] = []
+        self.on_started = asyncio.Event()
+        self.finish_on = asyncio.Event()
+        self.finish_on.set()
+
+    async def actuate(
+        self,
+        token: EffectToken,
+        operation: ActuationOperation | AbortOperation,
+        *,
+        is_current: Callable[[], bool],
+    ) -> ActuationResult:
+        assert is_current()
+        self.operations.append((token, operation))
+        self.currency.append(is_current)
+        if operation is ActuationOperation.PTT_ON:
+            self.on_started.set()
+            await self.finish_on.wait()
+        return ActuationResult.ACCEPTED
+
+
+async def _managed_reconnect_path(tmp_path: Path):
+    radio = YaesuCatRadio("/dev/null", profile="ftx1", audio_driver=MagicMock())
+    transport = radio._transport
+    transport._connected = True
+    transport._writer = SimpleNamespace(close=lambda: None, wait_closed=AsyncMock())
+    for _ in range(5):
+        transport._stats.record_error("fixture disconnect")
+
+    async def connect() -> None:
+        transport._writer = SimpleNamespace(close=lambda: None, wait_closed=AsyncMock())
+        transport._connected = True
+        transport._stats.record_success()
+
+    transport.connect = AsyncMock(side_effect=connect)
+    actuator = _ReconnectActuator()
+    composition = ManagedTxComposition(actuator, config_path=tmp_path / "tx.json")
+    install_managed_tx_composition(radio, composition)
+    store = StateStore()
+    await composition.transport_ready(radio)
+    await composition.bind_state_store(store)
+    composition.transport_ready = AsyncMock(wraps=composition.transport_ready)
+    poller = radio.create_observation_poller(callback=lambda observations: None)
+    poller.bind_provider_generation(
+        capture=lambda: store.provider_generation,
+        advance=store.begin_provider_generation,
+    )
+    poller.bind_managed_tx_authority(composition.authority)
+    return radio, poller, store, composition, actuator
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("late_on", [False, True])
+async def test_managed_reconnect_restores_current_provider_without_replaying_on(
+    tmp_path: Path,
+    late_on: bool,
+) -> None:
+    radio, poller, store, composition, actuator = await _managed_reconnect_path(
+        tmp_path
+    )
+    authority = composition.authority
+    try:
+        if late_on:
+            actuator.finish_on.clear()
+        old = await authority.submit_ptt(True, "old-owner")
+        assert old.outcome is ManagedTxOutcome.ACCEPTED
+        await asyncio.wait_for(actuator.on_started.wait(), 1)
+        if not late_on:
+            await old.wait_settlement()
+        original_connect = radio._transport.connect
+
+        async def connect() -> None:
+            await original_connect()
+            before = await authority.snapshot()
+            assert before.provider_generation is None
+            assert before.state.release_required
+            actuator.finish_on.set()
+            await old.wait_settlement()
+            assert (await authority.snapshot()).state.release_required
+
+        radio._transport.connect = AsyncMock(side_effect=connect)
+        old_currency = actuator.currency[0]
+        for generation in (1, 2):
+            for _ in range(5):
+                radio._transport._stats.record_error("fixture disconnect")
+            radio._transport._last_reconnect = 0
+            await poller._try_reconnect()
+
+            composition.transport_ready.assert_awaited_with(radio._transport._writer)
+            assert composition.transport_ready.await_count == generation
+            composition.validate_state_store(store)
+            snapshot = await authority.snapshot()
+            assert store.provider_generation == generation
+            assert snapshot.provider_generation == generation + 1
+            assert snapshot.state.intent.kind is ManagedTxIntentKind.RX
+            assert not snapshot.state.release_required
+            assert not old_currency()
+            assert (
+                sum(op is ActuationOperation.PTT_ON for _, op in actuator.operations)
+                == generation
+            )
+            assert actuator.operations[-1][1] is ActuationOperation.FORCE_RECEIVE
+            assert actuator.operations[-1][0].provider_generation == generation + 1
+
+            assert (
+                await authority.ptt_down(f"fresh-{generation}")
+                is ManagedTxOutcome.ACCEPTED
+            )
+            assert actuator.operations[-1][1] is ActuationOperation.PTT_ON
+            assert actuator.operations[-1][0].provider_generation == generation + 1
+    finally:
+        actuator.finish_on.set()
+        termination = asyncio.Event()
+        termination.set()
+        await composition.shutdown(termination)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", ["failure", "provider", "transport", "cooldown"])
+async def test_managed_reconnect_does_not_publish_failed_or_stale_readiness(
+    tmp_path: Path, boundary: str
+) -> None:
+    radio, poller, store, composition, actuator = await _managed_reconnect_path(
+        tmp_path
+    )
+    transport = radio._transport
+    original_connect = transport.connect
+
+    async def connect() -> None:
+        if boundary == "failure":
+            raise CatTransportError("reconnect failed")
+        await original_connect()
+        if boundary == "provider":
+            store.begin_provider_generation()
+        elif boundary == "transport":
+            radio._transport = SimpleNamespace(stats=SimpleNamespace(reconnects=0))
+
+    transport.connect = AsyncMock(side_effect=connect)
+    if boundary == "cooldown":
+        transport._last_reconnect = time.monotonic()
+    try:
+        await poller._try_reconnect()
+        composition.transport_ready.assert_not_awaited()
+        assert (await composition.authority.snapshot()).provider_generation is None
+        assert (
+            await composition.authority.ptt_down("fresh") is ManagedTxOutcome.REJECTED
+        )
+        assert not actuator.operations
+        with pytest.raises(RuntimeError, match="not current"):
+            composition.validate_state_store(store)
+    finally:
+        termination = asyncio.Event()
+        termination.set()
+        await composition.shutdown(termination)
 
 
 def _canonical_ptt_path(


### PR DESCRIPTION
Complete the existing managed TX composition in two providers: Yaesu publishes readiness after a successful current reconnect, and the external rigctld poller binds authority, validates queue currency and executes canonical positive submissions. Failed/stale reconnects and commands remain unavailable; old ON is not replayed, and OFF remains reachable.

This co-lands the independently reviewed MOR-2331 and MOR-2332 implementations, superseding PR #3181. Both connect providers to the same composed contract. No new authority, queue or transport implementation is introduced. Two external-poller test fixtures now use the real constructor. The shared MOR-1469 test isolation fix removes a reproduced GC warning leak that failed both PRs' required CI; active-object diagnostics remain tested.

Validation on isolated Mac mini checkouts:

- Yaesu: real-composition RED 2 failed / 4 passed; owned test file GREEN 177 passed.
- External rigctld: real WebServer + composition + FakeRigctldServer startup RED; 55 + 6 focused cases passed. Corrected existing dispatch fixtures: 51 passed. Preliminary harness failures are recorded separately.
- GC isolation: deterministic foreign-object contamination RED; lifecycle file 6 passed; two bounded 16-worker runs each 762 passed; forcing the owned object active still fails.
- Changed-file lint/format, diff checks and local/Mini source hashes passed. These results cover the component commits; the combined head receives one natural CI cycle and scoped independent review using the existing code verdicts.

The natural CI run exposed the existing MOR-2080 fixture-preflight timeout: its real Vite build ran for 15.287 seconds against a 15-second limit. The test now uses the existing isolated pool and a bounded 30-second timeout, retaining the real subprocess and PASS assertion. On an isolated Mini checkout, direct preflight passed in 4.56 seconds and the single isolated test passed in 6.071 seconds. No capture implementation changed and no manual full-suite rerun was added.

Linear: [MOR-2331](https://linear.app/morozsm/issue/MOR-2331), [MOR-2332](https://linear.app/morozsm/issue/MOR-2332), [MOR-1469](https://linear.app/morozsm/issue/MOR-1469), [MOR-2080](https://linear.app/morozsm/issue/MOR-2080). Hardware acceptance remains separate. Seven files, 546 changed lines; the seventh file fixes the pre-existing CI obstruction encountered by this provider integration without introducing a separate product mechanism.
