### PR TITLE
feat(MOR-2359): qualify radio-wide meter display observations

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/display-observation.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/display-observation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { FieldStatus, ServerState } from '$lib/types/state';
 import { IC7300_CAPABILITIES as capsFixture, IC7300_STATE as stateFixture } from './fixtures/ic7300-profile';
-import { qualifyDisplayObservation } from '../display-observation';
+import { qualifyDisplayObservation, qualifyRadioDisplayObservation } from '../display-observation';
 
 const fresh: FieldStatus = {
   storePath: 'main.rf_gain', observed: true, freshness: 'fresh', availability: 'available',
@@ -74,5 +74,50 @@ describe('stateless display observation qualifier', () => {
       expect(project(0.7, state)).toEqual({ state: 'unknown', reason: 'identity-unresolved' });
     }
     expect(project(0.2, snapshot({ freshness: 'stale' }))).toEqual({ state: 'stale', value: 0.2 });
+  });
+});
+
+describe('radio-wide display observation qualifier (MOR-2359)', () => {
+  const radioState = (status: Partial<FieldStatus> = {}): ServerState => ({
+    ...snapshot(), fieldStatus: { powerMeter: { ...fresh, ...status } },
+  });
+  const qualify = (state: ServerState | null = radioState(), capabilities: Capabilities | null = caps) =>
+    qualifyRadioDisplayObservation({ state, caps: capabilities, path: 'powerMeter', structural: true, value: 0 });
+
+  it('qualifies a fractional marker and zero without any receiver evidence', () => {
+    expect(qualify({ ...radioState(), active: undefined, main: undefined } as unknown as ServerState))
+      .toEqual({ state: 'current', value: 0 });
+    expect(qualify(radioState({ freshness: 'stale' }))).toEqual({ state: 'stale', value: 0 });
+    expect(qualify(radioState({ availability: 'stale' }))).toEqual({ state: 'stale', value: 0 });
+  });
+  it.each([null, undefined, -1, NaN, Infinity, 0.5, Number.MAX_SAFE_INTEGER + 1])(
+    'rejects invalid matching provider generation %s', (providerGeneration) => {
+      expect(qualify({ ...radioState(), providerGeneration } as ServerState, { ...caps, providerGeneration } as Capabilities))
+        .toEqual({ state: 'unknown', reason: 'identity-unresolved' });
+    },
+  );
+  it('requires both matching contract identities', () => {
+    for (const state of [null, { ...radioState(), stateContractVersion: undefined }]) {
+      expect(qualify(state)).toEqual({ state: 'unknown', reason: 'identity-unresolved' });
+    }
+    for (const capabilities of [null, { ...caps, providerGeneration: 2 }, { ...caps, stateContractVersion: undefined }]) {
+      expect(qualify(radioState(), capabilities)).toEqual({ state: 'unknown', reason: 'identity-unresolved' });
+    }
+  });
+  it('does not accept receiver paths through the radio-wide entry point', () => {
+    expect(qualifyRadioDisplayObservation({ state: snapshot(), caps, path: 'main.rfGain', structural: true, value: 0 }))
+      .toEqual({ state: 'unknown', reason: 'identity-unresolved' });
+  });
+  it.each([
+    [{}, 'not-observed'], [{ powerMeter: { ...fresh, observed: false } }, 'not-observed'],
+    [{ powerMeter: { ...fresh, lastObservedMonotonic: null } }, 'invalid-evidence'],
+    [{ powerMeter: { ...fresh, availability: 'missing' } }, 'invalid-evidence'],
+  ] as const)('shares evidence validation for %j', (fieldStatus, reason) => {
+    expect(qualify({ ...radioState(), fieldStatus })).toEqual({ state: 'unknown', reason });
+  });
+  it('leaves stale receiver-scoped RF gain qualification unchanged', () => {
+    expect(project(0.7, snapshot({ freshness: 'stale' }))).toEqual({ state: 'stale', value: 0.7 });
+    expect(qualifyDisplayObservation({ state: radioState(), caps, receiver: 'MAIN', path: 'powerMeter', structural: true, value: 0 }))
+      .toEqual({ state: 'unknown', reason: 'identity-unresolved' });
   });
 });

