### PR TITLE
fix(MOR-2345): dekey when microphone capture dies

### DIFF
--- a/frontend/src/lib/audio/__tests__/audio-manager.isolated.test.ts
+++ b/frontend/src/lib/audio/__tests__/audio-manager.isolated.test.ts
@@ -30,6 +30,7 @@ vi.mock('../tx-mic', () => ({
   TxMic: class {
     start = txStart;
     stop = txStop;
+    get active() { return true; }
     static supported() { return true; }
   },
 }));

--- a/frontend/src/lib/audio/__tests__/tx-codec-negotiation.isolated.test.ts
+++ b/frontend/src/lib/audio/__tests__/tx-codec-negotiation.isolated.test.ts
@@ -15,6 +15,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TxMic } from '../tx-mic';
+import { ManagedTxController, type ManagedOperation } from '../../runtime/tx-controller/managed-controller';
 import { AUDIO_HEADER_SIZE, CODEC_PCM16, SAMPLE_RATE } from '../constants';
 
 const setTxCodecFallbackMock = vi.fn();
@@ -109,10 +110,14 @@ function sentTypes(ws: FakeWebSocket): string[] {
  * only way the PCM16 leg can fail on a browser that has WebCodecs.
  */
 function installMediaGlobals({ contextSampleRate = SAMPLE_RATE } = {}) {
-  const track = { stop: vi.fn(), kind: 'audio' };
+  const track = Object.assign(new EventTarget(), { stop: vi.fn(), kind: 'audio' });
+  let finishRead!: (value: any) => void;
+  let rejectRead!: (reason: Error) => void;
+  const pendingRead = new Promise<any>((resolve, reject) => { finishRead = resolve; rejectRead = reject; });
+  let encoderCallbacks: AudioEncoderInit;
   const reader = {
-    read: vi.fn(() => Promise.resolve({ done: true })),
-    cancel: vi.fn().mockResolvedValue(undefined),
+    read: vi.fn(() => pendingRead),
+    cancel: vi.fn(async () => { finishRead({ done: true }); }),
   };
   const encoder = { configure: vi.fn(), encode: vi.fn(), close: vi.fn(), state: 'configured' };
   let processor: any = null;
@@ -126,7 +131,8 @@ function installMediaGlobals({ contextSampleRate = SAMPLE_RATE } = {}) {
     }),
     close: vi.fn().mockResolvedValue(undefined),
   };
-  (globalThis as any).AudioEncoder = function (this: any) {
+  (globalThis as any).AudioEncoder = function (this: any, callbacks: AudioEncoderInit) {
+    encoderCallbacks = callbacks;
     Object.assign(this, encoder);
     return encoder;
   };
@@ -134,13 +140,20 @@ function installMediaGlobals({ contextSampleRate = SAMPLE_RATE } = {}) {
     return { readable: { getReader: () => reader } };
   };
   (globalThis as any).AudioContext = vi.fn(function () { return context; });
-  const stream = { getTracks: () => [track], getAudioTracks: () => [track] };
+  const stream = { getTracks: () => [track], getAudioTracks: () => [track] } as unknown as MediaStream;
   Object.defineProperty(globalThis, 'navigator', {
     value: { mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) } },
     writable: true,
     configurable: true,
   });
