### PR TITLE
fix(MOR-2363): retire residual browser credentials and update migration guides

### DIFF
--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -24,20 +24,32 @@ covered by tests. Pro and other supervisors should depend on the stable routes
 below, not on browser static assets, private handler classes, or routes marked
 diagnostic/experimental.
 
-## Auth Model
+## Application authentication removal
 
-If web server is started with `--auth-token`, `--auth-token-file`, or
-`RIGPLANE_AUTH_TOKEN` in managed mode, all `/api/*` HTTP routes require:
+Core HTTP and WebSocket clients that can reach the listener need no application
+credential. Bearer headers and query tokens no longer authenticate requests.
+This changes the previous token-protected route semantics without changing the
+`/api/v1` route names. See `src/rigplane/web/web_routing.py: dispatch_http_request`
+and `src/rigplane/web/server.py: WebServer._handle_websocket`.
 
-```
-Authorization: Bearer <token>
-```
+Remove `--auth-token` and `--auth-token-file` from `web` and `station` launch
+arguments: they now fail during argument parsing, before radio startup, without
+reading a token file. `RIGPLANE_AUTH_TOKEN` is ignored. Programmatic callers must
+omit `WebConfig.auth_token` or leave it empty; a nonempty value raises
+`ValueError`. See `src/rigplane/cli/__init__.py: _reject_retired_auth_option`,
+`_cmd_web`, and `src/rigplane/web/server.py: WebConfig.__post_init__`.
 
-WebSocket routes additionally allow query token:
+Radio login credentials, bind selection and TLS options retain their existing
+roles. Diagnostic send/save/delete requests still use preview-bound
+`X-Diagnostic-CSRF`; diagnostic submission still requires consent. Diagnostic
+Origin checks apply to those diagnostic handlers, not globally to ordinary
+commands or WebSocket upgrades. See `src/rigplane/web/server.py:
+WebServer._handle_diagnose_send` and `src/rigplane/web/handlers/diagnostics.py:
+check_origin_or_loopback`.
 
-```
-ws://host:8080/api/v1/ws?token=<token>
-```
+The `authRequired` runtime and station fields remain Boolean and are now `false`
+(`src/rigplane/web/server.py: WebServer._serve_runtime`,
+`WebServer._station_readiness_payload`).
 
 ## HTTP Endpoints
 
@@ -102,9 +114,6 @@ Stable supervisor routes:
 | `/api/v1/audio` | Audio control and media frames | when radio/audio backend supports audio |
 | `/api/v1/audio-scope` | Audio FFT spectrum stream | when audio FFT is available |
 
-WebSocket auth accepts the same bearer header as HTTP. Query token auth is also
-accepted for browser/WebSocket clients that cannot set headers.
-
 ### Optional WebRTC DataChannels
 
 WebRTC is optional and requires the `rigplane[webrtc]` extra (`aiortc`). There
@@ -163,8 +172,7 @@ routes are not the Pro supervisor contract unless they are promoted into
 
 ## `GET /healthz`
 
