### PR TITLE
feat(MOR-2368): expose frame provenance through the existing scope host

### DIFF
--- a/frontend/src/lib/runtime/__tests__/scope-frame-host.test.ts
+++ b/frontend/src/lib/runtime/__tests__/scope-frame-host.test.ts
@@ -89,6 +89,147 @@ function rig() {
 }
 
 describe('ScopeFrameHost MOR-2326 lifecycle', () => {
+  it('publishes resolution and receipt from one read, sharing the qualified envelope', async () => {
+    const { channels, controller, host } = rig();
+    host.updateAuthority({ source: 'hardware', receiver: 'MAIN', providerGeneration: 12 });
+    const handle = await controller.hardwareScopeDriver.start();
+    channels.scope.transition('connected');
+    const updates = vi.fn();
+    const legacy = vi.fn();
+    host.subscribePresentation(updates);
+    host.subscribe(legacy);
+    const read = vi.spyOn(controller, 'snapshotFrameEvidence');
+    const input = frame();
+    channels.scope.fire(input);
+
+    expect(read).toHaveBeenCalledTimes(1);
+    const projected = updates.mock.lastCall![0];
+    const evidence = read.mock.results[0].value;
+    expect(projected.envelope).toBe(evidence.envelope);
+    expect(projected.authority).toBe(evidence.authority);
+    expect(projected.resolution).toBe(legacy.mock.lastCall![0]);
+    expect(projected.resolution.state).toBe('live');
+    expect(projected.envelope.acceptedSequence).toBeGreaterThan(0);
+    expect(Object.isFrozen(projected)).toBe(true);
+    expect(Object.isFrozen(projected.authority)).toBe(true);
+    expect(Object.isFrozen(projected.envelope)).toBe(true);
+    expect(Object.isFrozen(projected.envelope.frame)).toBe(true);
+    expect(Object.isFrozen(projected.resolution)).toBe(true);
+    expect(Object.isFrozen(projected.resolution.frame.normalizedBins)).toBe(true);
+    new Uint8Array(input).fill(0);
+    expect([...projected.envelope.frame.pixels]).toEqual([0, 128, 255]);
+    expect(projected.resolution.frame.normalizedBins).toEqual([0, 128 / 255, 1]);
+    expect(host.snapshotPresentation()).toEqual(projected);
+    await controller.hardwareScopeDriver.stop(handle);
+    host.dispose();
+  });
+
+  it('publishes exact expiry and selected-receiver null despite unrelated raw liveness', async () => {
+    const { time, channels, controller, host } = rig();
+    host.updateAuthority({ source: 'hardware', receiver: 'MAIN', providerGeneration: 1 });
+    const handle = await controller.hardwareScopeDriver.start();
+    channels.scope.transition('connected');
+    const updates = vi.fn();
+    host.subscribePresentation(updates);
+    channels.scope.fire(frame());
+    const live = updates.mock.lastCall![0];
+    time.advance(499);
+    expect(host.snapshotPresentation().resolution.state).toBe('live');
+    time.advance(1);
+    expect(updates.mock.lastCall![0]).toMatchObject({
+      envelope: live.envelope, resolution: { state: 'ghost', reason: 'stale' },
+    });
+    expect(live.resolution.state).toBe('live');
+    channels.scope.fire(frame(1));
+    expect(controller.hardwareScopeFrameLive).toBe(true);
+    expect(updates.mock.lastCall![0]).toMatchObject({
+      envelope: null, resolution: { state: 'ghost', reason: 'missing' },
+    });
+    channels.scope.fire(frame());
+    channels.scope.transition('reconnecting');
+    expect(updates.mock.lastCall![0].resolution.state).toBe('ghost');
+    await controller.hardwareScopeDriver.stop(handle);
+    expect(updates.mock.lastCall![0].envelope).toBeNull();
+    expect(host.snapshotPresentation().authority.demanded).toBe(false);
+    host.updateAuthority(null);
+    expect(updates.mock.lastCall![0].envelope).toBeNull();
+    host.dispose();
+  });
+
+  it('retires provider receipts, rejects old callbacks, and recovers on re-acquisition', async () => {
+    const { channels, controller, host } = rig();
+    host.updateAuthority({ source: 'hardware', receiver: 'MAIN', providerGeneration: 1 });
+    let handle = await controller.hardwareScopeDriver.start();
+    channels.scope.transition('connected');
+    const updates = vi.fn();
+    host.subscribePresentation(updates);
+    channels.scope.fire(frame());
+    const original = updates.mock.lastCall![0];
+    host.updateAuthority({ source: 'hardware', receiver: 'MAIN', providerGeneration: 2 });
+    expect(updates.mock.lastCall![0]).toMatchObject({
+      envelope: null, authority: { providerGeneration: 2 }, resolution: { state: 'ghost' },
+    });
+    channels.scope.fire(frame());
+    expect(host.snapshotPresentation().envelope).toBeNull();
+    await controller.hardwareScopeDriver.stop(handle);
+    handle = await controller.hardwareScopeDriver.start();
+    channels.scope.transition('reconnecting');
+    channels.scope.transition('connected');
+    channels.scope.fire(frame());
+    const renewed = updates.mock.lastCall![0];
+    expect(renewed.resolution.state).toBe('live');
+    expect(renewed.envelope.providerGeneration).toBe(2);
+    expect(renewed.envelope.acceptedSequence).toBeGreaterThan(original.envelope.acceptedSequence);
+    expect(renewed.envelope.transportEpoch).toBeGreaterThan(original.envelope.transportEpoch);
+    channels.scope.fire(new ArrayBuffer(16));
+    expect(updates.mock.lastCall![0].resolution.state).toBe('ghost');
+    expect(original.resolution.state).toBe('live');
+    await controller.hardwareScopeDriver.stop(handle);
+    host.dispose();
+  });
+
+  it.each([-1, NaN, Infinity])('rejects invalid clock age %s in the presentation', async (age) => {
+    const { time, channels, controller, host } = rig();
+    host.updateAuthority({ source: 'hardware', receiver: 'MAIN', providerGeneration: 1 });
+    const handle = await controller.hardwareScopeDriver.start();
+    channels.scope.transition('connected');
+    channels.scope.fire(frame());
+    time.advance(age);
+    expect(host.snapshotPresentation().resolution.state).toBe('ghost');
+    await controller.hardwareScopeDriver.stop(handle);
+    host.dispose();
+  });
+
+  it('shares one evidence subscription and isolates/removes presentation subscribers', () => {
+    const { controller, host } = rig();
+    host.dispose();
+    const unsubscribe = vi.fn();
+    const subscribe = vi.spyOn(controller, 'subscribeFrameEvidence').mockReturnValue(unsubscribe);
+    const owner = new ScopeFrameHost(controller);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const healthy = vi.fn();
+    const legacy = vi.fn();
+    owner.subscribePresentation(() => { throw new Error('observer'); });
+    const remove = owner.subscribePresentation(healthy);
+    owner.subscribe(legacy);
+    const notify = subscribe.mock.calls[0][0];
+    notify();
+    expect(healthy).toHaveBeenCalledTimes(1);
+    expect(legacy).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith('Scope frame host subscriber failed', expect.any(Error));
+    remove();
+    notify();
+    expect(healthy).toHaveBeenCalledTimes(1);
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    owner.dispose();
+    owner.dispose();
+    owner.subscribePresentation(healthy);
+    notify();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(healthy).toHaveBeenCalledTimes(1);
+    expect(legacy).toHaveBeenCalledTimes(2);
+  });
+
   it.each([
     ['hardware', 'hardwareScopeDriver', 'scope'],
     ['audio-fft', 'audioFftDriver', 'audio-scope'],

--- a/frontend/src/lib/runtime/scope-frame-host.ts
+++ b/frontend/src/lib/runtime/scope-frame-host.ts
@@ -1,5 +1,5 @@
 import { toScopeDisplayFrame } from './adapters/scope-adapter';
-import type { ScopeController } from './scope-controller.svelte';
+import type { ScopeController, ScopeFrameEvidence } from './scope-controller.svelte';
 import {
   resolveLcdSpectrumFrame,
   type LcdSpectrumFrameResolution,
@@ -14,6 +14,10 @@ export interface ScopeFrameHostAuthority {
 }
 
 type ResolutionHandler = (resolution: LcdSpectrumFrameResolution) => void;
+export interface ScopeFramePresentation extends ScopeFrameEvidence {
+  readonly resolution: LcdSpectrumFrameResolution;
+}
+type PresentationHandler = (presentation: ScopeFramePresentation) => void;
 
 /**
  * Runtime-side owner of the MOR-2321 display-frame resolution. Wiring supplies
@@ -22,6 +26,7 @@ type ResolutionHandler = (resolution: LcdSpectrumFrameResolution) => void;
  */
 export class ScopeFrameHost {
   private readonly listeners = new Map<number, ResolutionHandler>();
+  private readonly presentationListeners = new Map<number, PresentationHandler>();
   private nextId = 0;
   private authority: ScopeFrameHostAuthority | null = null;
   private unsubscribeEvidence: () => void;
@@ -46,7 +51,25 @@ export class ScopeFrameHost {
   }
 
   snapshot(): LcdSpectrumFrameResolution {
-    return this.resolve();
+    return this.snapshotPresentation().resolution;
+  }
+
+  snapshotPresentation(): ScopeFramePresentation {
+    const evidence = this.controller.snapshotFrameEvidence();
+    const authority = this.authority;
+    const candidate = authority ? toScopeDisplayFrame(evidence.envelope, evidence.authority) : null;
+    const resolution = Object.freeze(resolveLcdSpectrumFrame(candidate, {
+      source: authority?.source ?? 'hardware',
+      receiver: authority?.receiver ?? null,
+    }));
+    return Object.freeze({ ...evidence, resolution });
+  }
+
+  subscribePresentation(handler: PresentationHandler): () => void {
+    if (this.disposed) return () => {};
+    const id = this.nextId++;
+    this.presentationListeners.set(id, handler);
+    return () => { this.presentationListeners.delete(id); };
   }
 
   subscribe(handler: ResolutionHandler): () => void {
@@ -62,27 +85,22 @@ export class ScopeFrameHost {
     this.unsubscribeEvidence();
     this.controller.setFrameAuthority(null);
     this.listeners.clear();
-  }
-
-  private resolve(): LcdSpectrumFrameResolution {
-    const authority = this.authority;
-    if (!authority) {
-      return resolveLcdSpectrumFrame(null, { source: 'hardware', receiver: null });
-    }
-    const evidence = this.controller.snapshotFrameEvidence();
-    const candidate = toScopeDisplayFrame(evidence.envelope, evidence.authority);
-    return resolveLcdSpectrumFrame(candidate, {
-      source: authority.source,
-      receiver: authority.receiver,
-    });
+    this.presentationListeners.clear();
   }
 
   private publish(): void {
     if (this.disposed) return;
-    const resolution = this.resolve();
+    const presentation = this.snapshotPresentation();
     for (const listener of [...this.listeners.values()]) {
       try {
-        listener(resolution);
+        listener(presentation.resolution);
+      } catch (error) {
+        console.warn('Scope frame host subscriber failed', error);
+      }
+    }
+    for (const listener of [...this.presentationListeners.values()]) {
+      try {
+        listener(presentation);
       } catch (error) {
         console.warn('Scope frame host subscriber failed', error);
       }


### PR DESCRIPTION
ScopeFrameHost now exposes frame provenance and LCD resolution together through `snapshotPresentation()` and `subscribePresentation()`. Each publication reads controller evidence once and delivers the same resolved display object to existing LCD subscribers and the new presentation subscribers. This is the prerequisite for coherent passband display in MOR-2367; it does not implement overlay retention.

Existing LCD API shapes and the single controller subscription remain. The presentation/resolution containers and existing receipt metadata are frozen; receipt pixel bytes remain the existing writable Uint8Array, so the API does not promise deep pixel immutability or add another pixel history. A disconnect publishes null/ghost immediately even when the controller's demanded-health flag changes afterward; downstream consumers must respect null/ghost.

Validation: baseline7 host tests, initial RED3 new failures, final82 focused host/authority tests passed. Types and two-path ESLint passed. Mutations adding a second evidence read and suppressing ghost notifications each failed their targeted case; equivalent explicit object construction passed14 host cases, followed by restored82-case green. Exact499/500ms, invalidation, listener/disposal and copied-input-buffer behavior are covered. Commands and counts come from the builder's Vitest, npm check, ESLint and git show runs.

Two files,176 additions +17 deletions =193 changed lines. The larger consumer design exceeded the estimated1000-line ceiling, so this is its explicitly owned prerequisite. Natural required CI and independent exact-head review remain integration gates. No UI/baseline, controller, radio, install or release change.

Linear: [MOR-2368](https://linear.app/morozsm/issue/MOR-2368), parent MOR-2367.
