### PR TITLE
fix(MOR-2353): authenticate browser before control startup

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -270,6 +270,7 @@
     let cleanupBootstrap: (() => void) | null = null;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
     let mounted = true;
+    const bootstrapAbort = new AbortController();
     const handleResize = () => {
       windowWidth = window.innerWidth;
       windowHeight = window.innerHeight;
@@ -278,7 +279,7 @@
 
     (async () => {
       try {
-        cleanupBootstrap = await runtime.bootstrap();
+        cleanupBootstrap = await runtime.bootstrap(bootstrapAbort.signal);
         if (!mounted) return cleanupBootstrap();
         txAuthorityReady = true;
         backendError = null;
@@ -286,6 +287,7 @@
         console.error('init error:', err);
         if (!mounted) return;
         backendError = t('core.app.backendError', { detail: String(err) });
+        if (err instanceof Error && err.name === 'AuthenticationError') return;
         if (retryCount < MAX_RETRIES) {
           const delay = RETRY_DELAYS[Math.min(retryCount, RETRY_DELAYS.length - 1)];
           retrying = true;
@@ -302,6 +304,7 @@
 
     return () => {
       mounted = false;
+      bootstrapAbort.abort();
       presentationActive = false;
       txAuthorityReady = false;
       txHost.dispose();

--- a/frontend/src/__tests__/first-browser-auth.component.test.ts
+++ b/frontend/src/__tests__/first-browser-auth.component.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import { MockWebSocket, instances } from '$lib/transport/__tests__/support/fake-ws-backend';
+import stateFixture from '$lib/runtime/adapters/__tests__/fixtures/ic7300-state.json';
+import capsFixture from '$lib/runtime/adapters/__tests__/fixtures/ic7300-capabilities.json';
+
+vi.mock('../skins/registry', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../skins/registry')>(),
+  loadSkin: async () => (await import('./LayoutStub.svelte')).default,
+  presentationResourcePlan: () => [],
+}));
+vi.mock('../AppGlobalHost.svelte', async () => ({ default: (await import('./LayoutStub.svelte')).default }));
+vi.mock('../lib/local-extensions/LocalExtensionsHost.svelte', async () => ({ default: (await import('./LayoutStub.svelte')).default }));
+vi.mock('$lib/runtime/tx-controller/managed-app-host', () => ({
+  provideManagedAppTxHost: () => ({ refreshAuthority() {}, dispose() {}, release() {} }),
+}));
+vi.mock('../lib/media/media-session', () => ({ initMediaSession() {}, destroyMediaSession() {} }));
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: { onChange: () => () => {}, onTxAudioDied: () => () => {}, rxEnabled: false },
+}));
+
+import App from '../App.svelte';
+import { runtime } from '$lib/runtime/frontend-runtime';
+import { disconnectAll } from '$lib/transport/ws-client';
+
+const credential = 'synthetic-first-entry';
+const caps = { ...capsFixture, stateContractVersion: 1, providerGeneration: 0 };
+const requests: string[] = [];
+let app: ReturnType<typeof mount> | undefined;
+let protectedServer = true;
+const promptMock = vi.fn();
+const fetchMock = vi.fn();
+
+async function settle() {
+  for (let i = 0; i < 25; i++) { await Promise.resolve(); flushSync(); }
+}
+function startApp() {
+  app = mount(App, { target: document.body });
+  flushSync();
+}
+function response(status: number, body: unknown = {}) {
+  return { status, ok: status === 200, json: async () => body };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  document.body.innerHTML = '';
+  instances.length = 0;
+  requests.length = 0;
+  protectedServer = true;
+  vi.stubGlobal('WebSocket', MockWebSocket);
+  vi.stubGlobal('prompt', promptMock);
+  vi.stubGlobal('fetch', fetchMock);
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  promptMock.mockImplementation(() => {
+    expect(instances).toHaveLength(0);
+    expect(localStorage.getItem('rigplane-auth-token')).toBeNull();
+    return credential;
+  });
+  fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
+    requests.push(url);
+    expect(url.startsWith('/api/v1/')).toBe(true);
+    expect(url).not.toContain(credential);
+    expect(init.redirect).toBe('error');
+    const authorized = new Headers(init.headers).get('Authorization') === `Bearer ${credential}`;
+    if (protectedServer && !authorized) return response(401);
+    return response(200, url.endsWith('/capabilities') ? caps : { version: 'test' });
+  });
+});
+afterEach(async () => {
+  if (app) { await unmount(app); app = undefined; }
+  disconnectAll();
+  await settle();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('first browser authentication through App and the real runtime', () => {
+  it('prompts from empty storage before control WS, then accepts state and capabilities', async () => {
+    startApp();
+    await settle();
+    expect(promptMock).toHaveBeenCalledExactlyOnceWith('Enter auth token:');
+    expect(requests).toEqual(['/api/v1/info', '/api/v1/info']);
+    expect(localStorage.getItem('rigplane-auth-token')).toBe(credential);
+    expect(instances).toHaveLength(1);
+    const socket = instances[0];
+    expect(new URL(socket.url).searchParams.get('token')).toBe(credential);
+    socket.simulateOpen();
+    const state = { ...stateFixture, stateContractVersion: 1, providerGeneration: 0 };
+    socket.simulateMessage(JSON.stringify({ type: 'state_update', data: { type: 'full', data: state, stateContractVersion: 1, providerGeneration: 0 } }));
+    await settle();
+    expect(requests.at(-1)).toBe('/api/v1/capabilities');
+    expect(runtime.caps?.model).toBe(caps.model);
+    expect(runtime.state?.main.freqHz).toBe(state.main.freqHz);
+    expect(runtime.connectionWs).toBe(true);
+    expect(document.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it.each(['valid stored token', 'no-auth server'])('preserves %s startup', async (mode) => {
+    if (mode === 'valid stored token') localStorage.setItem('rigplane-auth-token', credential);
+    else protectedServer = false;
+    startApp();
+    await settle();
+    expect(promptMock).not.toHaveBeenCalled();
+    expect(requests).toEqual(['/api/v1/info']);
+    expect(instances).toHaveLength(1);
+  });
+
+  it.each([null, '', 'synthetic-wrong'])('stops cancelled or rejected input %s without automatic reload', async (answer) => {
+    vi.useFakeTimers();
+    promptMock.mockReturnValue(answer);
+    startApp();
+    await settle();
+    expect(promptMock).toHaveBeenCalledTimes(1);
+    expect(instances).toHaveLength(0);
+    expect(localStorage.getItem('rigplane-auth-token')).toBeNull();
+    expect(document.querySelector('[role="alert"]')?.textContent).toMatch(/reload/i);
+    expect(document.querySelector('.retry-indicator')).toBeNull();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(promptMock).toHaveBeenCalledTimes(1);
+    expect(requests).toHaveLength(answer ? 2 : 1);
+    vi.useRealTimers();
+  });
+
+  it.each(['network', '503'])('does not turn %s failure into an auth prompt', async (failure) => {
+    if (failure === 'network') fetchMock.mockRejectedValue(new TypeError('Network unavailable'));
+    else fetchMock.mockResolvedValue(response(503));
+    startApp();
+    await settle();
+    expect(promptMock).not.toHaveBeenCalled();
+    expect(instances).toHaveLength(0);
+    expect(document.querySelector('.retry-indicator')).not.toBeNull();
+  });
+
+  it.each([200, 401])('does not prompt or open WS if unmounted before preflight %s', async (status) => {
+    let finish!: (value: ReturnType<typeof response>) => void;
+    fetchMock.mockImplementation(() => new Promise((resolve) => { finish = resolve; }));
+    startApp();
+    await settle();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const signal = fetchMock.mock.calls[0][1].signal as AbortSignal;
+    await unmount(app!); app = undefined;
+    expect(signal.aborted).toBe(true);
+    finish(response(status));
+    await settle();
+    expect(promptMock).not.toHaveBeenCalled();
+    expect(instances).toHaveLength(0);
+  });
+
+  it('does not request credentials when bootstrap was already cancelled', async () => {
+    const abort = new AbortController();
+    abort.abort();
+    await expect(runtime.bootstrap(abort.signal)).rejects.toMatchObject({ name: 'AbortError' });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(promptMock).not.toHaveBeenCalled();
+    expect(instances).toHaveLength(0);
+  });
+});

--- a/frontend/src/__tests__/presentation-switch-resources.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-resources.component.test.ts
@@ -61,6 +61,7 @@ const h = vi.hoisted(() => ({
 vi.mock('$lib/transport/http-client', async (importOriginal) => ({
   ...await importOriginal<typeof import('$lib/transport/http-client')>(),
   fetchCapabilities: vi.fn(),
+  fetchInfo: vi.fn().mockResolvedValue({}),
 }));
 vi.mock('$lib/transport/ws-client', () => ({
   connect: vi.fn(),

--- a/frontend/src/components-v2/panels/lcd/__tests__/audio-fft-demand.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/audio-fft-demand.isolated.test.ts
@@ -77,6 +77,7 @@ const mocks = vi.hoisted(() => {
 vi.mock('$lib/transport/http-client', async (importOriginal) => ({
   ...await importOriginal<typeof import('$lib/transport/http-client')>(),
   fetchCapabilities: mocks.fetchCapabilities,
+  fetchInfo: vi.fn().mockResolvedValue({}),
   startPolling: mocks.startPolling,
   setPollingMultiplier: vi.fn(),
   clearEtag: vi.fn(),

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-routing-restoration.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-routing-restoration.component.test.ts
@@ -3,6 +3,10 @@ import type { Capabilities } from '$lib/types/capabilities';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
 
 const h = vi.hoisted(() => ({ tx: null as ManagedAppTxController | null }));
+vi.mock('$lib/transport/http-client', async (importOriginal) => ({
+  ...await importOriginal<typeof import('$lib/transport/http-client')>(),
+  fetchInfo: vi.fn().mockResolvedValue({}),
+}));
 vi.mock('$lib/transport/ws-client', () => ({
   connect: vi.fn(), sendRaw: vi.fn(), sendCommand: vi.fn(),
   getControlSession: () => ({ state: 'connected', epoch: 1 }),

--- a/frontend/src/lib/runtime/__tests__/frontend-runtime.isolated.test.ts
+++ b/frontend/src/lib/runtime/__tests__/frontend-runtime.isolated.test.ts
@@ -17,6 +17,7 @@ import { effect_root, render_effect } from 'svelte/internal/client';
 vi.mock('$lib/transport/http-client', async (importOriginal) => ({
   ...await importOriginal<typeof import('$lib/transport/http-client')>(),
   fetchCapabilities: vi.fn(),
+  fetchInfo: vi.fn().mockResolvedValue({}),
 }));
 
 vi.mock('$lib/transport/ws-client', () => ({

--- a/frontend/src/lib/runtime/frontend-runtime.ts
+++ b/frontend/src/lib/runtime/frontend-runtime.ts
@@ -25,6 +25,7 @@ import {
 } from '$lib/stores/connection.svelte';
 import { getAudioState, setVolume, setMuted, toggleMute } from '$lib/stores/audio.svelte';
 import * as transport from '$lib/transport/ws-client';
+import { fetchInfo } from '$lib/transport/http-client';
 import { audioManager } from '$lib/audio/audio-manager';
 import { makeAudioRoutingHandlers } from './commands/panel-commands';
 import { clearLegacyPendingModInputRestore } from './adapters/mod-input-auto.svelte';
@@ -274,7 +275,7 @@ class FrontendRuntime {
    *
    * @returns A cleanup function that tears down presentation resources when called.
    */
-  async bootstrap(): Promise<() => void> {
+  async bootstrap(signal?: AbortSignal): Promise<() => void> {
     // If already completed, return cached cleanup.
     if (this._bootstrapCleanup !== null) {
       return this._bootstrapCleanup;
@@ -286,7 +287,7 @@ class FrontendRuntime {
     }
 
     // Set sentinel before first await to serialize concurrent callers.
-    this._bootstrapInFlight = this._doBootstrap();
+    this._bootstrapInFlight = this._doBootstrap(signal);
 
     try {
       return await this._bootstrapInFlight;
@@ -300,7 +301,10 @@ class FrontendRuntime {
    * Private implementation of bootstrap. Separated so the sentinel
    * can be set before this async function starts.
    */
-  private async _doBootstrap(): Promise<() => void> {
+  private async _doBootstrap(signal?: AbortSignal): Promise<() => void> {
+    await fetchInfo(signal);
+    signal?.throwIfAborted();
+
     // A new App instance re-arms the runtime: `_ended` is latched by the
     // previous instance's cleanup and would otherwise fail every facade
     // (`acquireHardwareScope`, `subscribeDx`, `setRxLive`) closed forever.

--- a/frontend/src/lib/transport/http-client.ts
+++ b/frontend/src/lib/transport/http-client.ts
@@ -6,25 +6,40 @@ export { getAuthHeaders, getAuthToken };
 
 const BASE = '/api/v1';
 
-function handleUnauthorized(): void {
+export class AuthenticationError extends Error {
+  override name = 'AuthenticationError';
+}
+
+async function authenticatedFetch(path: string, signal?: AbortSignal): Promise<Response> {
+  signal?.throwIfAborted();
+  const res = await fetch(path, { headers: getAuthHeaders(), signal, redirect: 'error' });
+  signal?.throwIfAborted();
+  if (res.status !== 401) return res;
+
   const token = prompt('Enter auth token:');
-  if (token) {
-    localStorage.setItem('rigplane-auth-token', token);
-    location.reload();
+  if (!token) {
+    throw new AuthenticationError('Authentication cancelled. Reload the page to try again.');
   }
+  signal?.throwIfAborted();
+  const retry = await fetch(path, {
+    headers: { Authorization: `Bearer ${token}` }, signal, redirect: 'error',
+  });
+  signal?.throwIfAborted();
+  if (retry.status === 401) {
+    throw new AuthenticationError('Auth token rejected. Reload the page to try again.');
+  }
+  if (retry.ok) localStorage.setItem('rigplane-auth-token', token);
+  return retry;
 }
 
 export async function fetchCapabilities(): Promise<Capabilities> {
-  const res = await fetch(`${BASE}/capabilities`, { headers: getAuthHeaders() });
-  if (res.status === 401) { handleUnauthorized(); throw new Error('Unauthorized'); }
+  const res = await authenticatedFetch(`${BASE}/capabilities`);
   if (!res.ok) throw new Error(`fetchCapabilities: ${res.status}`);
   return validateCapabilities(await res.json());
 }
 
-/** Fetch server info (version, uptime). Used by StatusBar component (Sprint 2). */
-export async function fetchInfo(): Promise<InfoResponse> {
-  const res = await fetch(`${BASE}/info`, { headers: getAuthHeaders() });
-  if (res.status === 401) { handleUnauthorized(); throw new Error('Unauthorized'); }
+export async function fetchInfo(signal?: AbortSignal): Promise<InfoResponse> {
+  const res = await authenticatedFetch(`${BASE}/info`, signal);
   if (!res.ok) throw new Error(`fetchInfo: ${res.status}`);
   return res.json() as Promise<InfoResponse>;
 }


### PR DESCRIPTION
A fresh browser could load static assets but never reach credential entry: the protected control WebSocket had to deliver state before the HTTP capabilities request could trigger the existing 401 prompt. Startup now requests same-origin server info first, verifies one entered token before storing it, and then starts the existing control session. Cancelled/rejected credentials show the existing error overlay with deliberate reload instructions; network errors retain the existing retry path. App teardown cancels an unfinished preflight.

Owns [MOR-2353](https://linear.app/morozsm/issue/MOR-2353). Public fetch callers remain compatible; `bootstrap` and `fetchInfo` accept an optional AbortSignal. Capabilities/state acceptance, WebSocket credential policy, backend/provider/PTT code are unchanged. HTTP preflight and credential verification reject redirects.

Validation on Mac Mini, with a private worktree and its own `npm ci`:

- Causal RED against `281bbb45dfc52197672e263f70e07443e0086cfd`: the new mounted-App/real-runtime startup test observed zero credential prompts before the fix.
- At `9dae54ca`, focused Vitest gate: 151 tests passed in 9 files, including 11 first-auth cases, real HTTP helper/WS/state stores, valid and no-auth startup, rejected/cancelled input, network/503 handling, same-origin WS restrictions, pending-preflight teardown, presentation switching and existing App lifecycle coverage.
- Reviewer/quick CI identified one additional existing routing-restoration fixture without an info preflight stub. The final `b02f6c7c` fixture-only correction preserves its real runtime/routing and all assertions; the requested routing-restoration + first-auth pair passed 14 tests in 2 files on Mini.
- At `9dae54ca`, `npm run lint` passed and `npm run check` reported zero errors/warnings, including Svelte and TypeScript projects. All three production blobs are identical at `b02f6c7c` (the production-path diff is empty); only four fixture lines were added. Final `git diff --check`: passed.

The eight-file scope (+203/-14) is one startup correction: three production files, one new startup integration test and four existing HTTP fixture adjustments. The new integration suite uses synthetic HTTP/WS boundaries and stubbed presentation/media/TX hosts; it proves real runtime state/capability acceptance and App error DOM, not installed full-skin or physical-radio acceptance. No live radio service, hardware/browser session, Python suite, build or publication was performed in this lane. The coordinator owns normal CI, independent exact-head review, final installed first-login smoke and explicit binding of unchanged backend evidence.
