### PR TITLE
fix(MOR-2344): preserve later rigctld ON after an owned OFF

### DIFF
--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -511,7 +511,11 @@ class _RigctldCommandExecutor:
         cancelling = 0 if task is None else task.cancelling()
         try:
             if not on:
-                receipt = await authority.submit_ptt(False, owner)
+                receipt = (
+                    await submission
+                    if submission is not None
+                    else await authority.submit_ptt(False, owner)
+                )
             else:
                 loop = asyncio.get_running_loop()
                 if submission is None:

--- a/tests/test_rigctld_managed_ingress_scheduling.py
+++ b/tests/test_rigctld_managed_ingress_scheduling.py
@@ -406,6 +406,19 @@ async def test_pending_on_defers_handler_state_evaluation_until_predecessor(mana
 @pytest.mark.parametrize("provider_error", [False, True])
 async def test_off_bypasses_but_later_on_keeps_held_frequency_barrier(managed, provider_error):
     await _key(managed)
+    later_on_received = asyncio.Event()
+    start, execute = managed.authority.start_ptt_submission, managed.server._rig_handler.execute
+    def observed(on, owner, **kwargs):
+        submission = start(on, owner, **kwargs)
+        if on:
+            later_on_received.set()
+        return submission
+    async def gated(cmd, **kwargs):
+        if cmd.long_cmd == "set_ptt" and not int(cmd.args[0]):
+            await asyncio.wait_for(later_on_received.wait(), _WAIT)
+        return await execute(cmd, **kwargs)
+    managed.authority.start_ptt_submission = observed
+    managed.server._rig_handler.execute = gated
     managed.radio.fail_frequency = provider_error
     await _send(managed, f"F {_FREQUENCY}", "T 0", "T 1")
     await asyncio.wait_for(managed.radio.entered.wait(), _WAIT)


### PR DESCRIPTION
When a rigctld client sends a held frequency write followed by `T 0` and `T 1`, the server starts the OFF submission on receipt, then the handler submits that same OFF again. The second owner cancellation can revoke the later ON, returning `RPRT -9` despite its correct wire order. Reuse the existing ingress submission for OFF; direct handler calls without one retain the original submission fallback.

The regression now holds OFF handler execution until the later ON has registered, preserving the original frequency/OFF/ON reply and effect assertions while making the ordering deterministic. Source diagnosis and a synchronous submission trace reproduced both failures on isolated Python 3.12; this was a source defect, not runner load.

Validation on isolated Mac mini environments at this change: regression RED before the handler fix (both variants); complete `tests/test_rigctld_managed_ingress_scheduling.py` GREEN on Python 3.11, 3.12 and 3.13 (33 passed each), including release-debt and cancellation cases. The `ptt_submission=None` test uses an immediate handler stub and does not establish executed fallback coverage; the real fallback branch was inspected in the independent review. Changed-file Ruff check/format and `git diff --check` passed. No full-suite duplicate, hardware execution, release rebuild or publication.

Owner: https://linear.app/morozsm/issue/MOR-2344/beta-acceptance-resolve-deterministic-python-312-rigctld-offlater-on

