### PR TITLE
fix: share TX observation semantics across LCD telemetry (MOR-2371)

### DIFF
--- a/frontend/src/semantic/__tests__/radio-display-model.test.ts
+++ b/frontend/src/semantic/__tests__/radio-display-model.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type {
-  RadioViewModel, ReceiverIndicatorViewModel, TxAuxField,
+  DisplayObservation, MeterRfState, RadioViewModel, ReceiverIndicatorViewModel, TxAuxField,
 } from '../radio-view-model';
 import { topologyFixtures } from '../fixtures/topologies';
 import { projectPeerSplitDisplay } from '../radio-display-model';
+import { projectTxMeterDisplay } from '../tx-meter-display';
 
 const availability = (structural = true, operational = true) => ({ structural, operational });
 const known = <T>(value: T): TxAuxField<T> => ({ reading: { status: 'known', value }, availability: availability() });
@@ -122,7 +123,7 @@ describe('projectPeerSplitDisplay', () => {
     expect(display.activeReceiver?.front.attenuator).toEqual({ state: 'known', value: 0 });
     expect(display.activeReceiver?.front.ipPlus).toEqual({ state: 'inactive' });
     expect(display.activeReceiver?.front.digiSel).toEqual({ state: 'unsupported' });
-    expect(display.telemetry.power).toEqual({ state: 'unknown', relevant: false });
+    expect(display.telemetry.power).toMatchObject({ state: 'unknown', relevant: false });
   });
 
   it('does not treat a hardware RF scope as an AF-FFT source', () => {
@@ -243,3 +244,31 @@ describe('single-receiver LCD display slots', () => {
     expect(projectPeerSplitDisplay(fixture).receivers[1].frequency).toEqual({ state: 'unknown' });
   });
 });
+
+const txObservations: (DisplayObservation<number> | undefined)[] = [
+  undefined, { state: 'current', value: 0 }, { state: 'current', value: 12.345 },
+  { state: 'stale', value: 87.654 }, { state: 'unknown', reason: 'not-observed' },
+];
+for (const structural of [false, true]) for (const operational of [false, true]) for (const rfState of ['receiving', 'transmitting', 'uncertain', 'unknown'] as MeterRfState[])
+  for (const relevant of [false, true]) for (const display of txObservations) {
+    it(`additive TX telemetry ${structural}/${operational}/${rfState}/${relevant}/${display?.state ?? 'legacy'}/${display && 'value' in display ? display.value : ''}`, () => {
+      const input = view();
+      input.meters!.rfState = rfState;
+      for (const key of ['power', 'swr', 'alc'] as const) input.meters![key] = {
+        availability: availability(structural, operational), reading: { status: 'known', value: 87.654 }, relevant,
+        ...(display ? { display } : {}),
+      };
+      const before = structuredClone(input);
+      const output = projectPeerSplitDisplay(input);
+      for (const key of ['power', 'swr', 'alc'] as const) {
+        const { txDisplay, ...legacy } = output.telemetry[key];
+        expect(txDisplay).toEqual(projectTxMeterDisplay(input.meters![key], rfState));
+        expect(legacy).toEqual(!structural ? { state: 'unsupported', relevant } : operational
+          ? { state: 'known', value: 87.654, relevant } : { state: 'unknown', relevant });
+      }
+      expect(output.telemetry.drainVoltage).toEqual({ state: 'known', value: 13.8, relevant: true });
+      expect(output.telemetry.drainCurrent).toEqual({ state: 'known', value: 0.7, relevant: true });
+      expect(output.telemetry.compression).toEqual({ state: 'unknown', relevant: false });
+      expect(input).toEqual(before);
+    });
+  }

--- a/frontend/src/semantic/radio-display-model.ts
+++ b/frontend/src/semantic/radio-display-model.ts
@@ -1,7 +1,8 @@
 import type {
-  MeterField, RadioViewModel, ReceiverId, ReceiverIndicatorViewModel, TxAuxField,
+  DisplayObservedMeterField, MeterRfState, MeterField, RadioViewModel, ReceiverId, ReceiverIndicatorViewModel, TxAuxField,
   VfoSlotId, VfoViewModel,
 } from './radio-view-model';
