### PR TITLE
fix(MOR-2349): refresh authentication for audio and scope WebSockets

### DIFF
--- a/frontend/src/__tests__/presentation-switch-resources.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-resources.component.test.ts
@@ -58,7 +58,8 @@ const h = vi.hoisted(() => ({
 }));
 
 // ── Bottom boundary only: transport, HTTP, audio, scope channels ──
-vi.mock('$lib/transport/http-client', () => ({
+vi.mock('$lib/transport/http-client', async (importOriginal) => ({
+  ...await importOriginal<typeof import('$lib/transport/http-client')>(),
   fetchCapabilities: vi.fn(),
 }));
 vi.mock('$lib/transport/ws-client', () => ({

--- a/frontend/src/components-v2/panels/lcd/__tests__/audio-fft-demand.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/audio-fft-demand.isolated.test.ts
@@ -74,7 +74,8 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock('$lib/transport/http-client', () => ({
+vi.mock('$lib/transport/http-client', async (importOriginal) => ({
+  ...await importOriginal<typeof import('$lib/transport/http-client')>(),
   fetchCapabilities: mocks.fetchCapabilities,
   startPolling: mocks.startPolling,
   setPollingMultiplier: vi.fn(),

--- a/frontend/src/lib/audio/__tests__/audio-manager.isolated.test.ts
+++ b/frontend/src/lib/audio/__tests__/audio-manager.isolated.test.ts
@@ -61,7 +61,7 @@ class FakeWebSocket {
   onerror: ((event: unknown) => void) | null = null;
   onclose: ((event: { code: number; reason: string }) => void) | null = null;
 
-  constructor(_url: string) {
+  constructor(public url: string) {
     FakeWebSocket.instances.push(this);
   }
 
@@ -285,5 +285,67 @@ describe('AudioManager reconnect coalescing (MOR-924)', () => {
     expect(secondStart[0].client_id).toBe(clientId);
 
     audioManager.stopRx();
+  });
+});
+
+
+describe('AudioManager current WebSocket authentication', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    FakeWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+    vi.stubGlobal('location', { protocol: 'https:', host: 'radio.example.test' });
+    localStorage.clear();
+  });
+
+  afterEach(async () => {
+    const { audioManager } = await import('../audio-manager');
+    audioManager.stopRx();
+    vi.restoreAllMocks();
+    localStorage.clear();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the current encoded token on initial RX and each reconnect', async () => {
+    const { audioManager } = await import('../audio-manager');
+    for (const token of ['synthetic +&?=#/ token', 'synthetic-rotated', null]) {
+      if (token) localStorage.setItem('rigplane-auth-token', token);
+      else localStorage.removeItem('rigplane-auth-token');
+      if (!FakeWebSocket.instances.length) audioManager.startRx();
+      else {
+        FakeWebSocket.instances.at(-1)!.serverClose();
+        await vi.advanceTimersByTimeAsync(1000);
+      }
+      const socket = FakeWebSocket.instances.at(-1)!;
+      const url = new URL(socket.url);
+      expect(url.origin).toBe('wss://radio.example.test');
+      expect(url.pathname).toBe('/api/v1/audio');
+      expect(url.searchParams.getAll('token')).toEqual(token ? [token] : []);
+      socket.open();
+    }
+  });
+
+  it('does not log the error event carrying the authenticated socket URL', async () => {
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+    localStorage.setItem('rigplane-auth-token', 'synthetic-private');
+    const { audioManager } = await import('../audio-manager');
+    audioManager.startRx();
+    const socket = FakeWebSocket.instances[0];
+    socket.onerror?.({ target: socket });
+    expect(errorLog).toHaveBeenCalledWith('[audio-ws] error');
+    expect(JSON.stringify(errorLog.mock.calls)).not.toContain('synthetic-private');
+  });
+
+  it('keeps initial and reconnected anonymous RX token-free', async () => {
+    const { audioManager } = await import('../audio-manager');
+    audioManager.startRx();
+    FakeWebSocket.instances[0].serverClose();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(FakeWebSocket.instances.map((socket) => socket.url)).toEqual([
+      'wss://radio.example.test/api/v1/audio',
+      'wss://radio.example.test/api/v1/audio',
+    ]);
   });
 });

--- a/frontend/src/lib/audio/audio-manager.ts
+++ b/frontend/src/lib/audio/audio-manager.ts
@@ -12,6 +12,7 @@ import { RxPlayer, type RxAudioFocus } from './rx-player';
 import { TxMic, type TxCodec } from './tx-mic';
 import { setAudioConnected } from '../stores/connection.svelte';
 import { setRxEnabled, setTxEnabled, setTxCodecFallback } from '../stores/audio.svelte';
+import { authenticatedWsUrl } from '../transport/ws-url';
 import { getCapabilities } from '$lib/stores/capabilities.svelte';
 
 export type AudioFocus = RxAudioFocus;
@@ -254,7 +255,7 @@ class AudioManager {
 
     const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
     const url = `${proto}//${location.host}/api/v1/audio`;
-    const ws = new WebSocket(url);
+    const ws = new WebSocket(authenticatedWsUrl(url));
     ws.binaryType = 'arraybuffer';
     this.ws = ws;
 
@@ -299,8 +300,8 @@ class AudioManager {
       }
     };
 
-    ws.onerror = (e) => {
-      console.error('[audio-ws] error', e);
+    ws.onerror = () => {
+      console.error('[audio-ws] error');
       ws.close();
     };
 

--- a/frontend/src/lib/runtime/__tests__/frontend-runtime.isolated.test.ts
+++ b/frontend/src/lib/runtime/__tests__/frontend-runtime.isolated.test.ts
@@ -14,7 +14,8 @@ import { effect_root, render_effect } from 'svelte/internal/client';
 
 // ── Mock transport and store modules before importing the runtime ──
 
-vi.mock('$lib/transport/http-client', () => ({
+vi.mock('$lib/transport/http-client', async (importOriginal) => ({
+  ...await importOriginal<typeof import('$lib/transport/http-client')>(),
   fetchCapabilities: vi.fn(),
 }));
 

--- a/frontend/src/lib/transport/__tests__/ws-auth.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-auth.isolated.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MockWebSocket, instances } from './support/fake-ws-backend';
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.useFakeTimers();
+  vi.stubGlobal('WebSocket', MockWebSocket);
+  vi.stubGlobal('location', { protocol: 'https:', host: 'radio.example.test' });
+  instances.length = 0;
+  localStorage.clear();
+  vi.spyOn(console, 'info').mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  const { disconnectAll } = await import('../ws-client');
+  disconnectAll();
+  localStorage.clear();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function expectCurrentToken(token: string | null, path: string): void {
+  const url = new URL(instances.at(-1)!.url, 'https://radio.example.test');
+  expect(url.pathname).toBe(path);
+  expect(url.searchParams.getAll('token')).toEqual(token ? [token] : []);
+}
+
+async function rotateAndReconnect(token: string | null): Promise<void> {
+  if (token) localStorage.setItem('rigplane-auth-token', token);
+  else localStorage.removeItem('rigplane-auth-token');
+  instances.at(-1)!.simulateClose();
+  await vi.advanceTimersByTimeAsync(1250);
+}
+
+describe('production WebSocket authentication', () => {
+  it('refreshes control credentials on automatic and explicit reconnect, preserving query parameters', async () => {
+    const { connect, disconnectAll, reconnectAll, getLastCloseInfo } = await import('../ws-client');
+    const first = 'synthetic +&?=#/ token';
+    localStorage.setItem('rigplane-auth-token', first);
+    connect('/api/v1/ws?receiver=1&token=synthetic-old&token=synthetic-older');
+    expectCurrentToken(first, '/api/v1/ws');
+    instances[0].simulateOpen();
+    await rotateAndReconnect('synthetic-rotated');
+    expectCurrentToken('synthetic-rotated', '/api/v1/ws');
+    expect(new URL(instances.at(-1)!.url, 'https://radio.example.test').searchParams.get('receiver')).toBe('1');
+    localStorage.removeItem('rigplane-auth-token');
+    instances.at(-1)!.simulateOpen();
+    disconnectAll();
+    reconnectAll();
+    expectCurrentToken(null, '/api/v1/ws');
+    expect(JSON.stringify(getLastCloseInfo())).not.toContain('synthetic');
+    expect(JSON.stringify(vi.mocked(console.info).mock.calls)).not.toContain('synthetic');
+  });
+
+  it('keeps anonymous control initial and reconnect token-free', async () => {
+    const { connect } = await import('../ws-client');
+    connect();
+    expectCurrentToken(null, '/api/v1/ws');
+    await rotateAndReconnect(null);
+    expectCurrentToken(null, '/api/v1/ws');
+  });
+
+  it.each([
+    ['audioFftDriver', '/api/v1/audio-scope'],
+    ['hardwareScopeDriver', '/api/v1/scope'],
+  ] as const)('authenticates actual ScopeController %s on initial and changed/absent-token reconnect', async (driverName, path) => {
+    const { ScopeController } = await import('../../runtime/scope-controller.svelte');
+    const controller = new ScopeController();
+    const driver = controller[driverName];
+    localStorage.setItem('rigplane-auth-token', 'synthetic +&?=#/ token');
+    const handle = await driver.start();
+    expectCurrentToken('synthetic +&?=#/ token', path);
+    instances.at(-1)!.simulateOpen();
+    await rotateAndReconnect('synthetic-rotated');
+    expectCurrentToken('synthetic-rotated', path);
+    instances.at(-1)!.simulateOpen();
+    await rotateAndReconnect(null);
+    expectCurrentToken(null, path);
+    await driver.stop(handle);
+  });
+
+  it.each(['audioFftDriver', 'hardwareScopeDriver'] as const)('keeps anonymous %s initial and reconnect token-free', async (driverName) => {
+    const { ScopeController } = await import('../../runtime/scope-controller.svelte');
+    const controller = new ScopeController();
+    const driver = controller[driverName];
+    const handle = await driver.start();
+    const firstUrl = instances.at(-1)!.url;
+    await rotateAndReconnect(null);
+    expect(instances.at(-1)!.url).toBe(firstUrl);
+    expect(new URL(firstUrl, 'https://radio.example.test').searchParams.has('token')).toBe(false);
+    await driver.stop(handle);
+  });
+
+  it.each(['wss://other.example.test/api/v1/scope', 'wss://radio.example.test:9443/api/v1/scope', 'ws://radio.example.test/api/v1/scope'])('does not attach application credentials to unrelated origin %s', async (url) => {
+    const { WsChannel } = await import('../ws-client');
+    localStorage.setItem('rigplane-auth-token', 'synthetic-private');
+    const channel = new WsChannel();
+    channel.connect(url);
+    expect(instances.at(-1)!.url).toBe(url);
+    channel.disconnect();
+  });
+});

--- a/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
@@ -4,7 +4,8 @@ import type { Capabilities } from '../../types/capabilities';
 import { MockWebSocket, instances } from './support/fake-ws-backend';
 
 const fetchCapabilities = vi.hoisted(() => vi.fn());
-vi.mock('../http-client', () => ({ fetchCapabilities }));
+vi.mock('../http-client', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../http-client')>(), fetchCapabilities }));
 
 // ─── End-to-end fidelity test: REAL ws-client → REAL radio.svelte store ──────
 //

--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -67,7 +67,8 @@ vi.mock('../../stores/capabilities.svelte', () => ({
   setCapabilities: vi.fn(() => true),
 }));
 
-vi.mock('../http-client', () => ({
+vi.mock('../http-client', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../http-client')>(),
   fetchCapabilities: vi.fn(() => new Promise(() => {})),
 }));
 

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -4,6 +4,7 @@ import { isLiveRadioAvailable, setWsConnected, markStateUpdated, setReconnecting
 import { isValidServerState, matchesCurrentCapabilityTopology, resetRadioState, setRadioState } from '../stores/radio.svelte';
 import { capabilitiesMatchGeneration, clearCapabilities, setCapabilities } from '../stores/capabilities.svelte';
 import { fetchCapabilities } from './http-client';
+import { authenticatedWsUrl, withoutWsAuthToken } from './ws-url';
 
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
 export interface ControlSessionTransition {
@@ -218,7 +219,7 @@ export class WsChannel {
   connect(url: string) {
     const rs = this.ws?.readyState;
     if (rs === WebSocket.OPEN || rs === WebSocket.CONNECTING) return;
-    this.url = url;
+    this.url = withoutWsAuthToken(url);
     this.intentionalClose = false;
     // A fresh explicit connect supersedes any stale "reconnect once visible"
     // debt from a previous, unrelated hidden episode.
@@ -228,7 +229,7 @@ export class WsChannel {
 
   private _open() {
     this.setState(this.attempt === 0 ? 'connecting' : 'reconnecting');
-    const ws = new WebSocket(this.url);
+    const ws = new WebSocket(authenticatedWsUrl(this.url));
     let socketEpoch = 0;
     ws.binaryType = 'arraybuffer';
     this.ws = ws;
@@ -987,11 +988,7 @@ _ctrl.onMessage((msg) => {
 });
 
 export function connect(url: string = '/api/v1/ws') {
-  const token = typeof globalThis.localStorage?.getItem === 'function'
-    ? globalThis.localStorage.getItem('rigplane-auth-token')
-    : null;
-  const wsUrl = token ? `${url}?token=${encodeURIComponent(token)}` : url;
-  _ctrl.connect(wsUrl);
+  _ctrl.connect(url);
 }
 
 /** Send a raw JSON message (e.g. subscribe) and register it for re-send on reconnect. */

--- a/frontend/src/lib/transport/ws-url.ts
+++ b/frontend/src/lib/transport/ws-url.ts
@@ -1,0 +1,23 @@
+import { getAuthToken } from './http-client';
+
+function resolveWsUrl(url: string): URL {
+  return new URL(url, `${location.protocol}//${location.host}/`);
+}
+
+export function withoutWsAuthToken(url: string): string {
+  const resolved = resolveWsUrl(url);
+  if (!resolved.searchParams.has('token')) return url;
+  resolved.searchParams.delete('token');
+  return resolved.toString();
+}
+
+export function authenticatedWsUrl(url: string): string {
+  const cleanUrl = withoutWsAuthToken(url);
+  const resolved = resolveWsUrl(cleanUrl);
+  const protocol = resolved.protocol.replace(/^ws/, 'http');
+  if (protocol !== location.protocol || resolved.host !== location.host) return cleanUrl;
+  const token = getAuthToken();
+  if (!token) return cleanUrl;
+  resolved.searchParams.set('token', token);
+  return resolved.toString();
+}


### PR DESCRIPTION
## Problem and change

AudioManager and ScopeController opened audio/scope WebSockets without the configured application token; control reconnects reused a captured token URL and malformed existing query parameters. Build the authenticated URL from the existing current-token getter on every connection attempt. Preserve unrelated query parameters, replace stale/duplicate tokens, retain anonymous connections, and restrict automatic credentials to the page's corresponding WebSocket origin. Keep credentials out of cached close diagnostics and audio error-event logs.

Closes scope of [MOR-2349](https://linear.app/morozsm/issue/MOR-2349). Consumes the helper merged in #3197. This is one transport-authentication change across 10 files: three production files, two focused test files, and five existing HTTP-client partial-mock adaptations. No backend auth policy, capture-death lifecycle, or TX authority change.

## Validation

All product checks ran in isolated Mac Mini checkouts with their own `npm ci`, using fake transports and audio only.

- Before implementation: 4 missing/corrupt-auth failures, 15 passes.
- Frozen development source: focused audio/transport regressions 212 passed; full frontend 408 files / 8842 tests passed; `npm run check` (zero errors/warnings), lint, and build passed.
- Final branch carries only this owned commit onto current main; all 10 owned blobs match the validated development commit. Final focused integration recheck: 9 files / 150 tests passed, covering current source and capture-death compatibility; natural CI validates the combined main tree.
- Installed App handshake/binary-frame evidence and owner-present RF acceptance remain separate. AudioManager.startTx readiness before socket acceptance is an existing, separate lifecycle limitation.

Independent exact-head agent review and required CI remain merge gates.
