### PR TITLE
Fix FTX-1 generic ATU route and state normalization

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -958,7 +958,8 @@ get_vox        = { cat = { read = "VX;", parse = "VX{state};" } }
 set_vox        = { cat = { write = "VX{state};" } }
 get_lock       = { cat = { read = "LK;", parse = "LK{state};" } }
 set_lock       = { cat = { write = "LK{state};" } }
-# AC: p1=int/ext, p2=ATU/ATAS, p3=OFF/ON/tune
+# FTX-1 CAT Operation Reference 2508-C, AC table, printed page 6.
+# AC: p1=internal0/external1; p2=ATU0/ATAS2; ATU p3=OFF0/ON1/START3 (2 reserved).
 get_tuner      = { cat = { read = "AC;", parse = "AC{src}{type}{state};" } }
 set_tuner      = { cat = { write = "AC{src}{type}{state};" } }
 # CO: Contour (S-DX) / APF — func: 0=contour on/off, 1=freq, 2=APF on/off, 3=APF freq

--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -272,7 +272,7 @@ class YaesuObservationRadio(Protocol):
 
     async def read_clarifier_freq(self, receiver: int = 0) -> int: ...
 
-    async def read_tuner(self) -> int: ...
+    async def get_tuner_status(self) -> int: ...
 
     async def read_lock(self) -> bool: ...
 
@@ -1123,16 +1123,15 @@ class YaesuObservationAdapter:
                     )
         # Antenna tuner (MOR-455) — GLOBAL operator-control state (CAT ``AC``),
         # gated on the ``tuner`` runtime capability, mirroring the legacy
-        # poller's ``"tuner" in caps`` gate. Emitted as the raw device int
-        # (0-3); cross-vendor calibration is MOR-453.
+        # poller's ``"tuner" in caps`` gate; the generic getter normalizes AC.
         if self._has_runtime_capability("tuner") and self._can_poll(_TUNER):
-            ok, value = await self._safe_read("tuner", self.radio.read_tuner())
+            ok, value = await self._safe_read("tuner", self.radio.get_tuner_status())
             if ok and value is not None:
                 observations.append(
                     adapter.observation(
                         _TUNER,
                         int(value),
-                        native_id="read_tuner",
+                        native_id="get_tuner_status",
                     )
                 )
         # Dial lock (MOR-455) — GLOBAL tx_state bool (CAT ``LK``), gated on the

--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -164,6 +164,7 @@ class YaesuCatPoller:
         if self._capture_provider_generation is not None:
             self._cancel_deferred_entry("provider binding replaced")
         self._capture_provider_generation = capture
+        self._radio._bind_tuner_provider_generation(capture)
         self._advance_provider_generation = advance
 
     def bind_managed_tx_authority(self, authority: ManagedWriteAdmission) -> None:
@@ -1263,7 +1264,7 @@ class YaesuCatPoller:
             case SetVox(on=on):
                 await radio.set_vox(on)
             case SetTunerStatus(value=value):
-                await radio.set_tuner(value)
+                await radio.set_tuner_status(value)
             case SetMonitor(on=on):
                 await radio.set_monitor_on(on)
             case SetMonitorGain(level=level):

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -164,6 +164,7 @@ class YaesuCatRadio:
         """
         self._config: RigConfig = _load_config(profile)
         self._profile_cache: RadioProfile | None = None
+        self._tuner_provider_generation: Callable[[], int] | None = None
         self._transport = YaesuCatTransport(device=device, baudrate=baudrate)
         self._state = RadioState()
         self._audio_bus: AudioBus | None = None
@@ -2486,7 +2487,7 @@ class YaesuCatRadio:
         """Read antenna tuner state (AC) without mutating legacy state.
 
         Returns:
-            0=OFF, 1=ON, 2=tuning, 3=tune-start.
+            Native AC state; interpretation depends on the reported tuner type.
         """
         result = await self._query("get_tuner")
         return int(result["state"])
@@ -2495,12 +2496,12 @@ class YaesuCatRadio:
         """Get antenna tuner state (AC).
 
         Returns:
