### PR TITLE
feat(MOR-2372): add persistent calibrated LCD TX scales

### DIFF
--- a/frontend/src/components-v2/layout/LcdLayout.svelte
+++ b/frontend/src/components-v2/layout/LcdLayout.svelte
@@ -77,6 +77,13 @@
       ? { canvas: segmentlineGroup.canvas, minScale: segmentlineGroup.scaling.minScale }
       : undefined,
   );
+  const frameBorder = 1;
+  // The slot keeps the native aspect outside its border; reserve both inner axes.
+  let stageFrameMinimum = $derived(segmentlineStage ? Math.ceil(Math.max(
+    segmentlineStage.canvas.w * segmentlineStage.minScale + 2 * frameBorder,
+    (segmentlineStage.canvas.h * segmentlineStage.minScale + 2 * frameBorder)
+      * segmentlineStage.canvas.w / segmentlineStage.canvas.h,
+  )) : undefined);
   let segmentlineDisplay: LcdDisplayVariantId = $derived(
     variant === 'unified-instrument' ? 'dominant'
       : variant === 'panadapter-first' ? 'panadapter'
@@ -120,11 +127,12 @@
   });
 </script>
 
-<div class="lcd-layout">
+<div class="lcd-layout" style:--lcd-frame-border={`${frameBorder}px`}>
   <StatusBar {showManagedTotControl} />
   <KeyboardHandler config={keyboardConfig} onAction={keyboardHandlers.dispatch} />
 
-  <section class="content-row">
+  <section class="content-row" class:fixed-native-stage={!!segmentlineStage}
+    style:--stage-frame-minimum={stageFrameMinimum === undefined ? undefined : `${stageFrameMinimum}px`}>
     <div class="content-left">
       <LeftSidebar hideTxPanel />
     </div>
@@ -212,6 +220,12 @@
     gap: 5px;
     min-height: 0;
     overflow: hidden;
+  }
+
+  .content-row.fixed-native-stage {
+    /* Keep controls usable below the stage floor; the whole row scrolls. */
+    grid-template-columns: minmax(216px, 228px) minmax(var(--stage-frame-minimum), 1fr) minmax(216px, 228px);
+    overflow-x: auto;
   }
 
   .content-left,
@@ -347,7 +361,7 @@
     min-width: 0;
     overflow: hidden;
     background: var(--v2-bg-card);
-    border: 1px solid var(--v2-border-darker);
+    border: var(--lcd-frame-border) solid var(--v2-border-darker);
     border-radius: 4px;
   }
 </style>