+import { projectTxMeterDisplay, type TxMeterDisplay } from './tx-meter-display';
 
 export type DisplayValue<T> =
   | { readonly state: 'known'; readonly value: T }
@@ -19,7 +20,10 @@ export type DisplayOffset =
   | { readonly state: 'inactive'; readonly offsetHz?: number }
   | { readonly state: 'unknown' | 'unsupported' };
 
-export type DisplayTelemetry = DisplayValue<number> & { readonly relevant: boolean };
+export type DisplayTelemetry = DisplayValue<number> & {
+  readonly relevant: boolean;
+  readonly txDisplay?: TxMeterDisplay;
+};
 
 export type DisplaySlotId = ReceiverId | VfoSlotId;
 
@@ -215,6 +219,10 @@ function telemetry(field: MeterField | undefined): DisplayTelemetry {
   return { ...value, relevant: field?.relevant ?? false };
 }
 
+function txTelemetry(field: DisplayObservedMeterField | undefined, rfState: MeterRfState): DisplayTelemetry {
+  return { ...telemetry(field), txDisplay: projectTxMeterDisplay(field, rfState) };
+}
+
 export function projectPeerSplitDisplay(view: RadioViewModel): PeerSplitDisplayModel {
   const singleAb = view.topologyId === '1/ab' && view.vfoScheme === 'ab';
   const main = receiverDisplay(view, 'MAIN', singleAb ? 'A' : undefined);
@@ -249,9 +257,9 @@ export function projectPeerSplitDisplay(view: RadioViewModel): PeerSplitDisplayM
     telemetry: {
       drainVoltage: telemetry(view.meters?.drainVoltage),
       drainCurrent: telemetry(view.meters?.drainCurrent),
-      power: telemetry(view.meters?.power),
-      swr: telemetry(view.meters?.swr),
-      alc: telemetry(view.meters?.alc),
+      power: txTelemetry(view.meters?.power, view.meters?.rfState ?? 'unknown'),
+      swr: txTelemetry(view.meters?.swr, view.meters?.rfState ?? 'unknown'),
+      alc: txTelemetry(view.meters?.alc, view.meters?.rfState ?? 'unknown'),
       compression: telemetry(view.meters?.compression),
     },
   };

--- a/frontend/src/skins/segmentline/CenterstageDisplay.svelte
+++ b/frontend/src/skins/segmentline/CenterstageDisplay.svelte
@@ -8,7 +8,7 @@
   import LcdFrequencyReadout from './LcdFrequencyReadout.svelte';
   import LcdLinearSMeter from './LcdLinearSMeter.svelte';
   import { resolveLcdSpectrumFrame } from './lcd-display-contract';