-            0=OFF, 1=ON, 2=tuning, 3=tune-start.
+            Native AC state; interpretation depends on the reported tuner type.
         """
         return await self.read_tuner()
 
     async def set_tuner(self, state: int, src: int = 0, typ: int = 0) -> None:
-        """Set antenna tuner (AC). state: 0=OFF, 1=ON, 2=tune."""
+        """Write native AC state to the explicitly selected source and type."""
         params = {"src": str(src), "type": str(typ), "state": str(state)}
         if state == 0 or self._local_tx_work is None:
             await self._write("set_tuner", **params)
@@ -2662,13 +2663,70 @@ class YaesuCatRadio:
         """Alias for AdvancedControlCapable compatibility."""
         await self.set_processor(on)
 
+    def _bind_tuner_provider_generation(self, capture: Callable[[], int]) -> None:
+        self._tuner_provider_generation = capture
+
+    async def _read_atu_route(self) -> tuple[str, str, int, Callable[[], bool]]:
+        transport = self._transport
+        reconnects = transport.stats.reconnects
+        writer = transport._writer
+        capture = self._tuner_provider_generation
+        generation = None if capture is None else capture()
+
+        def current() -> bool:
+            return (
+                self._transport is transport
+                and transport.connected
+                and transport.stats.reconnects == reconnects
+                and transport._writer is writer
+                and self._tuner_provider_generation is capture
+                and (capture is None or capture() == generation)
+            )
+
+        result = await self._query("get_tuner")
+        if not current():
+            raise CommandError(
+                "Tuner connection or provider changed during acquisition"
+            )
+        src, typ, state = result.get("src"), result.get("type"), result.get("state")
+        # FTX-1 CAT Operation Reference 2508-C, AC table, printed page 6.
+        native_to_status = {"0": 0, "1": 1, "3": 2}
+        if src not in ("0", "1") or typ != "0" or state not in native_to_status:
+            raise ValueError(f"Unsupported ATU response: {result!r}")
+        return src, typ, native_to_status[state], current
+
     async def get_tuner_status(self) -> int:
-        """AdvancedControlCapable alias. Returns tuner state (0=OFF, 1=ON, 2=tuning)."""
-        return await self.get_tuner()
+        """Return generic ATU status: 0=OFF, 1=ON, 2=tuning/start."""
+        _, _, status, _ = await self._read_atu_route()
+        return status
 
     async def set_tuner_status(self, value: int) -> None:
-        """AdvancedControlCapable alias."""
-        await self.set_tuner(value)
+        """Set 0=OFF, 1=ON, or 2=START using a fresh complete AC response.
+
+        Native ``set_tuner`` retains explicit source/type addressing. This
+        generic call preserves the acquired route; a front-panel selection
+        change between reply and write is not an atomic transaction.
+        """
+        if type(value) is not int or value not in (0, 1, 2):
+            raise ValueError("Tuner value must be 0, 1, or 2")
+
+        async def write(fence_current: Callable[[], bool]) -> None:
+            try:
+                src, typ, _, route_current = await self._read_atu_route()
+            except (ValueError, KeyError) as exc:
+                raise CommandError(f"Cannot acquire ATU route: {exc}") from exc
+            await self._write(
+                "set_tuner",
+                src=src,
+                type=typ,
+                state=str(3 if value == 2 else value),
+                is_current=lambda: route_current() and fence_current(),
+            )
+
+        if value == 0 or self._local_tx_work is None:
+            await write(lambda: True)
+        else:
+            await self._local_tx_work.run(write)
 
     async def send_cw_text(self, text: str) -> None:
         """Send CW text via keyer (KY command), split into 24-character chunks.

--- a/tests/test_fenced_local_tx_providers.py
+++ b/tests/test_fenced_local_tx_providers.py
@@ -30,6 +30,7 @@ def _fenced_radio(fence: TxAbortFence | None) -> YaesuCatRadio:
     radio = YaesuCatRadio("/dev/null", tx_abort_fence=fence)
     transport = radio._transport
     transport._connected = True
+    transport.query = AsyncMock(return_value="AC101")
     transport.flush_rx = AsyncMock(return_value=0)
     transport._drain_responses = AsyncMock(return_value=0)
     transport._raw_write = AsyncMock()
@@ -136,16 +137,21 @@ async def test_force_receive_suppresses_remaining_cw_chunks() -> None:
 
 
 @pytest.mark.asyncio
-async def test_unmanaged_calls_keep_the_direct_write_contract() -> None:
+async def test_unmanaged_calls_keep_native_writes_and_guard_generic_tuner() -> None:
     radio = _fenced_radio(None)
     radio._transport.write = AsyncMock()
 
     await radio.send_cw_text("CQ")
     await radio.set_tuner_status(2)
 
