### PR TITLE
fix(MOR-2358): host semantic scope controls in the SDR toolbar

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, onMount } from 'svelte';
+  import { onDestroy, onMount, type Snippet } from 'svelte';
   import '../theme/index';
   import { setTheme, getTheme, setVfoTheme, getVfoTheme } from '../theme/theme-switcher';
   
@@ -14,7 +14,7 @@
   
   import { runtime } from '$lib/runtime';
   import { applyModeDefault } from '$lib/stores/tuning.svelte';
-  import { getKeyboardConfig, hasAnyScope, hasSpectrum } from '$lib/stores/capabilities.svelte';
+  import { getKeyboardConfig, getScopeSource, hasAnyScope, hasSpectrum } from '$lib/stores/capabilities.svelte';
   import type { SkinId } from '../../skins/registry';
   import { declaredSurfaces, getLayout } from '../../presentation/layouts/contract';
   // Side-effect import: populates the LAYOUT registry `getLayout` resolves
@@ -79,6 +79,9 @@
   // zone, and letting a subtraction bring the legacy twin back would be
   // force-show through the back door — the one thing the plan may never do.
   let declared = $derived(declaredSurfaces(getLayout(skinId)));
+  let scopeControlsInRegionContent = $derived(
+    skinId === 'sdr-test' && declared.has('scopeControls') && hasSpectrum() && getScopeSource() === 'hardware',
+  );
   let semanticDeck = $derived(declared.has('vfo'));
   // R9 — ONE key/unkey authority, and this line is where that count is decided.
   //
@@ -269,13 +272,13 @@
   });
 </script>
 
