### PR TITLE
fix: preserve fenced PBT display observations (MOR-1692)

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -552,7 +552,7 @@
       if (Number.isSafeInteger(generation)) for (const receiver of ['MAIN', 'SUB'] as const) {
         for (const field of ['pbtInner', 'pbtOuter'] as const) {
           const marker = runtime.state?.fieldStatus?.[`${receiver.toLowerCase()}.${field}`]?.lastObservedMonotonic;
-          if (typeof marker === 'number' && Number.isSafeInteger(marker)) {
+          if (typeof marker === 'number' && Number.isFinite(marker) && marker >= 0) {
             const key = pbtFloorKey(generation as number, receiver, field);
             pbtObservationFloors.set(key, Math.max(pbtObservationFloors.get(key) ?? -1, marker as number));
           }
@@ -575,12 +575,15 @@
       const path = `${receiver?.status === 'known' && receiver.receiver === 'SUB' ? 'sub' : 'main'}.${name}`;
       const status = state?.fieldStatus?.[path];
       const observedAt = status?.lastObservedMonotonic;
-      return status?.observed && status.freshness === 'fresh' && status.availability === 'available'
-        && typeof observedAt === 'number' && Number.isSafeInteger(observedAt)
+      const display = canonicalView?.filterPassband?.[name].display;
+      const admitted = boundary !== null && status?.observed
+        && typeof observedAt === 'number' && Number.isFinite(observedAt) && observedAt >= 0
         && observedAt > (typeof generation === 'number' && receiver?.status === 'known'
-          ? pbtObservationFloors.get(pbtFloorKey(generation, receiver.receiver, name)) ?? -1 : -1)
-        ? { status: 'fresh' as const, marker: { source: 'field' as const, value: observedAt as number } }
-        : { status: status?.freshness === 'stale' ? 'stale' as const : 'unavailable' as const };
+          ? pbtObservationFloors.get(pbtFloorKey(generation, receiver.receiver, name)) ?? -1 : -1);
+      return admitted && (display?.state === 'current' || display?.state === 'stale')
+        ? { status: display.state === 'current' ? 'fresh' as const : 'stale' as const,
+          marker: { source: 'field' as const, value: observedAt } }
+        : { status: 'unavailable' as const };
     };
     return { boundary, fields: { pbtInner: field('pbtInner'), pbtOuter: field('pbtOuter') } };
   };
@@ -592,8 +595,7 @@
       const current = canonicalView?.filterPassband?.[field];
       return retained !== null && incoming.status === 'fresh'
         && incoming.marker.source === retained.marker.source && incoming.marker.value === retained.marker.value
-        && current?.reading.status === 'known' && current.reading.value === retained.value
-        && current.availability.operational;
+        && current?.display?.state === 'current' && current.display.value === retained.value;
     };
     const previous = retainedMatchesCanonical('pbtInner') || retainedMatchesCanonical('pbtOuter') ? {
       ...untrack(() => pbtPresentation),
@@ -607,10 +609,20 @@
       filterPassband: {
         ...canonicalView.filterPassband,
         ...(evidence.fields.pbtInner.status !== 'fresh' ? {
-          pbtInner: { reading: { status: 'unknown' as const }, availability: { ...canonicalView.filterPassband.pbtInner.availability, operational: false } },
+          pbtInner: {
+            reading: { status: 'unknown' as const },
+            availability: { ...canonicalView.filterPassband.pbtInner.availability, operational: false },
+            display: evidence.fields.pbtInner.status === 'stale' ? canonicalView.filterPassband.pbtInner.display
+              : { state: 'unknown' as const, reason: 'invalid-evidence' as const },
+          },
         } : {}),
         ...(evidence.fields.pbtOuter.status !== 'fresh' ? {
-          pbtOuter: { reading: { status: 'unknown' as const }, availability: { ...canonicalView.filterPassband.pbtOuter.availability, operational: false } },
+          pbtOuter: {
+            reading: { status: 'unknown' as const },
+            availability: { ...canonicalView.filterPassband.pbtOuter.availability, operational: false },
+            display: evidence.fields.pbtOuter.status === 'stale' ? canonicalView.filterPassband.pbtOuter.display
+              : { state: 'unknown' as const, reason: 'invalid-evidence' as const },
+          },
         } : {}),
       },
     } : canonicalView;