-  return { track, reader, encoder, context, getProcessor: () => processor };
+  return {
+    track, stream, reader, encoder, context, getProcessor: () => processor,
+    eof: () => finishRead({ done: true }),
+    sample: (value: unknown) => finishRead({ done: false, value }),
+    reject: () => rejectRead(new Error('capture reader failed')),
+    encoderError: () => encoderCallbacks.error(new DOMException('encoder failed')),
+    encoderOutput: () => encoderCallbacks.output({ byteLength: 1, copyTo: vi.fn() } as unknown as EncodedAudioChunk, {}),
+  };
 }
 
 function clearMediaGlobals(): void {
@@ -260,6 +273,148 @@ describe('AudioManager consumes the server TX codec ack', () => {
     expect(died).toEqual(['throwing', 'kept']);
     unsubscribeThrowing();
     unsubscribeThrowing(); // idempotent
+  });
+
+  it.each(['eof', 'reject', 'encoderError', 'encode-throws', 'opus-ended', 'pcm-ended'] as const)(
+    'capture %s reaches the existing canonical ForceOFF exactly once', async (failure) => {
+      const media = installMediaGlobals();
+      if (failure === 'pcm-ended') delete (globalThis as any).AudioEncoder;
+      const { audioManager } = await import('../audio-manager');
+      const died = vi.fn();
+      audioManager.onTxAudioDied(died);
+      const submit = vi.fn<(operation: ManagedOperation) => Promise<'accepted'>>(async () => 'accepted');
+      const tx = new ManagedTxController({
+        snapshot: () => ({ phase: 'idle', intent: null, radioTx: 'off', txRisk: 'none',
+          fault: null, faultDetail: null, fresh: true, releaseRequired: false,
+          configuredSeconds: 180, remainingMs: null, lastOperation: null }),
+        refresh: async () => {}, invalidate: vi.fn(), sendPtt: async () => 'accepted',
+        submit, setTot: async () => {}, startAudio: () => audioManager.startTx(),
+        stopLocalAudio: () => audioManager.stopTx(),
+        onAudioDied: (handler) => audioManager.onTxAudioDied(handler),
+      });
+      try {
+        tx.transmitOn();
+        await vi.waitFor(() => expect(submit).toHaveBeenCalledExactlyOnceWith('transmit_on'));
+        FakeWebSocket.instances[0].open();
+        if (failure === 'opus-ended' || failure === 'pcm-ended') media.track.dispatchEvent(new Event('ended'));
+        else if (failure === 'encode-throws') {
+          media.encoder.encode.mockImplementationOnce(() => { throw new Error('encode failed'); });
+          media.sample({ close: vi.fn() });
+        } else media[failure]();
+        if (failure === 'encoderError') {
+          media.track.dispatchEvent(new Event('ended'));
+          media.eof();
+        }
+        await vi.waitFor(() => expect(died).toHaveBeenCalledOnce());
+        expect(submit.mock.calls).toEqual([['transmit_on'], ['force_off']]);
+        expect(audioManager.txEnabled).toBe(false);
+        expect(audioManager.txCodec).toBeNull();
+        expect(media.track.stop).toHaveBeenCalledOnce();
+        // Concurrent and late producer signals cannot submit another global OFF.
+        media.track.dispatchEvent(new Event('ended'));
+        if (failure !== 'pcm-ended') media.encoderError();
+        media.eof();
+        await Promise.resolve();
+        expect(died).toHaveBeenCalledOnce();
+        expect(submit).toHaveBeenCalledTimes(2);
+      } finally { tx.dispose(); audioManager.stopTx(); }
+    },
+  );
+
+  it.each(['eof', 'reject'] as const)('does not enable TX when capture %s occurs during start', async (failure) => {
+    const media = installMediaGlobals();
+    const { audioManager } = await import('../audio-manager');
+    media[failure]();
+    expect(await audioManager.startTx()).not.toBeNull();
+    expect(audioManager.txEnabled).toBe(false);
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+
+  it('cancels pending microphone permission without a late audio start or death notification', async () => {
+    const media = installMediaGlobals();
+    let grant!: (stream: MediaStream) => void;
+    vi.mocked(navigator.mediaDevices.getUserMedia).mockImplementationOnce(() => new Promise((resolve) => { grant = resolve; }));
+    const { audioManager } = await import('../audio-manager');
+    const died = vi.fn();
+    audioManager.onTxAudioDied(died);
+    const starting = audioManager.startTx();
+    audioManager.stopTx();
+    grant(media.stream);
+    expect(await starting).not.toBeNull();
+    expect(audioManager.txEnabled).toBe(false);
+    expect(media.track.stop).toHaveBeenCalledOnce();
+    expect(died).not.toHaveBeenCalled();
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+
+  it('does not stop a replacement capture when cancelled permission resolves late', async () => {
+    const old = installMediaGlobals();
+    let grant!: (stream: MediaStream) => void;
+    vi.mocked(navigator.mediaDevices.getUserMedia).mockImplementationOnce(() => new Promise((resolve) => { grant = resolve; }));
+    const { audioManager } = await import('../audio-manager');
+    const starting = audioManager.startTx();
+    audioManager.stopTx();
+    const current = installMediaGlobals();
+    expect(await audioManager.startTx()).toBeNull();
+    grant(old.stream);
+    expect(await starting).not.toBeNull();
+    expect(old.track.stop).toHaveBeenCalledOnce();
+    expect(current.track.stop).not.toHaveBeenCalled();
+    expect(audioManager.txEnabled).toBe(true);
+    audioManager.stopTx();
+  });
+
+  it('ignores an old reader rejection after restart', async () => {
+    const old = installMediaGlobals();
+    old.reader.cancel.mockImplementationOnce(async () => {});
+    const { audioManager } = await import('../audio-manager');
+    const died = vi.fn();
+    audioManager.onTxAudioDied(died);
+    await audioManager.startTx();
+    audioManager.stopTx();
+    installMediaGlobals();
+    await audioManager.startTx();
+    old.reject();
+    await Promise.resolve();
+    expect(audioManager.txEnabled).toBe(true);
+    expect(died).not.toHaveBeenCalled();
+    audioManager.stopTx();
+  });
+
+  it('ignores old capture callbacks after restart and intentional codec-switch cancellation', async () => {
+    const old = installMediaGlobals();
+    old.reader.cancel.mockImplementationOnce(async () => {}); // terminal result arrives after restart
+    const oldTrackListener = vi.spyOn(old.track, 'addEventListener');
+    const { audioManager } = await import('../audio-manager');
+    const died = vi.fn();
+    audioManager.onTxAudioDied(died);
+    await audioManager.startTx();
+    audioManager.stopTx();
+    const current = installMediaGlobals();
+    await audioManager.startTx();
+    const ws = FakeWebSocket.instances.at(-1)!;
+    ws.open();
+    const sentBefore = ws.sent.length;
+    old.encoderOutput();
+    old.encoderError();
+    const oldEnded = oldTrackListener.mock.calls[0][1] as EventListener;
+    oldEnded(new Event('ended'));
+    const lateSample = { close: vi.fn() };
+    old.sample(lateSample);
+    await Promise.resolve();
+    expect(lateSample.close).toHaveBeenCalledOnce();
+    expect(current.encoder.encode).not.toHaveBeenCalled();
+    expect(ws.sent).toHaveLength(sentBefore);
+    expect(audioManager.txEnabled).toBe(true);
+    expect(died).not.toHaveBeenCalled();
+    ws.serverText({ type: 'audio_tx_format', codec: 'pcm16', opus_decode: false });
+    current.encoderError();
+    await Promise.resolve();
+    expect(audioManager.txCodec).toBe('pcm16');
+    expect(died).not.toHaveBeenCalled();
+    audioManager.stopTx();
+    current.track.dispatchEvent(new Event('ended'));
+    expect(died).not.toHaveBeenCalled();
   });
 
   it('leaves the pin alone when the ack names a codec it does not know', async () => {

--- a/frontend/src/lib/audio/__tests__/tx-mic.test.ts
+++ b/frontend/src/lib/audio/__tests__/tx-mic.test.ts
@@ -6,8 +6,8 @@ let mockTrack: any, mockEncoder: any, mockReader: any;
 beforeEach(() => {
   delete (globalThis as any).AudioContext;
   delete (globalThis as any).webkitAudioContext;
-  mockTrack = { stop: vi.fn(), kind: 'audio' };
-  mockReader = { read: vi.fn(() => Promise.resolve({ done: true })), cancel: vi.fn().mockResolvedValue(undefined) };
+  mockTrack = Object.assign(new EventTarget(), { stop: vi.fn(), kind: 'audio' });
+  mockReader = { read: vi.fn(() => new Promise(() => {})), cancel: vi.fn().mockResolvedValue(undefined) };
   mockEncoder = { configure: vi.fn(), encode: vi.fn(), close: vi.fn(), state: 'configured' };
   (globalThis as any).AudioEncoder = function (this: any) { Object.assign(this, mockEncoder); return mockEncoder; };
   (globalThis as any).MediaStreamTrackProcessor = function () {

--- a/frontend/src/lib/audio/audio-manager.ts
+++ b/frontend/src/lib/audio/audio-manager.ts
@@ -97,7 +97,7 @@ class AudioManager {
           console.warn(`[audio-ws] TX frame dropped, WS state=${this.ws?.readyState}`);
         }
       }
-    });
+    }, (reason) => this._failTxAudio(reason));
   }
 
   /** Register a change callback for reactive UI updates. Returns unsubscribe fn. */
@@ -221,6 +221,7 @@ class AudioManager {
     if (this._txEnabled) return null;
     const err = await this.txMic.start();
     if (err) return err;
+    if (!this.txMic.active) return 'TX MIC: capture stopped before start completed';
     this._txEnabled = true;
     setTxEnabled(true);
     this.connect();
@@ -232,13 +233,13 @@ class AudioManager {
   }
 
   stopTx(): void {
+    this.txMic.stop();
     if (!this._txEnabled) return;
     this._txEnabled = false;
     setTxEnabled(false);
     if (this.ws?.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify({ type: 'audio_stop', direction: 'tx' }));
     }
-    this.txMic.stop();
     this.maybeDisconnect();
     this.notify();
   }
@@ -373,20 +374,11 @@ class AudioManager {
     this._setTxCodecFallback(msg.opus_decode === false);
   }
 
-  /**
-   * End browser TX audio after the codec switch could not be completed.
-   *
-   * The server cannot decode Opus and the PCM16 leg refused to start, so no
-   * audio can reach the air on this session. Ending it takes the same
-   * teardown a failed TX audio start takes — `stopTx()` releases the
-   * server-side TX lease, which disarms the radio's TX audio leg — and the
-   * fallback indication is cleared so nothing claims transmission is working
-   * while the transmitter is keyed. The next key re-runs `txMic.start()` on
-   * the pinned PCM16 path and returns this same error from `startTx()`, the
-   * input the TX controller turns into `audio-failed` and de-keys on.
-   */
+  /** End failed capture/codec audio and notify the existing canonical de-key path. */
   private _failTxAudio(reason: string): void {
-    console.error(`[audio-ws] TX codec switch failed, stopping TX audio: ${reason}`);
+    // A failure during preparation is returned by startTx, before TX admission.
+    if (!this._txEnabled) return;
+    console.error(`[audio-ws] TX audio failed, stopping TX audio: ${reason}`);
     this._setTxCodecFallback(false);
     this.stopTx();
     // Snapshot + isolate: one throwing subscriber must not starve the rest.

--- a/frontend/src/lib/audio/tx-mic.ts
+++ b/frontend/src/lib/audio/tx-mic.ts
@@ -47,11 +47,14 @@ export class TxMic {
   private seq = 0;
   private _active = false;
   private sendFn: TxSendFn;
+  // Capture-local identity also cancels getUserMedia that settles after stop().
+  private captureGeneration = 0;
+  private removeTrackEnded: (() => void) | null = null;
   // Sticky: the server told us it cannot decode Opus (MOR-1791). Kept across
   // start/stop so every later PTT opens on PCM16 from the very first frame.
   private pcm16Pinned = false;
 
-  constructor(sendFn: TxSendFn) {
+  constructor(sendFn: TxSendFn, private readonly onCaptureDied?: (reason: string) => void) {
     this.sendFn = sendFn;
   }
 
@@ -149,8 +152,10 @@ export class TxMic {
       return 'TX MIC: microphone capture not supported';
     }
 
+    const generation = ++this.captureGeneration;
+    let stream: MediaStream;
     try {
-      this.stream = await getUserMedia({
+      stream = await getUserMedia({
         audio: {
           channelCount: CHANNELS,
           sampleRate: SAMPLE_RATE,
@@ -162,7 +167,20 @@ export class TxMic {
       return 'TX MIC: permission denied';
     }
 
+    if (generation !== this.captureGeneration) {
+      stream.getTracks().forEach(track => track.stop());
+      return 'TX MIC: capture start cancelled';
+    }
+    this.stream = stream;
     this._active = true;
+    const track = stream.getAudioTracks()[0];
+    const onEnded = () => this.failCapture(generation, 'microphone track ended');
+    track.addEventListener('ended', onEnded);
+    this.removeTrackEnded = () => track.removeEventListener('ended', onEnded);
+    if (track.readyState === 'ended') {
+      onEnded();
+      return 'TX MIC: microphone track ended';
+    }
     this.seq = 0;
     this.pcmPending = [];
 
@@ -170,13 +188,13 @@ export class TxMic {
       return this.startPcmFallback();
     }
 
-    const track = this.stream.getAudioTracks()[0];
     const processor = new MediaStreamTrackProcessor({ track });
-    this.reader = processor.readable.getReader();
+    const reader = this.reader = processor.readable.getReader();
 
     let sentFrames = 0;
-    this.encoder = new AudioEncoder({
+    const encoder = this.encoder = new AudioEncoder({
       output: (chunk: EncodedAudioChunk) => {
+        if (!this._active || this.encoder !== encoder || generation !== this.captureGeneration) return;
         const payload = new Uint8Array(chunk.byteLength);
         chunk.copyTo(payload);
         const header = buildTxHeader(this.seq++);
@@ -190,7 +208,7 @@ export class TxMic {
         }
       },
       error: (err: DOMException) => {
-        console.warn('TxMic: encoder error', err);
+        if (this.encoder === encoder) this.failCapture(generation, `encoder error: ${err.message}`);
       },
     });
 
@@ -202,12 +220,15 @@ export class TxMic {
     });
 
     // Read loop
-    this.readLoop();
+    void this.readLoop(reader, encoder, generation);
     return null;
   }
 
   stop(): void {
     this._active = false;
+    ++this.captureGeneration;
+    this.removeTrackEnded?.();
+    this.removeTrackEnded = null;
     if (this.pcmProcessor) {
       this.pcmProcessor.disconnect();
       this.pcmProcessor.onaudioprocess = null;
@@ -231,14 +252,13 @@ export class TxMic {
 
   /** Tear down the WebCodecs encoder leg, leaving the MediaStream open. */
   private stopOpusCapture(): void {
-    if (this.reader) {
-      this.reader.cancel().catch(() => {});
-      this.reader = null;
-    }
-    if (this.encoder) {
-      try { this.encoder.close(); } catch { /* ok */ }
-      this.encoder = null;
-    }
+    const reader = this.reader;
+    const encoder = this.encoder;
+    // Invalidate before cancellation/close can deliver their terminal callbacks.
+    this.reader = null;
+    this.encoder = null;
+    reader?.cancel().catch(() => {});
+    try { encoder?.close(); } catch { /* ok */ }
   }
 
   /**
@@ -271,9 +291,9 @@ export class TxMic {
     }
 
     this.pcmSource = this.audioContext.createMediaStreamSource(this.stream);
-    this.pcmProcessor = this.audioContext.createScriptProcessor(1024, CHANNELS, CHANNELS);
+    const processor = this.pcmProcessor = this.audioContext.createScriptProcessor(1024, CHANNELS, CHANNELS);
     this.pcmProcessor.onaudioprocess = (event: AudioProcessingEvent) => {
-      if (!this._active) return;
+      if (!this._active || this.pcmProcessor !== processor) return;
       const input = event.inputBuffer.getChannelData(0);
       this.queuePcmSamples(input);
     };
@@ -305,30 +325,35 @@ export class TxMic {
     }
   }
 
-  private async readLoop(): Promise<void> {
-    let samplesRead = 0;
-    console.log('[TxMic] read loop started');
-    while (this._active && this.reader) {
+  private failCapture(generation: number, reason: string): void {
+    if (!this._active || generation !== this.captureGeneration) return;
+    this.stop();
+    this.onCaptureDied?.(`TX MIC: ${reason}`);
+  }
+
+  private async readLoop(
+    reader: ReadableStreamDefaultReader<AudioData>, encoder: AudioEncoder, generation: number,
+  ): Promise<void> {
+    const current = () => this._active && this.reader === reader && generation === this.captureGeneration;
+    while (current()) {
       let result: ReadableStreamReadResult<AudioData>;
       try {
-        result = await this.reader.read();
+        result = await reader.read();
       } catch (err) {
-        console.error('[TxMic] read error:', err);
+        if (current()) this.failCapture(generation, `capture reader failed: ${String(err)}`);
         break;
       }
-      if (!result || result.done) {
-        console.log('[TxMic] read loop done');
+      if (result.done) {
+        if (current()) this.failCapture(generation, 'capture reader ended');
         break;
       }
-      if (this.encoder && this._active) {
-        this.encoder.encode(result.value);
-        samplesRead++;
-        if (samplesRead <= 3 || samplesRead % 100 === 0) {
-          console.log(`[TxMic] encoded sample #${samplesRead}`);
-        }
+      try {
+        if (current()) encoder.encode(result.value);
+      } catch (err) {
+        if (current()) this.failCapture(generation, `encoder failed: ${String(err)}`);
+      } finally {
+        result.value.close();
       }
-      result.value.close();
     }
-    console.log('[TxMic] read loop exited, samples=' + samplesRead);
   }
 }

--- a/frontend/src/lib/runtime/tx-controller/__tests__/browser-dependencies-fault-injection.isolated.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/browser-dependencies-fault-injection.isolated.test.ts
@@ -73,6 +73,7 @@ describe('managed browser TX fault injection', () => {
     const { TxMic } = await import('$lib/audio/tx-mic');
     const { audioManager } = await import('$lib/audio/audio-manager');
     const startMic = vi.spyOn(TxMic.prototype, 'start').mockResolvedValue(null);
+    const activeMic = vi.spyOn(TxMic.prototype, 'active', 'get').mockReturnValue(true);
     const audioDied = vi.fn();
     instances.length = 0;
     vi.stubGlobal('WebSocket', MockWebSocket);
@@ -94,6 +95,7 @@ describe('managed browser TX fault injection', () => {
       tx.dispose();
       audioManager.stopTx();
       startMic.mockRestore();
+      activeMic.mockRestore();
       vi.unstubAllGlobals();
     }
   });


### PR DESCRIPTION
Microphone reader EOF/rejection, encoder failure, or an ended capture track previously left TX audio marked active and never reached the existing canonical dekey callback. TxMic now tears down the failed capture and reports it to AudioManager's existing audio-died path, which ManagedTxController already translates into ForceOFF.

Capture/resource identity suppresses callbacks from stopped or replaced captures and intentional Opus→PCM cancellation. A cancelled pending microphone permission request cannot enable TX later, and capture death during preparation returns a start failure. Concurrent failure signals notify once. No watchdog, new TX authority, or server behavior is introduced.

Validation on an isolated Mac Mini checkout with its own npm install:

- Original source discriminator: 9 RED / 21 PASS; real TxMic + AudioManager connected to ManagedTxController, with controlled browser media APIs.
- Final focused audio + TX-controller suite: 169 PASS across 16 files. Covers EOF/read rejection, encoder callback and synchronous encode failures, Opus/PCM track death, intentional stop/switch, stale callbacks, and pending permission cancellation/replacement.
- Changed-file ESLint, Svelte/TypeScript checks (0 errors/warnings), and frontend build passed.
- Six files, two production files. Healthy media fixtures now use pending reads; existing healthy TxMic mocks expose active capture without changing their assertions.

Boundary: these are source-level browser-media fault tests. No physical microphone-loss/RF acceptance or packaged candidate rebuild was performed here; owner-present capture-death/dekey evidence remains a separate release gate.

Linear: https://linear.app/morozsm/issue/MOR-2345/beta-acceptance-verify-and-repair-actual-microphone-capture-death
