### PR TITLE
feat(MOR-2366): expose shared modulation input selection

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
@@ -90,7 +90,10 @@ vi.mock('$lib/audio/audio-manager', () => ({
   audioManager: {
     onChange: () => () => {}, getAppliedAudioConfig: () => null, start: vi.fn(), stop: vi.fn(), setVolume: vi.fn(), toggleMute: vi.fn() },
 }));
-vi.mock('$lib/utils/tx-permit', () => ({ getTxPermit: vi.fn(() => 'allowed') }));
+vi.mock('$lib/utils/tx-permit', async (importOriginal) => ({
+  ...await importOriginal<typeof import('$lib/utils/tx-permit')>(),
+  getTxPermit: vi.fn(() => 'allowed'),
+}));
 vi.mock('$lib/stores/tuning.svelte', () => ({ applyModeDefault: vi.fn() }));
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   hasTx: vi.fn(() => true), hasDualReceiver: vi.fn(() => false), hasAnyScope: vi.fn(() => false),
@@ -210,7 +213,10 @@ vi.mock('$lib/runtime/props/panel-props', async (importOriginal) => {
 
 import MobileRadioLayout from '../MobileRadioLayout.svelte';
 import mobileLayoutSource from '../MobileRadioLayout.svelte?raw';
-import { hasTx, hasDualReceiver } from '$lib/stores/capabilities.svelte';
+import { hasTx, hasDualReceiver, getCapabilities } from '$lib/stores/capabilities.svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import { MOD_INPUT_SOURCES } from '$lib/radio/mod-input';
 import {
   radio, subscribeRadioState,
 } from '$lib/stores/radio.svelte';
@@ -274,6 +280,44 @@ afterEach(() => {
 });
 
 describe('MobileRadioLayout structure', () => {
+  it('offers the common MOD-input selector in portrait without navigation or TX activity (MOR-2366)', () => {
+    const oldCaps = getCapabilities();
+    vi.mocked(getCapabilities).mockReturnValue({
+      ...oldCaps, model: 'fixture', receivers: 1, vfoScheme: 'ab',
+      capabilities: ['mod_input_routing'],
+    } as Capabilities);
+    const fresh = { storePath: 'fixture', observed: true, freshness: 'fresh', availability: 'available' };
+    (radio as unknown as { current: ServerState | null }).current = {
+      active: 'MAIN', main: { mode: 'USB', dataMode: 0 }, dataOffModInput: 5,
+      fieldStatus: { dataOffModInput: fresh },
+    } as unknown as ServerState;
+    try {
+      const t = mountMobile();
+      const deck = t.querySelector('.m-semantic-deck')!;
+      const select = deck.querySelector<HTMLSelectElement>('[data-testid="rx-audio-mod-select"]');
+      expect(select).not.toBeNull();
+      expect(select!.disabled).toBe(false);
+      expect([...select!.options].map((option) => option.text))
+        .toEqual(MOD_INPUT_SOURCES.map((option) => option.label));
+      expect(t.querySelectorAll('[data-testid="semantic-radio-surfaces"]')).toHaveLength(1);
+      expect(t.querySelectorAll('[data-testid="rx-audio-surface"]')).toHaveLength(1);
+      const navigation = [...t.querySelectorAll('.m-chip')].map((chip) => chip.textContent);
+      const listeners = tx.listenerCount();
+      select!.value = '3';
+      select!.dispatchEvent(new Event('change', { bubbles: true }));
+      flushSync();
+      expect(radioIntentSpy).toHaveBeenCalledExactlyOnceWith(3);
+      expect(select!.value).toBe('5');
+      expect([...t.querySelectorAll('.m-chip')].map((chip) => chip.textContent)).toEqual(navigation);
+      expect(t.querySelectorAll('[id^="m-chip-panel-"]')).toHaveLength(1);
+      expect(tx.listenerCount()).toBe(listeners);
+      expect(tx.trace()).toEqual([]);
+      expect(wsFrameSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.mocked(getCapabilities).mockReturnValue(oldCaps);
+    }
+  });
+
   it('mounts without errors', () => {
     expect(mountMobile().children.length).toBeGreaterThan(0);
   });

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -1075,6 +1075,7 @@
         onRoutingFocus={(focus) => routingIntents.onFocusChange(focus)}
         onRoutingSplit={(split) => routingIntents.onSplitStereoChange(split)}
         onSetModInputLan={setModInputLan}
+        onModInputChange={semanticHandlers.mode.onModInputChange}
       />
     {/if}
   {/snippet}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
@@ -113,6 +113,7 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
 
 import { audioManager } from '$lib/audio/audio-manager';
 import { sendCommand } from '$lib/transport/ws-client';
+import { MOD_INPUT_SOURCES, modInputCommand, modInputStateKey } from '$lib/radio/mod-input';
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
 import { makeAudioRoutingHandlers, makeModeHandlers, makeRxAudioHandlers } from '$lib/runtime/commands/panel-commands';
@@ -342,6 +343,74 @@ describe('routing prefs stay unowned by this layer (MOR-1274 carry-forward 2)', 
 });
 
 /* ── (d) the MOD-input remedy, and the untouched warning ───────── */
+
+describe('common MOD-input selector reaches the existing mode handler (MOR-2366)', () => {
+  function selectSource(source: number): HTMLSelectElement {
+    const select = el('mod-select') as HTMLSelectElement;
+    expect(select).not.toBeNull();
+    select.value = String(source);
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    flushSync();
+    return select;
+  }
+
+  it.each(MOD_INPUT_SOURCES)('dispatches the $label source exactly once', ({ value }) => {
+    render();
+    expect(selectSource(value).disabled).toBe(false);
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_data_off_mod_input', { source: value });
+    expect(text('mod-source')).toBe('MOD: LAN');
+    expect(el('mod-input')!.dataset.readiness).toBe('ready');
+  });
+
+  it.each([0, 1, 2, 3])('routes DATA group %i to its own source command', (dataMode) => {
+    const state = liveState();
+    h.state = {
+      ...state, main: { ...state.main, dataMode },
+      [modInputStateKey(dataMode)]: 3,
+      fieldStatus: { ...state.fieldStatus, [modInputStateKey(dataMode)]: fresh },
+    };
+    render();
+    selectSource(1);
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith(modInputCommand(dataMode), { source: 1 });
+  });
+
+  it.each(['active', 'main.dataMode', 'dataOffModInput'])(
+    'preserves command admission when %s becomes unavailable after rendering', (path) => {
+      render();
+      const state = liveState();
+      h.state = {
+        ...state,
+        fieldStatus: { ...state.fieldStatus, [path]: { ...fresh, availability: 'missing' } },
+      };
+      selectSource(3);
+      expect(sendCommand).not.toHaveBeenCalled();
+    },
+  );
+
+  it('renders an unread source as disabled and sends nothing', () => {
+    h.state = liveState({ dataOffModInput: null });
+    render();
+    expect(selectSource(0).disabled).toBe(true);
+    expect(text('mod-source')).toBe('MOD: —');
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it.each([-1, 4, null])('preserves admission for invalid DATA group %s', (dataMode) => {
+    render();
+    const state = liveState();
+    h.state = { ...state, main: { ...state.main, dataMode } };
+    selectSource(3);
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('omits the selector without modulation routing capability', () => {
+    h.caps = liveCaps(AUDIO_TAGS.filter((tag) => tag !== 'mod_input_routing'));
+    render();
+    expect(el('surface')).not.toBeNull();
+    expect(el('mod-select')).toBeNull();
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+});
 
 describe('a MOD-input mismatch keeps exactly one one-click remedy', () => {
   const mismatched = () => { h.state = liveState({ dataOffModInput: 0 } as Partial<ServerState>); };

--- a/frontend/src/semantic/RxAudioSurface.svelte
+++ b/frontend/src/semantic/RxAudioSurface.svelte
@@ -48,7 +48,7 @@
   prefs were never restored", which renders present-and-unobserved.
 -->
 <script module lang="ts">
-  import { modInputSourceLabel } from '$lib/radio/mod-input';
+  import { MOD_INPUT_SOURCES, modInputSourceLabel } from '$lib/radio/mod-input';
   import type {
     AudioFocus, ModInputReadiness, MonitorMode, RxAudioField,
   } from './radio-view-model';
@@ -64,12 +64,7 @@
   export const SPLIT_CHOICES = [[true, 'on'], [false, 'off']] as const;
   /** The ONE rendering of "not measured". Never 0, never 'both', never 'off'. */
   export const UNKNOWN_TEXT = '—';
-  /** MOR-1384 — the restored audio-link-lost words. English is hardcoded here
-   *  exactly like every other string on this surface (the MOR-1373 semantic
-   *  i18n policy is still open); the v2 key `core.overlay.audioLinkLost` is
-   *  NOT reused, and its "— reconnecting…" clause is deliberately dropped: a
-   *  retry in flight is client behaviour this contract does not carry, and
-   *  this surface may not consult the audio manager to find out. */
+  /** MOR-1384 — audio-link loss without an inferred retry state. */
   export const LINK_LOST_TEXT = 'live audio link lost';
   /** Readiness words. `mismatch` names the consequence, not just the state. */
   export const READINESS_LABEL: Record<ModInputReadiness['status'], string> = {
@@ -88,6 +83,7 @@
 </script>
 
 <script lang="ts">
+  import { t } from '$lib/i18n';
   import type { RadioViewModel } from './radio-view-model';
 
   interface Props {
@@ -97,15 +93,30 @@
     onRoutingFocus?: (focus: AudioFocus) => void;
     onRoutingSplit?: (split: boolean) => void;
     onSetModInputLan?: () => void;
+    onModInputChange?: (source: number) => void;
   }
   let {
     view, onMonitorMode, onAfLevel, onRoutingFocus, onRoutingSplit, onSetModInputLan,
+    onModInputChange,
   }: Props = $props();
 
   /** Absent group ⇒ this surface renders nothing (S0 optional-group doctrine):
    *  a radio with no audio chain gets no empty panel and no zone had to learn
    *  about it. */
   let rx = $derived(view.rxAudio);
+  let modInputValue = $derived(
+    rx?.modInputSource.reading.status === 'known'
+      && modInputSourceLabel(rx.modInputSource.reading.value) !== null
+      ? String(rx.modInputSource.reading.value) : '',
+  );
+  let modInputUsable = $derived(!!rx && usable(rx.modInputSource) && modInputValue !== '');
+
+  function changeModInput(select: HTMLSelectElement): void {
+    const value = select.value;
+    const source = MOD_INPUT_SOURCES.find((option) => String(option.value) === value);
+    select.value = modInputValue;
+    if (modInputUsable && source) onModInputChange?.(source.value);
+  }
   /** Rule (3): the FACT, not a capability re-derivation. */
   let liveOffered = $derived(rx?.liveAudio.structural === true);
   /** MOR-1384 — the v2 `RxAudioPanel` link-lost readout, restored from the SAME
@@ -214,6 +225,23 @@
         data-readiness={rx.modInputReadiness.status}
         data-observed={usable(rx.modInputSource)}
       >
+        <label class="rx-audio-mod-selector">
+          <span>{t('core.modePanel.modInputLabel')}</span>
+          <select
+            data-testid="rx-audio-mod-select"
+            aria-label={t('core.modePanel.modInputAria')}
+            value={modInputValue}
+            disabled={!modInputUsable}
+            onchange={(event) => changeModInput(event.currentTarget)}
+          >
+            {#if modInputValue === ''}
+              <option value="" disabled>{UNKNOWN_TEXT}</option>
+            {/if}
+            {#each MOD_INPUT_SOURCES as option (option.value)}
+              <option value={String(option.value)}>{option.label}</option>
+            {/each}
+          </select>
+        </label>
         <span data-testid="rx-audio-mod-source">MOD: {rx.modInputSource.reading.status === 'known'
           ? modInputSourceLabel(rx.modInputSource.reading.value) ?? UNKNOWN_TEXT
           : UNKNOWN_TEXT}</span>
@@ -237,10 +265,12 @@
   .rx-audio-surface { display: flex; flex-direction: column; gap: 0.25rem; }
   .rx-audio-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin: 0; }
   .rx-audio-level { display: flex; align-items: baseline; gap: 0.5rem; }
+  .rx-audio-mod-selector { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; max-width: 100%; }
+  .rx-audio-mod-selector select { min-width: 0; max-width: 100%; }
   .rx-audio-name { min-width: 4ch; }
   .rx-audio-choice[aria-checked='true'] { font-weight: 700; }
   /* Second channel beside `data-observed`, never the only one: the unknown
      text itself is the primary one and survives forced-colors. */
   [data-observed='false'] { font-style: italic; }
-  button:disabled, input:disabled { cursor: not-allowed; }
+  button:disabled, input:disabled, select:disabled { cursor: not-allowed; }
 </style>

--- a/frontend/src/semantic/__tests__/RxAudioSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RxAudioSurface.test.ts
@@ -24,6 +24,9 @@
 import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
+import { MOD_INPUT_SOURCES } from '$lib/radio/mod-input';
+import { t } from '$lib/i18n';
 import RxAudioSurface, {
   FOCUS_CHOICES, LINK_LOST_TEXT, MONITOR_MODES, READINESS_LABEL, SPLIT_CHOICES, UNKNOWN_TEXT,
 } from '../RxAudioSurface.svelte';
@@ -65,6 +68,7 @@ type Handlers = {
   onRoutingFocus?: (focus: AudioFocus) => void;
   onRoutingSplit?: (split: boolean) => void;
   onSetModInputLan?: () => void;
+  onModInputChange?: (source: number) => void;
 };
 
 function render(view: RadioViewModel, handlers: Handlers = {}) {
@@ -86,10 +90,10 @@ describe('the RX-audio surface owns no audio lifetime (MOR-972 P0 / MOR-1058)', 
   /** The whole static import closure of the file, allow-listed. Kills: adding
    *  ANY import that could reach transport or the audio manager — including
    *  through a relative specifier, which a `$lib/...` regex would miss. */
-  it('imports nothing but the fact contract and the pure MOD-input constants', () => {
+  it('imports only the fact contract, MOD-input vocabulary and localization', () => {
     const specifiers = [...CODE.matchAll(/from\s+'([^']+)'/g)].map((m) => m[1]);
     expect(specifiers.length).toBeGreaterThan(0);
-    expect([...new Set(specifiers)].sort()).toEqual(['$lib/radio/mod-input', './radio-view-model']);
+    expect([...new Set(specifiers)].sort()).toEqual(['$lib/i18n', '$lib/radio/mod-input', './radio-view-model']);
   });
 
   // Kills: `onMount(() => audioManager.startRx())` and every relative of it.
@@ -114,7 +118,7 @@ describe('the RX-audio surface owns no audio lifetime (MOR-972 P0 / MOR-1058)', 
     const props = CODE.slice(CODE.indexOf('interface Props'), CODE.indexOf('}: Props'));
     expect([...props.matchAll(/^\s{4}(\w+)[?]?:/gm)].map((m) => m[1])).toEqual([
       'view', 'onMonitorMode', 'onAfLevel', 'onRoutingFocus', 'onRoutingSplit',
-      'onSetModInputLan',
+      'onSetModInputLan', 'onModInputChange',
     ]);
   });
 
@@ -417,6 +421,80 @@ describe('routing focus and split are rendered from the facts and emitted absolu
 });
 
 /* ── (e) MOD-input readiness keeps a one-click remedy ──────────── */
+
+describe('MOD-input selection uses observed facts and absolute intents (MOR-2366)', () => {
+  it.each(MOD_INPUT_SOURCES)('offers the full vocabulary and emits $label once', ({ value }) => {
+    const onModInputChange = vi.fn();
+    const r = render(base(), { onModInputChange });
+    const select = r.el('mod-select') as HTMLSelectElement;
+    expect(select).not.toBeNull();
+    expect([...select.options].map((option) => [Number(option.value), option.text]))
+      .toEqual(MOD_INPUT_SOURCES.map((option) => [option.value, option.label]));
+    expect(select.disabled).toBe(false);
+    expect(select.getAttribute('aria-label')).toBe(t('core.modePanel.modInputAria'));
+    expect(select.closest('label')?.textContent).toContain(t('core.modePanel.modInputLabel'));
+    select.value = String(value);
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    flushSync();
+    expect(onModInputChange).toHaveBeenCalledExactlyOnceWith(value);
+    expect(select.value).toBe('5');
+    expect(r.text('mod-source')).toBe('MOD: LAN');
+    r.dispose();
+  });
+
+  it.each([
+    ['unread', unread<number>()],
+    ['unavailable', known(3, DEGRADED)],
+    ['unrecognized', known(99)],
+  ] as const)('keeps %s selection inert even for a synthetic change', (_name, field) => {
+    const onModInputChange = vi.fn();
+    const r = render(withRx({ modInputSource: field }), { onModInputChange });
+    const select = r.el('mod-select') as HTMLSelectElement;
+    expect(select).not.toBeNull();
+    expect(select.disabled).toBe(true);
+    expect(select.value).toBe(field.reading.status === 'known' && field.reading.value === 3 ? '3' : '');
+    if (select.value === '') expect(select.selectedOptions[0].text).toBe(UNKNOWN_TEXT);
+    select.value = '0';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(onModInputChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('rejects a source outside the shared vocabulary', () => {
+    const onModInputChange = vi.fn();
+    const r = render(base(), { onModInputChange });
+    const select = r.el('mod-select') as HTMLSelectElement;
+    expect(select).not.toBeNull();
+    select.add(new Option('invalid', '99'));
+    select.value = '99';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(onModInputChange).not.toHaveBeenCalled();
+    expect(select.value).toBe('5');
+    r.dispose();
+  });
+
+  it('follows unknown, readback and unavailable transitions without emitting', () => {
+    const facts = new SvelteMap([['view', withRx({ modInputSource: unread<number>() })]]);
+    const onModInputChange = vi.fn();
+    const component = mount(RxAudioSurface, {
+      target, props: { get view() { return facts.get('view')!; }, onModInputChange },
+    });
+    flushSync();
+    const select = target.querySelector<HTMLSelectElement>('[data-testid="rx-audio-mod-select"]');
+    expect(select).not.toBeNull();
+    for (const [field, value, disabled] of [
+      [known(4), '4', false], [known(1), '1', false],
+      [known(1, DEGRADED), '1', true], [unread<number>(), '', true],
+    ] as const) {
+      facts.set('view', withRx({ modInputSource: field }));
+      flushSync();
+      expect(select!.value).toBe(value);
+      expect(select!.disabled).toBe(disabled);
+    }
+    expect(onModInputChange).not.toHaveBeenCalled();
+    unmount(component);
+  });
+});
 
 describe('MOD-input readiness is stated, and a mismatch is never a dead end', () => {
   it('names the observed source and reports LAN readiness', () => {


### PR DESCRIPTION
The common RX audio surface now exposes the six existing modulation-input choices through the bound mode handler. This closes a functional gap before LCD sidebars can replace the legacy ModePanel with the same semantic controls used by the SDR face.

Selection follows observed source/readiness facts and returns to the observed value after an intent until readback arrives. Unknown, invalid and unavailable states cannot emit selector commands. The existing LAN readiness remedy, receive monitor/routing and command admission remain in place; no VM schema, frame/TX host or legacy suppression is added.

Validation: builder focused baseline132 tests, initial RED28 failures, final162 passed across surface/wiring/mobile files; five wrong-map mutation cases failed while LAN selection and the existing LAN remedy passed. Restored code passed types and changed-file ESLint. Two additional common-wiring/cockpit DOM guard files passed90 tests. Mobile evidence covers DOM/behavior, not pixel geometry. Commands and counts come from the builder's Vitest, npm check, ESLint and git show runs.

Five files, 235 additions +13 deletions =248 changed lines. Independent exact-head review and natural required CI gate integration. No radio deployment or release; full LCD shared-control cutover remains open.

Linear: [MOR-2366](https://linear.app/morozsm/issue/MOR-2366), parent MOR-2232.