-Process liveness probe for local supervisors. This endpoint is intentionally
-outside `/api/*`, so it does not require bearer auth.
+Process liveness probe for local supervisors.
 
 ```json
 {
@@ -189,8 +197,6 @@ and HTTP `503` while the process is alive but the station is not ready.
 ## `GET /api/v1/runtime`
 
 Machine-readable runtime status for managed local supervisors and diagnostics.
-When auth is configured, this endpoint requires the same bearer token as other
-`/api/*` routes.
 
 ```json
 {
@@ -199,7 +205,7 @@ When auth is configured, this endpoint requires the same bearer token as other
   "version": "2.0.3",
   "bind": { "host": "127.0.0.1", "port": 8080 },
   "logPath": "/Users/me/Library/Logs/rigplane.log",
-  "authRequired": true,
+  "authRequired": false,
   "backend": "rigplane",
   "radio": {
     "model": "IC-7610",
@@ -211,7 +217,7 @@ When auth is configured, this endpoint requires the same bearer token as other
     "readiness": "ready_with_radio",
     "radioAvailable": true,
     "backend": "rigplane",
-    "authRequired": true,
+    "authRequired": false,
     "message": "Station server is ready with an attached radio."
   },
   "rigctld": {
@@ -323,7 +329,6 @@ import json
 import urllib.request
 
 base_url = "http://127.0.0.1:8080"
-token = None  # or "your-token"
 
 payload = {
     "id": "display-type-b",
@@ -340,8 +345,6 @@ request = urllib.request.Request(
     headers={"Content-Type": "application/json"},
     method="POST",
 )
-if token:
-    request.add_header("Authorization", f"Bearer {token}")
 
 with urllib.request.urlopen(request, timeout=5) as response:
     result = json.load(response)
@@ -718,7 +721,7 @@ curl http://127.0.0.1:8080/api/v1/capabilities
 
 Prefer structured commands whenever a command exists. Use `send_civ` for
 vendor-specific CI-V that is not yet abstracted, such as display/menu settings.
-It still lets RigPlane own the radio connection, queueing, pacing, auth policy,
+It still lets RigPlane own the radio connection, queueing, pacing,
 and safety checks; it just does not return response bytes.
 
 Python example:
@@ -728,7 +731,6 @@ import json
 import urllib.request
 
 base_url = "http://127.0.0.1:8080"
-token = None  # or "your-token"
 
 batch = {
     "id": "vara-fm",
@@ -749,8 +751,6 @@ request = urllib.request.Request(
     headers={"Content-Type": "application/json"},
     method="POST",
 )
-if token:
-    request.add_header("Authorization", f"Bearer {token}")
 
 with urllib.request.urlopen(request, timeout=30) as response:
     result = json.load(response)
@@ -822,9 +822,7 @@ client.loop_forever()
 
 ## `GET /api/v1/station`
 
-Friendly station-server status for desktop supervisors and setup tools. When
-auth is configured, this endpoint requires the same bearer token as other
-`/api/*` routes.
+Friendly station-server status for desktop supervisors and setup tools.
 
 ```json
 {
@@ -843,7 +841,7 @@ auth is configured, this endpoint requires the same bearer token as other
     "readiness": "ready_with_radio",
     "radioAvailable": true,
     "backend": "rigplane",
-    "authRequired": true,
+    "authRequired": false,
     "message": "Station server is ready with an attached radio."
   },
   "radio": {
@@ -862,6 +860,10 @@ Current readiness values are:
 - `no_usb_radio_connected`
 - `lan_radio_unsupported_or_not_found`
 - `requires_configuration_or_auth`
+
+`requires_configuration_or_auth` retains its compatibility spelling and refers
+to radio target configuration, not an application credential prompt
+(`src/rigplane/web/server.py: WebServer._station_readiness_payload`).
 
 UDP discovery responses use the same `rigplane.station.discovery.v1` schema.
 Single-station responses keep the same top-level `kind: "station_server"`,

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -777,20 +777,15 @@ rigplane web --no-rigctld
 # Custom ports
 rigplane web --port 9090 --rigctld-port 4533
 
-# Require token for /api and WebSocket channels
-rigplane web --auth-token "change-me"
-rigplane web --auth-token-file ./runtime-token
-
 # Managed local runtime for a supervising desktop app
-RIGPLANE_AUTH_TOKEN="$(openssl rand -hex 24)" rigplane station --port 0
-rigplane station --port 0 --auth-token-file ./runtime-token
+rigplane station --port 0
 ```
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--host` | `0.0.0.0` | Web server bind address |
 | `--port` | `8080` | Web server port |
-| `--managed` | off | Use managed local defaults: loopback bind, auth required, embedded rigctld on loopback |
+| `--managed` | off | Use managed local defaults: loopback bind, embedded rigctld on loopback |
 | `--static-dir PATH` | — | Serve static files from a custom directory (default: built-in assets) |
 | `--bridge DEVICE` | — | Start audio bridge with named virtual device |
 | `--bridge-tx-device DEVICE` | — | Separate TX-only device for bidirectional bridge (e.g. `BlackHole 16ch`) |
@@ -799,27 +794,32 @@ rigplane station --port 0 --auth-token-file ./runtime-token
 | `--rigctld-port` | `4532` | Rigctld listen port |
 | `--dx-cluster HOST:PORT` | — | Connect to DX cluster server for real-time spot overlays (opt-in) |
 | `--callsign CALL` | — | Your callsign for DX cluster login (required with `--dx-cluster`) |
-| `--auth-token TOKEN` | — | Require `Authorization: Bearer <TOKEN>` for `/api/*` and WS channels |
-| `--auth-token-file PATH` | — | Read API/WS bearer token from a file |
+
+Core clients that can reach the web listener need no application credential.
+Remove the retired `--auth-token` and `--auth-token-file` flags from existing
+`web` and `station` launch commands: either flag now fails during argument
+parsing, before radio startup, without reading a token file. The environment
+variable `RIGPLANE_AUTH_TOKEN` is ignored (`src/rigplane/cli/__init__.py:
+_reject_retired_auth_option`, `_cmd_web`). For Python callers,
+`WebConfig.auth_token` must be omitted or empty; nonempty values raise
+`ValueError` (`src/rigplane/web/server.py: WebConfig.__post_init__`).
 
 ### `station`
 
 Start the managed local station runtime. This is a convenience command for
-supervisors such as desktop shells: it runs the web/API server on loopback,
-requires API/WebSocket auth, and enables embedded rigctld on loopback for local
+supervisors such as desktop shells: it runs the web/API server on loopback
+and enables embedded rigctld on loopback for local
 clients such as RigPlane Pro.
 
 ```bash
-export RIGPLANE_AUTH_TOKEN="$(openssl rand -hex 24)"
 rigplane station --port 0
 ```
 
 `station` shares the radio connection flags from the top-level CLI, including
 `--host`, `--user`, `--pass-file`, `--backend`, `--serial-port`, and model/CI-V
-options. Prefer `--auth-token-file` or `RIGPLANE_AUTH_TOKEN` over `--auth-token`
-so the local API token does not appear in process listings. Explicit
-`--auth-token` wins over `--auth-token-file`; the file wins over
-`RIGPLANE_AUTH_TOKEN`.
+options. Radio login credentials, bind selection and TLS options are unchanged
+by application-auth removal (`src/rigplane/cli/__init__.py: _build_parser`,
+`_apply_managed_runtime_defaults`, `_cmd_web`).
 
 After the web listener binds, `station` writes one JSON startup event to stdout:
 
@@ -834,7 +834,7 @@ When UDP discovery is enabled, `rigplane station` and `rigplane web` answer
 `RIGPLANE_DISCOVER\n` broadcasts with a `rigplane.station.discovery.v1` JSON
 payload. The payload includes the base URL, `/healthz`, `/readyz`,
 `/api/v1/runtime`, `/api/v1/station`, version, display name, radio model,
-backend, auth-required flag, and a readiness value such as
+backend, `authRequired: false`, and a readiness value such as
 `ready_with_radio`, `no_usb_radio_connected`, or
 `radio_powered_off_or_unreachable`.
 
@@ -1057,8 +1057,6 @@ rigplane proxy --radio 192.168.1.100 --listen 10.8.0.1
 | `--static-dir PATH` | `web` | *(built-in)* | Serve static web assets from a custom directory instead of the built-in UI |
 | `--dx-cluster HOST:PORT` | `web` | *(none)* | Connect to a DX cluster server for real-time spot overlays |
 | `--callsign CALL` | `web` | *(none)* | Your callsign for DX cluster login (required with `--dx-cluster`) |
-| `--auth-token TOKEN` | `web` | *(none)* | Require Bearer auth for API/WS endpoints |
-| `--auth-token-file PATH` | `web`, `station` | *(none)* | Read Bearer auth token from a file |
 | `--tls` | `web` | off | Enable HTTPS with auto-generated self-signed certificate |
 | `--tls-cert PATH` | `web` | *(none)* | Path to TLS certificate PEM file |
 | `--tls-key PATH` | `web` | *(none)* | Path to TLS private key PEM file |
@@ -1077,9 +1075,6 @@ rigplane web --static-dir /opt/icom-ui/dist
 
 # Connect to a DX cluster and show spot overlays on the waterfall
 rigplane web --dx-cluster dxc.nc7j.com:7373 --callsign KN4KYD
-
-# Protect API + WS endpoints with a bearer token
-rigplane web --auth-token "change-me"
 ```
 
 ## Exit Codes

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -98,23 +98,22 @@ When override is used, the backend logs a warning because timeout risk increases
 
 The library sends pings every 500ms automatically. If the radio doesn't receive pings for its timeout period (usually 10–30 seconds), it drops the connection.
 
-### Web UI API returns 401 Unauthorized
+### Startup rejects retired application-auth flags
 
-**Symptom:** `GET /api/v1/info` (or WebSocket connect) fails with HTTP 401.
+**Symptom:** `Application authentication was removed; remove --auth-token and --auth-token-file.`
 
-**Cause:** Web server was started with `--auth-token`, but request does not include token.
+Remove both retired flags from the service or supervisor launch arguments.
+They fail during argument parsing, before radio startup, and no token file is
+read (`src/rigplane/cli/__init__.py: _reject_retired_auth_option`).
+`RIGPLANE_AUTH_TOKEN` is ignored (`src/rigplane/cli/__init__.py: _cmd_web`).
+Python callers must omit `WebConfig.auth_token` or leave it empty
+(`src/rigplane/web/server.py: WebConfig.__post_init__`).
 
-**Fixes:**
-
-```bash
-# HTTP API
-curl -H "Authorization: Bearer <TOKEN>" http://127.0.0.1:8080/api/v1/info
-```
-
-For WebSocket clients, send either:
-
-- `Authorization: Bearer <TOKEN>` header, or
-- `?token=<TOKEN>` query parameter.
+Reachable Core HTTP and WebSocket clients need no application credential. If
+`/api/v1/info` still returns `401`, check which process or intermediary answers
+the URL; Core no longer performs the application-token check
+(`src/rigplane/web/web_routing.py: dispatch_http_request`). Existing radio login
+failures still require the radio credentials described above.
 
 ### `radio_connect` returns `backend_recovering`
 

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -19,8 +19,8 @@ rigplane web
 # Explicit host/port
 rigplane web --host 0.0.0.0 --port 9090
 
-# Require API/WebSocket auth token
-rigplane web --auth-token "change-me"
+# Managed local runtime on loopback
+rigplane station --port 0
 ```
 
 Open `http://<server-ip>:8080` (or your custom port).
@@ -88,13 +88,21 @@ These are primarily used by automation, deployment scripts, and operator tooling
 | `GET` | `/api/v1/eibi/identify?...` | Broadcast station identification |
 | `GET` | `/api/v1/eibi/bands` | EiBi band list |
 
-### Auth behavior (`--auth-token`)
+### Application credentials
 
-- `GET /api/*` requires `Authorization: Bearer <token>`.
-- WebSocket endpoints accept either:
-  - `Authorization: Bearer <token>`, or
-  - `?token=<token>` query parameter.
-- Static files (`/`, JS, CSS, assets) are still served without token.
+Clients that can reach Core's web listener need no application credential for
+HTTP or WebSocket access. The browser does not prompt for, read, persist or send
+an application token (`frontend/src/lib/auth.ts: getAuthToken`,
+`frontend/src/lib/transport/http-client.ts: fetchInfo`). Old browser
+token entries may remain inert; preference migration leaves them untouched
+(`frontend/src/lib/migrate-legacy-storage.ts: migrateLegacyStorage`).
+
+Remove `--auth-token` and `--auth-token-file` from old launch commands; these
+flags now fail before radio startup. `RIGPLANE_AUTH_TOKEN` is ignored. See the
+[CLI migration note](cli.md#web) and [API migration contract](../api/web.md#application-authentication-removal)
+for the empty-only `WebConfig.auth_token` compatibility field and diagnostic
+CSRF, Origin and consent behavior. Radio credentials, bind selection and TLS
+options retain their existing roles.
 
 !!! note "Audio bridge control path"
     Runtime bridge activation is typically done from CLI flags
@@ -224,7 +232,7 @@ Use `/api/v1/capabilities` before sending model-specific batches; not every
 radio exposes the same receivers, memory operations, audio routing controls, or
 feature toggles. Prefer these structured commands over raw CI-V for routine
 automation so RigPlane remains the single owner of the radio connection,
-queueing, pacing, auth policy, and safety checks.
+queueing, pacing, and safety checks.
 
 For vendor-specific CI-V commands that are not yet covered by structured
 commands, use the queued `send_civ` escape hatch. The payload mirrors the
@@ -283,7 +291,6 @@ import json
 import urllib.request
 
 base_url = "http://127.0.0.1:8080"
-token = None  # or "your-token"
 
 payload = {
     "id": "display-type-b",
@@ -300,8 +307,6 @@ request = urllib.request.Request(
     headers={"Content-Type": "application/json"},
     method="POST",
 )
-if token:
-    request.add_header("Authorization", f"Bearer {token}")
 
 with urllib.request.urlopen(request, timeout=5) as response:
     result = json.load(response)

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -287,7 +287,6 @@
         console.error('init error:', err);
         if (!mounted) return;
         backendError = t('core.app.backendError', { detail: String(err) });
-        if (err instanceof Error && err.name === 'AuthenticationError') return;
         if (retryCount < MAX_RETRIES) {
           const delay = RETRY_DELAYS[Math.min(retryCount, RETRY_DELAYS.length - 1)];
           retrying = true;

--- a/frontend/src/lib/__tests__/migrate-legacy-storage.test.ts
+++ b/frontend/src/lib/__tests__/migrate-legacy-storage.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import {
   __resetMigrationStateForTests,
@@ -34,19 +34,39 @@ Object.defineProperty(globalThis, 'localStorage', {
 });
 
 describe('migrateLegacyStorage', () => {
+  afterEach(() => vi.restoreAllMocks());
+
   beforeEach(() => {
     localStorageMock.clear();
     __resetMigrationStateForTests();
   });
 
   it('copies a hyphenated legacy key to its new key and removes the legacy entry', () => {
-    localStorageMock.setItem('icom-lan-auth-token', 'tok-abc');
+    localStorageMock.setItem('icom-lan-layout', 'lcd');
 
     migrateLegacyStorage();
 
-    expect(localStorageMock.getItem('rigplane-auth-token')).toBe('tok-abc');
-    expect(localStorageMock.getItem('icom-lan-auth-token')).toBeNull();
+    expect(localStorageMock.getItem('rigplane-layout')).toBe('lcd');
+    expect(localStorageMock.getItem('icom-lan-layout')).toBeNull();
     expect(localStorageMock.getItem(SENTINEL_KEY)).toBe('1');
+  });
+
+  it.each([null, 'retired-current-token'])('leaves retired credentials untouched with current token %s', (currentToken) => {
+    localStorageMock.setItem('icom-lan-auth-token', 'retired-legacy-token');
+    if (currentToken !== null) localStorageMock.setItem('rigplane-auth-token', currentToken);
+    const before = localStorageMock._dump();
+    const getItem = vi.spyOn(localStorageMock, 'getItem');
+    const setItem = vi.spyOn(localStorageMock, 'setItem');
+    const removeItem = vi.spyOn(localStorageMock, 'removeItem');
+
+    migrateLegacyStorage();
+
+    for (const key of ['icom-lan-auth-token', 'rigplane-auth-token']) {
+      expect(getItem).not.toHaveBeenCalledWith(key);
+      expect(setItem.mock.calls.some(([writtenKey]) => writtenKey === key)).toBe(false);
+      expect(removeItem).not.toHaveBeenCalledWith(key);
+    }
+    expect(localStorageMock._dump()).toEqual({ ...before, [SENTINEL_KEY]: '1' });
   });
 
   it('copies a colon-namespaced legacy key to its new key', () => {
@@ -88,24 +108,24 @@ describe('migrateLegacyStorage', () => {
 
   it('is a no-op when sentinel is already set', () => {
     localStorageMock.setItem(SENTINEL_KEY, '1');
-    localStorageMock.setItem('icom-lan-auth-token', 'should-not-migrate');
+    localStorageMock.setItem('icom-lan-layout', 'should-not-migrate');
 
     migrateLegacyStorage();
 
     // Already-migrated sentinel means we don't touch the legacy key.
-    expect(localStorageMock.getItem('icom-lan-auth-token')).toBe('should-not-migrate');
-    expect(localStorageMock.getItem('rigplane-auth-token')).toBeNull();
+    expect(localStorageMock.getItem('icom-lan-layout')).toBe('should-not-migrate');
+    expect(localStorageMock.getItem('rigplane-layout')).toBeNull();
   });
 
   it('does not overwrite existing new-key data when both legacy and new are present', () => {
-    localStorageMock.setItem('icom-lan-auth-token', 'old-token');
-    localStorageMock.setItem('rigplane-auth-token', 'new-token-already-set');
+    localStorageMock.setItem('icom-lan-layout', 'standard');
+    localStorageMock.setItem('rigplane-layout', 'lcd');
 
     migrateLegacyStorage();
 
-    expect(localStorageMock.getItem('rigplane-auth-token')).toBe('new-token-already-set');
+    expect(localStorageMock.getItem('rigplane-layout')).toBe('lcd');
     // Legacy still removed so it can't drift.
-    expect(localStorageMock.getItem('icom-lan-auth-token')).toBeNull();
+    expect(localStorageMock.getItem('icom-lan-layout')).toBeNull();
   });
 
   it('repeated calls in the same session do not re-do work', () => {
@@ -128,7 +148,6 @@ describe('migrateLegacyStorage', () => {
   });
 
   it('migrates a representative sample of all key categories at once', () => {
-    localStorageMock.setItem('icom-lan-auth-token', 'tok');
     localStorageMock.setItem('icom-lan-layout', 'lcd');
     localStorageMock.setItem('icom-lan-lcd-display-mode', 'dim');
     localStorageMock.setItem('icom-lan-hidden-layers', '[]');
@@ -141,7 +160,6 @@ describe('migrateLegacyStorage', () => {
 
     migrateLegacyStorage();
 
-    expect(localStorageMock.getItem('rigplane-auth-token')).toBe('tok');
     expect(localStorageMock.getItem('rigplane-layout')).toBe('lcd');
     expect(localStorageMock.getItem('rigplane-lcd-display-mode')).toBe('dim');
     expect(localStorageMock.getItem('rigplane-hidden-layers')).toBe('[]');

--- a/frontend/src/lib/api/__tests__/diagnostics.test.ts
+++ b/frontend/src/lib/api/__tests__/diagnostics.test.ts
@@ -91,12 +91,20 @@ describe('previewBundle', () => {
     expect(result.csrf_token).toBe('csrf-xyz');
   });
 
-  it('includes Authorization header when auth token is stored', async () => {
+  it.each([
+    ['preview', () => previewBundle({})],
+    ['send', () => sendBundle('prev-abc', 'csrf-xyz')],
+    ['save', () => saveBundle('prev-abc', 'csrf-xyz')],
+    ['delete', () => deletePreview('prev-abc', 'csrf-xyz')],
+  ])('%s neither reads stored credentials nor sends Authorization', async (_name, request) => {
     // Stub a minimal localStorage — robust against earlier tests that may
     // have replaced globalThis.localStorage (vitest fast-pool isolate:false).
-    const store: Record<string, string> = { 'rigplane-auth-token': 'tok-secret' };
+    const store: Record<string, string> = {
+      'rigplane-auth-token': 'tok-secret',
+      'icom-lan-auth-token': 'legacy-secret',
+    };
     const stub = {
-      getItem: (k: string) => (k in store ? store[k] : null),
+      getItem: vi.fn((k: string) => (k in store ? store[k] : null)),
       setItem: (k: string, v: string) => {
         store[k] = v;
       },
@@ -116,10 +124,11 @@ describe('previewBundle', () => {
     const fetchMock = vi.fn().mockResolvedValue(fakeOkResponse(makePreviewResponse()));
     globalThis.fetch = fetchMock;
 
-    await previewBundle({});
+    await request();
 
     const [, init] = fetchMock.mock.calls[0];
-    expect(init.headers.Authorization).toBe('Bearer tok-secret');
+    expect(new Headers(init.headers).has('Authorization')).toBe(false);
+    expect(stub.getItem).not.toHaveBeenCalled();
   });
 
   it('throws DiagnosticsApiError with server-supplied code on 4xx', async () => {

--- a/frontend/src/lib/api/diagnostics.ts
+++ b/frontend/src/lib/api/diagnostics.ts
@@ -12,10 +12,6 @@
  * presentation components must NOT import it; they should pass callbacks
  * down to the dialog wiring instead.
  *
- * Auth header behaviour mirrors `transport/http-client.ts` (Bearer token
- * from localStorage, key `icom-lan-auth-token`). The helper is duplicated
- * here on purpose — keeping `lib/api/` independent of transport internals.
- *
  * See `docs/plans/2026-05-03-diagnostic-data-collection-design.md` §4.9.
  */
 
