### PR TITLE
fix: retain qualified RF gain display observations (MOR-1413)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/display-observation.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/display-observation.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import { IC7300_CAPABILITIES as capsFixture, IC7300_STATE as stateFixture } from './fixtures/ic7300-profile';
+import { qualifyDisplayObservation } from '../display-observation';
+
+const fresh: FieldStatus = {
+  storePath: 'main.rf_gain', observed: true, freshness: 'fresh', availability: 'available',
+  lastObservedMonotonic: 310658.42975425,
+};
+const caps = { ...capsFixture, stateContractVersion: 1, providerGeneration: 1, receivers: 1 } as Capabilities;
+const snapshot = (status: Partial<FieldStatus> = {}): ServerState => ({
+  ...stateFixture, stateContractVersion: 1, providerGeneration: 1, active: 'MAIN',
+  main: { ...stateFixture.main, rfGain: 0 },
+  fieldStatus: { 'main.rfGain': { ...fresh, ...status } },
+} as ServerState);
+function project<T extends number | string | boolean>(
+  value: T | undefined, state: ServerState | null = snapshot(),
+  capabilities: Capabilities | null = caps, structural = true,
+) {
+  return qualifyDisplayObservation({ state, caps: capabilities, receiver: 'MAIN', path: 'main.rfGain', structural, value });
+}
+
+describe('stateless display observation qualifier', () => {
+  it.each([0, false, 0.5, 'USB'] as const)('retains current and stale %s without truthiness coercion', (value) => {
+    expect(project(value)).toEqual({ state: 'current', value });
+    expect(project(value, snapshot({ freshness: 'stale', availability: 'stale' })))
+      .toEqual({ state: 'stale', value });
+  });
+  it('separates structural absence and never-observed defaults', () => {
+    expect(project(0, snapshot(), caps, false)).toEqual({ state: 'unsupported' });
+    expect(project(0, snapshot({ observed: false }))).toEqual({ state: 'unknown', reason: 'not-observed' });
+    expect(project(0, { ...snapshot(), fieldStatus: {} })).toEqual({ state: 'unknown', reason: 'not-observed' });
+  });
+  it.each([undefined, NaN, Infinity, ''] as const)('rejects invalid value %s', (value) => {
+    expect(project(value)).toEqual({ state: 'unknown', reason: 'invalid-value' });
+  });
+  it.each([undefined, null, NaN, Infinity, -1])('rejects invalid observation marker %s', (lastObservedMonotonic) => {
+    expect(project(0, snapshot({ lastObservedMonotonic })))
+      .toEqual({ state: 'unknown', reason: 'invalid-evidence' });
+  });
+  it('accepts fractional seconds without rounding and lets explicit stale ancestors downgrade a fresh leaf', () => {
+    const state = snapshot();
+    state.fieldStatus!.main = { ...fresh, freshness: 'stale', availability: 'stale' };
+    expect(project(0, state)).toEqual({ state: 'stale', value: 0 });
+    expect(state.fieldStatus!['main.rfGain'].lastObservedMonotonic).toBe(310658.42975425);
+  });
+  it.each([{ observed: false }, { availability: 'missing' as const }])('vetoes an explicitly unobserved parent: %j', (status) => {
+    const state = snapshot();
+    state.fieldStatus!.main = { ...fresh, ...status };
+    expect(project(0, state).state).toBe('unknown');
+  });
+  it('does not use a parent observation as evidence for an absent leaf', () => {
+    const state = { ...snapshot(), fieldStatus: { main: fresh } };
+    expect(project(0, state)).toEqual({ state: 'unknown', reason: 'not-observed' });
+  });
+  it('checks all explicit ancestors rather than allowing a fresh nearest parent to bypass an older stale ancestor', () => {
+    const state = snapshot();
+    state.fieldStatus!['main.nested'] = fresh;
+    state.fieldStatus!['main.nested.value'] = fresh;
+    state.fieldStatus!.main = { ...fresh, freshness: 'stale' };
+    expect(qualifyDisplayObservation({ state, caps, receiver: 'MAIN', path: 'main.nested.value', structural: true, value: 0 }))
+      .toEqual({ state: 'stale', value: 0 });
+  });
+  it.each([
+    null, { ...caps, providerGeneration: 2 }, { ...caps, providerGeneration: undefined },
+    { ...caps, stateContractVersion: undefined },
+  ])('fails closed on capability identity %j', (capabilities) => {
+    expect(project(0, snapshot(), capabilities)).toEqual({ state: 'unknown', reason: 'identity-unresolved' });
+  });
+  it('does not reuse values across reset, missing generation or contradictory receiver topology', () => {
+    expect(project(0.7)).toEqual({ state: 'current', value: 0.7 });
+    for (const state of [null, { ...snapshot(), providerGeneration: undefined }, { ...snapshot(), active: 'SUB' as const }]) {
+      expect(project(0.7, state)).toEqual({ state: 'unknown', reason: 'identity-unresolved' });
+    }
+    expect(project(0.2, snapshot({ freshness: 'stale' }))).toEqual({ state: 'stale', value: 0.2 });
+  });
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 /**
  * MOR-1065 — the live adapter behind the semantic VFO / RX-TX surfaces.
  *
@@ -863,5 +864,40 @@ describe('the emitted model carries only contract data', () => {
       'receiverIndicators', 'scope', 'scopeControls', 'split',
       'topologyId', 'txPermit', 'txTarget', 'vfoScheme', 'vfos',
     ]);
+  });
+});
+
+
+describe('RF gain additive display observation', () => {
+  const displayCaps = { ...INDICATOR_CAPS, stateContractVersion: 1, providerGeneration: 1 };
+  function displayState(stale = false) {
+    const state = indicatorState({ stateContractVersion: 1, providerGeneration: 1 });
+    state.fieldStatus!['main.rfGain'] = {
+      ...fresh, lastObservedMonotonic: 310658.42975425,
+      ...(stale ? { freshness: 'stale' as const, availability: 'stale' as const } : {}),
+    };
+    return state;
+  }
+  it.each([false, true])('preserves every strict model member for stale=%s', (stale) => {
+    const view = toRadioViewModel(displayState(stale), displayCaps, RECEIVING)!;
+    const strictJson = JSON.stringify(view, (key, value) => key === 'display' ? undefined : value);
+    const digest = createHash('sha256').update(strictJson).digest('hex');
+    expect(digest).toBe(stale ? 'b4b5cff2b85557e39baa48e4d73c756e12ff026488ffa05a1ef558ca0b3f0507' : '379a5f00e3bebae780e4215af4e014351df2a07fc067d412f97df6aeadca840f');
+  });
+  it.each([false, true])('projects explicit display without admitting stale RFgain, stale=%s', (stale) => {
+    const view = model(displayState(stale), displayCaps, RECEIVING);
+    expect(view.receiverIndicators![0].rfGain).toEqual({
+      reading: stale ? { status: 'unknown' } : { status: 'known', value: 0 },
+      availability: { structural: true, operational: !stale },
+      display: { state: stale ? 'stale' : 'current', value: 0 },
+    });
+  });
+  it('does not classify a fresh but nonoperational SUB as stale', () => {
+    const state = displayState();
+    state.dualWatch = false;
+    state.fieldStatus!['sub.rfGain'] = { ...fresh, lastObservedMonotonic: 310658.42975425 };
+    const view = model(state, { ...displayCaps, capabilities: displayCaps.capabilities.filter((cap) => cap !== 'dual_rx') }, RECEIVING);
+    expect(view.receiverIndicators![1].rfGain.availability.operational).toBe(false);
+    expect(view.receiverIndicators![1].rfGain.display).toEqual({ state: 'current', value: 0.75 });
   });
 });

--- a/frontend/src/lib/runtime/adapters/display-observation.ts
+++ b/frontend/src/lib/runtime/adapters/display-observation.ts
@@ -1,0 +1,58 @@
+import type { Capabilities } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import type { DisplayObservation, ReceiverId } from '../../../semantic/radio-view-model';
+
+type Scalar = number | string | boolean;
+
+function hasObservation(status: FieldStatus): boolean {
+  return status.observed === true;
+}
+
+function validEvidence(status: FieldStatus): boolean {
+  return (status.freshness === 'fresh' || status.freshness === 'stale')
+    && (status.availability === 'available' || status.availability === 'stale')
+    && typeof status.lastObservedMonotonic === 'number'
+    && Number.isFinite(status.lastObservedMonotonic) && status.lastObservedMonotonic >= 0;
+}
+
+export function qualifyDisplayObservation<T extends Scalar>({
+  state, caps, receiver, path, structural, value,
+}: {
+  state: ServerState | null;
+  caps: Capabilities | null;
+  receiver: ReceiverId;
+  path: string;
+  structural: boolean;
+  value: T | undefined;
+}): DisplayObservation<T> {
+  if (!structural) return { state: 'unsupported' };
+  const generation = state?.providerGeneration;
+  const receiverKey = receiver === 'MAIN' ? 'main' : 'sub';
+  if (!state || !caps || state.stateContractVersion !== 1 || caps.stateContractVersion !== 1
+    || typeof generation !== 'number' || !Number.isSafeInteger(generation) || generation < 0
+    || caps.providerGeneration !== generation
+    || (caps.receivers !== 1 && caps.receivers !== 2)
+    || (receiver === 'SUB' && caps.receivers !== 2)
+    || (state.active === 'SUB' && caps.receivers !== 2)
+    || !state[receiverKey] || !path.startsWith(`${receiverKey}.`)) {
+    return { state: 'unknown', reason: 'identity-unresolved' };
+  }
+  const leaf = state.fieldStatus?.[path];
+  if (!leaf || !hasObservation(leaf)) return { state: 'unknown', reason: 'not-observed' };
+  const statuses = [leaf];
+  let prefix = path;
+  for (let dot = prefix.lastIndexOf('.'); dot > 0; dot = prefix.lastIndexOf('.')) {
+    prefix = prefix.slice(0, dot);
+    const parent = state.fieldStatus?.[prefix];
+    if (!parent) continue;
+    if (!hasObservation(parent)) return { state: 'unknown', reason: 'not-observed' };
+    statuses.push(parent);
+  }
+  if (!statuses.every(validEvidence)) return { state: 'unknown', reason: 'invalid-evidence' };
+  if ((typeof value !== 'number' && typeof value !== 'boolean' && typeof value !== 'string')
+    || (typeof value === 'number' && !Number.isFinite(value)) || value === '') {
+    return { state: 'unknown', reason: 'invalid-value' };
+  }
+  const stale = statuses.some((status) => status.freshness === 'stale' || status.availability === 'stale');
+  return { state: stale ? 'stale' : 'current', value };
+}

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -37,6 +37,7 @@ import type {
   RadioWideIndicatorsViewModel, DualActionBlockViewModel,
 } from '../../../semantic/radio-view-model';
 import type { TxAuthoritySnapshot } from '../../../semantic/rx-tx-surface';
+import { qualifyDisplayObservation } from './display-observation';
 import { isFieldAvailable } from '$lib/state/field-status';
 import { modInputStateKey } from '$lib/radio/mod-input';
 import { flattenBands, findActiveBand } from '$lib/radio/band-plan';
@@ -782,7 +783,13 @@ function deriveReceiverIndicators(
       notchMode: txAuxField(hasNotch, notchOperational, notchMode),
       attenuator: strictField(hasAttenuator, 'att', numOrUndef(rx?.att)),
       preamp: strictField(hasPreamp, 'preamp', numOrUndef(rx?.preamp)),
-      rfGain: strictField(hasRfGain, 'rfGain', numOrUndef(rx?.rfGain)),
+      rfGain: {
+        ...strictField(hasRfGain, 'rfGain', numOrUndef(rx?.rfGain)),
+        display: qualifyDisplayObservation({
+          state, caps, receiver, path: path('rfGain'), structural: hasRfGain,
+          value: numOrUndef(rx?.rfGain),
+        }),
+      },
       digiSel: strictField(hasDigiSel, 'digisel', boolOrUndef(rx?.digisel)),
       ipPlus: strictField(hasIpPlus, 'ipplus', boolOrUndef(rx?.ipplus)),
     };

--- a/frontend/src/semantic/VfoIndicatorRow.svelte
+++ b/frontend/src/semantic/VfoIndicatorRow.svelte
@@ -150,6 +150,7 @@
       <span
         class="fact"
         data-indicator-fact="rf-gain"
+        role="img"
         data-state={indicator.rfGain.reading.status}
         data-display-state={indicator.rfGain.display?.state ?? (indicator.rfGain.reading.status === 'known' ? 'current' : 'unknown')}
         aria-label={`RF gain ${rfGainNumber(indicator.rfGain)}${indicator.rfGain.display?.state === 'stale' ? ' (stale, last observed)' : ''}`}

--- a/frontend/src/semantic/VfoIndicatorRow.svelte
+++ b/frontend/src/semantic/VfoIndicatorRow.svelte
@@ -7,7 +7,7 @@
   import type { Snippet } from 'svelte';
   import LinearSMeter from '../components-v2/meters/LinearSMeter.svelte';
   import type {
-    RadioWideIndicatorsViewModel, ReceiverIndicatorField,
+    DisplayObservedField, RadioWideIndicatorsViewModel, ReceiverIndicatorField,
     ReceiverIndicatorViewModel, TxAuxField,
   } from './radio-view-model';
 
@@ -29,6 +29,12 @@
 
   function numeric(field: ReceiverIndicatorField<number>): string {
     return field.reading.status === 'known' ? String(field.reading.value) : '—';
+  }
+
+  function rfGainNumber(field: DisplayObservedField<number>): string {
+    if (!field.display) return numeric(field);
+    return field.display.state === 'current' || field.display.state === 'stale'
+      ? String(field.display.value) : '—';
   }
 
   function agc(field: ReceiverIndicatorViewModel['agcMode']): string {
@@ -140,10 +146,22 @@
         DIGI-SEL {booleanLabel(indicator.digiSel)}
       </span>
     {/if}
-    {#if indicator.rfGain.availability.structural}
-      <span class="fact" data-indicator-fact="rf-gain" data-state={indicator.rfGain.reading.status}>
-        RFG {numeric(indicator.rfGain)}
-      </span>
+    {#if indicator.rfGain.availability.structural && indicator.rfGain.display?.state !== 'unsupported'}
+      <span
+        class="fact"
+        data-indicator-fact="rf-gain"
+        data-state={indicator.rfGain.reading.status}
+        data-display-state={indicator.rfGain.display?.state ?? (indicator.rfGain.reading.status === 'known' ? 'current' : 'unknown')}
+        aria-label={`RF gain ${rfGainNumber(indicator.rfGain)}${indicator.rfGain.display?.state === 'stale' ? ' (stale, last observed)' : ''}`}
+      >RFG {rfGainNumber(indicator.rfGain)}<span
+          class="stale-cue"
+          style:display="inline-block"
+          style:width="1ch"
+          style:margin-inline-start="0.25ch"
+          aria-hidden="true"
+          title="Stale: last observed value"
+          style:visibility={indicator.rfGain.display?.state === 'stale' ? 'visible' : 'hidden'}
+        >◷</span></span>
     {/if}
   </div>
 </section>

--- a/frontend/src/semantic/__tests__/VfoIndicatorRow.test.ts
+++ b/frontend/src/semantic/__tests__/VfoIndicatorRow.test.ts
@@ -211,6 +211,8 @@ describe('RF gain display observation', () => {
     const marker = node.querySelector('.stale-cue')!;
     const text = node.textContent;
     expect(text).toContain('RFG 0.75');
+    expect(target.querySelector('[role="img"][aria-label="RF gain 0.75"]')).toBe(node);
+    expect(node.hasAttribute('tabindex')).toBe(false);
     expect(getComputedStyle(marker).visibility).toBe('hidden');
     expect(getComputedStyle(marker).width).toBe('1ch');
     flushSync(() => state.set('indicator', indicator({ rfGain: {
@@ -221,13 +223,15 @@ describe('RF gain display observation', () => {
     expect(node.textContent).toBe(text);
     expect(node.getAttribute('data-state')).toBe('unknown');
     expect(node.getAttribute('data-display-state')).toBe('stale');
-    expect(node.getAttribute('aria-label')).toContain('stale');
+    expect(target.querySelector('[role="img"][aria-label="RF gain 0.75 (stale, last observed)"]')).toBe(node);
     expect(getComputedStyle(marker).visibility).toBe('visible');
     expect(marker.textContent?.trim()).not.toBe('');
     expect(target.querySelector('[aria-live], button, input')).toBeNull();
     flushSync(() => state.set('indicator', current));
     expect(node.textContent).toBe(text);
     expect(node.getAttribute('data-display-state')).toBe('current');
+    expect(target.querySelector('[role="img"][aria-label="RF gain 0.75"]')).toBe(node);
+    expect(target.querySelector('[role="img"][aria-label*="stale"]')).toBeNull();
     expect(getComputedStyle(marker).visibility).toBe('hidden');
   });
   it('does not display a strict fallback default when explicit observation is unknown', () => {

--- a/frontend/src/semantic/__tests__/VfoIndicatorRow.test.ts
+++ b/frontend/src/semantic/__tests__/VfoIndicatorRow.test.ts
@@ -1,3 +1,4 @@
+import { SvelteMap } from 'svelte/reactivity';
 import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { flushSync, mount, unmount, type ComponentProps } from 'svelte';
@@ -197,5 +198,48 @@ describe('MOR-2342 addressed meter appearance', () => {
     const source = readFileSync('src/semantic/VfoIndicatorRow.svelte', 'utf8');
     expect(source).toMatch(/\[data-indicator-appearance='standard'\] \.s-meter \{\s*width: 100%; max-width: 600px; height: 58px;/);
     expect(source).toContain("svg[data-variant='vfo-wide']");
+  });
+});
+
+
+describe('RF gain display observation', () => {
+  it.each(['semantic', 'standard', 'sdr'] as const)('keeps the same text and DOM footprint through current/stale/current for %s', (appearance) => {
+    const current = indicator({ rfGain: { ...known(0.75), display: { state: 'current', value: 0.75 } } });
+    const state = new SvelteMap([['indicator', current]]);
+    render({ appearance, get indicator() { return state.get('indicator'); } });
+    const node = target.querySelector('[data-indicator-fact="rf-gain"]')!;
+    const marker = node.querySelector('.stale-cue')!;
+    const text = node.textContent;
+    expect(text).toContain('RFG 0.75');
+    expect(getComputedStyle(marker).visibility).toBe('hidden');
+    expect(getComputedStyle(marker).width).toBe('1ch');
+    flushSync(() => state.set('indicator', indicator({ rfGain: {
+      ...unknown<number>(), display: { state: 'stale', value: 0.75 },
+    } })));
+    expect(target.querySelector('[data-indicator-fact="rf-gain"]')).toBe(node);
+    expect(node.querySelector('.stale-cue')).toBe(marker);
+    expect(node.textContent).toBe(text);
+    expect(node.getAttribute('data-state')).toBe('unknown');
+    expect(node.getAttribute('data-display-state')).toBe('stale');
+    expect(node.getAttribute('aria-label')).toContain('stale');
+    expect(getComputedStyle(marker).visibility).toBe('visible');
+    expect(marker.textContent?.trim()).not.toBe('');
+    expect(target.querySelector('[aria-live], button, input')).toBeNull();
+    flushSync(() => state.set('indicator', current));
+    expect(node.textContent).toBe(text);
+    expect(node.getAttribute('data-display-state')).toBe('current');
+    expect(getComputedStyle(marker).visibility).toBe('hidden');
+  });
+  it('does not display a strict fallback default when explicit observation is unknown', () => {
+    render({ indicator: indicator({ rfGain: {
+      ...known(0), display: { state: 'unknown', reason: 'not-observed' },
+    } }) });
+    const node = target.querySelector('[data-indicator-fact="rf-gain"]')!;
+    expect(node.textContent).toContain('RFG —');
+    expect(node.textContent).not.toContain('RFG 0');
+  });
+  it('keeps a display-unsupported RFgain absent', () => {
+    render({ indicator: indicator({ rfGain: { ...known(0), display: { state: 'unsupported' } } }) });
+    expect(target.querySelector('[data-indicator-fact="rf-gain"]')).toBeNull();
   });
 });

--- a/frontend/src/semantic/__tests__/radio-view-model.test.ts
+++ b/frontend/src/semantic/__tests__/radio-view-model.test.ts
@@ -400,3 +400,36 @@ describe('validateRadioViewModel', () => {
     })).toThrow(TypeError);
   });
 });
+
+
+describe('receiver RF gain display facet validation', () => {
+  function withDisplay(display: unknown): RadioViewModel {
+    const field = { reading: { status: 'unknown' }, availability: { structural: true, operational: false } };
+    return { ...valid(), receiverIndicators: [{
+      receiver: 'MAIN', availability: field.availability,
+      sMeter: field, bandwidthHz: field, agcMode: field, nbActive: field, nrActive: field,
+      notchMode: field, attenuator: field, preamp: field, digiSel: field, ipPlus: field,
+      rfGain: { ...field, display },
+    }] } as RadioViewModel;
+  }
+  it.each([
+    { state: 'current', value: 0 }, { state: 'stale', value: 0.75 },
+    { state: 'unknown', reason: 'not-observed' }, { state: 'unsupported' },
+  ])('round-trips typed RF gain display %j without changing strict facts', (display) => {
+    const view = withDisplay(display);
+    expect(validateRadioViewModel(view)).toEqual(view);
+  });
+  it.each([
+    { state: 'current', value: false }, { state: 'stale', value: Infinity },
+    { state: 'current' }, { state: 'unknown' }, { state: 'unknown', reason: 'made-up' },
+    { state: 'unknown', reason: 'not-observed', value: 0 }, { state: 'unsupported', value: 0 },
+    { state: 'stale', value: 0, permitted: true },
+  ])('rejects malformed display %j', (display) => {
+    expect(() => validateRadioViewModel(withDisplay(display))).toThrow();
+  });
+  it('keeps unmigrated receiver fields strict rather than accepting arbitrary display facets', () => {
+    const view = withDisplay({ state: 'current', value: 0 });
+    Object.assign(view.receiverIndicators![0].sMeter, { display: { state: 'stale', value: 0 } });
+    expect(() => validateRadioViewModel(view)).toThrow();
+  });
+});

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -134,6 +134,15 @@ export interface TxAuxField<T> {
   reading: TxAuxReading<T>;
   availability: Availability;
 }
+export type DisplayObservation<T> =
+  | { readonly state: 'current' | 'stale'; readonly value: T }
+  | { readonly state: 'unknown'; readonly reason: 'not-observed' | 'invalid-value' | 'invalid-evidence' | 'identity-unresolved' }
+  | { readonly state: 'unsupported' };
+
+export interface DisplayObservedField<T> extends TxAuxField<T> {
+  readonly display?: DisplayObservation<T>;
+}
+
 export type AtuStatus = 'off' | 'on' | 'tuning';
 
 /**
@@ -1018,7 +1027,7 @@ export interface ReceiverIndicatorViewModel {
   notchMode: ReceiverIndicatorField<'off' | 'auto' | 'manual'>;
   attenuator: ReceiverIndicatorField<number>;
   preamp: ReceiverIndicatorField<number>;
-  rfGain: ReceiverIndicatorField<number>;
+  rfGain: DisplayObservedField<number>;
   digiSel: ReceiverIndicatorField<boolean>;
   ipPlus: ReceiverIndicatorField<boolean>;
 }
@@ -1419,6 +1428,38 @@ function validateTxAux(value: unknown, path: string): TxAuxViewModel {
   };
 }
 
+function validateDisplayObservation<T>(
+  value: unknown, path: string, validateValue: (v: unknown, p: string) => T,
+): DisplayObservation<T> {
+  const v = record(value, path);
+  if (v.state === 'current' || v.state === 'stale') {
+    exactKeys(v, ['state', 'value'], path);
+    return { state: v.state, value: validateValue(v.value, `${path}.value`) };
+  }
+  if (v.state === 'unknown') {
+    exactKeys(v, ['state', 'reason'], path);
+    return { state: 'unknown', reason: oneOf(v.reason,
+      ['not-observed', 'invalid-value', 'invalid-evidence', 'identity-unresolved'] as const, `${path}.reason`) };
+  }
+  if (v.state === 'unsupported') {
+    exactKeys(v, ['state'], path);
+    return { state: 'unsupported' };
+  }
+  return invalid(`${path}.state`, "'current' | 'stale' | 'unknown' | 'unsupported'");
+}
+
+function validateDisplayObservedField<T>(
+  value: unknown, path: string, validateValue: (v: unknown, p: string) => T,
+): DisplayObservedField<T> {
+  const v = record(value, path);
+  exactKeys(v, ['reading', 'availability', 'display'], path);
+  const strict = validateTxAuxField({ reading: v.reading, availability: v.availability }, path, validateValue);
+  return {
+    ...strict,
+    ...(v.display !== undefined ? { display: validateDisplayObservation(v.display, `${path}.display`, validateValue) } : {}),
+  };
+}
+
 function validateReceiverIndicator(value: unknown, path: string): ReceiverIndicatorViewModel {
   const v = record(value, path);
   exactKeys(v, [
@@ -1445,7 +1486,7 @@ function validateReceiverIndicator(value: unknown, path: string): ReceiverIndica
     ),
     attenuator: validateTxAuxField(v.attenuator, `${path}.attenuator`, num),
     preamp: validateTxAuxField(v.preamp, `${path}.preamp`, num),
-    rfGain: validateTxAuxField(v.rfGain, `${path}.rfGain`, num),
+    rfGain: validateDisplayObservedField(v.rfGain, `${path}.rfGain`, num),
     digiSel: validateTxAuxField(v.digiSel, `${path}.digiSel`, bool),
     ipPlus: validateTxAuxField(v.ipPlus, `${path}.ipPlus`, bool),
   };


### PR DESCRIPTION
RF gain previously became a dash when its observation aged, even though the accepted snapshot retained its last value. This adds `current(value)`, `stale(value)`, `unknown(reason)` and `unsupported` display observations, migrating only the receiver RF gain readout in `VfoIndicatorRow`. A stale value keeps its numeric text and gains a reserved clock cue and accessible stale description.

The qualifier uses the current snapshot without a cache. It requires matching state/capability provider provenance, receiver identity, an explicitly observed leaf and finite fractional observation markers; explicit ancestor status can veto or downgrade the leaf. Missing provenance does not turn raw defaults into retained observations. Freshness remains distinct from operational availability.

Eight files form one MOR-1413 vertical slice: vocabulary/parser, qualifier, adapter, common readout and their tests (336 changed lines). Existing strict readings, availability, command/TX admission, RF state, ATU and all unmigrated field validators stay unchanged. RF gain formatting remains `String(value)`; this is not the remaining field migration or LCD display-projection migration.

Validation on an isolated Mini worktree:
- Test-first adapter and component/parser witnesses failed before production edits.
- 167 focused tests passed for the data/projection slice. The final accessibility-only correction passed the 20-test component file, including supported role/name queries across current→stale→current; the strengthened test failed before adding the named readout role. Unchanged qualifier/contract suites were not repeated.
- Full strict-model hashes captured before production edits remain equal for fresh and stale fixtures after removing only the new display members.
- Final `npm run check`: zero errors/warnings; targeted ESLint and `git diff --check` passed. The data/projection candidate production build passed; it was not repeated for the role/test-only correction.
- Component tests exercise current→stale→current for semantic, Standard and SDR appearances with stable text/node identity and reserved cue styling. They do not claim measured browser geometry or live-radio acceptance.

Independent review and exact-head CI pending. Full suites remain CI-owned. No live radio, service, serial, browser or settings changes.
