### PR TITLE
fix: ignore stale WebSocket close callbacks

### DIFF
--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -326,6 +326,72 @@ describe('WsChannel', () => {
     expect(received).toEqual([currentFrame]);
   });
 
+  it('ignores a delayed close from a socket replaced after intentional disconnect', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    const received: ArrayBuffer[] = [];
+    ch.onBinary((frame) => received.push(frame));
+
+    ch.connect('ws://test');
+    const first = instances[0];
+    first.simulateOpen();
+    first.close = vi.fn(() => { first.readyState = MockWebSocket.CLOSED; });
+
+    ch.disconnect();
+    ch.connect('ws://test');
+    const replacement = instances[1];
+    replacement.simulateOpen();
+
+    first.simulateClose(1000, 'delayed close', true);
+    const currentFrame = new ArrayBuffer(2);
+    replacement.simulateMessage(currentFrame);
+    vi.advanceTimersByTime(60_000);
+
+    expect(ch.state).toBe('connected');
+    expect(ch.isConnected()).toBe(true);
+    expect(received).toEqual([currentFrame]);
+    expect(instances).toHaveLength(2);
+  });
+
+  it('keeps one channel across a deferred-close hardware demand reacquisition', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const { ScopeController } = await import('../../runtime/scope-controller.svelte');
+    const { PresentationResourceHost } = await import('../../runtime/resource-host');
+    const ch = new WsChannel();
+    const controller = new ScopeController(() => ch);
+    const host = new PresentationResourceHost<unknown>('orientation-session');
+    host.configure('hardware-scope', {
+      available: true,
+      selected: true,
+      driver: controller.hardwareScopeDriver,
+    });
+
+    const portrait = host.acquire('hardware-scope', 'portrait');
+    await Promise.resolve();
+    await Promise.resolve();
+    const first = instances[0];
+    first.simulateOpen();
+    first.close = vi.fn(() => { first.readyState = MockWebSocket.CLOSED; });
+
+    host.release(portrait);
+    const landscape = host.acquire('hardware-scope', 'landscape');
+    await Promise.resolve();
+    await Promise.resolve();
+    const replacement = instances[1];
+    replacement.simulateOpen();
+
+    first.simulateClose(1000, 'delayed close', true);
+    vi.advanceTimersByTime(60_000);
+
+    expect(host.snapshot('hardware-scope')).toMatchObject({ demand: 1, health: 'streaming' });
+    expect(ch.state).toBe('connected');
+    expect(ch.isConnected()).toBe(true);
+    expect(instances).toHaveLength(2);
+
+    host.release(landscape);
+    await host.teardown();
+  });
+
   it('emits correlated PTT delivery events without fabricating RF state', async () => {
     const { WsChannel } = await import('../ws-client');
     const ch = new WsChannel();

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -307,6 +307,7 @@ export class WsChannel {
         timestamp: Date.now(),
       };
       console.info('[ws] closed', _lastCloseInfo);
+      if (this.ws !== ws) return;
       this._clearHeartbeat();
       this.trackedNonPttCommands.clear();
       this.trackedLifecycleCommands.clear();


### PR DESCRIPTION
Fixes the hardware-scope socket accumulation reproduced by rotating the installed UI from mobile portrait to landscape. A delayed close callback from socket A could clear its replacement B and schedule C, producing the observed 1→2→3 established connections across orientation and desktop restoration.

The named WebSocket channel now ignores close callbacks from sockets it no longer owns after retaining close diagnostics. A deterministic deferred-close regression covers B staying connected, delivering frames, and opening no C after the backoff interval. A second focused test exercises the real `PresentationResourceHost` and `ScopeController` hardware release/reacquire seam used by the orientation remount.

Linear: [MOR-2356](https://linear.app/morozsm/issue/MOR-2356/beta-acceptance-ignore-stale-websocket-close-callbacks-after-scope)

Validation:

- RED on `5336c56206a051e22df91fa25839d388f0c92f6f`: both new deferred-close tests failed with channel state `reconnecting`.
- GREEN: focused transport, WebSocket auth, scope-controller, and resource-demand files — 131 passed.
- `npm run check` — 0 errors, 0 warnings.
- `npm run lint` — passed.
- `npm run build` — passed.

The existing focused suite continues to cover unexpected current-socket reconnect, intentional disconnect, close diagnostics, and authentication. Installed mobile-orientation acceptance remains a separate root-owned post-merge candidate check; this PR makes no hardware or UI-pixel claim.