--- a/frontend/src/lib/runtime/adapters/__tests__/meters-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/meters-adapter.test.ts
@@ -111,6 +111,77 @@ describe('meters TX truth comes from the App TX authority (R9 / MOR-1235)', () =
   });
 });
 
+describe('target meter display provenance (MOR-2359)', () => {
+  const targets = [['power', 'powerMeter'], ['swr', 'swrMeter'], ['alc', 'alcMeter']] as const;
+  const observed = { ...fresh, lastObservedMonotonic: 310658.42975425 };
+  const capabilities = caps({ stateContractVersion: 1, providerGeneration: 1 });
+  function stateWith(status: Partial<FieldStatus> = {}): ServerState {
+    return meterState({
+      stateContractVersion: 1, providerGeneration: 1,
+      fieldStatus: { ...meterState().fieldStatus,
+        ...Object.fromEntries(targets.map(([, path]) => [path, { ...observed, ...status }])),
+      },
+    });
+  }
+  it.each(targets)('projects current/stale/never-observed independently for %s', (meter, path) => {
+    const state = stateWith();
+    expect(model(state, capabilities, TX).meters![meter].display).toEqual({ state: 'current', value: state[path] });
+    for (const status of [{ freshness: 'stale' }, { availability: 'stale' }] as const) {
+      expect(model(stateWith(status), capabilities, TX).meters![meter].display).toEqual({ state: 'stale', value: state[path] });
+    }
+    expect(model(stateWith({ observed: false }), capabilities, TX).meters![meter].display)
+      .toEqual({ state: 'unknown', reason: 'not-observed' });
+    expect(model({ ...state, fieldStatus: {} }, capabilities, TX).meters![meter].display)
+      .toEqual({ state: 'unknown', reason: 'not-observed' });
+  });
+  it.each(targets)('preserves valid zero and rejects invalid %s scalars', (meter, path) => {
+    expect(model({ ...stateWith(), [path]: 0 }, capabilities, TX).meters![meter].display)
+      .toEqual({ state: 'current', value: 0 });
+    for (const value of [NaN, Infinity, null, '1', false]) {
+      expect(model({ ...stateWith(), [path]: value }, capabilities, TX).meters![meter].display)
+        .toEqual({ state: 'unknown', reason: 'invalid-value' });
+    }
+    expect(model({ ...stateWith(), [path]: undefined }, capabilities, TX).meters![meter].display)
+      .toEqual({ state: 'unsupported' });
+    expect(model(stateWith(), { ...capabilities, tx: false }, TX).meters![meter].display)
+      .toEqual({ state: 'unsupported' });
+  });
+  it('requires observation markers and matching identity but not active receiver freshness', () => {
+    for (const lastObservedMonotonic of [null, undefined, NaN, Infinity, -1]) {
+      expect(model(stateWith({ lastObservedMonotonic }), capabilities, TX).meters!.power.display)
+        .toEqual({ state: 'unknown', reason: 'invalid-evidence' });
+    }
+    for (const providerGeneration of [undefined, 2]) {
+      expect(model({ ...stateWith(), providerGeneration }, capabilities, TX).meters!.power.display)
+        .toEqual({ state: 'unknown', reason: 'identity-unresolved' });
+    }
+    const state = stateWith();
+    state.fieldStatus!.active = { ...stale, observed: false };
+    expect(model(state, capabilities, TX).meters!.power.display).toEqual({ state: 'current', value: 0.6 });
+  });
+  it('changes no strict meter facts across RF authority states', () => {
+    for (const tx of [RX, TX, { radioTx: 'off', txRisk: 'uncertain' }, { radioTx: 'unknown', txRisk: 'none' }] as const) {
+      for (const status of [{}, { freshness: 'stale', availability: 'stale' }, { observed: false }] as const) {
+        const state = stateWith(status);
+        const meters = model(state, capabilities, tx).meters!;
+        const relevant = meters.rfState !== 'receiving';
+        for (const [meter, path] of targets) {
+          const { display, ...strict } = meters[meter];
+          expect(display).toBeDefined();
+          const operational = !('freshness' in status && status.freshness === 'stale');
+          expect(strict).toEqual({
+            reading: operational ? { status: 'known', value: state[path] } : { status: 'unknown' },
+            availability: { structural: true, operational }, relevant,
+          });
+        }
+        for (const meter of ['signal', 'compression', 'drainVoltage', 'drainCurrent'] as const) {
+          expect(meters[meter]).not.toHaveProperty('display');
+        }
+      }
+    }
+  });
+});
+
 describe('meters evidence gate and per-meter derivation (MOR-1262 slice 2A)', () => {
   it('emits no meters when capabilities are absent', () => {
     expect(toRadioViewModel(meterState(), null, RX)).toBeNull();
@@ -160,6 +231,7 @@ describe('meters evidence gate and per-meter derivation (MOR-1262 slice 2A)', ()
     const meters = model(meterState({ alcMeter: undefined }), caps(), TX).meters!;
     expect(meters.alc).toEqual({
       reading: { status: 'unknown' }, availability: { structural: false, operational: false }, relevant: true,
+      display: { state: 'unsupported' },
     });
   });
 
@@ -169,6 +241,7 @@ describe('meters evidence gate and per-meter derivation (MOR-1262 slice 2A)', ()
     }), caps(), TX).meters!;
     expect(meters.swr).toEqual({
       reading: { status: 'unknown' }, availability: { structural: true, operational: false }, relevant: true,
+      display: { state: 'unknown', reason: 'identity-unresolved' },
     });
   });
 

