### PR TITLE
feat(MOR-2362): stop browser application-token collection and transport

### DIFF
--- a/frontend/src/__tests__/first-browser-auth.component.test.ts
+++ b/frontend/src/__tests__/first-browser-auth.component.test.ts
@@ -22,12 +22,12 @@ vi.mock('$lib/audio/audio-manager', () => ({
 import App from '../App.svelte';
 import { runtime } from '$lib/runtime/frontend-runtime';
 import { disconnectAll } from '$lib/transport/ws-client';
+import { fetchInfo, getAuthHeaders, getAuthToken } from '$lib/transport/http-client';
 
 const credential = 'synthetic-first-entry';
 const caps = { ...capsFixture, stateContractVersion: 1, providerGeneration: 0 };
 const requests: string[] = [];
 let app: ReturnType<typeof mount> | undefined;
-let protectedServer = true;
 const promptMock = vi.fn();
 const fetchMock = vi.fn();
 
@@ -48,23 +48,16 @@ beforeEach(() => {
   document.body.innerHTML = '';
   instances.length = 0;
   requests.length = 0;
-  protectedServer = true;
   vi.stubGlobal('WebSocket', MockWebSocket);
   vi.stubGlobal('prompt', promptMock);
   vi.stubGlobal('fetch', fetchMock);
   vi.spyOn(console, 'error').mockImplementation(() => {});
-  promptMock.mockImplementation(() => {
-    expect(instances).toHaveLength(0);
-    expect(localStorage.getItem('rigplane-auth-token')).toBeNull();
-    return credential;
-  });
   fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
     requests.push(url);
     expect(url.startsWith('/api/v1/')).toBe(true);
     expect(url).not.toContain(credential);
     expect(init.redirect).toBe('error');
-    const authorized = new Headers(init.headers).get('Authorization') === `Bearer ${credential}`;
-    if (protectedServer && !authorized) return response(401);
+    expect(new Headers(init.headers).has('Authorization')).toBe(false);
     return response(200, url.endsWith('/capabilities') ? caps : { version: 'test' });
   });
 });
@@ -77,16 +70,18 @@ afterEach(async () => {
   vi.unstubAllGlobals();
 });
 
-describe('first browser authentication through App and the real runtime', () => {
-  it('prompts from empty storage before control WS, then accepts state and capabilities', async () => {
+describe('credential-free App and real runtime startup', () => {
+  it.each([null, credential])('connects and accepts state/capabilities with retired stored token %s', async (stored) => {
+    if (stored) localStorage.setItem('rigplane-auth-token', stored);
+    const reads = vi.spyOn(localStorage, 'getItem');
+    const writes = vi.spyOn(localStorage, 'setItem');
     startApp();
     await settle();
-    expect(promptMock).toHaveBeenCalledExactlyOnceWith('Enter auth token:');
-    expect(requests).toEqual(['/api/v1/info', '/api/v1/info']);
-    expect(localStorage.getItem('rigplane-auth-token')).toBe(credential);
+    expect(promptMock).not.toHaveBeenCalled();
+    expect(requests).toEqual(['/api/v1/info']);
     expect(instances).toHaveLength(1);
     const socket = instances[0];
-    expect(new URL(socket.url).searchParams.get('token')).toBe(credential);
+    expect(new URL(socket.url, 'http://localhost').searchParams.has('token')).toBe(false);
     socket.simulateOpen();
     const state = { ...stateFixture, stateContractVersion: 1, providerGeneration: 0 };
     socket.simulateMessage(JSON.stringify({ type: 'state_update', data: { type: 'full', data: state, stateContractVersion: 1, providerGeneration: 0 } }));
@@ -96,37 +91,15 @@ describe('first browser authentication through App and the real runtime', () => 
     expect(runtime.state?.main.freqHz).toBe(state.main.freqHz);
     expect(runtime.connectionWs).toBe(true);
     expect(document.querySelector('[role="alert"]')).toBeNull();
+    for (const key of ['rigplane-auth-token', 'icom-lan-auth-token']) {
+      expect(reads).not.toHaveBeenCalledWith(key);
+      expect(writes).not.toHaveBeenCalledWith(key, expect.anything());
+    }
   });
 
-  it.each(['valid stored token', 'no-auth server'])('preserves %s startup', async (mode) => {
-    if (mode === 'valid stored token') localStorage.setItem('rigplane-auth-token', credential);
-    else protectedServer = false;
-    startApp();
-    await settle();
-    expect(promptMock).not.toHaveBeenCalled();
-    expect(requests).toEqual(['/api/v1/info']);
-    expect(instances).toHaveLength(1);
-  });
-
-  it.each([null, '', 'synthetic-wrong'])('stops cancelled or rejected input %s without automatic reload', async (answer) => {
-    vi.useFakeTimers();
-    promptMock.mockReturnValue(answer);
-    startApp();
-    await settle();
-    expect(promptMock).toHaveBeenCalledTimes(1);
-    expect(instances).toHaveLength(0);
-    expect(localStorage.getItem('rigplane-auth-token')).toBeNull();
-    expect(document.querySelector('[role="alert"]')?.textContent).toMatch(/reload/i);
-    expect(document.querySelector('.retry-indicator')).toBeNull();
-    await vi.advanceTimersByTimeAsync(60_000);
-    expect(promptMock).toHaveBeenCalledTimes(1);
-    expect(requests).toHaveLength(answer ? 2 : 1);
-    vi.useRealTimers();
-  });
-
-  it.each(['network', '503'])('does not turn %s failure into an auth prompt', async (failure) => {
+  it.each(['network', '503', '401'])('does not turn %s failure into an auth prompt', async (failure) => {
     if (failure === 'network') fetchMock.mockRejectedValue(new TypeError('Network unavailable'));
-    else fetchMock.mockResolvedValue(response(503));
+    else fetchMock.mockResolvedValue(response(Number(failure)));
     startApp();
     await settle();
     expect(promptMock).not.toHaveBeenCalled();
@@ -149,12 +122,35 @@ describe('first browser authentication through App and the real runtime', () => 
     expect(instances).toHaveLength(0);
   });
 
-  it('does not request credentials when bootstrap was already cancelled', async () => {
+  it('does not fetch or open WS when bootstrap was already cancelled', async () => {
     const abort = new AbortController();
     abort.abort();
     await expect(runtime.bootstrap(abort.signal)).rejects.toMatchObject({ name: 'AbortError' });
     expect(fetchMock).not.toHaveBeenCalled();
     expect(promptMock).not.toHaveBeenCalled();
     expect(instances).toHaveLength(0);
+  });
+
+  it('keeps deprecated helpers empty without accessing browser storage', () => {
+    localStorage.setItem('rigplane-auth-token', credential);
+    const reads = vi.spyOn(localStorage, 'getItem');
+    const writes = vi.spyOn(localStorage, 'setItem');
+    expect(getAuthToken()).toBeNull();
+    expect(getAuthHeaders()).toEqual({});
+    expect(reads).not.toHaveBeenCalled();
+    expect(writes).not.toHaveBeenCalled();
+  });
+
+  it.each([401, 503])('reports HTTP %s once without prompting, retrying or persisting', async (status) => {
+    const reads = vi.spyOn(localStorage, 'getItem');
+    const writes = vi.spyOn(localStorage, 'setItem');
+    fetchMock.mockResolvedValue(response(status));
+    await expect(fetchInfo()).rejects.toThrow(`fetchInfo: ${status}`);
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith('/api/v1/info', {
+      headers: {}, signal: undefined, redirect: 'error',
+    });
+    expect(promptMock).not.toHaveBeenCalled();
+    expect(reads).not.toHaveBeenCalled();
+    expect(writes).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/first-browser-auth.component.test.ts
+++ b/frontend/src/__tests__/first-browser-auth.component.test.ts
@@ -91,10 +91,8 @@ describe('credential-free App and real runtime startup', () => {
     expect(runtime.state?.main.freqHz).toBe(state.main.freqHz);
     expect(runtime.connectionWs).toBe(true);
     expect(document.querySelector('[role="alert"]')).toBeNull();
-    for (const key of ['rigplane-auth-token', 'icom-lan-auth-token']) {
-      expect(reads).not.toHaveBeenCalledWith(key);
-      expect(writes).not.toHaveBeenCalledWith(key, expect.anything());
-    }
+    expect(reads.mock.calls.filter(([key]) => key.endsWith('auth-token'))).toEqual([]);
+    expect(writes.mock.calls.filter(([key]) => key.endsWith('auth-token'))).toEqual([]);
   });
 
   it.each(['network', '503', '401'])('does not turn %s failure into an auth prompt', async (failure) => {

--- a/frontend/src/components/spectrum/__tests__/BandPlanOverlay.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/BandPlanOverlay.component.test.ts
@@ -196,7 +196,7 @@ describe('BandPlanOverlay (component)', () => {
     expect(titles).toContain('SSB-R');
   });
 
-  it('reads auth when the debounced request runs and keeps 401 fallback behavior', async () => {
+  it('ignores retired tokens when the debounced request runs and keeps 401 fallback behavior', async () => {
     localStorage.setItem('rigplane-auth-token', 'stale-token');
     mockFetch.mockResolvedValue({ ok: false, status: 401 } as Response);
     const { target } = mountOverlay({
@@ -210,7 +210,7 @@ describe('BandPlanOverlay (component)', () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       '/api/v1/band-plan/segments?start=13825000&end=14525000',
-      { headers: { Authorization: 'Bearer current-token' } },
+      { headers: {} },
     );
     expect(target.querySelectorAll('.band-segment')).toHaveLength(3);
   });

--- a/frontend/src/components/spectrum/__tests__/EiBiBrowser.authority.isolated.test.ts
+++ b/frontend/src/components/spectrum/__tests__/EiBiBrowser.authority.isolated.test.ts
@@ -110,7 +110,7 @@ afterEach(() => {
 });
 
 describe('MOR-1409 A05b EiBi tune authority', () => {
-  it('authenticates status, bands, and stations with a fresh token read', async () => {
+  it('fetches status, bands, and stations without retired credentials', async () => {
     localStorage.setItem('rigplane-auth-token', 'status-token');
     h.fetch.mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
@@ -143,16 +143,16 @@ describe('MOR-1409 A05b EiBi tune authority', () => {
 
     const calls = h.fetch.mock.calls;
     expect(calls.find(([url]) => String(url).includes('/status'))?.[1]).toEqual({
-      headers: { Authorization: 'Bearer status-token' },
+      headers: {},
     });
     for (const suffix of ['/bands', '/stations']) {
       expect(calls.find(([url]) => String(url).includes(suffix))?.[1]).toEqual({
-        headers: { Authorization: 'Bearer query-token' },
+        headers: {},
       });
     }
   });
 
-  it('authenticates the fetch POST without changing its body or content type', async () => {
+  it('omits retired credentials from the fetch POST and preserves its body and content type', async () => {
     localStorage.setItem('rigplane-auth-token', 'fetch-token');
     h.fetch.mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
@@ -180,7 +180,6 @@ describe('MOR-1409 A05b EiBi tune authority', () => {
       expect(h.fetch).toHaveBeenCalledWith('/api/v1/eibi/fetch', {
         method: 'POST',
         headers: {
-          Authorization: 'Bearer fetch-token',
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ force: false }),

--- a/frontend/src/components/spectrum/__tests__/SpectrumToolbar.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumToolbar.component.test.ts
@@ -550,8 +550,8 @@ describe('structural and browser-local behavior', () => {
   });
 });
 
-describe('band-plan HTTP authentication', () => {
-  it('authenticates GETs and rereads the token for the existing config POST', async () => {
+describe('band-plan credential-free HTTP', () => {
+  it('omits retired credentials from GETs and the existing config POST', async () => {
     fetchMock.mockImplementation(async (input, init) => {
       const url = String(input);
       if (url.endsWith('/layers')) {
@@ -576,10 +576,10 @@ describe('band-plan HTTP authentication', () => {
 
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
     expect(fetchMock).toHaveBeenCalledWith('/api/v1/band-plan/layers', {
-      headers: { Authorization: 'Bearer read-token' },
+      headers: {},
     });
     expect(fetchMock).toHaveBeenCalledWith('/api/v1/band-plan/config', {
-      headers: { Authorization: 'Bearer read-token' },
+      headers: {},
     });
 
     localStorage.setItem('rigplane-auth-token', 'write-token');
@@ -598,7 +598,6 @@ describe('band-plan HTTP authentication', () => {
       expect(fetchMock).toHaveBeenCalledWith('/api/v1/band-plan/config', {
         method: 'POST',
         headers: {
-          Authorization: 'Bearer write-token',
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ region: 'CA' }),

--- a/frontend/src/lib/audio/__tests__/audio-manager.isolated.test.ts
+++ b/frontend/src/lib/audio/__tests__/audio-manager.isolated.test.ts
@@ -289,7 +289,7 @@ describe('AudioManager reconnect coalescing (MOR-924)', () => {
 });
 
 
-describe('AudioManager current WebSocket authentication', () => {
+describe('AudioManager credential-free WebSockets', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.useFakeTimers();
@@ -308,7 +308,7 @@ describe('AudioManager current WebSocket authentication', () => {
     vi.unstubAllGlobals();
   });
 
-  it('uses the current encoded token on initial RX and each reconnect', async () => {
+  it('ignores stored application tokens on initial RX and each reconnect', async () => {
     const { audioManager } = await import('../audio-manager');
     for (const token of ['synthetic +&?=#/ token', 'synthetic-rotated', null]) {
       if (token) localStorage.setItem('rigplane-auth-token', token);
@@ -322,12 +322,12 @@ describe('AudioManager current WebSocket authentication', () => {
       const url = new URL(socket.url);
       expect(url.origin).toBe('wss://radio.example.test');
       expect(url.pathname).toBe('/api/v1/audio');
-      expect(url.searchParams.getAll('token')).toEqual(token ? [token] : []);
+      expect(url.searchParams.getAll('token')).toEqual([]);
       socket.open();
     }
   });
 
-  it('does not log the error event carrying the authenticated socket URL', async () => {
+  it('does not log the error event carrying the socket URL', async () => {
     const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
     localStorage.setItem('rigplane-auth-token', 'synthetic-private');
     const { audioManager } = await import('../audio-manager');

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,4 +1,3 @@
-/** @deprecated Core no longer uses application authentication tokens. */
 export function getAuthToken(): string | null {
   return null;
 }

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,15 +1,9 @@
-/** Read the current application authentication token for one request. */
+/** @deprecated Core no longer uses application authentication tokens. */
 export function getAuthToken(): string | null {
-  const storage = globalThis.localStorage;
-  if (!storage || typeof storage.getItem !== 'function') {
-    return null;
-  }
-  return storage.getItem('rigplane-auth-token');
+  return null;
 }
 
-/** Build the authorization headers for one request from current storage. */
+/** @deprecated Application authentication headers are no longer produced here. */
 export function getAuthHeaders(): Record<string, string> {
-  const token = getAuthToken();
-  if (token) return { Authorization: `Bearer ${token}` };
   return {};
 }

--- a/frontend/src/lib/runtime/__tests__/system-controller.test.ts
+++ b/frontend/src/lib/runtime/__tests__/system-controller.test.ts
@@ -129,7 +129,7 @@ describe('SystemController HTTP-polling registration removal (A10)', () => {
   });
 });
 
-describe('SystemController HTTP authentication', () => {
+describe('SystemController credential-free HTTP', () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
@@ -143,7 +143,7 @@ describe('SystemController HTTP authentication', () => {
     localStorage.clear();
   });
 
-  it('reads the current token for power commands and preserves each POST body', async () => {
+  it('ignores retired tokens for power commands and preserves each POST body', async () => {
     fetchMock.mockResolvedValue({ ok: true } as Response);
     const { controller } = fixture();
 
@@ -157,7 +157,6 @@ describe('SystemController HTTP authentication', () => {
     expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/v1/radio/power', {
       method: 'POST',
       headers: {
-        Authorization: 'Bearer power-one',
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ state: 'on' }),
@@ -165,7 +164,6 @@ describe('SystemController HTTP authentication', () => {
     expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/v1/radio/power', {
       method: 'POST',
       headers: {
-        Authorization: 'Bearer power-two',
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ state: 'off' }),
@@ -173,7 +171,7 @@ describe('SystemController HTTP authentication', () => {
     expect(fetchMock).toHaveBeenNthCalledWith(
       3,
       '/api/v1/eibi/identify?freq=14074000',
-      { headers: { Authorization: 'Bearer identify-token' } },
+      { headers: {} },
     );
   });
 

--- a/frontend/src/lib/transport/__tests__/managed-transmit-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/managed-transmit-client.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ManagedTransmitClient } from '../managed-transmit-client';
 const document = { schemaVersion: 1, sampledAt: '2026-09-04T00:00:00.000Z', managedTransmit: { status: 'available', intent: { kind: 'rx' }, releaseRequired: false, lastError: null, lastActuation: null, abortErrors: [], tot: { configuredSeconds: 180, active: true, remainingMs: 900, expiresAt: 'ignored' } }, txObservation: { observedPtt: 'unknown' } };
 
-describe('ManagedTransmitClient HTTP authentication', () => {
+describe('ManagedTransmitClient credential-free HTTP', () => {
   const requests = [
     { name: 'snapshot', path: '', method: 'GET', body: undefined, call: (client: ManagedTransmitClient) => client.snapshot(), result: document },
     { name: 'command', path: '/command', method: 'POST', body: { operation: 'transmit_on' }, call: (client: ManagedTransmitClient) => client.command('transmit_on'), result: 'accepted' },
@@ -12,7 +12,7 @@ describe('ManagedTransmitClient HTTP authentication', () => {
   beforeEach(() => {
     const values = new Map<string, string>();
     vi.stubGlobal('localStorage', {
-      getItem: (key: string) => values.get(key) ?? null,
+      getItem: vi.fn((key: string) => values.get(key) ?? null),
       setItem: (key: string, value: string) => values.set(key, value),
       removeItem: (key: string) => values.delete(key),
     });
@@ -28,12 +28,13 @@ describe('ManagedTransmitClient HTTP authentication', () => {
     return fetchMock;
   }
 
-  it.each(requests)('authenticates $name with the application token and preserves the request', async ({ path, method, body, call, result }) => {
+  it.each(requests)('ignores a stored application token for $name and preserves the request', async ({ path, method, body, call, result }) => {
     localStorage.setItem('rigplane-auth-token', 'synthetic-test-token');
-    const fetchMock = respondTo('Bearer synthetic-test-token');
+    const fetchMock = respondTo(null);
 
     await expect(call(new ManagedTransmitClient())).resolves.toEqual(result);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem).not.toHaveBeenCalled();
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe(`/api/v1/managed-transmit${path}`);
     expect(init?.method ?? 'GET').toBe(method);
@@ -41,16 +42,17 @@ describe('ManagedTransmitClient HTTP authentication', () => {
     expect(new Headers(init?.headers).get('Content-Type')).toBe(body === undefined ? null : 'application/json');
   });
 
-  it.each(requests)('uses rotated and removed application tokens on the same client for $name', async ({ name, call, result }) => {
+  it.each(requests)('ignores rotated and removed application tokens on the same client for $name', async ({ call, result }) => {
     const client = new ManagedTransmitClient();
     localStorage.setItem('rigplane-auth-token', 'synthetic-first-token');
-    respondTo('Bearer synthetic-first-token');
+    respondTo(null);
     await expect(call(client)).resolves.toEqual(result);
     localStorage.setItem('rigplane-auth-token', 'synthetic-next-token');
-    respondTo('Bearer synthetic-next-token');
+    respondTo(null);
     await expect(call(client)).resolves.toEqual(result);
     localStorage.removeItem('rigplane-auth-token');
-    await expect(call(client)).rejects.toThrow(`managed transmit ${name}: 401`);
+    await expect(call(client)).resolves.toEqual(result);
+    expect(localStorage.getItem).not.toHaveBeenCalled();
   });
 
   it.each(requests)('supports an unauthenticated server for $name without an Authorization header', async ({ call, result }) => {
@@ -72,12 +74,12 @@ describe('ManagedTransmitClient HTTP authentication', () => {
     await expect(new ManagedTransmitClient().snapshot()).resolves.toEqual(document);
   });
 
-  it('preserves an authenticated command rejection', async () => {
+  it('preserves a command rejection without application credentials', async () => {
     localStorage.setItem('rigplane-auth-token', 'synthetic-test-token');
     const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 409 });
     vi.stubGlobal('fetch', fetchMock);
     await expect(new ManagedTransmitClient().command('force_off')).resolves.toBe('rejected');
-    expect(new Headers(fetchMock.mock.calls[0][1].headers).get('Authorization')).toBe('Bearer synthetic-test-token');
+    expect(new Headers(fetchMock.mock.calls[0][1].headers).get('Authorization')).toBeNull();
   });
 });
 describe('ManagedTransmitClient', () => { it('uses only managed authority routes and exact command body', async () => { globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, status: 202, json: async () => document }); const client = new ManagedTransmitClient(); await client.command('force_off'); expect(fetch).toHaveBeenCalledWith('/api/v1/managed-transmit/command', expect.objectContaining({ body: JSON.stringify({ operation: 'force_off' }) })); }); it('rejects a malformed document rather than deriving legacy truth', async () => { globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ ...document, txObservation: { observedPtt: true } }) }); await expect(new ManagedTransmitClient().snapshot()).rejects.toThrow('txObservation.observedPtt'); }); it.each([{ operation: 'unknown', result: 'accepted', attemptId: 'x' }, { operation: 'ptt_on', result: 'future', attemptId: 'x' }, { operation: 'ptt_on', result: 'accepted' }])('rejects malformed last actuation', async (lastActuation) => { globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ ...document, managedTransmit: { ...document.managedTransmit, lastActuation } }) }); await expect(new ManagedTransmitClient().snapshot()).rejects.toThrow('lastActuation'); }); it.each([[{ operation: 'unknown', error: 'x' }], [{ operation: 'stop_cw' }], [{ operation: 'stop_cw', error: 'x', extra: true }]])('rejects malformed abort errors', async (abortErrors) => { globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ ...document, managedTransmit: { ...document.managedTransmit, abortErrors } }) }); await expect(new ManagedTransmitClient().snapshot()).rejects.toThrow('abortErrors'); }); });

--- a/frontend/src/lib/transport/__tests__/ws-auth.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-auth.isolated.test.ts
@@ -20,10 +20,10 @@ afterEach(async () => {
   vi.unstubAllGlobals();
 });
 
-function expectCurrentToken(token: string | null, path: string): void {
+function expectNoToken(path: string): void {
   const url = new URL(instances.at(-1)!.url, 'https://radio.example.test');
   expect(url.pathname).toBe(path);
-  expect(url.searchParams.getAll('token')).toEqual(token ? [token] : []);
+  expect(url.searchParams.getAll('token')).toEqual([]);
 }
 
 async function rotateAndReconnect(token: string | null): Promise<void> {
@@ -33,22 +33,22 @@ async function rotateAndReconnect(token: string | null): Promise<void> {
   await vi.advanceTimersByTimeAsync(1250);
 }
 
-describe('production WebSocket authentication', () => {
-  it('refreshes control credentials on automatic and explicit reconnect, preserving query parameters', async () => {
+describe('credential-free production WebSockets', () => {
+  it('ignores retired storage on automatic and explicit reconnect, preserving query parameters', async () => {
     const { connect, disconnectAll, reconnectAll, getLastCloseInfo } = await import('../ws-client');
     const first = 'synthetic +&?=#/ token';
     localStorage.setItem('rigplane-auth-token', first);
     connect('/api/v1/ws?receiver=1&token=synthetic-old&token=synthetic-older');
-    expectCurrentToken(first, '/api/v1/ws');
+    expectNoToken('/api/v1/ws');
     instances[0].simulateOpen();
     await rotateAndReconnect('synthetic-rotated');
-    expectCurrentToken('synthetic-rotated', '/api/v1/ws');
+    expectNoToken('/api/v1/ws');
     expect(new URL(instances.at(-1)!.url, 'https://radio.example.test').searchParams.get('receiver')).toBe('1');
     localStorage.removeItem('rigplane-auth-token');
     instances.at(-1)!.simulateOpen();
     disconnectAll();
     reconnectAll();
-    expectCurrentToken(null, '/api/v1/ws');
+    expectNoToken('/api/v1/ws');
     expect(JSON.stringify(getLastCloseInfo())).not.toContain('synthetic');
     expect(JSON.stringify(vi.mocked(console.info).mock.calls)).not.toContain('synthetic');
   });
@@ -56,27 +56,27 @@ describe('production WebSocket authentication', () => {
   it('keeps anonymous control initial and reconnect token-free', async () => {
     const { connect } = await import('../ws-client');
     connect();
-    expectCurrentToken(null, '/api/v1/ws');
+    expectNoToken('/api/v1/ws');
     await rotateAndReconnect(null);
-    expectCurrentToken(null, '/api/v1/ws');
+    expectNoToken('/api/v1/ws');
   });
 
   it.each([
     ['audioFftDriver', '/api/v1/audio-scope'],
     ['hardwareScopeDriver', '/api/v1/scope'],
-  ] as const)('authenticates actual ScopeController %s on initial and changed/absent-token reconnect', async (driverName, path) => {
+  ] as const)('keeps actual ScopeController %s token-free on initial and changed/absent-token reconnect', async (driverName, path) => {
     const { ScopeController } = await import('../../runtime/scope-controller.svelte');
     const controller = new ScopeController();
     const driver = controller[driverName];
     localStorage.setItem('rigplane-auth-token', 'synthetic +&?=#/ token');
     const handle = await driver.start();
-    expectCurrentToken('synthetic +&?=#/ token', path);
+    expectNoToken(path);
     instances.at(-1)!.simulateOpen();
     await rotateAndReconnect('synthetic-rotated');
-    expectCurrentToken('synthetic-rotated', path);
+    expectNoToken(path);
     instances.at(-1)!.simulateOpen();
     await rotateAndReconnect(null);
-    expectCurrentToken(null, path);
+    expectNoToken(path);
     await driver.stop(handle);
   });
 

--- a/frontend/src/lib/transport/http-client.ts
+++ b/frontend/src/lib/transport/http-client.ts
@@ -6,40 +6,26 @@ export { getAuthHeaders, getAuthToken };
 
 const BASE = '/api/v1';
 
+/** @deprecated Retained for source compatibility; HTTP requests do not throw this error. */
 export class AuthenticationError extends Error {
   override name = 'AuthenticationError';
 }
 
-async function authenticatedFetch(path: string, signal?: AbortSignal): Promise<Response> {
+async function fetchApiResponse(path: string, signal?: AbortSignal): Promise<Response> {
   signal?.throwIfAborted();
   const res = await fetch(path, { headers: getAuthHeaders(), signal, redirect: 'error' });
   signal?.throwIfAborted();
-  if (res.status !== 401) return res;
-
-  const token = prompt('Enter auth token:');
-  if (!token) {
-    throw new AuthenticationError('Authentication cancelled. Reload the page to try again.');
-  }
-  signal?.throwIfAborted();
-  const retry = await fetch(path, {
-    headers: { Authorization: `Bearer ${token}` }, signal, redirect: 'error',
-  });
-  signal?.throwIfAborted();
-  if (retry.status === 401) {
-    throw new AuthenticationError('Auth token rejected. Reload the page to try again.');
-  }
-  if (retry.ok) localStorage.setItem('rigplane-auth-token', token);
-  return retry;
+  return res;
 }
 
 export async function fetchCapabilities(): Promise<Capabilities> {
-  const res = await authenticatedFetch(`${BASE}/capabilities`);
+  const res = await fetchApiResponse(`${BASE}/capabilities`);
   if (!res.ok) throw new Error(`fetchCapabilities: ${res.status}`);
   return validateCapabilities(await res.json());
 }
 
 export async function fetchInfo(signal?: AbortSignal): Promise<InfoResponse> {
-  const res = await authenticatedFetch(`${BASE}/info`, signal);
+  const res = await fetchApiResponse(`${BASE}/info`, signal);
   if (!res.ok) throw new Error(`fetchInfo: ${res.status}`);
   return res.json() as Promise<InfoResponse>;
 }


### PR DESCRIPTION
## Change

Shared browser HTTP and WebSocket transports stop collecting or transmitting application tokens. Deprecated token helpers return null/empty headers without reading storage, and HTTP requests no longer prompt, persist credentials or retry with a Bearer header. Ordinary fetch errors, redirect refusal and cancellation remain.

The existing WS URL helper strips legacy token query parameters; its now-empty token getter prevents adding another. Radio/audio session identities and managed-TX admission are unchanged. `AuthenticationError` temporarily remains as an inert source-compatibility export; App has a remaining name-based error branch, not an import of this class (`rg -n AuthenticationError frontend/src`). Companion C removes that branch and the export. Diagnostic headers, legacy storage migration and migration docs remain C scope; residual public API authentication metadata and documentation require a bounded follow-up. This is not the final installed auth-removal candidate.

## Validation

Eight focused files passed 186 tests, including actual App/runtime startup, shared transport callers, initial/reconnect URLs, stored-token and no-storage-access assertions, and existing managed/audio negative cases. ESLint on ten changed files and scoped svelte-check passed. Restoring the two original production modules caused 9 targeted failures; source was restored before the final passing run. Storage spies target the actual storage object installed by the Vitest setup.

Ten files (+87/-116, 203 changed lines measured with `git diff --numstat f8a8fb0a1...HEAD` at f32edd286) exceed the soft six-file threshold because two shared production helpers serve the eight existing consumer test files. The branch remains based on f8a8fb0a1; backend A has since merged on disjoint files. Required Ready PR CI tests the combination, and independent exact-head review remains pending. No local full suite, hardware validation, deployment or release publication.

Linear: https://linear.app/morozsm/issue/MOR-2362
Parent MOR-2360 and operator acceptance remain open.
