### PR TITLE
Restore LCD Panadapter and S-meter display parity

### DIFF
--- a/frontend/src/lib/renderers/__tests__/spectrum-renderer.test.ts
+++ b/frontend/src/lib/renderers/__tests__/spectrum-renderer.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { renderSpectrum, SpectrumRenderer, defaultSpectrumOptions, type SpectrumOptions } from '../spectrum-renderer';
+import {
+  renderSpectrum, SpectrumRenderer, defaultSpectrumOptions, spectrumDisplayAmplitude,
+  type SpectrumOptions,
+} from '../spectrum-renderer';
 
 function createMockCtx() {
   const log = {
@@ -209,5 +212,19 @@ describe('SpectrumRenderer', () => {
     const { ctx: c2, log: l2 } = createMockCtx();
     renderer.render(c2, new Uint8Array(10).fill(10), 10, 100, opts());
     expect(l2.fills).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('spectrumDisplayAmplitude', () => {
+  it('preserves the established zero, mid-scale, and clamp transfer', () => {
+    expect(spectrumDisplayAmplitude(0, 0)).toBe(0);
+    expect(spectrumDisplayAmplitude(40, 0)).toBeCloseTo(Math.sqrt(0.5), 8);
+    expect(spectrumDisplayAmplitude(80, 0)).toBe(1);
+    expect(spectrumDisplayAmplitude(255, 0)).toBe(1);
+  });
+
+  it('keeps the existing reference adjustment in the shared transfer', () => {
+    expect(spectrumDisplayAmplitude(40, 30)).toBeCloseTo(Math.sqrt(0.75), 8);
+    expect(spectrumDisplayAmplitude(40, -30)).toBe(0.5);
   });
 });

--- a/frontend/src/lib/renderers/spectrum-renderer.ts
+++ b/frontend/src/lib/renderers/spectrum-renderer.ts
@@ -44,6 +44,14 @@ function clamp(v: number, lo: number, hi: number): number {
   return v < lo ? lo : v > hi ? hi : v;
 }
 
+const SPECTRUM_AMPLITUDE_MAX = 80;
+
+export function spectrumDisplayAmplitude(sample: number, refLevel: number): number {
+  const refAdjust = (refLevel / 60) * 40;
+  const adjusted = clamp(sample + refAdjust, 0, SPECTRUM_AMPLITUDE_MAX);
+  return Math.sqrt(adjusted / SPECTRUM_AMPLITUDE_MAX);
+}
+
 type GradCache = { grad: CanvasGradient; height: number; fillColor: string };
 
 /**
@@ -117,14 +125,11 @@ export function renderSpectrum(
   // Gain boost: map 0-80 → full height with sqrt curve for better contrast
   // at low signal levels (IC-7610 scope data typically peaks at ~55)
   // Ref level: -30..+30 dB → ±40 on 0-80 scale (same mapping as waterfall)
-  const refAdjust = (options.refLevel / 60) * 40;
   const yPoints = new Float32Array(width);
   for (let x = 0; x < width; x++) {
     const idx = Math.min(n - 1, Math.floor((x / width) * n));
-    const adjusted = Math.min(80, Math.max(0, data[idx] + refAdjust));
-    const amp = Math.min(1.0, adjusted / 80);
-    const boosted = Math.sqrt(amp);
-    yPoints[x] = height * (1 - boosted);
+    const amplitude = spectrumDisplayAmplitude(data[idx], options.refLevel);
+    yPoints[x] = height * (1 - amplitude);
   }
 
   // Filled area under spectrum (gradient cached per-instance; recreated only when height or fillColor changes)
@@ -284,7 +289,6 @@ export class SpectrumRenderer {
     options: SpectrumOptions,
   ): void {
     // Draw peak hold as subtle gray fill between current spectrum and peak line
-    const refAdjust = (options.refLevel / 60) * 40;
     const n = currentData.length;
     
     ctx.fillStyle = 'rgba(200, 200, 200, 0.25)';
@@ -293,9 +297,8 @@ export class SpectrumRenderer {
     // Start from left, draw current spectrum line
     for (let x = 0; x < width; x++) {
       const idx = Math.min(n - 1, Math.floor((x / width) * n));
-      const adjusted = Math.min(80, Math.max(0, currentData[idx] + refAdjust));
-      const amp = Math.min(1.0, adjusted / 80);
-      const y = height * (1 - Math.sqrt(amp));
+      const amplitude = spectrumDisplayAmplitude(currentData[idx], options.refLevel);
+      const y = height * (1 - amplitude);
       if (x === 0) ctx.moveTo(x, y);
       else ctx.lineTo(x, y);
     }
@@ -303,9 +306,8 @@ export class SpectrumRenderer {
     // Draw back along peak line (right to left)
     for (let i = peaks.length - 1; i >= 0; i--) {
       const x = (i / peaks.length) * width;
-      const peakAdjusted = Math.min(80, Math.max(0, peaks[i] + refAdjust));
-      const amp = Math.min(1.0, peakAdjusted / 80);
-      const y = height * (1 - Math.sqrt(amp));
+      const amplitude = spectrumDisplayAmplitude(peaks[i], options.refLevel);
+      const y = height * (1 - amplitude);
       ctx.lineTo(x, y);
     }
     

--- a/frontend/src/skins/segmentline/LcdLinearSMeter.svelte
+++ b/frontend/src/skins/segmentline/LcdLinearSMeter.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
+  import { createSmoother } from '$lib/utils/smoothing.svelte';
   import type { DisplayValue } from '../../semantic/radio-display-model';
   import { meterFill } from './lcd-display-helpers';
 
@@ -7,12 +9,24 @@
   }
 
   let { field }: Props = $props();
+
+  const smoother = createSmoother(0.06, 0.1);
+  let displayFill = $derived(field.state === 'known' ? smoother.value : 0);
+
+  $effect(() => {
+    smoother.update(meterFill(field));
+  });
+
+  onMount(() => {
+    smoother.start();
+    return () => smoother.stop();
+  });
 </script>
 
 <div class="s-meter" data-state={field.state}>
   <span class="meter-label">S</span>
   <div class="meter-track">
-    <div class="meter-fill" style:width={`${meterFill(field) * 100}%`}></div>
+    <div class="meter-fill" style:width={`${displayFill * 100}%`}></div>
     <span class="meter-threshold"></span>
   </div>
   <div class="meter-scale" aria-hidden="true">

--- a/frontend/src/skins/segmentline/LcdRfPanadapter.svelte
+++ b/frontend/src/skins/segmentline/LcdRfPanadapter.svelte
@@ -12,6 +12,7 @@
 
 <script lang="ts">
   import { getPassbandGeometry } from '../../components/spectrum/passband-geometry';
+  import { spectrumDisplayAmplitude } from '../../lib/renderers/spectrum-renderer';
   import type { PeerSplitReceiverDisplay } from '../../semantic/radio-display-model';
   import { resolveLcdSpectrumFrame } from './lcd-display-contract';
 
@@ -121,7 +122,8 @@
     {/if}
     {#each renderBins as sample, index}
       {@const binWidth = PLOT_WIDTH / renderBins.length}
-      {@const binHeight = sample * (PLOT_HEIGHT - 4)}
+      {@const displaySample = spectrumDisplayAmplitude(sample * 255, 0)}
+      {@const binHeight = displaySample * (PLOT_HEIGHT - 4)}
       <rect
         class="rf-bin"
         data-rf-bin={index}

--- a/frontend/src/skins/segmentline/__tests__/LcdLinearSMeter.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/LcdLinearSMeter.component.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { DisplayValue } from '../../../semantic/radio-display-model';
+import { meterFill } from '../lcd-display-helpers';
+
+const smoothing = vi.hoisted(() => {
+  const instances: Array<{
+    update: ReturnType<typeof vi.fn>;
+    start: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+  }> = [];
+  const createSmoother = vi.fn((_attack: number, _release: number) => {
+    let value = 0.75;
+    const instance = {
+      update: vi.fn((next: number) => { value = next; }),
+      start: vi.fn(),
+      stop: vi.fn(),
+    };
+    instances.push(instance);
+    return {
+      get value() { return value; },
+      update: instance.update,
+      start: instance.start,
+      stop: instance.stop,
+    };
+  });
+  return { createSmoother, instances };
+});
+
+vi.mock('$lib/utils/smoothing.svelte', () => ({
+  createSmoother: smoothing.createSmoother,
+}));
+
+import LcdLinearSMeter from '../LcdLinearSMeter.svelte';
+
+let component: ReturnType<typeof mount> | null = null;
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+  smoothing.createSmoother.mockClear();
+  smoothing.instances.length = 0;
+});
+
+function render(field: DisplayValue<number>): HTMLElement {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(LcdLinearSMeter, { target, props: { field } });
+  flushSync();
+  return target;
+}
+
+describe('LcdLinearSMeter ballistics wiring', () => {
+  it('uses Standard/SDR attack and release constants and starts the shared smoother', () => {
+    const field = { state: 'known', value: 10 } as const;    render(field);
+
+    expect(smoothing.createSmoother).toHaveBeenCalledWith(0.06, 0.1);
+    expect(smoothing.instances[0]?.update).toHaveBeenCalledWith(meterFill(field));
+    expect(smoothing.instances[0]?.start).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { state: 'unknown' } as const,
+    { state: 'unsupported' } as const,
+  ])('keeps $state meter facts at a truthful zero target', (field) => {
+    const target = render(field);
+
+    expect(target.querySelector('.s-meter')?.getAttribute('data-state')).toBe(field.state);
+    expect(target.querySelector('.meter-fill')?.getAttribute('style')).toContain('width: 0%');
+    expect(smoothing.instances[0]?.update).toHaveBeenCalledWith(0);
+  });
+
+  it('stops the smoother on unmount so no presentation callback survives', () => {
+    render({ state: 'known', value: -18 });
+    const instance = smoothing.instances[0];
+
+    expect(instance?.start).toHaveBeenCalledOnce();
+    unmount(component!);
+    component = null;
+    expect(instance?.stop).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/skins/segmentline/__tests__/LcdRfPanadapter.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/LcdRfPanadapter.component.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { afterEach, describe, expect, it } from 'vitest';
 import { mount, unmount } from 'svelte';
+import { spectrumDisplayAmplitude } from '../../../lib/renderers/spectrum-renderer';
 import type { LcdSpectrumFrame } from '../lcd-display-contract';
 import LcdRfPanadapter, {
   type LcdRfPanadapterPassband,
@@ -168,5 +169,30 @@ describe('LcdRfPanadapter', () => {
     )).toHaveLength(0);
     expect(target.innerHTML).not.toMatch(/onclick|onpointer|onwheel/i);
     expect(source).not.toMatch(/(?:lib\/runtime|stores?\/|controller|transport|socket|demand)/i);
+  });
+});
+
+describe('LcdRfPanadapter hardware amplitude parity', () => {
+  it('keeps normalized raw bins immutable while applying the shared display transfer', () => {
+    const bins = Object.freeze([0, 40 / 255, 80 / 255, 1]);
+    const target = render(hardwareFrame({ normalizedBins: bins }));
+    const rendered = [...target.querySelectorAll('[data-rf-bin]')];
+
+    expect([...bins]).toEqual([0, 40 / 255, 80 / 255, 1]);
+    expect(rendered.map((node) => Number(node.getAttribute('data-rf-sample')))).toEqual(bins);
+    expect(rendered.map((node) => Number(node.getAttribute('height')))).toEqual([
+      0,
+      spectrumDisplayAmplitude(40, 0) * 94,
+      94,
+      94,
+    ]);
+  });
+
+  it('continues to reject audio FFT frames instead of applying RF transfer to them', () => {
+    const target = render(hardwareFrame({ source: 'audio-fft' }));
+
+    expect(target.querySelector('[data-testid="lcd-rf-panadapter"]')
+      ?.getAttribute('data-frame-reason')).toBe('source-mismatch');
+    expect(target.querySelectorAll('[data-rf-bin]')).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Problem

LCD Panadapter renders normalized hardware scope bytes linearly across the full 0..255 range, making ordinary signals much lower contrast than the Standard/SDR spectrum. The LCD S-meter also steps directly between radio updates while Standard/SDR applies established meter ballistics.

## Result

- Extract the existing Standard/SDR 0..80 clamp and square-root amplitude transfer into a pure helper and reuse it for LCD hardware Panadapter bins.
- Keep the immutable normalized-bin frame contract and audio-FFT rejection unchanged.
- Apply the existing Standard/SDR 60 ms attack / 100 ms release smoother to the LCD S-meter, including shared reduced-motion behavior and teardown.
- Leave Panadapter vector temporal processing for separate acceptance; this PR does not claim to fix its frame cadence.

Linear owner: MOR-1413.

## Validation

- `npm test -- --run src/lib/renderers/__tests__/spectrum-renderer.test.ts src/skins/segmentline/__tests__/LcdRfPanadapter.component.test.ts src/skins/segmentline/__tests__/LcdLinearSMeter.component.test.ts` — 51 passed
- `npm run check` — 0 errors, 0 warnings
- focused ESLint over all six changed files — passed
- `npm test` — 411 files, 8,880 tests passed
- `git diff --check` — passed

Hardware/UI acceptance remains owner-present and is not claimed by these source-only checks.