--- a/frontend/src/components-v2/wiring/__tests__/semantic-pbt-continuity.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-pbt-continuity.component.test.ts
@@ -83,7 +83,72 @@ describe('mounted PBT continuity is fenced by the live control session (MOR-1706
 
   it('does not carry a generation-seven floor into generation-eight marker one', () => {
     accept(state(100, -200, 100)); render(); transition('disconnected', 1); expect(value('pbtInner')).toBeNull();
+    transition('connected', 1);
     expect(setCapabilities(caps(8))).toBe(true); accept(state(900, -900, 1, 8)); flushSync();
     expect(value('pbtInner')).not.toBeNull(); expect(h.commands).not.toHaveBeenCalled(); expect(txHarness.trace()).toEqual([]);
+  });
+});
+
+
+describe('mounted fractional PBT display (MOR-1692)', () => {
+  const update = (inner: number, marker: number, observedMarker: number, stale = false) => {
+    const next = state(inner, 128, marker, 7, 'MAIN', 'fresh', observedMarker);
+    if (stale) next.fieldStatus!['main.pbtInner'] = { ...fresh(observedMarker), freshness: 'stale', availability: 'stale' };
+    accept(next); flushSync();
+  };
+  const row = () => target.querySelector<HTMLElement>('[data-testid="filter-pbtInner"]')!;
+
+  it('keeps the row and slot through fractional stale edges, readback and unknown; rejects synthetic input', () => {
+    update(150, 2, 310658.42975425); render();
+    const wrapper = row(), slot = wrapper.querySelector('[data-pbt-slot]');
+    const confirmed = value('pbtInner'); expect(confirmed).not.toBeNull(); expect(slot).not.toBeNull();
+    update(150, 3, 310658.42975425, true);
+    expect(row()).toBe(wrapper); expect(row().querySelector('[data-pbt-slot]')).toBe(slot);
+    expect(value('pbtInner')).toBe(confirmed); expect(row().dataset.presentation).toBe('retained');
+    const slider = row().querySelector('input')!;
+    expect(slider.disabled).toBe(true); slider.value = '500'; slider.dispatchEvent(new Event('input', { bubbles: true })); flushSync();
+    expect(h.commands).not.toHaveBeenCalled();
+    update(160, 4, 310659.1);
+    expect(row().dataset.presentation).toBe('confirmed'); expect(value('pbtInner')).not.toBe(confirmed);
+    transition('disconnected', 1, false); transition('connected', 1, false); flushSync();
+    expect(row()).toBe(wrapper); expect(row().querySelector('[data-pbt-slot]')).toBe(slot); expect(value('pbtInner')).toBeNull();
+    update(160, 5, 310659.1, true); expect(value('pbtInner')).toBeNull();
+    update(170, 6, 310659.2, true); expect(value('pbtInner')).not.toBeNull(); expect(row().dataset.presentation).toBe('retained');
+    expect(h.commands).not.toHaveBeenCalled(); expect(txHarness.trace()).toEqual([]);
+  });
+
+  it.each([20.25, 20.0])('rejects a conflicting replay at %s and its synthetic input', (marker) => {
+    update(150, 2, 20.25); render(); const confirmed = value('pbtInner');
+    update(170, 3, marker);
+    const input = row().querySelector('input')!;
+    expect(input.value).toBe(confirmed); expect(input.disabled).toBe(true);
+    input.value = '500'; input.dispatchEvent(new Event('input', { bubbles: true })); flushSync();
+    expect(h.commands).not.toHaveBeenCalled();
+    update(180, 4, 20.5); expect(row().querySelector('input')!.disabled).toBe(false);
+    expect(value('pbtInner')).not.toBe(confirmed);
+  });
+
+  it('never retains a drag target in place of the observed readback', () => {
+    update(150, 2, 20.25); render(); const confirmed = value('pbtInner');
+    const input = row().querySelector('input')!;
+    input.value = '500'; input.dispatchEvent(new Event('input', { bubbles: true })); flushSync();
+    expect(h.commands).toHaveBeenCalled(); h.commands.mockClear();
+    update(150, 3, 20.25, true);
+    expect(value('pbtInner')).toBe(confirmed);
+    expect(row().querySelector('output')?.textContent).toBe(confirmed);
+    expect(row().querySelector('input')!.disabled).toBe(true);
+    expect(h.commands).not.toHaveBeenCalled();
+    update(160, 4, 20.5); expect(value('pbtInner')).not.toBe(confirmed);
+  });
+
+  it('admits stale first, respects an unobserved ancestor, and accepts a low new-generation marker', () => {
+    update(150, 2, 10.5, true); render(); expect(value('pbtInner')).not.toBeNull(); expect(row().dataset.presentation).toBe('retained');
+    transition('disconnected', 1); expect(value('pbtInner')).toBeNull();
+    const hidden = state(180, 128, 3, 7, 'MAIN', 'fresh', 11.5);
+    hidden.fieldStatus!.main = { ...fresh(11.5), observed: false };
+    accept(hidden); transition('connected', 1); expect(value('pbtInner')).toBeNull();
+    expect(setCapabilities(caps(8))).toBe(true);
+    accept(state(190, 128, 1, 8, 'MAIN', 'fresh', 0.25)); flushSync();
+    expect(value('pbtInner')).not.toBeNull(); expect(row().dataset.presentation).toBe('confirmed');
   });
 });

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts
@@ -150,10 +150,10 @@ describe('filterPassband per-field structural gates (MOR-1284)', () => {
   it('pbtInner/pbtOuter are structurally absent when pbt is declared but caps carries no usable pbt_inner range', () => {
     const view = model(bareState(), caps({ capabilities: ['pbt'] }));
     expect(view.filterPassband!.pbtInner).toEqual({
-      reading: { status: 'unknown' }, availability: { structural: false, operational: false },
+      reading: { status: 'unknown' }, availability: { structural: false, operational: false }, display: { state: 'unsupported' },
     });
     expect(view.filterPassband!.pbtOuter).toEqual({
-      reading: { status: 'unknown' }, availability: { structural: false, operational: false },
+      reading: { status: 'unknown' }, availability: { structural: false, operational: false }, display: { state: 'unsupported' },
     });
   });
 
@@ -375,8 +375,8 @@ describe('pbtInner/pbtOuter/ifShift are deterministic in (state, caps) — MOR-1
       const absent = {
         reading: { status: 'unknown' as const }, availability: { structural: false, operational: false },
       };
-      expect(view.filterPassband!.pbtInner).toEqual(absent);
-      expect(view.filterPassband!.pbtOuter).toEqual(absent);
+      expect(view.filterPassband!.pbtInner).toEqual({ ...absent, display: { state: 'unsupported' } });
+      expect(view.filterPassband!.pbtOuter).toEqual({ ...absent, display: { state: 'unsupported' } });
       expect(view.filterPassband!.ifShift).toEqual(absent);
     },
   );
@@ -622,5 +622,59 @@ describe('filterPassband validator round-trip (MOR-1284)', () => {
       main: { ...bareState().main, filterShape: 'sharp' as unknown as number },
     }), caps({ filters: ['FIL1'] }));
     expect(view.filterPassband!.filterShape.reading).toEqual({ status: 'unknown' });