@@ -76,16 +72,6 @@ export class DiagnosticsApiError extends Error {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function getAuthHeaders(): Record<string, string> {
-  const storage = globalThis.localStorage;
-  if (!storage || typeof storage.getItem !== 'function') {
-    return {};
-  }
-  const token = storage.getItem('rigplane-auth-token');
-  if (token) return { Authorization: `Bearer ${token}` };
-  return {};
-}
-
 interface ErrorBody {
   error?: string;
   message?: string;
@@ -124,7 +110,7 @@ async function raiseFromResponse(
 export async function previewBundle(req: PreviewRequest): Promise<PreviewResponse> {
   const res = await fetch(`${BASE}/preview`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(req),
   });
   if (!res.ok) await raiseFromResponse(res, 'preview_failed');
@@ -147,7 +133,6 @@ export async function sendBundle(
     headers: {
       'Content-Type': 'application/json',
       'X-Diagnostic-CSRF': csrfToken,
-      ...getAuthHeaders(),
     },
     body: JSON.stringify({ preview_id: previewId, consent: true }),
   });
@@ -168,7 +153,6 @@ export async function saveBundle(
     headers: {
       'Content-Type': 'application/json',
       'X-Diagnostic-CSRF': csrfToken,
-      ...getAuthHeaders(),
     },
     body: JSON.stringify({ preview_id: previewId }),
   });
@@ -187,7 +171,7 @@ export async function deletePreview(
 ): Promise<void> {
   const res = await fetch(`${BASE}/preview/${previewId}`, {
     method: 'DELETE',
-    headers: { 'X-Diagnostic-CSRF': csrfToken, ...getAuthHeaders() },
+    headers: { 'X-Diagnostic-CSRF': csrfToken },
   });
   if (!res.ok) await raiseFromResponse(res, 'delete_failed');
 }

--- a/frontend/src/lib/migrate-legacy-storage.ts
+++ b/frontend/src/lib/migrate-legacy-storage.ts
@@ -20,11 +20,10 @@
  */
 
 const LEGACY_TO_NEW: Record<string, string> = {
-  // Hyphenated (legacy v1) — auth token, layout, LCD modes, hidden layers,
+  // Hyphenated (legacy v1) — layout, LCD modes, hidden layers,
   // skin selection. Some keys (`icom-lan-skin`, `icom-lan-lcd-variant`,
   // `icom-lan-skin-migrated-0.18`) are not currently produced by this
   // codebase, but v1.x users may still have them in browser storage.
-  'icom-lan-auth-token': 'rigplane-auth-token',
   'icom-lan-layout': 'rigplane-layout',
   'icom-lan-lcd-display-mode': 'rigplane-lcd-display-mode',
   'icom-lan-hidden-layers': 'rigplane-hidden-layers',

--- a/frontend/src/lib/transport/http-client.ts
+++ b/frontend/src/lib/transport/http-client.ts
@@ -6,11 +6,6 @@ export { getAuthHeaders, getAuthToken };
 
 const BASE = '/api/v1';
 
-/** @deprecated Retained for source compatibility; HTTP requests do not throw this error. */
-export class AuthenticationError extends Error {
-  override name = 'AuthenticationError';
-}
-
 async function fetchApiResponse(path: string, signal?: AbortSignal): Promise<Response> {
   signal?.throwIfAborted();
   const res = await fetch(path, { headers: getAuthHeaders(), signal, redirect: 'error' });


### PR DESCRIPTION
Completes the browser credential cleanup after MOR-2361 and MOR-2362: diagnostics no longer reads a stored application token or sends Bearer headers, and legacy preference migration no longer copies credentials. App bootstrap retains ordinary retry handling; the unused AuthenticationError export is removed.

The public API, CLI, web UI and troubleshooting guides now describe token-free application access and migration from retired launch flags. Radio login, diagnostic Origin/CSRF/consent, credential redaction and TX/PTT guards retain their existing behavior. Stored old browser tokens remain inert.

Scope: [MOR-2363](https://linear.app/morozsm/issue/MOR-2363), child of MOR-2360. Ten files form one residual credential-lifecycle and migration contract; `git diff --shortstat origin/main...HEAD` reports 134 additions and 129 deletions (263 changed lines). This exceeds the soft file threshold and stays within both hard limits. Separate MOR-2365 owns live API auth metadata and the security/migration overview.

Validation: the builder ran 12 focused Vitest files (326 tests passed), `npm run check` (Svelte zero errors/warnings and both tsc configurations passed), ESLint on the six changed frontend files, the rebrand gate, and `git diff --check`. Restoring the original diagnostic credential helper and token migration produced six expected test failures; the restored implementation passed. `rg -n AuthenticationError frontend/src` found no remaining browser references. No full suite was run locally; required natural CI and independent exact-head review gate integration. Local doc citation/link validation could not execute because the installed Bash lacks associative arrays. No radio deployment or release publication is included.
