### PR TITLE
fix(MOR-2350): authenticate power and spectrum requests

### DIFF
--- a/frontend/src/components/spectrum/BandPlanOverlay.svelte
+++ b/frontend/src/components/spectrum/BandPlanOverlay.svelte
@@ -14,6 +14,7 @@
     shouldSkipFetch,
     type RemoteSegment,
   } from './band-plan-logic';
+  import { getAuthHeaders } from '$lib/auth';
 
   interface Props {
     startFreq: number;
@@ -62,7 +63,8 @@
         const fetchStart = Math.max(0, start - margin);
         const fetchEnd = end + margin;
         const resp = await fetch(
-          `/api/v1/band-plan/segments?start=${fetchStart}&end=${fetchEnd}`
+          `/api/v1/band-plan/segments?start=${fetchStart}&end=${fetchEnd}`,
+          { headers: getAuthHeaders() },
         );
         if (resp.ok) {
           const data = await resp.json();

--- a/frontend/src/components/spectrum/EiBiBrowser.svelte
+++ b/frontend/src/components/spectrum/EiBiBrowser.svelte
@@ -2,6 +2,7 @@
   import {
     bindVfoTunerContext, getVfoHandlers,
   } from '$lib/runtime/adapters/panel-adapters';
+  import { getAuthHeaders } from '$lib/auth';
 
   const vfoHandlers = getVfoHandlers();
   const vfoContext = bindVfoTunerContext();
@@ -73,7 +74,7 @@
 
   async function checkStatus() {
     try {
-      const resp = await fetch('/api/v1/eibi/status');
+      const resp = await fetch('/api/v1/eibi/status', { headers: getAuthHeaders() });
       if (resp.ok) {
         statusInfo = await resp.json();
         loaded = statusInfo.loaded;
@@ -86,7 +87,7 @@
     try {
       const resp = await fetch('/api/v1/eibi/fetch', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { ...getAuthHeaders(), 'Content-Type': 'application/json' },
         body: JSON.stringify({ force: false }),
       });
       const data = await resp.json();
@@ -101,7 +102,7 @@
 
   async function loadBands() {
     try {
-      const resp = await fetch('/api/v1/eibi/bands');
+      const resp = await fetch('/api/v1/eibi/bands', { headers: getAuthHeaders() });
       if (resp.ok) {
         const data = await resp.json();
         availableBands = data.bands ?? [];
@@ -121,7 +122,9 @@
     params.set('limit', String(limit));
 
     try {
-      const resp = await fetch(`/api/v1/eibi/stations?${params}`);
+      const resp = await fetch(`/api/v1/eibi/stations?${params}`, {
+        headers: getAuthHeaders(),
+      });
       if (resp.ok) {
         const data = await resp.json();
         stations = data.stations ?? [];

--- a/frontend/src/components/spectrum/SpectrumToolbar.svelte
+++ b/frontend/src/components/spectrum/SpectrumToolbar.svelte
@@ -6,6 +6,7 @@
   import { runtime } from '$lib/runtime/frontend-runtime';
   import { toSpectrumAuthority } from '$lib/runtime/adapters/scope-adapter';
   import { bindSemanticSurfaceHandlers } from '$lib/runtime/adapters/panel-adapters';
+  import { getAuthHeaders } from '$lib/auth';
   import ScopeSettingsPopover from './ScopeSettingsPopover.svelte';
   import {
     SPAN_LABELS, SPEED_LABELS, SPEED_STATIC_LABEL, MODE_BUTTONS,
@@ -113,8 +114,8 @@
   async function fetchLayers() {
     try {
       const [layerResp, configResp] = await Promise.all([
-        fetch('/api/v1/band-plan/layers'),
-        fetch('/api/v1/band-plan/config'),
+        fetch('/api/v1/band-plan/layers', { headers: getAuthHeaders() }),
+        fetch('/api/v1/band-plan/config', { headers: getAuthHeaders() }),
       ]);
       if (layerResp.ok) {
         const data = await layerResp.json();
@@ -132,7 +133,7 @@
     try {
       const resp = await fetch('/api/v1/band-plan/config', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { ...getAuthHeaders(), 'Content-Type': 'application/json' },
         body: JSON.stringify({ region }),
       });
       if (resp.ok) {

--- a/frontend/src/components/spectrum/__tests__/BandPlanOverlay.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/BandPlanOverlay.component.test.ts
@@ -85,6 +85,7 @@ function mountOverlay(props: OverlayProps) {
 
 beforeEach(() => {
   cleanups = [];
+  localStorage.clear();
   vi.useFakeTimers();
   mockFetch.mockReset();
   // Default: fetch returns empty segments so local fallback is used
@@ -99,6 +100,7 @@ afterEach(() => {
   document.body.innerHTML = '';
   vi.useRealTimers();
   vi.restoreAllMocks();
+  localStorage.clear();
 });
 
 // ── Tests ──
@@ -192,6 +194,25 @@ describe('BandPlanOverlay (component)', () => {
     const titles = Array.from(segments).map((s) => s.getAttribute('title'));
     expect(titles).toContain('CW-R');
     expect(titles).toContain('SSB-R');
+  });
+
+  it('reads auth when the debounced request runs and keeps 401 fallback behavior', async () => {
+    localStorage.setItem('rigplane-auth-token', 'stale-token');
+    mockFetch.mockResolvedValue({ ok: false, status: 401 } as Response);
+    const { target } = mountOverlay({
+      startFreq: 14_000_000,
+      endFreq: 14_350_000,
+    });
+    localStorage.setItem('rigplane-auth-token', 'current-token');
+
+    await vi.advanceTimersByTimeAsync(150);
+    flushSync();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/band-plan/segments?start=13825000&end=14525000',
+      { headers: { Authorization: 'Bearer current-token' } },
+    );
+    expect(target.querySelectorAll('.band-segment')).toHaveLength(3);
   });
 
   it('hidden layers are filtered out', async () => {

--- a/frontend/src/components/spectrum/__tests__/EiBiBrowser.authority.isolated.test.ts
+++ b/frontend/src/components/spectrum/__tests__/EiBiBrowser.authority.isolated.test.ts
@@ -64,6 +64,7 @@ function doubleClick(row: HTMLTableRowElement): void {
 }
 
 beforeEach(() => {
+  localStorage.clear();
   target = document.createElement('div');
   document.body.appendChild(target);
   h.read.mockReset();
@@ -105,9 +106,88 @@ afterEach(() => {
   component = undefined;
   target.remove();
   vi.unstubAllGlobals();
+  localStorage.clear();
 });
 
 describe('MOR-1409 A05b EiBi tune authority', () => {
+  it('authenticates status, bands, and stations with a fresh token read', async () => {
+    localStorage.setItem('rigplane-auth-token', 'status-token');
+    h.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/status')) {
+        localStorage.setItem('rigplane-auth-token', 'query-token');
+        return { ok: true, json: async () => ({ loaded: true, languages: [], countries: [] }) } as Response;
+      }
+      if (url.includes('/bands')) {
+        return { ok: true, json: async () => ({ bands: [] }) } as Response;
+      }
+      if (url.includes('/stations')) {
+        return {
+          ok: true,
+          json: async () => ({
+            stations: [{
+              freq_khz: 14_074.125,
+              station: 'Auth Test', language_name: 'English', language: 'E',
+              time_str: '0000-2400', days: '', target: 'Test', country: 'T',
+              band: 'test', remarks: '', on_air: true,
+            }],
+            total: 1,
+            pages: 1,
+          }),
+        } as Response;
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+
+    await mountBrowser();
+
+    const calls = h.fetch.mock.calls;
+    expect(calls.find(([url]) => String(url).includes('/status'))?.[1]).toEqual({
+      headers: { Authorization: 'Bearer status-token' },
+    });
+    for (const suffix of ['/bands', '/stations']) {
+      expect(calls.find(([url]) => String(url).includes(suffix))?.[1]).toEqual({
+        headers: { Authorization: 'Bearer query-token' },
+      });
+    }
+  });
+
+  it('authenticates the fetch POST without changing its body or content type', async () => {
+    localStorage.setItem('rigplane-auth-token', 'fetch-token');
+    h.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/status')) {
+        return { ok: true, json: async () => ({ loaded: false }) } as Response;
+      }
+      if (url.includes('/fetch')) {
+        return { ok: true, json: async () => ({ status: 'ok' }) } as Response;
+      }
+      if (url.includes('/bands')) {
+        return { ok: true, json: async () => ({ bands: [] }) } as Response;
+      }
+      if (url.includes('/stations')) {
+        return { ok: true, json: async () => ({ stations: [], total: 0, pages: 0 }) } as Response;
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    component = mount(EiBiBrowser, { target, props: { visible: true } });
+    flushSync();
+    await vi.waitFor(() => expect(target.querySelector<HTMLButtonElement>('.eibi-fetch-btn')).not.toBeNull());
+
+    target.querySelector<HTMLButtonElement>('.eibi-fetch-btn')!.click();
+
+    await vi.waitFor(() => {
+      expect(h.fetch).toHaveBeenCalledWith('/api/v1/eibi/fetch', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer fetch-token',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ force: false }),
+      });
+    });
+  });
+
   it('has no direct transport/command edge and binds the reviewed VFO seam', () => {
     const source = readFileSync('src/components/spectrum/EiBiBrowser.svelte', 'utf8');
     expect(source).toContain('getVfoHandlers');

--- a/frontend/src/components/spectrum/__tests__/SpectrumToolbar.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumToolbar.component.test.ts
@@ -4,7 +4,7 @@
  * from the merged spectrum selector while actions use the bound scope family.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mount, unmount, flushSync } from 'svelte';
+import { mount, unmount, flushSync, tick } from 'svelte';
 import { readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { resolve } from 'node:path';
@@ -128,6 +128,7 @@ vi.mock('../ScopeSettingsPopover.svelte', () => ({ default: vi.fn() }));
 globalThis.fetch = vi.fn(() =>
   Promise.resolve({ ok: false, json: () => Promise.resolve({}) } as Response),
 );
+const fetchMock = vi.mocked(globalThis.fetch);
 
 import SpectrumToolbar from '../SpectrumToolbar.svelte';
 
@@ -242,7 +243,11 @@ function clearIntentSpies() {
 
 beforeEach(() => {
   components = [];
+  localStorage.clear();
   vi.clearAllMocks();
+  fetchMock.mockImplementation(() =>
+    Promise.resolve({ ok: false, json: () => Promise.resolve({}) } as Response),
+  );
   tuningHarness.state.autoStep = false;
   capabilityHarness.scope = true;
   capabilityHarness.dual = true;
@@ -258,6 +263,7 @@ beforeEach(() => {
 afterEach(() => {
   components.forEach((component) => unmount(component));
   document.body.innerHTML = '';
+  localStorage.clear();
 });
 
 // ── Canonical selector and one-time binder ─────────────────────────────────
@@ -541,6 +547,63 @@ describe('structural and browser-local behavior', () => {
     const component = components.pop()!;
     unmount(component);
     expect(target.querySelector('.spectrum-toolbar')).toBeNull();
+  });
+});
+
+describe('band-plan HTTP authentication', () => {
+  it('authenticates GETs and rereads the token for the existing config POST', async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/layers')) {
+        return {
+          ok: true,
+          json: async () => ({ layers: [{ layer: 'ham', name: 'Ham' }, { layer: 'eibi', name: 'EiBi' }] }),
+        } as Response;
+      }
+      if (url.endsWith('/config') && init?.method === 'POST') {
+        return { ok: true, json: async () => ({}) } as Response;
+      }
+      if (url.endsWith('/config')) {
+        return {
+          ok: true,
+          json: async () => ({ region: 'US', availableRegions: ['US', 'CA'] }),
+        } as Response;
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    localStorage.setItem('rigplane-auth-token', 'read-token');
+    const target = mountToolbar();
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(fetchMock).toHaveBeenCalledWith('/api/v1/band-plan/layers', {
+      headers: { Authorization: 'Bearer read-token' },
+    });
+    expect(fetchMock).toHaveBeenCalledWith('/api/v1/band-plan/config', {
+      headers: { Authorization: 'Bearer read-token' },
+    });
+
+    localStorage.setItem('rigplane-auth-token', 'write-token');
+    await tick();
+    await vi.waitFor(() => {
+      expect(target.querySelector<HTMLButtonElement>('.layer-toggle-btn')).not.toBeNull();
+    });
+    target.querySelector<HTMLButtonElement>('.layer-toggle-btn')!.click();
+    flushSync();
+    const caButton = Array.from(target.querySelectorAll<HTMLButtonElement>('.region-btn'))
+      .find((item) => item.textContent?.trim() === 'CA');
+    expect(caButton).toBeDefined();
+    caButton!.click();
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/band-plan/config', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer write-token',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ region: 'CA' }),
+      });
+    });
   });
 });
 

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,15 @@
+/** Read the current application authentication token for one request. */
+export function getAuthToken(): string | null {
+  const storage = globalThis.localStorage;
+  if (!storage || typeof storage.getItem !== 'function') {
+    return null;
+  }
+  return storage.getItem('rigplane-auth-token');
+}
+
+/** Build the authorization headers for one request from current storage. */
+export function getAuthHeaders(): Record<string, string> {
+  const token = getAuthToken();
+  if (token) return { Authorization: `Bearer ${token}` };
+  return {};
+}

--- a/frontend/src/lib/runtime/__tests__/system-controller.test.ts
+++ b/frontend/src/lib/runtime/__tests__/system-controller.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SystemController } from '../system-controller';
 
@@ -126,5 +126,70 @@ describe('SystemController HTTP-polling registration removal (A10)', () => {
     };
     expect(surface.registerPolling).toBeUndefined();
     expect(surface.setStopPolling).toBeUndefined();
+  });
+});
+
+describe('SystemController HTTP authentication', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    localStorage.clear();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  it('reads the current token for power commands and preserves each POST body', async () => {
+    fetchMock.mockResolvedValue({ ok: true } as Response);
+    const { controller } = fixture();
+
+    localStorage.setItem('rigplane-auth-token', 'power-one');
+    await controller.powerOn();
+    localStorage.setItem('rigplane-auth-token', 'power-two');
+    await controller.powerOff();
+    localStorage.setItem('rigplane-auth-token', 'identify-token');
+    await controller.identifyFrequency(14_074_000);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/v1/radio/power', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer power-one',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ state: 'on' }),
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/v1/radio/power', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer power-two',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ state: 'off' }),
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      '/api/v1/eibi/identify?freq=14074000',
+      { headers: { Authorization: 'Bearer identify-token' } },
+    );
+  });
+
+  it('omits authorization without a token and preserves existing 401 behavior', async () => {
+    const { controller } = fixture();
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      text: async () => 'Unauthorized',
+    } as Response);
+    await expect(controller.powerOn()).rejects.toThrow('Unauthorized');
+
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 401 } as Response);
+    await expect(controller.identifyFrequency(14_074_000)).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/v1/eibi/identify?freq=14074000',
+      { headers: {} },
+    );
   });
 });

--- a/frontend/src/lib/runtime/system-controller.ts
+++ b/frontend/src/lib/runtime/system-controller.ts
@@ -11,6 +11,7 @@ import { audioManager } from '$lib/audio/audio-manager';
 import { destroyMediaSession, initMediaSession } from '$lib/media/media-session';
 import { setRadioStatus } from '$lib/stores/connection.svelte';
 import { resetRadioState } from '$lib/stores/radio.svelte';
+import { getAuthHeaders } from '$lib/auth';
 
 export interface EibiStation {
   name?: string;
@@ -60,7 +61,7 @@ export class SystemController {
   async powerOn(): Promise<void> {
     const resp = await fetch('/api/v1/radio/power', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { ...getAuthHeaders(), 'Content-Type': 'application/json' },
       body: JSON.stringify({ state: 'on' }),
     });
     if (!resp.ok) throw new Error(await resp.text());
@@ -69,7 +70,7 @@ export class SystemController {
   async powerOff(): Promise<void> {
     const resp = await fetch('/api/v1/radio/power', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { ...getAuthHeaders(), 'Content-Type': 'application/json' },
       body: JSON.stringify({ state: 'off' }),
     });
     if (!resp.ok) throw new Error(await resp.text());
@@ -130,7 +131,9 @@ export class SystemController {
 
   async identifyFrequency(freqHz: number): Promise<EibiResult | null> {
     try {
-      const resp = await fetch(`/api/v1/eibi/identify?freq=${freqHz}`);
+      const resp = await fetch(`/api/v1/eibi/identify?freq=${freqHz}`, {
+        headers: getAuthHeaders(),
+      });
       if (!resp.ok) return null;
       return await resp.json();
     } catch {

--- a/frontend/src/lib/transport/http-client.ts
+++ b/frontend/src/lib/transport/http-client.ts
@@ -1,21 +1,10 @@
 import { validateCapabilities, type Capabilities } from '../types/capabilities';
 import type { InfoResponse } from '../types/protocol';
+import { getAuthHeaders, getAuthToken } from '../auth';
+
+export { getAuthHeaders, getAuthToken };
 
 const BASE = '/api/v1';
-
-export function getAuthToken(): string | null {
-  const storage = globalThis.localStorage;
-  if (!storage || typeof storage.getItem !== 'function') {
-    return null;
-  }
-  return storage.getItem('rigplane-auth-token');
-}
-
-export function getAuthHeaders(): Record<string, string> {
-  const token = getAuthToken();
-  if (token) return { Authorization: `Bearer ${token}` };
-  return {};
-}
 
 function handleUnauthorized(): void {
   const token = prompt('Enter auth token:');


### PR DESCRIPTION
## Scope

- Linked issue / task: [MOR-2350](https://linear.app/morozsm/issue/MOR-2350)
- Compatibility impact: existing HTTP requests now carry the configured application Bearer token; methods, bodies, content types, response handling, storage key, and exported helper names are unchanged

Power, EiBi, and band-plan callers previously omitted authorization even though the backend centrally protects every `/api/` route when authentication is configured. Each request now reads the current token through the shared auth utility. The utility owns only the existing storage-to-header behavior; `transport/http-client.ts` re-exports both helper names so the reviewed MOR-2348 managed-transmit contract remains source-compatible. This location also keeps cross-cutting credentials out of the radio-transport authority boundary without adding a lint exemption or routing presentation code through a system controller.

## Verification

- [x] Focused RED before production edits: 6 auth assertions failed / 122 existing assertions passed across 4 files
- [x] Focused auth and compatibility set on the Mini dev tree: 7 files / 296 tests passed
- [x] Full frontend suite on the Mini dev tree: 407 files / 8836 tests passed
- [x] `npm run check` on the Mini dev tree: 0 errors / 0 warnings
- [x] `npm run lint` on the Mini dev tree: passed
- [x] `npm run build` on the Mini dev tree: passed
- [x] Public/open-core boundary checked
- [x] Release or migration impact documented if applicable

The Mini used an isolated checkout and a real `npm ci`. These commands ran on the working tree based on MOR-2348 commit `89e7b743`, whose owned changes were then committed as `5887f73e`. The ten owned blobs were carried byte-identically to PR head `38f86184` on main `0e5d9a16`; the full tree changed because that base includes MOR-2349, so these local results are not claimed as an exact-head full-suite run. Natural PR CI supplies exact-head integration evidence. No suite was repeated solely for base movement. No radio, power command, RF, or acceptance service was accessed.

## Agent Review

- [ ] Independent agent review comment posted before merge
- Reviewer:
- Result: `Agent Review: PASS` / `Agent Review: BLOCKED`

## Notes

- Out of scope / follow-ups: `/api/local/v1/rc28/tuning-step` has no production handler in Core, so its deployed auth policy remains unknown and this PR does not claim it is fixed. Audio/WebSocket work is owned separately by MOR-2349.