-{#snippet sdrRegionContent()}
+{#snippet sdrRegionContent(scopeControls: Snippet | undefined)}
   <section class="content-row">
     <main class="content-center center-column">
       {#if hasAnyScope()}
         <div class="spectrum-slot">
           <div class="spectrum-frame">
-            <SpectrumPanel hideSourceControls={true} hideScopeControls={declared.has('scopeControls')} />
+            <SpectrumPanel hideSourceControls={true} hideScopeControls={declared.has('scopeControls')} {scopeControls} />
           </div>
         </div>
       {/if}
@@ -302,7 +305,7 @@
 
     <section class="receiver-deck" bind:this={receiverDeckElement} style={receiverDeckStyle}>
       {#if semanticDeck}
-        <SemanticRadioSurfaces regions={true} regionContent={sdrRegionContent}
+        <SemanticRadioSurfaces regions={true} regionContent={sdrRegionContent} {scopeControlsInRegionContent}
           regionExtras={desktopRegionExtras} vfoAppearance={skinId === 'sdr-test' ? 'sdr' : 'standard'} />
       {/if}
     </section>

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
@@ -350,7 +350,10 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
   getControlRange: vi.fn(() => ({ min: 0, max: 255 })),
 }));
 
-import { hasDualReceiver } from '$lib/stores/capabilities.svelte';
+import { getScopeSource, hasAnyScope, hasDualReceiver, hasSpectrum } from '$lib/stores/capabilities.svelte';
+import { sdrTestLayout } from '../../../presentation/layouts/declarations';
+import { readWorkspace } from '../../../presentation/workspace/contract';
+import { resolveSurfacePlan, SURFACE_PLAN_CONTEXT_KEY, type SurfacePlan } from '../../../presentation/workspace/resolution';
 
 let components: ReturnType<typeof mount>[] = [];
 
@@ -362,10 +365,10 @@ let components: ReturnType<typeof mount>[] = [];
  */
 const UNDECLARED = 'no-such-layout' as SkinId;
 
-function mountLayout(skinId: SkinId = 'desktop-v2') {
+function mountLayout(skinId: SkinId = 'desktop-v2', plan?: SurfacePlan) {
   const t = document.createElement('div');
   document.body.appendChild(t);
-  const component = mount(RadioLayout, { target: t, props: { skinId } });
+  const component = mount(RadioLayout, { target: t, props: { skinId }, context: plan ? new Map([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]) : undefined });
   flushSync();
   components.push(component);
   return t;
@@ -377,6 +380,9 @@ beforeEach(() => {
   radio.current = null;
   rt.state = null;
   vi.mocked(hasDualReceiver).mockReturnValue(false);
+  vi.mocked(getScopeSource).mockReturnValue(null);
+  vi.mocked(hasSpectrum).mockReturnValue(true);
+  vi.mocked(hasAnyScope).mockReturnValue(true);
   vi.mocked(resolveSkinId).mockReturnValue('desktop-v2');
   // JSDOM defaults to 0x0 — force desktop dimensions so isMobile stays false
   Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1440 });
@@ -663,5 +669,33 @@ describe('RadioLayout with radioState', () => {
     radio.current = sampleState as any;
     const t = mountLayout(UNDECLARED);
     expect(t.querySelector('.bottom-dock [data-testid="meters-dock-panel"]')).not.toBeNull();
+  });
+});
+
+
+describe('SDR hardware scope snippet routing (MOR-2358)', () => {
+  it.each([
+    ['sdr-test', 'hardware', true, true],
+    ['desktop-v2', 'hardware', true, false],
+    ['sdr-test', 'audio_fft', true, false],
+    ['sdr-test', null, true, false],
+    ['sdr-test', 'hardware', false, false],
+    [UNDECLARED, 'hardware', true, false],
+  ] as const)('%s / %s / spectrum %s selects hosted placement %s', (skin, source, spectrum, expected) => {
+    vi.mocked(getScopeSource).mockReturnValue(source);
+    vi.mocked(hasSpectrum).mockReturnValue(spectrum);
+    const target = mountLayout(skin);
+    const stub = target.querySelector('.spectrum-panel-stub'); expect(stub).not.toBeNull();
+    expect(stub?.getAttribute('data-has-scope-controls')).toBe(String(expected));
+    expect(stub?.getAttribute('data-hide-scope-controls')).toBe(String(skin !== UNDECLARED));
+  });
+
+  it('keeps declaration-derived suppression when the workspace subtracts scope controls', () => {
+    vi.mocked(getScopeSource).mockReturnValue('hardware');
+    const plan = resolveSurfacePlan(sdrTestLayout, readWorkspace({ version: 1, visibleSurfaces: { 'scope-controls': [] } }).workspace);
+    const target = mountLayout('sdr-test', plan);
+    const stub = target.querySelector('.spectrum-panel-stub');
+    expect(stub?.getAttribute('data-has-scope-controls')).toBe('true');
+    expect(stub?.getAttribute('data-hide-scope-controls')).toBe('true');
   });
 });

--- a/frontend/src/components-v2/layout/__tests__/SpectrumPanelStub.svelte
+++ b/frontend/src/components-v2/layout/__tests__/SpectrumPanelStub.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   // MOR-1369 (S6b-1) — records the `hideScopeControls` prop RadioLayout
   // passes through, so tests here can assert the channel wiring without
   // paying for SpectrumPanel's full canvas/runtime mount (that coverage
@@ -10,13 +11,16 @@
   let {
     hideScopeControls = false,
     hideAutoStepToggle = false,
-  }: { hideScopeControls?: boolean; hideAutoStepToggle?: boolean } = $props();
+    scopeControls,
+  }: { hideScopeControls?: boolean; hideAutoStepToggle?: boolean; scopeControls?: Snippet } = $props();
 </script>
 
 <div
   class="spectrum-panel spectrum-panel-stub"
   data-hide-scope-controls={hideScopeControls}
   data-hide-auto-step-toggle={hideAutoStepToggle}
+  data-has-scope-controls={scopeControls !== undefined}
 >
   Spectrum Stub
