### PR TITLE
feat(MOR-2361): retire Core application token gates

### DIFF
--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -565,6 +565,12 @@ def _finalize_ptt_args(
         args.state = "on"
 
 
+def _reject_retired_auth_option(_value: str) -> str:
+    raise argparse.ArgumentTypeError(
+        "Application authentication was removed; remove --auth-token and --auth-token-file."
+    )
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = _RigplaneArgumentParser(
         prog="rigplane",
@@ -1400,16 +1406,18 @@ def _build_parser() -> argparse.ArgumentParser:
     web_p.add_argument(
         "--auth-token",
         dest="auth_token",
-        default="",
+        type=_reject_retired_auth_option,
+        default=None,
         metavar="TOKEN",
-        help="Bearer token for API authentication (empty = no auth)",
+        help=argparse.SUPPRESS,
     )
     web_p.add_argument(
         "--auth-token-file",
         dest="auth_token_file",
-        default="",
+        type=_reject_retired_auth_option,
+        default=None,
         metavar="PATH",
-        help="Read Bearer token for API authentication from PATH",
+        help=argparse.SUPPRESS,
     )
     web_p.add_argument(
         "--tls-cert",
@@ -1488,16 +1496,18 @@ def _build_parser() -> argparse.ArgumentParser:
     station_p.add_argument(
         "--auth-token",
         dest="auth_token",
-        default="",
+        type=_reject_retired_auth_option,
+        default=None,
         metavar="TOKEN",
-        help="Bearer token for API authentication (prefer RIGPLANE_AUTH_TOKEN)",
+        help=argparse.SUPPRESS,
     )
     station_p.add_argument(
         "--auth-token-file",
         dest="auth_token_file",
-        default="",
+        type=_reject_retired_auth_option,
+        default=None,
         metavar="PATH",
-        help="Read Bearer token for API authentication from PATH (preferred for supervisors)",
+        help=argparse.SUPPRESS,
     )
     station_p.add_argument(
         "--no-discovery",
@@ -2168,10 +2178,6 @@ def _audio_frame_bytes(
     sample_rate: int, channels: int, frame_ms: int = _AUDIO_FRAME_MS
 ) -> int:
     return sample_rate * channels * _PCM_SAMPLE_WIDTH_BYTES * frame_ms // 1000
-
-
-def _read_auth_token_file(path: str) -> str:
-    return Path(path).expanduser().read_text(encoding="utf-8").strip()
 
 
 def _validate_audio_format_args(sample_rate: int, channels: int) -> str | None:
@@ -3773,27 +3779,6 @@ async def _cmd_web(
         config_kwargs["dx_callsign"] = callsign
 
     managed_runtime = getattr(args, "managed_runtime", False)
-    auth_token = getattr(args, "auth_token", "")
-    auth_token_file = getattr(args, "auth_token_file", "")
-    if not auth_token and auth_token_file:
-        try:
-            auth_token = _read_auth_token_file(auth_token_file)
-        except OSError as exc:
-            print(
-                f"Error: failed to read --auth-token-file: {exc}",
-                file=sys.stderr,
-            )
-            return 1
-    if managed_runtime and not auth_token:
-        auth_token = os.environ.get("RIGPLANE_AUTH_TOKEN", "").strip()
-    if managed_runtime and not auth_token:
-        print(
-            "Error: managed mode requires auth. Set RIGPLANE_AUTH_TOKEN or pass --auth-token-file.",
-            file=sys.stderr,
-        )
-        return 1
-    if auth_token:
-        config_kwargs["auth_token"] = auth_token
     if managed_runtime:
         config_kwargs["emit_startup_event"] = True
 

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import asyncio
 import copy
 import gzip as _gzip
-import hmac
 import json
 import logging
 import math
@@ -653,7 +652,7 @@ class WebConfig:
     dx_cluster_host: str = ""
     dx_cluster_port: int = 0
     dx_callsign: str = ""
-    auth_token: str = ""  # empty = no auth required
+    auth_token: str = ""  # deprecated: only the empty compatibility value is accepted
     tls_cert: str = ""  # path to cert PEM (empty = auto self-signed)
     tls_key: str = ""  # path to key PEM (empty = auto self-signed)
     tls: bool = False  # enable TLS (HTTPS with auto self-signed cert)
@@ -667,6 +666,12 @@ class WebConfig:
     # PCM16↔Opus switching on detected slow/lossy links. Off (default) =
     # static MOR-584 per-connection codecs, never switched mid-stream.
     audio_adaptive_egress: bool = False
+
+    def __post_init__(self) -> None:
+        if self.auth_token:
+            raise ValueError(
+                "Application authentication was removed; auth_token must be empty."
+            )
 
 
 class ConnectionManager:
@@ -3211,7 +3216,7 @@ class WebServer:
             "radioAvailable": bool(radio_payload["radioReady"]),
             "backend": backend,
             "health": health,
-            "authRequired": bool(self._config.auth_token),
+            "authRequired": False,
             "message": message,
         }
 
@@ -3357,7 +3362,7 @@ class WebServer:
                 "version": __version__,
                 "bind": self._runtime_bind_payload(),
                 "logPath": self._runtime_log_path,
-                "authRequired": bool(self._config.auth_token),
+                "authRequired": False,
                 "backend": getattr(radio, "backend_id", None)
                 if radio is not None
                 else None,
@@ -5941,20 +5946,6 @@ class WebServer:
         headers: dict[str, str],
         query: dict[str, list[str]] | None = None,
     ) -> None:
-        # Auth check: accept Bearer header or ?token= query param
-        if self._config.auth_token:
-            auth_header = headers.get("authorization", "")
-            token_param = (query or {}).get("token", [""])[0]
-            expected_bearer = f"Bearer {self._config.auth_token}"
-            token_bytes = self._config.auth_token.encode("utf-8")
-            header_ok = hmac.compare_digest(
-                auth_header.encode("utf-8"), expected_bearer.encode("utf-8")
-            )
-            query_ok = hmac.compare_digest(token_param.encode("utf-8"), token_bytes)
-            if not header_ok and not query_ok:
-                await _send_response(writer, 401, "Unauthorized", b"Unauthorized", {})
-                return
-
         ws_key = headers.get("sec-websocket-key", "")
         if not ws_key:
             await _send_response(writer, 400, "Bad Request", b"Missing key", {})

--- a/src/rigplane/web/web_routing.py
+++ b/src/rigplane/web/web_routing.py
@@ -17,7 +17,6 @@ reference rather than an early ``from .server import _send_response``.
 from __future__ import annotations
 
 import asyncio
-import hmac
 import json
 import logging
 from typing import TYPE_CHECKING
@@ -50,22 +49,6 @@ async def dispatch_http_request(
     from . import server as _server_mod  # noqa: TID251
 
     _send_response = _server_mod._send_response
-
-    # Auth check for API endpoints
-    if server._config.auth_token and path.startswith("/api/"):
-        auth_header = (headers or {}).get("authorization", "")
-        expected = f"Bearer {server._config.auth_token}"
-        if not hmac.compare_digest(
-            auth_header.encode("utf-8"), expected.encode("utf-8")
-        ):
-            await _send_response(
-                writer,
-                401,
-                "Unauthorized",
-                b'{"error":"unauthorized","message":"Valid auth token required"}',
-                {"Content-Type": "application/json", "WWW-Authenticate": "Bearer"},
-            )
-            return
 
     if path == "/healthz":
         if method not in ("GET", "HEAD"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2094,10 +2094,6 @@ class TestRemainingPortPreflight:
                     str(free_web_port),
                     "--rigctld-port",
                     str(occupied_rigctld_port),
-                    # Sidestep the unrelated managed-mode auth requirement so
-                    # this test isolates the preflight/port-check path.
-                    "--auth-token",
-                    "test-token",
                 ]
             )
             assert args.web_host == "127.0.0.1"

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -842,11 +842,18 @@ def test_station_parser_is_managed_web_runtime() -> None:
 @pytest.mark.parametrize("command", [["web"], ["web", "--managed"], ["station"]])
 @pytest.mark.parametrize("option", ["--auth-token", "--auth-token-file"])
 @pytest.mark.parametrize("value", ["synthetic-private-value", ""])
+@pytest.mark.parametrize("joined", [False, True])
 def test_retired_auth_options_reject_before_runtime_without_disclosure(
-    command, option, value, monkeypatch, capsys,
+    command,
+    option,
+    value,
+    joined,
+    monkeypatch,
+    capsys,
 ) -> None:
     monkeypatch.setenv("ICOM_LOG_FILE", "off")
-    monkeypatch.setattr("sys.argv", ["rigplane", *command, f"{option}={value}"])
+    option_args = [f"{option}={value}"] if joined else [option, value]
+    monkeypatch.setattr("sys.argv", ["rigplane", *command, *option_args])
     with (
         patch("rigplane.cli._run", return_value=0) as run,
         patch("rigplane.cli.os._exit", side_effect=AssertionError("runtime reached")),
@@ -862,7 +869,10 @@ def test_retired_auth_options_reject_before_runtime_without_disclosure(
     create.assert_not_called()
     read.assert_not_called()
     output = capsys.readouterr()
-    assert "Application authentication was removed; remove --auth-token and --auth-token-file." in output.err
+    assert (
+        "Application authentication was removed; remove --auth-token and --auth-token-file."
+        in output.err
+    )
     assert "synthetic-private-value" not in output.err + output.out
 
 

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -814,17 +814,17 @@ def _web_cmd_args(*, web_bridge: str | None) -> argparse.Namespace:
     )
 
 
-def test_web_managed_parser_defaults_to_loopback_and_auth_required() -> None:
+def test_web_managed_parser_defaults_without_auth() -> None:
     parser = _build_parser()
 
-    args = parser.parse_args(["web", "--managed", "--auth-token-file", "token.txt"])
+    args = parser.parse_args(["web", "--managed"])
 
     assert args.command == "web"
     assert args.managed_runtime is True
     assert args.web_host == "127.0.0.1"
     assert args.web_rigctld is True
-    assert args.auth_token == ""
-    assert args.auth_token_file == "token.txt"
+    assert args.auth_token is None
+    assert args.auth_token_file is None
 
 
 def test_station_parser_is_managed_web_runtime() -> None:
@@ -839,106 +839,64 @@ def test_station_parser_is_managed_web_runtime() -> None:
     assert args.web_rigctld is True
 
 
-@pytest.mark.asyncio
-async def test_cmd_web_managed_requires_auth_token(
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize("command", [["web"], ["web", "--managed"], ["station"]])
+@pytest.mark.parametrize("option", ["--auth-token", "--auth-token-file"])
+@pytest.mark.parametrize("value", ["synthetic-private-value", ""])
+def test_retired_auth_options_reject_before_runtime_without_disclosure(
+    command, option, value, monkeypatch, capsys,
 ) -> None:
-    radio = AsyncMock()
-    args = _web_cmd_args(web_bridge=None)
-    args.managed_runtime = True
-    args.auth_token = ""
-    monkeypatch.delenv("RIGPLANE_AUTH_TOKEN", raising=False)
-
-    rc = await _cmd_web(radio, args)
-
-    assert rc == 1
-    assert (
-        "Set RIGPLANE_AUTH_TOKEN or pass --auth-token-file" in capsys.readouterr().err
-    )
+    monkeypatch.setenv("ICOM_LOG_FILE", "off")
+    monkeypatch.setattr("sys.argv", ["rigplane", *command, f"{option}={value}"])
+    with (
+        patch("rigplane.cli._run", return_value=0) as run,
+        patch("rigplane.cli.os._exit", side_effect=AssertionError("runtime reached")),
+        patch("rigplane.cli.logging.basicConfig"),
+        patch("rigplane.cli.signal.signal"),
+        patch("rigplane.cli.create_radio") as create,
+        patch("pathlib.Path.read_text") as read,
+        pytest.raises(SystemExit) as exc,
+    ):
+        main()
+    assert exc.value.code == 2
+    run.assert_not_called()
+    create.assert_not_called()
+    read.assert_not_called()
+    output = capsys.readouterr()
+    assert "Application authentication was removed; remove --auth-token and --auth-token-file." in output.err
+    assert "synthetic-private-value" not in output.err + output.out
 
 
 @pytest.mark.asyncio
-async def test_cmd_web_managed_uses_auth_token_file(
-    tmp_path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    radio = AsyncMock()
-    captured: dict[str, object] = {}
-    monkeypatch.setenv("RIGPLANE_AUTH_TOKEN", "env-token")
-    token_file = tmp_path / "token.txt"
-    token_file.write_text(" file-token \n", encoding="utf-8")
+@pytest.mark.parametrize("command", [["web"], ["web", "--managed"], ["station"]])
+@pytest.mark.parametrize("environment", [None, "synthetic-ignored-env"])
+async def test_web_launch_without_application_auth(command, environment, monkeypatch):
+    if environment is None:
+        monkeypatch.delenv("RIGPLANE_AUTH_TOKEN", raising=False)
+    else:
+        monkeypatch.setenv("RIGPLANE_AUTH_TOKEN", environment)
+    args = _build_parser().parse_args(command)
+    args.web_rigctld = False
+    captured = {}
 
     class FakeWebServer:
-        def __init__(self, _radio, cfg):
-            captured["cfg"] = cfg
+        def __init__(self, radio, cfg):
+            captured["config"] = cfg
             self._runtime_log_path = None
 
         async def serve_forever(self):
             raise asyncio.CancelledError
 
-    args = _web_cmd_args(web_bridge=None)
-    args.managed_runtime = True
-    args.auth_token = ""
-    args.auth_token_file = str(token_file)
-
     with patch("rigplane.web.server.WebServer", FakeWebServer):
-        assert await _cmd_web(radio, args) == 0
-
-    assert captured["cfg"].auth_token == "file-token"
-
-
-@pytest.mark.asyncio
-async def test_cmd_web_auth_token_precedence_over_file_and_env(
-    tmp_path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    radio = AsyncMock()
-    captured: dict[str, object] = {}
-    monkeypatch.setenv("RIGPLANE_AUTH_TOKEN", "env-token")
-    token_file = tmp_path / "token.txt"
-    token_file.write_text("file-token\n", encoding="utf-8")
-
-    class FakeWebServer:
-        def __init__(self, _radio, cfg):
-            captured["cfg"] = cfg
-            self._runtime_log_path = None
-
-        async def serve_forever(self):
-            raise asyncio.CancelledError
-
-    args = _web_cmd_args(web_bridge=None)
-    args.managed_runtime = True
-    args.auth_token = "argv-token"
-    args.auth_token_file = str(token_file)
-
-    with patch("rigplane.web.server.WebServer", FakeWebServer):
-        assert await _cmd_web(radio, args) == 0
-
-    assert captured["cfg"].auth_token == "argv-token"
+        assert await _cmd_web(AsyncMock(), args) == 0
+    cfg = captured["config"]
+    managed = command != ["web"]
+    assert cfg.auth_token == ""
+    assert cfg.host == ("127.0.0.1" if managed else "0.0.0.0")
+    assert cfg.emit_startup_event is managed
 
 
 @pytest.mark.asyncio
-async def test_cmd_web_auth_token_file_failure_surfaces(
-    capsys: pytest.CaptureFixture[str],
-    tmp_path,
-) -> None:
-    radio = AsyncMock()
-    missing = tmp_path / "missing-token.txt"
-
-    args = _web_cmd_args(web_bridge=None)
-    args.managed_runtime = True
-    args.auth_token = ""
-    args.auth_token_file = str(missing)
-
-    rc = await _cmd_web(radio, args)
-
-    assert rc == 1
-    assert "failed to read --auth-token-file" in capsys.readouterr().err
-
-
-@pytest.mark.asyncio
-async def test_cmd_web_managed_uses_env_auth_and_loopback_embedded_rigctld(
+async def test_cmd_web_managed_ignores_env_auth_and_keeps_loopback_rigctld(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     radio = AsyncMock()
@@ -977,7 +935,7 @@ async def test_cmd_web_managed_uses_env_auth_and_loopback_embedded_rigctld(
         assert await _cmd_web(radio, args) == 0
 
     cfg = captured["cfg"]
-    assert cfg.auth_token == "env-token"
+    assert cfg.auth_token == ""
     assert cfg.host == "127.0.0.1"
     assert cfg.emit_startup_event is True
     assert captured["runtime_log_path"] == "/tmp/rigplane-managed.log"

--- a/tests/test_web_api_contract.py
+++ b/tests/test_web_api_contract.py
@@ -156,7 +156,7 @@ async def test_control_domains_round_trip_through_both_capability_endpoints(
         radio_ready=False,
     )
     server = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
-    headers = {"authorization": "Bearer token"}
+    headers = {}
     for path in ("/api/v1/info", "/api/v1/capabilities"):
         writer = _Writer()
         await server._handle_http(writer, "GET", path, headers=headers)  # noqa: SLF001
@@ -277,7 +277,7 @@ def test_command_batch_docs_use_numeric_data_mode_contract() -> None:
 async def test_stable_http_payloads_satisfy_required_field_contract() -> None:
     srv = WebServer(
         None,
-        WebConfig(host="127.0.0.1", port=0, auth_token="token", radio_model="IC-7610"),
+        WebConfig(host="127.0.0.1", port=0, radio_model="IC-7610"),
     )
     srv._server = type(  # noqa: SLF001
         "_Server",
@@ -288,7 +288,7 @@ async def test_stable_http_payloads_satisfy_required_field_contract() -> None:
             ]
         },
     )()
-    headers = {"authorization": "Bearer token"}
+    headers = {}
 
     for path, expected_status in (
         ("/healthz", 200),

--- a/tests/test_web_auth_compare_digest.py
+++ b/tests/test_web_auth_compare_digest.py
@@ -1,29 +1,15 @@
-"""Tests for timing-safe token comparison (issue #947).
-
-Verifies that the HTTP API and WebSocket auth paths in web/server.py
-use ``hmac.compare_digest`` for token comparison. These tests don't
-measure timing directly — they assert correctness (accept on match,
-reject on mismatch) and that the module imports ``hmac``.
-"""
+"""Application-token retirement contracts (MOR-2361)."""
 
 from __future__ import annotations
 
 import asyncio
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from rigplane.web import server as web_server
 from rigplane.web.server import WebConfig, WebServer
-
-
-def test_server_module_imports_hmac() -> None:
-    """Regression guard: ensure the web server imports hmac.
-
-    If this fails, someone has removed the import and fallen back to
-    timing-unsafe `==` comparisons.
-    """
-    assert hasattr(web_server, "hmac")
 
 
 class _MemoryWriter:
@@ -52,98 +38,72 @@ class _MemoryWriter:
         return ("127.0.0.1", 0)
 
 
-def _make_server(token: str) -> WebServer:
-    cfg = WebConfig(auth_token=token)
-    return WebServer(radio=None, config=cfg)
+
+@pytest.mark.parametrize("token", ["retired-private-value", " ", "unicode-λ"])
+def test_nonempty_legacy_config_is_rejected_without_disclosure(token):
+    with pytest.raises(ValueError) as exc:
+        WebConfig(auth_token=token)
+    assert str(exc.value) == "Application authentication was removed; auth_token must be empty."
 
 
-def test_http_api_accepts_correct_bearer_token() -> None:
-    """HTTP API endpoint accepts the correct Bearer token."""
-    srv = _make_server("s3cr3t")
+@pytest.mark.asyncio
+@pytest.mark.parametrize("header", [None, "Bearer wrong", "wrong", "Bearer unicode-λ"])
+@pytest.mark.parametrize("path", ["/api/v1/info", "/api/v1/state", "/api/v1/capabilities", "/api/v1/runtime", "/api/v1/station"])
+async def test_http_dispatch_needs_no_application_token(header, path):
+    srv = WebServer(radio=None, config=WebConfig())
+    # The retained compatibility attribute cannot reactivate the retired gate.
+    srv._config.auth_token = "retired-private-value"
     writer = _MemoryWriter()
-    headers = {"authorization": "Bearer s3cr3t"}
-
-    async def run() -> None:
-        # _handle_http needs a reader too; use an empty one for a GET with no body.
-        reader = asyncio.StreamReader()
-        reader.feed_eof()
-        await srv._handle_http(writer, "GET", "/api/v1/info", headers, reader, None)  # type: ignore[arg-type]
-
-    asyncio.run(run())
-    # Correct token → should NOT produce a 401.
-    assert b"401" not in bytes(writer.buffer[:32])
+    headers = {"authorization": header} if header is not None else {}
+    await srv._handle_http(writer, "GET", path, headers)
+    assert bytes(writer.buffer).startswith(b"HTTP/1.1 200 ")
+    assert b"retired-private-value" not in writer.buffer
+    assert b'"authRequired": true' not in writer.buffer
 
 
-def test_http_api_rejects_wrong_bearer_token() -> None:
-    """HTTP API endpoint rejects a bearer value that differs from the token."""
-    srv = _make_server("s3cr3t")
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/api/v1/ws", "/api/v1/scope", "/api/v1/audio-scope", "/api/v1/audio"])
+@pytest.mark.parametrize("legacy_token", [False, True])
+async def test_all_ws_channels_upgrade_without_application_auth(monkeypatch, path, legacy_token):
+    srv = WebServer(radio=None, config=WebConfig())
+    srv._config.auth_token = "retired-private-value"
+    srv._audio_fft_scope = object()
+    handlers = {}
+    for name in ("ControlHandler", "ScopeHandler", "AudioHandler"):
+        factory = MagicMock(return_value=MagicMock(run=AsyncMock()))
+        monkeypatch.setattr(web_server, name, factory)
+        handlers[name] = factory
     writer = _MemoryWriter()
-    headers = {"authorization": "Bearer wrong"}
+    headers = {"sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ=="}
+    if legacy_token:
+        headers["authorization"] = "Bearer wrong"
+    await srv._handle_websocket(
+        asyncio.StreamReader(), writer, path, headers,
+        {"token": ["wrong"]} if legacy_token else {},
+    )
+    assert bytes(writer.buffer).startswith(b"HTTP/1.1 101 ")
+    expected = "ControlHandler" if path.endswith("/ws") else "AudioHandler" if path.endswith("/audio") else "ScopeHandler"
+    handlers[expected].return_value.run.assert_awaited_once()
+    assert sum(factory.call_count for factory in handlers.values()) == 1
 
-    async def run() -> None:
-        reader = asyncio.StreamReader()
-        reader.feed_eof()
-        await srv._handle_http(writer, "GET", "/api/v1/info", headers, reader, None)  # type: ignore[arg-type]
 
-    asyncio.run(run())
-    assert b"401" in bytes(writer.buffer[:32])
-
-
-def test_http_api_rejects_missing_bearer_prefix() -> None:
-    """Header without the `Bearer ` prefix must be rejected."""
-    srv = _make_server("s3cr3t")
+@pytest.mark.asyncio
+async def test_ws_still_rejects_missing_key():
+    srv = WebServer(radio=None, config=WebConfig())
     writer = _MemoryWriter()
-    headers = {"authorization": "s3cr3t"}  # no prefix
-
-    async def run() -> None:
-        reader = asyncio.StreamReader()
-        reader.feed_eof()
-        await srv._handle_http(writer, "GET", "/api/v1/info", headers, reader, None)  # type: ignore[arg-type]
-
-    asyncio.run(run())
-    assert b"401" in bytes(writer.buffer[:32])
+    await srv._handle_websocket(asyncio.StreamReader(), writer, "/api/v1/ws", {})
+    assert bytes(writer.buffer).startswith(b"HTTP/1.1 400 ")
 
 
-@pytest.mark.parametrize(
-    "auth_header,token_param,should_pass",
-    [
-        ("Bearer s3cr3t", "", True),
-        ("", "s3cr3t", True),
-        ("Bearer wrong", "", False),
-        ("", "wrong", False),
-        ("Bearer wrong", "wrong", False),
-    ],
-)
-def test_websocket_auth_matrix(
-    auth_header: str, token_param: str, should_pass: bool
-) -> None:
-    """WebSocket upgrade path accepts either header OR query token when correct."""
-    srv = _make_server("s3cr3t")
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path,reason", [("/api/v1/unknown", "unknown channel"), ("/api/v1/audio-scope", "audio FFT scope not available")])
+async def test_ws_still_refuses_unavailable_channels(monkeypatch, path, reason):
+    srv = WebServer(radio=None, config=WebConfig())
     writer = _MemoryWriter()
-    headers = {
-        "upgrade": "websocket",
-        "connection": "Upgrade",
-        "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
-        "sec-websocket-version": "13",
-    }
-    if auth_header:
-        headers["authorization"] = auth_header
-    query = {"token": [token_param]} if token_param else {}
-
-    async def run() -> None:
-        reader = asyncio.StreamReader()
-        reader.feed_eof()
-        await srv._handle_websocket(  # type: ignore[attr-defined]
-            reader,
-            writer,
-            "/api/v1/ws",
-            headers,
-            query,  # type: ignore[arg-type]
-        )
-
-    asyncio.run(run())
-    head = bytes(writer.buffer[:32])
-    if should_pass:
-        assert b"401" not in head
-    else:
-        assert b"401" in head
+    ws = MagicMock(close=AsyncMock())
+    monkeypatch.setattr(web_server, "WebSocketConnection", MagicMock(return_value=ws))
+    await srv._handle_websocket(
+        asyncio.StreamReader(), writer, path,
+        {"sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ=="},
+    )
+    ws.close.assert_awaited_once_with(1008, reason)

--- a/tests/test_web_auth_compare_digest.py
+++ b/tests/test_web_auth_compare_digest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -38,19 +39,30 @@ class _MemoryWriter:
         return ("127.0.0.1", 0)
 
 
-
 @pytest.mark.parametrize("token", ["retired-private-value", " ", "unicode-λ"])
 def test_nonempty_legacy_config_is_rejected_without_disclosure(token):
     with pytest.raises(ValueError) as exc:
         WebConfig(auth_token=token)
-    assert str(exc.value) == "Application authentication was removed; auth_token must be empty."
+    assert (
+        str(exc.value)
+        == "Application authentication was removed; auth_token must be empty."
+    )
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("header", [None, "Bearer wrong", "wrong", "Bearer unicode-λ"])
-@pytest.mark.parametrize("path", ["/api/v1/info", "/api/v1/state", "/api/v1/capabilities", "/api/v1/runtime", "/api/v1/station"])
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v1/info",
+        "/api/v1/state",
+        "/api/v1/capabilities",
+        "/api/v1/runtime",
+        "/api/v1/station",
+    ],
+)
 async def test_http_dispatch_needs_no_application_token(header, path):
-    srv = WebServer(radio=None, config=WebConfig())
+    srv = WebServer(radio=None, config=WebConfig(radio_model="IC-7300"))
     # The retained compatibility attribute cannot reactivate the retired gate.
     srv._config.auth_token = "retired-private-value"
     writer = _MemoryWriter()
@@ -58,13 +70,22 @@ async def test_http_dispatch_needs_no_application_token(header, path):
     await srv._handle_http(writer, "GET", path, headers)
     assert bytes(writer.buffer).startswith(b"HTTP/1.1 200 ")
     assert b"retired-private-value" not in writer.buffer
-    assert b'"authRequired": true' not in writer.buffer
+    data = json.loads(bytes(writer.buffer).split(b"\r\n\r\n", 1)[1])
+    if path == "/api/v1/runtime":
+        assert data["authRequired"] is False
+        assert data["station"]["authRequired"] is False
+    elif path == "/api/v1/station":
+        assert data["station"]["authRequired"] is False
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("path", ["/api/v1/ws", "/api/v1/scope", "/api/v1/audio-scope", "/api/v1/audio"])
+@pytest.mark.parametrize(
+    "path", ["/api/v1/ws", "/api/v1/scope", "/api/v1/audio-scope", "/api/v1/audio"]
+)
 @pytest.mark.parametrize("legacy_token", [False, True])
-async def test_all_ws_channels_upgrade_without_application_auth(monkeypatch, path, legacy_token):
+async def test_all_ws_channels_upgrade_without_application_auth(
+    monkeypatch, path, legacy_token
+):
     srv = WebServer(radio=None, config=WebConfig())
     srv._config.auth_token = "retired-private-value"
     srv._audio_fft_scope = object()
@@ -78,11 +99,20 @@ async def test_all_ws_channels_upgrade_without_application_auth(monkeypatch, pat
     if legacy_token:
         headers["authorization"] = "Bearer wrong"
     await srv._handle_websocket(
-        asyncio.StreamReader(), writer, path, headers,
+        asyncio.StreamReader(),
+        writer,
+        path,
+        headers,
         {"token": ["wrong"]} if legacy_token else {},
     )
     assert bytes(writer.buffer).startswith(b"HTTP/1.1 101 ")
-    expected = "ControlHandler" if path.endswith("/ws") else "AudioHandler" if path.endswith("/audio") else "ScopeHandler"
+    expected = (
+        "ControlHandler"
+        if path.endswith("/ws")
+        else "AudioHandler"
+        if path.endswith("/audio")
+        else "ScopeHandler"
+    )
     handlers[expected].return_value.run.assert_awaited_once()
     assert sum(factory.call_count for factory in handlers.values()) == 1
 
@@ -96,14 +126,22 @@ async def test_ws_still_rejects_missing_key():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("path,reason", [("/api/v1/unknown", "unknown channel"), ("/api/v1/audio-scope", "audio FFT scope not available")])
+@pytest.mark.parametrize(
+    "path,reason",
+    [
+        ("/api/v1/unknown", "unknown channel"),
+        ("/api/v1/audio-scope", "audio FFT scope not available"),
+    ],
+)
 async def test_ws_still_refuses_unavailable_channels(monkeypatch, path, reason):
     srv = WebServer(radio=None, config=WebConfig())
     writer = _MemoryWriter()
     ws = MagicMock(close=AsyncMock())
     monkeypatch.setattr(web_server, "WebSocketConnection", MagicMock(return_value=ws))
     await srv._handle_websocket(
-        asyncio.StreamReader(), writer, path,
+        asyncio.StreamReader(),
+        writer,
+        path,
         {"sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ=="},
     )
     ws.close.assert_awaited_once_with(1008, reason)

--- a/tests/test_web_command_batch_http.py
+++ b/tests/test_web_command_batch_http.py
@@ -599,11 +599,13 @@ async def test_http_command_without_auth_keeps_read_only_guard() -> None:
     writer = await _post_json(
         srv,
         "/api/v1/commands",
-        {"name": "set_freq", "params": {"freq": 144_030_000}},
+        {"name": "ptt", "params": {"state": True}},
     )
 
     assert writer.response_status == 403
     assert writer.response_body["error"] == "read_only"
+
+    assert srv.command_queue.drain() == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_command_batch_http.py
+++ b/tests/test_web_command_batch_http.py
@@ -438,12 +438,12 @@ async def test_http_raw_civ_transaction_rejects_read_only() -> None:
 
 
 @pytest.mark.asyncio
-async def test_http_raw_civ_transaction_requires_auth_when_configured() -> None:
+async def test_http_raw_civ_transaction_without_auth_keeps_read_only_guard() -> None:
     radio = _radio()
     radio.send_civ_transaction = AsyncMock()
     srv = WebServer(
         radio,
-        WebConfig(host="127.0.0.1", port=0, auth_token="secret"),
+        WebConfig(host="127.0.0.1", port=0, read_only=True),
     )
 
     writer = await _post_json(
@@ -452,8 +452,8 @@ async def test_http_raw_civ_transaction_requires_auth_when_configured() -> None:
         {"command": 0x1A, "data": "015301", "expect": "ack"},
     )
 
-    assert writer.response_status == 401
-    assert writer.response_body["error"] == "unauthorized"
+    assert writer.response_status == 403
+    assert writer.response_body["error"] == "read_only"
     radio.send_civ_transaction.assert_not_awaited()
 
 
@@ -590,10 +590,10 @@ async def test_http_raw_civ_rejected_in_read_only_mode() -> None:
 
 
 @pytest.mark.asyncio
-async def test_http_command_requires_auth_when_configured() -> None:
+async def test_http_command_without_auth_keeps_read_only_guard() -> None:
     srv = WebServer(
         _radio(),
-        WebConfig(host="127.0.0.1", port=0, auth_token="secret"),
+        WebConfig(host="127.0.0.1", port=0, read_only=True),
     )
 
     writer = await _post_json(
@@ -602,8 +602,8 @@ async def test_http_command_requires_auth_when_configured() -> None:
         {"name": "set_freq", "params": {"freq": 144_030_000}},
     )
 
-    assert writer.response_status == 401
-    assert writer.response_body["error"] == "unauthorized"
+    assert writer.response_status == 403
+    assert writer.response_body["error"] == "read_only"
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_diagnostics.py
+++ b/tests/test_web_diagnostics.py
@@ -114,8 +114,8 @@ def _make_reader(data: bytes = b"") -> asyncio.StreamReader:
     return reader
 
 
-def _make_server(host: str = "127.0.0.1", auth_token: str = "") -> WebServer:
-    cfg = WebConfig(host=host, port=8080, auth_token=auth_token)
+def _make_server(host: str = "127.0.0.1") -> WebServer:
+    cfg = WebConfig(host=host, port=8080)
     srv = WebServer(radio=None, config=cfg)
     return srv
 
@@ -577,15 +577,14 @@ async def test_send_after_expiry_returns_404(
 
 
 @pytest.mark.asyncio
-async def test_api_auth_inherited(
+async def test_api_preview_needs_no_application_token(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """When auth_token is configured, /api/v1/diagnose/* requires Bearer auth."""
     _register_test_contributor()
     _stub_dirs(monkeypatch, tmp_path)
-    srv = _make_server(auth_token="t0p-s3cret")
+    srv = _make_server()
     try:
-        # No auth header → 401.
+        # No application token.
         body = json.dumps({"description": "test"}).encode()
         writer = _FakeWriter()
         await srv._handle_http(
@@ -596,16 +595,16 @@ async def test_api_auth_inherited(
             _make_reader(body),
             None,
         )
-        assert writer.response_status == 401
+        assert writer.response_status == 200
 
-        # With correct Bearer → 200.
+        # A retired token-looking header confers no additional authority.
         body = json.dumps({"description": "test"}).encode()
         writer2 = _FakeWriter()
         await srv._handle_http(
             writer2,  # type: ignore[arg-type]
             "POST",
             "/api/v1/diagnose/preview",
-            _post_headers(body, authorization="Bearer t0p-s3cret"),
+            _post_headers(body, authorization="Bearer retired-test-token"),
             _make_reader(body),
             None,
         )

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -1608,7 +1608,7 @@ async def test_runtime_endpoint_reports_process_bind_radio_and_bridge_status() -
         radio_ready=True,
         capabilities=set(),
     )
-    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0, auth_token="token"))
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
     srv._server = _FakeAsyncServer()  # noqa: SLF001
     srv._audio_bridge = SimpleNamespace(  # noqa: SLF001
         running=True,
@@ -1622,7 +1622,7 @@ async def test_runtime_endpoint_reports_process_bind_radio_and_bridge_status() -
         writer,
         "GET",
         "/api/v1/runtime",
-        headers={"authorization": "Bearer token"},
+        headers={},
     )
 
     status, data = _response_json(writer)
@@ -1632,7 +1632,8 @@ async def test_runtime_endpoint_reports_process_bind_radio_and_bridge_status() -
     assert data["version"]
     assert data["bind"] == {"host": "127.0.0.1", "port": 4242}
     assert data["logPath"] == "/tmp/rigplane.log"
-    assert data["authRequired"] is True
+    assert data["authRequired"] is False
+    assert data["station"]["authRequired"] is False
     assert data["backend"] == "rigplane"
     assert data["radio"] == {
         "model": "IC-7610",


### PR DESCRIPTION
## Change and compatibility

Core web and managed station launches no longer require an application Bearer token. Ordinary HTTP API requests and WebSocket upgrades at `/api/v1/ws`, `/api/v1/scope`, `/api/v1/audio-scope` and `/api/v1/audio` pass through the existing route/protocol/admission checks without a blanket application-token check. Endpoint paths were checked in `WebServer._handle_websocket` and its parameterized upgrade tests.

Remove `--auth-token` and `--auth-token-file` from launch configurations: these retired options now fail with a fixed error before opening the radio and without reading a token file. `RIGPLANE_AUTH_TOKEN` has no effect; Python callers must leave `WebConfig.auth_token` empty. Runtime/station `authRequired` metadata is false. This changes the access contract: reachable clients no longer need an application credential. Radio protocol credentials, bind/TLS settings, managed TX admission, read-only TX restrictions, ForceOff/TOT, and diagnostic CSRF/Origin/consent guards retain their existing behavior.

This is backend slice A of https://linear.app/morozsm/issue/MOR-2361 under MOR-2360. Browser transport/storage and public migration documentation follow in bounded companion work. Existing installed launch arguments must be migrated at the combined installation; this PR alone does not claim a final installable auth-removal candidate or operator acceptance.

## Validation

`uv run pytest` over the seven changed files and six unchanged managed-TX/redaction guard files passed 656 tests; the exact command is recorded in the builder handback. Changed-file Ruff check/format passed and `uv run mypy --strict src/rigplane/web` passed (27 files). Restoring the old HTTP/WS token gates as a temporary mutation failed 28 targeted cases; the source was restored before the final passing run. No local full suite or hardware test was run. Natural required CI and independent exact-head review are pending.

The original 49-failure RED checkpoint is preserved. Subsequent fixture/profile, parametrization-signature and station-envelope assertion mistakes were corrected against existing production contracts; they did not require weakening production guards.

Ten files (+206/-283, 489 changed lines from `git diff --stat 84d8e6...HEAD`) exceed the six-file soft threshold because three production entrypoints and their seven existing test files establish one launch/HTTP/WS compatibility contract. No paths outside that lease changed. No release publication or new TX/PTT authority.
