### PR TITLE
fix: preserve single-receiver LCD A/B display slots (MOR-1413)

### DIFF
--- a/frontend/src/semantic/__tests__/radio-display-model.test.ts
+++ b/frontend/src/semantic/__tests__/radio-display-model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type {
   RadioViewModel, ReceiverIndicatorViewModel, TxAuxField,
 } from '../radio-view-model';
+import { topologyFixtures } from '../fixtures/topologies';
 import { projectPeerSplitDisplay } from '../radio-display-model';
 
 const availability = (structural = true, operational = true) => ({ structural, operational });
@@ -177,5 +178,68 @@ describe('projectPeerSplitDisplay', () => {
       else if (value && typeof value === 'object') Object.values(value).forEach(visit);
     };
     expect(() => visit(display)).not.toThrow();
+  });
+});
+
+function singleAb(active: 'A' | 'B' | null, knownB = true): RadioViewModel {
+  const fixture = topologyFixtures['1/ab'];
+  return {
+    ...view(), ...fixture,
+    scope: view().scope,
+    receiverIndicators: [indicator('MAIN')],
+    vfos: fixture.vfos.map((vfo) => ({
+      ...vfo,
+      frequencyHz: vfo.slot.kind === 'slotted' && vfo.slot.id === 'B' && !knownB
+        ? null : vfo.frequencyHz,
+      isActive: vfo.slot.kind === 'slotted' && vfo.slot.id === active,
+      isActiveSlot: vfo.slot.kind === 'slotted' && vfo.slot.id === active,
+    })),
+  };
+}
+
+describe('single-receiver LCD display slots', () => {
+  it.each(['A', 'B'] as const)('keeps A left and B right with %s active without duplicating receiver facts', (active) => {
+    const display = projectPeerSplitDisplay(singleAb(active));
+    expect(display.receivers.map((slot) => slot.label)).toEqual(['VFO A', 'VFO B']);
+    expect(display.receivers.map((slot) => slot.receiver)).toEqual(['MAIN', 'MAIN']);
+    expect(display.receivers.map((slot) => slot.vfoSlot)).toEqual(['A', 'B']);
+    expect(display.receivers.map((slot) => slot.frequency)).toEqual([
+      { state: 'known', value: 7_100_000 }, { state: 'known', value: 7_150_000 },
+    ]);
+    expect(display.activeReceiver?.vfoSlot).toBe(active);
+    for (const slot of display.receivers) {
+      const selected = slot.vfoSlot === active;
+      expect(slot.activity).toBe(selected ? 'active' : 'inactive');
+      expect(slot.operational).toBe(selected);
+      expect(slot.sMeter).toEqual(selected ? { state: 'known', value: -18 } : { state: 'unknown' });
+      expect(slot.bandwidthHz.state).toBe(selected ? 'known' : 'unknown');
+      expect(slot.dsp.agc.state).toBe(selected ? 'known' : 'unknown');
+      expect(slot.front.rfGain.state).toBe(selected ? 'known' : 'unknown');
+      expect(slot.spectrum).toBe(selected ? 'waiting' : 'inactive');
+    }
+  });
+
+  it.each(['A', 'B'] as const)('keeps unobserved B unknown with %s active', (active) => {
+    const display = projectPeerSplitDisplay(singleAb(active, false));
+    expect(display.receivers[0].frequency).toEqual({ state: 'known', value: 7_100_000 });
+    expect(display.receivers[1].frequency).toEqual({ state: 'unknown' });
+  });
+
+  it('does not assign MAIN telemetry or FFT when the active A/B slot is unobserved', () => {
+    const display = projectPeerSplitDisplay(singleAb(null));
+    expect(display.activeReceiver).toBeNull();
+    for (const slot of display.receivers) {
+      expect(slot.activity).toBe('unknown');
+      expect(slot.sMeter).toEqual({ state: 'unknown' });
+      expect(slot.spectrum).toBe('unknown');
+    }
+  });
+
+  it('does not fill a missing B observation with A or an unknown relative slot', () => {
+    const fixture = singleAb('A');
+    fixture.vfos = [fixture.vfos[0], {
+      ...fixture.vfos[1], slot: { kind: 'unknown' }, frequencyHz: 9_999_000,
+    }];
+    expect(projectPeerSplitDisplay(fixture).receivers[1].frequency).toEqual({ state: 'unknown' });
   });
 });

