### PR TITLE
fix: admit FTX tuner status commands

### DIFF
--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -689,9 +689,21 @@ class YaesuCatRadio:
 
     def supports_command(self, command: str, *, receiver: int | None = None) -> bool:
         """Return profile-derived support only for an executable operation."""
-        supported = supports_callable(self.profile, command) and callable(
-            getattr(self, command, None)
-        )
+        tuner_dependencies = {
+            "get_tuner_status": ("get_tuner",),
+            "set_tuner_status": ("get_tuner", "set_tuner"),
+        }.get(command)
+        if tuner_dependencies is None:
+            profile_supported = supports_callable(self.profile, command)
+        else:
+            profile_supported = (
+                command not in self.profile.absent_command_names
+                and all(
+                    supports_callable(self.profile, dependency)
+                    for dependency in tuner_dependencies
+                )
+            )
+        supported = profile_supported and callable(getattr(self, command, None))
         if receiver is None:
             return supported
         if not supported or command not in {

--- a/tests/test_ftx1_tuner_route.py
+++ b/tests/test_ftx1_tuner_route.py
@@ -21,6 +21,8 @@ from rigplane.runtime.managed_tx_state import (
     ActuationResult,
     EffectToken,
 )
+from rigplane.web.radio_poller import CommandQueue
+from test_managed_tx_authority import authority as make_authority
 from test_web_ptt_readonly import _make_handler
 from test_yaesu_cat_poller import _set_fresh_ptt_observation
 
@@ -63,6 +65,49 @@ async def test_same_route_off_readback_restore(src: int, path: str) -> None:
     ]
     assert radio._transport.query.await_count == 5
     assert all(call.args == ("AC;",) for call in radio._transport.query.await_args_list)
+
+
+@pytest.mark.asyncio
+async def test_managed_handler_admits_off_and_rejects_positive_during_tx() -> None:
+    radio = radio_with_answer("AC101")
+    managed, *_ = make_authority()
+    handler, _ = _make_handler(radio=radio, authority=managed)
+    queue = CommandQueue()
+    handler._server.command_queue = queue
+    poller = YaesuCatPoller(radio, command_queue=queue)
+    poller.bind_provider_generation(
+        capture=lambda: handler._server.command_state_store.provider_generation
+    )
+    poller.bind_managed_tx_authority(managed)
+
+    async def execute(value: int) -> dict[str, object]:
+        pending = asyncio.create_task(
+            handler._enqueue_command("set_tuner_status", {"value": value})
+        )
+        await queue.wait(timeout=0.1)
+        await poller._drain_commands()
+        return await pending
+
+    try:
+        submission = await managed.submit_ptt(True, "owner")
+        await submission.wait_settlement()
+
+        assert await execute(0) == {"value": 0}
+        assert [call.args[0] for call in radio._transport.query.await_args_list] == [
+            "AC;"
+        ]
+        assert [call.args[0] for call in radio._transport.write.await_args_list] == [
+            "AC100;"
+        ]
+
+        with pytest.raises(CommandError, match="transmit authority"):
+            await execute(1)
+        assert radio._transport.query.await_count == 1
+        assert radio._transport.write.await_count == 1
+    finally:
+        release = await managed.submit_ptt(False, "owner")
+        await release.wait_settlement()
+        await managed.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_supports_command.py
+++ b/tests/test_supports_command.py
@@ -13,6 +13,7 @@ import pytest
 
 from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
 from rigplane.commands import get_unselected_mode
+from rigplane.core.command_dispatch import prepare_command_intent
 from rigplane.profiles import RadioProfile
 from rigplane.profiles.rig_loader import discover_rigs
 from rigplane.radio import CoreRadio
@@ -415,6 +416,60 @@ class TestYaesuSupportsCommand:
 
     def test_set_repeater_shift_is_profile_derived_and_executable(self, yaesu_radio):
         assert yaesu_radio.supports_command("set_repeater_shift")