-    assert [call.kwargs for call in radio._transport.write.await_args_list] == [{}, {}]
+    cw_call, tuner_call = radio._transport.write.await_args_list
+    assert cw_call.kwargs == {}
+    assert tuner_call.kwargs["is_current"]() is True
+    radio._transport.stats.reconnects += 1
+    assert tuner_call.kwargs["is_current"]() is False
+    radio._transport.query.assert_awaited_once_with("AC;")
     assert radio._transport.write.await_args_list[0].args[0].startswith("KY ")
-    assert radio._transport.write.await_args_list[1].args[0].startswith("AC")
+    assert tuner_call.args == ("AC103;",)
 
 
 def _icom_radio() -> CoreRadio:

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -1969,14 +1969,15 @@ async def test_set_compressor_off_delegates_to_set_processor(connected_radio):
 
 
 @pytest.mark.asyncio
-async def test_get_tuner_status_delegates_to_get_tuner(connected_radio):
+async def test_get_tuner_status_reads_atu(connected_radio):
     connected_radio._transport.query = AsyncMock(return_value="AC001")
     result = await connected_radio.get_tuner_status()
     assert isinstance(result, int)
 
 
 @pytest.mark.asyncio
-async def test_set_tuner_status_delegates_to_set_tuner(connected_radio):
+async def test_set_tuner_status_acquires_atu_route(connected_radio):
+    connected_radio._transport.query = AsyncMock(return_value="AC101")
     connected_radio._transport.write = AsyncMock()
     await connected_radio.set_tuner_status(1)
     connected_radio._transport.write.assert_called_once()