-  import { stateText, telemetryText } from './lcd-display-helpers';
+  import { stateText, telemetryText, telemetryDescription } from './lcd-display-helpers';
 
   interface Props {
     model: PeerSplitDisplayModel;
@@ -170,6 +170,7 @@
     {#each telemetry as item}
       <span
         class:irrelevant={!item.field.relevant}
+        role="group" aria-label={telemetryDescription(item.label, item.field)}
         data-state={item.field.state}
         style:visibility={item.field.state === 'unsupported' ? 'hidden' : 'visible'}
       ><small>{item.label}</small> {telemetryText(item.field)}</span>

--- a/frontend/src/skins/segmentline/LcdTelemetryRail.svelte
+++ b/frontend/src/skins/segmentline/LcdTelemetryRail.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { PeerSplitDisplayModel } from '../../semantic/radio-display-model';
-  import { telemetryText } from './lcd-display-helpers';
+  import { telemetryText, telemetryDescription } from './lcd-display-helpers';
 
   interface Props {
     telemetry: PeerSplitDisplayModel['telemetry'];
@@ -24,7 +24,8 @@
   </div>
   <div class="telemetry">
     {#each items as item}
-      <span class:irrelevant={!item.field.relevant} data-state={item.field.state}>
+      <span class:irrelevant={!item.field.relevant} data-state={item.field.state}
+        role="group" aria-label={telemetryDescription(item.label, item.field)}>
         <small>{item.label}</small> {telemetryText(item.field)}
       </span>
     {/each}

--- a/frontend/src/skins/segmentline/PanadapterDisplay.svelte
+++ b/frontend/src/skins/segmentline/PanadapterDisplay.svelte
@@ -7,7 +7,7 @@
   import LcdRfPanadapter, {
     type LcdRfPanadapterPassband,
   } from './LcdRfPanadapter.svelte';
-  import { stateText, telemetryText } from './lcd-display-helpers';
+  import { stateText, telemetryText, telemetryDescription } from './lcd-display-helpers';
 
   interface Props {
     model: PeerSplitDisplayModel;
@@ -107,7 +107,8 @@
       <div class="telemetry" data-testid="panadapter-telemetry">
         {#each telemetryItems as item}
           {#if item.field.state !== 'unsupported'}
-            <span class:irrelevant={!item.field.relevant} data-state={item.field.state}>
+            <span class:irrelevant={!item.field.relevant} data-state={item.field.state}
+              role="group" aria-label={telemetryDescription(item.label, item.field)}>
               <small>{item.label}</small> {telemetryText(item.field)}
             </span>
           {/if}

--- a/frontend/src/skins/segmentline/__tests__/lcd-display-helpers.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/lcd-display-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type {
-  DisplayOffset, DisplayValue, PeerSplitReceiverDisplay,
+  DisplayOffset, DisplayTelemetry, DisplayValue, PeerSplitReceiverDisplay,
 } from '../../../semantic/radio-display-model';
 import {
   fftInputState,
@@ -9,7 +9,7 @@ import {
   formatOffset,
   meterFill,
   notchIndicators,
-  stateText,
+  stateText, telemetryText, telemetryDescription,
 } from '../lcd-display-helpers';
 
 const known = <T>(value: T): DisplayValue<T> => ({ state: 'known', value });
@@ -107,3 +107,31 @@ describe('LCD display helpers', () => {
     expect(fftInputState(receiver, undefined)).toBe('missing');
   });
 });
+
+it.each([
+  [{ state: 'known', value: 12.345, relevant: false }, '12.35'],
+  [{ state: 'known', value: 0, relevant: true }, '0'],
+  [{ state: 'unknown', relevant: true }, '?'],
+  [{ state: 'unsupported', relevant: false }, '?'],
+] satisfies [DisplayTelemetry, string][])('keeps legacy telemetry formatting %j', (field, text) => {
+  expect(telemetryText(field)).toBe(text);
+});
+
+for (const relevance of ['idle', 'relevant', 'indeterminate'] as const)
+  for (const observation of [{ state: 'current', value: 12.345 }, { state: 'current', value: 0 },
+    { state: 'stale', value: 87.654 }, { state: 'unknown', reason: 'not-observed' }] as const) {
+    it(`formats TX ${relevance}/${observation.state}/${'value' in observation ? observation.value : ''}`, () => {
+      const field: DisplayTelemetry = { state: 'known', value: 207, relevant: true,
+        txDisplay: { supported: true, relevance, observation } };
+      const text = telemetryText(field);
+      const description = telemetryDescription('PWR', field);
+      expect(text).toBe(relevance === 'idle' ? 'IDLE' : observation.state === 'stale' ? 'STALE'
+        : observation.state === 'unknown' ? '?' : `${Number(observation.value.toFixed(2))}${relevance === 'indeterminate' ? ' ?' : ''}`);
+      expect(description).toContain('PWR');
+      expect(description).not.toMatch(/207|87.65/);
+      if (relevance === 'idle') expect(description).toContain('Not measuring in RX');
+      if (relevance === 'indeterminate') expect(description).toContain('RF relevance indeterminate');
+      if (relevance !== 'idle' && observation.state === 'stale') expect(description).toContain('Stale observation');
+      if (relevance !== 'idle' && observation.state === 'unknown') expect(description).toContain('Not observed');
+    });
+  }

--- a/frontend/src/skins/segmentline/__tests__/tx-meter-telemetry.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/tx-meter-telemetry.component.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
+import type { DisplayObservation, MeterRfState } from '../../../semantic/radio-view-model';
+import { projectPeerSplitDisplay, type PeerSplitDisplayModel } from '../../../semantic/radio-display-model';
+import { topologyFixtures, withMeters } from '../../../semantic/fixtures/topologies';
+import PeerSplitDisplay from '../PeerSplitDisplay.svelte';
+import DominantUnifiedDisplay from '../DominantUnifiedDisplay.svelte';
+import CenterstageDisplay from '../CenterstageDisplay.svelte';
+import PanadapterDisplay from '../PanadapterDisplay.svelte';
+
+const variants = [PeerSplitDisplay, DominantUnifiedDisplay, CenterstageDisplay, PanadapterDisplay];
+const names = ['peer-split', 'dominant-unified', 'centerstage', 'panadapter'];
+const targets = ['PWR', 'SWR', 'ALC'];
+function model(rf: MeterRfState, relevant: boolean, observation: DisplayObservation<number>, structural = true) {
+  const view = withMeters(topologyFixtures['2/main_sub'], rf);
+  for (const key of ['power', 'swr', 'alc'] as const) view.meters![key] = {
+    availability: { structural, operational: true }, reading: { status: 'known', value: 87.654 },
+    relevant, display: observation,
+  };
+  return projectPeerSplitDisplay(view);
+}
+const observations = [{ state: 'current', value: 12.345 }, { state: 'stale', value: 87.654 },
+  { state: 'unknown', reason: 'not-observed' }] as const;
+function slot(root: HTMLElement, label: string): HTMLElement | undefined {
+  return [...root.querySelectorAll('small')].find((node) => node.textContent === label)?.parentElement ?? undefined;
+}
+for (const [index, Component] of variants.entries()) describe(names[index], () => {
+  for (const structural of [false, true]) for (const rf of ['receiving', 'transmitting', 'uncertain', 'unknown'] as MeterRfState[])
+    for (const relevant of [false, true]) for (const observation of observations) {
+      it(`${structural}/${rf}/${relevant}/${observation.state}`, () => {
+        const root = document.createElement('div');
+        document.body.append(root);
+        const component = mount(Component, { target: root, props: { model: model(rf, relevant, observation, structural) } });
+        flushSync();
+        try {
+          for (const label of targets) {
+            const el = slot(root, label);
+            if (!structural) {
+              if (Component === PanadapterDisplay) expect(el).toBeUndefined();
+              else expect(el?.dataset.state).toBe('unsupported');
+              continue;
+            }
+            expect(el).toBeDefined();
+            const idle = rf === 'receiving' && !relevant;
+            const indeterminate = !idle && !(rf === 'transmitting' && relevant);
+            const expected = idle ? 'IDLE' : observation.state === 'stale' ? 'STALE'
+              : observation.state === 'unknown' ? '?' : `12.35${indeterminate ? ' ?' : ''}`;
+            expect(el!.textContent?.trim()).toBe(`${label} ${expected}`);
+            const description = el!.getAttribute('aria-label') ?? '';
+            expect(description).toContain(label);
+            expect(description).not.toMatch(/87.65/);
+            if (idle) expect(description).toContain('Not measuring in RX');
+            if (indeterminate) expect(description).toContain('RF relevance indeterminate');
+            if (!idle && observation.state === 'stale') expect(description).toContain('Stale observation');
+            if (!idle && observation.state === 'unknown') expect(description).toContain('Not observed');
+            if (!idle && observation.state === 'current') expect(description).toContain('12.35');
+          }
+          expect(root.querySelectorAll('button,input,select,textarea')).toHaveLength(0);
+        } finally { unmount(component); root.remove(); }
+      });
+    }
+  it('retains the same slots through current → idle → stale → unknown → zero and preserves unrelated text', () => {
+    const props: { model: PeerSplitDisplayModel } = proxy({ model: model('transmitting', true, observations[0]) });
+    const root = document.createElement('div'); document.body.append(root);
+    const component = mount(Component, { target: root, props }); flushSync();
+    try {
+      const nodes = targets.map((label) => slot(root, label)!);
+      const other = ['VD', 'ID', 'COMP'].map((label) => slot(root, label)!.textContent);
+      for (const [rf, relevant, observation, text] of [
+        ['receiving', false, observations[0], 'IDLE'], ['transmitting', true, observations[1], 'STALE'],
+        ['transmitting', true, observations[2], '?'], ['transmitting', true, { state: 'current', value: 0 }, '0'],
+      ] as const) {
+        props.model = model(rf, relevant, observation); flushSync();
+        expect(nodes.every((node, i) => node === slot(root, targets[i]) && node.isConnected)).toBe(true);
+        expect(nodes.map((node) => node.textContent?.trim())).toEqual(targets.map((label) => `${label} ${text}`));
+        expect(['VD', 'ID', 'COMP'].map((label) => slot(root, label)!.textContent)).toEqual(other);
+      }
+    } finally { unmount(component); root.remove(); }
+  });
+});

--- a/frontend/src/skins/segmentline/lcd-display-helpers.ts
+++ b/frontend/src/skins/segmentline/lcd-display-helpers.ts
@@ -40,7 +40,24 @@ export function meterFill(field: DisplayValue<number>): number {
 }
 
 export function telemetryText(field: DisplayTelemetry): string {
-  return field.state === 'known' ? String(Number(field.value.toFixed(2))) : '?';
+  const tx = field.txDisplay;
+  if (!tx) return field.state === 'known' ? String(Number(field.value.toFixed(2))) : '?';
+  if (!tx.supported) return '?';
+  if (tx.relevance === 'idle') return 'IDLE';
+  if (tx.observation.state === 'stale') return 'STALE';
+  if (tx.observation.state !== 'current') return '?';
+  return `${Number(tx.observation.value.toFixed(2))}${tx.relevance === 'indeterminate' ? ' ?' : ''}`;
+}
+
+export function telemetryDescription(label: string, field: DisplayTelemetry): string {
+  const tx = field.txDisplay;
+  if (!tx) return `${label}: ${field.state === 'known' ? telemetryText(field)
+    : field.state === 'unsupported' ? 'Unsupported' : 'Not observed'}`;
+  if (!tx.supported) return `${label}: Unsupported`;
+  if (tx.relevance === 'idle') return `${label}: Not measuring in RX`;
+  const cue = tx.relevance === 'indeterminate' ? 'RF relevance indeterminate. ' : '';
+  return `${label}: ${cue}${tx.observation.state === 'stale' ? 'Stale observation'
+    : tx.observation.state === 'current' ? `Current observation: ${Number(tx.observation.value.toFixed(2))}` : 'Not observed'}`;
 }
 
 function envelope(


### PR DESCRIPTION
LCD Power, SWR and ALC readouts now consume the same TX observation/relevance projection as the common meter surface. Confirmed receive displays IDLE without a retained numeric measurement; stale observations display STALE; indeterminate relevance remains explicit. Current observations and legacy telemetry retain their existing numeric formatting.

The additive `DisplayTelemetry.txDisplay` facet preserves existing fields and unrelated VD/ID/COMP behavior. One shared formatter/describer serves the rail, Centerstage and Panadapter; PeerSplit and DominantUnified inherit the rail. This eight-file unit connects the model contract, helpers, three consumers and their tests without adding a skin-specific RF classifier or command path.

Validation: the seven-file focused Vitest command passed 449 tests, including 160 model combinations, 192 four-variant component combinations, stable element transitions and existing consumer controls. Eight invalid mutations were killed; an equivalent formatting control passed 449. `npm run check`, changed-scope ESLint and diff checks passed.

Exact Linux regeneration run 33988362209 used this head. Pixelmatch comparison of all 29 captures stayed below the existing visual tolerance; inspection of peer-split desktop confirms the intended target readouts change to IDLE. The small glyph changes are below that pixel gate, so the focused semantic/component assertions establish their behavior. No PNG or manifest is changed: the captures also contain existing unrelated badge/clock differences, which are not adopted here. This changes telemetry semantics only: literal LCD TX scales, installation and operator acceptance remain outstanding. No radio operation, deployment or release.

Linear: https://linear.app/morozsm/issue/MOR-2371