--- a/frontend/src/skins/segmentline/CenterstageDisplay.svelte
+++ b/frontend/src/skins/segmentline/CenterstageDisplay.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LcdTxMeterScales from './LcdTxMeterScales.svelte';
   import type {
     DisplayValue,
     PeerSplitDisplayModel,
@@ -86,9 +87,6 @@
   const telemetry = $derived([
     { label: 'VD', field: model.telemetry.drainVoltage },
     { label: 'ID', field: model.telemetry.drainCurrent },
-    { label: 'PWR', field: model.telemetry.power },
-    { label: 'SWR', field: model.telemetry.swr },
-    { label: 'ALC', field: model.telemetry.alc },
     { label: 'COMP', field: model.telemetry.compression },
   ]);
 </script>
@@ -175,6 +173,7 @@
         style:visibility={item.field.state === 'unsupported' ? 'hidden' : 'visible'}
       ><small>{item.label}</small> {telemetryText(item.field)}</span>
     {/each}
+    <LcdTxMeterScales power={model.telemetry.power} swr={model.telemetry.swr} alc={model.telemetry.alc} />
   </footer>
 </div>
 

--- a/frontend/src/skins/segmentline/LcdTelemetryRail.svelte
+++ b/frontend/src/skins/segmentline/LcdTelemetryRail.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LcdTxMeterScales from './LcdTxMeterScales.svelte';
   import type { PeerSplitDisplayModel } from '../../semantic/radio-display-model';
   import { telemetryText, telemetryDescription } from './lcd-display-helpers';
 
@@ -11,9 +12,6 @@
   const items = $derived([
     { label: 'VD', field: model.drainVoltage },
     { label: 'ID', field: model.drainCurrent },
-    { label: 'PWR', field: model.power },
-    { label: 'SWR', field: model.swr },
-    { label: 'ALC', field: model.alc },
     { label: 'COMP', field: model.compression },
   ]);
 </script>
@@ -22,13 +20,14 @@
   <div class="memory-seam" data-state="unsupported" aria-hidden="true">
     {#each [0, 1, 2, 3] as slot}<span data-memory-slot={slot}>MEM</span>{/each}
   </div>
-  <div class="telemetry">
+  <div class="telemetry" style:row-gap="0">
     {#each items as item}
       <span class:irrelevant={!item.field.relevant} data-state={item.field.state}
         role="group" aria-label={telemetryDescription(item.label, item.field)}>
         <small>{item.label}</small> {telemetryText(item.field)}
       </span>
     {/each}
+    <LcdTxMeterScales power={model.power} swr={model.swr} alc={model.alc} />
   </div>
 </footer>
 
@@ -44,7 +43,8 @@
   .memory-seam { display: flex; gap: 5px; color: var(--ink-ghost); font-size: 9px; letter-spacing: 0.1em; }
   .memory-seam span { min-width: 42px; padding: 2px 5px; border: 1px solid currentColor; }
   .memory-seam[data-state='unsupported'] { visibility: hidden; }
-  .telemetry { display: flex; gap: 14px; align-items: center; color: var(--ink-telemetry); font-size: 10px; }
+  .telemetry { flex: 1; justify-content: flex-end; display: flex; gap: 14px; align-items: center; color: var(--ink-telemetry); font-size: 10px; }
+  .telemetry > span { line-height: 10px; }
   .telemetry small { opacity: 0.7; font-size: inherit; }
   .telemetry .irrelevant { opacity: 0.34; }
   .telemetry [data-state='unsupported'] { visibility: hidden; }

--- a/frontend/src/skins/segmentline/LcdTxMeterScales.svelte
+++ b/frontend/src/skins/segmentline/LcdTxMeterScales.svelte
@@ -22,10 +22,11 @@
   {#each items as item (item.label)}
     {@const tx = item.field.txDisplay}
     {#if tx?.supported}
+      {@const readout = telemetryText(item.field, item.format)}
       {@const fraction = tx.relevance !== 'idle' && tx.observation.state === 'current' ? item.level(tx.observation.value) : 0}
       <div class="tx-scale" data-tx-scale={item.label} role="group"
         aria-label={telemetryDescription(item.label, item.field, item.format)}>
-        <small>{item.label}</small> <span class="readout">{telemetryText(item.field, item.format)}</span>
+        <small>{item.label}</small> <span class="readout" class:long-readout={readout.length > 8}>{readout}</span>
         <svg viewBox={`0 0 ${width} 6`} preserveAspectRatio="none" aria-hidden="true">
           {#each Array(count) as _, index}
             {@const fill = Math.max(0, Math.min(1, fraction * count - index))}
@@ -41,9 +42,10 @@
 </div>
 
 <style>
-  .lcd-tx-scales { display: grid; grid-template-columns: repeat(auto-fit, minmax(84px, 1fr)); gap: 12px; flex: 1; min-width: 0; max-width: 600px; grid-column: 1 / -1; }
-  .tx-scale { display: grid; grid-template-columns: auto minmax(0, 1fr); grid-template-rows: 12px 6px; gap: 2px 5px; min-width: 0; color: var(--ink-soft); font-size: 10px; line-height: 12px; }
+  .lcd-tx-scales { display: grid; grid-template-columns: repeat(auto-fit, minmax(84px, 1fr)); gap: 2px; flex: 1; min-width: 0; max-width: 600px; grid-column: 1 / -1; }
+  .tx-scale { display: grid; grid-template-columns: auto minmax(0, 1fr); grid-template-rows: 16px 6px; gap: 2px 0; min-width: 0; color: var(--ink-soft); font-size: 16px; line-height: 16px; }
   small { font: inherit; }
   .readout { text-align: right; white-space: nowrap; }
+  .long-readout { font-size: 14px; }
   svg { display: block; width: 100%; height: 6px; grid-column: 1 / -1; outline: 1px solid var(--ink-ghost); }
 </style>

--- a/frontend/src/skins/segmentline/LcdTxMeterScales.svelte
+++ b/frontend/src/skins/segmentline/LcdTxMeterScales.svelte
@@ -42,7 +42,7 @@
 </div>
 
 <style>
-  .lcd-tx-scales { display: grid; grid-template-columns: repeat(auto-fit, minmax(84px, 1fr)); gap: 2px; flex: 1; min-width: 0; max-width: 600px; grid-column: 1 / -1; }
+  .lcd-tx-scales { display: grid; grid-template-columns: repeat(auto-fit, minmax(84px, 1fr)); gap: 1px; flex: 1; min-width: 0; max-width: 600px; grid-column: 1 / -1; }
   .tx-scale { display: grid; grid-template-columns: auto minmax(0, 1fr); grid-template-rows: 16px 6px; gap: 2px 0; min-width: 0; color: var(--ink-soft); font-size: 16px; line-height: 16px; }
   small { font: inherit; }
   .readout { text-align: right; white-space: nowrap; }

--- a/frontend/src/skins/segmentline/LcdTxMeterScales.svelte
+++ b/frontend/src/skins/segmentline/LcdTxMeterScales.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import type { PeerSplitDisplayModel } from '../../semantic/radio-display-model';
+  import { SEGMENTLINE_SEGMENT_COUNT } from '../../presentation/languages/segmentline/meters-renderer';
+  import { SEGMENTLINE_TOKENS } from '../../presentation/languages/segmentline/tokens';
+  import { normalizePower, formatPowerWatts, swrLevel, formatSwr, alcLevel, formatAlc } from '../../components-v2/panels/meter-utils';
+  import { telemetryText, telemetryDescription } from './lcd-display-helpers';
+
+  let { power, swr, alc }: Pick<PeerSplitDisplayModel['telemetry'], 'power' | 'swr' | 'alc'> = $props();
+  const count = SEGMENTLINE_SEGMENT_COUNT;
+  const segmentWidth = Number.parseFloat(SEGMENTLINE_TOKENS.meters.trackWidth);
+  const gap = Number.parseFloat(SEGMENTLINE_TOKENS.meters.segmentGap);
+  const pitch = segmentWidth + gap;
+  const width = count * pitch - gap;
+  const items = $derived([
+    { label: 'PWR', field: power, level: normalizePower, format: formatPowerWatts },
+    { label: 'SWR', field: swr, level: swrLevel, format: formatSwr },
+    { label: 'ALC', field: alc, level: alcLevel, format: formatAlc },
+  ]);
+</script>
+
+<div class="lcd-tx-scales" data-testid="lcd-tx-scales">
+  {#each items as item (item.label)}
+    {@const tx = item.field.txDisplay}
+    {#if tx?.supported}
+      {@const fraction = tx.relevance !== 'idle' && tx.observation.state === 'current' ? item.level(tx.observation.value) : 0}
+      <div class="tx-scale" data-tx-scale={item.label} role="group"
+        aria-label={telemetryDescription(item.label, item.field, item.format)}>
+        <small>{item.label}</small> <span class="readout">{telemetryText(item.field, item.format)}</span>
+        <svg viewBox={`0 0 ${width} 6`} preserveAspectRatio="none" aria-hidden="true">
+          {#each Array(count) as _, index}
+            {@const fill = Math.max(0, Math.min(1, fraction * count - index))}
+            <rect data-tx-segment={index} x={index * pitch} y="0" width={segmentWidth} height="6" fill="var(--ink-ghost)" />
+            {#if fill > 0}
+              <rect data-tx-fill={index} x={index * pitch} y="0" width={segmentWidth * fill} height="6" fill="var(--ink-strong)" />
+            {/if}
+          {/each}
+        </svg>
+      </div>
+    {/if}
+  {/each}
+</div>
+
+<style>
+  .lcd-tx-scales { display: grid; grid-template-columns: repeat(auto-fit, minmax(84px, 1fr)); gap: 12px; flex: 1; min-width: 0; max-width: 600px; grid-column: 1 / -1; }
+  .tx-scale { display: grid; grid-template-columns: auto minmax(0, 1fr); grid-template-rows: 12px 6px; gap: 2px 5px; min-width: 0; color: var(--ink-soft); font-size: 10px; line-height: 12px; }
+  small { font: inherit; }
+  .readout { text-align: right; white-space: nowrap; }
+  svg { display: block; width: 100%; height: 6px; grid-column: 1 / -1; outline: 1px solid var(--ink-ghost); }
+</style>

--- a/frontend/src/skins/segmentline/PanadapterDisplay.svelte
+++ b/frontend/src/skins/segmentline/PanadapterDisplay.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LcdTxMeterScales from './LcdTxMeterScales.svelte';
   import type { PeerSplitDisplayModel } from '../../semantic/radio-display-model';
   import LcdAfFft from './LcdAfFft.svelte';
   import LcdFilterScope from './LcdFilterScope.svelte';
@@ -37,9 +38,6 @@
   const telemetryItems = $derived([
     { label: 'VD', field: model.telemetry.drainVoltage },
     { label: 'ID', field: model.telemetry.drainCurrent },
-    { label: 'PWR', field: model.telemetry.power },
-    { label: 'SWR', field: model.telemetry.swr },
-    { label: 'ALC', field: model.telemetry.alc },
     { label: 'COMP', field: model.telemetry.compression },
   ]);
 </script>
@@ -113,6 +111,7 @@
             </span>
           {/if}
         {/each}
+        <LcdTxMeterScales power={model.telemetry.power} swr={model.telemetry.swr} alc={model.telemetry.alc} />
       </div>
     </aside>
   </div>
@@ -199,7 +198,9 @@
   .unknown-af-plot { min-height: 0; }
   .telemetry {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    min-height: 62px;
+    align-content: end;
     gap: 4px 10px;
     border-top: 1px solid var(--ink-soft);
     padding-top: 8px;

--- a/frontend/src/skins/segmentline/__tests__/LcdTxMeterScales.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/LcdTxMeterScales.component.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
+import type { DisplayTelemetry } from '../../../semantic/radio-display-model';
+import type { Capabilities } from '$lib/types/capabilities';
+import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
+import LcdTxMeterScales from '../LcdTxMeterScales.svelte';
+
+const field = (txDisplay: DisplayTelemetry['txDisplay']): DisplayTelemetry => ({
+  state: 'known', value: 207, relevant: true, txDisplay,
+});
+const current = (value: number): DisplayTelemetry => field({ supported: true, relevance: 'relevant', observation: { state: 'current', value } });
+function render(value: DisplayTelemetry) {
+  const props = proxy({ power: value, swr: value, alc: value });
+  const root = document.createElement('div'); document.body.append(root);
+  const component = mount(LcdTxMeterScales, { target: root, props }); flushSync();
+  return { root, props, close: () => { unmount(component); root.remove(); } };
+}
+afterEach(clearCapabilities);
+
+for (const supported of [false, true]) for (const relevance of ['idle', 'relevant', 'indeterminate'] as const)
+  for (const observation of [{ state: 'current', value: 128 }, { state: 'stale', value: 128 },
+    { state: 'unknown', reason: 'not-observed' }] as const) {
+    it(`${supported}/${relevance}/${observation.state}`, () => {
+      const { root, close } = render(field(supported ? { supported, relevance, observation } : { supported }));
+      try {
+        expect(root.querySelectorAll('[data-tx-scale]')).toHaveLength(supported ? 3 : 0);
+        expect(root.querySelectorAll('[data-tx-segment]')).toHaveLength(supported ? 60 : 0);
+        const measured = supported && relevance !== 'idle' && observation.state === 'current';
+        expect(root.querySelectorAll('[data-tx-fill]')).toHaveLength(measured ? 33 : 0);
+        for (const cell of root.querySelectorAll('[data-tx-scale]')) {
+          const text = cell.textContent ?? '';
+          expect(text).not.toContain('207');
+          expect(cell.getAttribute('aria-label')).not.toContain('207');
+          expect(text).toContain(relevance === 'idle' ? 'IDLE' : observation.state === 'stale' ? 'STALE' : observation.state === 'unknown' ? '?' : '128 raw');
+          if (!measured) expect(cell.getAttribute('aria-label')).not.toContain('128');
+          if (relevance === 'indeterminate') expect(cell.getAttribute('aria-label')).toContain('RF relevance indeterminate');
+        }
+        expect(root.querySelectorAll('button,input,select,[tabindex]')).toHaveLength(0);
+      } finally { close(); }
+    });
+  }
+
+it('retains tracks and segments when only the additive facet changes', () => {
+  const { root, props, close } = render(current(200));
+  try {
+    const nodes = [...root.querySelectorAll('[data-tx-scale],svg,[data-tx-segment]')];
+    props.power = props.swr = props.alc = field({ supported: true, relevance: 'idle', observation: { state: 'current', value: 200 } });
+    flushSync();
+    expect(nodes.every((node) => node.isConnected)).toBe(true);
+    expect(root.querySelectorAll('[data-tx-fill]')).toHaveLength(0);
+    expect(root.textContent).not.toMatch(/200|207/);
+    props.power = props.swr = props.alc = current(10); flushSync();
+    expect(nodes.every((node) => node.isConnected)).toBe(true);
+    expect(root.querySelectorAll('[data-tx-fill]')).toHaveLength(3);
+  } finally { close(); }
+});
+
+it('does not recover a legacy numeric reading when the facet is absent', () => {
+  const { root, close } = render(field(undefined));
+  try { expect(root.querySelectorAll('[data-tx-scale]')).toHaveLength(0); } finally { close(); }
+});
+
+function caps(): Capabilities {
+  return { model: 'test', scope: false, audio: false, tx: true, capabilities: ['tx'], receivers: 1,
+    vfoScheme: 'ab', freqRanges: [], modes: [], filters: [], txBands: null,
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['opus'] }, webrtc: { available: false, enabled: false },
+    stateContractVersion: 1, providerGeneration: 0,
+    meterCalibrations: {
+      power: [{ raw: 0, actual: 0, label: '0' }, { raw: 255, actual: 200, label: '200' }],
+      swr: [{ raw: 0, actual: 1, label: '1' }, { raw: 255, actual: 4, label: '4+' }],
+      alc: [{ raw: 0, actual: 0, label: '0' }, { raw: 255, actual: 1, label: '1' }],
+    },
+  };
+}
+
+describe('canonical meter calibration', () => {
+  it('uses a 200W maximum and SWR ratio without a second interpolation', () => {
+    setCapabilities(caps());
+    const { root, props, close } = render(current(100));
+    try {
+      expect(root.querySelector('[data-tx-scale="PWR"]')?.textContent).toContain('100W');
+      expect(root.querySelectorAll('[data-tx-scale="PWR"] [data-tx-fill]')).toHaveLength(10);
+      props.swr = current(2); props.alc = current(0.5); flushSync();
+      expect(root.querySelector('[data-tx-scale="SWR"]')?.textContent).toContain('2.0');
+      expect(root.querySelectorAll('[data-tx-scale="SWR"] [data-tx-fill]')).toHaveLength(10);
+      expect(root.querySelector('[data-tx-scale="ALC"]')?.textContent).toContain('50%');
+      expect(root.querySelectorAll('[data-tx-scale="ALC"] [data-tx-fill]')).toHaveLength(10);
+      props.power = props.swr = props.alc = current(0); flushSync();
+      expect(root.textContent).toContain('0W'); expect(root.textContent).toContain('1.0'); expect(root.textContent).toContain('0%');
+      expect(root.textContent).not.toContain('IDLE');
+      expect(root.querySelectorAll('[data-tx-fill]')).toHaveLength(0);
+    } finally { close(); }
+  });
+  it('uses an ALC redline without inventing a calibration table', () => {
+    const capabilities = caps(); capabilities.meterCalibrations = {}; capabilities.meterRedlines = { alc: 100 };
+    setCapabilities(capabilities);
+    const { root, close } = render(current(50));
+    try {
+      expect(root.querySelector('[data-tx-scale="ALC"]')?.textContent).toContain('50%');
+      expect(root.querySelectorAll('[data-tx-scale="ALC"] [data-tx-fill]')).toHaveLength(10);
+    } finally { close(); }
+  });
+});

--- a/frontend/src/skins/segmentline/__tests__/LcdTxMeterScales.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/LcdTxMeterScales.component.test.ts
@@ -103,3 +103,22 @@ describe('canonical meter calibration', () => {
     } finally { close(); }
   });
 });
+
+for (const calibrated of [false, true]) it(`keeps honest long ${calibrated ? 'calibrated' : 'raw'} uncertainty readouts`, () => {
+  if (calibrated) {
+    const capabilities = caps(); capabilities.meterCalibrations!.power![1].actual = 20000;
+    setCapabilities(capabilities);
+  }
+  const { root, props, close } = render(field({ supported: true, relevance: 'indeterminate',
+    observation: { state: 'current', value: calibrated ? 10000 : 255 } }));
+  try {
+    const cell = root.querySelector('[data-tx-scale="PWR"]')!, readout = cell.querySelector('.readout')!;
+    expect(readout.textContent).toBe(calibrated ? '10000W ?' : '255 raw ?');
+    expect(readout.classList.contains('long-readout')).toBe(!calibrated);
+    expect(cell.getAttribute('aria-label')).toContain(calibrated ? '10000W' : '255 raw');
+    expect(cell.getAttribute('aria-label')).toContain('RF relevance indeterminate');
+    expect(cell.querySelectorAll('[data-tx-fill]')).toHaveLength(calibrated ? 10 : 20);
+    props.power = current(0); flushSync();
+    expect(readout.isConnected).toBe(true); expect(readout.classList.contains('long-readout')).toBe(false);
+  } finally { close(); }
+});

--- a/frontend/src/skins/segmentline/__tests__/lcd-display-helpers.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/lcd-display-helpers.test.ts
@@ -135,3 +135,15 @@ for (const relevance of ['idle', 'relevant', 'indeterminate'] as const)
       if (relevance !== 'idle' && observation.state === 'unknown') expect(description).toContain('Not observed');
     });
   }
+
+it('delegates only a current TX observation to the optional formatter', () => {
+  const format = (value: number) => `${value}W`;
+  const current: DisplayTelemetry = { state: 'known', value: 207, relevant: true,
+    txDisplay: { supported: true, relevance: 'relevant', observation: { state: 'current', value: 100 } } };
+  expect(telemetryText(current, format)).toBe('100W');
+  expect(telemetryDescription('PWR', current, format)).toBe('PWR: Current observation: 100W');
+  const idle: DisplayTelemetry = { ...current, txDisplay: { supported: true, relevance: 'idle', observation: { state: 'current', value: 100 } } };
+  const forbidden = () => { throw new Error('unmeasured value formatted'); };
+  expect(telemetryText(idle, forbidden)).toBe('IDLE');
+  expect(telemetryDescription('PWR', idle, forbidden)).toBe('PWR: Not measuring in RX');
+});

--- a/frontend/src/skins/segmentline/__tests__/tx-meter-telemetry.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/tx-meter-telemetry.component.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
 // @ts-expect-error -- Svelte does not publish types for its reactive test harness.
 import { proxy } from 'svelte/internal/client';
@@ -9,6 +9,9 @@ import PeerSplitDisplay from '../PeerSplitDisplay.svelte';
 import DominantUnifiedDisplay from '../DominantUnifiedDisplay.svelte';
 import CenterstageDisplay from '../CenterstageDisplay.svelte';
 import PanadapterDisplay from '../PanadapterDisplay.svelte';
+
+import { clearCapabilities } from '$lib/stores/capabilities.svelte';
+afterEach(clearCapabilities);
 
 const variants = [PeerSplitDisplay, DominantUnifiedDisplay, CenterstageDisplay, PanadapterDisplay];
 const names = ['peer-split', 'dominant-unified', 'centerstage', 'panadapter'];
@@ -38,15 +41,14 @@ for (const [index, Component] of variants.entries()) describe(names[index], () =
           for (const label of targets) {
             const el = slot(root, label);
             if (!structural) {
-              if (Component === PanadapterDisplay) expect(el).toBeUndefined();
-              else expect(el?.dataset.state).toBe('unsupported');
+              expect(el).toBeUndefined();
               continue;
             }
             expect(el).toBeDefined();
             const idle = rf === 'receiving' && !relevant;
             const indeterminate = !idle && !(rf === 'transmitting' && relevant);
             const expected = idle ? 'IDLE' : observation.state === 'stale' ? 'STALE'
-              : observation.state === 'unknown' ? '?' : `12.35${indeterminate ? ' ?' : ''}`;
+              : observation.state === 'unknown' ? '?' : `12 raw${indeterminate ? ' ?' : ''}`;
             expect(el!.textContent?.trim()).toBe(`${label} ${expected}`);
             const description = el!.getAttribute('aria-label') ?? '';
             expect(description).toContain(label);
@@ -55,8 +57,12 @@ for (const [index, Component] of variants.entries()) describe(names[index], () =
             if (indeterminate) expect(description).toContain('RF relevance indeterminate');
             if (!idle && observation.state === 'stale') expect(description).toContain('Stale observation');
             if (!idle && observation.state === 'unknown') expect(description).toContain('Not observed');
-            if (!idle && observation.state === 'current') expect(description).toContain('12.35');
+            if (!idle && observation.state === 'current') expect(description).toContain('12 raw');
           }
+          expect(root.querySelectorAll('[data-testid="lcd-tx-scales"]')).toHaveLength(1);
+          expect(root.querySelectorAll('[data-tx-scale]')).toHaveLength(structural ? 3 : 0);
+          expect(root.querySelectorAll('[data-tx-segment]')).toHaveLength(structural ? 60 : 0);
+          expect(root.querySelectorAll('[data-tx-fill]')).toHaveLength(structural && !(rf === 'receiving' && !relevant) && observation.state === 'current' ? 3 : 0);
           expect(root.querySelectorAll('button,input,select,textarea')).toHaveLength(0);
         } finally { unmount(component); root.remove(); }
       });
@@ -67,12 +73,15 @@ for (const [index, Component] of variants.entries()) describe(names[index], () =
     const component = mount(Component, { target: root, props }); flushSync();
     try {
       const nodes = targets.map((label) => slot(root, label)!);
+      const tracks = [...root.querySelectorAll('[data-tx-segment], [data-tx-scale] svg')];
+      const protectedNodes = [...root.querySelectorAll('.frequency,.s-meter,.scope-block,.rf-plot')];
       const other = ['VD', 'ID', 'COMP'].map((label) => slot(root, label)!.textContent);
       for (const [rf, relevant, observation, text] of [
         ['receiving', false, observations[0], 'IDLE'], ['transmitting', true, observations[1], 'STALE'],
-        ['transmitting', true, observations[2], '?'], ['transmitting', true, { state: 'current', value: 0 }, '0'],
+        ['transmitting', true, observations[2], '?'], ['transmitting', true, { state: 'current', value: 0 }, '0 raw'],
       ] as const) {
         props.model = model(rf, relevant, observation); flushSync();
+        expect([...tracks, ...protectedNodes].every((node) => node.isConnected)).toBe(true);
         expect(nodes.every((node, i) => node === slot(root, targets[i]) && node.isConnected)).toBe(true);
         expect(nodes.map((node) => node.textContent?.trim())).toEqual(targets.map((label) => `${label} ${text}`));
         expect(['VD', 'ID', 'COMP'].map((label) => slot(root, label)!.textContent)).toEqual(other);

--- a/frontend/src/skins/segmentline/lcd-display-helpers.ts
+++ b/frontend/src/skins/segmentline/lcd-display-helpers.ts
@@ -39,17 +39,19 @@ export function meterFill(field: DisplayValue<number>): number {
     : 0;
 }
 
-export function telemetryText(field: DisplayTelemetry): string {
+const numericTelemetry = (value: number): string => String(Number(value.toFixed(2)));
+
+export function telemetryText(field: DisplayTelemetry, format = numericTelemetry): string {
   const tx = field.txDisplay;
-  if (!tx) return field.state === 'known' ? String(Number(field.value.toFixed(2))) : '?';
+  if (!tx) return field.state === 'known' ? numericTelemetry(field.value) : '?';
   if (!tx.supported) return '?';
   if (tx.relevance === 'idle') return 'IDLE';
   if (tx.observation.state === 'stale') return 'STALE';
   if (tx.observation.state !== 'current') return '?';
-  return `${Number(tx.observation.value.toFixed(2))}${tx.relevance === 'indeterminate' ? ' ?' : ''}`;
+  return `${format(tx.observation.value)}${tx.relevance === 'indeterminate' ? ' ?' : ''}`;
 }
 
-export function telemetryDescription(label: string, field: DisplayTelemetry): string {
+export function telemetryDescription(label: string, field: DisplayTelemetry, format = numericTelemetry): string {
   const tx = field.txDisplay;
   if (!tx) return `${label}: ${field.state === 'known' ? telemetryText(field)
     : field.state === 'unsupported' ? 'Unsupported' : 'Not observed'}`;
@@ -57,7 +59,7 @@ export function telemetryDescription(label: string, field: DisplayTelemetry): st
   if (tx.relevance === 'idle') return `${label}: Not measuring in RX`;
   const cue = tx.relevance === 'indeterminate' ? 'RF relevance indeterminate. ' : '';
   return `${label}: ${cue}${tx.observation.state === 'stale' ? 'Stale observation'
-    : tx.observation.state === 'current' ? `Current observation: ${Number(tx.observation.value.toFixed(2))}` : 'Not observed'}`;
+    : tx.observation.state === 'current' ? `Current observation: ${format(tx.observation.value)}` : 'Not observed'}`;
 }
 
 function envelope(

--- a/frontend/tests/e2e/visual/visual-baselines.spec.ts
+++ b/frontend/tests/e2e/visual/visual-baselines.spec.ts
@@ -42,6 +42,7 @@ const FROZEN_CLOCK = new Date('2026-01-01T14:32:00Z');
 interface Spec {
   name: string;
   fixture: string;
+  display?: 'centerstage';
   language?: 'studioline' | 'fieldline';
   mode?: 'light';
   viewport?: typeof DESKTOP;
@@ -89,6 +90,8 @@ const COCKPIT: Spec[] = [
   },
   { name: 'tx-phase-fault--desktop--fieldline', fixture: 'tx-phase-fault', language: 'fieldline' },
   { name: 'peer-split-chassis--desktop', fixture: 'peer-split-chassis', freezeClock: true },
+  { name: 'centerstage--desktop', fixture: 'peer-split-chassis', display: 'centerstage', freezeClock: true },
+  { name: 'centerstage--1100x800', fixture: 'peer-split-chassis', display: 'centerstage', viewport: NARROW, freezeClock: true },
   { name: 'unified-instrument--desktop', fixture: 'lcd-unified-instrument' },
   { name: 'panadapter-first--desktop', fixture: 'lcd-panadapter-first' },
   {
@@ -109,7 +112,8 @@ for (const spec of COCKPIT) {
     await page.setViewportSize(spec.viewport ?? DESKTOP);
     const url = `/fixtures/index.html?fixture=${spec.fixture}&theme=v2`
       + (spec.language ? `&language=${spec.language}` : '')
-      + (spec.mode ? `&mode=${spec.mode}` : '');
+      + (spec.mode ? `&mode=${spec.mode}` : '')
+      + (spec.display ? `&display=${spec.display}` : '');
     await page.goto(url, { waitUntil: 'load' });
     await page.waitForSelector('body[data-harness-ready="true"]');
     await expect(page).toHaveScreenshot(`${spec.name}.png`, { animations: 'disabled', caret: 'hide' });
@@ -200,5 +204,76 @@ for (const compact of [true, false]) for (const stateText of ['IDLE', 'STALE', '
     expect(Math.max(...geometry.oldOverlap.overlaps)).toBeGreaterThan(0);
     expect(geometry.oldOverlap.readings).toEqual(geometry.actual.readings);
     expect(geometry.restored).toEqual(geometry.actual);
+  });
+}
+
+const LCD_TX_GEOMETRY = [
+  ['peer-split', 'peer-split-chassis&display=peer', 'peer-split-display', 540],
+  ['dominant', 'lcd-unified-instrument', 'dominant-unified-display', 540],
+  ['centerstage', 'peer-split-chassis&display=centerstage', 'centerstage-display', 540],
+  ['panadapter', 'lcd-panadapter-first', 'panadapter-display', 594],
+] as const;
+for (const viewport of [DESKTOP, NARROW]) for (const [variant, fixture, testId, nativeHeight] of LCD_TX_GEOMETRY) {
+  test(`LCD TX geometry -- ${variant} -- ${viewport.width}`, async ({ page }, testInfo) => {
+    await page.setViewportSize(viewport);
+    await page.goto(`/fixtures/index.html?fixture=${fixture}&theme=v2`);
+    await page.waitForSelector('body[data-harness-ready="true"]');
+    await page.evaluate(() => document.fonts.ready);
+    const result = await page.getByTestId(testId).evaluate((display) => {
+      const group = display.querySelector<HTMLElement>('[data-testid="lcd-tx-scales"]')!;
+      const stage = display.closest<HTMLElement>('.scaled-stage')!;
+      const box = (node: Element) => {
+        const { x, y, width, height } = node.getBoundingClientRect();
+        return { x, y, width, height };
+      };
+      const overlap = (a: Element, b: Element) => {
+        const aa = a.getBoundingClientRect(), bb = b.getBoundingClientRect();
+        return Math.max(0, Math.min(aa.right, bb.right) - Math.max(aa.left, bb.left))
+          * Math.max(0, Math.min(aa.bottom, bb.bottom) - Math.max(aa.top, bb.top));
+      };
+      const contained = (child: Element, parent: Element) => {
+        const a = child.getBoundingClientRect(), b = parent.getBoundingClientRect();
+        return a.left >= b.left - 0.5 && a.right <= b.right + 0.5 && a.top >= b.top - 0.5 && a.bottom <= b.bottom + 0.5;
+      };
+      const protectedNodes = [...display.querySelectorAll('.frequency,.s-meter,.scope-block,.rf-plot,.af-block')];
+      const before = protectedNodes.map(box);
+      const cells = [...group.querySelectorAll<HTMLElement>('[data-tx-scale]')];
+      const geometry = cells.map((cell) => {
+        const label = cell.querySelector('small')!, value = cell.querySelector('.readout')!, track = cell.querySelector('svg')!;
+        return { label: label.textContent, box: box(cell), textHeight: box(value).height,
+          nativeFontSize: parseFloat(getComputedStyle(value).fontSize),
+          contained: [label, value, track].every((node) => contained(node, cell)) && contained(cell, display),
+          overlap: overlap(label, value), overflow: cell.scrollWidth > cell.clientWidth,
+          segments: cell.querySelectorAll('[data-tx-segment]').length,
+          segmentsVisible: [...cell.querySelectorAll('[data-tx-segment]')].every((node) => box(node).width > 0 && box(node).height > 0),
+          measured: cell.querySelectorAll('[data-tx-fill]').length,
+        };
+      });
+      const otherText = [...display.querySelectorAll('small')].filter((node) => ['VD', 'ID', 'COMP'].includes(node.textContent ?? '')).map((node) => node.parentElement!);
+      const overlaps = otherText.flatMap((node) => cells.map((cell) => overlap(node, cell)));
+      group.style.display = 'none';
+      const withoutScales = protectedNodes.map(box);
+      group.style.removeProperty('display');
+      group.style.width = '20px'; group.style.flex = 'none';
+      const squeezedOverflow = group.scrollWidth > group.clientWidth;
+      group.style.removeProperty('width'); group.style.removeProperty('flex');
+      return { group: box(group), geometry, overlaps, squeezedOverflow, before, withoutScales,
+        restored: protectedNodes.map(box), stage: { width: stage.offsetWidth, height: stage.offsetHeight },
+        railHeight: display.querySelector<HTMLElement>('.aux-rail,.telemetry-only,[data-testid="panadapter-telemetry"]')!.offsetHeight,
+        controls: display.querySelectorAll('button,input,select,[tabindex]').length };
+    });
+    await testInfo.attach('lcd-tx-geometry', { body: JSON.stringify(result, null, 2), contentType: 'application/json' });
+    expect(result.stage).toEqual({ width: 1280, height: nativeHeight });
+    expect(result.railHeight).toBe(variant === 'dominant' ? 35 : variant === 'panadapter' ? 62 : 31);
+    expect(result.geometry.map((cell) => cell.label)).toEqual(['PWR', 'SWR', 'ALC']);
+    for (const cell of result.geometry) {
+      expect(cell.contained).toBe(true); expect(cell.overflow).toBe(false); expect(cell.overlap).toBe(0);
+      expect(cell.segments).toBe(20); expect(cell.segmentsVisible).toBe(true); expect(cell.measured).toBe(0);
+      expect(cell.nativeFontSize).toBeGreaterThanOrEqual(10); expect(cell.textHeight).toBeGreaterThan(0);
+    }
+    expect(result.overlaps.every((area) => area === 0)).toBe(true);
+    expect(result.before.length).toBeGreaterThan(3);
+    expect(result.withoutScales).toEqual(result.before); expect(result.restored).toEqual(result.before);
+    expect(result.squeezedOverflow).toBe(true); expect(result.controls).toBe(0);
   });
 }

--- a/frontend/tests/e2e/visual/visual-baselines.spec.ts
+++ b/frontend/tests/e2e/visual/visual-baselines.spec.ts
@@ -218,7 +218,12 @@ for (const viewport of [DESKTOP, NARROW]) for (const [variant, fixture, testId, 
     await page.setViewportSize(viewport);
     await page.goto(`/fixtures/index.html?fixture=${fixture}&theme=v2`);
     await page.waitForSelector('body[data-harness-ready="true"]');
-    await page.evaluate(() => document.fonts.ready);
+    const fonts = await page.evaluate(async () => {
+      const loaded = await document.fonts.load('16px "Share Tech Mono"', 'PWR SWR ALC IDLE STALE 10000W ? 255 raw ?');
+      await document.fonts.ready;
+      return loaded.map((font) => ({ family: font.family, status: font.status }));
+    });
+    expect(fonts).toEqual([{ family: 'Share Tech Mono', status: 'loaded' }]);
     const result = await page.getByTestId(testId).evaluate((display) => {
       const group = display.querySelector<HTMLElement>('[data-testid="lcd-tx-scales"]')!;
       const stage = display.closest<HTMLElement>('.scaled-stage')!;
@@ -263,8 +268,10 @@ for (const viewport of [DESKTOP, NARROW]) for (const [variant, fixture, testId, 
         const value = cell.querySelector<HTMLElement>('.readout')!, label = cell.querySelector('small')!;
         const previous = value.textContent; value.textContent = text;
         value.classList.toggle('long-readout', text.length > 8);
-        const result = { text, effectiveFont: parseFloat(getComputedStyle(value).fontSize) * scale,
-          height: box(value).height, overflow: value.scrollWidth > value.clientWidth || cell.scrollWidth > cell.clientWidth,
+        const range = document.createRange(); range.selectNodeContents(value);
+        const renderedWidth = range.getBoundingClientRect().width, availableWidth = box(value).width;
+        const result = { text, renderedWidth, availableWidth, font: getComputedStyle(value).fontFamily, effectiveFont: parseFloat(getComputedStyle(value).fontSize) * scale,
+          height: box(value).height, overflow: renderedWidth > availableWidth || value.scrollWidth > value.clientWidth || cell.scrollWidth > cell.clientWidth,
           overlap: overlap(label, value), contained: contained(value, cell) && contained(cell, rail),
           protectedBounds: protectedNodes.map(box) };
         value.textContent = previous; value.classList.remove('long-readout');
@@ -297,7 +304,7 @@ for (const viewport of [DESKTOP, NARROW]) for (const [variant, fixture, testId, 
     }
     for (const readout of result.longReadouts) {
       expect(readout.effectiveFont).toBeGreaterThanOrEqual(readout.text.length > 8 ? 7 : 8);
-      expect(readout.height).toBeGreaterThanOrEqual(8); expect(readout.overflow).toBe(false);
+      expect(readout.height).toBeGreaterThanOrEqual(8); expect(readout.overflow, JSON.stringify({ ...readout, protectedBounds: undefined, fonts })).toBe(false);
       expect(readout.overlap).toBe(0); expect(readout.contained).toBe(true);
       expect(readout.protectedBounds).toEqual(result.before);
     }

--- a/frontend/tests/e2e/visual/visual-baselines.spec.ts
+++ b/frontend/tests/e2e/visual/visual-baselines.spec.ts
@@ -238,10 +238,19 @@ for (const viewport of [DESKTOP, NARROW]) for (const [variant, fixture, testId, 
       const protectedNodes = [...display.querySelectorAll('.frequency,.s-meter,.scope-block,.rf-plot,.af-block')];
       const before = protectedNodes.map(box);
       const cells = [...group.querySelectorAll<HTMLElement>('[data-tx-scale]')];
+      const scale = box(stage).width / stage.offsetWidth;
+      const rail = display.querySelector<HTMLElement>('.aux-rail,.telemetry-only,[data-testid="panadapter-telemetry"]')!;
+      const visibleAncestors: Element[] = [];
+      for (let parent = group.parentElement; parent; parent = parent.parentElement) {
+        if (getComputedStyle(parent).overflow !== 'visible') visibleAncestors.push(parent);
+      }
       const geometry = cells.map((cell) => {
         const label = cell.querySelector('small')!, value = cell.querySelector('.readout')!, track = cell.querySelector('svg')!;
         return { label: label.textContent, box: box(cell), textHeight: box(value).height,
-          nativeFontSize: parseFloat(getComputedStyle(value).fontSize),
+          effectiveFont: parseFloat(getComputedStyle(value).fontSize) * scale,
+          labelFont: parseFloat(getComputedStyle(label).fontSize) * scale, labelHeight: box(label).height,
+          trackHeight: box(track).height, railContained: contained(cell, rail),
+          ancestorContained: visibleAncestors.every((parent) => contained(cell, parent)),
           contained: [label, value, track].every((node) => contained(node, cell)) && contained(cell, display),
           overlap: overlap(label, value), overflow: cell.scrollWidth > cell.clientWidth,
           segments: cell.querySelectorAll('[data-tx-segment]').length,
@@ -249,6 +258,18 @@ for (const viewport of [DESKTOP, NARROW]) for (const [variant, fixture, testId, 
           measured: cell.querySelectorAll('[data-tx-fill]').length,
         };
       });
+      // Geometry probes preserve canonical strings; component tests verify formatter/class selection.
+      const longReadouts = ['10000W ?', '255 raw ?'].flatMap((text) => cells.map((cell) => {
+        const value = cell.querySelector<HTMLElement>('.readout')!, label = cell.querySelector('small')!;
+        const previous = value.textContent; value.textContent = text;
+        value.classList.toggle('long-readout', text.length > 8);
+        const result = { text, effectiveFont: parseFloat(getComputedStyle(value).fontSize) * scale,
+          height: box(value).height, overflow: value.scrollWidth > value.clientWidth || cell.scrollWidth > cell.clientWidth,
+          overlap: overlap(label, value), contained: contained(value, cell) && contained(cell, rail),
+          protectedBounds: protectedNodes.map(box) };
+        value.textContent = previous; value.classList.remove('long-readout');
+        return result;
+      }));
       const otherText = [...display.querySelectorAll('small')].filter((node) => ['VD', 'ID', 'COMP'].includes(node.textContent ?? '')).map((node) => node.parentElement!);
       const overlaps = otherText.flatMap((node) => cells.map((cell) => overlap(node, cell)));
       group.style.display = 'none';
@@ -257,23 +278,87 @@ for (const viewport of [DESKTOP, NARROW]) for (const [variant, fixture, testId, 
       group.style.width = '20px'; group.style.flex = 'none';
       const squeezedOverflow = group.scrollWidth > group.clientWidth;
       group.style.removeProperty('width'); group.style.removeProperty('flex');
-      return { group: box(group), geometry, overlaps, squeezedOverflow, before, withoutScales,
+      return { group: box(group), geometry, longReadouts, overlaps, squeezedOverflow, before, withoutScales,
         restored: protectedNodes.map(box), stage: { width: stage.offsetWidth, height: stage.offsetHeight },
         railHeight: display.querySelector<HTMLElement>('.aux-rail,.telemetry-only,[data-testid="panadapter-telemetry"]')!.offsetHeight,
         controls: display.querySelectorAll('button,input,select,[tabindex]').length };
     });
     await testInfo.attach('lcd-tx-geometry', { body: JSON.stringify(result, null, 2), contentType: 'application/json' });
     expect(result.stage).toEqual({ width: 1280, height: nativeHeight });
-    expect(result.railHeight).toBe(variant === 'dominant' ? 35 : variant === 'panadapter' ? 62 : 31);
+    expect(result.railHeight).toBe(variant === 'dominant' ? 39 : variant === 'panadapter' ? 62 : 31);
     expect(result.geometry.map((cell) => cell.label)).toEqual(['PWR', 'SWR', 'ALC']);
     for (const cell of result.geometry) {
       expect(cell.contained).toBe(true); expect(cell.overflow).toBe(false); expect(cell.overlap).toBe(0);
       expect(cell.segments).toBe(20); expect(cell.segmentsVisible).toBe(true); expect(cell.measured).toBe(0);
-      expect(cell.nativeFontSize).toBeGreaterThanOrEqual(10); expect(cell.textHeight).toBeGreaterThan(0);
+      expect(cell.effectiveFont).toBeGreaterThanOrEqual(8); expect(cell.textHeight).toBeGreaterThanOrEqual(8);
+      expect(cell.labelFont).toBeGreaterThanOrEqual(8); expect(cell.labelHeight).toBeGreaterThanOrEqual(8);
+      expect(cell.trackHeight).toBeGreaterThanOrEqual(3); expect(cell.railContained).toBe(true);
+      expect(cell.ancestorContained).toBe(true);
+    }
+    for (const readout of result.longReadouts) {
+      expect(readout.effectiveFont).toBeGreaterThanOrEqual(readout.text.length > 8 ? 7 : 8);
+      expect(readout.height).toBeGreaterThanOrEqual(8); expect(readout.overflow).toBe(false);
+      expect(readout.overlap).toBe(0); expect(readout.contained).toBe(true);
+      expect(readout.protectedBounds).toEqual(result.before);
     }
     expect(result.overlaps.every((area) => area === 0)).toBe(true);
     expect(result.before.length).toBeGreaterThan(3);
     expect(result.withoutScales).toEqual(result.before); expect(result.restored).toEqual(result.before);
     expect(result.squeezedOverflow).toBe(true); expect(result.controls).toBe(0);
+  });
+}
+
+for (const width of [1280, 1100, 1000, 760]) for (const [variant, fixture, , nativeHeight] of LCD_TX_GEOMETRY.filter(([name]) => name === 'dominant' || name === 'panadapter')) {
+  test(`LCD shell fit -- ${variant} -- ${width}`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width, height: 800 });
+    await page.goto(`/fixtures/index.html?fixture=${fixture}&theme=v2`);
+    await page.waitForSelector('body[data-harness-ready="true"]');
+    await page.evaluate(() => document.fonts.ready);
+    if (width < 1100) {
+      const row = page.locator('.content-row'), bounds = (await row.boundingBox())!;
+      await page.mouse.move(bounds.x + 1, bounds.y + 1); await page.mouse.wheel(400, 0);
+      await expect.poll(() => row.evaluate((node) => node.scrollLeft)).toBeGreaterThan(0);
+      await row.evaluate((node) => { node.scrollLeft = 0; });
+    }
+    const result = await page.evaluate(() => {
+      const row = document.querySelector<HTMLElement>('.content-row')!, frame = row.querySelector<HTMLElement>('.lcd-frame')!;
+      const stage = frame.querySelector<HTMLElement>('.scaled-stage')!, holder = frame.querySelector<HTMLElement>('.scaled-stage-holder')!;
+      const border = parseFloat(getComputedStyle(frame).borderLeftWidth), w = stage.offsetWidth, h = stage.offsetHeight;
+      const floor = Math.ceil(Math.max(w * 0.5 + 2 * border, (h * 0.5 + 2 * border) * w / h));
+      const box = (node: Element) => node.getBoundingClientRect();
+      const horizontal = (a: DOMRect, b: DOMRect) => a.left >= b.left - 0.5 && a.right <= b.right + 0.5;
+      const sides = [...row.querySelectorAll<HTMLElement>('.content-left,.content-right')].map((side) => {
+        const controls = [...side.querySelectorAll<HTMLElement>('button,input,select,[tabindex]')].filter((node) => box(node).width > 0);
+        const labels = controls.filter((node) => node.tagName === 'BUTTON').map((node) => {
+          const range = document.createRange(); range.selectNodeContents(node);
+          return horizontal(range.getBoundingClientRect(), box(node));
+        });
+        const control = controls.filter((node) => !node.matches(':disabled')).at(-1)!;
+        control.focus(); control.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+        const r = box(control), hit = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+        return { width: box(side).width, count: controls.length, contained: controls.every((node) => horizontal(box(node), box(side))),
+          labels: labels.every(Boolean), focused: document.activeElement === control, hit: hit === control || control.contains(hit) };
+      });
+      frame.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+      const s = box(stage), f = box(frame), inner = box(holder), viewport = box(row);
+      const stageVisible = horizontal(s, inner) && s.top >= inner.top - 0.5 && s.bottom <= inner.bottom + 0.5
+        && horizontal(s, f) && horizontal(s, viewport);
+      const scroll = row.scrollWidth - row.clientWidth, native = { w, h }, center = f.width;
+      // The absence of a resolved stage retains the cockpit/scope grid rule.
+      row.classList.remove('fixed-native-stage');
+      const fallback = getComputedStyle(row).gridTemplateColumns.split(' ').map(parseFloat);
+      row.classList.add('fixed-native-stage'); row.scrollLeft = 0;
+      return { floor, native, center, stageVisible, sides, scroll, fallback };
+    });
+    await testInfo.attach('lcd-shell-fit', { body: JSON.stringify(result), contentType: 'application/json' });
+    expect(result.native).toEqual({ w: 1280, h: nativeHeight });
+    expect(result.center).toBeGreaterThanOrEqual(result.floor); expect(result.stageVisible).toBe(true);
+    expect(result.sides.map((side) => side.count)).toEqual([53, 31]);
+    for (const side of result.sides) {
+      expect(side.width).toBe(width === 1280 ? 228 : width === 1100 ? 217.5 : 216);
+      expect(side.contained && side.labels && side.focused && side.hit).toBe(true);
+    }
+    expect(result.fallback).toEqual([228, width - 476, 228]);
+    expect(result.scroll > 0).toBe(width < 1100);
   });
 }


### PR DESCRIPTION
Source freeze: 10 code files + 0 regenerated baseline files = 10 files, 433 changed lines. The coordinator-authorized exception permits the reviewed final baseline set up to 19 files; replace this line with actual final counts after adoption.

LCD Power, SWR and ALC previously had text readings without persistent printed scales. Add one passive 20-segment LCD component across Peer, Dominant, Centerstage and Panadapter. Supported scales retain their DOM while RX shows empty IDLE, stale/missing observations remain empty with their cue, and current readings use canonical capability calibration and honest units, including zero and raw values. The full shared TX display facet remains authoritative; VD/ID/COMP output is preserved.

Keep labels and ordinary readouts at least 8 effective pixels, with a 7px minimum for long honest readouts such as `255 raw ?`. Reserve the declared native stage floor and frame border in the LCD shell. Sidebars retain 228px preferred width, shrink to a usable 216px floor, then the entire constrained row scrolls horizontally. Native canvases and proportions are unchanged; 1280 primary geometry is exact, while 1100 gains the small uniform scale/position adjustment required to show the whole stage. Cockpit/scope keep their existing grid.

Validation: 316 focused tests (301 meter/display cases plus 15 existing LCD-layout controls), 22 fixture browser checks, Svelte/TypeScript checks and focused lint passed. Browser checks explicitly load the bundled font and measure actual text Range widths, effective text size, honest long values, clipping ancestors, native geometry, sidebar control/label containment, focus/hit testing and real horizontal wheel scrolling at 1000/760. Eight shell mutations and six earlier readability mutations were detected; equivalent controls passed. No full local suite or hardware validation.

Pending before ready: exact Linux artifact inspection and conditional baseline adoption, final counts above, exact-head CI and independent review. MOR-1413 operator acceptance remains open; the 7px long-readout edge is explicit.

Current Linux validation is FAILED (test_failure): regeneration run 33993832517 at 9eadd814334033747e1547474400d0a377df0eb1 passed 51/53 tests but failed both Dominant long-readout cases. The logged loaded-font text Range for `10000W ?` exceeds its available width (44.9583 vs 42.8704px at 1280; 36.0146 vs 34.3420px at 1100). Local results above are macOS-only and do not establish Linux fit. No generated PNG or manifest has been adopted. The bounded correction cycle is stopped; this PR stays Draft pending a revised plan and owner continuation.
