### PR TITLE
docs(MOR-1101): clarify source build prerequisites

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -16,7 +16,17 @@ description: Install RigPlane from PyPI on macOS, Linux, or Windows — Python 3
 pip install rigplane
 ```
 
+The prebuilt wheel includes the Web UI and does not require Node.js or npm.
+If pip must build from a source distribution instead, follow the source-build
+requirements below.
+
 ## Install from Source
+
+Building from a Git checkout or source distribution requires Node.js and npm.
+The build runs `npm ci` and downloads frontend dependencies from the npm
+registry unless they are already cached. The source-distribution install path
+has been verified with Node.js 20.20.2 and npm 10.8.2; this is the tested
+toolchain, not a claim that other versions are supported.
 
 ```bash
 git clone https://github.com/rigplane/rigplane-core.git

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -4,7 +4,7 @@ The frontend lives in ``frontend/`` and its build output (``frontend/dist``)
 is gitignored. At runtime the SPA is served from ``src/rigplane/web/static``,
 so the package must ship the built assets at that location.
 
-This hook makes every build target (wheel *and* sdist) self-contained:
+This hook gives each build target the frontend payload needed for its role:
 
 * If ``frontend/dist/index.html`` is missing and a ``frontend/`` source tree is
   present, it builds the SPA with ``npm`` (``npm ci``/``npm install`` then
@@ -15,6 +15,11 @@ This hook makes every build target (wheel *and* sdist) self-contained:
   does not rebuild it.
 * The built ``frontend/dist`` is force-included at ``src/rigplane/web/static``
   for whichever target is building, centralizing the mapping in one place.
+
+A built wheel contains the Web UI and needs no Node.js to install. A source
+distribution contains the frontend source but not ``frontend/dist``; building
+a wheel from that sdist invokes this hook and requires Node.js/npm to compile
+the Web UI.
 
 Without this, ``pip install git+https://...`` (a direct wheel build) would not
 bundle the SPA and the desktop UI would 404.
@@ -55,9 +60,9 @@ class FrontendBuildHook(BuildHookInterface):  # type: ignore[type-arg]
             raise RuntimeError(
                 "Building rigplane from source requires Node.js/npm to build "
                 "the web UI (frontend/dist is not present and could not be "
-                "built). Install Node.js/npm, or build a wheel/sdist on a "
-                "machine that has them (the resulting artifact is "
-                "self-contained and needs no Node.js to install)."
+                "built). Install Node.js/npm, or install a prebuilt wheel "
+                "(the wheel includes the web UI and needs no Node.js to "
+                "install)."
             )
 
         lockfile = frontend_dir / "package-lock.json"


### PR DESCRIPTION
## Scope

- Linked issue / task: [MOR-1101](https://linear.app/morozsm/issue/MOR-1101)
- Compatibility impact: docs only; no API, CLI, config, wire, packaging hook, or runtime behavior change

The source installation guide listed only Python prerequisites even though the verified 3.0.0b1 sdist consumer path rebuilt the Web UI with npm. This change distinguishes the prebuilt wheel from Git/sdist builds, records the tested Node.js 20.20.2/npm 10.8.2 toolchain and registry/cache requirement, and corrects the build-hook prose and missing-npm advice to describe only the wheel as Node-free to install.

## Verification

- [x] Relevant local checks run: `git diff --check`; doc citation and link gates; `python -m py_compile hatch_build.py`; strict MkDocs build
- [x] Public/open-core boundary checked
- [x] Release or migration impact documented if applicable

Artifact claims were checked against the preserved 3.0.0b1 wheel (`2b9f289531a1cc9926cf313eb18319d3926c9fc926c934b4c66ff941a8b4fff8`) and sdist (`910da1c81631da394e0608fcb2a7b543449f970ad8bfb9f68ef4a66a2ee0a097`): the wheel has 104 runtime static files, while the sdist has 822 `frontend/src` files and no `frontend/dist` files. The completed isolated sdist install used Node.js 20.20.2/npm 10.8.2 and ran `npm ci` plus Vite.

## Agent Review

- [ ] Independent agent review comment posted before merge
- Reviewer:
- Result: `Agent Review: PASS` / `Agent Review: BLOCKED`

## Notes

- Out of scope / follow-ups: no release, merge, tag, packaging behavior change, or transfer of acceptance from the preserved 18f7 artifact
- Product tests were not rerun for this prose-only correction; completed artifact/install evidence is reused.
