### PR TITLE
feat(MOR-2364): preserve qualified VFO readouts without stale tuning

### DIFF
--- a/frontend/fixtures/assertions.ts
+++ b/frontend/fixtures/assertions.ts
@@ -476,7 +476,10 @@ export function runAssertions(
       + `expected ${structurallyZoneless} (vfo/rx-tx surface controls, MOR-1069 exempt)`);
   }
   check('no-negative-tabindex-and-no-aria-hidden-control',
-    controls().every((el) => Number(el.getAttribute('tabindex') ?? '0') >= 0
+    controls().every((el) => (Number(el.getAttribute('tabindex') ?? '0') >= 0
+      // Retained inert readouts keep focus context but are not native Tab stops.
+      || (el.matches('div.freq[role="group"][aria-disabled="true"][tabindex="-1"]')
+        && el.closest('[data-vfo-freq][data-freq-tunable="false"]') !== null))
       && el.closest('[aria-hidden="true"]') === null),
     `${controls().length} focusable controls`);
 

--- a/frontend/fixtures/catalog.ts
+++ b/frontend/fixtures/catalog.ts
@@ -22,8 +22,9 @@ import {
   IDLE_TX, type AudioRuntimeState, type ModGuardProps, type TxSnapshot,
 } from './harness-state';
 
-const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
-const stale = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
+// Synthetic observation provenance for these fixtures, not a radio measurement.
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 0 };
+const stale = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale', lastObservedMonotonic: 0 };
 
 type FieldStatusMap = Record<string, unknown>;
 const statuses = (paths: readonly string[], entry: unknown = fresh): FieldStatusMap =>
