### PR TITLE
docs: explain browser microphone secure-context requirement

### DIFF
--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -33,8 +33,8 @@ that API only in a secure context, such as browser-trusted HTTPS; a private-LAN
 See the [W3C Secure Contexts specification](https://www.w3.org/TR/secure-contexts/)
 and the [MDN getUserMedia reference](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
 
-For a remote browser, start the Web UI with Core TLS support (`--tls`, or
-`--tls-cert` and `--tls-key` with certificates trusted by the browser), install
+For a remote browser, start the Web UI with Core TLS support using
+`--tls-cert` and `--tls-key` together, with a certificate valid and trusted for the server hostname; `--tls` alone generates self-signed TLS and does not establish browser certificate trust. Install
 the [`tls` extra](installation.md#optional-dependencies) when needed, and open the
 resulting `https://` URL. A browser connected through an SSH loopback tunnel
 may instead use `http://localhost:<forwarded-port>` because loopback is a

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -25,6 +25,23 @@ rigplane web --auth-token "change-me"
 
 Open `http://<server-ip>:8080` (or your custom port).
 
+### Browser microphone requirement
+
+Browser voice TX uses `getUserMedia()` to capture the microphone. Browsers expose
+that API only in a secure context, such as browser-trusted HTTPS; a private-LAN
+`http://<server-ip>` URL is not the same as `localhost` or a loopback origin.
+See the [W3C Secure Contexts specification](https://www.w3.org/TR/secure-contexts/)
+and the [MDN getUserMedia reference](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
+
+For a remote browser, start the Web UI with Core TLS support (`--tls`, or
+`--tls-cert` and `--tls-key` with certificates trusted by the browser), install
+the [`tls` extra](installation.md#optional-dependencies) when needed, and open the
+resulting `https://` URL. A browser connected through an SSH loopback tunnel
+may instead use `http://localhost:<forwarded-port>` because loopback is a
+browser-trusted origin; the LAN HTTP URL itself remains insecure. This
+requirement affects browser microphone capture and voice TX; it does not imply
+that every control or receive operation fails over HTTP.
+
 ## What Runs Where
 
 | Layer | Implementation | Notes |

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -34,13 +34,14 @@ See the [W3C Secure Contexts specification](https://www.w3.org/TR/secure-context
 and the [MDN getUserMedia reference](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
 
 For a remote browser, start the Web UI with Core TLS support using
-`--tls-cert` and `--tls-key` together, with a certificate valid and trusted for the server hostname; `--tls` alone generates self-signed TLS and does not establish browser certificate trust. Install
-the [`tls` extra](installation.md#optional-dependencies) when needed, and open the
-resulting `https://` URL. A browser connected through an SSH loopback tunnel
-may instead use `http://localhost:<forwarded-port>` because loopback is a
-browser-trusted origin; the LAN HTTP URL itself remains insecure. This
-requirement affects browser microphone capture and voice TX; it does not imply
-that every control or receive operation fails over HTTP.
+`--tls-cert` and `--tls-key` together. Use a certificate valid and trusted for
+the server hostname. The `--tls` option alone generates self-signed TLS and
+does not establish browser certificate trust. Install the [`tls` extra](installation.md#optional-dependencies) when needed, and open the resulting
+`https://` URL. A browser connected through an SSH loopback tunnel may instead
+use `http://localhost:<forwarded-port>` because loopback is a browser-trusted
+origin; the LAN HTTP URL itself remains insecure. This requirement affects
+browser microphone capture and voice TX; it does not imply that every control
+or receive operation fails over HTTP.
 
 ## What Runs Where
 

--- a/docs/release-notes/2026-beta-known-limitations.md
+++ b/docs/release-notes/2026-beta-known-limitations.md
@@ -17,7 +17,10 @@ that class of defect is release-blocking by definition and is not on this list.
 - **Browser voice TX requires a secure browser context.** `getUserMedia()` is
   available to the Web UI only over browser-trusted HTTPS or a local loopback
   origin such as `localhost`; a private-LAN HTTP URL is not a loopback origin.
-  Use Core TLS setup with `--tls-cert` and `--tls-key` together, using a certificate valid and trusted for the server hostname; `--tls` alone generates self-signed TLS and does not establish browser certificate trust, and open the resulting `https://` URL, or access a loopback endpoint through
+  Use Core TLS setup with `--tls-cert` and `--tls-key` together. Use a certificate
+  valid and trusted for the server hostname. The `--tls` option alone generates
+  self-signed TLS and does not establish browser certificate trust. Open the
+  resulting `https://` URL. Alternatively, access a loopback endpoint through
   an SSH tunnel. This limitation concerns microphone capture and voice TX; it
   does not make all control or RX operations unavailable over HTTP.
 

--- a/docs/release-notes/2026-beta-known-limitations.md
+++ b/docs/release-notes/2026-beta-known-limitations.md
@@ -17,8 +17,7 @@ that class of defect is release-blocking by definition and is not on this list.
 - **Browser voice TX requires a secure browser context.** `getUserMedia()` is
   available to the Web UI only over browser-trusted HTTPS or a local loopback
   origin such as `localhost`; a private-LAN HTTP URL is not a loopback origin.
-  Use Core TLS setup (`rigplane web --tls`, or `--tls-cert` with `--tls-key`)
-  and open the resulting `https://` URL, or access a loopback endpoint through
+  Use Core TLS setup with `--tls-cert` and `--tls-key` together, using a certificate valid and trusted for the server hostname; `--tls` alone generates self-signed TLS and does not establish browser certificate trust, and open the resulting `https://` URL, or access a loopback endpoint through
   an SSH tunnel. This limitation concerns microphone capture and voice TX; it
   does not make all control or RX operations unavailable over HTTP.
 

--- a/docs/release-notes/2026-beta-known-limitations.md
+++ b/docs/release-notes/2026-beta-known-limitations.md
@@ -12,6 +12,16 @@ reclassification without a corresponding line here is incomplete.
 None of the items below produces false transmit state or routes RF incorrectly;
 that class of defect is release-blocking by definition and is not on this list.
 
+## Browser microphone capture
+
+- **Browser voice TX requires a secure browser context.** `getUserMedia()` is
+  available to the Web UI only over browser-trusted HTTPS or a local loopback
+  origin such as `localhost`; a private-LAN HTTP URL is not a loopback origin.
+  Use Core TLS setup (`rigplane web --tls`, or `--tls-cert` with `--tls-key`)
+  and open the resulting `https://` URL, or access a loopback endpoint through
+  an SSH tunnel. This limitation concerns microphone capture and voice TX; it
+  does not make all control or RX operations unavailable over HTTP.
+
 ## Receive-control feedback and precision
 
 - **PBT values can briefly blank or show a transient endpoint during


### PR DESCRIPTION
The Web UI guide advertises browser voice TX over a LAN URL without explaining that microphone capture requires a secure browser context. Document the supported browser-trusted HTTPS and localhost/loopback routes, and clarify that Core's automatic self-signed TLS does not establish browser certificate trust.

Updates the guide and beta known-limitations register only. The documented certificate/key flags were checked against the current CLI configuration path. Browser requirements link to W3C and MDN documentation.

Validation: `git diff --check` passes at the final head. Strict MkDocs build passed at `ec47f8ae235537b9180269eb49a68ca6b5be9327`; the final delta only splits sentences and wraps the same Markdown without changing links or facts. No runtime, radio, or microphone execution is claimed by this documentation change.

Linear: https://linear.app/morozsm/issue/MOR-2357/beta-documentation-state-the-secure-context-requirement-for-browser