+  });
+});
+
+
+describe('PBT display observations (MOR-1692)', () => {
+  const range: ControlRange = { raw_min: 0, raw_max: 200, raw_center: 100, display_min: -900, display_max: 900 };
+  const ownCaps = caps({ capabilities: ['pbt'], controls: { pbt_inner: range } });
+  const observed = { ...fresh, lastObservedMonotonic: 310658.42975425 };
+  const source = (status: FieldStatus | undefined = observed, raw = 150): ServerState => bareState({
+    stateContractVersion: 1, providerGeneration: 0,
+    main: { ...bareState().main, pbtInner: raw, pbtOuter: 100 },
+    fieldStatus: { ...bareState().fieldStatus, ...(status ? { 'main.pbtInner': status } : {}), 'main.pbtOuter': observed },
+  });
+
+  it.each(['fresh', 'stale'] as const)('adds %s scaled display without changing strict facts', (freshness) => {
+    const input = source({ ...observed, freshness, availability: freshness === 'fresh' ? 'available' : 'stale' });
+    const result = model(input, ownCaps).filterPassband!;
+    const { display, ...strict } = result.pbtInner;
+    expect(display).toEqual({ state: freshness === 'fresh' ? 'current' : 'stale', value: 450 });
+    expect(strict).toEqual({ reading: freshness === 'fresh' ? { status: 'known', value: 450 } : { status: 'unknown' }, availability: { structural: true, operational: freshness === 'fresh' } });
+    expect(result.pbtOuter.display).toEqual({ state: 'current', value: 0 });
+    const { display: outerDisplay, ...strictOuter } = result.pbtOuter;
+    const absent = { reading: { status: 'unknown' }, availability: { structural: false, operational: false } };
+    expect({ ...result, pbtInner: strict, pbtOuter: strictOuter }).toEqual({
+      filterShape: absent, filterShapeControlStructural: false, ifShiftControlStructural: false, dataMode: absent,
+      ifShift: { reading: freshness === 'fresh' ? { status: 'known', value: 225 } : { status: 'unknown' }, availability: { structural: true, operational: freshness === 'fresh' } },
+      pbtInner: strict,
+      pbtOuter: { reading: { status: 'known', value: 0 }, availability: { structural: true, operational: true } },
+    });
+    expect(outerDisplay).toEqual({ state: 'current', value: 0 });
+    expect(validateRadioViewModel(model(input, ownCaps))).toEqual(model(input, ownCaps));
+  });
+
+  it.each([
+    ['missing marker', { ...fresh }, 'invalid-evidence'],
+    ['unobserved', { ...observed, observed: false }, 'not-observed'],
+    ['negative marker', { ...observed, lastObservedMonotonic: -0.5 }, 'invalid-evidence'],
+  ] as const)('rejects %s without fabricating a measurement', (_name, status, reason) => {
+    expect(model(source(status), ownCaps).filterPassband!.pbtInner.display).toEqual({ state: 'unknown', reason });
+  });
+
+  it('rejects missing metadata, invalid values, caps mismatch and absent scale', () => {
+    const missing = source(); delete missing.fieldStatus!['main.pbtInner'];
+    expect(model(missing, ownCaps).filterPassband!.pbtInner.display).toEqual({ state: 'unknown', reason: 'not-observed' });
+    expect(model(source(observed, NaN), ownCaps).filterPassband!.pbtInner.display).toEqual({ state: 'unknown', reason: 'invalid-value' });
+    expect(model(source(), { ...ownCaps, providerGeneration: 2 }).filterPassband!.pbtInner.display).toEqual({ state: 'unknown', reason: 'identity-unresolved' });
+    expect(model(source(), { ...ownCaps, controls: {} }).filterPassband!.pbtInner.display).toEqual({ state: 'unsupported' });
+  });
+
+  it.each(['stale', 'unobserved'] as const)('honors a %s ancestor independently of a fresh leaf', (parent) => {
+    const input = source(); input.fieldStatus!.main = parent === 'stale'
+      ? { ...observed, freshness: 'stale', availability: 'stale' } : { ...observed, observed: false };
+    expect(model(input, ownCaps).filterPassband!.pbtInner.display).toEqual(parent === 'stale'
+      ? { state: 'stale', value: 450 } : { state: 'unknown', reason: 'not-observed' });
   });
 });

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -548,8 +548,20 @@ function deriveFilterPassband(
     // dead" doctrine `ifShiftControlStructural` above already established,
     // never a plausible IC-7610-shaped reading manufactured from a
     // module-global store fallback (see the `pbtScale` doc comment above).
-    pbtInner: txAuxField(hasPbtCap && hasPbtRange, pbtInnerObserved, pbtInnerHz),
-    pbtOuter: txAuxField(hasPbtCap && hasPbtRange, pbtOuterObserved, pbtOuterHz),
+    pbtInner: {
+      ...txAuxField(hasPbtCap && hasPbtRange, pbtInnerObserved, pbtInnerHz),
+      display: qualifyDisplayObservation({
+        state, caps, receiver: onSub ? 'SUB' : 'MAIN', path: `${base}pbtInner`,
+        structural: hasPbtCap && hasPbtRange, value: pbtInnerHz,
+      }),
+    },
+    pbtOuter: {
+      ...txAuxField(hasPbtCap && hasPbtRange, pbtOuterObserved, pbtOuterHz),
+      display: qualifyDisplayObservation({
+        state, caps, receiver: onSub ? 'SUB' : 'MAIN', path: `${base}pbtOuter`,
+        structural: hasPbtCap && hasPbtRange, value: pbtOuterHz,
+      }),
+    },
     dataMode: txAuxField(hasDataModeCap, dataModeObserved, numOrUndef(rx?.dataMode)),
   };
 }