--- a/frontend/src/lib/runtime/adapters/display-observation.ts
+++ b/frontend/src/lib/runtime/adapters/display-observation.ts
@@ -15,6 +15,29 @@ function validEvidence(status: FieldStatus): boolean {
     && Number.isFinite(status.lastObservedMonotonic) && status.lastObservedMonotonic >= 0;
 }
 
+function validIdentity(state: ServerState | null, caps: Capabilities | null): state is ServerState {
+  const generation = state?.providerGeneration;
+  return !!state && !!caps && state.stateContractVersion === 1 && caps.stateContractVersion === 1
+    && typeof generation === 'number' && Number.isSafeInteger(generation) && generation >= 0
+    && caps.providerGeneration === generation;
+}
+
+export function qualifyRadioDisplayObservation<T extends Scalar>({
+  state, caps, path, structural, value,
+}: {
+  state: ServerState | null;
+  caps: Capabilities | null;
+  path: string;
+  structural: boolean;
+  value: T | undefined;
+}): DisplayObservation<T> {
+  if (!structural) return { state: 'unsupported' };
+  if (!validIdentity(state, caps) || path === '' || path.includes('.')) {
+    return { state: 'unknown', reason: 'identity-unresolved' };
+  }
+  return qualifyEvidence(state, path, value);
+}
+
 export function qualifyDisplayObservation<T extends Scalar>({
   state, caps, receiver, path, structural, value,
 }: {
@@ -26,17 +49,18 @@ export function qualifyDisplayObservation<T extends Scalar>({
   value: T | undefined;
 }): DisplayObservation<T> {
   if (!structural) return { state: 'unsupported' };
-  const generation = state?.providerGeneration;
   const receiverKey = receiver === 'MAIN' ? 'main' : 'sub';
-  if (!state || !caps || state.stateContractVersion !== 1 || caps.stateContractVersion !== 1
-    || typeof generation !== 'number' || !Number.isSafeInteger(generation) || generation < 0
-    || caps.providerGeneration !== generation
+  if (!validIdentity(state, caps) || !caps
     || (caps.receivers !== 1 && caps.receivers !== 2)
     || (receiver === 'SUB' && caps.receivers !== 2)
     || (state.active === 'SUB' && caps.receivers !== 2)
     || !state[receiverKey] || !path.startsWith(`${receiverKey}.`)) {
     return { state: 'unknown', reason: 'identity-unresolved' };
   }
+  return qualifyEvidence(state, path, value);
+}
+
+function qualifyEvidence<T extends Scalar>(state: ServerState, path: string, value: T | undefined): DisplayObservation<T> {
   const leaf = state.fieldStatus?.[path];
   if (!leaf || !hasObservation(leaf)) return { state: 'unknown', reason: 'not-observed' };
   const statuses = [leaf];

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -37,7 +37,7 @@ import type {
   RadioWideIndicatorsViewModel, DualActionBlockViewModel,
 } from '../../../semantic/radio-view-model';
 import type { TxAuthoritySnapshot } from '../../../semantic/rx-tx-surface';
-import { qualifyDisplayObservation } from './display-observation';
+import { qualifyDisplayObservation, qualifyRadioDisplayObservation } from './display-observation';
 import { isFieldAvailable } from '$lib/state/field-status';
 import { modInputStateKey } from '$lib/radio/mod-input';
 import { flattenBands, findActiveBand } from '$lib/radio/band-plan';
@@ -317,12 +317,18 @@ function deriveMeters(
   if (!raws.some((v) => v !== undefined)) return undefined;
   const txMeter = (raw: unknown, path: string): MeterField =>
     meterField(hasTx && raw !== undefined, topFieldAvailable(state, path), raw, onTx);
+  const displayTxMeter = (raw: unknown, path: string) => ({
+    ...txMeter(raw, path),
+    display: qualifyRadioDisplayObservation({
+      state, caps, path, structural: hasTx && raw !== undefined, value: numOrUndef(raw),
+    }),
+  });
   return {
     rfState,
     signal: meterField(rx?.sMeter !== undefined, topFieldAvailable(state, sPath), rx?.sMeter, !onTx),
-    power: txMeter(powerMeter, 'powerMeter'),
-    swr: txMeter(swrMeter, 'swrMeter'),
-    alc: txMeter(alcMeter, 'alcMeter'),
+    power: displayTxMeter(powerMeter, 'powerMeter'),
+    swr: displayTxMeter(swrMeter, 'swrMeter'),
+    alc: displayTxMeter(alcMeter, 'alcMeter'),
     compression: txMeter(compMeter, 'compMeter'),
     // Vd is the station's supply rail, not a TX reading: it is worth showing
     // in every RF state (the dock keeps it on instantaneous display for the

--- a/frontend/src/semantic/__tests__/meters.test.ts
+++ b/frontend/src/semantic/__tests__/meters.test.ts
@@ -32,6 +32,40 @@ const AVAIL = { structural: true, operational: true } as const;
 const base = topologyFixtures['1/single'];
 const RF_STATES: readonly MeterRfState[] = ['receiving', 'transmitting', 'uncertain', 'unknown'];
 
+describe('target meter display observation contract (MOR-2359)', () => {
+  function withDisplay(meter: string, display: unknown) {
+    const view = withMeters(base);
+    const field = view.meters![meter as keyof Omit<MetersViewModel, 'rfState'>];
+    return { ...view, meters: { ...view.meters, [meter]: { ...field, display } } };
+  }
+  it.each(['power', 'swr', 'alc'])('round-trips optional display only on %s', (meter) => {
+    for (const display of [
+      { state: 'current', value: 0 }, { state: 'stale', value: 0.5 },
+      { state: 'unknown', reason: 'not-observed' }, { state: 'unsupported' },
+    ]) {
+      const view = withDisplay(meter, display);
+      expect(validateRadioViewModel(JSON.parse(JSON.stringify(view)))).toEqual(view);
+    }
+  });
+  it.each(['signal', 'compression', 'drainVoltage', 'drainCurrent'])(
+    'keeps exact-key rejection on unmigrated %s', (meter) => {
+      expect(() => validateRadioViewModel(withDisplay(meter, { state: 'current', value: 1 })))
+        .toThrow(new RegExp(`\\$\\.meters\\.${meter}:.*display`));
+    },
+  );
+  it.each([
+    null, {}, { state: 'current' }, { state: 'current', value: '1' },
+    { state: 'current', value: NaN }, { state: 'stale', value: Infinity },
+    { state: 'stale', value: 1, extra: true }, { state: 'unknown', reason: 'stale' },
+    { state: 'unknown', reason: 'not-observed', value: 0 }, { state: 'unsupported', value: 0 },
+  ])('rejects malformed display %j', (display) => {
+    for (const meter of ['power', 'swr', 'alc']) {
+      expect(() => validateRadioViewModel(withDisplay(meter, display)))
+        .toThrow(new RegExp(`\\$\\.meters\\.${meter}\\.display`));
+    }
+  });
+});
+
 describe('meters (MOR-1262 slice 2A)', () => {
   // ── Kill-test 1: absence is byte-identical, not a new default shape ──────
   it('validates a meters-absent model and never adds the key', () => {

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -187,6 +187,10 @@ export interface MeterField {
   relevant: boolean;
 }
 
+export interface DisplayObservedMeterField extends MeterField {
+  readonly display?: DisplayObservation<number>;
+}
+
 /**
  * The authoritative RF state the meters are read against. Member-for-member
  * the RX/TX surface's own `RfState` (`rx-tx-surface.ts`, MOR-1064) — declared
@@ -204,9 +208,9 @@ export type MeterRfState = 'receiving' | 'transmitting' | 'uncertain' | 'unknown
 export interface MetersViewModel {
   rfState: MeterRfState;
   signal: MeterField;
-  power: MeterField;
-  swr: MeterField;
-  alc: MeterField;
+  power: DisplayObservedMeterField;
+  swr: DisplayObservedMeterField;
+  alc: DisplayObservedMeterField;
   compression: MeterField;
   drainVoltage: MeterField;
   drainCurrent: MeterField;
@@ -1362,6 +1366,16 @@ function validateMeterField(value: unknown, path: string): MeterField {
   };
 }
 
+function validateDisplayObservedMeterField(value: unknown, path: string): DisplayObservedMeterField {
+  const v = record(value, path);
+  exactKeys(v, ['reading', 'availability', 'relevant', 'display'], path);
+  const strict = validateMeterField({ reading: v.reading, availability: v.availability, relevant: v.relevant }, path);
+  return {
+    ...strict,
+    ...(v.display !== undefined ? { display: validateDisplayObservation(v.display, `${path}.display`, num) } : {}),
+  };
+}
+
 /** This `exactKeys` list is exactly the seven meters the adapter reads plus
  *  the authoritative `rfState` — no speculative keys (MOR-1244 finding N4).
  *  See `radio-view-model-adapter.ts::deriveMeters`. */
@@ -1373,9 +1387,9 @@ function validateMeters(value: unknown, path: string): MetersViewModel {
   return {
     rfState: oneOf(v.rfState, METER_RF_STATES, `${path}.rfState`),
     signal: validateMeterField(v.signal, `${path}.signal`),
-    power: validateMeterField(v.power, `${path}.power`),
-    swr: validateMeterField(v.swr, `${path}.swr`),
-    alc: validateMeterField(v.alc, `${path}.alc`),
+    power: validateDisplayObservedMeterField(v.power, `${path}.power`),
+    swr: validateDisplayObservedMeterField(v.swr, `${path}.swr`),
+    alc: validateDisplayObservedMeterField(v.alc, `${path}.alc`),
     compression: validateMeterField(v.compression, `${path}.compression`),
     drainVoltage: validateMeterField(v.drainVoltage, `${path}.drainVoltage`),
     drainCurrent: validateMeterField(v.drainCurrent, `${path}.drainCurrent`),


### PR DESCRIPTION
## Change

Power, ALC and SWR gain an optional display-observation facet that distinguishes current, stale, unknown and unsupported values. Their existing strict readings, availability, RF relevance and authority remain unchanged. A radio-wide qualifier shares evidence validation with the receiver qualifier without misclassifying top-level telemetry as MAIN data.

This is the data prerequisite for persistent RX-idle meter scales, not the renderer change. Existing non-target meter validation stays exact. No acquisition, TTL, RF classifier, command or renderer changes.

## Validation

Eight focused files passed 333 tests. `npm run check` and six-file ESLint passed. A captured baseline from actual f8a8fb0a1 source was compared across 480 complete RadioViewModel projections with deep equality after stripping only the three added facets; values including undefined were preserved using Node v8 serialization. Missing display, removed generation match, and stale-to-current mutations failed 4, 4 and 12 targeted cases respectively; source was restored before final tests.

Six files, +211/-15 =226 changed lines, measured with `git show --stat HEAD`. Independent exact-head review and natural required CI are pending. No local full suite, hardware validation or release publication.

Linear: https://linear.app/morozsm/issue/MOR-2359
Persistent instruments and all-skin/operator acceptance under MOR-1413 remain separate work.
