### PR TITLE
fix(MOR-1413): place LCD menu first

### DIFF
--- a/frontend/src/components-v2/layout/LcdLayout.svelte
+++ b/frontend/src/components-v2/layout/LcdLayout.svelte
@@ -174,12 +174,12 @@
          amber glass (`cockpit`/`scope`) keeps its legacy presentation for
          this slice; MOR-1162 redesigns it. -->
     <div class="content-right">
+      <VfoControlPanel hideVfoFacts />
       {#if !segmentlineStage}
         <div class="semantic-slot">
           <SemanticRadioSurfaces />
         </div>
       {/if}
-      <VfoControlPanel hideVfoFacts />
       <RightSidebar hideTxPanel />
     </div>
   </section>

--- a/frontend/src/components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts
@@ -314,6 +314,17 @@ describe('the migrated LCD entrypoints own VFO/TX through the semantic surfaces'
     expect(column.querySelector('[data-testid="rx-tx-surface"]')).not.toBeNull();
   });
 
+  // MOR-1413: the retained radio-operation menu is the first top-right block;
+  // semantic VFO/TX facts follow it without changing either component's owner.
+  it.each(VARIANTS)('places the existing VFO menu first in the %s top-right column', (variant) => {
+    const column = render(variant).querySelector('.content-right')!;
+    const menu = column.querySelector('.vfo-ctrl-panel')!;
+    const semantic = column.querySelector('[data-testid="semantic-radio-surfaces"]')!;
+
+    expect(column.firstElementChild).toBe(menu);
+    expect(menu.compareDocumentPosition(semantic) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+  });
+
   // MUTATION KILLED: adding the surfaces alongside the legacy TX panel. The
   // LCD would then ship two PTT affordances — the exact duplicate ownership
   // MOR-1099 exists to retire, on the layout that also renders TX indication.


### PR DESCRIPTION
The LCD right column showed semantic VFO/TX facts before the retained radio-operation menu. This places the existing VFO control panel first for cockpit and scope layouts while preserving the semantic fact/TX owner, hidden duplicate VFO facts, sidebar TX suppression, and segmentline composition.

Validation:
- `npx vitest run src/components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts` (33 passed)
- `npm run check`
- `npx eslint src/components-v2/layout/LcdLayout.svelte src/components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts`

The added test failed for both cockpit and scope before the sibling reorder and passed afterward.
