### PR TITLE
Fix USB MOD warning and keep mobile PTT reachable

### DIFF
--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -980,6 +980,12 @@
     pointer-events: auto;
   }
 
+  @media (orientation: portrait) {
+    .m-mod-input-warning {
+      right: max(96px, calc(84px + env(safe-area-inset-right, 0px)));
+    }
+  }
+
   /* ── Landscape layout ── */
   .m-landscape {
     position: fixed;

--- a/frontend/src/lib/runtime/adapters/__tests__/mod-input-auto.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mod-input-auto.isolated.test.ts
@@ -124,7 +124,16 @@ function setState(overrides: Record<string, unknown> = {}): void {
 }
 
 function useDualReceiverCapabilities(): void {
-  setCapabilities({ capabilities: ['data_mode'], receivers: 2, vfoScheme: 'main_sub', stateContractVersion: 1, providerGeneration: 0 } as never);
+  setCapabilities({
+    capabilities: ['data_mode'],
+    receivers: 2,
+    vfoScheme: 'main_sub',
+    audioTx: true,
+    audioTxRoute: 'lan',
+    audioTxRequiredModInputSource: 5,
+    stateContractVersion: 1,
+    providerGeneration: 0,
+  } as never);
 }
 
 function missingStatus() {
@@ -191,7 +200,14 @@ beforeEach(() => {
   vi.mocked(runtime.startTx).mockResolvedValue(null);
   vi.mocked(runtime.stopTx).mockClear();
   resetRadioState();
-  setCapabilities({ capabilities: ['data_mode'], stateContractVersion: 1, providerGeneration: 0 } as never);
+  setCapabilities({
+    capabilities: ['data_mode'],
+    audioTx: true,
+    audioTxRoute: 'lan',
+    audioTxRequiredModInputSource: 5,
+    stateContractVersion: 1,
+    providerGeneration: 0,
+  } as never);
   dismissModInputTxGuard();
 });
 

--- a/frontend/src/lib/runtime/adapters/__tests__/mod-input-tx-guard.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mod-input-tx-guard.isolated.test.ts
@@ -110,7 +110,16 @@ function setState(overrides: Record<string, unknown> = {}): void {
 }
 
 function useDualReceiverCapabilities(): void {
-  setCapabilities({ capabilities: ['data_mode'], receivers: 2, vfoScheme: 'main_sub', stateContractVersion: 1, providerGeneration: 0 } as never);
+  setCapabilities({
+    capabilities: ['data_mode'],
+    receivers: 2,
+    vfoScheme: 'main_sub',
+    audioTx: true,
+    audioTxRoute: 'lan',
+    audioTxRequiredModInputSource: 5,
+    stateContractVersion: 1,
+    providerGeneration: 0,
+  } as never);
 }
 
 function missingStatus() {
@@ -132,7 +141,14 @@ beforeEach(() => {
   vi.mocked(runtime.startTx).mockClear();
   vi.mocked(runtime.stopTx).mockClear();
   resetRadioState();
-  setCapabilities({ capabilities: ['data_mode'], stateContractVersion: 1, providerGeneration: 0 } as never);
+  setCapabilities({
+    capabilities: ['data_mode'],
+    audioTx: true,
+    audioTxRoute: 'lan',
+    audioTxRequiredModInputSource: 5,
+    stateContractVersion: 1,
+    providerGeneration: 0,
+  } as never);
   dismissModInputTxGuard();
 });
 
@@ -149,6 +165,54 @@ describe('armModInputTxGuard (MOR-617)', () => {
 
   it('does not fire when the source is LAN', () => {
     setState({ main: receiver(1), data1ModInput: 5 });
+
+    armModInputTxGuard();
+
+    expect(deriveModInputTxGuardProps().visible).toBe(false);
+  });
+
+  it('does not offer Set LAN for a USB route with no declared required source', () => {
+    setCapabilities({
+      capabilities: ['data_mode'],
+      audioTx: true,
+      audioTxRoute: 'usb',
+      audioTxRequiredModInputSource: null,
+      stateContractVersion: 1,
+      providerGeneration: 0,
+    } as never);
+    setState({ main: receiver(1), data1ModInput: 0 });
+
+    armModInputTxGuard();
+
+    expect(deriveModInputTxGuardProps()).toEqual({
+      visible: false,
+      sourceLabel: null,
+    });
+  });
+
+  it('does not fire when the LAN route has no declared required source', () => {
+    setCapabilities({
+      capabilities: ['data_mode'],
+      audioTx: true,
+      audioTxRoute: 'lan',
+      audioTxRequiredModInputSource: null,
+      stateContractVersion: 1,
+      providerGeneration: 0,
+    } as never);
+    setState({ main: receiver(1), data1ModInput: 0 });
+
+    armModInputTxGuard();
+
+    expect(deriveModInputTxGuardProps().visible).toBe(false);
+  });
+
+  it('does not fire without an audio-route declaration', () => {
+    setCapabilities({
+      capabilities: ['data_mode'],
+      stateContractVersion: 1,
+      providerGeneration: 0,
+    } as never);
+    setState({ main: receiver(1), data1ModInput: 0 });
 
     armModInputTxGuard();
 
@@ -209,6 +273,26 @@ describe('armModInputTxGuard (MOR-617)', () => {
 });
 
 describe('guard clearing (MOR-617)', () => {
+  it('clears a latched LAN warning when the declaration changes to USB', () => {
+    setState({ main: receiver(1), data1ModInput: 0 });
+    armModInputTxGuard();
+    expect(deriveModInputTxGuardProps().visible).toBe(true);
+
+    setCapabilities({
+      capabilities: ['data_mode'],
+      audioTx: true,
+      audioTxRoute: 'usb',
+      audioTxRequiredModInputSource: null,
+      stateContractVersion: 1,
+      providerGeneration: 1,
+    } as never);
+
+    expect(deriveModInputTxGuardProps()).toEqual({
+      visible: false,
+      sourceLabel: null,
+    });
+  });
+
   it('clears when readback reports the source became LAN', () => {
     setState({ main: receiver(1), data1ModInput: 0 });
     armModInputTxGuard();

--- a/frontend/src/lib/runtime/adapters/mod-input-tx-guard.svelte.ts
+++ b/frontend/src/lib/runtime/adapters/mod-input-tx-guard.svelte.ts
@@ -1,13 +1,11 @@
 /**
  * MOD-input TX preflight guard (MOR-617, T3 of epic MOR-614).
  *
- * Root cause this guards against: when the active DATA group's MOD-input
- * source is not LAN, network voice TX from the web UI modulates from
- * MIC/ACC/USB instead of the network audio stream — open-mic feedback or
- * dead air. The guard is armed at the moment the web TX audio path starts
- * (see `tx-adapter.startTx`) and surfaces a non-blocking warning with a
- * one-click "Set LAN" fix that reuses the existing per-group SET command
- * (T1/MOR-615 backend, T2/MOR-616 helpers).
+ * When browser TX declares that its audio route requires LAN, the guard
+ * warns if the active DATA group's MOD-input source does not match. It is
+ * armed when the web TX audio path starts (see `tx-adapter.startTx`) and
+ * offers a one-click "Set LAN" fix through the existing per-group SET
+ * command (T1/MOR-615 backend, T2/MOR-616 helpers).
  *
  * Warn-only by design: TX is never blocked and the rig is never changed
  * silently — auto-set is a separate opt-in (T4/MOR-618).
@@ -42,10 +40,8 @@ export interface ModInputTxGuardProps {
 let armed = $state(false);
 
 /**
- * The active receiver group's MOD-input source when it warrants a warning,
- * or null when the guard must stay quiet: no state, no data_mode capability,
- * group not yet read (fieldStatus missing), source unknown (null) or
- * already LAN.
+ * The active receiver group's MOD-input source when a declared LAN route
+ * warrants a warning, or null when the guard must stay quiet.
  */
 function offendingSource(
   state: ServerState | null,
@@ -53,6 +49,10 @@ function offendingSource(
 ): number | null {
   if (!state) return null;
   if (!(caps?.capabilities?.includes('data_mode') ?? false)) return null;
+  if (
+    caps?.audioTxRoute !== 'lan'
+    || caps.audioTxRequiredModInputSource !== LAN_MOD_INPUT_SOURCE
+  ) return null;
   const rx = state.active === 'SUB' ? state.sub : state.main;
   const key = modInputStateKey(rx?.dataMode ?? 0);
   if (getFieldAvailability(state, key) === 'missing') return null;
@@ -62,9 +62,9 @@ function offendingSource(
 }
 
 /**
- * Evaluate the preflight at network-voice-TX start. Arms the warning when
- * the active group's source is known and not LAN; otherwise clears any
- * stale latch. Never blocks the TX path.
+ * Evaluate the preflight at browser-audio-TX start. Arms the warning when
+ * the declared LAN requirement is not met; otherwise clears any stale latch.
+ * Never blocks the TX path.
  */
 export function armModInputTxGuard(): void {
   armed = offendingSource(getRadioState(), getCapabilities()) !== null;

--- a/frontend/tests/e2e/i18n/mobile-tx-warning-clearance.spec.ts
+++ b/frontend/tests/e2e/i18n/mobile-tx-warning-clearance.spec.ts
@@ -1,0 +1,255 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { writeFileSync } from 'node:fs';
+import { mockCapabilities, mockInfo, mockState } from './fixtures';
+import type { Capabilities } from '../../../src/lib/types/capabilities';
+import type { ServerState } from '../../../src/lib/types/state';
+
+const workspace = {
+  version: 1,
+  layout: 'standard',
+  designLanguage: 'studioline',
+  theme: 'github-light',
+};
+
+const state = {
+  ...mockState,
+  active: 'MAIN',
+  main: { ...mockState.main, dataMode: 0 },
+  dataOffModInput: 3,
+} satisfies ServerState;
+
+const capabilities = {
+  ...mockCapabilities,
+  capabilities: [...new Set([...mockCapabilities.capabilities, 'data_mode', 'mod_input_routing'])],
+  dataModeCount: 3,
+  audioTx: true,
+  audioTxRoute: 'lan',
+  audioTxRequiredModInputSource: 5,
+} satisfies Capabilities;
+
+const managedTransmit = {
+  schemaVersion: 1,
+  sampledAt: '2026-09-05T04:00:00.000Z',
+  managedTransmit: {
+    status: 'available',
+    intent: { kind: 'rx' },
+    releaseRequired: false,
+    lastError: null,
+    lastActuation: null,
+    abortErrors: [],
+    tot: { configuredSeconds: 180, active: false, remainingMs: null, expiresAt: null },
+  },
+  txObservation: { observedPtt: 'off' },
+};
+
+interface ControlCommand {
+  id: string;
+  name: string;
+}
+
+test.use({ hasTouch: true, isMobile: true });
+
+async function prepare(page: Page) {
+  const controlCommands: ControlCommand[] = [];
+  const managedCommands: string[] = [];
+
+  await page.addInitScript((value) => {
+    localStorage.setItem('rigplane:workspace', JSON.stringify(value));
+    localStorage.setItem('rigplane.i18n.locale', 'en-US');
+
+    const browser = window as Window & {
+      __txMedia?: { context: AudioContext; oscillator: OscillatorNode; stream: MediaStream };
+      __trustedPointerTargets?: Array<{ event: string; trusted: boolean; target: string }>;
+    };
+    browser.__trustedPointerTargets = [];
+    Reflect.defineProperty(window, 'AudioEncoder', { configurable: true, value: undefined });
+    Reflect.defineProperty(window, 'MediaStreamTrackProcessor', { configurable: true, value: undefined });
+    for (const eventName of ['pointerdown', 'pointerup', 'pointercancel', 'lostpointercapture']) {
+      document.addEventListener(eventName, (event) => {
+        const target = event.target instanceof Element ? event.target : null;
+      browser.__trustedPointerTargets?.push({
+          event: event.type,
+          trusted: event.isTrusted,
+          target: target?.closest('button')?.getAttribute('aria-label')
+            ?? target?.getAttribute('data-testid')
+            ?? target?.tagName
+            ?? 'unknown',
+        });
+      }, true);
+    }
+
+    if (!navigator.mediaDevices) {
+      Object.defineProperty(navigator, 'mediaDevices', { configurable: true, value: {} });
+    }
+    Object.defineProperty(navigator.mediaDevices, 'getUserMedia', {
+      configurable: true,
+      value: async () => {
+        if (!browser.__txMedia) {
+          const context = new AudioContext();
+          const destination = context.createMediaStreamDestination();
+          const oscillator = context.createOscillator();
+          oscillator.connect(destination);
+          oscillator.start();
+          browser.__txMedia = { context, oscillator, stream: destination.stream };
+        }
+        return browser.__txMedia.stream.clone();
+      },
+    });
+  }, workspace);
+
+  await page.route('**/api/**', async (route) => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    if (request.method() === 'POST' && pathname === '/api/v1/managed-transmit/command') {
+      const body = request.postDataJSON() as { operation: string };
+      managedCommands.push(body.operation);
+      await route.fulfill({ status: 202, contentType: 'application/json', body: '{}' });
+      return;
+    }
+    if (request.method() !== 'GET') {
+      await route.fulfill({ status: 404, contentType: 'application/json', body: '{}' });
+      return;
+    }
+    const responses: Record<string, unknown> = {
+      '/api/v1/state': state,
+      '/api/v1/capabilities': capabilities,
+      '/api/v1/managed-transmit': managedTransmit,
+      '/api/v1/info': mockInfo,
+    };
+    await route.fulfill({
+      status: pathname.startsWith('/api/local/') ? 404 : 200,
+      contentType: 'application/json',
+      body: JSON.stringify(responses[pathname] ?? {}),
+    });
+  });
+
+  await page.routeWebSocket(/.*/, (socket) => {
+    const pathname = new URL(socket.url()).pathname;
+    socket.onMessage((message) => {
+      if (pathname !== '/api/v1/ws' || typeof message !== 'string') return;
+      const frame = JSON.parse(message) as { id?: string; name?: string; type?: string };
+      if ((frame.type !== 'cmd' && frame.type !== 'command') || !frame.id || !frame.name) return;
+      controlCommands.push({ id: frame.id, name: frame.name });
+      setTimeout(() => socket.send(JSON.stringify({ type: 'response', id: frame.id, ok: true })), 0);
+    });
+    if (pathname === '/api/v1/ws') {
+      socket.send(JSON.stringify({ type: 'state_update', data: { ...state, type: 'full', data: state } }));
+    }
+  });
+
+  return { controlCommands, managedCommands };
+}
+
+async function settled(page: Page) {
+  await expect(page.locator('.m-layout, .m-landscape')).toBeVisible();
+  await page.evaluate(() => document.fonts.ready);
+}
+
+async function hitAtCenter(locator: Locator) {
+  return locator.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    const x = rect.left + rect.width / 2;
+    const y = rect.top + rect.height / 2;
+    const hit = document.elementFromPoint(x, y);
+    return {
+      x,
+      y,
+      hit: hit instanceof Element
+        ? hit.closest('button')?.getAttribute('aria-label')
+          ?? hit.getAttribute('data-testid')
+          ?? hit.getAttribute('aria-label')
+          ?? hit.tagName
+        : null,
+      contained: hit !== null && element.contains(hit),
+    };
+  });
+}
+
+async function holdAndRelease(page: Page, locator: Locator, whileHeld: () => Promise<void>) {
+  const box = await locator.boundingBox();
+  expect(box).not.toBeNull();
+  const x = box!.x + box!.width / 2;
+  const y = box!.y + box!.height / 2;
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: [{ x, y }],
+  });
+  await page.waitForTimeout(90);
+  await whileHeld();
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+  await cdp.detach();
+}
+
+test('persistent LAN MOD warning leaves mobile TX recovery controls reachable', async ({ page }, info) => {
+  const commands = await prepare(page);
+  await page.setViewportSize({ width: 430, height: 932 });
+  await page.goto('/');
+  await settled(page);
+
+  const fab = page.getByRole('button', { name: 'Push to talk' });
+  const floatingWarning = page.locator('.m-mod-input-warning').getByTestId('mod-input-tx-warning');
+  await holdAndRelease(page, fab, async () => {
+    await expect.poll(() => commands.controlCommands.map(({ name }) => name)).toEqual(['ptt_on']);
+  });
+  await expect(floatingWarning).toBeVisible();
+  await page.waitForTimeout(400);
+
+  const secondPressHit = await hitAtCenter(fab);
+  await info.attach('portrait-warning-hit-test', {
+    body: JSON.stringify(secondPressHit, null, 2),
+    contentType: 'application/json',
+  });
+  await page.screenshot({ path: info.outputPath('portrait-warning.png') });
+  expect(secondPressHit.contained).toBe(true);
+  expect(secondPressHit.hit).toBe('Push to talk');
+
+  await holdAndRelease(page, fab, async () => {
+    await expect.poll(() => commands.controlCommands.filter(({ name }) => name === 'ptt_on'))
+      .toHaveLength(2);
+  });
+  await expect.poll(() => commands.controlCommands.map(({ name }) => name), { timeout: 2_000 })
+    .toEqual(['ptt_on', 'ptt_off', 'ptt_on', 'ptt_off']);
+
+  const trustedPointers = await page.evaluate(() => (
+    window as Window & { __trustedPointerTargets?: Array<{ event: string; trusted: boolean; target: string }> }
+  ).__trustedPointerTargets ?? []);
+  expect(trustedPointers.filter(({ event, target }) =>
+    (event === 'pointerdown' || event === 'pointerup') && target === 'Push to talk'))
+    .toEqual([
+      { event: 'pointerdown', trusted: true, target: 'Push to talk' },
+      { event: 'pointerup', trusted: true, target: 'Push to talk' },
+      { event: 'pointerdown', trusted: true, target: 'Push to talk' },
+      { event: 'pointerup', trusted: true, target: 'Push to talk' },
+    ]);
+
+  await page.setViewportSize({ width: 932, height: 430 });
+  await expect(page.locator('.m-landscape')).toBeVisible();
+  await expect(floatingWarning).toBeVisible();
+  const landscapePtt = page.locator('.m-ls-ptt');
+  const unkey = page.locator('.m-ls-unkey');
+  expect((await hitAtCenter(landscapePtt)).contained).toBe(true);
+  expect((await hitAtCenter(unkey)).contained).toBe(true);
+  const forceOffsBeforeClick = commands.managedCommands.filter((name) => name === 'force_off').length;
+  expect(forceOffsBeforeClick).toBe(0);
+  await unkey.click();
+  await expect.poll(() => commands.managedCommands.filter((name) => name === 'force_off'))
+    .toHaveLength(forceOffsBeforeClick + 1);
+
+  await page.evaluate(async () => {
+    if (document.fullscreenElement) await document.exitFullscreen();
+  });
+  await page.setViewportSize({ width: 430, height: 932 });
+  await expect(page.locator('.m-layout')).toBeVisible();
+  await page.locator('.m-content').evaluate((element) => { element.scrollTop = element.scrollHeight; });
+  await expect(floatingWarning).toBeVisible();
+  expect((await hitAtCenter(fab)).contained).toBe(true);
+  await floatingWarning.getByTestId('mod-input-dismiss').click();
+  await expect(page.getByTestId('mod-input-tx-warning')).toHaveCount(0);
+  writeFileSync(info.outputPath('evidence.json'), JSON.stringify({
+    secondPressHit,
+    controlCommands: commands.controlCommands,
+    managedCommands: commands.managedCommands,
+    trustedPointers,
+  }, null, 2));
+});


### PR DESCRIPTION
## Problem and behavior

When browser TX used a declared USB audio route, the MOD-input guard still assumed LAN and offered “Set LAN.” A persistent legitimate warning could also cover the portrait PTT button, so a second trusted touch reached the warning instead of the TX control.

The guard now shows its existing LAN-specific warning and remedy only when capabilities declare `audioTxRoute: lan` with required MOD source `5`. USB, missing, and null requirements stay quiet, while a declared LAN mismatch still warns and clears reactively when the declaration or readback changes. On mobile portrait layouts, the floating warning reserves the PTT button’s horizontal footprint; landscape PTT, Unkey, warning visibility, and dismissal remain available.

Linear: https://linear.app/morozsm/issue/MOR-2351/beta-acceptance-respect-declared-mod-audio-route-and-keep-mobile-ptt

## Validation

Run on the isolated macOS build host with Node 20.20.2 and a worktree-local `npm ci`:

- `npm test`: 8,850 passed; two stale `mod-input-auto` fixtures failed because they expected the LAN warning without declaring the LAN route. The fixtures were corrected, and their focused file then passed 26/26. Per the bounded cadence, the full suite was not repeated; exact-head PR CI is the final full-suite gate.
- `npx playwright test -c ./playwright.i18n.config.ts tests/e2e/i18n/mobile-tx-warning-clearance.spec.ts`: 1 passed. The real App fixture kept a persistent declared-LAN warning visible while two trusted portrait touch gestures reached PTT, then verified landscape PTT/Unkey, portrait after scroll/rotation, and warning dismissal.
- `npm run check`: 0 errors and 0 warnings.
- `npm run lint`: passed.
- `npm run build`: passed.
- Guard regression: exact-bug mutation failed 4 new cases; restored focused suite passed 18/18.
- `git diff --check`: passed.

Backend source is unchanged; the existing base backend matrix is reused and normal PR CI supplies the required backend gates.

## Scope limits

This does not claim physical radio or modulated-voice acceptance. MOR-1245 retains the separate duplicate-warning scope, and MOR-2092 retains broader per-radio MOD-source validation. No visual baselines changed.