@@ -43,6 +44,7 @@ function mainSubState(active: 'MAIN' | 'SUB' = 'MAIN', entry: unknown = fresh): 
   const slot = (hz: number) => ({ freqHz: hz, mode: 'USB', filterNum: 1 });
   const receiver = (hz: number) => ({ vfoA: slot(hz), vfoB: slot(hz + 30000), activeSlot: 'A' });
   return {
+    stateContractVersion: 1, providerGeneration: 1,
     active, split: true, dualWatch: true, ptt: false,
     txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
     main: receiver(14250000), sub: receiver(21295000),
@@ -73,6 +75,7 @@ function abSharedState(active: 'MAIN' | 'SUB' = 'SUB'): ServerState {
     'sub.freqHz', 'sub.mode', 'sub.filter'];
   const receiver = (hz: number) => ({ freqHz: hz, mode: 'CW', filter: 1 });
   return {
+    stateContractVersion: 1, providerGeneration: 1,
     active, split: false, dualWatch: true, ptt: false,
     txTarget: { status: 'known', receiver: active, slot: null, frequencyHz: 14250000 },
     main: receiver(14250000), sub: receiver(14250000),
@@ -97,6 +100,7 @@ function abSharedSubUnobserved(): ServerState {
 function singleState(): ServerState {
   const paths = [...RADIO_WIDE, 'main.freqHz', 'main.mode', 'main.filter'];
   return {
+    stateContractVersion: 1, providerGeneration: 1,
     active: 'MAIN', split: false, dualWatch: false, ptt: false,
     txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14195000 },
     main: { freqHz: 14195000, mode: 'USB', filter: 1 },
@@ -110,6 +114,7 @@ function abState(): ServerState {
     'main.vfoA.freqHz', 'main.vfoA.mode', 'main.vfoA.filterNum',
     'main.vfoB.freqHz', 'main.vfoB.mode', 'main.vfoB.filterNum'];
   return {
+    stateContractVersion: 1, providerGeneration: 1,
     active: 'MAIN', split: true, dualWatch: false, ptt: false,
     txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14195000 },
     main: {

--- a/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
+++ b/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
+import { writable, fromStore } from 'svelte/store';
 import type { ComponentProps } from 'svelte';
 import type { ServerState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
@@ -109,6 +110,52 @@ function mountDisplay(props: ComponentProps<typeof FrequencyDisplayInteractive>)
   flushSync();
   return t;
 }
+
+describe('display-only frequency and disabled arithmetic', () => {
+  it.each([{ freq: null, disabled: false }, { freq: 14250000, disabled: true }])('rejects every gesture with %j', (authority) => {
+    const onFreqChange = vi.fn();
+    const root = mountDisplay({ ...authority, displayHz: 7100000, onFreqChange });
+    const primitive = root.querySelector('.freq')!;
+    expect(primitive.textContent?.replace(/\s/g, '')).toBe('7.100.000');
+    expect(primitive.getAttribute('aria-disabled')).toBe('true');
+    for (const digit of primitive.querySelectorAll('.digit')) {
+      digit.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      const wheel = new WheelEvent('wheel', { deltaY: -1, bubbles: true, cancelable: true });
+      digit.dispatchEvent(wheel);
+      for (const key of ['ArrowUp', 'ArrowDown']) primitive.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+      expect(onFreqChange).not.toHaveBeenCalled();
+      expect(wheel.defaultPrevented).toBe(false);
+    }
+    flushSync();
+    expect(primitive.querySelector('.selected')).toBeNull();
+    expect(onFreqChange).not.toHaveBeenCalled();
+  });
+  it('shows null as unknown and preserves valid zero', () => {
+    expect(mountDisplay({ freq: null }).querySelector('.freq')!.textContent?.trim()).toBe('—');
+    expect(mountDisplay({ freq: 0 }).querySelector('.freq')!.textContent?.replace(/\s/g, '')).toBe('.000.000');
+  });
+  it('clears the armed digit on disable or context change and uses strict input after rearming', () => {
+    const control = writable({ disabled: false, contextKey: 'MAIN:A' });
+    const live = fromStore(control);
+    const onFreqChange = vi.fn();
+    const root = mountDisplay({ freq: 14250000, displayHz: 7100000, onFreqChange,
+      get disabled() { return live.current.disabled; }, get contextKey() { return live.current.contextKey; },
+    });
+    const primitive = root.querySelector('.freq')!;
+    const digit = primitive.querySelectorAll('.digit').item(6);
+    for (const contextKey of ['MAIN:A', 'MAIN:B']) {
+      digit.dispatchEvent(new MouseEvent('click', { bubbles: true })); flushSync();
+      control.set({ disabled: contextKey === 'MAIN:A', contextKey }); flushSync();
+      control.set({ disabled: false, contextKey }); flushSync();
+      primitive.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      digit.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true }));
+      expect(onFreqChange).not.toHaveBeenCalled();
+    }
+    digit.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    primitive.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    expect(onFreqChange).toHaveBeenCalledExactlyOnceWith(14250001);
+  });
+});
 
 beforeEach(async () => {
   vi.resetModules();

--- a/frontend/src/components-v2/layout/KeyboardHandler.svelte
+++ b/frontend/src/components-v2/layout/KeyboardHandler.svelte
@@ -55,11 +55,23 @@
   }
 
   function dispatch(action: KeyboardActionConfig): void {
+    if (frequencyActionBlocked(action)) return;
     if (action.action === 'toggle_help') {
       helpOpen = !helpOpen;
       return;
     }
     onAction(action);
+  }
+
+  function inertFrequencyReadout(): boolean {
+    const focused = document.activeElement;
+    const readout = focused?.closest('[data-vfo-freq]');
+    return !!readout && (readout.getAttribute('data-freq-tunable') === 'false'
+      || focused?.closest('[aria-disabled="true"]') !== null);
+  }
+
+  function frequencyActionBlocked(action: KeyboardActionConfig): boolean {
+    return inertFrequencyReadout() && (action.action === 'tune' || action.action === 'band_select');
   }
 
   /**
@@ -122,7 +134,7 @@
       isDigitKey(event.key) && !event.ctrlKey && !event.metaKey && !event.altKey
       && document.activeElement?.closest('[data-vfo-freq]')
     ) {
-      if (isFrequencyDisplayFocused(document.activeElement)) {
+      if (!inertFrequencyReadout() && isFrequencyDisplayFocused(document.activeElement)) {
         routeDigitToFrequencyEntry(event.key);
       }
       // MOR-1444 B2 (round-2 review): mirrors the MOR-1449 Tab guard
@@ -165,7 +177,7 @@
       return;
     }
 
-    const sequenceStarts = resolveSequenceStarts(event, keyboardConfig);
+    const sequenceStarts = resolveSequenceStarts(event, keyboardConfig).filter((action) => !frequencyActionBlocked(action));
     if (sequenceStarts.length) {
       event.preventDefault();
       pendingSequences = sequenceStarts;

--- a/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
+import { writable, fromStore } from 'svelte/store';
+import type { RadioViewModel } from '../../../semantic/radio-view-model';
 
 import KeyboardHandler from '../KeyboardHandler.svelte';
 import {
@@ -88,6 +90,92 @@ describe('KeyboardHandler', () => {
     expect(onAction).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'tune', params: { direction: 'up', fine: false } }),
     );
+  });
+
+  describe('retained inert frequency readouts (MOR-2364)', () => {
+    const bindings: KeyboardConfig = { ...config, bindings: [
+      ...config.bindings,
+      ...['ArrowDown', 'PageUp', 'PageDown', 'j'].map((key) => ({
+        id: key, section: 'Tuning', sequence: [key], action: 'tune',
+      })),
+      { id: 'leader-tune', section: 'Tuning', sequence: ['g', 't'], action: 'tune' },
+      { id: 'leader-band', section: 'Tuning', sequence: ['g', 'b'], action: 'band_select' },
+      { id: 'band-digit', section: 'Bands', sequence: ['7'], action: 'band_select' },
+      { id: 'band-letter', section: 'Bands', sequence: ['b'], action: 'band_select' },
+      { id: 'stop', section: 'Safety', sequence: ['Escape'], action: 'scan_stop' },
+      { id: 'leader-stop', section: 'Safety', sequence: ['g', 's'], action: 'scan_stop' },
+    ] };
+    function harness(initial: 'current' | 'null' | 'disabled' = 'current') {
+      const base = topologyFixtures['1/single'];
+      const current: RadioViewModel = { ...base, vfos: base.vfos.map((vfo) => ({ ...vfo, display: {
+        frequencyHz: { state: 'current', value: vfo.frequencyHz! },
+        mode: { state: 'current', value: 'USB' }, filter: { state: 'current', value: 'FIL1' },
+      } })) };
+      const initialView = initial === 'null' ? { ...current, vfos: current.vfos.map((vfo) => ({ ...vfo, frequencyHz: null })) } : current;
+      const state = writable({ viewModel: initialView, disabled: initial === 'disabled' });
+      const live = fromStore(state);
+      const target = document.createElement('div'); document.body.appendChild(target);
+      const onTuneFrequency = vi.fn(); const onAction = vi.fn();
+      components.push(mount(VfoSurface, { target, props: { onTuneFrequency,
+        get viewModel() { return live.current.viewModel; }, get disabled() { return live.current.disabled; },
+      } }));
+      const handler = mountHandler({ config: bindings, onAction });
+      const input = document.createElement('input'); input.setAttribute('data-freq-entry', ''); document.body.appendChild(input);
+      flushSync(); const frequency = target.querySelector<HTMLElement>('.freq')!; frequency.focus();
+      function set(kind: 'current' | 'null' | 'ancestor-stale' | 'disabled') {
+        state.set({ disabled: kind === 'disabled', viewModel: { ...current, vfos: current.vfos.map((vfo) => ({ ...vfo,
+          frequencyHz: kind === 'null' ? null : vfo.frequencyHz,
+          display: { ...vfo.display!, frequencyHz: { state: kind === 'current' || kind === 'disabled' ? 'current' : 'stale', value: vfo.frequencyHz! } },
+        })) } }); flushSync();
+      }
+      const key = (key: string, flags: KeyboardEventInit = {}) => {
+        const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...flags });
+        frequency.dispatchEvent(event); flushSync(); return event;
+      };
+      return { set, key, frequency, input, onAction, onTuneFrequency, handler };
+    }
+    it.each(['null', 'ancestor-stale', 'disabled'] as const)('blocks direct and leader tuning/digits while %s, then restores current routing', (kind) => {
+      const h = harness(); h.set(kind);
+      expect(document.activeElement).toBe(h.frequency);
+      for (const key of ['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'j', 'b', '7']) h.key(key);
+      for (const suffix of ['t', 'b', '7']) { h.key('g'); h.key(suffix); }
+      expect(h.onAction).not.toHaveBeenCalled(); expect(h.onTuneFrequency).not.toHaveBeenCalled();
+      expect(h.input.value).toBe(''); expect(document.activeElement).toBe(h.frequency);
+      expect(h.handler.querySelector('.keyboard-leader-pill')).toBeNull();
+      h.set('current'); h.key('ArrowUp');
+      expect(h.onAction).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ action: 'tune' }));
+      h.key('7'); expect(h.input.value).toBe('7'); expect(document.activeElement).toBe(h.input);
+    });
+    it('checks a leader continuation against the current inert state', () => {
+      const h = harness(); h.key('g'); h.set('ancestor-stale'); h.key('t');
+      expect(h.onAction).not.toHaveBeenCalled(); expect(h.handler.querySelector('.keyboard-leader-pill')).toBeNull();
+      h.set('current'); h.key('g'); h.key('t');
+      expect(h.onAction).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ action: 'tune' }));
+    });
+    it.each(['null', 'disabled'] as const)('cannot arm a tuning leader from an initially %s readout', (initial) => {
+      const h = harness(initial); h.key('ArrowUp'); h.key('7'); h.key('g');
+      h.set('current'); h.key('t');
+      expect(h.onAction).not.toHaveBeenCalled(); expect(h.input.value).toBe('');
+      h.key('g'); h.key('t');
+      expect(h.onAction).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ action: 'tune' }));
+    });
+    it('preserves Tab, native modifiers, stop/help and shortcuts outside an inert readout', () => {
+      const h = harness(); h.set('ancestor-stale');
+      h.key('g'); expect(h.key('Tab').defaultPrevented).toBe(false);
+      expect(h.handler.querySelector('.keyboard-leader-pill')).toBeNull();
+      for (const flags of [{ ctrlKey: true }, { metaKey: true }, { altKey: true }]) {
+        expect(h.key('7', flags).defaultPrevented).toBe(false);
+        expect(h.key('ArrowUp', flags).defaultPrevented).toBe(false);
+      }
+      h.key('Escape'); h.key('g'); h.key('s');
+      expect(h.onAction.mock.calls.map(([action]) => action.action)).toEqual(['scan_stop', 'scan_stop']);
+      h.key('?'); expect(h.handler.querySelector('[role="dialog"]')).not.toBeNull();
+      h.onAction.mockClear(); h.frequency.blur();
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '7' }));
+      expect(h.onAction.mock.calls.map(([action]) => action.action)).toEqual(['tune', 'band_select']);
+      expect(h.input.value).toBe('');
+    });
   });
 
   it('supports leader sequences for focus actions', () => {

--- a/frontend/src/components-v2/wiring/__tests__/fixture-focus-assertion.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/fixture-focus-assertion.isolated.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { runAssertions } from '../../../../fixtures/assertions';
+import { fixtureById } from '../../../../fixtures/catalog';
+
+const inert = '<div class="freq" role="group" aria-disabled="true" tabindex="-1">14.250.000</div>';
+const wrap = (html: string) => `<span data-vfo-freq data-freq-tunable="false">${html}</span>`;
+function admitted(html: string): boolean {
+  document.body.innerHTML = `<div data-testid="dual-receiver-cockpit">${html}</div>`;
+  const result = runAssertions(fixtureById('caps-unloaded')!.expect!)
+    .find(result => result.name === 'no-negative-tabindex-and-no-aria-hidden-control');
+  expect(result).toBeDefined();
+  return result!.ok;
+}
+afterEach(() => { document.body.innerHTML = ''; });
+
+describe('fixture focus assertion retained readout exception', () => {
+  it('admits the inert readout and ordinary controls', () => {
+    expect(admitted(wrap(inert) + '<button>Stop</button><input><a href="#help">Help</a>')).toBe(true);
+  });
+  it('admits the restored current readout through the normal tabindex rule', () => {
+    expect(admitted('<span data-vfo-freq data-freq-tunable="true">'
+      + inert.replace('aria-disabled="true"', 'aria-disabled="false"').replace('tabindex="-1"', 'tabindex="0"')
+      + '</span>')).toBe(true);
+  });
+  it.each([
+    ['enabled frequency', wrap(inert.replace('aria-disabled="true"', 'aria-disabled="false"'))],
+    ['enabled VFO hook', wrap(inert).replace('data-freq-tunable="false"', 'data-freq-tunable="true"')],
+    ['missing VFO hook', inert],
+    ['disabled button', '<button aria-disabled="true" tabindex="-1">Stop</button>'],
+    ['disabled link', '<a href="#help" aria-disabled="true" tabindex="-1">Help</a>'],
+    ['disabled input', '<input aria-disabled="true" tabindex="-1">'],
+    ['unrelated group', '<div role="group" aria-disabled="true" tabindex="-1">Group</div>'],
+    ['non-primitive group in VFO', wrap(inert.replace('class="freq"', ''))],
+    ['wrong element in VFO', wrap(inert.replaceAll('div', 'button'))],
+    ['wrong role in VFO', wrap(inert.replace('role="group"', 'role="button"'))],
+    ['hidden readout', wrap(inert.replace('role="group"', 'role="group" aria-hidden="true"'))],
+    ['hidden ancestor', `<section aria-hidden="true">${wrap(inert)}</section>`],
+    ['hidden ordinary control', '<section aria-hidden="true"><button>Stop</button></section>'],
+  ])('rejects %s', (_label, html) => { expect(admitted(html)).toBe(false); });
+});

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -163,7 +163,7 @@ import {
   ManagedAppTxHarness, type ManagedAppTxServerSnapshot,
 } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
 
-const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 0 };
 const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
 
 /** Every txAux raw field the MOR-1244 adapter reads, all observed fresh. */
@@ -190,6 +190,7 @@ function liveState(withTxAux: boolean): ServerState {
     ...slot(hz), vfoA: slot(hz), vfoB: slot(hz + 50000), activeSlot: 'A', filter: 1,
   });
   return {
+    stateContractVersion: 1, providerGeneration: 1,
     active: 'MAIN', split: false, dualWatch: false, ptt: false,
     txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
     main: receiver(14250000), sub: receiver(14300000),
@@ -199,6 +200,7 @@ function liveState(withTxAux: boolean): ServerState {
 }
 
 const liveCaps = (withTxAux: boolean): Capabilities => ({
+  stateContractVersion: 1, providerGeneration: 1,
   model: 'fixture', scope: false, audio: true, tx: true,
   capabilities: withTxAux
     ? ['audio', 'tx', 'dual_rx', 'vox', 'compressor', 'monitor', 'tuner', 'drive_gain']
@@ -324,9 +326,10 @@ describe('the txAux surface mounts only when the view model carries the group', 
    * RECEIVER instead of per radio. MAIN B and SUB B keep their text nodes — the
    * intra-receiver hazard B1 found stays closed.
    */
-  const DEFAULT_PATH_OUTLINE = 'div p div div span span div span span span span span span span span span span span span span '
-    + 'div span span span button div span span div span span span span span span span span span span span button '
-    + 'div span span span button div section header strong div div div '
+  // Four VFO tiles now reserve a cue container, marker and accessible reason.
+  const DEFAULT_PATH_OUTLINE = 'div p div div span span div span span span span span span span span span span span span span span span span '
+    + 'div span span span span span span button div span span div span span span span span span span span span span span span span span button '
+    + 'div span span span span span span button div section header strong div div div '
     + 'section header strong div div div section div span '
     + 'div button button div button button p span span section p span span span p div button button '
     + 'ul section div button button button label span input output div button button button output '
@@ -346,6 +349,12 @@ describe('the txAux surface mounts only when the view model carries the group', 
     h.caps = liveCaps(false);
     render();
     expect(testids()).toEqual(DEFAULT_PATH_TESTIDS);
+    const cues = target.querySelectorAll('[data-vfo-stale-cue]');
+    expect(cues).toHaveLength(4);
+    for (const cue of cues) {
+      expect(cue.children).toHaveLength(2);
+      expect(cue.getAttribute('aria-hidden')).toBe('true');
+    }
     expect(outline()).toBe(DEFAULT_PATH_OUTLINE);
   });
 

--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -89,6 +89,154 @@ const unobservedState = (): ServerState => ({
   ...observedState(), fieldStatus: {},
 } as ServerState);
 
+describe('qualified VFO display observations', () => {
+  const dc = { ...TOPOLOGY_CAPS['1/single'], stateContractVersion: 1, providerGeneration: 1 };
+  function ds(isStale = false): ServerState {
+    const state = observedState({ stateContractVersion: 1, providerGeneration: 1 });
+    state.fieldStatus = Object.fromEntries(Object.keys(state.fieldStatus!).map((path) =>
+      [path, { ...(isStale && /\.(freqHz|mode|filter|filterNum)$/.test(path) ? stale : fresh), lastObservedMonotonic: 0 }]));
+    return state;
+  }
+  const display = (state: ServerState | null, c: Capabilities = dc) => toRadioViewModel(state, c)!.vfos[0].display;
+  const strictBaselines: Record<string, unknown> = {
+    '1/single:false': [
+      {"receiver":"MAIN","slot":{"kind":"unslotted"},"label":"MAIN","frequencyHz":14250000,"mode":"USB","filter":"FIL1","isActive":true,"isActiveSlot":true,"isTxTarget":false},
+    ],
+    '1/single:true': [
+      {"receiver":"MAIN","slot":{"kind":"unslotted"},"label":"MAIN","frequencyHz":null,"mode":null,"filter":null,"isActive":true,"isActiveSlot":true,"isTxTarget":false},
+    ],
+    '1/ab:false': [
+      {"receiver":"MAIN","slot":{"kind":"slotted","id":"A"},"label":"MAIN A","frequencyHz":14250000,"mode":"USB","filter":"FIL1","isActive":true,"isActiveSlot":true,"isTxTarget":true},
+      {"receiver":"MAIN","slot":{"kind":"slotted","id":"B"},"label":"MAIN B","frequencyHz":14300000,"mode":"USB","filter":"FIL1","isActive":false,"isActiveSlot":false,"isTxTarget":false},
+    ],
+    '1/ab:true': [
+      {"receiver":"MAIN","slot":{"kind":"slotted","id":"A"},"label":"MAIN A","frequencyHz":null,"mode":null,"filter":null,"isActive":true,"isActiveSlot":true,"isTxTarget":true},
+      {"receiver":"MAIN","slot":{"kind":"slotted","id":"B"},"label":"MAIN B","frequencyHz":null,"mode":null,"filter":null,"isActive":false,"isActiveSlot":false,"isTxTarget":false},
+    ],
+    '2/ab_shared:false': [
+      {"receiver":"MAIN","slot":{"kind":"unslotted"},"label":"MAIN","frequencyHz":14250000,"mode":"USB","filter":"FIL1","isActive":true,"isActiveSlot":true,"isTxTarget":false},
+      {"receiver":"SUB","slot":{"kind":"unslotted"},"label":"SUB","frequencyHz":14300000,"mode":"USB","filter":"FIL1","isActive":false,"isActiveSlot":true,"isTxTarget":false},
+    ],
+    '2/ab_shared:true': [
+      {"receiver":"MAIN","slot":{"kind":"unslotted"},"label":"MAIN","frequencyHz":null,"mode":null,"filter":null,"isActive":true,"isActiveSlot":true,"isTxTarget":false},
+      {"receiver":"SUB","slot":{"kind":"unslotted"},"label":"SUB","frequencyHz":null,"mode":null,"filter":null,"isActive":false,"isActiveSlot":true,"isTxTarget":false},
+    ],
+    '2/main_sub:false': [
+      {"receiver":"MAIN","slot":{"kind":"slotted","id":"A"},"label":"MAIN A","frequencyHz":14250000,"mode":"USB","filter":"FIL1","isActive":true,"isActiveSlot":true,"isTxTarget":true},
+      {"receiver":"MAIN","slot":{"kind":"slotted","id":"B"},"label":"MAIN B","frequencyHz":14300000,"mode":"USB","filter":"FIL1","isActive":false,"isActiveSlot":false,"isTxTarget":false},
+      {"receiver":"SUB","slot":{"kind":"slotted","id":"A"},"label":"SUB A","frequencyHz":14300000,"mode":"USB","filter":"FIL1","isActive":false,"isActiveSlot":true,"isTxTarget":false},
+      {"receiver":"SUB","slot":{"kind":"slotted","id":"B"},"label":"SUB B","frequencyHz":14350000,"mode":"USB","filter":"FIL1","isActive":false,"isActiveSlot":false,"isTxTarget":false},
+    ],
+    '2/main_sub:true': [
+      {"receiver":"MAIN","slot":{"kind":"slotted","id":"A"},"label":"MAIN A","frequencyHz":null,"mode":null,"filter":null,"isActive":true,"isActiveSlot":true,"isTxTarget":true},
+      {"receiver":"MAIN","slot":{"kind":"slotted","id":"B"},"label":"MAIN B","frequencyHz":null,"mode":null,"filter":null,"isActive":false,"isActiveSlot":false,"isTxTarget":false},
+      {"receiver":"SUB","slot":{"kind":"slotted","id":"A"},"label":"SUB A","frequencyHz":null,"mode":null,"filter":null,"isActive":false,"isActiveSlot":true,"isTxTarget":false},
+      {"receiver":"SUB","slot":{"kind":"slotted","id":"B"},"label":"SUB B","frequencyHz":null,"mode":null,"filter":null,"isActive":false,"isActiveSlot":false,"isTxTarget":false},
+    ],
+  };
+
+  it.each([false, true, false])('qualifies first accepted snapshots with stale=%s', (isStale) => {
+    expect(display(ds(isStale))).toEqual({
+      frequencyHz: { state: isStale ? 'stale' : 'current', value: 14250000 },
+      mode: { state: isStale ? 'stale' : 'current', value: 'USB' },
+      filter: { state: isStale ? 'stale' : 'current', value: 'FIL1' },
+    });
+  });
+  it('accepts zero frequency/filter and rejects non-scalar or empty values', () => {
+    const state = ds(true);
+    state.main = { ...state.main, freqHz: 0, filter: 0 };
+    expect(display(state)?.frequencyHz).toEqual({ state: 'stale', value: 0 });
+    expect(display(state)?.filter).toEqual({ state: 'stale', value: 'FIL0' });
+    state.main = { ...state.main, freqHz: NaN, mode: '', filter: Infinity };
+    expect(Object.values(display(state)!)).toEqual(Array(3).fill({ state: 'unknown', reason: 'invalid-value' }));
+    state.main.freqHz = false as unknown as number;
+    expect(display(state)?.frequencyHz).toEqual({ state: 'unknown', reason: 'invalid-value' });
+  });
+  it.each([
+    undefined, { ...fresh, observed: false }, { ...fresh },
+    { ...fresh, lastObservedMonotonic: -1 },
+    { ...fresh, lastObservedMonotonic: 1, availability: 'unavailable' },
+  ])('rejects missing or invalid leaf evidence %#', (status) => {
+    const state = ds();
+    state.fieldStatus!['main.freqHz'] = status as FieldStatus;
+    expect(display(state)?.frequencyHz.state).toBe('unknown');
+  });
+  it.each(['main', 'main.vfoA'])('honors ancestor veto and ancestor staleness at %s', (path) => {
+    const c = { ...dc, vfoScheme: 'ab' as const, vfoReadback: 'absolute' as const };
+    const state = ds();
+    state.fieldStatus![path] = { ...fresh, observed: false, lastObservedMonotonic: 0 };
+    expect(display(state, c)?.frequencyHz).toEqual({ state: 'unknown', reason: 'not-observed' });
+    state.fieldStatus![path] = { ...stale, lastObservedMonotonic: 0 };
+    expect(display(state, c)?.frequencyHz).toEqual({ state: 'stale', value: 14250000 });
+  });
+  it('fences capability generation, contract, reset and unresolved slot identity without caching', () => {
+    expect(display(ds())?.frequencyHz.state).toBe('current');
+    for (const c of [{ ...dc, providerGeneration: 2 }, { ...dc, stateContractVersion: undefined }]) {
+      expect(display(ds(), c)?.frequencyHz).toEqual({ state: 'unknown', reason: 'identity-unresolved' });
+    }
+    expect(display(null)?.frequencyHz.state).toBe('unknown');
+    const state = ds();
+    state.main = { ...state.main, vfoA: undefined, vfoB: undefined };
+    expect(display(state, { ...dc, vfoScheme: 'ab', vfoReadback: 'absolute' })?.frequencyHz)
+      .toEqual({ state: 'unknown', reason: 'identity-unresolved' });
+    expect(display(ds(true))?.frequencyHz).toEqual({ state: 'stale', value: 14250000 });
+  });
+  it.each([
+    { providerGeneration: undefined }, { providerGeneration: -1 },
+    { stateContractVersion: undefined }, { active: 'SUB' as const },
+  ])('rejects unresolved state identity %#', (overrides) => {
+    expect(display({ ...ds(), ...overrides })?.frequencyHz)
+      .toEqual({ state: 'unknown', reason: 'identity-unresolved' });
+  });
+  it('does not carry a receiver display into a new generation or fabricate a missing value', () => {
+    const first = ds(true);
+    const next = ds(true);
+    next.providerGeneration = 2;
+    next.main.freqHz = 7100000;
+    const nextCaps = { ...dc, providerGeneration: 2 };
+    expect(display(first)?.frequencyHz).toEqual({ state: 'stale', value: 14250000 });
+    expect(display(next, nextCaps)?.frequencyHz).toEqual({ state: 'stale', value: 7100000 });
+    next.fieldStatus = {};
+    expect(display(next, nextCaps)?.frequencyHz).toEqual({ state: 'unknown', reason: 'not-observed' });
+    const missing = ds();
+    missing.main.freqHz = undefined as unknown as number;
+    expect(display(missing)?.frequencyHz).toEqual({ state: 'unknown', reason: 'invalid-value' });
+  });
+  it.each(Object.keys(TOPOLOGY_CAPS))('uses each %s position path and preserves strict baseline', (id) => {
+    const c = { ...TOPOLOGY_CAPS[id], stateContractVersion: 1, providerGeneration: 1 };
+    for (const isStale of [false, true]) {
+      const state = ds(isStale);
+      const view = toRadioViewModel(state, c)!;
+      const strict = view.vfos.map(({ display: _display, ...vfo }) => vfo);
+      const baseline = topologyFixtures[id as keyof typeof topologyFixtures].vfos;
+      // Capture the complete pre-change projection separately from display assertions.
+      expect(strict).toEqual(strictBaselines[`${id}:${isStale}`]);
+      expect(view.vfos).toHaveLength(baseline.length);
+      for (const vfo of view.vfos) {
+        const rx = vfo.receiver === 'MAIN' ? state.main : state.sub;
+        const raw = vfo.slot.kind === 'slotted' ? rx[vfo.slot.id === 'A' ? 'vfoA' : 'vfoB']! : rx;
+        expect(vfo.display?.frequencyHz).toEqual({ state: isStale ? 'stale' : 'current', value: raw.freqHz });
+      }
+    }
+  });
+  it('keeps relative selected/unselected provenance separate from absolute A/B', () => {
+    const state = ds(true);
+    delete state.fieldStatus!['main.activeSlot'];
+    state.main.unselectedVfo = slot(7100000, 'LSB');
+    for (const leaf of ['freqHz', 'mode', 'filterNum']) {
+      state.fieldStatus![`main.unselectedVfo.${leaf}`] = { ...stale, lastObservedMonotonic: 0 };
+    }
+    const c = { ...dc, vfoScheme: 'ab' as const, vfoReadback: 'selected_unselected' as const };
+    const view = toRadioViewModel(state, c)!;
+    expect(view.vfos.map((vfo) => [vfo.slot, vfo.display?.frequencyHz, vfo.isActiveSlot])).toEqual([
+      [{ kind: 'relative', role: 'selected' }, { state: 'stale', value: 14250000 }, true],
+      [{ kind: 'relative', role: 'unselected' }, { state: 'stale', value: 7100000 }, false],
+    ]);
+    state.main.unselectedVfo = undefined;
+    expect(toRadioViewModel(state, c)!.vfos[1].display?.frequencyHz.state).toBe('unknown');
+  });
+});
+
 function model(
   state: ServerState | null, capabilities: Capabilities | null,
   tx?: MetersTxAuthority | null,

--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { fixtureById } from '../../../../../fixtures/catalog';
 /**
  * MOR-1065 — the live adapter behind the semantic VFO / RX-TX surfaces.
  *
@@ -90,6 +91,19 @@ const unobservedState = (): ServerState => ({
 } as ServerState);
 
 describe('qualified VFO display observations', () => {
+  it.each(['topology-2-main-sub', 'topology-1-single', 'topology-2-ab-shared',
+    'tx-phase-rx', 'tx-phase-tx', 'tx-phase-fault'])('keeps %s fixture current with explicit synthetic observation evidence', (id) => {
+    const fixture = fixtureById(id)!;
+    const state = structuredClone(fixture.state()!);
+    const capabilities = fixture.caps()!;
+    for (const vfo of toRadioViewModel(state, capabilities)!.vfos) {
+      expect(vfo.slot.kind).not.toBe('unknown');
+      expect(vfo.frequencyHz).not.toBeNull();
+      expect(vfo.display?.frequencyHz).toEqual({ state: 'current', value: vfo.frequencyHz });
+      expect(vfo.display?.mode).toEqual({ state: 'current', value: vfo.mode });
+      expect(vfo.display?.filter).toEqual({ state: 'current', value: vfo.filter });
+    }
+  });
   const dc = { ...TOPOLOGY_CAPS['1/single'], stateContractVersion: 1, providerGeneration: 1 };
   function ds(isStale = false): ServerState {
     const state = observedState({ stateContractVersion: 1, providerGeneration: 1 });

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -1550,6 +1550,10 @@ export function toRadioViewModel(
         // fabrication MOR-988 §3.2 forbids.
         : [{ slot: { kind: 'unknown' }, base: `${key}.`, filterKey: 'filter', src: rx }];
     return positions.map(({ slot, base, filterKey, src }) => {
+      const displayObservation = <T extends number | string>(leaf: string, value: T | undefined) =>
+        slot.kind === 'unknown' ? { state: 'unknown' as const, reason: 'identity-unresolved' as const }
+          : qualifyDisplayObservation({ state, caps, receiver, path: `${base}${leaf}`, structural: true, value });
+      const filter = src?.[filterKey];
       // MOR-1335 (G4): the per-RECEIVER half of "active", named on its own so a
       // receiver-scoped intent has a slot to address on EVERY receiver — not
       // only on the active one. `activeSlot` is already the gated read above,
@@ -1565,6 +1569,12 @@ export function toRadioViewModel(
             ? (slot.role === 'selected' ? 'Selected VFO' : 'Unselected VFO')
             : receiver,
         ...readings(state, base, filterKey, src),
+        display: {
+          frequencyHz: displayObservation('freqHz', typeof src?.freqHz === 'number' ? src.freqHz : undefined),
+          mode: displayObservation('mode', typeof src?.mode === 'string' ? src.mode : undefined),
+          filter: displayObservation(filterKey,
+            typeof filter === 'number' && Number.isFinite(filter) ? `FIL${filter}` : undefined),
+        },
         // Unchanged in meaning, restated on the new fact: the radio-wide active
         // VFO IS the active receiver's active slot.
         isActive: activeReceiver.status === 'known' && activeReceiver.receiver === receiver

--- a/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
+++ b/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
@@ -14,7 +14,10 @@
      * +15.7 MHz — a TX-out-of-band hazard). `freq` must never be sourced
      * from `pendingDisplayHz` — that is precisely the bug.
      */
-    freq: number;
+    freq: number | null;
+    displayHz?: number | null;
+    disabled?: boolean;
+    contextKey?: string;
     compact?: boolean;
     active?: boolean;
     receiver?: 'main' | 'sub';
@@ -61,6 +64,9 @@
 
   let {
     freq,
+    displayHz,
+    disabled = false,
+    contextKey,
     compact = false,
     active = true,
     receiver = 'main',
@@ -88,14 +94,23 @@
 
   let selectedDigitIndex = $state<number | null>(null);
   let hoveredDigitIndex = $state<number | null>(null);
+  let inert = $derived(disabled || freq === null || !Number.isFinite(freq));
+  $effect(() => {
+    void inert;
+    void contextKey;
+    void receiver;
+    selectedDigitIndex = null;
+    hoveredDigitIndex = null;
+  });
 
   let pending = $derived(pendingDisplayHz !== null);
-  // RENDER off the pending target when present — `freq` (confirmed) stays
-  // untouched by this and is read ONLY inside the gesture handlers below.
-  let allDigits = $derived(splitFrequencyToDigits(pendingDisplayHz ?? freq));
+  // Pending and historical readouts never replace the strict arithmetic input.
+  let shownFrequency = $derived(pendingDisplayHz ?? (displayHz === undefined ? freq : displayHz));
+  let allDigits = $derived(shownFrequency === null ? [] : splitFrequencyToDigits(shownFrequency));
   let groups = $derived(groupDigitsForDisplay(allDigits));
 
   function handleWheel(digit: DigitInfo, event: WheelEvent) {
+    if (inert || freq === null) return;
     // MOR-1639: scrolling over a VFO readout is ordinary page navigation
     // until the operator deliberately picks THIS digit. Do not consume an
     // unarmed event: that both preserves page scrolling and guarantees no
@@ -110,11 +125,13 @@
   }
 
   function handleDigitClick(digit: DigitInfo, event: MouseEvent) {
+    if (inert) return;
     event.stopPropagation();
     selectedDigitIndex = digit.digitIndex;
   }
 
   function handleKeyDown(event: KeyboardEvent) {
+    if (inert || freq === null) return;
     if (selectedDigitIndex === null) return;
     const digit = allDigits.find(d => d.digitIndex === selectedDigitIndex);
     if (!digit) return;
@@ -130,6 +147,7 @@
   }
 
   function handleDigitEnter(digit: DigitInfo) {
+    if (inert) return;
     hoveredDigitIndex = digit.digitIndex;
   }
 
@@ -154,9 +172,13 @@
   data-vfo-freq={vfoFreqHook ? '' : undefined}
   data-vfo-active={vfoFreqHook ? active : undefined}
   aria-describedby={pending && pendingAnnouncement ? pendingId : undefined}
+  aria-disabled={inert}
   style={Object.entries(cssVars).map(([k, v]) => `${k}:${v}`).join(';')}
-  tabindex="0" role="group" aria-label="Frequency display" onkeydown={handleKeyDown}
+  tabindex={inert ? -1 : 0} role="group" aria-label="Frequency display" onkeydown={handleKeyDown}
 >
+  {#if shownFrequency === null}
+    <span>—</span>
+  {:else}
   {#each groups.mhz as digit}
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -198,6 +220,7 @@
       onmouseleave={handleDigitLeave}
     >{digit.char}</span>
   {/each}
+  {/if}
   {#if pending && pendingAnnouncement}
     <span id={pendingId} class="sr-only">{pendingAnnouncement}</span>
   {/if}
@@ -243,6 +266,8 @@
   .digit:hover {
     color: var(--freq-hover-color, var(--v2-text-white, #ffffff));
   }
+
+  .freq[aria-disabled='true'] .digit { cursor: default; }
 
   .digit.hovered::after {
     content: '';

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -515,7 +515,7 @@
       >
         <span class="vfo-role">{roleLabel(vfo)}</span>
         <span
-          class="vfo-freq"
+          class="vfo-freq" class:display-unknown={displayHz === null && pendingHz === null}
           {...(appearance === 'semantic' ? freq?.attributes ?? {} : {})}
           data-vfo-freq
           data-freq-tunable={!readoutDisabled(vfo)}
@@ -892,7 +892,12 @@
     display: grid; grid-template-columns: 1fr auto; gap: 6px;
     padding: 0; border: 0; background: transparent;
   }
-  .receiver-instrument .vfo-role { font-size: 12px; letter-spacing: .1em; }
+  /* Share the role cell and its following gap; auto placement would add a row. */
+  .receiver-instrument .vfo-stale-cue {
+    grid-column: 1; grid-row: 1; justify-self: end; align-self: start;
+    transform: translateX(100%); line-height: 1; letter-spacing: normal;
+  }
+  .receiver-instrument .vfo-role { grid-column: 1; grid-row: 1; font-size: 12px; letter-spacing: .1em; }
   .receiver-instrument .vfo-mode { font-size: 12px; grid-column: 1; }
   .receiver-instrument .vfo-freq {
     grid-column: 1 / -1; grid-row: 3; white-space: nowrap;
@@ -904,6 +909,10 @@
   .receiver-instrument :where(.vfo-freq) { font-weight: 700; }
   .receiver-instrument .vfo-freq :global(.freq) {
     font-size: inherit; line-height: inherit; font-weight: inherit; font-family: inherit;
+  }
+  /* A retained null primitive keeps the established instrument placeholder paint. */
+  .receiver-instrument .vfo-freq.display-unknown :global(.freq) {
+    font: inherit; letter-spacing: inherit; color: inherit; text-shadow: inherit;
   }
   .receiver-instrument .is-active .vfo-freq {
     color: var(--v2-vfo-main-freq-active, #7cfce5);

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -42,7 +42,7 @@
   import VfoIndicatorRow from './VfoIndicatorRow.svelte';
   import { splitFrequencyToDigits, groupDigitsForDisplay } from '../primitives/frequency/frequency-tuning';
   import { renderSlot } from './design-language-renderers';
-  import type { BooleanFact, RadioViewModel, VfoViewModel } from './radio-view-model';
+  import type { BooleanFact, DisplayObservation, RadioViewModel, VfoViewModel } from './radio-view-model';
 
   interface Props {
     viewModel: RadioViewModel;
@@ -318,69 +318,26 @@
    * out-of-the-box tile text on the live bench.
    */
   function frequencyDisplay(vfo: VfoViewModel): ReturnType<typeof renderSlot> {
-    return renderSlot('frequencyDisplay', { frequencyHz: vfo.frequencyHz });
+    return renderSlot('frequencyDisplay', { frequencyHz: displayValue(vfo.display?.frequencyHz, vfo.frequencyHz) });
   }
 
-  /**
-   * MOR-1322 (S3b) — per-digit tuning parity with the legacy VfoHeader, under
-   * the owner's option (b): tuning OPTS OUT of the design language. The
-   * MOR-1275 `frequencyDisplay` renderer stays display-only — it is never asked
-   * to produce interactive markup — and the digit control self-renders.
-   *
-   * COMPOSITION RULE: one readout slot (`.vfo-freq`), two MUTUALLY EXCLUSIVE
-   * fillings, and BOTH now opt out of the language's text (MOR-1482 extends
-   * the same option-(b) precedent from the tunable branch to this one).
-   * Tunable → the self-rendered digit control; not tunable → `formatFrequency`,
-   * unconditionally, language active or not. Never both: two elements painting
-   * the same frequency is a double readout, and the operator must see exactly
-   * one number per VFO. Because both fillings read the SAME single fact
-   * (`vfo.frequencyHz`), they cannot show conflicting values by construction —
-   * that is the property the tests pin, in both language states.
-   *
-   * The language keeps its claim on the REGION either way: `freq.attributes`
-   * are spread onto the slot in both branches, so a language's tokens/hooks
-   * still decorate the frequency area. What opts out is the rendering of the
-   * VALUE — including, as of MOR-1482, the value's TEXT — which is exactly
-   * what "the renderer stays display-only" means, taken one step further.
-   *
-   * Two-level gating (MOR-977), and the split matters — it is what makes the
-   * guard REACHABLE and therefore independently testable:
-   *   STRUCTURAL (`hasTunableFrequency`) — no observed frequency, no tune
-   *     intent wired, or the tile is NOT ITS RECEIVER'S ACTIVE SLOT: there is
-   *     nothing this tile can tune, so no control mounts and the slot shows the
-   *     plain readout. ABSENT.
-   *
-   *     The active-slot term is load-bearing and was a real bug without it
-   *     (MOR-1322 verification B1). The tune intent is RECEIVER-scoped —
-   *     `set_freq {receiver}` writes that receiver's *active* VFO — so a
-   *     control on a tile that is not that receiver's active slot would take
-   *     its step from VFO B's digits and move VFO A: the operator scrolls one
-   *     VFO and watches a different one move.
-   *
-   *     MOR-1335 (G4) qualifies the term PER RECEIVER. B1 first spelled it
-   *     `isActive`, which is globally unique, so on `2/main_sub` (IC-7610) only
-   *     one tile on the WHOLE radio was tunable and the SUB receiver lost the
-   *     per-digit tuning the legacy `VfoPanel` had. That legacy shape is the
-   *     specification: ONE widget per RECEIVER, over that receiver's current
-   *     frequency. `isActiveSlot` is exactly that correspondence, and it does
-   *     not widen the hazard — the hazard is INTRA-receiver (which VFO of this
-   *     receiver `set_freq` lands on), and the intent carries `vfo.receiver`,
-   *     so a SUB tile can only ever address SUB. Unobserved active-slot
-   *     readings are `false` on both of that receiver's slots (the contract's
-   *     fail-closed rule), so an unknown never becomes a tunable guess.
-   *   OPERATIONAL (`disabled`, a MOR-1256 strip whose receiver is present but
-   *     unavailable) — the control DOES mount, marked `aria-disabled`, and
-   *     `tuneFrequency` refuses the dispatch. PRESENT BUT INERT, exactly as the
-   *     select controls in this same surface behave.
-   *
-   * Folding `disabled` into the structural gate instead would make the guard
-   * unreachable from the DOM — a mutant deleting it would survive, which is
-   * precisely the MOR-1321 B2 finding. Here the markup gate and the handler
-   * guard are two mechanisms on two different conditions, and each is pinned
-   * on its own by bypassing the other.
-   */
+  function displayValue<T>(display: DisplayObservation<T> | undefined, strict: T | null): T | null {
+    if (display === undefined) return strict;
+    return display.state === 'current' || display.state === 'stale' ? display.value : null;
+  }
+
+  function hasDigitReadout(vfo: VfoViewModel): boolean {
+    return vfo.isActiveSlot && onTuneFrequency !== undefined
+      && (vfo.frequencyHz !== null || vfo.display !== undefined);
+  }
+
   function hasTunableFrequency(vfo: VfoViewModel): boolean {
     return vfo.isActiveSlot && vfo.frequencyHz !== null && onTuneFrequency !== undefined;
+  }
+
+  function readoutDisabled(vfo: VfoViewModel): boolean {
+    return disabled || !hasTunableFrequency(vfo)
+      || (vfo.display !== undefined && vfo.display.frequencyHz.state !== 'current');
   }
 
   function tuneFrequency(vfo: VfoViewModel, frequencyHz: number): void {
@@ -539,6 +496,11 @@
       {@const selectDisabled = selectable && (vfo.slot.kind === 'unknown' || disabled)}
       {@const freq = frequencyDisplay(vfo)}
       {@const pendingHz = pendingFrequencyHz?.[vfo.receiver] ?? null}
+      {@const displayHz = displayValue(vfo.display?.frequencyHz, vfo.frequencyHz)}
+      {@const displayMode = displayValue(vfo.display?.mode, vfo.mode)}
+      {@const displayFilter = displayValue(vfo.display?.filter, vfo.filter)}
+      {@const staleDisplay = Object.values(vfo.display ?? {}).some((field) => field.state === 'stale')}
+      {@const staleId = `${reasonIdPrefix}-display-${i}`}
       <div
         class="vfo-tile"
         class:is-active={vfo.isActive}
@@ -552,19 +514,16 @@
         data-vfo-tx-target={vfo.isTxTarget}
       >
         <span class="vfo-role">{roleLabel(vfo)}</span>
-        <!--
-          MOR-1322 — ONE readout slot, two mutually exclusive fillings. See the
-          `tuneFrequency` comment for the composition rule and why "alongside"
-          cannot mean two visible numbers.
-        -->
         <span
           class="vfo-freq"
           {...(appearance === 'semantic' ? freq?.attributes ?? {} : {})}
           data-vfo-freq
-          data-freq-tunable={hasTunableFrequency(vfo) && !disabled}
-          aria-disabled={hasTunableFrequency(vfo) && disabled ? 'true' : undefined}
+          data-freq-tunable={!readoutDisabled(vfo)}
+          data-display-state={vfo.display?.frequencyHz.state}
+          aria-disabled={hasDigitReadout(vfo) && readoutDisabled(vfo) ? 'true' : undefined}
+          aria-describedby={staleDisplay ? staleId : undefined}
         >
-          {#if hasTunableFrequency(vfo)}
+          {#if hasDigitReadout(vfo)}
             <!--
               MOR-1441 REVIEW FIX (severe): `freq` is ALWAYS confirmed radio
               truth (`vfo.frequencyHz`), never `pendingHz` — the pending
@@ -584,7 +543,10 @@
               redundant `[data-vfo-freq]` inside it.
             -->
             <FrequencyDisplayInteractive
-              freq={vfo.frequencyHz ?? 0}
+              freq={vfo.frequencyHz}
+              {displayHz}
+              disabled={readoutDisabled(vfo)}
+              contextKey={`${viewModel.topologyId}:${vfo.receiver}:${slotKey(vfo.slot)}`}
               pendingDisplayHz={pendingHz}
               pendingAnnouncement={pendingHz !== null ? t('core.vfo.freq.pendingAnnouncement') : undefined}
               compact={appearance === 'semantic'}
@@ -613,10 +575,15 @@
               a future hero-scale mount (not this tile) is the intended
               consumer.
             -->
-            {formatFrequency(vfo.frequencyHz)}
+            {formatFrequency(displayHz)}
           {/if}
         </span>
-        <span class="vfo-mode">{vfo.mode ?? '—'}{vfo.filter ? ` / ${vfo.filter}` : ''}</span>
+        <span class="vfo-mode">{displayMode ?? '—'}{displayFilter ? ` / ${displayFilter}` : ''}</span>
+        <span id={staleId} class="vfo-stale-cue" class:stale={staleDisplay}
+          data-vfo-stale-cue aria-hidden={!staleDisplay}
+          title={staleDisplay ? t('core.rxTx.target.reason.stale') : undefined}>
+          <span aria-hidden="true">†</span><span class="sr-only">{t('core.rxTx.target.reason.stale')}</span>
+        </span>
         {#if vfo.isTxTarget}
           <span class="vfo-badge" data-vfo-tx-badge>{t('core.vfo.txTarget.label')}</span>
         {/if}
@@ -887,6 +854,8 @@
   .vfo-tile { display: flex; align-items: center; gap: 6px; padding: 4px 8px; border: 1px solid var(--v2-border-panel, rgba(255, 255, 255, 0.12)); border-radius: 4px; background: var(--v2-bg-panel, rgba(255, 255, 255, 0.03)); }
   .vfo-tile.is-active { border-color: var(--v2-accent-cyan, #00d4ff); }
   .vfo-role { font-weight: 700; color: var(--v2-text-secondary, rgba(255, 255, 255, 0.8)); }
+  .vfo-stale-cue { visibility: hidden; font-size: 10px; inline-size: 1ch; flex: 0 0 1ch; }
+  .vfo-stale-cue.stale { visibility: visible; }
   .vfo-badge { padding: 1px 4px; border-radius: 3px; font-size: 10px; color: var(--v2-accent-red, #ff2020); border: 1px solid var(--v2-accent-red, #ff2020); }
   .vfo-select, .fact-toggle, .vfo-op { border: 1px solid var(--v2-border-panel, rgba(255, 255, 255, 0.12)); border-radius: 4px; background: transparent; color: inherit; cursor: pointer; padding: 3px 6px; }
   .vfo-select:disabled, .fact-toggle:disabled, .vfo-op:disabled { color: var(--v2-text-disabled, rgba(255, 255, 255, 0.3)); cursor: not-allowed; }

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -856,6 +856,13 @@
   .vfo-role { font-weight: 700; color: var(--v2-text-secondary, rgba(255, 255, 255, 0.8)); }
   .vfo-stale-cue { visibility: hidden; font-size: 10px; inline-size: 1ch; flex: 0 0 1ch; }
   .vfo-stale-cue.stale { visibility: visible; }
+  /* Reserve the semantic tile's upper trailing corner, not another flex gap.
+     A flow slot can wrap a 375px phone row even while its cue is hidden. */
+  [data-vfo-appearance='semantic'] .vfo-tile { position: relative; }
+  [data-vfo-appearance='semantic'] .vfo-stale-cue {
+    position: absolute; inset-inline-end: 1px; inset-block-start: 1px;
+    line-height: 1; letter-spacing: normal;
+  }
   .vfo-badge { padding: 1px 4px; border-radius: 3px; font-size: 10px; color: var(--v2-accent-red, #ff2020); border: 1px solid var(--v2-accent-red, #ff2020); }
   .vfo-select, .fact-toggle, .vfo-op { border: 1px solid var(--v2-border-panel, rgba(255, 255, 255, 0.12)); border-radius: 4px; background: transparent; color: inherit; cursor: pointer; padding: 3px 6px; }
   .vfo-select:disabled, .fact-toggle:disabled, .vfo-op:disabled { color: var(--v2-text-disabled, rgba(255, 255, 255, 0.3)); cursor: not-allowed; }

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -19,6 +19,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { mount, unmount, flushSync } from 'svelte';
+import { writable, fromStore } from 'svelte/store';
 import type { ComponentProps } from 'svelte';
 import VfoSurface from '../VfoSurface.svelte';
 import {
@@ -27,6 +28,9 @@ import {
 } from '../radio-view-model';
 import { topologyFixtures, withAudioOnlyScope, type TopologyFixtureId } from '../fixtures/topologies';
 import { createTuningAccumulator } from '$lib/runtime/commands/tuning-accumulator';
+import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
 import { setLocale, _resetLocale } from '$lib/i18n/store.svelte';
 import { splitFrequencyToDigits, groupDigitsForDisplay } from '../../primitives/frequency/frequency-tuning';
 
@@ -42,6 +46,135 @@ function mountSurface(props: ComponentProps<typeof VfoSurface>): HTMLElement {
   components.push(component);
   return target;
 }
+
+describe('VFO qualified display continuity', () => {
+  function view(state: 'current' | 'stale' | 'unknown'): RadioViewModel {
+    const base = topologyFixtures['1/single'];
+    const display = {
+      frequencyHz: state === 'unknown' ? { state, reason: 'not-observed' as const } : { state, value: 14250000 },
+      mode: state === 'unknown' ? { state, reason: 'not-observed' as const } : { state, value: 'USB' },
+      filter: state === 'unknown' ? { state, reason: 'not-observed' as const } : { state, value: 'FIL1' },
+    };
+    return { ...base, vfos: base.vfos.map((vfo) => ({ ...vfo, display,
+      frequencyHz: state === 'current' ? 14250000 : null,
+      mode: state === 'current' ? 'USB' : null, filter: state === 'current' ? 'FIL1' : null,
+    })) };
+  }
+  it.each(['semantic', 'sdr', 'standard'] as const)('%s retains primitive/digits/cue through freshness-only transitions', (appearance) => {
+    const model = writable(view('current'));
+    const live = fromStore(model);
+    const onTuneFrequency = vi.fn();
+    const root = mountSurface({ get viewModel() { return live.current; }, appearance, onTuneFrequency });
+    const primitive = root.querySelector('.freq')!;
+    const digits = [...primitive.querySelectorAll('.digit')];
+    const cue = root.querySelector('[data-vfo-stale-cue]')!;
+    expect(cue).not.toBeNull();
+    digits.at(-1)!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    flushSync();
+    for (const state of ['stale', 'current'] as const) {
+      model.set(view(state)); flushSync();
+      expect(root.querySelector('.freq')).toBe(primitive);
+      expect(primitive.querySelectorAll('.digit')).toHaveLength(digits.length);
+      digits.forEach((digit, index) => expect(primitive.querySelectorAll('.digit')[index]).toBe(digit));
+      expect(root.querySelector('[data-vfo-stale-cue]')).toBe(cue);
+      expect(primitive.textContent?.replace(/\s/g, '')).toBe('14.250.000');
+      expect(root.querySelector('.vfo-mode')!.textContent).toBe('USB / FIL1');
+      expect(primitive.getAttribute('aria-disabled')).toBe(String(state === 'stale'));
+      expect(cue.getAttribute('aria-hidden')).toBe(String(state !== 'stale'));
+      expect(cue.textContent).not.toBe('');
+      const wheel = new WheelEvent('wheel', { deltaY: -1, cancelable: true, bubbles: true });
+      digits.at(-1)!.dispatchEvent(wheel);
+      primitive.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      flushSync();
+      expect(wheel.defaultPrevented).toBe(false);
+      expect(onTuneFrequency).not.toHaveBeenCalled();
+    }
+    digits.at(-1)!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    digits.at(-1)!.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true }));
+    expect(onTuneFrequency).toHaveBeenCalledExactlyOnceWith('MAIN', 14250001);
+  });
+  it('renders first stale, unknown, unsupported and readonly slots without fabricating frequency', () => {
+    const root = mountSurface({ viewModel: view('stale') });
+    expect(root.querySelector('.vfo-freq')!.textContent?.trim()).toBe('14.250.000');
+    expect(root.querySelector('.digit')).toBeNull();
+    const unknown = mountSurface({ viewModel: view('unknown'), onTuneFrequency: vi.fn() });
+    expect(unknown.querySelector('.freq')!.textContent?.trim()).toBe('—');
+    expect(unknown.querySelector('.digit')).toBeNull();
+    const unsupported = view('current');
+    unsupported.vfos = unsupported.vfos.map((vfo) => ({ ...vfo, display: { frequencyHz: { state: 'unsupported' }, mode: { state: 'unsupported' }, filter: { state: 'unsupported' } } }));
+    expect(mountSurface({ viewModel: unsupported }).querySelector('.vfo-freq')!.textContent?.trim()).toBe('—');
+  });
+  it.each(['en-US', 'ru-RU'] as const)('exposes the localized stale reason with a reserved non-color marker in %s', (locale) => {
+    setLocale(locale);
+    try {
+      const root = mountSurface({ viewModel: view('stale'), onTuneFrequency: vi.fn() });
+      const cue = root.querySelector<HTMLElement>('[data-vfo-stale-cue]')!;
+      expect(cue.querySelector('[aria-hidden="true"]')!.textContent).toBe('†');
+      expect(cue.querySelector('.sr-only')!.textContent).toBe(cue.title);
+      expect(cue.title).toBe(locale === 'en-US' ? 'the last reading is too old to trust'
+        : 'последние данные устарели и не заслуживают доверия');
+      expect(root.querySelector('[data-vfo-freq]')!.getAttribute('aria-describedby')).toBe(cue.id);
+    } finally { _resetLocale(); }
+  });
+  it('keeps pending feedback separate and computes renewed gestures from strict frequency', () => {
+    const onTuneFrequency = vi.fn();
+    const root = mountSurface({ viewModel: view('current'), onTuneFrequency, pendingFrequencyHz: { MAIN: 14300000 } });
+    const primitive = root.querySelector('.freq')!;
+    expect(primitive.getAttribute('data-freq-status')).toBe('pending');
+    expect(primitive.textContent?.replace(/\s/g, '')).toContain('14.300.000');
+    const digit = primitive.querySelectorAll('.digit').item(7);
+    digit.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    primitive.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    expect(onTuneFrequency).toHaveBeenCalledExactlyOnceWith('MAIN', 14250001);
+  });
+  it('the parent callback independently rejects a stale/null strict frequency', () => {
+    const source = readFileSync('src/semantic/VfoSurface.svelte', 'utf8');
+    const body = source.match(/function tuneFrequency\(vfo: VfoViewModel, frequencyHz: number\): void \{([\s\S]*?)\n  \}/)![1];
+    const invoke = new Function('disabled', 'vfo', 'frequencyHz', 'onTuneFrequency', body);
+    const tune = vi.fn();
+    invoke(false, view('stale').vfos[0], 15000000, tune);
+    invoke(true, view('current').vfos[0], 15000000, tune);
+    invoke(false, { ...view('current').vfos[0], isActiveSlot: false }, 15000000, tune);
+    expect(tune).not.toHaveBeenCalled();
+    invoke(false, view('current').vfos[0], 14250001, tune);
+    expect(tune).toHaveBeenCalledExactlyOnceWith('MAIN', 14250001);
+  });
+  it('a stale ancestor disables the local readout while a fresh leaf keeps its strict frequency', () => {
+    const caps = { receivers: 1, vfoScheme: 'single', capabilities: [],
+      stateContractVersion: 1, providerGeneration: 1 } as unknown as Capabilities;
+    const state = { stateContractVersion: 1, providerGeneration: 1, active: 'MAIN',
+      main: { freqHz: 14250000, mode: 'USB', filter: 1 },
+      fieldStatus: Object.fromEntries(['main', 'main.freqHz', 'main.mode', 'main.filter'].map((path) => [path, {
+        observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 0,
+      }])),
+    } as unknown as ServerState;
+    const model = writable(toRadioViewModel(state, caps)!);
+    const live = fromStore(model);
+    const onTuneFrequency = vi.fn();
+    const root = mountSurface({ get viewModel() { return live.current; }, onTuneFrequency });
+    const primitive = root.querySelector('.freq')!;
+    const digit = primitive.querySelectorAll('.digit').item(7);
+    digit.dispatchEvent(new MouseEvent('click', { bubbles: true })); flushSync();
+    state.fieldStatus!.main.freshness = 'stale';
+    const staleView = toRadioViewModel(state, caps)!;
+    expect(staleView.vfos[0].frequencyHz).toBe(14250000);
+    expect(staleView.vfos[0].display?.frequencyHz.state).toBe('stale');
+    model.set(staleView); flushSync();
+    expect(root.querySelector('.freq')).toBe(primitive);
+    digit.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    digit.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true }));
+    primitive.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    expect(onTuneFrequency).not.toHaveBeenCalled();
+    expect(primitive.getAttribute('aria-disabled')).toBe('true');
+    state.fieldStatus!.main.freshness = 'fresh';
+    model.set(toRadioViewModel(state, caps)!); flushSync();
+    digit.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true }));
+    expect(onTuneFrequency).not.toHaveBeenCalled();
+    digit.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    digit.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true }));
+    expect(onTuneFrequency).toHaveBeenCalledExactlyOnceWith('MAIN', 14250001);
+  });
+});
 
 beforeEach(() => {
   components = [];

--- a/frontend/src/semantic/__tests__/radio-view-model.test.ts
+++ b/frontend/src/semantic/__tests__/radio-view-model.test.ts
@@ -22,6 +22,37 @@ function valid(): RadioViewModel {
   };
 }
 
+describe('VFO display facet', () => {
+  const display = {
+    frequencyHz: { state: 'stale', value: 0 },
+    mode: { state: 'current', value: 'USB' },
+    filter: { state: 'unsupported' },
+  };
+  const withDisplay = (facet: unknown) => {
+    const base = valid();
+    return { ...base, vfos: [{ ...base.vfos[0], display: facet }] };
+  };
+  it('round-trips the opt-in facet and preserves the legacy shape', () => {
+    expect(validateRadioViewModel(valid())).toEqual(valid());
+    expect(validateRadioViewModel(withDisplay(display))).toEqual(withDisplay(display));
+    expect(validateRadioViewModel(withDisplay({ ...display,
+      frequencyHz: { state: 'unknown', reason: 'identity-unresolved' },
+    })).vfos[0].frequencyHz).toBe(14195000);
+  });
+  it.each([
+    null, {}, { ...display, rawState: {} }, { ...display, mode: undefined },
+    { ...display, frequencyHz: { state: 'stale', value: null } },
+    { ...display, frequencyHz: { state: 'current', value: NaN } },
+    { ...display, frequencyHz: { state: 'current', value: false } },
+    { ...display, mode: { state: 'current', value: 1 } },
+    { ...display, filter: { state: 'stale', value: 1 } },
+    { ...display, mode: { state: 'unknown', reason: 'guessed' } },
+    { ...display, filter: { state: 'unsupported', value: 'FIL1' } },
+  ])('rejects malformed facet %#', (facet) => {
+    expect(() => validateRadioViewModel(withDisplay(facet))).toThrow(TypeError);
+  });
+});
+
 describe('validateRadioViewModel', () => {
   it('accepts a well-formed view model and round-trips it unchanged', () => {
     const model = valid();

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -67,6 +67,11 @@ export interface VfoViewModel {
   frequencyHz: number | null;
   mode: string | null;
   filter: string | null;
+  readonly display?: {
+    readonly frequencyHz: DisplayObservation<number>;
+    readonly mode: DisplayObservation<string>;
+    readonly filter: DisplayObservation<string>;
+  };
   /** The ACTIVE RECEIVER's active VFO — globally unique across the radio. */
   isActive: boolean;
   /**
@@ -1280,7 +1285,7 @@ function validateVfo(value: unknown, path: string): VfoViewModel {
   const v = record(value, path);
   exactKeys(
     v,
-    ['receiver', 'slot', 'label', 'frequencyHz', 'mode', 'filter', 'isActive', 'isActiveSlot', 'isTxTarget'],
+    ['receiver', 'slot', 'label', 'frequencyHz', 'mode', 'filter', 'isActive', 'isActiveSlot', 'isTxTarget', 'display'],
     path,
   );
   return {
@@ -1293,6 +1298,17 @@ function validateVfo(value: unknown, path: string): VfoViewModel {
     isActive: bool(v.isActive, `${path}.isActive`),
     isActiveSlot: bool(v.isActiveSlot, `${path}.isActiveSlot`),
     isTxTarget: bool(v.isTxTarget, `${path}.isTxTarget`),
+    ...(v.display !== undefined ? { display: validateVfoDisplay(v.display, `${path}.display`) } : {}),
+  };
+}
+
+function validateVfoDisplay(value: unknown, path: string): NonNullable<VfoViewModel['display']> {
+  const v = record(value, path);
+  exactKeys(v, ['frequencyHz', 'mode', 'filter'], path);
+  return {
+    frequencyHz: validateDisplayObservation(v.frequencyHz, `${path}.frequencyHz`, num),
+    mode: validateDisplayObservation(v.mode, `${path}.mode`, str),
+    filter: validateDisplayObservation(v.filter, `${path}.filter`, str),
   };
 }
 

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -881,6 +881,7 @@ describe('operational audio-scope availability (scope=false + audioFft=true)', (
    * within itself, so the second mount's id is never the first's.
    */
   const markup = (): string => target.innerHTML
+    .replace(/vfo-reason-\d+-/g, 'vfo-reason-N-')
     .replace(/rx-tx-\d+/g, 'rx-tx-N')
     .replace(/tx-aux-blocked-\d+/g, 'tx-aux-blocked-N')
     // MOR-1481 rework (R2): every per-field reason id (`tx-aux-reason-N-atu`,

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -23,7 +23,8 @@ function fixture(known: boolean) {
   function observe(obj: object, prefix = '') {
     for (const [key, value] of Object.entries(obj)) {
       const path = prefix ? `${prefix}.${key}` : key;
-      fields[path] = { observed: true, freshness: 'fresh', availability: 'available', storePath: path };
+      // Synthetic observation provenance for this fixture, not a radio measurement.
+      fields[path] = { observed: true, freshness: 'fresh', availability: 'available', storePath: path, lastObservedMonotonic: 0 };
       if (value && typeof value === 'object') observe(value, path);
     }
   }
@@ -48,12 +49,13 @@ function fixture(known: boolean) {
   return { state, caps };
 }
 
-async function boot(page: Page, layout: string, width: number, known: boolean) {
-  const { state, caps } = fixture(known);
+async function boot(page: Page, layout: string, width: number, known: boolean, language = 'studioline', productionUnknown = false) {
+  const { state, caps } = productionUnknown
+    ? { state: structuredClone(mockState), caps: structuredClone(mockCapabilities) } : fixture(known);
   await page.setViewportSize({ width, height: width === 900 ? 900 : 1000 });
-  await page.addInitScript(({ state, layout, width }) => {
+  await page.addInitScript(({ state, layout, width, language }) => {
     localStorage.setItem('rigplane:workspace', JSON.stringify({ version: 1, layout,
-      designLanguage: 'studioline', theme: width === 900 ? 'github-light' : 'nord' }));
+      designLanguage: language, theme: width === 900 ? 'github-light' : 'nord' }));
     localStorage.setItem('rigplane.i18n.locale', width === 900 ? 'ru-RU' : 'en-US');
     const commands: unknown[] = [];
     Object.assign(window, { geometryCommands: commands });
@@ -70,12 +72,16 @@ async function boot(page: Page, layout: string, width: number, known: boolean) {
           this.readyState = 1;
           const open = new Event('open'); this.dispatchEvent(open); this.onopen?.(open);
           if (new URL(url, location.href).pathname === '/api/v1/ws') {
-            const e = new MessageEvent('message', { data: JSON.stringify({ type: 'state_update',
-              data: { type: 'full', data: state, revision: state.revision,
-                stateRevision: state.stateRevision, freshnessRevision: state.freshnessRevision,
-                observationSeq: state.observationSeq, stateContractVersion: state.stateContractVersion,
-                providerGeneration: state.providerGeneration } }) });
-            this.dispatchEvent(e); this.onmessage?.(e);
+            const emit = (next: typeof state) => {
+              const e = new MessageEvent('message', { data: JSON.stringify({ type: 'state_update',
+                data: { type: 'full', data: next, revision: next.revision,
+                  stateRevision: next.stateRevision, freshnessRevision: next.freshnessRevision,
+                  observationSeq: next.observationSeq, stateContractVersion: next.stateContractVersion,
+                  providerGeneration: next.providerGeneration } }) });
+              this.dispatchEvent(e); this.onmessage?.(e);
+            };
+            emit(state);
+            window.addEventListener('geometry-state', e => emit((e as CustomEvent<typeof state>).detail));
           }
         });
       }
@@ -83,7 +89,7 @@ async function boot(page: Page, layout: string, width: number, known: boolean) {
       close() { this.readyState = 3; const e = new Event('close'); this.dispatchEvent(e); this.onclose?.(e); }
     }
     Object.assign(window, { WebSocket: Socket });
-  }, { state, layout, width });
+  }, { state, layout, width, language });
   await page.route('**/api/**', route => {
     const name = new URL(route.request().url()).pathname.split('/').pop();
     const body = name === 'state' ? state : name === 'capabilities' ? caps : name === 'info' ? mockInfo
@@ -170,4 +176,70 @@ for (const layout of ['standard', 'sdr-test', 'lcd-scope', 'lcd-cockpit']) {
       await info.attach('geometry', { path: screenshot, contentType: 'image/png' });
     });
   }
+}
+
+// The cue must share existing instrument space, including while it is hidden.
+for (const layout of ['standard', 'sdr-test']) for (const language of ['studioline', 'fieldline']) {
+  test(`${layout} ${language} instrument cue adds no tracks through recovery`, async ({ page }, info) => {
+    await boot(page, layout, 1440, false, language, true);
+    // SDR opts out of the selected design language; assert the actual production state.
+    if (layout === 'standard') await expect(page.locator('html')).toHaveAttribute('data-design-language', language);
+    else expect(await page.locator('html').getAttribute('data-design-language')).toBeNull();
+    await expect(page.locator('[data-vfo-appearance]').first()).toHaveAttribute('data-vfo-appearance', layout === 'standard' ? 'standard' : 'sdr');
+    const frequency = page.locator('.receiver-instrument [data-vfo-freq]').first();
+    await expect(frequency).toHaveText('—');
+    const paint = await frequency.evaluate(e => {
+      const read = (e: Element) => { const s = getComputedStyle(e); return [s.fontFamily, s.fontSize, s.fontWeight, s.lineHeight, s.color, s.textShadow, s.letterSpacing]; };
+      return { outer: read(e), inner: read(e.querySelector('.freq')!) };
+    });
+    expect(paint.inner).toEqual(paint.outer);
+    const measure = () => page.locator('.receiver-instrument').evaluateAll(instruments => {
+      const rect = (e: Element) => e.getBoundingClientRect().toJSON();
+      return instruments.map(instrument => {
+        const cues = [...instrument.querySelectorAll<HTMLElement>('[data-vfo-stale-cue]')];
+        const geometry = () => [...instrument.querySelectorAll('.vfo-tile,.vfo-role,.vfo-freq,.vfo-mode,.vfo-select')].map(rect);
+        const present = geometry();
+        cues.forEach(cue => { cue.style.display = 'none'; }); const absent = geometry();
+        cues.forEach(cue => { cue.style.display = ''; });
+        return { present, absent };
+      });
+    });
+    const unknown = await measure(); unknown.forEach(box => expect(box.present).toEqual(box.absent));
+    await info.attach('unknown-bounds', { body: JSON.stringify(unknown), contentType: 'application/json' });
+    // The shared production unknown fixture remains evidence-free; recovery uses the IC fixture.
+    await boot(page, layout, 1440, false, language);
+    let current: Awaited<ReturnType<typeof measure>> | undefined;
+    for (const [index, stateName] of ['current', 'stale', 'current'].entries()) {
+      const state = fixture(true).state;
+      Object.assign(state, { revision: index + 2, stateRevision: index + 2,
+        freshnessRevision: index + 2, observationSeq: index + 2 });
+      if (stateName === 'stale') for (const [path, field] of Object.entries(state.fieldStatus ?? {})) {
+        if (!/^main\.(?:unselectedVfo\.)?(?:freqHz|mode|filter|filterNum)$/.test(path)) continue;
+        Object.assign(field, { freshness: 'stale', availability: 'stale' });
+      }
+      await page.evaluate(state => window.dispatchEvent(new CustomEvent('geometry-state', { detail: state })), state);
+      await expect(frequency).toHaveAttribute('data-display-state', stateName);
+      await expect(frequency).toContainText('035');
+      const boxes = await measure(); boxes.forEach(box => expect(box.present).toEqual(box.absent));
+      await info.attach(`${stateName}-${index}-bounds`, { body: JSON.stringify(boxes), contentType: 'application/json' });
+      if (current) expect(boxes).toEqual(current); else current = boxes;
+      if (stateName === 'stale') {
+        const cues = page.locator('.receiver-instrument [data-vfo-stale-cue]');
+        expect(await cues.count()).toBeGreaterThan(0);
+        for (const cue of await cues.all()) {
+          await expect(cue).toHaveAttribute('aria-hidden', 'false');
+          await expect(cue).toBeVisible();
+          expect(await cue.evaluate(cue => {
+            const marker = cue.firstElementChild!.getBoundingClientRect();
+            return [...cue.parentElement!.children].filter(e => e !== cue).every(e => {
+              const b = e.getBoundingClientRect();
+              return marker.right <= b.left || marker.left >= b.right || marker.bottom <= b.top || marker.top >= b.bottom;
+            });
+          })).toBe(true);
+        }
+        await page.screenshot({ path: info.outputPath('instrument-stale.png'), fullPage: true });
+      }
+    }
+    expect(await page.evaluate(() => (window as unknown as { geometryCommands: { type: string }[] }).geometryCommands.filter(c => c.type === 'cmd'))).toEqual([]);
+  });
 }

--- a/frontend/tests/e2e/visual/visual-baselines.spec.ts
+++ b/frontend/tests/e2e/visual/visual-baselines.spec.ts
@@ -116,6 +116,58 @@ for (const spec of COCKPIT) {
   });
 }
 
+/** MOR-2364: real line boxes catch phone wrapping even if a PNG is re-pinned. */
+test('VFO phone cue preserves one-line fit and freshness geometry', async ({ page }) => {
+  await page.setViewportSize(PHONE);
+  await page.goto('/fixtures/index.html?fixture=topology-2-main-sub&theme=v2');
+  await page.waitForSelector('body[data-harness-ready="true"]');
+  await page.evaluate(() => document.fonts.ready);
+  const result = await page.evaluate(() => {
+    const tiles = [...document.querySelectorAll<HTMLElement>('[data-vfo-tile]')];
+    const cues = tiles.map((tile) => tile.querySelector<HTMLElement>('[data-vfo-stale-cue]')!);
+    const rect = (el: Element) => {
+      const { x, y, width, height } = el.getBoundingClientRect();
+      return { x, y, width, height };
+    };
+    const geometry = () => tiles.map((tile) => ({ tile: rect(tile),
+      content: [...tile.children].filter((el) => !el.matches('[data-vfo-stale-cue]')).map(rect),
+    }));
+    const lineCounts = () => tiles.flatMap((tile) =>
+      [...tile.querySelectorAll('.vfo-role, .vfo-mode, .vfo-select')].map((el) => {
+        const range = document.createRange(); range.selectNodeContents(el);
+        return new Set([...range.getClientRects()].map((box) => box.top)).size;
+      }));
+    // Removing the cue models the pre-feature footprint, independent of host fonts.
+    cues.forEach((cue) => { cue.style.display = 'none'; });
+    const withoutCue = geometry();
+    cues.forEach((cue) => { cue.style.display = ''; });
+    const current = geometry(); const lines = lineCounts();
+    // This is a CSS layout probe; component tests drive real observation transitions.
+    cues.forEach((cue) => cue.classList.add('stale'));
+    const stale = geometry();
+    const clear = cues.map((cue, index) => {
+      const marker = cue.firstElementChild!.getBoundingClientRect();
+      const tile = tiles[index].getBoundingClientRect();
+      if (marker.width <= 0 || marker.height <= 0 || marker.left < tile.left
+        || marker.right > tile.right || marker.top < tile.top || marker.bottom > tile.bottom) return false;
+      return [...tiles[index].children].filter((el) => el !== cue).every((el) => {
+        const box = el.getBoundingClientRect();
+        return marker.right <= box.left || marker.left >= box.right
+          || marker.bottom <= box.top || marker.top >= box.bottom;
+      });
+    });
+    const visible = cues.map((cue) => getComputedStyle(cue).visibility);
+    cues.forEach((cue) => cue.classList.remove('stale'));
+    return { withoutCue, current, stale, restored: geometry(), lines, clear, visible };
+  });
+  expect(result.lines.every((count) => count === 1)).toBe(true);
+  expect(result.current).toEqual(result.withoutCue);
+  expect(result.stale).toEqual(result.current);
+  expect(result.restored).toEqual(result.current);
+  expect(result.clear).toEqual([true, true, true, true]);
+  expect(result.visible).toEqual(['visible', 'visible', 'visible', 'visible']);
+});
+
 /** The MOR-1088 mobile PTT pair: idle FAB and a real pointer-held FAB. */
 test('ptt-idle--mobile', async ({ page }) => {
   await page.setViewportSize(PHONE);


### PR DESCRIPTION
17 code + 0 regenerated baselines = 17 files

A previously observed VFO frequency remains visible through temporary stale evidence with a reserved non-color cue and localized explanation. Display continuity does not authorize tuning: inert focused digits cannot reach direct, digit-entry or leader-key tune/band shortcuts, and fresh evidence restores interaction. The additive display facet uses existing observation qualification and receiver/slot identity; strict command fields remain separate.

The cue occupies no semantic row width and adds no implicit Standard/SDR grid track. Instrument role/cue placement is explicit, and the retained null primitive inherits the previous unknown-placeholder typography. Positive synthetic fixtures carry observation timestamps; intentionally unknown shared fixtures remain unknown. The existing375px guard preserves the phone layout.

This is one display/interaction contract across model, adapter, primitive, surface, keyboard handler, fixtures and tests. The coordinator grants the delegated seventeen-file exception;891 additions plus deletions remain below1000. The owner explicitly authorized one additional correction/test/independent-review cycle after the prior BLOCKED candidate. This head addresses its instrument grid and fixture-provenance findings; prior failure evidence remains in review history.

Validation at725218d53d33b11842b2209edfbac76042d8bc03:499 focused tests across eight files;20 production geometry cases;375px phone guard; Svelte/TypeScript checks and changed-scope lint passed. Four added production cases cover the exact shared unknown shape, then current→stale→current observation updates, unchanged rectangles, visible non-overlapping cue, inherited placeholder paint and zero commands. Forcing cue placement back to automatic grid placement fails all four cases; restored source passes20. Existing direct/digit/leader and strict-field regression evidence is retained.

The two local production StudioLine screenshot comparisons still fail against Linux-approved snapshots on macOS. The recorded builder same-Mac comparison against pre-feature VfoSurface/FrequencyDisplayInteractive found zero differing decoded pixels (private mor2364-instrument-old-new-pixels.json). An independent same-host repeat found8 dark/14 light decoded differences confined to top-right chrome, with zero differences under the shipped comparator; this supports preserved VFO geometry and paint without claiming exact whole-image repeatability. Natural Linux i18n smoke subsequently passed67 cases in quick33991397155; that required run failed later on fixture classification of retained inert frequency groups. No PNG or manifest is changed. The final Ready head receives natural Linux quick/visual and fresh independent exact-head review.

Linear: https://linear.app/morozsm/issue/MOR-2364

No radio operation, deployment or release. Installed all-skin/operator acceptance remains outstanding.


Final harness compatibility head4c949b06a30d8c6f9bfd04ea2ef8564fdbe0031a adds only fixtures/assertions.ts and a40-line actual-assertion isolated test. The negative-tabindex exception recognizes only the retained inert frequency DIV group under an explicitly untunable VFO hook; aria-hidden remains forbidden and the global controls selector is unchanged. Production focus/authority code is unchanged from independently reviewed7252 (PASS5554781546). Fifteen actual-assertion cases pass, including unrelated/hidden/enabled negative controls; broadening the exception fails9 cases and the restored/equivalent predicate passes. Fourteen targeted captures (the12 CI failures plus2 valid reference controls) pass. The combined focused focus/keyboard/assertion subset passes261 tests; types/lint pass. Fresh natural CI and exact-head review are required for this final head.