+  {#if scopeControls}{@render scopeControls()}{/if}
 </div>

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -86,7 +86,8 @@
   interface Props {
     strips?: 'single' | 'dual';
     regions?: boolean;
-    regionContent?: Snippet;
+    regionContent?: Snippet<[Snippet | undefined]>;
+    scopeControlsInRegionContent?: boolean;
     regionExtras?: Snippet<['left' | 'right']>;
     vfoAppearance?: 'semantic' | 'sdr' | 'standard';
     displayFrameSource?: LcdSpectrumSource;
@@ -113,7 +114,7 @@
    * `zoneOwning()` returns non-null on both faces.
    */
   let {
-    strips = 'single', regions = false, regionContent, regionExtras, vfoAppearance = 'semantic', displayFrameSource, readonlyDisplay,
+    strips = 'single', regions = false, regionContent, scopeControlsInRegionContent = false, regionExtras, vfoAppearance = 'semantic', displayFrameSource, readonlyDisplay,
   }: Props = $props();
 
   /**
@@ -1380,6 +1381,10 @@
     {/if}
   {/snippet}
 
+  {#snippet zonedScopeControls()}
+    {@render zoned('scopeControls', view?.scopeControls !== undefined, scopeControlsSurface, allowBareSurfaces)}
+  {/snippet}
+
   {#if strips === 'dual'}
     <!--
       MOR-1258: the zone now carries RxTxSurface AND the two TX-adjacent
@@ -1454,12 +1459,13 @@
       {#if regionExtras}{@render regionExtras('left')}{/if}
       </div>
       <div class:desktop-controls-center={vfoAppearance !== 'semantic'} class:region-passthrough={vfoAppearance === 'semantic'}>
-      {@render zoned(
-        'scopeControls', view?.scopeControls !== undefined, scopeControlsSurface,
-        allowBareSurfaces,
-      )}
+      {#if !scopeControlsInRegionContent || !regionContent}
+        {@render zonedScopeControls()}
+      {/if}
       {@render zoned('scopeDisplay', view?.scopeDisplay !== undefined, scopeDisplaySurface, allowBareSurfaces)}
-      {#if regionContent}{@render regionContent()}{/if}
+      {#if regionContent}
+        {@render regionContent(scopeControlsInRegionContent ? zonedScopeControls : undefined)}
+      {/if}
       </div>
       <div class:desktop-controls-right={vfoAppearance !== 'semantic'} class:region-passthrough={vfoAppearance === 'semantic'}>
       {#if singleOrder.includes('rxTx')}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
@@ -24,7 +24,8 @@
  *   (c) the default path (no `scope` capability) stays byte-identical.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { flushSync, mount, unmount } from 'svelte';
+import { createRawSnippet, flushSync, mount, unmount, type Snippet } from 'svelte';
+import SpectrumPanelStub from '../../layout/__tests__/SpectrumPanelStub.svelte';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
@@ -83,14 +84,14 @@ import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/suppor
 // S5/S6-pre subtraction asymmetry, since `useSurfacePlan()` falls back to
 // `NO_PLAN` on a standalone mount.
 import {
-  desktopV2Layout, dualReceiverCockpitLayout,
+  desktopV2Layout, dualReceiverCockpitLayout, sdrTestLayout,
 } from '../../../presentation/layouts/declarations';
 import { readWorkspace } from '../../../presentation/workspace/contract';
 import {
   resolveSurfacePlan, SURFACE_PLAN_CONTEXT_KEY, type SurfacePlan,
 } from '../../../presentation/workspace/resolution';
 
-const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' } as const;
 const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
 
 /** A radio that has observed every `scopeControls` leaf — every field this
@@ -146,7 +147,7 @@ let target: HTMLDivElement;
 let component: ReturnType<typeof mount> | null = null;
 let txHarness: ManagedAppTxHarness;
 
-function render(props: { strips?: 'single' | 'dual' } = {}, plan?: SurfacePlan): void {
+function render(props: { strips?: 'single' | 'dual'; regions?: boolean; scopeControlsInRegionContent?: boolean; regionContent?: Snippet<[Snippet | undefined]> } = {}, plan?: SurfacePlan): void {
   target = document.createElement('div');
   document.body.appendChild(target);
   const context = plan === undefined
@@ -371,5 +372,84 @@ describe('desktop-v2 declares a REAL scope-controls zone; the cockpit mounts not
   it('still mounts nothing in the dual-receiver cockpit — its manifest is untouched by this slice', () => {
     render({ strips: 'dual' }, planFor(dualReceiverCockpitLayout, {}));
     expect(el('scope-controls-surface')).toBeNull();
+  });
+});
+
+
+describe('SDR hosted semantic scope controls (MOR-2358)', () => {
+  const regionContent = createRawSnippet<[Snippet | undefined]>((scopeControls) => ({
+    render: () => '<div class="spectrum-toolbar" data-testid="scope-toolbar-host"></div>',
+    setup(element) {
+      const child = mount(SpectrumPanelStub, { target: element, props: { scopeControls: scopeControls?.() } });
+      return () => { unmount(child); };
+    },
+  }));
+  const plan = (fields: Record<string, unknown> = {}) => resolveSurfacePlan(sdrTestLayout, readWorkspace({ version: 1, ...fields }).workspace);
+  const hosted = () => render({ regions: true, scopeControlsInRegionContent: true, regionContent }, plan());
+
+  it('moves exactly one zoned surface into region content with no former center sibling', () => {
+    hosted();
+    expect(target.querySelectorAll('[data-testid="scope-controls-surface"]')).toHaveLength(1);
+    const surface = el('scope-controls-surface')!;
+    expect(surface.closest('[data-zone-id="scope-controls"]')).not.toBeNull();
+    expect(surface.closest('[data-testid="scope-toolbar-host"]')).not.toBeNull();
+  });
+
+  it.each([
+    ['scope-mode-2', 0, 'set_scope_mode', { mode: 2 }],
+    ['scope-hold', 0, 'set_scope_hold', { on: true }],
+    ['scope-ref', 1, 'set_scope_ref', { ref: 0 }],
+  ] as const)('hosted %s dispatches exactly the existing command', (id, index, command, params) => {
+    hosted();
+    const element = el(id)!;
+    const control = element.tagName === 'BUTTON' ? element : element.querySelectorAll('button')[index]!;
+    expect(control.closest('[data-testid="scope-toolbar-host"]')).not.toBeNull();
+    control.click(); flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith(command, params);
+  });
+
+  it.each([0, 1, 2, 3, null])('preserves the semantic mode applicability matrix for mode %s', (mode) => {
+    const source = liveState({ scopeControls: { ...liveState().scopeControls!, mode: mode ?? 0 } });
+    if (mode === null) source.fieldStatus!['scopeControls.mode'] = { ...fresh, observed: false, freshness: 'unknown', availability: 'missing' };
+    useState(source); hosted();
+    for (const name of ['mode', 'speed', 'hold', 'ref', 'dual', 'receiver', 'duringTx', 'centerType', 'vbwNarrow', 'rbw']) {
+      const leaf = el(`scope-${name}`); expect(leaf).not.toBeNull();
+      expect(leaf!.closest('[data-testid="scope-toolbar-host"]')).not.toBeNull();
+    }
+    expect(el('scope-edge') !== null).toBe(mode === 1 || mode === 3);
+    expect(el('scope-span') !== null).toBe(mode === 0 || mode === 2);
+    if (mode === null) expect((el('scope-mode-0') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it.each(['stale', 'unobserved'] as const)('keeps a supported %s leaf disabled and rejects a synthetic click', (status) => {
+    const source = liveState();
+    source.fieldStatus!['scopeControls.hold'] = { ...fresh, observed: status !== 'unobserved', freshness: status === 'stale' ? 'stale' : 'unknown', availability: status === 'stale' ? 'stale' : 'missing' };
+    useState(source); hosted();
+    const hold = el('scope-hold') as HTMLButtonElement;
+    expect(hold.closest('[data-testid="scope-toolbar-host"]')).not.toBeNull(); expect(hold.disabled).toBe(true);
+    hold.dispatchEvent(new MouseEvent('click', { bubbles: true })); flushSync(); expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('removes unsupported receiver leaves while keeping the supported surface hosted', () => {
+    h.caps = liveCaps(['scope']); hosted();
+    expect(target.querySelectorAll('[data-testid="scope-controls-surface"]')).toHaveLength(1);
+    expect(el('scope-controls-surface')!.closest('[data-testid="scope-toolbar-host"]')).not.toBeNull();
+    expect(el('scope-dual')).toBeNull(); expect(el('scope-receiver')).toBeNull();
+  });
+
+  it('honors regions plan subtraction without a bare fallback', () => {
+    render({ regions: true, scopeControlsInRegionContent: true, regionContent }, plan({ visibleSurfaces: { 'scope-controls': [] } }));
+    expect(el('scope-toolbar-host')).not.toBeNull(); expect(el('scope-controls-surface')).toBeNull();
+  });
+
+  it('keeps the surface when the placement flag has no region-content consumer', () => {
+    render({ regions: true, scopeControlsInRegionContent: true }, plan());
+    expect(el('scope-controls-surface')?.closest('[data-zone-id="scope-controls"]')).not.toBeNull();
+    expect(target.querySelectorAll('[data-testid="scope-controls-surface"]')).toHaveLength(1);
+  });
+
+  it('leaves standalone non-regions rendering unchanged', () => {
+    render({ scopeControlsInRegionContent: true, regionContent });
+    expect(el('scope-controls-surface')).not.toBeNull(); expect(el('scope-toolbar-host')).toBeNull();
   });
 });

--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { untrack } from 'svelte';
+  import { untrack, type Snippet } from 'svelte';
   import SpectrumCanvas from './SpectrumCanvas.svelte';
   import WaterfallCanvas from './WaterfallCanvas.svelte';
   import DxOverlay from './DxOverlay.svelte';
@@ -60,7 +60,9 @@
   // layouts that have no `applyModeDefault()` driver for the shared
   // tuning-step store. `MobileRadioLayout` passes `true`; `RadioLayout`
   // omits it (defaults `false`, toggle shown) because it owns the driver.
-  let { hideSourceControls = false, hideScopeControls = false, hideAutoStepToggle = false } = $props();
+  let { hideSourceControls = false, hideScopeControls = false, hideAutoStepToggle = false, scopeControls }: {
+    hideSourceControls?: boolean; hideScopeControls?: boolean; hideAutoStepToggle?: boolean; scopeControls?: Snippet;
+  } = $props();
 
   const vfoHandlers = getVfoHandlers();
   const filterHandlers = getFilterHandlers();
@@ -569,7 +571,7 @@
       </button>
     </div>
   {:else}
-  <SpectrumToolbar bind:enableAvg bind:enablePeakHold bind:brtLevel bind:colorScheme bind:fullscreen bind:showBandPlan bind:hiddenLayers bind:showEiBi {scopeDemandOn} onScopeDemandChange={setScopeDemand} {hideSourceControls} {hideScopeControls} {hideAutoStepToggle} />
+  <SpectrumToolbar bind:enableAvg bind:enablePeakHold bind:brtLevel bind:colorScheme bind:fullscreen bind:showBandPlan bind:hiddenLayers bind:showEiBi {scopeDemandOn} onScopeDemandChange={setScopeDemand} {hideSourceControls} {hideScopeControls} {hideAutoStepToggle} {scopeControls} />
   {/if}
   <div class="spectrum-with-scales">
     <div class="db-scale">

--- a/frontend/src/components/spectrum/SpectrumToolbar.svelte
+++ b/frontend/src/components/spectrum/SpectrumToolbar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { getTuningStep, adjustTuningStep, isAutoStep, setAutoStep, formatStep } from '../../lib/stores/tuning.svelte';
   import { t } from '$lib/i18n';
   import { type ColorSchemeName } from '../../lib/renderers/waterfall-renderer';
@@ -19,6 +20,23 @@
     name: string;
     layer: string;
     file: string;
+  }
+
+  interface Props {
+    enableAvg?: boolean;
+    enablePeakHold?: boolean;
+    brtLevel?: number;
+    colorScheme?: ColorSchemeName;
+    fullscreen?: boolean;
+    showBandPlan?: boolean;
+    hiddenLayers?: string[];
+    showEiBi?: boolean;
+    scopeDemandOn?: boolean;
+    onScopeDemandChange?: (enabled: boolean) => void;
+    hideSourceControls?: boolean;
+    hideScopeControls?: boolean;
+    hideAutoStepToggle?: boolean;
+    scopeControls?: Snippet;
   }
 
   let {
@@ -91,7 +109,8 @@
      * needs no change; `MobileRadioLayout` passes `true` explicitly.
      */
     hideAutoStepToggle = false,
-  } = $props();
+    scopeControls,
+  }: Props = $props();
 
   const scopeHandlers = bindSemanticSurfaceHandlers().scopeControls;
 
