### PR TITLE
fix: preserve selected Python compatibility contracts for 3.0 beta

### DIFF
--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -470,6 +470,22 @@ class RadioProfile:
     # authority. Appended to preserve the positional constructor contract.
     ctcss_tones_centihz: tuple[int, ...] | None = None
 
+    @property
+    def vfo_swap_code(self) -> int | None:
+        """Deprecated alias; use ``swap_ab_code`` or ``swap_main_sub_code``.
+
+        Retained for 3.x compatibility with the v2.11.1 truthy fallback.
+        """
+        return self.swap_main_sub_code or self.swap_ab_code
+
+    @property
+    def vfo_equal_code(self) -> int | None:
+        """Deprecated alias; use ``equal_ab_code`` or ``equal_main_sub_code``.
+
+        Retained for 3.x compatibility with the v2.11.1 truthy fallback.
+        """
+        return self.equal_main_sub_code or self.equal_ab_code
+
     def supports_capability(self, capability: str) -> bool:
         return capability in self.capabilities
 

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -4613,15 +4613,28 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         _, freq = parse_tone_freq_response(resp, ctcss_tones_centihz=domain)
         return freq
 
-    async def set_tone_freq(self, freq_centihz: int, receiver: int = 0) -> None:
+    async def set_tone_freq(
+        self,
+        freq_hz: int | None = None,
+        receiver: int = 0,
+        *,
+        freq_centihz: int | None = None,
+    ) -> None:
         """Set CTCSS tone frequency in exact centiHz (0x1B 0x00)."""