--- a/frontend/src/semantic/radio-display-model.ts
+++ b/frontend/src/semantic/radio-display-model.ts
@@ -1,6 +1,6 @@
 import type {
   MeterField, RadioViewModel, ReceiverId, ReceiverIndicatorViewModel, TxAuxField,
-  VfoViewModel,
+  VfoSlotId, VfoViewModel,
 } from './radio-view-model';
 
 export type DisplayValue<T> =
@@ -21,8 +21,11 @@ export type DisplayOffset =
 
 export type DisplayTelemetry = DisplayValue<number> & { readonly relevant: boolean };
 
+export type DisplaySlotId = ReceiverId | VfoSlotId;
+
 export interface PeerSplitReceiverDisplay {
   readonly receiver: ReceiverId;
+  readonly vfoSlot?: VfoSlotId;
   readonly label: string;
   readonly activity: 'active' | 'inactive' | 'unknown';
   readonly operational: boolean;
@@ -83,9 +86,9 @@ export interface PeerSplitDisplayModel {
 
 type Fact<T> = Pick<TxAuxField<T>, 'reading' | 'availability'>;
 
-function displayValue<T>(field: Fact<T> | undefined): DisplayValue<T> {
+function displayValue<T>(field: Fact<T> | undefined, observed = true): DisplayValue<T> {
   if (!field || !field.availability.structural) return { state: 'unsupported' };
-  if (!field.availability.operational || field.reading.status === 'unknown') return { state: 'unknown' };
+  if (!observed || !field.availability.operational || field.reading.status === 'unknown') return { state: 'unknown' };
   return { state: 'known', value: field.reading.value };
 }
 
@@ -93,8 +96,8 @@ function directValue<T>(value: T | null | undefined): DisplayValue<T> {
   return value === null || value === undefined ? { state: 'unknown' } : { state: 'known', value };
 }
 
-function displayIndicator(field: Fact<boolean> | undefined): DisplayIndicator {
-  const value = displayValue(field);
+function displayIndicator(field: Fact<boolean> | undefined, observed = true): DisplayIndicator {
+  const value = displayValue(field, observed);
   if (value.state !== 'known') return value;
   return { state: value.value ? 'active' : 'inactive' };
 }
@@ -116,13 +119,24 @@ function receiverIndicator(
   return view.receiverIndicators?.find((indicator) => indicator.receiver === receiver);
 }
 
-function receiverDisplay(view: RadioViewModel, receiver: ReceiverId): PeerSplitReceiverDisplay {
-  const vfo = selectedVfo(view, receiver);
+function receiverDisplay(
+  view: RadioViewModel, receiver: ReceiverId, vfoSlot?: VfoSlotId,
+): PeerSplitReceiverDisplay {
+  const vfo = vfoSlot
+    ? view.vfos.find((candidate) => candidate.receiver === receiver
+      && candidate.slot.kind === 'slotted' && candidate.slot.id === vfoSlot)
+    : selectedVfo(view, receiver);
   const indicator = receiverIndicator(view, receiver);
+  const selectedSlots = view.vfos.filter((candidate) => candidate.receiver === receiver
+    && candidate.slot.kind === 'slotted' && candidate.isActiveSlot);
+  const selectedSlot = selectedSlots.length === 1 ? selectedSlots[0] : undefined;
   const activity = view.activeReceiver.status === 'unknown'
+    || (vfoSlot !== undefined && selectedSlot === undefined)
     ? 'unknown'
-    : view.activeReceiver.receiver === receiver ? 'active' : 'inactive';
+    : view.activeReceiver.receiver === receiver && (!vfoSlot || vfo === selectedSlot)
+      ? 'active' : 'inactive';
   const isActive = activity === 'active';
+  const observed = vfoSlot === undefined || isActive;
   const scopeStructural = view.scope.audioFftScope.structural;
   const spectrum = !scopeStructural ? 'unsupported'
     : activity === 'unknown' ? 'unknown'
@@ -130,33 +144,34 @@ function receiverDisplay(view: RadioViewModel, receiver: ReceiverId): PeerSplitR
 
   return {
     receiver,
-    label: view.vfoScheme === 'ab_shared'
+    ...(vfoSlot ? { vfoSlot } : {}),
+    label: vfoSlot ? `VFO ${vfoSlot}` : view.vfoScheme === 'ab_shared'
       ? (receiver === 'MAIN' ? 'VFO A' : 'VFO B')
       : vfo?.label || receiver,
     activity,
-    operational: indicator?.availability.operational ?? false,
+    operational: observed && (indicator?.availability.operational ?? false),
     frequency: directValue(vfo?.frequencyHz),
     mode: directValue(vfo?.mode),
     filter: directValue(vfo?.filter),
     band: isActive ? displayValue(view.band?.currentBand) : { state: 'unsupported' },
-    sMeter: displayValue(indicator?.sMeter),
-    bandwidthHz: displayValue(indicator?.bandwidthHz),
+    sMeter: displayValue(indicator?.sMeter, observed),
+    bandwidthHz: displayValue(indicator?.bandwidthHz, observed),
     ifShiftHz: isActive ? displayValue(view.filterPassband?.ifShift) : { state: 'unsupported' },
     pbtInnerHz: isActive ? displayValue(view.filterPassband?.pbtInner) : { state: 'unsupported' },
     pbtOuterHz: isActive ? displayValue(view.filterPassband?.pbtOuter) : { state: 'unsupported' },
     spectrum,
     dsp: {
-      agc: displayValue(indicator?.agcMode),
-      nb: displayIndicator(indicator?.nbActive),
-      nr: displayIndicator(indicator?.nrActive),
-      notch: displayValue(indicator?.notchMode),
+      agc: displayValue(indicator?.agcMode, observed),
+      nb: displayIndicator(indicator?.nbActive, observed),
+      nr: displayIndicator(indicator?.nrActive, observed),
+      notch: displayValue(indicator?.notchMode, observed),
     },
     front: {
-      preamp: displayValue(indicator?.preamp),
-      attenuator: displayValue(indicator?.attenuator),
-      rfGain: displayValue(indicator?.rfGain),
-      digiSel: displayIndicator(indicator?.digiSel),
-      ipPlus: displayIndicator(indicator?.ipPlus),
+      preamp: displayValue(indicator?.preamp, observed),
+      attenuator: displayValue(indicator?.attenuator, observed),
+      rfGain: displayValue(indicator?.rfGain, observed),
+      digiSel: displayIndicator(indicator?.digiSel, observed),
+      ipPlus: displayIndicator(indicator?.ipPlus, observed),
     },
   };
 }
@@ -201,8 +216,9 @@ function telemetry(field: MeterField | undefined): DisplayTelemetry {
 }
 
 export function projectPeerSplitDisplay(view: RadioViewModel): PeerSplitDisplayModel {
-  const main = receiverDisplay(view, 'MAIN');
-  const sub = receiverDisplay(view, 'SUB');
+  const singleAb = view.topologyId === '1/ab' && view.vfoScheme === 'ab';
+  const main = receiverDisplay(view, 'MAIN', singleAb ? 'A' : undefined);
+  const sub = singleAb ? receiverDisplay(view, 'MAIN', 'B') : receiverDisplay(view, 'SUB');
   const receivers = [main, sub] as const;
   const activeReceiver = receivers.find((receiver) => receiver.activity === 'active') ?? null;
   const shared = view.radioWideIndicators;

--- a/frontend/src/skins/segmentline/CenterstageDisplay.svelte
+++ b/frontend/src/skins/segmentline/CenterstageDisplay.svelte
@@ -62,7 +62,9 @@
 
   const active = $derived(model.activeReceiver ?? ghostReceiver);
   const activeIdentity = $derived(model.activeReceiver?.receiver ?? 'unknown');
-  const secondary = $derived(receiverById(
+  const fixedVfoSlots = $derived(model.receivers[0].vfoSlot !== undefined);
+  const primary = $derived(fixedVfoSlots ? model.receivers[0] : active);
+  const secondary = $derived(fixedVfoSlots ? model.receivers[1] : receiverById(
     model,
     model.activeReceiver?.receiver === 'SUB' ? 'MAIN' : 'SUB',
   ));
@@ -115,13 +117,14 @@
   <section
     class="hero-frequency"
     data-testid="centerstage-hero"
-    data-receiver={activeIdentity}
-    data-state={active.frequency.state}
-    style:opacity={active.frequency.state === 'unknown' ? 0.34 : 1}
-    style:visibility={active.frequency.state === 'unsupported' ? 'hidden' : 'visible'}
+    data-receiver={fixedVfoSlots ? primary.receiver : activeIdentity}
+    data-display-slot={primary.vfoSlot ?? primary.receiver}
+    data-state={primary.frequency.state}
+    style:opacity={primary.frequency.state === 'unknown' ? 0.34 : 1}
+    style:visibility={primary.frequency.state === 'unsupported' ? 'hidden' : 'visible'}
   >
-    <span class="receiver-tag">{model.activeReceiver?.label ?? 'ACTIVE'}{model.activeReceiver ? ' ●' : ''}</span>
-    <LcdFrequencyReadout receiver={active.receiver} field={active.frequency} />
+    <span class="receiver-tag">{primary.label}{primary.activity === 'active' ? ' ●' : ''}</span>
+    <LcdFrequencyReadout receiver={primary.vfoSlot ?? primary.receiver} field={primary.frequency} />
   </section>
 
   <section
@@ -133,7 +136,7 @@
     style:visibility={secondary.frequency.state === 'unsupported' ? 'hidden' : 'visible'}
   >
     <span class="secondary-tag">{secondary.label}{secondary.activity === 'active' ? ' ●' : ''}</span>
-    <LcdFrequencyReadout receiver={secondary.receiver} field={secondary.frequency} />
+    <LcdFrequencyReadout receiver={secondary.vfoSlot ?? secondary.receiver} field={secondary.frequency} />
     <span
       class="secondary-mode"
       data-state={secondary.mode.state}

--- a/frontend/src/skins/segmentline/DominantUnifiedDisplay.svelte
+++ b/frontend/src/skins/segmentline/DominantUnifiedDisplay.svelte
@@ -116,7 +116,7 @@
       data-state={main.frequency.state}
       style:visibility={main.frequency.state === 'unsupported' ? 'hidden' : undefined}
     >
-      <LcdFrequencyReadout receiver={main.receiver} field={main.frequency} />
+      <LcdFrequencyReadout receiver={main.vfoSlot ?? main.receiver} field={main.frequency} />
     </div>
     <div class="hero-facts">
       <span
@@ -158,7 +158,7 @@
       data-state={sub.frequency.state}
       style:visibility={sub.frequency.state === 'unsupported' ? 'hidden' : undefined}
     >
-      <LcdFrequencyReadout receiver={sub.receiver} field={sub.frequency} />
+      <LcdFrequencyReadout receiver={sub.vfoSlot ?? sub.receiver} field={sub.frequency} />
     </div>
     <div class="sub-facts">
       <span
@@ -187,19 +187,20 @@
       </span>
     </div>
     <div class="sub-offsets">
-      <LcdOffsetRail receiver={sub.receiver} offsets={model.offsets} />
+      <LcdOffsetRail receiver={sub.vfoSlot ?? sub.receiver} offsets={model.offsets} />
     </div>
   </section>
 
   <div class="meter-row">
-    {#each model.receivers as receiver (receiver.receiver)}
+    {#each model.receivers as receiver (receiver.vfoSlot ?? receiver.receiver)}
       <div
         class="meter-cell receiver-state-{receiver.activity}"
         data-testid="lcd-dominant-meter"
         data-receiver={receiver.receiver}
+        data-display-slot={receiver.vfoSlot ?? receiver.receiver}
         data-receiver-activity={receiver.activity}
       >
-        <span class="meter-receiver">{receiver.receiver}</span>
+        <span class="meter-receiver">{receiver.vfoSlot ?? receiver.receiver}</span>
         <LcdLinearSMeter field={receiver.sMeter} />
       </div>
     {/each}

--- a/frontend/src/skins/segmentline/LcdFilterScope.svelte
+++ b/frontend/src/skins/segmentline/LcdFilterScope.svelte
@@ -18,7 +18,7 @@
 </script>
 
 <div class="scope-block" data-scope-state={receiver.spectrum}>
-  <span class="scope-label" data-testid={`lcd-scope-label-${receiver.receiver}`}>
+  <span class="scope-label" data-testid={`lcd-scope-label-${receiver.vfoSlot ?? receiver.receiver}`}>
     {receiver.spectrum === 'unsupported' ? 'BANDPASS' : 'AF SCOPE · BANDPASS'}
   </span>
   <div class="scope-plot">
@@ -32,7 +32,7 @@
       data-testid="lcd-filter-envelope"
       viewBox="0 0 500 100"
       preserveAspectRatio="none"
-      aria-label={`${receiver.receiver} passive filter envelope`}
+      aria-label={`${receiver.vfoSlot ?? receiver.receiver} passive filter envelope`}
     >
       {#if envelopes.length > 0}
         {#each envelopes as item}

--- a/frontend/src/skins/segmentline/LcdFrequencyReadout.svelte
+++ b/frontend/src/skins/segmentline/LcdFrequencyReadout.svelte
@@ -7,11 +7,11 @@
   import { SEGMENTLINE_TOKENS } from '../../presentation/languages/segmentline/tokens';
   import type {
     DisplayValue,
-    PeerSplitReceiverDisplay,
+    DisplaySlotId,
   } from '../../semantic/radio-display-model';
 
   interface Props {
-    receiver: PeerSplitReceiverDisplay['receiver'];
+    receiver: DisplaySlotId;
     field: DisplayValue<number>;
   }
 

--- a/frontend/src/skins/segmentline/LcdOffsetRail.svelte
+++ b/frontend/src/skins/segmentline/LcdOffsetRail.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import type {
     PeerSplitDisplayModel,
-    PeerSplitReceiverDisplay,
+    DisplaySlotId,
   } from '../../semantic/radio-display-model';
   import { formatOffset } from './lcd-display-helpers';
 
   interface Props {
-    receiver: PeerSplitReceiverDisplay['receiver'];
+    receiver: DisplaySlotId;
     offsets: PeerSplitDisplayModel['offsets'];
   }
 

--- a/frontend/src/skins/segmentline/PanadapterDisplay.svelte
+++ b/frontend/src/skins/segmentline/PanadapterDisplay.svelte
@@ -51,13 +51,14 @@
   data-rf-state={model.rfState}
 >
   <div class="frequency-deck">
-    {#each model.receivers as receiver (receiver.receiver)}
+    {#each model.receivers as receiver (receiver.vfoSlot ?? receiver.receiver)}
       <section
         class="frequency-column"
         class:active={receiver.activity === 'active'}
         data-testid="panadapter-frequency-column"
         data-column-activity={receiver.activity}
         data-receiver={receiver.receiver}
+        data-display-slot={receiver.vfoSlot ?? receiver.receiver}
       >
         <div class="frequency-head">
           <span class="receiver-label">{receiver.label}{receiver.activity === 'active' ? ' ●' : ''}</span>
@@ -67,7 +68,7 @@
             <span data-state={receiver.band.state}>{stateText(receiver.band)}</span>
           </div>
         </div>
-        <LcdFrequencyReadout receiver={receiver.receiver} field={receiver.frequency} />
+        <LcdFrequencyReadout receiver={receiver.vfoSlot ?? receiver.receiver} field={receiver.frequency} />
         <LcdLinearSMeter field={receiver.sMeter} />
       </section>
     {/each}

--- a/frontend/src/skins/segmentline/PeerSplitDisplay.svelte
+++ b/frontend/src/skins/segmentline/PeerSplitDisplay.svelte
@@ -107,13 +107,14 @@
   </header>
 
   <div class="receiver-deck">
-    {#each model.receivers as receiver (receiver.receiver)}
+    {#each model.receivers as receiver (receiver.vfoSlot ?? receiver.receiver)}
       <section
         class="receiver-column"
         class:active={receiver.activity === 'active'}
         data-testid="lcd-peer-column"
         data-column-activity={receiver.activity}
         data-receiver={receiver.receiver}
+        data-display-slot={receiver.vfoSlot ?? receiver.receiver}
       >
         <div class="column-accent" aria-hidden="true"></div>
         <div class="column-head">
@@ -125,8 +126,8 @@
           </div>
         </div>
 
-        <LcdFrequencyReadout receiver={receiver.receiver} field={receiver.frequency} />
-        <LcdOffsetRail receiver={receiver.receiver} offsets={model.offsets} />
+        <LcdFrequencyReadout receiver={receiver.vfoSlot ?? receiver.receiver} field={receiver.frequency} />
+        <LcdOffsetRail receiver={receiver.vfoSlot ?? receiver.receiver} offsets={model.offsets} />
         <LcdLinearSMeter field={receiver.sMeter} />
         <LcdFilterScope
           {receiver}

--- a/frontend/src/skins/segmentline/__tests__/LcdVfoSlots.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/LcdVfoSlots.component.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mount, unmount } from 'svelte';
+import { projectPeerSplitDisplay } from '../../../semantic/radio-display-model';
+import type { RadioViewModel } from '../../../semantic/radio-view-model';
+import { topologyFixtures, withAudioOnlyScope } from '../../../semantic/fixtures/topologies';
+import PeerSplitDisplay from '../PeerSplitDisplay.svelte';
+import DominantUnifiedDisplay from '../DominantUnifiedDisplay.svelte';
+import CenterstageDisplay from '../CenterstageDisplay.svelte';
+import PanadapterDisplay from '../PanadapterDisplay.svelte';
+
+const variants = [PeerSplitDisplay, DominantUnifiedDisplay, CenterstageDisplay, PanadapterDisplay];
+const names = ['Peer Split', 'Unified', 'Centerstage', 'Panadapter'];
+let component: ReturnType<typeof mount> | undefined;
+afterEach(() => {
+  if (component) unmount(component);
+  component = undefined;
+  document.body.innerHTML = '';
+});
+
+function render(index: number, view: RadioViewModel) {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const model = projectPeerSplitDisplay(view);
+  const frame = {
+    source: 'audio-fft', receiver: 'MAIN', freshness: 'fresh',
+    startHz: 0, endHz: 4_000, normalizedBins: [0, 0.5, 1],
+  };
+  component = mount(variants[index], {
+    target,
+    props: {
+      model, normalizedFftBins: { MAIN: frame.normalizedBins },
+      audioFftFrame: frame, spectrumFrame: frame,
+    },
+  });
+  return target;
+}
+
+for (const [index, name] of names.entries()) {
+  describe(`${name} topology display slots`, () => {
+    it.each(['A', 'B'] as const)('keeps fixed A/B frequencies and one physical FFT with %s active', (active) => {
+      const fixture = withAudioOnlyScope(topologyFixtures['1/ab']);
+      const target = render(index, {
+        ...fixture,
+        vfos: fixture.vfos.map((vfo) => ({
+          ...vfo,
+          isActive: vfo.slot.kind === 'slotted' && vfo.slot.id === active,
+          isActiveSlot: vfo.slot.kind === 'slotted' && vfo.slot.id === active,
+        })),
+      });
+      const frequencies = [...target.querySelectorAll('[data-testid^="lcd-frequency-"]')];
+      expect(frequencies.map((node) => node.getAttribute('data-testid'))).toEqual([
+        'lcd-frequency-A', 'lcd-frequency-B',
+      ]);
+      expect(frequencies.map((node) => node.textContent?.replace(/\s/g, ''))).toEqual([
+        '7.100.000', '7.150.000',
+      ]);
+      expect(target.querySelectorAll('[data-fft-mode="live"]')).toHaveLength(1);
+      expect(target.querySelectorAll('[data-receiver="SUB"]')).toHaveLength(0);
+    });
+
+    it('renders an unknown B frequency without substituting A', () => {
+      const fixture = topologyFixtures['1/ab'];
+      const target = render(index, {
+        ...fixture,
+        vfos: fixture.vfos.map((vfo) => ({
+          ...vfo, frequencyHz: vfo.slot.kind === 'slotted' && vfo.slot.id === 'B' ? null : vfo.frequencyHz,
+        })),
+      });
+      expect(target.querySelector('[data-testid="lcd-frequency-B"]')?.getAttribute('data-state')).toBe('unknown');
+      expect(target.querySelector('[data-testid="lcd-frequency-A"]')?.getAttribute('data-state')).toBe('known');
+    });
+
+    it('preserves dual receiver frequency identities', () => {
+      const target = render(index, topologyFixtures['2/main_sub']);
+      expect([...target.querySelectorAll('[data-testid^="lcd-frequency-"]')]
+        .map((node) => node.getAttribute('data-testid'))).toEqual([
+        'lcd-frequency-MAIN', 'lcd-frequency-SUB',
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
Single-receiver A/B radios previously projected the selected MAIN VFO into the first LCD column and left the second column empty. The display model now fixes A/B to the first/second frequency slots across Peer Split, Unified, Centerstage and Panadapter. Physical receiver identity stays MAIN; receiver readings and AF FFT apply only to the observed active slot, and unobserved B remains unknown. Existing dual-receiver projection and Centerstage behavior are retained.

This is one MOR-1413 display-contract repair across ten files: the shared projection, four consumers, three passive display identity primitives, and two tests (261 changed lines). No command, TX admission, runtime, freshness or renderer transfer behavior changes. Centerstage keeps A/B frequency positions fixed for single-receiver radios while its summary, meter and FFT follow the selected VFO.

Validation on an isolated Mini worktree:
- Test-first model witness: 4 failures / 9 passes; four-variant witness: 12 failures / 4 dual-regression passes on b91.
- Focused Vitest run: 80 tests passed in six files, including active A/B, unknown B, unknown selection, physical FFT routing, and existing dual display regressions.
- `npm run check`: zero errors and warnings; targeted ESLint and `git diff --check` passed.
- `npm run build`: passed.
- Baseline `quick` run 33958252883 at 33354d4945ef1cdadf4ae7d4138bfc253152d74d is successful; `git diff --name-only 33354..b91b3fc -- frontend src/rigplane/web .github/workflows/quick.yml` is empty. Full suites remain CI-owned.

Independent review and exact-head CI are pending. No live radio or owner browser acceptance is claimed by these component tests.
