### PR TITLE
fix: version the extension host and preserve canonical transport results

### DIFF
--- a/.github/scripts/check-rebrand-allowlist.sh
+++ b/.github/scripts/check-rebrand-allowlist.sh
@@ -34,7 +34,7 @@ ALLOWLIST=(
     'docs/contracts/diagnostic-bundle-v2.md'
     # Local-extensions deprecation alias (cross-repo Pro contract).
     'frontend/src/lib/local-extensions/host-api.ts'
-    'frontend/src/lib/local-extensions/__tests__/host-api.test.ts'
+    'frontend/src/lib/local-extensions/__tests__/host-api.isolated.test.ts'
     'frontend/src/lib/api/diagnostics.ts'
     'frontend/src/lib/api/__tests__/diagnostics.test.ts'
     # Vendor-protocol diagram label (parallel to IcomSerial / YaesuCAT —

--- a/frontend/src/lib/local-extensions/__tests__/host-api.isolated.test.ts
+++ b/frontend/src/lib/local-extensions/__tests__/host-api.isolated.test.ts
@@ -1,7 +1,10 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
+import { connect, disconnect } from '$lib/transport/ws-client';
+import { MockWebSocket, instances } from '$lib/transport/__tests__/support/fake-ws-backend';
+import { setRadioHealth, setRadioReady } from '$lib/stores/connection.svelte';
 import {
   getCommandLifecycles,
   resetCommandLifecycle,
@@ -11,7 +14,7 @@ import {
   createLocalExtensionHostApi,
   installLocalExtensionHostApi,
   LOCAL_EXTENSION_HOST_API_VERSION,
-  type LocalExtensionHostApiV1,
+  type LocalExtensionHostApiV2,
   type LocalExtensionHostWindow,
   type RadioStateSubscriber,
 } from '../host-api';
@@ -39,6 +42,7 @@ describe('createLocalExtensionHostApi', () => {
     });
 
     expect(api.version).toBe(LOCAL_EXTENSION_HOST_API_VERSION);
+    expect(api.version).toBe(2);
     expect(api.getState()).toBe(state);
     expect(api.getCapabilities()).toBe(capabilities);
   });