+        if freq_hz is not None and freq_centihz is not None:
+            raise TypeError("set_tone_freq received both freq_hz and freq_centihz")
+        if freq_hz is None:
+            if freq_centihz is None:
+                raise TypeError("set_tone_freq missing required frequency")
+            freq_hz = freq_centihz
+
         self._check_connected()
         self._require_receiver(receiver, operation="set_tone_freq")
         domain = self._profile.ctcss_tones_centihz
 
         if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(0x1B, 0x00):
             civ = self._commands.set_tone_freq(
-                freq_centihz,
+                freq_hz,
                 to_addr=self._radio_addr,
                 receiver=RECEIVER_MAIN,
                 command29=False,
@@ -4644,7 +4657,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         cmd29 = self._profile.supports_cmd29(0x1B, 0x00)
         await self._send_fire_and_forget(
             self._commands.set_tone_freq(
-                freq_centihz,
+                freq_hz,
                 to_addr=self._radio_addr,
                 receiver=receiver,
                 command29=cmd29,
@@ -4691,15 +4704,28 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         _, freq = parse_tsql_freq_response(resp, ctcss_tones_centihz=domain)
         return freq
 
-    async def set_tsql_freq(self, freq_centihz: int, receiver: int = 0) -> None:
+    async def set_tsql_freq(
+        self,
+        freq_hz: int | None = None,
+        receiver: int = 0,
+        *,
+        freq_centihz: int | None = None,
+    ) -> None:
         """Set TSQL frequency in exact centiHz (0x1B 0x01)."""
+        if freq_hz is not None and freq_centihz is not None:
+            raise TypeError("set_tsql_freq received both freq_hz and freq_centihz")
+        if freq_hz is None:
+            if freq_centihz is None:
+                raise TypeError("set_tsql_freq missing required frequency")
+            freq_hz = freq_centihz
+
         self._check_connected()
         self._require_receiver(receiver, operation="set_tsql_freq")
         domain = self._profile.ctcss_tones_centihz
 
         if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(0x1B, 0x01):
             civ = self._commands.set_tsql_freq(
-                freq_centihz,
+                freq_hz,
                 to_addr=self._radio_addr,
                 receiver=RECEIVER_MAIN,
                 command29=False,
@@ -4722,7 +4748,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         cmd29 = self._profile.supports_cmd29(0x1B, 0x01)
         await self._send_fire_and_forget(
             self._commands.set_tsql_freq(
-                freq_centihz,
+                freq_hz,
                 to_addr=self._radio_addr,
                 receiver=receiver,
                 command29=cmd29,

--- a/tests/test_lifecycle_diagnostics.py
+++ b/tests/test_lifecycle_diagnostics.py
@@ -49,9 +49,15 @@ def test_radio_gc_when_disconnected_does_not_log_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """When a Radio is collected after disconnect, no WARN is emitted."""
-    # Collect cyclic garbage from prior tests before caplog starts observing this
-    # test's warning boundary.
+    foreign_radio = IcomRadio("192.168.1.2", model="IC-7610")
+    foreign_radio._conn_state = RadioConnectionState.CONNECTED
+    foreign_radio._gc_cycle = foreign_radio  # type: ignore[attr-defined]
+    del foreign_radio
+
+    # Model cyclic garbage from an unrelated test, then exclude its diagnostics
+    # from this instance's warning boundary.
     gc.collect()
+    caplog.clear()
     with caplog.at_level(logging.WARNING, logger="rigplane.runtime.radio"):
         radio = IcomRadio("192.168.1.1", model="IC-7610")
         assert radio._conn_state == RadioConnectionState.DISCONNECTED

--- a/tests/test_mor2337_profile_compatibility.py
+++ b/tests/test_mor2337_profile_compatibility.py
@@ -1,0 +1,79 @@
+"""Frozen v2.11.1 RadioProfile property consumers (MOR-2336 PY1/PY2)."""
+
+from dataclasses import replace
+
+import pytest
+
+from rigplane.profiles import RadioProfile, resolve_radio_profile
+
+
+@pytest.mark.parametrize("operation", ["swap", "equal"])
+@pytest.mark.parametrize("receiver_count,vfo_scheme", [(1, "ab"), (2, "main_sub")])
+@pytest.mark.parametrize(
+    "main_sub,ab,expected",
+    [
+        (0xB0, None, 0xB0),
+        (None, 0xB1, 0xB1),
+        (0xB0, 0xB1, 0xB0),
+        (None, None, None),
+        (0, 0xB1, 0xB1),
+        (0, None, None),
+        (None, 0, 0),
+        (0, 0, 0),
+    ],
+)
+def test_released_property_selection(
+    operation: str,
+    receiver_count: int,
+    vfo_scheme: str,
+    main_sub: int | None,
+    ab: int | None,
+    expected: int | None,
+) -> None:
+    profile = RadioProfile(
+        id="compatibility-consumer",
+        model="Compatibility consumer",
+        civ_addr=0x94,
+        receiver_count=receiver_count,
+        capabilities=frozenset(),
+        cmd29_routes=frozenset(),
+        vfo_scheme=vfo_scheme,
+        swap_main_sub_code=main_sub,
+        swap_ab_code=ab,
+        equal_main_sub_code=ab,
+        equal_ab_code=main_sub,
+    )
+
+    if operation == "swap":
+        assert profile.vfo_swap_code == expected
+        return
+    equal_profile = replace(
+        profile,
+        equal_main_sub_code=main_sub,
+        equal_ab_code=ab,
+        swap_main_sub_code=ab,
+        swap_ab_code=main_sub,
+    )
+    assert equal_profile.vfo_equal_code == expected
+
+
+@pytest.mark.parametrize(
+    "model,swap,equal",
+    [("IC-7300", 0xB0, 0xA0), ("IC-7610", 0xB0, 0xB1), ("FTX-1", None, None)],
+)
+def test_released_consumer_on_current_shipped_profile(
+    model: str, swap: int | None, equal: int | None
+) -> None:
+    profile = resolve_radio_profile(model=model)
+
+    assert profile.vfo_swap_code == swap
+    assert profile.vfo_equal_code == equal
+    updated = replace(
+        profile,
+        swap_main_sub_code=0x12,
+        equal_main_sub_code=0x34,
+    )
+    assert updated.vfo_swap_code == 0x12
+    assert updated.vfo_equal_code == 0x34
+    assert profile.vfo_swap_code == swap
+    assert profile.vfo_equal_code == equal

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -3795,6 +3795,54 @@ class TestToneTsqlParity:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
+        ("method_name", "freq_hz", "expected_tail"),
+        [
+            ("set_tone_freq", 8850, b"\x1b\x00\x00\x08\x85\xfd"),
+            ("set_tsql_freq", 11090, b"\x1b\x01\x00\x11\x09\xfd"),
+        ],
+    )
+    async def test_set_tone_frequency_accepts_protocol_keyword(
+        self,
+        radio: IcomRadio,
+        mock_transport: MockTransport,
+        method_name: str,
+        freq_hz: int,
+        expected_tail: bytes,
+    ) -> None:
+        await getattr(radio, method_name)(freq_hz=freq_hz)
+        assert mock_transport.sent_packets[-1].endswith(expected_tail)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "freq_centihz", "expected_tail"),
+        [
+            ("set_tone_freq", 8850, b"\x1b\x00\x00\x08\x85\xfd"),
+            ("set_tsql_freq", 11090, b"\x1b\x01\x00\x11\x09\xfd"),
+        ],
+    )
+    async def test_set_tone_frequency_preserves_centihz_keyword_alias(
+        self,
+        radio: IcomRadio,
+        mock_transport: MockTransport,
+        method_name: str,
+        freq_centihz: int,
+        expected_tail: bytes,
+    ) -> None:
+        await getattr(radio, method_name)(freq_centihz=freq_centihz)
+        assert mock_transport.sent_packets[-1].endswith(expected_tail)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method_name", ["set_tone_freq", "set_tsql_freq"])
+    async def test_set_tone_frequency_rejects_both_keyword_spellings(
+        self, radio: IcomRadio, mock_transport: MockTransport, method_name: str
+    ) -> None:
+        with pytest.raises(TypeError, match="both freq_hz and freq_centihz"):
+            await getattr(radio, method_name)(freq_hz=8850, freq_centihz=8850)
+
+        assert mock_transport.sent_packets == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
         ("method_name", "sub"),
         [("get_tone_freq", 0x00), ("get_tsql_freq", 0x01)],
     )


### PR DESCRIPTION
Preserve the selected Python compatibility contracts for 3.0 beta. The public RepeaterControlCapable protocol accepts `freq_hz=`, but the concrete Icom tone/TSQL setters rejected it. Both setters now accept the documented integer-centiHz keyword, preserve positional calls and `freq_centihz=`, and reject duplicate spellings before transport. RadioProfile also restores its two read-only compatibility properties using the exact released `main_sub or ab` behavior, including falsy fallback. Canonical fields remain the source of truth; there is no unit scaling, wire change or legacy TX emulation.

[MOR-2335](https://linear.app/morozsm/issue/MOR-2335), [MOR-2337](https://linear.app/morozsm/issue/MOR-2337). Official wire reference: IC-7300 Advanced Manual 11a, printed p.19-13, commands 1B 00/01. Mini CTCSS RED 4 failed / 2 passed; focused GREEN 57 passed. Profile property RED 35 failed; GREEN 35 passed. Ruff/format and local/Mini hashes matched for both component candidates. One combined natural CI and independent review validate the final five-file Python compatibility unit.

Includes the identical shared MOR-1469 GC-test isolation dependency from PR #3182 so CI can run concurrently without the known unrelated warning contamination. Its causal RED, 6-test GREEN, two 762-test xdist runs and negative mutation are recorded in that PR. This dependency introduces no radio behavior change. One independent exact-head review and natural CI gate this PR; no hardware validation is claimed.