--- a/frontend/src/semantic/FilterSurface.svelte
+++ b/frontend/src/semantic/FilterSurface.svelte
@@ -87,8 +87,9 @@
       : { state: 'unknown' as const, reason: 'not-observed' as const }
   );
   const pbtUsable = (f: DisplayObservedField<number>): boolean => usable(f) && pbtDisplay(f).state === 'current';
-  const numberOf = (f: TxAuxField<number>, fallback: number): number =>
-    f.reading.status === 'known' ? f.reading.value : fallback;
+  const numberOf = (f: DisplayObservedField<number>, fallback: number): number =>
+    f.display?.state === 'current' || f.display?.state === 'stale' ? f.display.value
+      : f.reading.status === 'known' ? f.reading.value : fallback;
   /** Never fabricates a selection: `usable` alone cannot narrow `reading` for
    *  the `===` comparison below, so the known-check is repeated explicitly. */
   const isSelected = (f: TxAuxField<unknown>, value: unknown): boolean =>
@@ -202,6 +203,18 @@
     {/if}
 
     {#if filterPassband}
+      {#snippet passbandRange(field: FilterPassbandLevelField, min: number, max: number, step: number)}
+        {@const display = field === 'ifShift' ? undefined : pbtDisplay(filterPassband[field])}
+        {#key display?.state}
+          <input
+            id={`${pendingFilterId}-${field}-input`} type="range" {min} {max} {step}
+            value={numberOf(filterPassband[field], min)}
+            aria-describedby={display?.state === 'stale' ? `${pendingFilterId}-${field}-description` : undefined}
+            disabled={field === 'ifShift' ? !usable(filterPassband[field]) : !pbtUsable(filterPassband[field])}
+            oninput={(event) => changePassband(field, event.currentTarget.valueAsNumber)}
+          />
+        {/key}
+      {/snippet}
       {#if filterPassband.filterShapeControlStructural}
         <div
           class="filter-choice-group" data-testid="filter-shape"
@@ -228,17 +241,10 @@
               data-disabled-reason={reasonOf(filterPassband[field])}
               data-presentation={display.state === 'current' ? 'confirmed' : display.state === 'stale' ? 'retained' : 'unknown'}
             >
-              <span class="filter-level-name">{label}</span>
+              <label class="filter-level-name" for={`${pendingFilterId}-${field}-input`}>{label}</label>
               <span class="pbt-slot" data-pbt-slot>
                 {#if display.state === 'current' || display.state === 'stale'}
-                  {#key display.state}
-                    <input
-                      type="range" {min} {max} {step} value={display.value} aria-label={label}
-                      aria-describedby={display.state === 'stale' ? descriptionId : undefined}
-                      disabled={!pbtUsable(filterPassband[field])}
-                      oninput={(event) => changePassband(field, event.currentTarget.valueAsNumber)}
-                    />
-                  {/key}
+                  {@render passbandRange(field, min, max, step)}
                 {:else}
                   <span class="pbt-unknown">{t('core.vfo.state.unknown')}</span>
                 {/if}
@@ -258,12 +264,7 @@
               data-presentation={presentationOf(filterPassband[field])}
             >
               <span class="filter-level-name">{label}</span>
-              <input
-                type="range" {min} {max} {step}
-                value={numberOf(filterPassband[field], min)}
-                disabled={!usable(filterPassband[field])}
-                oninput={(event) => changePassband(field, event.currentTarget.valueAsNumber)}
-              />
+              {@render passbandRange(field, min, max, step)}
               <output>{textOf(filterPassband[field])}</output>
             </label>
           {/if}

--- a/frontend/src/semantic/FilterSurface.svelte
+++ b/frontend/src/semantic/FilterSurface.svelte
@@ -55,7 +55,7 @@
   never something computed off the pending display.
 -->
 <script module lang="ts">
-  import type { TxAuxField } from './radio-view-model';
+  import type { DisplayObservedField, TxAuxField } from './radio-view-model';
 
   /** Fixed filter-shape choice set (SHARP/SOFT) — same two options
    *  `FilterPanel`'s shape buttons offer, `[value, label]`. */
@@ -81,6 +81,12 @@
     f.reading.status === 'known' ? String(f.reading.value) : '?';
   const presentationOf = (f: TxAuxField<unknown>): 'confirmed' | 'retained' | 'unknown' =>
     usable(f) ? 'confirmed' : f.reading.status === 'known' ? 'retained' : 'unknown';
+  const pbtDisplay = (f: DisplayObservedField<number>) => f.display ?? (
+    f.reading.status === 'known'
+      ? { state: usable(f) ? 'current' as const : 'stale' as const, value: f.reading.value }
+      : { state: 'unknown' as const, reason: 'not-observed' as const }
+  );
+  const pbtUsable = (f: DisplayObservedField<number>): boolean => usable(f) && pbtDisplay(f).state === 'current';
   const numberOf = (f: TxAuxField<number>, fallback: number): number =>
     f.reading.status === 'known' ? f.reading.value : fallback;
   /** Never fabricates a selection: `usable` alone cannot narrow `reading` for
@@ -134,6 +140,7 @@
    *  header, rule 3), this only routes the already-checked value onward. */
   function changePassband(field: FilterPassbandLevelField, value: number): void {
     if (!filterPassband || !usable(filterPassband[field])) return;
+    if (field !== 'ifShift' && !pbtUsable(filterPassband[field])) return;
     if (field === 'ifShift') onIfShiftChange?.(value);
     else if (field === 'pbtInner') onPbtInnerChange?.(value);
     else onPbtOuterChange?.(value);
@@ -212,14 +219,37 @@
       {/if}
       {#each FILTER_PASSBAND_LEVELS as [field, label, min, max, step] (field)}
         {#if field === 'ifShift' ? filterPassband.ifShiftControlStructural : filterPassband[field].availability.structural}
-          {#if (field === 'pbtInner' || field === 'pbtOuter') && filterPassband[field].reading.status !== 'known'}
+          {#if field === 'pbtInner' || field === 'pbtOuter'}
+            {@const display = pbtDisplay(filterPassband[field])}
+            {@const measured = display.state === 'current' || display.state === 'stale'}
+            {@const descriptionId = `${pendingFilterId}-${field}-description`}
             <div
-              class="filter-level" data-testid={`filter-${field}`} role="status"
-              aria-label={`${label}: unavailable; value not observed`}
-              data-disabled-reason={reasonOf(filterPassband[field])} data-presentation="unknown"
+              class="filter-level" data-testid={`filter-${field}`} role="group" aria-label={label}
+              data-disabled-reason={reasonOf(filterPassband[field])}
+              data-presentation={display.state === 'current' ? 'confirmed' : display.state === 'stale' ? 'retained' : 'unknown'}
             >
               <span class="filter-level-name">{label}</span>
-              <span>Unavailable — value not observed</span>
+              <span class="pbt-slot" data-pbt-slot>
+                {#if display.state === 'current' || display.state === 'stale'}
+                  {#key display.state}
+                    <input
+                      type="range" {min} {max} {step} value={display.value} aria-label={label}
+                      aria-describedby={display.state === 'stale' ? descriptionId : undefined}
+                      disabled={!pbtUsable(filterPassband[field])}
+                      oninput={(event) => changePassband(field, event.currentTarget.valueAsNumber)}
+                    />
+                  {/key}
+                {:else}
+                  <span class="pbt-unknown">{t('core.vfo.state.unknown')}</span>
+                {/if}
+              </span>
+              <output class="pbt-value" aria-live="off">{measured && 'value' in display ? display.value : '—'}</output>
+              <span class="pbt-cue" data-stale-cue title={display.state === 'stale' ? t('core.rxTx.target.reason.stale') : undefined}>
+                {#if display.state === 'stale'}<span aria-hidden="true">†</span>{/if}
+              </span>
+              {#if display.state === 'stale'}
+                <span class="sr-only" id={descriptionId}>{t('core.rxTx.target.reason.stale')}</span>
+              {/if}
             </div>
           {:else}
             <label
@@ -257,6 +287,11 @@
   .filter-choice-group { display: flex; flex-wrap: wrap; gap: 0.5rem; }
   .filter-level, .filter-readout { display: flex; align-items: baseline; gap: 0.5rem; }
   .filter-level-name { min-width: 8ch; }
+  .pbt-slot { display: inline-flex; align-items: center; width: 8rem; height: 1.5rem; }
+  .pbt-slot input { width: 100%; margin-inline: 0; }
+  .pbt-unknown { width: 100%; text-align: center; }
+  .pbt-value { min-width: 6ch; font-variant-numeric: tabular-nums; }
+  .pbt-cue { width: 1ch; }
   .filter-choice[aria-pressed='true'] { font-weight: 700; }
   .filter-choice:disabled { cursor: not-allowed; }
   /* MOR-1441 leg 2 — a pending (unconfirmed) target never renders identically

--- a/frontend/src/semantic/__tests__/FilterSurface.test.ts
+++ b/frontend/src/semantic/__tests__/FilterSurface.test.ts
@@ -752,6 +752,7 @@ describe('explicit PBT display (MOR-1692)', () => {
     withSurface(current, (s) => {
       const group = s.group(`filter-${field}`)!, input = s.input(`filter-${field}`)!;
       expect(input).not.toBeNull(); expect(input.disabled).toBe(true); expect(input.value).toBe('425');
+      expect(Array.from(input.labels ?? []).map((label) => label.textContent)).toContain(field === 'pbtInner' ? 'PBT inner' : 'PBT outer');
       expect(s.output(`filter-${field}`)?.textContent).toBe('425');
       expect(s.output(`filter-${field}`)?.getAttribute('aria-live')).toBe('off');
       const description = document.getElementById(input.getAttribute('aria-describedby')!);

--- a/frontend/src/semantic/__tests__/FilterSurface.test.ts
+++ b/frontend/src/semantic/__tests__/FilterSurface.test.ts
@@ -533,14 +533,17 @@ describe('unknown PBT has no fabricated numeric semantics (MOR-1705)', () => {
     ['pbtOuter', 'PBT outer', 'onPbtOuterChange'],
   ] as const;
 
-  it.each(PBT_FIELDS)('renders unknown %s as an accessible indeterminate status with no command target', (field, label, handler) => {
+  it.each(PBT_FIELDS)('renders unknown %s as an accessible non-live slot with no command target', (field, label, handler) => {
     const spy = vi.fn();
     const view = withPassbandField(base(), field, { unknown: true });
     withSurface(view, (s) => {
       const group = s.group(`filter-${field}`)!;
-      expect(group.getAttribute('role')).toBe('status');
-      expect(group.getAttribute('aria-label')).toBe(`${label}: unavailable; value not observed`);
-      expect(group.textContent).toContain('Unavailable — value not observed');
+      expect(group.getAttribute('role')).toBe('group');
+      expect(group.getAttribute('aria-label')).toBe(label);
+      expect(group.textContent).toContain('unknown');
+      expect(group.querySelector('[data-pbt-slot]')).not.toBeNull();
+      expect(group.querySelector('[aria-live]:not([aria-live="off"]), [role="status"]')).toBeNull();
+      expect(group.querySelector('output')?.getAttribute('aria-live')).toBe('off');
       expect(group.querySelector('input')).toBeNull();
       expect(group.querySelector('[aria-valuenow]')).toBeNull();
       expect(s.input(`filter-${field}`)).toBeNull();
@@ -738,5 +741,46 @@ describe('the surface never re-derives what the adapter already computed', () =>
     expect(source).not.toMatch(/\$lib\/transport/);
     expect(source).not.toMatch(/audio-manager/);
     expect(source).not.toMatch(/\$lib\/runtime/);
+  });
+});
+
+
+describe('explicit PBT display (MOR-1692)', () => {
+  it.each(['pbtInner', 'pbtOuter'] as const)('renders stale %s numerically with a non-live description and guarded input', (field) => {
+    const current = base(), onChange = vi.fn();
+    current.filterPassband![field] = { reading: { status: 'unknown' }, availability: { structural: true, operational: false }, display: { state: 'stale', value: 425 } };
+    withSurface(current, (s) => {
+      const group = s.group(`filter-${field}`)!, input = s.input(`filter-${field}`)!;
+      expect(input).not.toBeNull(); expect(input.disabled).toBe(true); expect(input.value).toBe('425');
+      expect(s.output(`filter-${field}`)?.textContent).toBe('425');
+      expect(s.output(`filter-${field}`)?.getAttribute('aria-live')).toBe('off');
+      const description = document.getElementById(input.getAttribute('aria-describedby')!);
+      expect(description?.textContent).toContain('the last reading is too old to trust');
+      expect(description?.getAttribute('role')).toBeNull(); expect(description?.getAttribute('aria-live')).toBeNull();
+      expect(group.querySelector('[data-stale-cue]')?.textContent).toContain('†');
+      input.value = '900'; input.dispatchEvent(new Event('input', { bubbles: true })); flushSync();
+      expect(onChange).not.toHaveBeenCalled();
+    }, { [field === 'pbtInner' ? 'onPbtInnerChange' : 'onPbtOuterChange']: onChange });
+  });
+
+  it('does not confuse current display with a separate operational gate', () => {
+    const current = base();
+    current.filterPassband!.pbtInner = { reading: { status: 'known', value: 0 }, availability: { structural: true, operational: false }, display: { state: 'current', value: 0 } };
+    withSurface(current, (s) => {
+      expect(s.group('filter-pbtInner')!.dataset.presentation).toBe('confirmed');
+      expect(s.input('filter-pbtInner')!.disabled).toBe(true);
+      expect(s.output('filter-pbtInner')!.textContent).toBe('0');
+      expect(s.group('filter-pbtInner')!.querySelector('[data-stale-cue]')?.textContent?.trim()).toBe('');
+    });
+  });
+
+  it('explicit unknown masks a legacy numeric reading and admits no synthetic event', () => {
+    const current = base(), onChange = vi.fn();
+    current.filterPassband!.pbtInner = { ...current.filterPassband!.pbtInner, display: { state: 'unknown', reason: 'invalid-evidence' } };
+    withSurface(current, (s) => {
+      const group = s.group('filter-pbtInner')!;
+      expect(s.input('filter-pbtInner')).toBeNull(); expect(group.querySelector('[aria-valuenow]')).toBeNull();
+      group.dispatchEvent(new Event('input', { bubbles: true })); flushSync(); expect(onChange).not.toHaveBeenCalled();
+    }, { onPbtInnerChange: onChange });
   });
 });

--- a/frontend/src/semantic/__tests__/pbt-presentation-continuity.test.ts
+++ b/frontend/src/semantic/__tests__/pbt-presentation-continuity.test.ts
@@ -140,3 +140,77 @@ describe('PBT presentation continuity', () => {
     expect(result.state).toEqual(EMPTY_PBT_PRESENTATION);
   });
 });
+
+
+describe('fractional PBT display admission (MOR-1692)', () => {
+  const observedView = (value = 100, state: 'current' | 'stale' = 'current') => {
+    const result = view(value);
+    result.filterPassband!.pbtInner = {
+      reading: state === 'current' ? { status: 'known', value } : { status: 'unknown' },
+      availability: { structural: true, operational: state === 'current' }, display: { state, value },
+    };
+    return result;
+  };
+  const markedStale = (value: number) => ({ status: 'stale', marker: { source: 'field', value } }) as const;
+
+  it('retains fractional current → stale → newer current with independent outer', () => {
+    const first = reduce(EMPTY_PBT_PRESENTATION, observedView(), evidence(fresh('field', 310658.42975425)));
+    expect(first.state.pbtInner?.marker.value).toBe(310658.42975425);
+    const next = reduce(first.state, observedView(100, 'stale'), evidence(markedStale(310658.42975425), fresh('field', 2)));
+    expect(next.view.filterPassband!.pbtInner).toMatchObject({ display: { state: 'stale', value: 100 }, availability: { operational: false } });
+    expect(next.view.filterPassband!.pbtOuter.availability.operational).toBe(true);
+    const final = reduce(next.state, observedView(200), evidence(fresh('field', 310658.5)));
+    expect(final.view.filterPassband!.pbtInner.display).toEqual({ state: 'current', value: 200 });
+  });
+
+  it('admits an already-stale first observation and keeps it inert', () => {
+    const result = reduce(EMPTY_PBT_PRESENTATION, observedView(0, 'stale'), evidence(markedStale(0.25)));
+    expect(result.state.pbtInner?.value).toBe(0);
+    expect(result.view.filterPassband!.pbtInner).toMatchObject({ reading: { status: 'known', value: 0 }, display: { state: 'stale', value: 0 }, availability: { operational: false } });
+  });
+
+  it.each([NaN, Infinity, -0.1])('rejects invalid marker %s without display leakage', (marker) => {
+    const result = reduce(EMPTY_PBT_PRESENTATION, observedView(), evidence(fresh('field', marker)));
+    expect(result.state.pbtInner).toBeNull();
+    expect(result.view.filterPassband!.pbtInner.display?.state).toBe('unknown');
+  });
+
+  it.each([unavailable, stale])('does not admit a raw display without marked evidence: $status', (incoming) => {
+    const result = reduce(EMPTY_PBT_PRESENTATION, observedView(999, 'stale'), evidence(incoming));
+    expect(result.view.filterPassband!.pbtInner.display?.state).toBe('unknown');
+  });
+
+  it('masks display when boundary is null or support disappears', () => {
+    const current = observedView();
+    expect(reduce(EMPTY_PBT_PRESENTATION, current, evidence(unavailable, unavailable, null)).view.filterPassband!.pbtInner.display?.state).toBe('unknown');
+    current.filterPassband!.pbtInner.availability.structural = false;
+    expect(reduce(EMPTY_PBT_PRESENTATION, current).view.filterPassband!.pbtInner.display).toEqual({ state: 'unsupported' });
+  });
+
+  it.each([9.25, 10.25])('does not replace retained display with conflicting marker %s', (marker) => {
+    const first = reduce(EMPTY_PBT_PRESENTATION, observedView(), evidence(fresh('field', 10.25)));
+    const result = reduce(first.state, observedView(999), evidence(fresh('field', marker)));
+    expect(result.view.filterPassband!.pbtInner.display).toEqual({ state: 'stale', value: 100 });
+    expect(result.view.filterPassband!.pbtInner.availability.operational).toBe(false);
+  });
+
+  it.each([
+    { providerGeneration: 2, receiver: 'MAIN', controlSession: 'a', epoch: 1 },
+    { providerGeneration: 1, receiver: 'SUB', controlSession: 'a', epoch: 1 },
+    { providerGeneration: 1, receiver: 'MAIN', controlSession: 'b', epoch: 2 },
+  ])('does not spread display across a changed boundary without new evidence: %j', (boundary) => {
+    const first = reduce(EMPTY_PBT_PRESENTATION, observedView(), evidence(fresh('field', 10.25)));
+    const result = reduce(first.state, observedView(999, 'stale'), evidence(unavailable, unavailable, boundary));
+    expect(result.state.pbtInner).toBeNull();
+    expect(result.view.filterPassband!.pbtInner.display?.state).toBe('unknown');
+    const next = reduce(result.state, observedView(200, 'stale'), evidence(markedStale(0.25), unavailable, boundary));
+    expect(next.view.filterPassband!.pbtInner.display).toEqual({ state: 'stale', value: 200 });
+  });
+
+  it('keeps current display current when an independent gate disables operation', () => {
+    const current = observedView(); current.filterPassband!.pbtInner.availability.operational = false;
+    const result = reduce(EMPTY_PBT_PRESENTATION, current, evidence(fresh('field', 0.5)));
+    expect(result.view.filterPassband!.pbtInner.display).toEqual({ state: 'current', value: 100 });
+    expect(result.view.filterPassband!.pbtInner.availability.operational).toBe(false);
+  });
+});

--- a/frontend/src/semantic/pbt-presentation-continuity.ts
+++ b/frontend/src/semantic/pbt-presentation-continuity.ts
@@ -8,7 +8,8 @@ export type PbtObservationMarker = Readonly<{
 }>;
 export type PbtFieldEvidence =
   | Readonly<{ status: 'fresh'; marker: PbtObservationMarker }>
-  | Readonly<{ status: 'stale' | 'unavailable' }>;
+  | Readonly<{ status: 'stale'; marker?: PbtObservationMarker }>
+  | Readonly<{ status: 'unavailable' }>;
 export interface PbtPresentationEvidence {
   /** Every change fences retained presentation values. */
   readonly boundary: Readonly<{
@@ -43,7 +44,7 @@ const boundaryEquals = (
   && left.receiver === right.receiver
   && left.controlSession === right.controlSession
   && left.epoch === right.epoch;
-const validMarker = (marker: PbtObservationMarker): boolean => Number.isSafeInteger(marker.value);
+const validMarker = (marker: PbtObservationMarker): boolean => Number.isFinite(marker.value) && marker.value >= 0;
 const snapshotBoundary = (
   boundary: NonNullable<PbtPresentationEvidence['boundary']>,
 ): NonNullable<PbtPresentationEvidence['boundary']> => Object.freeze({ ...boundary });
@@ -54,6 +55,7 @@ const snapshotRetained = (value: number, marker: PbtObservationMarker): Retained
 const retainedField = (field: RetainedPbt): FilterPassbandViewModel[PbtField] => ({
   reading: { status: 'known', value: field.value },
   availability: { structural: true, operational: false },
+  display: { state: 'stale', value: field.value },
 });
 
 /**
@@ -67,32 +69,58 @@ export function projectPbtPresentation(
   evidence: PbtPresentationEvidence,
 ): Readonly<{ state: Readonly<PbtPresentationState>; view: RadioViewModel }> {
   const passband = canonical.filterPassband;
-  if (!passband || evidence.boundary === null) {
-    return Object.freeze({ state: EMPTY_PBT_PRESENTATION, view: canonical });
-  }
+  if (!passband) return Object.freeze({ state: EMPTY_PBT_PRESENTATION, view: canonical });
   const sameBoundary = boundaryEquals(previous.boundary, evidence.boundary);
   const state: NextPbtPresentationState = {
-    boundary: snapshotBoundary(evidence.boundary), pbtInner: null, pbtOuter: null,
+    boundary: evidence.boundary === null ? null : snapshotBoundary(evidence.boundary), pbtInner: null, pbtOuter: null,
   };
   let projected: FilterPassbandViewModel | null = null;
   for (const field of FIELDS) {
     const current = passband[field];
     const retained = sameBoundary ? previous[field] : null;
     const incoming = evidence.fields[field];
-    if (!current.availability.structural) continue;
+    const maskDisplay = () => {
+      if (!current.display) return;
+      projected ??= { ...passband };
+      projected[field] = {
+        reading: { status: 'unknown' },
+        availability: { ...current.availability, operational: false },
+        display: current.availability.structural
+          ? { state: 'unknown', reason: evidence.boundary === null ? 'identity-unresolved' : 'invalid-evidence' }
+          : { state: 'unsupported' },
+      };
+    };
+    if (!current.availability.structural || evidence.boundary === null) {
+      maskDisplay();
+      continue;
+    }
     const currentValue = current.reading.status === 'known' && Number.isFinite(current.reading.value)
       ? current.reading.value : null;
-    const accepted = incoming.status === 'fresh'
+    const display = current.display;
+    const displayValue = display?.state === 'current' || display?.state === 'stale' ? display.value : null;
+    const displayAccepted = displayValue !== null && Number.isFinite(displayValue)
+      && incoming.status !== 'unavailable' && incoming.marker !== undefined && validMarker(incoming.marker)
+      && (incoming.status === 'fresh' ? display?.state === 'current' : display?.state === 'stale')
+      && (!retained || incoming.marker.value > retained.marker.value);
+    const accepted = !display && incoming.status === 'fresh'
       && validMarker(incoming.marker)
       && current.availability.operational
       && currentValue !== null
       && (!retained || incoming.marker.value > retained.marker.value);
-    if (accepted) {
+    if (displayAccepted) {
+      state[field] = snapshotRetained(displayValue, incoming.marker);
+      if (display?.state === 'stale') {
+        projected ??= { ...passband };
+        projected[field] = retainedField(state[field]!);
+      }
+    } else if (accepted) {
       state[field] = snapshotRetained(currentValue, incoming.marker);
     } else if (retained) {
       state[field] = retained;
       projected ??= { ...passband };
       projected[field] = retainedField(retained);
+    } else {
+      maskDisplay();
     }
   }
   const nextView = projected === null ? canonical : Object.freeze({ ...canonical, filterPassband: Object.freeze(projected) });

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -387,8 +387,8 @@ export interface FilterPassbandViewModel {
    * fact about the radio MODEL, not a live reading that can itself go stale.
    */
   ifShiftControlStructural: boolean;
-  pbtInner: FilterPassbandField<number>;
-  pbtOuter: FilterPassbandField<number>;
+  pbtInner: DisplayObservedField<number>;
+  pbtOuter: DisplayObservedField<number>;
   dataMode: FilterPassbandField<number>;
 }
 
@@ -1625,8 +1625,8 @@ function validateFilterPassband(value: unknown, path: string): FilterPassbandVie
     filterShapeControlStructural: bool(v.filterShapeControlStructural, `${path}.filterShapeControlStructural`),
     ifShift: validateTxAuxField(v.ifShift, `${path}.ifShift`, num),
     ifShiftControlStructural: bool(v.ifShiftControlStructural, `${path}.ifShiftControlStructural`),
-    pbtInner: validateTxAuxField(v.pbtInner, `${path}.pbtInner`, num),
-    pbtOuter: validateTxAuxField(v.pbtOuter, `${path}.pbtOuter`, num),
+    pbtInner: validateDisplayObservedField(v.pbtInner, `${path}.pbtInner`, num),
+    pbtOuter: validateDisplayObservedField(v.pbtOuter, `${path}.pbtOuter`, num),
     dataMode: validateTxAuxField(v.dataMode, `${path}.dataMode`, num),
   };
 }


### PR DESCRIPTION
PBT values now retain their last admitted observation across acquisition gaps, including fractional monotonic timestamps. Retained values stay disabled with a stale cue. Supported PBT controls show an inert slot when no admitted observation is available; unsupported controls are hidden. A fresh-to-stale transition also discards a dragged DOM position that was never confirmed by the radio.

This is one PBT display contract across the adapter, continuity reducer, wiring and renderer with their tests: 9 files, 422 changed lines (`git diff --stat 7f807e336c2a7cc2db5b0742eb9ad21c641d766f e6fd97c70c7c779ba97a95cfbac475300a85fbad`). That shared invariant explains the six-file soft-threshold crossing. Adapter strict readings and availability are preserved by fresh/stale parity tests; no backend, wire, CLI, TX or spectrum-authority changes. IF-shift and PBT use one shared passband range renderer, preserving the frozen feedback-debt inventory without changing its baseline or declaring a policy exemption.

Validation: the builder ran eleven focused Vitest files (297 tests passed), including the feedback-debt inventory/baseline/ownership checks, scoped svelte-check (0 errors/warnings), nine-file ESLint and diff whitespace checks. Restoring each integer-only observation guard separately killed 8 reducer tests, 1 session-floor test and 5 evidence-admission tests. The mounted drag regression failed before its correction. Reintroducing a split PBT range failed the inventory test; it was restored before final checks. Required natural CI and independent review apply to this Ready head.

Related: [MOR-1692](https://linear.app/morozsm/issue/MOR-1692), [MOR-2234](https://linear.app/morozsm/issue/MOR-2234), [MOR-1413](https://linear.app/morozsm/issue/MOR-1413). Keep MOR-1692 and operator acceptance open: owner-present browser/radio validation remains pending. This receiver-level change preserves the existing same-receiver VFO-context limitation; it does not establish coherent spectrum geometry or complete the broader freshness migration. No release publication.