@@ -148,7 +152,7 @@ describe('createLocalExtensionHostApi', () => {
 });
 
 describe('installLocalExtensionHostApi', () => {
-  function makeApi(): LocalExtensionHostApiV1 {
+  function makeApi(): LocalExtensionHostApiV2 {
     return createLocalExtensionHostApi({
       getState: () => null,
       getCapabilities: () => null,
@@ -167,9 +171,8 @@ describe('installLocalExtensionHostApi', () => {
 
     expect(fakeWindow.rigplaneExtensionHost).toBe(api);
     expect(fakeWindow.icomLanExtensionHost).toBe(api);
-    // Same instance under both names — Pro extensions written against v1.x
-    // see exactly the same object as new code reading the v2.x global.
     expect(fakeWindow.rigplaneExtensionHost).toBe(fakeWindow.icomLanExtensionHost);
+    expect(fakeWindow.icomLanExtensionHost?.version).toBe(2);
 
     uninstall();
   });
@@ -204,30 +207,75 @@ describe('installLocalExtensionHostApi', () => {
 
 // MOR-1409 A08: the default extension dispatch is catalog-validated facade
 // delegation. This block runs against the real intent facade and command
-// lifecycle store (no module mocks — this file lives in the `fast` project):
+// lifecycle store (no module mocks):
 // a facade dispatch is observable as a lifecycle record, while a raw
 // transport bypass would leave no record.
 describe('createDefaultLocalExtensionHostApi (MOR-1409 A08)', () => {
-  afterEach(() => {
-    resetCommandLifecycle();
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    instances.length = 0;
+    setRadioHealth(null);
+    setRadioReady(false);
   });
 
-  it('routes known catalog commands through the typed facade with a lifecycle record', () => {
+  afterEach(() => {
+    disconnect();
+    resetCommandLifecycle();
+    setRadioReady(false);
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('reports offline non-idempotent refusal with a lifecycle record', () => {
     const api = createDefaultLocalExtensionHostApi();
     const before = getCommandLifecycles().length;
 
-    expect(api.dispatchCommand('vfo_swap')).toBe(true);
+    expect(api.dispatchCommand('vfo_swap')).toBe(false);
 
     const records = getCommandLifecycles();
     expect(records).toHaveLength(before + 1);
-    expect(records.at(-1)).toMatchObject({ name: 'vfo_swap', params: {} });
+    expect(records.at(-1)).toMatchObject({ name: 'vfo_swap', params: {}, status: 'failed' });
+  });
+
+  it('returns false with pending lifecycle for a queued offline command that drains on connection', () => {
+    const api = createDefaultLocalExtensionHostApi();
+    expect(api.sendCommand('set_freq', { freq: 14_074_000, receiver: 0 })).toBe(false);
+    expect(getCommandLifecycles().at(-1)).toMatchObject({
+      name: 'set_freq', params: { freq: 14_074_000, receiver: 0 }, status: 'pending',
+    });
+    const queued = getCommandLifecycles().at(-1)!;
+    connect();
+    const socket = instances[0];
+    expect(socket.sent).toHaveLength(0);
+    socket.simulateOpen();
+    const commands = socket.sent.map((value) => JSON.parse(value)).filter((value) => value.type === 'cmd');
+    expect(commands).toEqual([{
+      type: 'cmd', name: 'set_freq', params: { freq: 14_074_000, receiver: 0 }, id: queued.id,
+    }]);
+    expect(getCommandLifecycles().at(-1)?.status).toBe('pending');
+  });
+
+  it.each(['sendCommand', 'dispatchCommand'] as const)('returns true for %s socket submission without admission or completion', (method) => {
+    const api = createDefaultLocalExtensionHostApi();
+    connect();
+    const socket = instances[0];
+    socket.simulateOpen();
+    setRadioReady(true);
+    socket.sent.length = 0;
+    expect(api[method]('set_mode', { mode: 'CW', receiver: 1 })).toBe(true);
+    const record = getCommandLifecycles().at(-1)!;
+    expect(socket.sent.map((value) => JSON.parse(value))).toEqual([{
+      type: 'cmd', name: 'set_mode', params: { mode: 'CW', receiver: 1 }, id: record.id,
+    }]);
+    expect(record.status).toBe('pending');
   });
 
   it('clones params so later caller mutation cannot alter the dispatched intent', () => {
     const api = createDefaultLocalExtensionHostApi();
     const params: Record<string, unknown> = { band: 20 };
 
-    expect(api.sendCommand('set_band', params)).toBe(true);
+    expect(api.sendCommand('set_band', params)).toBe(false);
     params.band = 40;
 
     expect(getCommandLifecycles().at(-1)).toMatchObject({

--- a/frontend/src/lib/local-extensions/__tests__/manifest.test.ts
+++ b/frontend/src/lib/local-extensions/__tests__/manifest.test.ts
@@ -60,7 +60,7 @@ describe('loadLocalExtensionManifest', () => {
   it('treats unsupported host API versions as no local extensions', async () => {
     const fetch = vi.fn().mockResolvedValue(mockResponse(200, {
       version: 1,
-      host_api: '2.0',
+      host_api: '3.0',
       extensions: [{ id: 'one', mount: 'floating-overlay', entry: '/local/one.js' }],
     }));
 
@@ -80,7 +80,7 @@ describe('loadLocalExtensionManifest', () => {
   it('loads valid same-origin floating overlay extensions', async () => {
     const fetch = vi.fn().mockResolvedValue(mockResponse(200, {
       version: 1,
-      host_api: '1.0',
+      host_api: '2.0',
       extensions: [
         {
           id: 'meter',
@@ -100,7 +100,7 @@ describe('loadLocalExtensionManifest', () => {
 
     expect(manifest).toEqual({
       version: 1,
-      host_api: '1.0',
+      host_api: '2.0',
       extensions: [
         {
           id: 'meter',
@@ -116,9 +116,18 @@ describe('loadLocalExtensionManifest', () => {
 });
 
 describe('parseLocalExtensionManifest', () => {
+  it.each(['1.0', undefined, '3.0', 2, null])('rejects incompatible host API %s', (host_api) => {
+    expect(parseLocalExtensionManifest({
+      version: 1,
+      ...(host_api === undefined ? {} : { host_api }),
+      extensions: [{ id: 'meter', mount: 'floating-overlay', entry: '/local/meter.js' }],
+    })).toBeNull();
+  });
+
   it('drops invalid extension descriptors', () => {
     const manifest = parseLocalExtensionManifest({
       version: 1,
+      host_api: '2.0',
       extensions: [
         { id: 'ok', mount: 'floating-overlay', entry: '/local/ok.js' },
         { id: '', mount: 'floating-overlay', entry: '/local/no-id.js' },
@@ -142,6 +151,7 @@ describe('parseLocalExtensionManifest', () => {
   it('returns null when no valid extensions remain', () => {
     expect(parseLocalExtensionManifest({
       version: 1,
+      host_api: '2.0',
       extensions: [
         { id: 'remote', mount: 'floating-overlay', entry: 'https://example.com/remote.js' },
       ],

--- a/frontend/src/lib/local-extensions/host-api.ts
+++ b/frontend/src/lib/local-extensions/host-api.ts
@@ -2,22 +2,24 @@ import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import { getCapabilities } from '$lib/stores/capabilities.svelte';
 import { getRadioState, subscribeRadioState } from '$lib/stores/radio.svelte';
-import { dispatchRadioIntent, type RadioIntent } from '$lib/runtime/commands/radio-intents';
+import { dispatchRadioIntentWithResult, type RadioIntent } from '$lib/runtime/commands/radio-intents';
 import {
   resetLocalExtensionKeyboardScope,
   setLocalExtensionKeyboardScope,
 } from './keyboard-scope';
 
-export const LOCAL_EXTENSION_HOST_API_VERSION = 1;
+export const LOCAL_EXTENSION_HOST_API_VERSION = 2;
 
 export type RadioStateSubscriber = (state: ServerState | null) => void;
 
-export interface LocalExtensionHostApiV1 {
+export interface LocalExtensionHostApiV2 {
   version: typeof LOCAL_EXTENSION_HOST_API_VERSION;
   getState(): ServerState | null;
   getCapabilities(): Capabilities | null;
   subscribeState(handler: RadioStateSubscriber): () => void;
+  /** Returns the client transport result, not radio delivery, server admission or completion. */
   sendCommand(name: string, params?: Record<string, unknown>): boolean;
+  /** Same acceptance result as sendCommand. */
   dispatchCommand(name: string, params?: Record<string, unknown>): boolean;
   setKeyboardScope(scope: string | null): void;
   register(extension: LocalExtensionRegistration): void;
@@ -36,18 +38,13 @@ export interface LocalExtensionRegistration {
   id: string;
   title?: string;
   mount?: string;
-  render(container: HTMLElement, api: LocalExtensionHostApiV1): void | (() => void);
+  render(container: HTMLElement, api: LocalExtensionHostApiV2): void | (() => void);
 }
 
 export interface LocalExtensionHostWindow extends Window {
-  /** Primary v2.x global. Pro local-extensions written for rigplane should read this. */
-  rigplaneExtensionHost?: LocalExtensionHostApiV1;
-  /**
-   * @deprecated Alias kept for v1.x extensions written against icom-lan.
-   * Will be removed in a future major. New code should use
-   * `rigplaneExtensionHost` instead.
-   */
-  icomLanExtensionHost?: LocalExtensionHostApiV1;
+  rigplaneExtensionHost?: LocalExtensionHostApiV2;
+  /** @deprecated Naming alias for the same v2 API; use rigplaneExtensionHost. */
+  icomLanExtensionHost?: LocalExtensionHostApiV2;
 }
 
 function cloneParams(params: Record<string, unknown> | undefined): Record<string, unknown> {
@@ -67,7 +64,7 @@ function dispatchVia(
 
 export function createLocalExtensionHostApi(
   deps: LocalExtensionHostDependencies,
-): LocalExtensionHostApiV1 {
+): LocalExtensionHostApiV2 {
   return {
     version: LOCAL_EXTENSION_HOST_API_VERSION,
     getState: deps.getState,
@@ -102,8 +99,7 @@ function dispatchThroughIntentFacade(
     return false;
   }
   try {
-    dispatchRadioIntent({ name, params: params ?? {} } as RadioIntent);
-    return true;
+    return dispatchRadioIntentWithResult({ name, params: params ?? {} } as RadioIntent).transportAccepted;
   } catch {
     return false;
   }
@@ -111,7 +107,7 @@ function dispatchThroughIntentFacade(
 
 export function createDefaultLocalExtensionHostApi(
   register: (extension: LocalExtensionRegistration) => void = () => {},
-): LocalExtensionHostApiV1 {
+): LocalExtensionHostApiV2 {
   return createLocalExtensionHostApi({
     getState: getRadioState,
     getCapabilities,
@@ -124,13 +120,9 @@ export function createDefaultLocalExtensionHostApi(
 
 export function installLocalExtensionHostApi(
   targetWindow: LocalExtensionHostWindow = window as LocalExtensionHostWindow,
-  api: LocalExtensionHostApiV1 = createDefaultLocalExtensionHostApi(),
+  api: LocalExtensionHostApiV2 = createDefaultLocalExtensionHostApi(),
 ): () => void {
-  // Primary v2.x global.
   targetWindow.rigplaneExtensionHost = api;
-  // Backwards-compat: Pro local-extensions written for v1.x icom-lan read
-  // `window.icomLanExtensionHost`. Expose the same instance under both names
-  // so existing extensions keep working without modification.
   targetWindow.icomLanExtensionHost = api;
   return () => {
     if (targetWindow.rigplaneExtensionHost === api) {

--- a/frontend/src/lib/local-extensions/manifest.ts
+++ b/frontend/src/lib/local-extensions/manifest.ts
@@ -1,6 +1,6 @@
 export const LOCAL_EXTENSION_MANIFEST_URL = '/api/local/v1/ui/manifest';
 export const LOCAL_EXTENSION_MANIFEST_VERSION = 1;
-export const LOCAL_EXTENSION_HOST_API_VERSION = '1.0';
+export const LOCAL_EXTENSION_HOST_API_VERSION = '2.0';
 
 export type LocalExtensionMount = 'floating-overlay';
 
@@ -15,7 +15,7 @@ export interface LocalExtensionDescriptor {
 
 export interface LocalExtensionManifest {
   version: typeof LOCAL_EXTENSION_MANIFEST_VERSION;
-  host_api?: typeof LOCAL_EXTENSION_HOST_API_VERSION;
+  host_api: typeof LOCAL_EXTENSION_HOST_API_VERSION;
   extensions: LocalExtensionDescriptor[];
 }
 
@@ -63,10 +63,7 @@ export function parseLocalExtensionManifest(
     return null;
   }
 
-  if (
-    manifest.host_api !== undefined
-    && manifest.host_api !== LOCAL_EXTENSION_HOST_API_VERSION
-  ) {
+  if (manifest.host_api !== LOCAL_EXTENSION_HOST_API_VERSION) {
     return null;
   }
 
@@ -113,13 +110,11 @@ export function parseLocalExtensionManifest(
     return null;
   }
 
-  return typeof manifest.host_api === 'string'
-    ? {
-        version: LOCAL_EXTENSION_MANIFEST_VERSION,
-        host_api: LOCAL_EXTENSION_HOST_API_VERSION,
-        extensions,
-      }
-    : { version: LOCAL_EXTENSION_MANIFEST_VERSION, extensions };
+  return {
+    version: LOCAL_EXTENSION_MANIFEST_VERSION,
+    host_api: LOCAL_EXTENSION_HOST_API_VERSION,
+    extensions,
+  };
 }
 
 export async function loadLocalExtensionManifest(
@@ -146,7 +141,17 @@ export async function loadLocalExtensionManifest(
   }
 
   try {
-    return parseLocalExtensionManifest(await response.json(), options.baseUrl);
+    const value: unknown = await response.json();
+    const manifest = asObject(value);
+    if (manifest?.version === LOCAL_EXTENSION_MANIFEST_VERSION
+      && manifest.host_api !== LOCAL_EXTENSION_HOST_API_VERSION) {
+      console.warn(
+        '[local-extensions] Extension manifest rejected: explicit host_api "2.0" is required. '
+        + 'Migrate to host version 2 canonical command names and parameters, including required receivers. '
+        + 'Command booleans report client transport acceptance only; PTT commands remain unsupported.',
+      );
+    }
+    return parseLocalExtensionManifest(value, options.baseUrl);
   } catch {
     return null;
   }

--- a/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
@@ -54,6 +54,77 @@ describe('typed non-PTT radio intents', () => {
     vi.useRealTimers();
   });
 
+  it.each([false, true])('returns transport acceptance %s separately from lifecycle', (transportAccepted) => {
+    harness.sendCommand.mockReturnValue(transportAccepted);
+    const result = intents.dispatchRadioIntentWithResult({
+      id: 'acceptance', name: 'set_freq', params: { freq: 14_074_000, receiver: 0 },
+    });
+    expect(result.transportAccepted).toBe(transportAccepted);
+    expect(result.lifecycle).toMatchObject({ id: 'acceptance', status: 'pending' });
+    expect(result.lifecycle).not.toHaveProperty('confirmedValue');
+    expect(harness.sendCommand).toHaveBeenCalledExactlyOnceWith(
+      'set_freq', { freq: 14_074_000, receiver: 0 }, 'acceptance',
+    );
+  });
+
+  it('preserves the original dispatch lifecycle return on transport refusal', () => {
+    harness.sendCommand.mockReturnValue(false);
+    const result = intents.dispatchRadioIntent({ id: 'old-caller', name: 'vfo_swap', params: {} });
+    expect(result).toMatchObject({ id: 'old-caller', name: 'vfo_swap', status: 'pending' });
+    expect(result).not.toHaveProperty('lifecycle');
+    expect(harness.sendCommand).toHaveBeenCalledExactlyOnceWith('vfo_swap', {}, 'old-caller');
+  });
+
+  it.each(['sendCommand', 'dispatchCommand'] as const)('host %s preserves non-TX consumer calls and each transport result', async (method) => {
+    const { createDefaultLocalExtensionHostApi } = await import('$lib/local-extensions/host-api');
+    const api = createDefaultLocalExtensionHostApi();
+    const examples = [
+      ['set_freq', { freq: 14_074_000, receiver: 0 }],
+      ['set_mode', { mode: 'CW', receiver: 1 }],
+      ['set_af_level', { level: 0.5, receiver: 0 }],
+      ['vfo_swap', {}],
+    ] as const;
+    for (const [name, params] of examples) {
+      for (const accepted of [false, true, false]) {
+        harness.sendCommand.mockClear().mockReturnValue(accepted);
+        expect(api[method](name, params)).toBe(accepted);
+        expect(harness.sendCommand).toHaveBeenCalledExactlyOnceWith(name, params, expect.any(String));
+        expect(lifecycle.getCommandLifecycles().at(-1)).toMatchObject({ name, params, status: 'pending' });
+      }
+    }
+  });
+
+  it('rejects obsolete TX and malformed extension requests before transport dispatch', async () => {
+    const { createDefaultLocalExtensionHostApi } = await import('$lib/local-extensions/host-api');
+    const api = createDefaultLocalExtensionHostApi();
+    for (const [name, params] of [
+      ['unknown', {}], ['ptt', { state: true }], ['ptt', { state: false }],
+      ['ptt_on', {}], ['ptt_off', {}], ['set_af_level', { level: 0.5 }],
+      ['set_freq', { freq: 14_074_000, extra: true }], ['set_freq', { freq: '14074000' }],
+    ] as const) {
+      expect(api.sendCommand(name, params)).toBe(false);
+      expect(api.dispatchCommand(name, params)).toBe(false);
+    }
+    expect(harness.sendCommand).not.toHaveBeenCalled();
+    expect(lifecycle.getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it.each(['1.0', undefined])('reports a migration message when loading host API %s', async (host_api) => {
+    const { loadLocalExtensionManifest } = await import('$lib/local-extensions/manifest');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({
+        version: 1, ...(host_api === undefined ? {} : { host_api }),
+        extensions: [{ id: 'meter', mount: 'floating-overlay', entry: '/local/meter.js' }],
+      }) });
+      expect(await loadLocalExtensionManifest({ fetch })).toBeNull();
+      expect(warn).toHaveBeenCalledExactlyOnceWith(expect.stringMatching(/host_api.*2\.0.*migrat/i));
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/PTT.*unsupported/));
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it('sends one exact three-argument envelope with no optimistic side channel', () => {
     const record = intents.dispatchRadioIntent({
       id: 'freq-1',

--- a/frontend/src/lib/runtime/commands/radio-intents.ts
+++ b/frontend/src/lib/runtime/commands/radio-intents.ts
@@ -115,6 +115,16 @@ export function currentControlSessionEpoch(): number {
 }
 
 export function dispatchRadioIntent(intent: RadioIntent): CommandLifecycle {
+  return dispatchRadioIntentWithResult(intent).lifecycle;
+}
+
+export interface RadioIntentDispatchResult {
+  readonly lifecycle: CommandLifecycle;
+  /** Result of sendCommand; offline queueing can return false without failing the lifecycle. */
+  readonly transportAccepted: boolean;
+}
+
+export function dispatchRadioIntentWithResult(intent: RadioIntent): RadioIntentDispatchResult {
   if (typeof intent !== 'object' || intent === null || Array.isArray(intent)) throw new TypeError('Invalid radio intent envelope');
   const candidate = intent as unknown as Record<PropertyKey, unknown>;
   if (Reflect.ownKeys(candidate).some((key) => typeof key !== 'string' || (key !== 'name' && key !== 'params' && key !== 'id'))) {
@@ -131,6 +141,6 @@ export function dispatchRadioIntent(intent: RadioIntent): CommandLifecycle {
   const id = (candidate.id as string | undefined) ?? makeCommandId();
   const originalEpoch = getControlSession().epoch;
   const lifecycle = beginCommand({ id, name, params: params as Record<string, unknown>, originalEpoch });
-  sendCommand(name, params as Record<string, unknown>, id);
-  return lifecycle;
+  const transportAccepted = sendCommand(name, params as Record<string, unknown>, id);
+  return { lifecycle, transportAccepted };
 }


### PR DESCRIPTION
The local extension host returned true even when canonical command transport returned false. Preserve the existing CommandLifecycle API through one common dispatch path and expose the actual transport result to the host. True means current-socket submission; false can still mean an idempotent command is queued offline. Neither value proves radio delivery, admission or completion, and false is not a cancellation guarantee.

This intentional 3.0 contract transition exposes host API 2 and LocalExtensionHostApiV2. Manifest schema 1 now requires explicit host_api 2.0; 1.0, omitted and unsupported versions are rejected with a migration warning. Both global names reference the same v2 object. Canonical non-TX operations remain available; no old PTT name or lifecycle is emulated.

[MOR-2339](https://linear.app/morozsm/issue/MOR-2339). Mini baseline 36 passed, regression RED 14 failed, final affected tests 52 passed. Real ws-client/intent/host tests cover offline false with later queue drain, live true with one envelope, and preserved pending lifecycle. Changed-file ESLint and scoped TypeScript passed; all tracked frontend bytes matched the tested Mini checkout. A mistaken initial offline-queue expectation and private typecheck harness setup were corrected and recorded separately.

One independent exact-head review and applicable CI gate merge. Migration docs/version metadata are handled by MOR-2340 before release. No full-suite, hardware or audible-output acceptance is claimed.
