### PR TITLE
fix(MOR-2343): preserve latched TX on browser session release

### DIFF
--- a/frontend/src/lib/runtime/tx-controller/__tests__/app-host.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/app-host.test.ts
@@ -102,13 +102,39 @@ describe('managed App TX host', () => {
     host.dispose();
   });
 
-  it('destroy discharges a started TRANSMIT obligation with exactly one ForceOFF', async () => {
+  it.each(['lifecycle', 'pre-disconnect', 'session-close', 'dispose'] as const)(
+    '%s preserves another client\'s latched TRANSMIT', async (release) => {
+    h.state = { ...idle(), phase: 'active', intent: 'latched', radioTx: 'on', releaseRequired: true };
+    const host = provideManagedAppTxHost(bindings());
+    if (release === 'lifecycle') h.lifecycle!();
+    if (release === 'pre-disconnect') await h.barrier!();
+    if (release === 'session-close') h.session!({ state: 'disconnected', epoch: 5 });
+    if (release === 'dispose') host.dispose();
+    await flush();
+    host.dispose();
+    await flush();
+    expect(h.submit).not.toHaveBeenCalled();
+    expect(h.sendPtt).not.toHaveBeenCalled();
+    expect(h.startAudio).not.toHaveBeenCalled();
+    expect(h.stopAudio).not.toHaveBeenCalled();
+  });
+
+  it.each(['lifecycle', 'pre-disconnect', 'session-close', 'dispose'] as const)(
+    '%s preserves this browser\'s admitted TRANSMIT while cleaning local audio', async (release) => {
     const host = provideManagedAppTxHost(bindings());
     getManagedAppTxController().transmitOn();
     await vi.waitFor(() => expect(h.submit).toHaveBeenCalledWith('transmit_on'));
-    host.dispose(); host.dispose();
-    await vi.waitFor(() => expect(h.submit.mock.calls.map(([operation]) => operation))
-      .toEqual(['transmit_on', 'force_off']));
+    h.state = { ...idle(), phase: 'active', intent: 'latched', radioTx: 'on', releaseRequired: true };
+    host.refreshAuthority();
+    await flush();
+    if (release === 'lifecycle') h.lifecycle!();
+    if (release === 'pre-disconnect') await h.barrier!();
+    if (release === 'session-close') h.session!({ state: 'disconnected', epoch: 5 });
+    if (release === 'dispose') host.dispose();
+    await flush();
+    host.dispose();
+    await flush();
+    expect(h.submit.mock.calls.map(([operation]) => operation)).toEqual(['transmit_on']);
     expect(h.sendPtt).not.toHaveBeenCalled();
     expect(h.stopAudio).toHaveBeenCalledTimes(1);
   });
@@ -124,6 +150,9 @@ describe('managed App TX host', () => {
     expect(h.sendPtt.mock.invocationCallOrder[1]).toBeLessThan(h.submit.mock.invocationCallOrder[0]!);
     host.dispose();
     await flush();
+    expect(h.submit).toHaveBeenCalledExactlyOnceWith('transmit_on');
+    expect(h.sendPtt.mock.calls.map(([operation]) => operation)).toEqual(['ptt_on', 'ptt_off']);
+    expect(h.stopAudio).toHaveBeenCalledTimes(1);
   });
 
   it('makes disposed callbacks and facade actions inert', async () => {

--- a/frontend/src/lib/runtime/tx-controller/__tests__/browser-dependencies-fault-injection.isolated.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/browser-dependencies-fault-injection.isolated.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ManagedTxController, type ManagedTxDependencies } from '../managed-controller';
+import { ManagedTxController, type ManagedTxDependencies, type ManagedOperation, type PttOperation } from '../managed-controller';
 import type { ManagedTxState } from '../managed-state';
+import { MockWebSocket, instances } from '$lib/transport/__tests__/support/fake-ws-backend';
 
 const state = (fresh = true): ManagedTxState => ({
   phase: 'idle', intent: null, radioTx: fresh ? 'off' : 'unknown',
@@ -9,15 +10,16 @@ const state = (fresh = true): ManagedTxState => ({
   remainingMs: null, lastOperation: null,
 });
 const h = { start: vi.fn<() => Promise<string | null>>(), stop: vi.fn(),
-  sendPtt: vi.fn<() => Promise<'accepted' | 'rejected'>>(async () => 'accepted'),
-  submit: vi.fn(async () => 'accepted' as const),
+  sendPtt: vi.fn<(operation: PttOperation) => Promise<'accepted' | 'rejected'>>(async () => 'accepted'),
+  submit: vi.fn<(operation: ManagedOperation) => Promise<'accepted' | 'rejected'>>(async () => 'accepted'),
   setTot: vi.fn(async () => {}),
   projected: state(), audioDied: () => {} };
-function controller(): ManagedTxController {
+function controller(overrides: Partial<ManagedTxDependencies> = {}): ManagedTxController {
   const dependencies: ManagedTxDependencies = {
     snapshot: () => h.projected, refresh: vi.fn(async () => {}), invalidate: vi.fn(),
     sendPtt: h.sendPtt, submit: h.submit, setTot: h.setTot, startAudio: h.start,
     stopLocalAudio: h.stop, onAudioDied: (handler) => { h.audioDied = handler; return vi.fn(); },
+    ...overrides,
   };
   return new ManagedTxController(dependencies);
 }
@@ -64,6 +66,99 @@ describe('managed browser TX fault injection', () => {
     await flush();
     h.audioDied();
     await vi.waitFor(() => expect(h.submit).toHaveBeenCalledExactlyOnceWith('force_off'));
+    expect(h.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('intentional AudioManager.stopTx during session release does not emit audio death or ForceOFF', async () => {
+    const { TxMic } = await import('$lib/audio/tx-mic');
+    const { audioManager } = await import('$lib/audio/audio-manager');
+    const startMic = vi.spyOn(TxMic.prototype, 'start').mockResolvedValue(null);
+    const audioDied = vi.fn();
+    instances.length = 0;
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    const tx = controller({
+      startAudio: () => audioManager.startTx(),
+      stopLocalAudio: () => audioManager.stopTx(),
+      onAudioDied: (handler) => audioManager.onTxAudioDied(() => { audioDied(); handler(); }),
+    });
+    try {
+      tx.transmitOn();
+      await vi.waitFor(() => expect(h.submit).toHaveBeenCalledExactlyOnceWith('transmit_on'));
+      expect(audioManager.txEnabled).toBe(true);
+      instances[0].simulateOpen();
+      await tx.releaseSession();
+      expect(audioManager.txEnabled).toBe(false);
+      expect(audioDied).not.toHaveBeenCalled();
+      expect(h.submit).toHaveBeenCalledExactlyOnceWith('transmit_on');
+    } finally {
+      tx.dispose();
+      audioManager.stopTx();
+      startMic.mockRestore();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it.each(['ptt', 'transmit'] as const)(
+    'session release cancels deferred %s audio preparation without a late ON', async (intent) => {
+    let ready!: (error: string | null) => void;
+    h.start.mockImplementationOnce(() => new Promise((resolve) => { ready = resolve; }));
+    const tx = controller();
+    if (intent === 'ptt') tx.pttOn(); else tx.transmitOn();
+    await tx.releaseSession();
+    ready(null);
+    await flush();
+    expect(h.sendPtt).not.toHaveBeenCalled();
+    expect(h.submit).not.toHaveBeenCalled();
+    expect(h.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['accepted', 'rejected'] as const)(
+    'session release leaves already submitted TRANSMIT admission to the server when it later settles %s', async (outcome) => {
+    let admitted!: (result: 'accepted' | 'rejected') => void;
+    h.submit.mockImplementationOnce(() => new Promise((resolve) => { admitted = resolve; }));
+    const tx = controller();
+    tx.transmitOn();
+    await flush();
+    expect(h.submit).toHaveBeenCalledExactlyOnceWith('transmit_on');
+    await tx.releaseSession();
+    admitted(outcome);
+    await flush();
+    expect(h.submit).toHaveBeenCalledExactlyOnceWith('transmit_on');
+    expect(h.sendPtt).not.toHaveBeenCalled();
+    expect(h.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['accepted', 'rejected'] as const)(
+    'session release sends owner PTT_OFF while PTT_ON admission later settles %s', async (outcome) => {
+    let admitted!: (result: 'accepted' | 'rejected') => void;
+    h.sendPtt.mockImplementationOnce(() => new Promise((resolve) => { admitted = resolve; }));
+    const tx = controller();
+    tx.pttOn();
+    await flush();
+    await tx.releaseSession();
+    admitted(outcome);
+    await flush();
+    expect(h.sendPtt.mock.calls).toEqual([['ptt_on'], ['ptt_off']]);
+    expect(h.submit).not.toHaveBeenCalled();
+    expect(h.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['accepted', 'rejected'] as const)(
+    'release during PTT-to-TRANSMIT handoff cancels the unsent latch after PTT_OFF settles %s', async (outcome) => {
+    let released!: (result: 'accepted' | 'rejected') => void;
+    const tx = controller();
+    tx.pttOn();
+    await flush();
+    h.sendPtt.mockImplementationOnce(() => new Promise((resolve) => { released = resolve; }));
+    tx.transmitOn();
+    await flush();
+    expect(h.sendPtt.mock.calls).toEqual([['ptt_on'], ['ptt_off']]);
+    await tx.releaseSession();
+    released(outcome);
+    await flush();
+    expect(h.submit).not.toHaveBeenCalled();
+    expect(h.sendPtt.mock.calls.map(([operation]) => operation))
+      .toEqual(['ptt_on', 'ptt_off', 'ptt_off']);
     expect(h.stop).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/lib/runtime/tx-controller/__tests__/integration-lifecycle-matrix.isolated.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/integration-lifecycle-matrix.isolated.test.ts
@@ -17,9 +17,10 @@ const h = vi.hoisted(() => ({
   stop: vi.fn(),
   restore: vi.fn(),
   submit: vi.fn(async () => 'accepted' as const),
+  latched: false,
 }));
 vi.mock('$lib/stores/managed-transmit.svelte', () => ({
-  managedTransmitSnapshot: () => ({ schemaVersion: 1, sampledAt: '2026-09-04T00:00:00Z', managedTransmit: { status: 'available', intent: { kind: 'rx' }, releaseRequired: false, lastError: null, lastActuation: null, abortErrors: [], tot: { configuredSeconds: 180, active: false, remainingMs: null, expiresAt: null } }, txObservation: { observedPtt: 'off' } }),
+  managedTransmitSnapshot: () => ({ schemaVersion: 1, sampledAt: '2026-09-04T00:00:00Z', managedTransmit: { status: 'available', intent: { kind: h.latched ? 'transmit' : 'rx' }, releaseRequired: h.latched, lastError: null, lastActuation: null, abortErrors: [], tot: { configuredSeconds: 180, active: false, remainingMs: null, expiresAt: null } }, txObservation: { observedPtt: 'off' } }),
   managedTransmitIsStale: () => false, managedTransmitRemainingMs: () => null,
   refreshManagedTransmit: vi.fn(async () => {}), invalidateManagedTransmit: vi.fn(), submitManagedTransmit: h.submit,
   setManagedTransmitTot: vi.fn(async () => {}),
@@ -150,6 +151,7 @@ describe('tx-controller integration lifecycle matrix — real WsChannel + real b
     h.stop.mockClear();
     h.restore.mockClear();
     h.submit.mockClear();
+    h.latched = false;
   });
 
   afterEach(() => {
@@ -214,6 +216,32 @@ describe('tx-controller integration lifecycle matrix — real WsChannel + real b
     expect(countFrames('ptt_off', socket)).toBe(0);
     confirmAuthority(controller, factory, getSession(), false, 3);
     expect(countFrames('ptt_on', socket)).toBe(0);
+  });
+
+  it.each(['requester', 'unrelated'] as const)(
+    '%s socket loss and reconnect preserve latched TRANSMIT without replaying ON', async (browser) => {
+    const { factory, controller, socket: socket0 } = await setup();
+    if (browser === 'requester') {
+      controller.transmitOn();
+      await flush();
+      expect(h.submit).toHaveBeenCalledExactlyOnceWith('transmit_on');
+    }
+    h.latched = true;
+    await controller.refresh();
+    expect(controller.snapshot().intent).toBe('latched');
+
+    socket0.simulateClose();
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(instances).toHaveLength(2);
+    const socket1 = instances[1];
+    socket1.simulateOpen();
+    await flush();
+
+    expect(h.submit.mock.calls).toEqual(browser === 'requester' ? [['transmit_on']] : []);
+    expect(countFrames('ptt_on', socket0, socket1)).toBe(0);
+    expect(countFrames('ptt_off', socket0, socket1)).toBe(0);
+    expect(h.stop).toHaveBeenCalledTimes(browser === 'requester' ? 1 : 0);
+    controller.dispose(); factory.dispose();
   });
 
   it('duplicate release coalescing: two release dispatches produce exactly one ptt_off frame', async () => {

--- a/frontend/src/lib/runtime/tx-controller/managed-controller.ts
+++ b/frontend/src/lib/runtime/tx-controller/managed-controller.ts
@@ -27,7 +27,6 @@ export class ManagedTxController {
   #pttAttempted = false;
   #audioPreparation: Promise<boolean> | null = null;
   #audioNeedsCleanup = false;
-  #transmitCleanupRequired = false;
   #forceOffInFlight: Promise<void> | null = null;
   #offAudioDied: () => void;
   #offPresentationTick: () => void;
@@ -116,9 +115,6 @@ export class ManagedTxController {
     if (this.#flow === 'ptt' || this.#pttAttempted) await Promise.race([
       this.pttOff(), new Promise<void>((resolve) => setTimeout(resolve, 500)),
     ]);
-    else if (this.#transmitCleanupRequired || (
-      this.#state.fresh && this.#state.intent === 'latched'
-    )) await this.#boundedForceOff();
     else { ++this.#generation; this.#flow = 'idle'; this.#stopAudio(); }
   }
 
@@ -159,7 +155,6 @@ export class ManagedTxController {
   async #sendTransmitOn(generation: number): Promise<void> {
     if (!await this.#prepareAudio()) return;
     if (generation !== this.#generation || this.#flow !== 'transmit') return;
-    this.#transmitCleanupRequired = true;
     if (this.#pttAttempted) {
       let released: Outcome;
       try { released = await this.dependencies.sendPtt('ptt_off'); }
@@ -184,21 +179,6 @@ export class ManagedTxController {
     this.#publish();
   }
 
-  async #boundedForceOff(): Promise<void> {
-    await Promise.race([
-      this.forceOff(),
-      new Promise<void>((resolve) => setTimeout(resolve, 500)),
-    ]);
-  }
-
-  #reconcileCleanupObligation(): void {
-    const state = this.#state;
-    if (state.fresh && state.intent === null && !state.releaseRequired
-      && state.lastOperation === 'force_receive') {
-      this.#transmitCleanupRequired = false;
-    }
-  }
-
   #prepareAudio(): Promise<boolean> {
     if (this.#audioPreparation !== null) return this.#audioPreparation;
     this.#audioNeedsCleanup = true;
@@ -220,7 +200,6 @@ export class ManagedTxController {
 
   #publish(): void {
     this.#state = this.dependencies.snapshot();
-    this.#reconcileCleanupObligation();
     for (const listener of this.#listeners) listener(this.#state);
   }
 }


### PR DESCRIPTION
Browser disconnect, page lifecycle release, or disposal could send global `force_off` merely because the browser had requested TRANSMIT or observed another client's latched state. This contradicted the accepted TX-authority transition table, which preserves latched TRANSMIT across requester and unrelated browser disconnects.

Session release now cancels local preparation, releases this browser's held or pending momentary PTT, and stops local media without inferring global ForceOff from latch state/history. The unused latch-cleanup flag and helpers are removed. Explicit operator ForceOff, unexpected audio-death handling, and server-owned TOT/provider/shutdown policy remain unchanged.

Linear owner: [MOR-2343](https://linear.app/morozsm/issue/MOR-2343/tx-authority-preserve-latched-transmit-across-browser-session-release).

Validation on an isolated Mac Mini checkout with its own dependencies:

- Discriminating RED at base `24fbe834ca6b42c4d9e3d0c5d2dc5a5d60528b90`: 14 failed / 23 passed across the three changed test files. Failures captured extra `force_off` through remote/requester App-host lifecycle callbacks, reconnect, upgrade teardown, and deferred admission.
- GREEN with the fix: all 37 tests in those files pass.
- Broader controller and audio codec scope: 72 tests / 10 files pass, including existing real App lifecycle and reconnect/de-key tests.
- Changed-path ESLint and `npm run check` pass; Svelte reports zero errors and warnings; `git diff --check` is clean.
- Added real AudioManager teardown coverage verifies intentional `stopTx` does not emit audio death or ForceOff; microphone start and the socket boundary are simulated.

This is a four-file frontend repair. It does not claim physical TX, final release-candidate acceptance, or complete backend coverage. No live radio/server or actual user profile was used. Independent exact-head review and required natural CI remain merge gates; final whole-path acceptance remains MOR-2305/2303/2304.