+
+    def test_tuner_aliases_follow_native_dependencies(self, yaesu_radio):
+        assert yaesu_radio.supports_command("get_tuner_status")
+        assert yaesu_radio.supports_command("set_tuner_status")
+        for value in (0, 1, 2):
+            intent = prepare_command_intent(
+                yaesu_radio,
+                "set_tuner_status",
+                {"value": value},
+                source="http",
+            )
+            assert intent.params["value"] == value
+
+    @pytest.mark.parametrize(
+        ("missing", "get_supported", "set_supported"),
+        (("get_tuner", False, False), ("set_tuner", True, False)),
+    )
+    def test_tuner_aliases_require_each_native_command(
+        self, yaesu_radio, missing, get_supported, set_supported
+    ):
+        yaesu_radio._profile_cache = _without(yaesu_radio.profile, missing)
+        assert yaesu_radio.supports_command("get_tuner_status") is get_supported
+        assert yaesu_radio.supports_command("set_tuner_status") is set_supported
+
+    @pytest.mark.parametrize(
+        ("absent", "get_supported", "set_supported"),
+        (("get_tuner", False, False), ("set_tuner", True, False)),
+    )
+    def test_tuner_aliases_reject_absent_native_command(
+        self, yaesu_radio, absent, get_supported, set_supported
+    ):
+        profile = yaesu_radio.profile
+        yaesu_radio._profile_cache = dataclasses.replace(
+            profile,
+            absent_command_names=profile.absent_command_names | {absent},
+        )
+        assert yaesu_radio.supports_command("get_tuner_status") is get_supported
+        assert yaesu_radio.supports_command("set_tuner_status") is set_supported
+
+    @pytest.mark.parametrize("alias", ("get_tuner_status", "set_tuner_status"))
+    def test_tuner_aliases_reject_explicit_generic_absence(self, yaesu_radio, alias):
+        profile = yaesu_radio.profile
+        yaesu_radio._profile_cache = dataclasses.replace(
+            profile,
+            absent_command_names=profile.absent_command_names | {alias},
+        )
+        assert not yaesu_radio.supports_command(alias)
+
+    @pytest.mark.parametrize("alias", ("get_tuner_status", "set_tuner_status"))
+    def test_tuner_aliases_require_public_callable(
+        self, monkeypatch, yaesu_radio, alias
+    ):
+        monkeypatch.setattr(YaesuCatRadio, alias, None)
+        assert not yaesu_radio.supports_command(alias)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The FTX-1 public `set_tuner_status` operation was rejected before queue admission because Yaesu support introspection did not relate the generic tuner API to its native `get_tuner` and `set_tuner` profile commands. This change admits `get_tuner_status` only when native `get_tuner` is callable and admits `set_tuner_status` only when both native operations are callable, while preserving explicit absence, executable-method, and receiver gates.

The production-shaped regression uses a real `ManagedTxAuthority`, `ControlHandler`, command queue, poller drain, and Yaesu backend with fake transport. Under managed TX, OFF is admitted and performs `AC;` / `AC101` / `AC100;`; a positive tuner request remains rejected before another CAT operation. Existing internal/external route preservation and START mapping tests remain unchanged.

Linear: MOR-2352

Validation:

- `uv run pytest tests/test_supports_command.py tests/test_ftx1_tuner_route.py -q` — 84 passed
- Narrow mutation restoring the old support predicate — production-path regression failed at `prepare_command_intent` before queue admission
- `uv run ruff check src/ tests/` — passed
- `uv run ruff format --check src/ tests/` — passed
- `uv run mypy --strict src/rigplane/web` — passed
- `uv run lint-imports` — 5 contracts kept
- Full suite reached 15,612 passed, 224 skipped, 15 xfailed, then its worker timed out in `tests/test_rigctld_server_coverage.py::test_max_clients_rejected`; a focused rerun also did not complete and was terminated. The changed paths do not include that test or rigctld server code.

Hardware validation remains separate.