--- a/tests/test_ftx1_tuner_route.py
+++ b/tests/test_ftx1_tuner_route.py
@@ -1,0 +1,253 @@
+"""FTX AC route preservation through public and typed tuner commands."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rigplane.backends.yaesu_cat.observations import YaesuObservationAdapter
+from rigplane.core.state_pipeline_contracts import FieldPath
+from rigplane.runtime.managed_tx_fence import TxAbortFence
+from rigplane.runtime.local_tx_work import LocalTxWorkRunner
+from rigplane.backends.yaesu_cat.poller import YaesuCatPoller
+from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
+from rigplane.backends.yaesu_cat.transport import CatTransportError
+from rigplane.core.exceptions import CommandError
+from rigplane.runtime._poller_types import SetTunerStatus
+from rigplane.runtime.managed_tx_state import (
+    ActuationOperation,
+    ActuationResult,
+    EffectToken,
+)
+from test_web_ptt_readonly import _make_handler
+from test_yaesu_cat_poller import _set_fresh_ptt_observation
+
+
+def radio_with_answer(answer: str = "AC101") -> YaesuCatRadio:
+    radio = YaesuCatRadio("/dev/null", audio_driver=MagicMock())
+    radio._transport._connected = True
+    radio._transport.query = AsyncMock(return_value=answer)
+    radio._transport.write = AsyncMock()
+    return radio
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("src", (0, 1))
+@pytest.mark.parametrize("path", ("public", "typed", "web"))
+async def test_same_route_off_readback_restore(src: int, path: str) -> None:
+    radio = radio_with_answer(f"AC{src}01")
+    poller = YaesuCatPoller(radio)
+    _set_fresh_ptt_observation(poller, active=False)
+    handler, _ = _make_handler(radio=radio)
+
+    async def set_status(value: int) -> None:
+        if path == "typed":
+            await poller._execute_command(SetTunerStatus(value))
+        elif path == "web":
+            await handler._enqueue_command("set_tuner_status", {"value": value})
+        else:
+            await radio.set_tuner_status(value)
+
+    assert await radio.get_tuner_status() == 1
+    await set_status(0)
+    radio._transport.query.return_value = f"AC{src}00"
+    assert await radio.get_tuner_status() == 0
+    await set_status(1)
+    radio._transport.query.return_value = f"AC{src}01"
+    assert await radio.get_tuner_status() == 1
+    assert [call.args[0] for call in radio._transport.write.await_args_list] == [
+        f"AC{src}00;",
+        f"AC{src}01;",
+    ]
+    assert radio._transport.query.await_count == 5
+    assert all(call.args == ("AC;",) for call in radio._transport.query.await_args_list)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw, expected", (("AC100", 0), ("AC101", 1), ("AC103", 2)))
+async def test_generic_state_domain(raw: str, expected: int) -> None:
+    radio = radio_with_answer(raw)
+    assert await radio.get_tuner_status() == expected
+
+
+@pytest.mark.asyncio
+async def test_generic_start_uses_native_three_and_raw_api_stays_native() -> None:
+    radio = radio_with_answer("AC103")
+    assert await radio.read_tuner() == 3
+    assert await radio.get_tuner() == 3
+    await radio.set_tuner_status(2)
+    assert radio._transport.write.await_args.args == ("AC103;",)
+    await radio.set_tuner(3, src=1, typ=0)
+    assert radio._transport.write.await_args.args == ("AC103;",)
+    await radio.set_tuner(1)
+    assert radio._transport.write.await_args.args == ("AC001;",)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "answer", ("AC201", "AC111", "AC121", "AC102", "AC10x", "AC10", "AC1000")
+)
+async def test_unknown_route_or_state_never_writes(answer: str) -> None:
+    radio = radio_with_answer(answer)
+    with pytest.raises((ValueError, CommandError)):
+        await radio.get_tuner_status()
+    with pytest.raises(CommandError):
+        await radio.set_tuner_status(0)
+    radio._transport.write.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", (-1, 3, True, "1"))
+async def test_invalid_generic_value_does_not_query_or_write(value: object) -> None:
+    radio = radio_with_answer()
+    with pytest.raises(ValueError):
+        await radio.set_tuner_status(value)
+    radio._transport.query.assert_not_awaited()
+    radio._transport.write.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_each_write_reacquires_route_and_does_not_reuse_success_after_failure() -> (
+    None
+):
+    radio = radio_with_answer()
+    await radio.set_tuner_status(0)
+    radio._transport.query.return_value = "AC001"
+    await radio.set_tuner_status(1)
+    radio._transport.query.return_value = "AC121"
+    with pytest.raises(CommandError):
+        await radio.set_tuner_status(0)
+    assert [call.args[0] for call in radio._transport.write.await_args_list] == [
+        "AC100;",
+        "AC001;",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "change", ("reconnect", "writer", "transport", "provider", "binding")
+)
+@pytest.mark.parametrize("boundary", ("reply", "write_gate"))
+async def test_currency_change_prevents_write(change: str, boundary: str) -> None:
+    radio = radio_with_answer()
+    transport = radio._transport
+    generation = [1]
+    poller = YaesuCatPoller(radio)
+    poller.bind_provider_generation(capture=lambda: generation[0])
+    raw_write = AsyncMock()
+    transport._raw_write = raw_write
+    transport.flush_rx = AsyncMock()
+    transport._drain_responses = AsyncMock(return_value=0)
+    del transport.write  # Exercise the real exchange gate and final currency check.
+
+    def invalidate() -> None:
+        if change == "reconnect":
+            transport.stats.reconnects += 1
+        elif change == "writer":
+            transport._writer = MagicMock()
+        elif change == "transport":
+            radio._transport = radio_with_answer()._transport
+        elif change == "provider":
+            generation[0] += 1
+        else:
+            poller.bind_provider_generation(capture=lambda: generation[0])
+
+    if boundary == "reply":
+
+        async def query(_command: str) -> str:
+            invalidate()
+            return "AC101"
+
+        transport.query.side_effect = query
+    else:
+        transport.flush_rx.side_effect = invalidate
+
+    with pytest.raises((CommandError, CatTransportError)):
+        await radio.set_tuner_status(0)
+    raw_write.assert_not_awaited()
+    if radio._transport is not transport:
+        radio._transport.write.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_force_receive_has_no_tuner_acquisition_dependency() -> None:
+    radio = radio_with_answer()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def query(_command: str) -> str:
+        entered.set()
+        await release.wait()
+        return "AC101"
+
+    radio._transport.query.side_effect = query
+    operation = asyncio.create_task(radio.set_tuner_status(0))
+    await entered.wait()
+    try:
+        result = await radio.actuate(
+            EffectToken(7, 3, "test"),
+            ActuationOperation.FORCE_RECEIVE,
+            is_current=lambda: True,
+        )
+        assert result is ActuationResult.ACCEPTED
+        assert radio._transport.write.await_args.args == ("TX0;",)
+        assert not operation.done()
+    finally:
+        release.set()
+        await operation
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "answer, expected", (("AC103", 2), ("AC101", 1), ("AC102", None), ("AC121", None))
+)
+async def test_real_ac_observation_normalizes_or_omits_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+    answer: str,
+    expected: int | None,
+) -> None:
+    radio = radio_with_answer(answer)
+    path = FieldPath.global_("operator_controls", "tuner_status")
+    monkeypatch.setattr(
+        YaesuObservationAdapter, "_can_poll", lambda self, field: field == path
+    )
+    observations = await YaesuObservationAdapter.from_radio(radio).poll_tx_controls()
+    if expected is None:
+        assert observations == ()
+    else:
+        assert len(observations) == 1
+        assert observations[0].path == path
+        assert observations[0].value == expected
+        assert observations[0].source.native_id == "get_tuner_status"
+    assert radio.radio_state.tuner_status == 0
+
+
+@pytest.mark.asyncio
+async def test_positive_ac_acquisition_is_inside_one_abort_fence() -> None:
+    radio = radio_with_answer()
+    fence = TxAbortFence()
+    runner = LocalTxWorkRunner(fence)
+    runner.run = AsyncMock(wraps=runner.run)
+    radio._local_tx_work = runner
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def query(_command: str) -> str:
+        entered.set()
+        await release.wait()
+        return "AC101"
+
+    radio._transport.query.side_effect = query
+    operation = asyncio.create_task(radio.set_tuner_status(1))
+    await entered.wait()
+    cleanup = fence.force_off()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await operation
+    await cleanup
+    runner.run.assert_awaited_once()
+    # The final guard must still reject a transport that delays admission.
+    for call in radio._transport.write.await_args_list:
+        assert call.kwargs["is_current"]() is False

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -163,11 +163,8 @@ def _make_radio() -> MagicMock:
     radio.read_clarifier = AsyncMock(return_value=(True, False))
     radio.get_clarifier_freq = AsyncMock(return_value=-250)
     radio.read_clarifier_freq = AsyncMock(return_value=-250)
-    # Tuner + dial-lock observation reads (MOR-455). ``read_tuner`` returns the
-    # raw device int (0=OFF, 1=ON, 2=tuning, 3=tune-start); ``read_lock``
-    # returns the dial-lock bool.
     radio.get_tuner = AsyncMock(return_value=2)
-    radio.read_tuner = AsyncMock(return_value=2)
+    radio.get_tuner_status = AsyncMock(return_value=2)
     radio.get_lock = AsyncMock(return_value=True)
     radio.read_lock = AsyncMock(return_value=True)
     # CW keyer family observation reads (MOR-456). ``read_keyer_speed`` returns
@@ -502,11 +499,11 @@ class _SideEffectingYaesuRadio:
         self.radio_state.rit_freq = value
         return value
 
-    async def read_tuner(self) -> int:
+    async def get_tuner_status(self) -> int:
         return 2
 
     async def get_tuner(self) -> int:
-        value = await self.read_tuner()
+        value = await self.get_tuner_status()
         self.radio_state.tuner_status = value
         return value
 
@@ -1148,7 +1145,7 @@ async def test_tx_controls_poll_emits_global_setpoints() -> None:
     radio.read_clarifier.assert_awaited_once()
     radio.read_clarifier_freq.assert_awaited_once()
     # Tuner + dial-lock each use a single read (MOR-455).
-    radio.read_tuner.assert_awaited_once()
+    radio.get_tuner_status.assert_awaited_once()
     radio.read_lock.assert_awaited_once()
     # CW keyer family each use a single read (MOR-456).
     radio.read_keyer_speed.assert_awaited_once()
@@ -1232,7 +1229,7 @@ async def test_tx_controls_poll_skips_fields_without_matching_runtime_capability
     radio.read_clarifier.assert_not_awaited()
     radio.read_clarifier_freq.assert_not_awaited()
     # Tuner + dial-lock are dropped: ``tuner``/``dial_lock`` caps absent (MOR-455).
-    radio.read_tuner.assert_not_awaited()
+    radio.get_tuner_status.assert_not_awaited()
     radio.read_lock.assert_not_awaited()
     # CW keyer family dropped: the ``cw`` runtime cap is absent here (MOR-456).
     radio.read_keyer_speed.assert_not_awaited()
@@ -1395,8 +1392,8 @@ async def test_adapter_uses_read_only_yaesu_paths_when_getters_mutate_state() ->
         ("global.tx_state.rit_tx", False),
         ("global.operator_controls.rit_freq", -250),
         # Tuner + dial-lock (MOR-455): gated on the ``tuner``/``dial_lock`` caps
-        # (present here); a single ``read_tuner``/``read_lock`` each — neither
-        # mutates legacy state. tuner_status is the raw device int (0-3).
+        # (present here); a single ``get_tuner_status``/``read_lock`` each — neither
+        # mutates legacy state. tuner_status is the generic ATU status (0-2).
         ("global.operator_controls.tuner_status", 2),
         ("global.tx_state.dial_lock", True),
         # CW keyer family (MOR-456): gated on the ``cw`` cap (present here); a

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -1411,7 +1411,7 @@ async def test_yaesu_immediate_hard_block_families_fail_before_dispatch(
     for command in commands:
         radio = make_radio()
         radio.set_ptt = AsyncMock()
-        radio.set_tuner = AsyncMock()
+        radio.set_tuner_status = AsyncMock()
         poller = YaesuCatPoller(radio, callback=lambda _: None)
         if active is not None:
             _set_fresh_ptt_observation(poller, active=active)
@@ -1420,7 +1420,7 @@ async def test_yaesu_immediate_hard_block_families_fail_before_dispatch(
             await poller._execute_command(command)  # noqa: SLF001
 
         radio.set_ptt.assert_not_awaited()
-        radio.set_tuner.assert_not_awaited()
+        radio.set_tuner_status.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1436,7 +1436,7 @@ async def test_yaesu_emergency_off_commands_bypass_immediate_gate(
     radio = make_radio()
     radio.set_ptt = AsyncMock()
     radio.set_powerstat = AsyncMock()
-    radio.set_tuner = AsyncMock()
+    radio.set_tuner_status = AsyncMock()
     poller = YaesuCatPoller(radio, callback=lambda _: None)
     if active is not None:
         _set_fresh_ptt_observation(poller, active=active)
@@ -1447,7 +1447,7 @@ async def test_yaesu_emergency_off_commands_bypass_immediate_gate(
 
     radio.set_ptt.assert_awaited_once_with(False)
     radio.set_powerstat.assert_awaited_once_with(False)
-    radio.set_tuner.assert_awaited_once_with(0)
+    radio.set_tuner_status.assert_awaited_once_with(0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_yaesu_web_projection.py
+++ b/tests/test_yaesu_web_projection.py
@@ -243,7 +243,7 @@ def _make_radio() -> MagicMock:
     # Tuner + dial-lock observation reads (MOR-455). tuner_status is a global
     # operator-control int (raw device scale, 0-3); dial_lock is a global
     # tx_state bool — both ride the tx-control lane.
-    radio.read_tuner = AsyncMock(return_value=2)
+    radio.get_tuner_status = AsyncMock(return_value=2)
     radio.read_lock = AsyncMock(return_value=True)
     # CW keyer family observation reads (MOR-456). key_speed/cw_pitch/break_in/
     # break_in_delay ride the tx-control lane (global operator-control ints);


### PR DESCRIPTION
Ordinary FTX-1 ATU OFF/ON could read an external tuner (`AC101`) and then address the internal tuner. Generic status/control now acquires and validates the complete AC response, preserves its source/type, and rejects a changed provider or connection at write admission. Web, typed dispatch, and observation projection use the corrected generic path.

The public generic domain remains 0=OFF, 1=ON, 2=tuning/start: native ATU 3 maps to generic 2 and generic START maps to native 3. Reserved native 2, ATAS, unknown sources, and malformed responses are rejected. Native `read_tuner`, `get_tuner`, and explicitly routed `set_tuner` retain their existing behavior and defaults. The mapping was checked against the FTX-1 CAT Operation Reference 2508-C, AC table, printed page 6.

Provider/session currency is checked after route acquisition and through the existing transport write guard. Positive work uses one existing abort-fence registration. FORCE_RECEIVE remains direct TX0. A front-panel route change between AC reply and write is not an atomic transaction; the command addresses the acquired route.

Validation:
- Focused baseline: 687 passed. New tests against the original implementation: 31 failed, 2 passed.
- Final focused provider/parser/dispatch/projection/fence/Web regression set: 725 passed, including 38 new tuner cases.
- Genuine mutations: internal-route regression killed by 3 external public/typed/Web cases; native START=2 killed by 1 case; removed route currency killed by 5 cases at the real transport write boundary. All mutations restored before the final run.
- `ruff check src/ tests/`, `ruff format --check src/ tests/`, `mypy --strict src/rigplane/web` (27 source files), `lint-imports` (5 contracts), and `git diff --check` passed.

Ten files / 384 changed lines form one correction: complete route acquisition, generic normalization, production dispatch/projection, and the fixtures/regressions that exercise those paths. No local full suite or physical radio action was performed. Exact-head CI and independent review remain required; physical OFF/read/restore on the installed artifact remains pending. Active auxiliary tune/CW abort acceptance remains outside this change.

Linear: https://linear.app/morozsm/issue/MOR-2352
