### PR TITLE
docs: align Core 3.0 beta migration and consumer witnesses

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2562,8 +2562,8 @@ These deprecation closures were announced in v0.19 and dropped on schedule.
 - Transport layer, authentication, CI-V commands, meters, PTT, keep-alive.
 - Clean-room Icom LAN UDP protocol implementation.
 
-[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v3.0.0b1...HEAD
-[3.0.0b1]: https://github.com/rigplane/rigplane-core/compare/v2.11.1...v3.0.0b1
+[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.11.1...HEAD
+[3.0.0b1]: https://github.com/rigplane/rigplane-core/compare/v2.11.1...HEAD
 [2.10.2]: https://github.com/rigplane/rigplane-core/compare/v2.10.1...v2.10.2
 [2.10.1]: https://github.com/rigplane/rigplane-core/compare/v2.10.0...v2.10.1
 [2.10.0]: https://github.com/rigplane/rigplane-core/compare/v2.9.0...v2.10.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0b1] — Unreleased candidate
+
+### Migration from 2.11.1
+
+- Core 3.0 beta uses selective compatibility. The [migration guide](migrate.md)
+  maps the frozen compatibility decisions to Python, receiver-state, HTTP,
+  extension-host, CLI, profile and rigctld consumer examples. All TX consumers
+  must adopt canonical ownership, admission, completion and OFF; the former
+  leave-keyed lifecycle is not emulated. Momentary PTT and latched TRANSMIT
+  are distinct operations.
+- The package target is `3.0.0b1` in `pyproject.toml` and the editable
+  `rigplane` entry of `uv.lock`. HTTP contract version 1 and the approved
+  extension-host target (numeric 2, manifest `host_api: "2.0"`) are separate
+  contracts. The host requires the explicit new declaration while retaining
+  manifest schema version 1. Installed-candidate compatibility is a separate
+  release gate; no release or full 2.x compatibility is claimed.
+- Core includes SDR preservation against the 2.11.1 behavior baseline.
+  Browser, packaging/rollback and hardware acceptance remain release gates;
+  Pro packaging and release follow separately.
+
+- **Profile aliases retain their released behavior.** The 3.0
+  compatibility bridge restores the deprecated read-only
+  `RadioProfile.vfo_swap_code` and `RadioProfile.vfo_equal_code` properties
+  after their development removal. Their exact released expressions are
+  `swap_main_sub_code or swap_ab_code` and
+  `equal_main_sub_code or equal_ab_code`. New consumers should select the
+  explicit A/B or MAIN/SUB operation appropriate to their radio; see the
+  [migration guide](migrate.md).
+- Icom CTCSS tone/TSQL setters accept the public integer-centiHz `freq_hz`
+  keyword and retain `freq_centihz` as an alternative. Supplying both
+  non-`None` spellings or neither raises `TypeError` before transport; there
+  is no unit scaling. See `src/rigplane/runtime/radio.py: CoreRadio.set_tone_freq`
+  and `CoreRadio.set_tsql_freq`, and the [migration guide](migrate.md).
+
 ### Breaking changes
 
 - **Tone-capable rig profiles must now declare a named CTCSS table (MOR-2129).**
@@ -313,14 +347,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the `Radio` protocol method never took a receiver for this reading —
   so this closes a footgun rather than changing observed behaviour; a caller
   that did pass `receiver=` now gets a `TypeError` instead of a silent SET.
-- **`RadioProfile.vfo_swap_code` and `RadioProfile.vfo_equal_code` are
-  removed** (mechanism-audit D2; both were self-documented deprecated since
-  issue #710). Read `swap_ab_code`/`swap_main_sub_code` (or
-  `equal_ab_code`/`equal_main_sub_code`) directly; the alias resolution the
-  properties performed was `swap_main_sub_code or swap_ab_code` (and the
-  `equal_` equivalent), so a caller that needs the old ordering inlines that
-  expression. No production code in this repository read either property —
-  consumers were tests only.
+
 - **`rigplane.commands.mode`/`tone`/`antenna`/`meters` builders require
   `cmd_map`; there is no hardcoded fallback (MOR-2008, batch 2 of
   `docs/plans/2026-08-29-profile-driven-command-bytes.md`).** All 40
@@ -570,60 +597,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **CLI: `rigplane ptt off` forces an unkey when no lease of its own matches
-  (MOR-1175, MOR-1182).** Under the managed TX runtime a rig keyed by a process
-  that has since died holds a lease no other invocation can match, so the
-  ordinary release was refused and the command warned and exited 0 — the crash
-  recovery `ptt off` exists for was gone. It now escalates to an
-  operator-forced unkey (attributed as such, never as a system release), and
-  its exit code becomes meaningful: `0` only when an unkey reached the wire or
-  was already in flight, `1` — with what the rig may still be doing — when it
-  did not. A *live* lease held by another TX session is refused rather than
-  preempted. `ptt on` is unaffected: its own teardown never escalates.
-
-- **Browser TX surfaces unified (PRs #2125, #2128, #2130, #2134).** Both desktop
-  TxPanel and mobile FAB + landscape strip now key through the single App-owned
-  TX controller with lease-correct gestures; duplicate presentation-local PTT
-  state machines and 3-minute safety timers removed. Operator-visible: re-keying
-  immediately after release waits for fresh authoritative PTT readback (button
-  shows unkeying state in between); latched transmission is released when its
-  panel unmounts, and on mobile also when the device rotates while latched
-  (fail-closed).
-
-- **Max-key-down coverage after the presentation-timer removal (MOR-1220).**
-  The 3-minute presentation-local timers removed above were UI-side and
-  backend-agnostic, so deleting them (MOR-1011/MOR-1012) traded that
-  frontend bound for the managed TX runtime's own supervisor watchdog on the
-  managed path — coverage that only exists where a runtime is armed. A 180s
-  backstop (`BACKEND_MAX_KEY_DOWN_SECONDS`) is now armed around the legacy
-  PTT write on the web UI's Icom poller, so a serial/USB Icom rig keyed from
-  the Web UI is bounded again. Current boundary: managed TX is armed on the
-  LAN `IcomRadio` path only (the supervisor watchdog covers it everywhere,
-  not just Web); serial/USB Icom is legacy, with full managed arm pending
-  MOR-1219; Yaesu CAT and the rigctld-client backend are legacy with no
-  supervisor, pending MOR-1190 (acceptance amended to include the key-down
-  bound; MOR-1190 gates the MOR-1033 FTX-1 hardware cert in the same
-  release). On an unmanaged rig this backstop bounds a key **the web poller
-  itself issued** and no other; see the rigctld entry below for the seat that
-  bounds a `rigctld` key. The CLI hold path (`ptt on --for`) arms no watchdog
-  at all — it unkeys when the hold ends or on Ctrl-C, so a hard-killed
-  process still leaves the rig keyed.
-
-- **Key-down bound for a `rigctld`-issued key on an unmanaged rig
-  (MOR-1904).** A `rigctld` client that keyed a serial/USB Icom, Yaesu CAT or
-  rigctld-client rig and then died left the transmitter up with nothing to
-  time it out: those backends arm no supervisor, MOR-1220's backstop bounds
-  only keys the web poller issued, and rigctld deliberately writes nothing on
-  socket close. `rigctld` now bounds a key it issued itself at the same 180s
-  (`BACKEND_MAX_KEY_DOWN_SECONDS`) and unkeys when it expires. Two
-  differences from the web-poller backstop above: it is cancelled by any PTT
-  write of either polarity from any `rigctld` session, and — unlike MOR-1220,
-  which fires on the deadline whatever the rig is doing — it is also
-  cancelled once the rig is *observed* back in receive by an observation
-  taken after that key. It deliberately outlives the socket that keyed it:
-  a client going away is not evidence the rig came off the air. It is a
-  damage bound only and grants no session any claim on the transmitter;
-  ownership stays with MOR-1219/MOR-1190.
+- **TX consumers migrate to canonical ownership and release.** Earlier
+  development entries described per-consumer leases, poller watchdogs and
+  UI-local teardown behavior that are superseded by the managed TX contract.
+  Use stable-owner WebSocket momentary PTT, explicit latched TRANSMIT only
+  when intended, and canonical ForceOff for unconditional release. Admission
+  is distinct from settlement and observed radio state. The concrete API and
+  timed CLI migration examples, source references and focused witnesses are
+  in the [migration guide](migrate.md).
 
 ### Removed
 
@@ -2581,7 +2562,8 @@ These deprecation closures were announced in v0.19 and dropped on schedule.
 - Transport layer, authentication, CI-V commands, meters, PTT, keep-alive.
 - Clean-room Icom LAN UDP protocol implementation.
 
-[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.10.2...HEAD
+[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v3.0.0b1...HEAD
+[3.0.0b1]: https://github.com/rigplane/rigplane-core/compare/v2.11.1...v3.0.0b1
 [2.10.2]: https://github.com/rigplane/rigplane-core/compare/v2.10.1...v2.10.2
 [2.10.1]: https://github.com/rigplane/rigplane-core/compare/v2.10.0...v2.10.1
 [2.10.0]: https://github.com/rigplane/rigplane-core/compare/v2.9.0...v2.10.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Migration from 2.11.1
 
-- Core 3.0 beta uses selective compatibility. The [migration guide](migrate.md)
+- Core 3.0 beta uses selective compatibility. The [migration guide](https://rigplane.dev/migrate/)
   maps the frozen compatibility decisions to Python, receiver-state, HTTP,
   extension-host, CLI, profile and rigctld consumer examples. All TX consumers
   must adopt canonical ownership, admission, completion and OFF; the former
@@ -38,12 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `swap_main_sub_code or swap_ab_code` and
   `equal_main_sub_code or equal_ab_code`. New consumers should select the
   explicit A/B or MAIN/SUB operation appropriate to their radio; see the
-  [migration guide](migrate.md).
+  [migration guide](https://rigplane.dev/migrate/).
 - Icom CTCSS tone/TSQL setters accept the public integer-centiHz `freq_hz`
   keyword and retain `freq_centihz` as an alternative. Supplying both
   non-`None` spellings or neither raises `TypeError` before transport; there
   is no unit scaling. See `src/rigplane/runtime/radio.py: CoreRadio.set_tone_freq`
-  and `CoreRadio.set_tsql_freq`, and the [migration guide](migrate.md).
+  and `CoreRadio.set_tsql_freq`, and the [migration guide](https://rigplane.dev/migrate/).
 
 ### Breaking changes
 
@@ -604,7 +604,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   when intended, and canonical ForceOff for unconditional release. Admission
   is distinct from settlement and observed radio state. The concrete API and
   timed CLI migration examples, source references and focused witnesses are
-  in the [migration guide](migrate.md).
+  in the [migration guide](https://rigplane.dev/migrate/).
 
 ### Removed
 

--- a/docs/api/public-api-surface.md
+++ b/docs/api/public-api-surface.md
@@ -225,8 +225,9 @@ From `frontend/src/lib/local-extensions/manifest.ts`:
 `host_api: "2.0"` is required. `parseLocalExtensionManifest` rejects omitted,
 `"1.0"`, malformed and unsupported host declarations. Migrate extension
 commands before declaring the new version. `installLocalExtensionHostApi`
-exposes the same v2 object as `window.rigplaneExtensionHost` and the deprecated
-`window.icomLanExtensionHost`; the latter does not provide v1 behavior.
+exposes the same v2 object through `window.rigplaneExtensionHost` and its
+deprecated naming alias; see the [migration guide](../migrate.md) for the
+alias spelling. The alias does not provide v1 behavior.
 
 The default host validates commands through
 `frontend/src/lib/runtime/commands/radio-intents.ts: dispatchRadioIntentWithResult`.

--- a/docs/api/public-api-surface.md
+++ b/docs/api/public-api-surface.md
@@ -198,9 +198,9 @@ It is a stable Pro-facing contract — treat it as tier 1 in this document.
 
 From `frontend/src/lib/local-extensions/host-api.ts`:
 
-- `LOCAL_EXTENSION_HOST_API_VERSION` (numeric constant, currently `1`)
+- `LOCAL_EXTENSION_HOST_API_VERSION` (numeric constant, currently `2`)
 - `RadioStateSubscriber` (type)
-- `LocalExtensionHostApiV1` (interface)
+- `LocalExtensionHostApiV2` (interface)
 - `LocalExtensionHostDependencies` (interface)
 - `LocalExtensionRegistration` (interface)
 - `LocalExtensionHostWindow` (interface)
@@ -211,8 +211,8 @@ From `frontend/src/lib/local-extensions/host-api.ts`:
 From `frontend/src/lib/local-extensions/manifest.ts`:
 
 - `LOCAL_EXTENSION_MANIFEST_URL` (constant)
-- `LOCAL_EXTENSION_MANIFEST_VERSION` (numeric constant)
-- `LOCAL_EXTENSION_HOST_API_VERSION` (string version, e.g. `"1.0"`,
+- `LOCAL_EXTENSION_MANIFEST_VERSION` (numeric constant, currently `1`)
+- `LOCAL_EXTENSION_HOST_API_VERSION` (string version, currently `"2.0"`,
   mirrors the numeric constant in `host-api.ts`)
 - `LocalExtensionMount` (type)
 - `LocalExtensionDescriptor` (interface)
@@ -220,6 +220,31 @@ From `frontend/src/lib/local-extensions/manifest.ts`:
 - `LoadManifestOptions` (interface)
 - `parseLocalExtensionManifest` (function)
 - `loadLocalExtensionManifest` (function)
+
+**Host 2 migration.** The manifest schema remains `version: 1`, but an explicit
+`host_api: "2.0"` is required. `parseLocalExtensionManifest` rejects omitted,
+`"1.0"`, malformed and unsupported host declarations. Migrate extension
+commands before declaring the new version. `installLocalExtensionHostApi`
+exposes the same v2 object as `window.rigplaneExtensionHost` and the deprecated
+`window.icomLanExtensionHost`; the latter does not provide v1 behavior.
+
+The default host validates commands through
+`frontend/src/lib/runtime/commands/radio-intents.ts: dispatchRadioIntentWithResult`.
+Only known non-TX commands with exact parameter shapes are accepted, including
+an explicit receiver wherever required. Unknown names, PTT names, extra keys
+and missing required parameters return `false` without dispatch.
+
+`LocalExtensionHostApiV2.sendCommand` and `dispatchCommand` return the current
+client transport boolean. `true` means the current socket accepted the send;
+an offline idempotent command can return `false` while queued with a pending
+lifecycle. Thus `false` is not cancellation or proof that no send can occur
+later. Neither result establishes radio acknowledgement, server admission or
+completion. These paths are exercised by
+`frontend/src/lib/local-extensions/__tests__/host-api.isolated.test.ts` and
+`frontend/src/lib/local-extensions/__tests__/manifest.test.ts`.
+See the [3.0 migration guide](../migrate.md) for examples and the distinct TX
+ownership contract. Package, host API and manifest-schema versions are
+separate; this Core contract does not certify a Pro release.
 
 **Breakage policy.** Additive changes only between major versions. Bump
 `LOCAL_EXTENSION_HOST_API_VERSION` (numeric, in `host-api.ts`) on any

--- a/docs/architecture/open-core-policy.md
+++ b/docs/architecture/open-core-policy.md
@@ -196,8 +196,11 @@ issue.
 Pro to inject UI extensions (panels, dock items, keyboard scopes, manifest
 entries) into the open-core frontend.
 
-- The current version constant is `LOCAL_EXTENSION_HOST_API_VERSION = 1` in
-  `host-api.ts`.
+- The current version constant is `LOCAL_EXTENSION_HOST_API_VERSION = 2` in
+  `host-api.ts`, with interface `LocalExtensionHostApiV2`. In `manifest.ts`,
+  the host version is `"2.0"`: an explicit `host_api: "2.0"` declaration is
+  required; omitted, `"1.0"` and unsupported host versions are rejected by
+  `parseLocalExtensionManifest`. The manifest schema remains `version: 1`.
 - Pro consumers call `installLocalExtensionHostApi()` and import types from
   `host-api.ts` and `manifest.ts`.
 - **Additive changes only** between major versions. Adding a new method,

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -1,8 +1,276 @@
 ---
-description: "Migrate from icom-lan to RigPlane: import paths, async API differences, configuration changes, and a checklist for existing scripts and Web UI deployments."
+description: "Migrate RigPlane 2.11.1 consumers to Core 3.0 beta, with historical icom-lan to RigPlane rename guidance."
 ---
 
-# Migrating from `icom-lan` to `rigplane`
+# Migrating to RigPlane Core 3.0 beta
+
+The initial package target is `3.0.0b1`. This is a major-version migration with
+selected compatibility aliases, not a promise that every 2.x consumer works
+unchanged. Core includes the browser SDR interface; Pro packaging and its
+release are a later, separate scope.
+
+Installed-package, browser and hardware acceptance apply to the final release
+candidate separately. The focused consumer examples below do not certify a
+release or blanket compatibility with every 2.x consumer.
+
+## Compatibility decisions from 2.11.1
+
+The row IDs below follow the frozen
+[MOR-2336 compatibility matrix](https://linear.app/morozsm/issue/MOR-2336).
+Its source baseline is tag `v2.11.1` at
+`997cca0e385e78cd47f630d398488d34df29cb17`; its static comparison snapshot is
+`0126ca218526ef9b3e1a29e821596a1009d06b2d`. A preservation decision requires a
+candidate witness before it becomes a tested compatibility claim.
+
+| Row | 2.11.1 consumer surface | 3.0 migration decision |
+|---|---|---|
+| PY1 | `profile.vfo_swap_code` | Retain the deprecated, read-only expression `swap_main_sub_code or swap_ab_code`. |
+| PY2 | `profile.vfo_equal_code` | Retain `equal_main_sub_code or equal_ab_code` with the same released fallback semantics. |
+| PY3 | `from rigplane import TransceiverStatusCapable` | Intentionally removed; no import-only replacement stub. |
+| PY4 | `RadioState(tx_freq_monitor=False)` and `.tx_freq_monitor` | Intentionally removed; remove this dependency. `txTarget` is not an alias. |
+| PY5 | `set_tone_freq(freq_hz=8850)` / `set_tsql_freq(freq_hz=8850)` | Integer centiHz remains the public contract; Icom accepts the public keyword and the `freq_centihz` alternative. |
+| PY6 | `rigplane.radio`, `rigplane.radio_protocol`, `rigplane.sync` | Retain existing module aliases and sync signatures; this does not retain the old TX lifecycle. |
+| PY7 | Backend config/factory and session construction | Preserve audited public construction surfaces; installed-candidate witness remains required. |
+| WEB1 | Root JSON `txFreqMonitor` | Removed; absence is not a measured `false`. |
+| WEB2 | Root JSON `notchFilter` | Select `main.notchFilter` or `sub.notchFilter` explicitly. |
+| WEB3 | HTTP `ptt` ON/OFF command payloads | Migrate to canonical owned momentary PTT or intentional latched TRANSMIT, described below. |
+| WEB4 | HTTP routes, response metadata, WS framing | Retain existing shapes with the WEB1–3 semantic exceptions; HTTP contract version stays independent of the package version. |
+| EXT1 | Extension command boolean | Report the actual client transport boolean through the canonical intent path; false may leave an offline command queued. |
+| EXT2 | Permissive extension command/parameter dispatch | Use strict non-TX intents with required parameters and receiver. |
+| EXT3 | Host numeric `1`, manifest `host_api: "1.0"` or omission | Host `2`, explicit `host_api: "2.0"`; reject old or omitted declarations. Manifest schema remains `version: 1`. |
+| CLI1 | `ptt on && sleep 10 && ptt off` | Use `rigplane ptt --for 10`; the command owns the hold and release. |
+| CLI2 | Other CLI inventory, entrypoints, Python/dependencies/extras | Preserve audited inventory; package metadata changes to the beta version. |
+| CFG1 | Tone-capable custom profile without a table | Declare a supported named `[ctcss]` table. |
+| WIRE1 | Empty successful response after raw timeout | Handle `RPRT -5` as an error. |
+| WIRE2 | Raw `w` in read-only mode | Handle `RPRT -22`, including for raw reads; use structured reads. |
+| WIRE3 | General rigctld framing and structured operations | Preserve audited wire shape; representative fake-provider witnesses remain required. |
+| OUT1 | Private internals, arbitrary external profiles, blanket 2.x emulation | No compatibility promise; Pro release and external-consumer census are outside this scope. |
+
+## Python APIs and CTCSS units
+
+For new profile consumers, select the operation that matches the radio's VFO
+model, using `swap_ab_code` / `equal_ab_code` or `swap_main_sub_code` /
+`equal_main_sub_code`. A missing code does not grant an operation. The retained
+PY1/PY2 aliases must reproduce the old `or` expression, including its falsy
+fallback; they must not choose a new receiver or issue radio commands.
+
+Remove `TransceiverStatusCapable`, `get_tx_freq_monitor`,
+`set_tx_freq_monitor` and `tx_freq_monitor` dependencies. There is no general
+mechanical replacement. If the intended function was XFC, inspect the actual
+radio's supported XFC operation; do not infer support from the removed names
+or substitute TX target selection. See the removal entry in the
+[changelog](CHANGELOG.md).
+
+The public `RepeaterControlCapable` contract uses integer hundredths of Hz,
+despite the parameter spelling `freq_hz`. These are the canonical calls for
+88.50 Hz on receiver 0:
+
+```python
+await radio.set_tone_freq(freq_hz=8850, receiver=0)
+await radio.set_tsql_freq(freq_hz=8850, receiver=0)
+```
+
+Only call setters supported by the connected radio and its profile. Receiver
+0 and 1 identify MAIN and SUB where available; choosing SUB does not create a
+second receiver. Do not multiply an existing integer-centiHz value by 100.
+Old Icom float-Hz behavior contradicted the already-published protocol; it is
+not the preserved units contract. The Icom implementation also retains
+`freq_centihz=8850` as an alternative spelling with the same integer units.
+Supplying both non-`None` spellings raises `TypeError` before transport, even
+when the values are equal; providing neither also raises `TypeError`.
+Use one spelling per call.
+
+Sources: `src/rigplane/core/radio_protocol.py: RepeaterControlCapable`;
+`src/rigplane/runtime/radio.py: CoreRadio.set_tone_freq` and
+`CoreRadio.set_tsql_freq`; `src/rigplane/profiles/__init__.py: RadioProfile`.
+
+## Receiver state and unknown values
+
+Replace a root notch read with a read for the receiver your consumer controls:
+
+```javascript
+// Old: const notch = state.notchFilter;
+const receiverKey = selectedReceiver === 0 ? 'main' : 'sub';
+const status = state.fieldStatus?.[`${receiverKey}.notchFilter`];
+const notch = status?.observed === true && status.availability === 'available'
+  ? state[receiverKey]?.notchFilter
+  : undefined;
+// Keep unavailable/missing values unavailable; do not use `?? 0` or `|| false`.
+```
+
+Here `selectedReceiver` must already be validated as a supported `0` or `1`.
+`notchFilter` is an integer value, not an ON/OFF boolean. MAIN and SUB may
+differ; the historical root field is not a reliable alias for either one.
+With fresh MAIN/SUB observations, the witnessed values were respectively 37
+and 192, with `fieldStatus` reporting `observed: true` and
+`availability: "available"`. With no SUB observation, the response still
+contained `sub.notchFilter: 0`, but its metadata was `observed: false`,
+`freshness: "unknown"`, `availability: "missing"`. That zero is not observed
+telemetry. A single-receiver IC-7300 fixture omitted both `sub` and its field
+metadata. Preserve freshness/status information in the display and apply
+capability checks; do not infer receiver availability from a numeric default.
+Stop reading `txFreqMonitor`; replacing it with `txTarget` or a constant false
+would invent different telemetry.
+
+Sources: `src/rigplane/core/radio_state.py: RadioState.to_dict` and
+`ReceiverState`; `src/rigplane/web/state_schema.py: ReceiverStatePublic`.
+Consumer witnesses:
+`tests/test_mor2338_web_compatibility.py: test_released_root_fields_migrate_to_explicit_receiver_state`,
+`test_unobserved_receiver_default_is_not_observed_notch_telemetry` and
+`test_single_receiver_payload_does_not_invent_sub_receiver`.
+
+## TX consumers: ownership, admission, completion and OFF
+
+Every TX consumer must use the new canonical lifecycle. No compatibility
+adapter emulates the former ownership, completion or leave-keyed behavior.
+
+The old HTTP command is intentionally rejected:
+
+```http
+POST /api/v1/commands
+Content-Type: application/json
+
+{"name":"ptt","params":{"state":true}}
+```
+
+On a writable server this is `409 unsupported_command`; the old HTTP OFF
+family is also not an unconditional release route. Read-only and unavailable
+servers can reject at earlier gates.
+The focused witness covers `ptt` with either boolean and `ptt_on` / `ptt_off`
+with empty parameters: all four are rejected without authority or radio calls.
+
+Choose the lifecycle before migrating the call:
+
+* **Momentary PTT:** use the canonical WebSocket PTT flow with a stable
+  connection owner. Press and release belong to that same session; reconnect
+  is not permission to replay an old press. Follow command admission and the
+  current managed state through release. An owner release is distinct from
+  unconditional OFF. The control command is `ptt` with `{"state":true}` on
+  press and `{"state":false}` on release, with a distinct command ID per
+  request. A response matching that ID with `ok: true` and `result.state`
+  acknowledges admission. Disconnect releases that owner's intent; it does
+  not issue unconditional ForceOff.
+* **Latched TRANSMIT:** only for a consumer intentionally requesting that
+  behavior, submit `{"operation":"transmit_on"}` to
+  `POST /api/v1/managed-transmit/command`. This is not a drop-in rename of a
+  momentary PTT request.
+* **Unconditional OFF:** submit `{"operation":"force_off"}` to the same
+  managed endpoint. This requests canonical release; it does not turn an
+  unavailable or unobserved radio into confirmed RX.
+
+An HTTP `202` with `result: "accepted"` establishes admission, not completed
+device execution or observed RF. Read the managed document at
+`GET /api/v1/managed-transmit` and distinguish operation progress from radio
+observation; failures, disconnects and unknown observations cannot be shown
+as confirmed ON or OFF. Do not retry positive TX automatically after a lost
+response. The WebSocket flow must likewise preserve command identity and
+session ownership rather than opening a fresh connection for each edge.
+
+Sources: `src/rigplane/web/handlers/control.py: ControlHandler._enqueue_managed_ptt`;
+`src/rigplane/web/server.py: WebServer._handle_http_managed_tx`.
+The focused witnesses in `tests/test_mor2338_web_compatibility.py`
+(`test_released_http_ptt_family_requires_explicit_migration`,
+`test_explicit_latched_http_contract_reports_admission_only` and
+`test_momentary_ws_commands_keep_owner_and_release_on_disconnect`) exercise
+real HTTP connection parsing on an ephemeral TCP listener and production
+WebSocket dispatch/JSON serialization with fake authority and radio. The WS
+witness does not exercise network upgrade/frame transport or RF. Both HTTP
+managed operations return `202 accepted` without waiting for settlement.
+
+For scripts, replace sequential leave-keyed shell commands:
+
+```bash
+# Old sequencing no longer describes the command lifecycle:
+# rigplane ptt on && sleep 10 && rigplane ptt off
+rigplane ptt --for 10
+```
+
+Supply your usual connection options. `ptt on` remains alive until interruption
+or the requested duration; release belongs to the holding command. Observe its
+exit/error outcome and actual radio state. This example is a TX operation,
+not an installation smoke test. Parser and lifecycle sources:
+`src/rigplane/cli/__init__.py: _finalize_ptt_args`, `_cmd_ptt`, `_hold_ptt`.
+
+## Core extension-host migration
+
+The host contract uses numeric version `2` and an explicit
+manifest declaration `host_api: "2.0"`. Old `"1.0"` and missing declarations
+must be rejected, rather than interpreted as evidence of compatibility. This
+version decision is separate from Python `3.0.0b1` and HTTP contract version 1.
+The manifest schema itself stays at `version: 1`. Migrate the commands before
+declaring the new host contract:
+
+```json
+{"version":1,"host_api":"2.0","extensions":[{"id":"my-control","entry":"/local/control.js","mount":"floating-overlay"}]}
+```
+
+The entry URL here is illustrative; it must resolve to your own extension
+asset. TypeScript embedders replace `LocalExtensionHostApiV1` with
+`LocalExtensionHostApiV2` from the host module.
+
+An extension should use a strict canonical non-TX intent, for example:
+
+```javascript
+const host = window.rigplaneExtensionHost;
+if (!host || host.version !== 2) throw new Error('Extension requires host API 2');
+const accepted = host.sendCommand('set_notch_filter', { value: 128, receiver: 0 });
+// `accepted` is client transport acceptance, not server admission or completion.
+```
+
+The boolean preserves the existing transport result: `true` means the current
+socket accepted the client send. An offline idempotent command may be queued
+while returning `false` and retaining a pending lifecycle. Therefore `false`
+does not prove that no command is queued; do not blindly retry it. Neither
+boolean establishes radio acknowledgement, server admission or completion.
+
+Use this only when the radio advertises the corresponding control. Unknown
+commands, PTT, extra parameters and a missing required receiver must not
+dispatch. `window.icomLanExtensionHost`, when retained, names the same new
+host object; it does not provide the old runtime. An extension that previously
+sent PTT through `sendCommand` must migrate its TX integration to the canonical
+ownership flow above, not rename its command through this non-TX facade.
+
+Sources: `frontend/src/lib/local-extensions/host-api.ts: installLocalExtensionHostApi`;
+`frontend/src/lib/runtime/commands/radio-intents.ts: dispatchRadioIntent`.
+
+## Custom profiles and rigctld diagnostics
+
+Tone-capable profiles declaring `repeater_tone`, `tsql` or `sql_type` require
+a named catalog reference. For a radio whose verified supported table is
+`standard_50`, the declaration is:
+
+```toml
+[ctcss]
+table = "standard_50"
+```
+
+The catalog is `rigs/_ctcss_tables_v1.toml`; `rigs/ic7300.toml: [ctcss]`
+provides a shipped example. Do not copy this name to another model without
+checking that model's supported table. Missing, unknown and malformed
+references fail loading. `ctcss_tones_centihz` is an ordered integer-centiHz
+table; its order matters for index-based providers. A table reference does
+not enable unsupported setters.
+
+For raw rigctld diagnostics, handle timeout as `RPRT -5`, not empty success.
+Read-only mode rejects every raw `w` request with `RPRT -22`, even a raw read;
+use supported structured reads such as `f` for frequency. Never fall back to
+raw commands to bypass read-only enforcement. See [rigctld API](api/rigctld.md)
+and `src/rigplane/rigctld/server.py: RigctldServer`.
+
+## Core SDR and acceptance scope
+
+The 2.11.1 SDR behavior is the required migration baseline: retain available
+spectrum/waterfall controls, tuning, VFO/mode/filter, radio controls, RX audio,
+meters, reachable managed PTT/ForceOff, screen navigation and persistence.
+This is an acceptance requirement, not a claim that the beta has passed it.
+Use each radio's actual capabilities; an unavailable stream is not a blank
+successful spectrum. Core packaging/install/rollback and browser/hardware
+acceptance remain separate evidence from these compatibility examples.
+
+## Historical migration: `icom-lan` v1 to `rigplane` v2
+
+The following rename guidance describes the v2 transition. Its compatibility
+and automatic-migration statements do not extend to the 3.0 changes above.
 
 `rigplane` is the new name of the project formerly known as `icom-lan` (v1.x).
 The rename shipped in v2.0.0 (May 2026). The old name was misleading — the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rigplane"
-version = "2.11.1"
+version = "3.0.0b1"
 description = "Multi-vendor radio control library and Web UI with native providers and planned Hamlib-backed CAT coverage"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_mor2338_web_compatibility.py
+++ b/tests/test_mor2338_web_compatibility.py
@@ -1,0 +1,245 @@
+"""MOR-2336 WEB1–4 consumer witnesses for selective v2.11.1 migration."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.web.protocol import decode_json
+from rigplane.web.server import WebConfig, WebServer
+from test_managed_tx_http_route import _Authority as _HttpAuthority
+from test_managed_tx_http_route import _server as _managed_server
+from test_web_managed_tx_ingress import _Authority as _WsAuthority
+from test_web_managed_tx_ingress import _eof_ws, _handler, _radio
+
+
+async def _request(
+    server: WebServer,
+    method: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    body = b"" if payload is None else json.dumps(payload).encode()
+    listener = await asyncio.start_server(
+        server._handle_connection,
+        "127.0.0.1",
+        0,  # noqa: SLF001
+    )
+    async with listener:
+        port = listener.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            writer.write(
+                (
+                    f"{method} {path} HTTP/1.1\r\n"
+                    f"Host: 127.0.0.1:{port}\r\n"
+                    "Content-Type: application/json\r\n"
+                    f"Content-Length: {len(body)}\r\n"
+                    "Connection: close\r\n\r\n"
+                ).encode()
+                + body
+            )
+            await writer.drain()
+            response = await asyncio.wait_for(reader.read(), timeout=5)
+        finally:
+            writer.close()
+            await writer.wait_closed()
+    headers, data = response.split(b"\r\n\r\n", 1)
+    return int(headers.split(b" ", 2)[1]), json.loads(data)
+
+
+def _state_server(model: str = "IC-7610") -> WebServer:
+    return WebServer(None, WebConfig(host="127.0.0.1", port=0, radio_model=model))
+
+
+def _notch(server: WebServer, receiver: str, value: int) -> None:
+    server.command_state_store.apply_current(
+        Observation(
+            path=FieldPath.receiver(receiver, "operator_controls", "notch_filter"),
+            value=value,
+            source=SourceMetadata(source="poll_response", provider="test"),
+            timestamp_monotonic=time.monotonic(),
+            max_age=None,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_released_root_fields_migrate_to_explicit_receiver_state() -> None:
+    server = _state_server()
+    _notch(server, "main", 37)
+    _notch(server, "sub", 192)
+
+    status, state = await _request(server, "GET", "/api/v1/state")
+
+    assert status == 200
+    assert "notchFilter" not in state
+    assert "txFreqMonitor" not in state
+    assert state["main"]["notchFilter"] == 37
+    assert state["sub"]["notchFilter"] == 192
+    for receiver in ("main", "sub"):
+        field = state["fieldStatus"][f"{receiver}.notchFilter"]
+        assert field["observed"] is True
+        assert field["availability"] == "available"
+    assert state["txTarget"] == {"status": "unknown", "reason": "not-observed"}
+
+
+@pytest.mark.asyncio
+async def test_unobserved_receiver_default_is_not_observed_notch_telemetry() -> None:
+    server = _state_server()
+    _notch(server, "main", 37)
+
+    status, state = await _request(server, "GET", "/api/v1/state")
+
+    assert status == 200
+    assert state["main"]["notchFilter"] == 37
+    assert state["sub"]["notchFilter"] == 0
+    field = state["fieldStatus"]["sub.notchFilter"]
+    assert field["observed"] is False
+    assert field["freshness"] == "unknown"
+    assert field["availability"] == "missing"
+    assert "notchFilter" not in state
+    assert "txFreqMonitor" not in state
+
+
+@pytest.mark.asyncio
+async def test_single_receiver_payload_does_not_invent_sub_receiver() -> None:
+    server = _state_server("IC-7300")
+    _notch(server, "main", 37)
+
+    status, state = await _request(server, "GET", "/api/v1/state")
+
+    assert status == 200
+    assert state["main"]["notchFilter"] == 37
+    assert "sub" not in state
+    assert "sub.notchFilter" not in state["fieldStatus"]
+    assert "notchFilter" not in state
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("name", "params"),
+    (
+        ("ptt", {"state": True}),
+        ("ptt", {"state": False}),
+        ("ptt_on", {}),
+        ("ptt_off", {}),
+    ),
+    ids=("ptt-on", "ptt-off", "on-alias", "off-alias"),
+)
+async def test_released_http_ptt_family_requires_explicit_migration(
+    name: str, params: dict[str, Any]
+) -> None:
+    radio = _radio()
+    authority = _WsAuthority()
+    server = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+    server._production_managed_tx_port = SimpleNamespace(authority=authority)  # noqa: SLF001
+
+    status, result = await _request(
+        server, "POST", "/api/v1/commands", {"name": name, "params": params}
+    )
+
+    assert status == 409
+    assert result == {
+        "ok": False,
+        "error": "unsupported_command",
+        "message": "momentary PTT requires a stable WebSocket owner; "
+        "use managed force_off for unconditional release",
+    }
+    assert authority.calls == []
+    assert authority.force_off_calls == 0
+    assert not server.command_queue.drain()
+    radio.set_ptt.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ("transmit_on", "force_off"))
+async def test_explicit_latched_http_contract_reports_admission_only(
+    operation: str,
+) -> None:
+    authority = _HttpAuthority()
+    server = _managed_server(authority)
+
+    status, result = await _request(
+        server,
+        "POST",
+        "/api/v1/managed-transmit/command",
+        {"operation": operation},
+    )
+
+    assert status == 202
+    assert result == {"ok": True, "operation": operation, "result": "accepted"}
+    assert authority.calls == [operation]
+    assert len(authority.submissions) == 1
+    assert authority.submissions[0].settlement_waits == 0
+
+
+@pytest.mark.asyncio
+async def test_momentary_ws_commands_keep_owner_and_release_on_disconnect() -> None:
+    authority = _WsAuthority()
+    ws = _eof_ws()
+    handler, _, radio = _handler(authority, ws=ws)
+
+    for command_id, on in (("press", True), ("release", False), ("press-again", True)):
+        await handler._dispatch_command(command_id, "ptt", {"state": on})  # noqa: SLF001
+        result = decode_json(ws.send_text.await_args.args[0])
+        assert result["id"] == command_id
+        assert result["ok"] is True
+        assert result["result"] == {"state": on}
+        assert authority.intent == ("ptt:websocket-test" if on else "rx")
+    await handler.run()
+
+    assert authority.calls == [
+        (True, "websocket-test"),
+        (False, "websocket-test"),
+        (True, "websocket-test"),
+    ]
+    assert authority.disconnect_calls == ["websocket-test"]
+    assert authority.intent == "rx"
+    assert authority.force_off_calls == 0
+    radio.set_ptt.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_released_get_metadata_and_ws_state_envelope_are_consumable() -> None:
+    server = _state_server()
+    _notch(server, "main", 37)
+    status, info = await _request(server, "GET", "/api/v1/info")
+    assert status == 200
+    assert {
+        "server",
+        "version",
+        "proto",
+        "radio",
+        "model",
+        "capabilities",
+        "connection",
+    } <= info.keys()
+    status, state = await _request(server, "GET", "/api/v1/state")
+    assert status == 200
+    assert isinstance(state["revision"], int)
+    assert isinstance(state["updatedAt"], str)
+
+    ws = SimpleNamespace(send_text=AsyncMock())
+    handler, _, _ = _handler(None, ws=ws)
+    handler._server = server  # noqa: SLF001
+    await handler._send_state_snapshot()  # noqa: SLF001
+    event = handler._event_queue.get_nowait()  # noqa: SLF001
+    await handler._send_json(event)  # noqa: SLF001
+    envelope = decode_json(ws.send_text.await_args.args[0])
+    assert envelope["type"] == "state_update"
+    assert envelope["data"]["type"] == "full"
+    assert envelope["data"]["data"]["main"]["notchFilter"] == 37
+    assert envelope["data"]["data"]["revision"] == state["revision"]
+    assert "txFreqMonitor" not in envelope["data"]["data"]

--- a/uv.lock
+++ b/uv.lock
@@ -2125,7 +2125,7 @@ wheels = [
 
 [[package]]
 name = "rigplane"
-version = "2.11.1"
+version = "3.0.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
7 code/docs + 0 regenerated baselines = 7 files

Migrate 2.11.1 consumers to the Core 3.0 beta contracts and retain executable HTTP/state examples alongside the guide. The guide covers all 21 frozen compatibility rows, receiver observation metadata, intentional legacy HTTP PTT rejection, canonical TX ownership/admission/completion/OFF, integer-centiHz setters, extension host 2, custom tone tables, timed CLI PTT and raw rigctld errors. Package and editable lock metadata become `3.0.0b1`, an **unreleased candidate**.

[MOR-2338](https://linear.app/morozsm/issue/MOR-2338) and [MOR-2340](https://linear.app/morozsm/issue/MOR-2340), with documentation ownership under [MOR-1101](https://linear.app/morozsm/issue/MOR-1101) and frozen decisions in [MOR-2336](https://linear.app/morozsm/issue/MOR-2336).

**Merge dependency: extension-host PR #3185 MUST land before this documentation merges.** This PR targets `main` and does not copy extension-host commits. Python compatibility already landed in #3183. Astra is the merge operator; independent review must assess this final head before the guarded merge.

The seven-file/670-changed-line soft threshold is justified by one compatibility acceptance unit: the guide and public contract, narrowly aligned host-version policy, reconciled changelog, two matching package-version files, and the frozen HTTP/state consumer witness. The hard 1000-line limit is not exceeded. Historical published changelog entries and v1-to-v2 migration guidance remain; superseded unreleased TX lease/watchdog claims are replaced by the canonical migration contract.

Validation:

- Reused MOR-2338 Mini evidence: **11 passed**, fake radio/authority, real ephemeral TCP HTTP parsing. WS evidence covers production dispatch and JSON serialization through fake `send_text`, not network upgrade/frame transport or RF. The witness was cherry-picked unchanged from `1e9d1bff6bcb60c2c010f2ee66532b514086b51b`.
- Doc citation and relative-link gates PASS; both baseline-growth checks PASS against `origin/main`; `git diff --check` PASS. Initial link failure exposed the root changelog symlink; the four new migration links now use the canonical documentation URL.
- Static TOML validation confirmed matching `3.0.0b1` and no other semantic metadata changes. All 21 matrix IDs and the exact file lease were checked. No local product suite rerun; this Ready PR receives its natural applicable CI.

Installed-wheel smoke (MOR-2341), hardware, browser/operator and final owner acceptance remain pending release gates. HTTP 202 is admission without settlement; unobserved SUB notch can serialize zero with missing/unknown metadata; an extension transport `false` can leave an offline command queued. No old TX lifecycle emulation, full compatibility, successful publication or Pro release is claimed. No tag or release is created.


Review corrections: removed the duplicate historical host-global spelling from the public API surface and linked the migration guide; both unreleased compare references use the existing `v2.11.1...HEAD` range (GitHub compare API resolves successfully); policy section 6 now states host API 2 / interface V2 and explicit manifest host_api 2.0 while preserving schema version 1. Citation, link, both baseline-growth, rebrand and diff checks PASS on the correction. No product suite was repeated.