@@ -372,6 +391,12 @@
     </div>
     {/if}
   {/if}
+  {#if hasCapability('scope') && hideScopeControls && scopeControls}
+    <div class="toolbar-separator"></div>
+    <div class="semantic-scope-controls-host toolbar-group-c">
+      {@render scopeControls()}
+    </div>
+  {/if}
   <div class="toolbar-separator"></div>
   <!-- Group D: Display (neutral wash) -->
   <div class="toolbar-group-d">
@@ -536,6 +561,31 @@
   .toolbar-group-d {
     /* Display only — neutral wash */
     background: rgba(255, 255, 255, 0.02);
+  }
+
+  .semantic-scope-controls-host {
+    min-width: 0;
+    max-width: 100%;
+    height: auto;
+    flex-wrap: wrap;
+  }
+
+  .semantic-scope-controls-host :global(.surface-zone),
+  .semantic-scope-controls-host :global(.semantic-control-panel) { display: contents; }
+
+  .semantic-scope-controls-host :global(.scope-controls-surface) {
+    min-width: 0;
+    max-width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  .semantic-scope-controls-host :global(.scope-row),
+  .semantic-scope-controls-host :global(.scope-stepper) {
+    flex-wrap: nowrap;
+    flex-shrink: 0;
+    white-space: nowrap;
   }
 
   .toolbar-separator {

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -4,7 +4,7 @@
  * child component slots, and event wiring.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mount, unmount, flushSync } from 'svelte';
+import { createRawSnippet, mount, unmount, flushSync } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -132,7 +132,10 @@ const runtimeHarness = vi.hoisted(() => {
     get state() { return state.currentState; },
     get caps() { return state.currentCaps; },
     onTxAudioDied: () => () => {},
+    defaultScopeStatus: { transport: 'connected' },
     scope: {
+      registerPresentationDriver: vi.fn(),
+      subscribe: vi.fn(() => () => {}),
       get hardwareScopeConnected() { return state.mockScopeConnected; },
       subscribeHardware: vi.fn((handler: (frame: TestScopeFrame) => void) => {
         state.capturedHardwareFrame = handler;
@@ -264,6 +267,7 @@ const appTxHostHarness = vi.hoisted(() => ({
 }));
 
 vi.mock('$lib/runtime/frontend-runtime', () => ({
+  presentationResources: { acquire: vi.fn(() => ({ resource: 'audio-fft', id: 1 })), release: vi.fn() },
   runtime: runtimeHarness.runtime,
 }));
 
@@ -1360,5 +1364,26 @@ describe('StatusBar default scope status consumption', () => {
     ['connected', 'green'],
   ] as const)('%s uses the %s tone', (state, expected) => {
     expect(indicatorTone(state)).toBe(expected);
+  });
+});
+
+
+describe('opaque semantic scope snippet forwarding (MOR-2358)', () => {
+  const scopeControls = createRawSnippet(() => ({ render: () => '<div data-testid="hosted-scope-probe">Semantic scope probe</div>' }));
+  it('renders the opaque snippet once inside the hardware toolbar', () => {
+    const target = mountPanel({ hideScopeControls: true, scopeControls });
+    expect(target.querySelectorAll('[data-testid="hosted-scope-probe"]')).toHaveLength(1);
+    expect(target.querySelector('[data-testid="hosted-scope-probe"]')?.closest('.spectrum-toolbar')).not.toBeNull();
+    expect(target.querySelector('.settings-group')).toBeNull();
+  });
+  it('keeps audio FFT source label and Viewer without rendering the hardware snippet', () => {
+    runtimeHarness.state.currentCaps = { scopeSource: 'audio_fft' };
+    const target = mountPanel({ hideScopeControls: true, scopeControls });
+    expect(target.querySelector('[data-testid="hosted-scope-probe"]')).toBeNull();
+    expect(target.querySelector('.spectrum-toolbar')).toBeNull();
+    expect(target.querySelector('.audio-source-label')?.textContent).toContain('Audio FFT · AF');
+    const viewer = target.querySelector<HTMLButtonElement>('[aria-label="Scope viewer"]')!;
+    expect(viewer.textContent).toContain('Viewer ON'); viewer.click(); flushSync(); expect(viewer.textContent).toContain('Viewer OFF');
+    expect(mockRuntime.scope.subscribeHardware).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/spectrum/__tests__/SpectrumToolbar.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumToolbar.component.test.ts
@@ -4,7 +4,7 @@
  * from the merged spectrum selector while actions use the bound scope family.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mount, unmount, flushSync, tick } from 'svelte';
+import { createRawSnippet, mount, unmount, flushSync, tick } from 'svelte';
 import { readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { resolve } from 'node:path';
@@ -775,16 +775,43 @@ describe('source and enforcement boundary', () => {
     expect(contract).not.toContain('  { path = "src/components/spectrum/EiBiBrowser.svelte", count = 1, owner = "MOR-1409" },');
   });
 
-  it('releases the old popover hash pin while keeping all Toolbar CSS byte-frozen', () => {
+  it('keeps the selector boundaries and pins the scoped toolbar CSS', () => {
     const popover = readFileSync(popoverPath, 'utf8');
     expect(popover).toContain('toSpectrumAuthority(runtime.state, runtime.caps)');
     expect(popover).toContain('bindSemanticSurfaceHandlers().scopeControls');
     expect(popover).not.toMatch(/stores\/radio\.svelte|sendCommand|\?\? false/);
     const source = readFileSync(sourcePath, 'utf8');
     const cssHash = createHash('sha256').update(source.slice(source.indexOf('<style>'))).digest('hex');
-    // MOR-1486: `.auto-badge` (the passive 'A' glyph) was removed and
-    // `.auto-step-toggle.active` (the new real toggle's amber styling) was
-    // added — this hash is re-pinned to that legitimate CSS change.
-    expect(cssHash).toBe('42438ae899f89f4f7b6aef982755c1e1e166945a98b5cb1d6cb246c4eef96e57');
+    // MOR-2358 adds host-scoped wrapping for the semantic scope surface.
+    expect(cssHash).toBe('d6c52fd99646af0b741c16241a2e6f1efb2ef016063ec93ef0e0fea2378f6931');
+  });
+});
+
+
+describe('semantic scope host (MOR-2358)', () => {
+  const scopeControls = createRawSnippet(() => ({ render: () => '<div data-testid="semantic-scope-probe">Semantic scope</div>' }));
+  it.each([
+    [true, true, true, true], [false, true, true, false],
+    [true, false, true, false], [true, true, false, false],
+  ])('scope=%s, suppression=%s, snippet=%s gates host=%s', (scope, hidden, snippet, hosted) => {
+    capabilityHarness.scope = scope;
+    const target = mountToolbar({ hideScopeControls: hidden, scopeControls: snippet ? scopeControls : undefined });
+    expect(target.querySelectorAll('[data-testid="semantic-scope-probe"]')).toHaveLength(hosted ? 1 : 0);
+    expect(target.querySelector('.semantic-scope-controls-host') !== null).toBe(hosted);
+  });
+
+  it('preserves local controls and suppresses the legacy radio subtree with the host', () => {
+    const target = mountToolbar({ hideScopeControls: true, scopeControls });
+    expect(target.querySelectorAll('.semantic-scope-controls-host')).toHaveLength(1);
+    for (const label of ['CTR', 'FIX', 'S-C', 'S-F', 'HOLD', 'DUAL', 'MAIN']) expect(button(target, label)).toBeUndefined();
+    expect(target.querySelector('.settings-group')).toBeNull();
+    for (const label of ['AUTO', 'AVG', 'PEAK', 'BANDS']) expect(button(target, label)).toBeDefined();
+    for (const label of ['STEP', 'VIEW', 'BRT']) expect(target.textContent).toContain(label);
+    expect(target.querySelector('.toolbar-select')).not.toBeNull(); expect(target.querySelector('.icon-btn')).not.toBeNull();
+    const step = buttons(target).find((item) => item.title === 'Increase tuning step')!; step.click();
+    button(target, 'AVG')!.click(); button(target, 'PEAK')!.click(); flushSync();
+    expect(tuningHarness.adjustTuningStep).toHaveBeenCalledExactlyOnceWith('up');
+    for (const [, spy] of scopeSpies()) expect(spy).not.toHaveBeenCalled();
+    expect(sendCommandAlarm).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Change

The SDR hardware spectrum toolbar now hosts the existing bound semantic scope-controls surface. Previously that surface occupied a separate center-column band. The existing semantic zone and intent owner remain, and declaration-based suppression prevents duplicate legacy controls.

This is one composition change across four production components and five test/support files (9 files, 262 additions and 31 deletions, measured with `git diff --stat origin/main...HEAD`). Passing the same opaque snippet through these components and checking each seam requires exceeding the six-file soft threshold. Standard and audio FFT retain their existing placement. Scope mode applicability remains unchanged: EDGE in FIX/S-F, SPAN in CTR/S-C.

## Validation

The frozen builder candidate passed 436 tests in 10 focused files, changed-scope ESLint, and scoped svelte-check (0 errors, 0 warnings). Missing-snippet and duplicate-snippet mutations each failed 12 wiring tests. These results come from the named commands and logs in the builder handback. The integrated commit has an identical tree to that tested candidate, verified with `git diff 3b88ffd847536680047851cbd0486387fc471bf7 HEAD`; no duplicate local full-suite run was performed.

Natural required PR CI and independent exact-head review are pending. Actual browser wrapping, clipping and keyboard acceptance at 1024/1280/1710 widths remains pending; component tests do not establish viewport geometry. No radio installation or hardware validation is claimed.

Linear scope and acceptance: https://linear.app/morozsm/issue/MOR-2358
This source change does not close MOR-2358 operator acceptance or the MOR-1413 umbrella. No backend, TX/PTT authority, public API or release publication changes.
