### PR TITLE
feat(MOR-2367): project coherent scope display through one managed owner

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -24,6 +24,7 @@
   // whether the legacy twins are suppressed can never depend on some other
   // module having pulled the barrel in first.
   import '../../presentation/layouts/declarations';
+  import type { ManagedScopeRegion } from '$lib/runtime/adapters/scope-display-projection';
   import SpectrumPanel from '../../components/spectrum/SpectrumPanel.svelte';
   import LeftSidebar from './LeftSidebar.svelte';
   import RightSidebar from './RightSidebar.svelte';
@@ -272,13 +273,15 @@
   });
 </script>
 
-{#snippet sdrRegionContent(scopeControls: Snippet | undefined)}
+{#snippet sdrRegionContent(scopeControls: Snippet | undefined, managedScope: ManagedScopeRegion | undefined)}
   <section class="content-row">
     <main class="content-center center-column">
       {#if hasAnyScope()}
         <div class="spectrum-slot">
           <div class="spectrum-frame">
-            <SpectrumPanel hideSourceControls={true} hideScopeControls={declared.has('scopeControls')} {scopeControls} />
+            <SpectrumPanel hideSourceControls={true} hideScopeControls={declared.has('scopeControls')} {scopeControls}
+              scopeProjection={managedScope?.projection} scopeDemanded={managedScope?.demanded}
+              onScopeDemandChange={managedScope?.setDemand} />
           </div>
         </div>
       {/if}
@@ -306,6 +309,7 @@
     <section class="receiver-deck" bind:this={receiverDeckElement} style={receiverDeckStyle}>
       {#if semanticDeck}
         <SemanticRadioSurfaces regions={true} regionContent={sdrRegionContent} {scopeControlsInRegionContent}
+          displayFrameSource={getScopeSource() === 'hardware' ? 'hardware' : undefined}
           regionExtras={desktopRegionExtras} vfoAppearance={skinId === 'sdr-test' ? 'sdr' : 'standard'} />
       {/if}
     </section>

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ScopeController } from '$lib/runtime/scope-controller.svelte';
+import { PresentationResourceHost } from '$lib/runtime/resource-host';
 import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
 
 const txHarness = new ManagedAppTxHarness({ stale: true });
@@ -39,6 +41,7 @@ vi.mock('../../../lib/media/media-session', () => ({
 }));
 
 vi.mock('../../../lib/runtime/frontend-runtime', () => ({
+  get presentationResources() { return rt.resources; },
   runtime: {
     state: null,
     onTxAudioDied: () => () => {},
@@ -54,7 +57,7 @@ vi.mock('../../../lib/runtime/frontend-runtime', () => ({
       source: null, available: false, resourceSelected: false, demand: 0,
       lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
     },
-    scope: { hardwareScopeConnected: false },
+    get scope() { return rt.scope; },
     bootstrap: vi.fn(async () => vi.fn()),
   },
 }));
@@ -62,9 +65,13 @@ vi.mock('../../../lib/runtime/frontend-runtime', () => ({
 // MOR-1235: `state` is a live getter over a mutable holder (default `null`,
 // reset per test) so a test can put a REAL `ptt` on the runtime state and
 // prove the meters dock ignores it in favour of the App TX authority.
-const rt = vi.hoisted(() => ({ state: null as unknown }));
+const rt = vi.hoisted(() => ({ state: null as unknown,
+  scope: null as unknown as ScopeController, resources: null as unknown as PresentationResourceHost<unknown>,
+  evidenceListeners: 0,
+}));
 
 vi.mock('$lib/runtime', () => ({
+  get presentationResources() { return rt.resources; },
   runtime: {
     get state() { return rt.state; },
     caps: null,
@@ -82,7 +89,7 @@ vi.mock('$lib/runtime', () => ({
       source: null, available: false, resourceSelected: false, demand: 0,
       lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
     },
-    scope: { hardwareScopeConnected: false },
+    get scope() { return rt.scope; },
   },
 }));
 
@@ -379,6 +386,14 @@ beforeEach(() => {
   components = [];
   radio.current = null;
   rt.state = null;
+  rt.scope = new ScopeController(() => { throw new Error('Routing fixture has no selected transport'); });
+  rt.resources = new PresentationResourceHost('routing');
+  rt.evidenceListeners = 0;
+  const subscribe = rt.scope.subscribeFrameEvidence.bind(rt.scope);
+  vi.spyOn(rt.scope, 'subscribeFrameEvidence').mockImplementation(fn => {
+    rt.evidenceListeners++; const stop = subscribe(fn);
+    return () => { stop(); rt.evidenceListeners--; };
+  });
   vi.mocked(hasDualReceiver).mockReturnValue(false);
   vi.mocked(getScopeSource).mockReturnValue(null);
   vi.mocked(hasSpectrum).mockReturnValue(true);
@@ -389,8 +404,12 @@ beforeEach(() => {
   Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 900 });
 });
 
-afterEach(() => {
-  components.forEach((c) => unmount(c));
+afterEach(async () => {
+  await Promise.all(components.map(c => unmount(c)));
+  expect(rt.evidenceListeners).toBe(0);
+  expect(rt.resources.snapshot('hardware-scope').demand).toBe(0);
+  expect(txHarness.listenerCount()).toBe(0);
+  await rt.resources.teardown();
   document.body.innerHTML = '';
   // Hygiene WITHIN this file. It runs in the `isolated` pool
   // (`vite.config.ts`), so these holders cannot leak into another file — but

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -525,9 +525,10 @@
     if (!managedScope) return undefined;
     const resolution = scopePresentation?.resolution;
     const frameMode = scopePresentation?.envelope?.frame.mode;
+    const acceptedSequence = scopePresentation?.envelope?.acceptedSequence;
     const projection = scopeDemanded && resolution?.state === 'live'
-      && typeof frameMode === 'number' && Number.isSafeInteger(frameMode)
-      ? { frame: resolution.frame, frameMode, passband: scopePassband.display } : null;
+      && typeof frameMode === 'number' && Number.isSafeInteger(frameMode) && acceptedSequence !== undefined
+      ? { frame: resolution.frame, frameMode, acceptedSequence, passband: scopePassband.display } : null;
     return { projection, demanded: scopeDemanded, setDemand: setManagedScopeDemand };
   });
   $effect(refreshScopePassband);

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -15,7 +15,9 @@
   import { onDestroy, untrack, type Snippet } from 'svelte';
   import { t } from '$lib/i18n';
   import { presentationResources, runtime } from '$lib/runtime';
-  import { ScopeFrameHost } from '$lib/runtime/scope-frame-host';
+  import { ScopeFrameHost, type ScopeFramePresentation } from '$lib/runtime/scope-frame-host';
+  import { EMPTY_SCOPE_PASSBAND_DISPLAY, projectScopePassbandDisplay } from '$lib/runtime/adapters/scope-passband-display';
+  import type { ManagedScopeRegion } from '$lib/runtime/adapters/scope-display-projection';
   import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
   import {
     EMPTY_PBT_PRESENTATION, projectPbtPresentation, type PbtField,
@@ -86,7 +88,7 @@
   interface Props {
     strips?: 'single' | 'dual';
     regions?: boolean;
-    regionContent?: Snippet<[Snippet | undefined]>;
+    regionContent?: Snippet<[Snippet | undefined, ManagedScopeRegion | undefined]>;
     scopeControlsInRegionContent?: boolean;
     regionExtras?: Snippet<['left' | 'right']>;
     vfoAppearance?: 'semantic' | 'sdr' | 'standard';
@@ -472,6 +474,10 @@
       toRadioViewModel(runtime.state, runtime.caps, txState, rxAudioSnapshot, scopeDisplaySnapshot),
     ),
   );
+  let managedScope = $derived(displayFrameSource === 'hardware' && regions && regionContent !== undefined);
+  let scopeDemanded = $state(true);
+  let scopePresentation = $state.raw<ScopeFramePresentation | null>(null);
+  let scopePassband = $state.raw(EMPTY_SCOPE_PASSBAND_DISPLAY);
   let selectedDisplayFrame = $state.raw<LcdSpectrumFrame | undefined>(undefined);
   let scopeFrameHost: ScopeFrameHost | null = null;
   let stopWatchingScopeFrameHost: (() => void) | null = null;
@@ -480,26 +486,58 @@
     selectedDisplayFrame = resolution.state === 'live' ? resolution.frame : undefined;
   }
 
+  function refreshScopePassband(): void {
+    if (!managedScope && untrack(() => scopePassband === EMPTY_SCOPE_PASSBAND_DISPLAY)) return;
+    const active = canonicalView?.vfos.filter(vfo => vfo.isActive) ?? [];
+    const vfo = active.length === 1 ? active[0] : null;
+    const selection = vfo && (vfo.slot.kind === 'slotted' || vfo.slot.kind === 'unslotted')
+      ? { receiver: vfo.receiver, slot: vfo.slot.kind === 'slotted' ? vfo.slot.id : 'single' as const } : null;
+    const input = { state: runtime.state, caps: runtime.caps, selection, session: controlSession,
+      frame: managedScope && scopeDemanded ? scopePresentation : null };
+    scopePassband = untrack(() => projectScopePassbandDisplay(scopePassband, input));
+  }
+  function acceptScopePresentation(presentation: ScopeFramePresentation): void {
+    scopePresentation = presentation;
+    if (scopeDemanded) acceptDisplayFrameResolution(presentation.resolution);
+    else selectedDisplayFrame = undefined;
+    untrack(refreshScopePassband);
+  }
+  let watchingManagedScope: boolean | null = null;
   function ensureScopeFrameHost(): ScopeFrameHost {
-    if (scopeFrameHost !== null) return scopeFrameHost;
-    scopeFrameHost = new ScopeFrameHost(runtime.scope);
-    stopWatchingScopeFrameHost = scopeFrameHost.subscribe(acceptDisplayFrameResolution);
+    scopeFrameHost ??= new ScopeFrameHost(runtime.scope);
+    if (watchingManagedScope !== managedScope) {
+      stopWatchingScopeFrameHost?.();
+      scopePresentation = null;
+      untrack(refreshScopePassband);
+      watchingManagedScope = managedScope;
+      stopWatchingScopeFrameHost = managedScope
+        ? scopeFrameHost.subscribePresentation(acceptScopePresentation)
+        : scopeFrameHost.subscribe(acceptDisplayFrameResolution);
+    }
     return scopeFrameHost;
   }
+  function setManagedScopeDemand(enabled: boolean): void {
+    scopeDemanded = enabled;
+    if (!enabled) selectedDisplayFrame = undefined;
+    untrack(refreshScopePassband);
+  }
+  let managedScopeRegion: ManagedScopeRegion | undefined = $derived.by(() => {
+    if (!managedScope) return undefined;
+    const resolution = scopePresentation?.resolution;
+    const frameMode = scopePresentation?.envelope?.frame.mode;
+    const projection = scopeDemanded && resolution?.state === 'live'
+      && typeof frameMode === 'number' && Number.isSafeInteger(frameMode)
+      ? { frame: resolution.frame, frameMode, passband: scopePassband.display } : null;
+    return { projection, demanded: scopeDemanded, setDemand: setManagedScopeDemand };
+  });
+  $effect(refreshScopePassband);
 
-  $effect(() => {
+  let scopeAuthority = $derived.by(() => {
     const source = displayFrameSource;
-    if (source === undefined) {
-      scopeFrameHost?.updateAuthority(null);
-      selectedDisplayFrame = undefined;
-      return;
-    }
-
-    const host = ensureScopeFrameHost();
     const stateGeneration = runtime.state?.providerGeneration;
     const capsGeneration = runtime.caps?.providerGeneration;
     const receiver = canonicalView?.activeReceiver;
-    const authority = receiver?.status === 'known'
+    return source !== undefined && receiver?.status === 'known'
       && typeof stateGeneration === 'number'
       && Number.isSafeInteger(stateGeneration)
       && stateGeneration >= 0
@@ -509,13 +547,30 @@
       && stateGeneration === capsGeneration
       ? { source, receiver: receiver.receiver, providerGeneration: stateGeneration }
       : null;
-    host.updateAuthority(authority);
-    acceptDisplayFrameResolution(host.snapshot());
+  });
+  let scopeLeaseGeneration = $derived(scopeAuthority?.providerGeneration ?? null);
+  $effect(() => {
+    const source = displayFrameSource;
+    if (source === undefined) {
+      scopeFrameHost?.updateAuthority(null);
+      selectedDisplayFrame = undefined;
+      scopePresentation = null;
+      untrack(refreshScopePassband);
+      return;
+    }
+
+    const host = ensureScopeFrameHost();
+    const authority = scopeAuthority;
+    untrack(() => {
+      host.updateAuthority(authority);
+      if (managedScope) acceptScopePresentation(host.snapshotPresentation());
+      else acceptDisplayFrameResolution(host.snapshot());
+    });
   });
 
   $effect(() => {
     const source = displayFrameSource;
-    if (source === undefined) return;
+    if (source === undefined || (managedScope && (!scopeDemanded || scopeLeaseGeneration === null))) return;
     ensureScopeFrameHost();
     const resource = source === 'audio-fft' ? 'audio-fft' : 'hardware-scope';
     const lease = presentationResources.acquire(resource, 'SemanticRadioSurfaces.readonlyDisplay');
@@ -532,6 +587,9 @@
     const host = scopeFrameHost;
     stopWatchingScopeFrameHost = null;
     scopeFrameHost = null;
+    scopePresentation = null;
+    selectedDisplayFrame = undefined;
+    scopePassband = EMPTY_SCOPE_PASSBAND_DISPLAY;
     try { stop?.(); } finally { host?.dispose(); }
   });
 
@@ -543,7 +601,7 @@
   let view = $state<RadioViewModel | null>(null);
   const readControlSession = 'controlSession' in runtime ? () => runtime.controlSession : undefined;
   const subscribeControlSession = 'subscribeControlSession' in runtime ? runtime.subscribeControlSession : undefined;
-  let controlSession = $state(readControlSession?.() ?? { state: 'disconnected', epoch: -1 });
+  let controlSession = $state(readControlSession?.() ?? { state: 'disconnected' as const, epoch: -1 });
   const pbtFloorKey = (generation: number, receiver: 'MAIN' | 'SUB', field: PbtField) =>
     `${generation}:${receiver}:${field}`;
   const unsubscribePbtSession = subscribeControlSession?.((next) => {
@@ -561,6 +619,7 @@
       }
     }
     controlSession = next;
+    untrack(refreshScopePassband);
   });
   onDestroy(() => unsubscribePbtSession?.());
   const pbtEvidence = (): PbtPresentationEvidence => {
@@ -1465,7 +1524,7 @@
       {/if}
       {@render zoned('scopeDisplay', view?.scopeDisplay !== undefined, scopeDisplaySurface, allowBareSurfaces)}
       {#if regionContent}
-        {@render regionContent(scopeControlsInRegionContent ? zonedScopeControls : undefined)}
+        {@render regionContent(scopeControlsInRegionContent ? zonedScopeControls : undefined, managedScopeRegion)}
       {/if}
       </div>
       <div class:desktop-controls-right={vfoAppearance !== 'semantic'} class:region-passthrough={vfoAppearance === 'semantic'}>

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-projection.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-projection.component.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRawSnippet, flushSync, mount, unmount, type Snippet } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
+import { createClassComponent } from 'svelte/legacy';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import type { RadioViewModel } from '../../../semantic/radio-view-model';
+import type { LcdSpectrumFrame } from '../../../skins/segmentline/lcd-display-contract';
+import type { ManagedScopeRegion } from '$lib/runtime/adapters/scope-display-projection';
+import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
+import { ScopeController } from '$lib/runtime/scope-controller.svelte';
+import * as passband from '$lib/runtime/adapters/scope-passband-display';
+import { ScopeFrameHost } from '$lib/runtime/scope-frame-host';
+import { PresentationResourceHost } from '$lib/runtime/resource-host';
+
+const h = vi.hoisted(() => ({
+  scope: null as unknown as ScopeController, resources: null as unknown as PresentationResourceHost<unknown>,
+  tx: null as unknown as ManagedAppTxController, session: { state: 'connected', epoch: 1 },
+  listeners: new Set<(next: { state: string; epoch: number }) => void>(),
+  frequency: vi.fn(), width: vi.fn(), raw: vi.fn(), acquire: vi.fn(),
+}));
+vi.mock('$lib/runtime', async () => {
+  const { radio } = await import('$lib/stores/radio.svelte');
+  const { getCapabilities } = await import('$lib/stores/capabilities.svelte');
+  return { get presentationResources() { return h.resources; }, runtime: {
+    get state() { return radio.current; }, get caps() { return getCapabilities(); },
+    get scope() { return h.scope; }, get controlSession() { return h.session; },
+    subscribeControlSession: (fn: (next: typeof h.session) => void) => { h.listeners.add(fn); return () => h.listeners.delete(fn); },
+    onTxAudioDied: () => () => {}, audio: { muted: true, rxEnabled: false, volume: 0 }, connectionAudio: false,
+    connectionStatus: 'connected', radioPowerOn: true, connection: { status: 'connected' },
+    defaultScopeStatus: { source: 'hardware', available: true, resourceSelected: true, demand: 1,
+      lifecycle: 'streaming', transport: 'connected', frameSeen: true },
+    subscribeDx: () => () => {},
+    acquireHardwareScope: (...args: unknown[]) => { h.acquire(...args); return h.resources.acquire('hardware-scope', 'panel'); },
+    releaseHardwareScope: (lease: Parameters<typeof h.resources.release>[0]) => h.resources.release(lease),
+  } };
+});
+vi.mock('$lib/runtime/frontend-runtime', async () => await import('$lib/runtime'));
+vi.mock('$lib/runtime/tx-controller/managed-app-host', () => ({ getManagedAppTxController: () => h.tx }));
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({ deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: null }), getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }) }));
+const pendingWidth = new SvelteMap<string, number>();
+vi.mock('$lib/runtime/adapters/panel-adapters', async (original) => ({
+  ...await original<typeof import('$lib/runtime/adapters/panel-adapters')>(),
+  getVfoHandlers: () => ({ onFreqChange: h.frequency }), getFilterHandlers: () => ({ onFilterWidthCommit: h.width }),
+  getFilterWidthCommandLifecycle: () => ({ busy: pendingWidth.has('target'), target: pendingWidth.get('target'), presentation: { receiver: 0 } }),
+}));
+
+import { radio, resetRadioState } from '$lib/stores/radio.svelte';
+import { clearCapabilities, setCapabilities, getCapabilities } from '$lib/stores/capabilities.svelte';
+import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
+import RadioLayout from '../../layout/RadioLayout.svelte';
+import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+
+function channel() {
+  const binary = new Set<(buffer: ArrayBuffer) => void>(), states = new Set<(state: string) => void>();
+  let state = 'disconnected';
+  return { get state() { return state; }, sessionEpoch: 1, connect: vi.fn(), disconnect: vi.fn(),
+    onBinary: (fn: (buffer: ArrayBuffer) => void) => { binary.add(fn); return () => binary.delete(fn); },
+    onStateChange: (fn: (value: string) => void) => { states.add(fn); return () => states.delete(fn); },
+    onSessionTransition: () => () => {},
+    connected() { state = 'connected'; for (const fn of states) fn(state); },
+    frame(receiver = 0) {
+      const buffer = new ArrayBuffer(19), view = new DataView(buffer);
+      view.setUint8(0, 1); view.setUint8(1, receiver); view.setUint32(3, 14_000_000, true);
+      view.setUint32(7, 14_100_000, true); view.setUint16(14, 3, true); new Uint8Array(buffer, 16).set([0, 128, 255]);
+      for (const fn of binary) fn(buffer); flushSync();
+    }, count: () => binary.size,
+  };
+}
+function fixture(scheme: 'single' | 'ab' = 'single') {
+  const rx = { freqHz: 14_050_000, mode: 'USB', filter: 1, dataMode: 0, filterWidth: 2400, ifShift: 0,
+    activeSlot: 'A', vfoA: { freqHz: 14_050_000, mode: 'USB', filterNum: 1 },
+    vfoB: { freqHz: 14_060_000, mode: 'USB', filterNum: 1 } };
+  const paths = ['active', 'split', 'dualWatch', ...Object.keys(rx).map(k => `main.${k}`),
+    ...['vfoA', 'vfoB'].flatMap(k => Object.keys(rx.vfoA).map(leaf => `main.${k}.${leaf}`))];
+  radio.current = { providerGeneration: 1, stateContractVersion: 1, active: 'MAIN', main: rx,
+    split: false, dualWatch: false, ptt: false, txTarget: { status: 'unknown' },
+    fieldStatus: Object.fromEntries(paths.map(path => [path, { storePath: path, observed: true,
+      freshness: 'fresh', availability: 'available', lastObservedMonotonic: 10 }])) } as ServerState;
+  expect(setCapabilities({ providerGeneration: 1, stateContractVersion: 1, model: 'fixture', scope: true,
+    scopeSource: 'hardware', audio: false, tx: false, capabilities: ['scope', 'filter_width', 'if_shift', 'data_mode'],
+    receivers: 1, vfoScheme: scheme, freqRanges: [], modes: ['USB'], filters: ['FIL1'],
+    filterConfig: { USB: { defaults: [2400], minHz: 100, maxHz: 3600, stepHz: 100 } },
+    txBands: [], audioConfig: { sampleRate: 48000, channels: 1, codecs: [] }, webrtc: { available: false, enabled: false },
+  } as unknown as Capabilities)).toBe(true);
+}
+function renew(marker: number, stale = false) {
+  const next = JSON.parse(JSON.stringify(radio.current!)) as ServerState;
+  for (const status of Object.values(next.fieldStatus!)) status.lastObservedMonotonic = marker;
+  for (const path of ['main.filterWidth', 'main.ifShift']) Object.assign(next.fieldStatus![path],
+    { freshness: stale ? 'stale' : 'fresh', availability: stale ? 'stale' : 'available' });
+  radio.current = next; flushSync();
+}
+let wire: ReturnType<typeof channel>, target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null, legacyComponent: ReturnType<typeof createClassComponent> | null;
+let tx: ManagedAppTxHarness;
+let region: (() => ManagedScopeRegion | undefined) | undefined;
+const snippet = createRawSnippet<[Snippet | undefined, ManagedScopeRegion | undefined]>((toolbar, managed) => {
+  region = managed;
+  return { render: () => '<div data-projection-probe></div>', setup: (element) => { element.setAttribute('data-toolbar', String(typeof toolbar())); } };
+});
+async function render(layout = true, skinId: 'desktop-v2' | 'sdr-test' = 'desktop-v2') {
+  target = document.createElement('div'); document.body.append(target);
+  component = layout ? mount(RadioLayout, { target, props: { skinId } })
+    : mount(SemanticRadioSurfaces, { target, props: { regions: true, displayFrameSource: 'hardware', regionContent: snippet, scopeControlsInRegionContent: true } });
+  flushSync(); await Promise.resolve(); flushSync(); wire.connected(); wire.frame();
+}
+function toggle() { target.querySelector<HTMLButtonElement>('.scope-demand-toggle')!.click(); flushSync(); }
+const overlay = () => target.querySelector<HTMLElement>('.passband-overlay');
+function clear() { for (const selector of ['canvas', '.freq-axis', '.passband-overlay', '.tune-line', '.passband-resize-zone']) expect(target.querySelector(selector), selector).toBeNull(); }
+
+beforeEach(() => {
+  vi.useFakeTimers(); vi.stubGlobal('requestAnimationFrame', () => 1); vi.stubGlobal('cancelAnimationFrame', () => {});
+  vi.stubGlobal('ResizeObserver', class { observe() {} unobserve() {} disconnect() {} });
+  const noop = () => {}; const ctx = new Proxy({ measureText: () => ({ width: 1 }),
+    createImageData: () => ({ data: new Uint8ClampedArray(4) }), getImageData: () => ({ data: new Uint8ClampedArray(4) }),
+    createLinearGradient: () => ({ addColorStop: noop }) }, { get: (obj, key) => key in obj ? obj[key as keyof typeof obj] : noop });
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(ctx as never);
+  tx = new ManagedAppTxHarness(); h.tx = tx.controller; h.session = { state: 'connected', epoch: 1 }; h.listeners.clear();
+  h.frequency.mockClear(); h.width.mockClear(); pendingWidth.clear(); h.acquire.mockClear(); wire = channel();
+  h.scope = new ScopeController(() => wire as never, { now: () => Date.now(), setTimeout, clearTimeout });
+  h.resources = new PresentationResourceHost('test');
+  h.resources.configure('hardware-scope', { available: true, selected: true, driver: h.scope.hardwareScopeDriver });
+  h.raw = vi.spyOn(h.scope, 'subscribeHardware'); fixture(); region = undefined; component = null; legacyComponent = null;
+});
+afterEach(async () => {
+  if (component) await unmount(component); legacyComponent?.$destroy(); flushSync(); await h.resources.teardown();
+  expect(h.listeners.size).toBe(0); expect(tx.trace()).toEqual([]);
+  document.body.innerHTML = ''; resetRadioState(); clearCapabilities(); vi.restoreAllMocks(); vi.unstubAllGlobals(); vi.useRealTimers();
+});
+
+describe('one managed scope owner through the real region and panel', () => {
+  it.each(['desktop-v2', 'sdr-test'] as const)('%s clears local OFF under an independent healthy lease and fences replay', async skin => {
+    await render(true, skin); const shared = h.resources.acquire('hardware-scope', 'independent');
+    expect(overlay()).not.toBeNull(); expect(h.raw).not.toHaveBeenCalled(); expect(h.acquire).not.toHaveBeenCalled();
+    expect(h.resources.snapshot('hardware-scope').demand).toBe(2);
+    toggle(); clear(); expect(h.resources.snapshot('hardware-scope').demand).toBe(1);
+    expect(h.scope.hardwareScopeConnected).toBe(true); wire.frame(); clear();
+    toggle(); expect(overlay()).toBeNull(); wire.frame(); expect(overlay()).toBeNull();
+    renew(11); expect(overlay()).not.toBeNull();
+    h.resources.release(shared);
+  });
+  it('propagates the real host frame expiry at exactly 500ms and requires renewed evidence', async () => {
+    await render(); expect(overlay()).not.toBeNull();
+    vi.advanceTimersByTime(499); flushSync(); expect(overlay()).not.toBeNull();
+    vi.advanceTimersByTime(1); flushSync(); clear(); expect(h.scope.hardwareScopeConnected).toBe(true);
+    wire.frame(); expect(overlay()).toBeNull(); renew(11); wire.frame(); expect(overlay()).not.toBeNull();
+    wire.frame(1); clear();
+  });
+  it('retains whole stale geometry and sends frequency-only pan while resize remains denied', async () => {
+    await render(); const edges = overlay()!.getAttribute('style'); renew(10, true); wire.frame();
+    expect(overlay()!.getAttribute('style')).toBe(edges); expect(target.querySelector('.passband-freshness')!.textContent).toContain('◷');
+    expect(target.querySelector('.passband-resize-zone')).toBeNull();
+    const surface = target.querySelector<HTMLElement>('.spectrum-area')!;
+    surface.getBoundingClientRect = () => ({ left: 0, width: 200 } as DOMRect);
+    for (const [type, x] of [['pointerdown', 100], ['pointermove', 120], ['pointerup', 120]] as const) {
+      surface.dispatchEvent(new PointerEvent(type, { bubbles: true, pointerId: 1, button: 0, clientX: x })); flushSync();
+    }
+    expect(h.frequency).toHaveBeenCalledOnce(); expect(h.width).not.toHaveBeenCalled();
+    renew(11); wire.frame(); expect(overlay()!.getAttribute('style')).toBe(edges);
+    expect(target.querySelector('.passband-freshness')!.textContent?.trim()).toBe('');
+  });
+  it('keeps one host/evidence subscription and resets display state on controller lifetime disposal', async () => {
+    const watch = vi.spyOn(h.scope, 'subscribeFrameEvidence'), dispose = vi.spyOn(ScopeFrameHost.prototype, 'dispose');
+    const authority = vi.spyOn(h.scope, 'setFrameAuthority');
+    await render(); expect(watch).toHaveBeenCalledOnce(); expect(wire.count()).toBe(1); expect(h.listeners.size).toBe(1);
+    await unmount(component!); component = null; flushSync(); await Promise.resolve();
+    expect(dispose).toHaveBeenCalledOnce(); expect(h.resources.snapshot('hardware-scope').demand).toBe(0);
+    expect(wire.count()).toBe(0); expect(authority.mock.calls.filter(([value]) => value === null)).toHaveLength(1);
+    renew(11, true); await render(); expect(overlay()).toBeNull();
+    expect(watch).toHaveBeenCalledTimes(2); renew(12); wire.frame(); expect(overlay()).not.toBeNull();
+  });
+  it('preserves toolbar argument one and exposes a passive nullable region with demand callback', async () => {
+    await render(false); expect(target.querySelector('[data-projection-probe]')?.getAttribute('data-toolbar')).toBe('function');
+    expect(region?.()?.projection?.frame.normalizedBins).toEqual([0, 128 / 255, 1]);
+    expect(region?.()?.projection?.passband.state).toBe('current');
+    region!()!.setDemand(false); flushSync(); expect(region!()!.projection).toBeNull(); expect(region!()!.demanded).toBe(false);
+    expect(h.frequency).not.toHaveBeenCalled(); expect(h.width).not.toHaveBeenCalled();
+  });
+  it('requires a post-boundary receipt even when geometry renews first', async () => {
+    await render(); const shared = h.resources.acquire('hardware-scope', 'independent');
+    toggle(); toggle(); renew(11); expect(overlay()).toBeNull();
+    wire.frame(); expect(overlay()).not.toBeNull(); h.resources.release(shared);
+  });
+  it.each(['single', 'ab'] as const)('uses the exact canonical %s VFO selection', async scheme => {
+    fixture(scheme); const project = vi.spyOn(passband, 'projectScopePassbandDisplay'); await render(false);
+    expect(project.mock.lastCall?.[1].selection).toEqual({ receiver: 'MAIN', slot: scheme === 'single' ? 'single' : 'A' });
+    if (scheme === 'ab') {
+      radio.current!.fieldStatus!['main.activeSlot'].observed = false; flushSync(); wire.frame();
+      expect(project.mock.lastCall?.[1].selection).toBeNull();
+      expect(region!()!.projection?.passband.state).toBe('unknown');
+    }
+  });
+  it('preserves explicit relative-slot unknown instead of selecting MAIN/A', async () => {
+    fixture('ab'); setCapabilities({ ...getCapabilities()!, vfoReadback: 'selected_unselected' });
+    radio.current!.fieldStatus!['main.activeSlot'].observed = false;
+    const project = vi.spyOn(passband, 'projectScopePassbandDisplay'); await render(false);
+    expect(project.mock.lastCall?.[1].selection).toBeNull(); expect(region!()!.projection?.passband.state).toBe('unknown');
+  });
+  it.each(['unknown receiver', 'generation mismatch'])('clears a live projection for %s', async boundary => {
+    setCapabilities({ ...getCapabilities()!, receivers: 2, vfoScheme: 'ab_shared', capabilities: [...getCapabilities()!.capabilities, 'dual_rx'] });
+    await render(); expect(overlay()).not.toBeNull();
+    if (boundary === 'unknown receiver') radio.current!.fieldStatus!.active.observed = false;
+    else setCapabilities({ ...getCapabilities()!, providerGeneration: 2 });
+    flushSync(); clear();
+  });
+  it('delivers coalesced disconnected/connected session boundaries before reactive effects can hide them', async () => {
+    await render(); const shared = h.resources.acquire('hardware-scope', 'independent');
+    for (const state of ['disconnected', 'connected']) {
+      h.session = { state, epoch: 1 }; for (const fn of h.listeners) fn(h.session);
+    }
+    flushSync(); expect(overlay()).toBeNull(); wire.frame(); expect(overlay()).toBeNull();
+    renew(11); expect(overlay()).not.toBeNull(); h.resources.release(shared);
+  });
+  it('switches between configured managed and readonly consumers without simultaneous subscriptions or resetting floors', async () => {
+    target = document.createElement('div'); document.body.append(target);
+    let active = 0, maximum = 0;
+    const managedSubscribe = ScopeFrameHost.prototype.subscribePresentation, readonlySubscribe = ScopeFrameHost.prototype.subscribe;
+    const managedWatch = vi.spyOn(ScopeFrameHost.prototype, 'subscribePresentation').mockImplementation(function (this: ScopeFrameHost, handler) {
+      active++; maximum = Math.max(maximum, active); const stop = managedSubscribe.call(this, handler);
+      return () => { stop(); active--; };
+    });
+    const readonlyWatch = vi.spyOn(ScopeFrameHost.prototype, 'subscribe').mockImplementation(function (this: ScopeFrameHost, handler) {
+      active++; maximum = Math.max(maximum, active); const stop = readonlySubscribe.call(this, handler);
+      return () => { stop(); active--; };
+    });
+    const evidence = vi.spyOn(h.scope, 'subscribeFrameEvidence');
+    const props = { regions: true, displayFrameSource: 'hardware' as const, regionContent: snippet };
+    legacyComponent = createClassComponent({ component: SemanticRadioSurfaces, target, props });
+    flushSync(); await Promise.resolve(); wire.connected(); wire.frame();
+    expect(region!()!.projection?.passband.state).toBe('current');
+    legacyComponent.$set({ regionContent: undefined }); flushSync();
+    expect(managedWatch).toHaveBeenCalledOnce(); expect(readonlyWatch).toHaveBeenCalledOnce();
+    legacyComponent.$set({ regionContent: snippet }); flushSync(); wire.frame();
+    expect(managedWatch).toHaveBeenCalledTimes(2); expect(evidence).toHaveBeenCalledOnce();
+    expect(region!()!.projection?.passband.state).toBe('unknown'); renew(11); wire.frame();
+    expect(region!()!.projection?.passband.state).toBe('current');
+    expect(h.resources.snapshot('hardware-scope').demand).toBe(1); expect(maximum).toBe(1); expect(active).toBe(1);
+    const shared = h.resources.acquire('hardware-scope', 'independent');
+    let frame: (() => LcdSpectrumFrame | undefined) | undefined;
+    const readonlyDisplay = createRawSnippet<[RadioViewModel, LcdSpectrumFrame?]>((_view, selected) => {
+      frame = selected; return { render: () => '<output data-passive-frame></output>' };
+    });
+    const setDemand = region!()!.setDemand;
+    legacyComponent.$set({ readonlyDisplay }); flushSync(); expect(frame?.()).toBeDefined();
+    setDemand(false); flushSync(); expect(frame?.()).toBeUndefined();
+    wire.frame(); expect(h.scope.hardwareScopeConnected).toBe(true); expect(frame?.()).toBeUndefined();
+    h.resources.release(shared);
+    legacyComponent.$destroy(); legacyComponent = null; flushSync(); expect(active).toBe(0);
+  });
+  it('keeps audio FFT layout on its legacy acquisition path with no hardware host', async () => {
+    setCapabilities({ ...getCapabilities()!, scope: false, capabilities: [], scopeSource: 'audio_fft', audioFftAvailable: true });
+    const watch = vi.spyOn(h.scope, 'subscribeFrameEvidence'), acquire = vi.spyOn(h.resources, 'acquire'); await render();
+    expect(watch).not.toHaveBeenCalled(); expect(h.raw).not.toHaveBeenCalled();
+    expect(acquire.mock.calls.filter(([resource, consumer]) => resource === 'audio-fft' && consumer === 'SpectrumPanel')).toHaveLength(1);
+    expect(target.querySelector('.audio-source-label')?.textContent).toContain('Audio FFT');
+  });
+
+  it('never retains the strict pending width target in the real reducer tuple', async () => {
+    const project = vi.spyOn(passband, 'projectScopePassbandDisplay'); await render();
+    const original = overlay()!.getAttribute('style');
+    const confirmed = project.mock.results.at(-1)!.value.display;
+    expect(confirmed.state).toBe('current');
+    pendingWidth.set('target', 3000); flushSync(); expect(overlay()!.getAttribute('style')).not.toBe(original);
+    renew(10, true); wire.frame(); expect(overlay()!.getAttribute('style')).toBe(original);
+    const retained = project.mock.results.at(-1)!.value.display;
+    expect(retained.state).toBe('stale'); expect(retained.tuple).toBe(confirmed.tuple); expect(retained.tuple.widthHz).toBe(2400);
+    pendingWidth.clear(); renew(11); wire.frame(); expect(overlay()!.getAttribute('style')).toBe(original);
+    expect(h.width).not.toHaveBeenCalled();
+  });
+
+  it('recovers normal managed startup when state arrives after hardware capabilities', async () => {
+    radio.current = null; await render(); clear();
+    fixture(); flushSync(); await Promise.resolve(); wire.connected(); wire.frame();
+    expect(overlay()).not.toBeNull();
+  });
+
+  it.each(['receiver', 'slot'] as const)('recovers startup after the canonical %s becomes known', async identity => {
+    fixture('ab');
+    if (identity === 'receiver') setCapabilities({ ...getCapabilities()!, receivers: 2, vfoScheme: 'ab_shared', capabilities: [...getCapabilities()!.capabilities, 'dual_rx'] });
+    const path = identity === 'receiver' ? 'active' : 'main.activeSlot';
+    radio.current!.fieldStatus![path].observed = false; await render(); expect(overlay()).toBeNull();
+    radio.current!.fieldStatus![path].observed = true; flushSync(); await Promise.resolve(); wire.connected(); wire.frame();
+    expect(overlay()).not.toBeNull(); expect(h.resources.snapshot('hardware-scope').demand).toBe(1);
+  });
+  it('reacquires only its own resource binding when provider generation changes', async () => {
+    const watch = vi.spyOn(h.scope, 'subscribeFrameEvidence'); await render(); expect(overlay()).not.toBeNull();
+    const acquired = vi.spyOn(h.resources, 'acquire'), released = vi.spyOn(h.resources, 'release');
+    radio.current!.providerGeneration = 2;
+    for (const status of Object.values(radio.current!.fieldStatus!)) status.lastObservedMonotonic = 1;
+    setCapabilities({ ...getCapabilities()!, providerGeneration: 2 });
+    flushSync(); await Promise.resolve(); await Promise.resolve(); wire.connected(); renew(1); wire.frame();
+    expect(overlay()).toBeNull(); renew(2); wire.frame(); expect(overlay()).not.toBeNull();
+    expect(acquired).toHaveBeenCalledOnce(); expect(released).toHaveBeenCalledOnce(); expect(watch).toHaveBeenCalledOnce();
+    expect(h.resources.snapshot('hardware-scope').demand).toBe(1);
+  });
+
+});

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-projection.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-projection.component.test.ts
@@ -8,6 +8,7 @@ import type { RadioViewModel } from '../../../semantic/radio-view-model';
 import type { LcdSpectrumFrame } from '../../../skins/segmentline/lcd-display-contract';
 import type { ManagedScopeRegion } from '$lib/runtime/adapters/scope-display-projection';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
+import { WaterfallRenderer } from '$lib/renderers/waterfall-renderer';
 import { ScopeController } from '$lib/runtime/scope-controller.svelte';
 import * as passband from '$lib/runtime/adapters/scope-passband-display';
 import { ScopeFrameHost } from '$lib/runtime/scope-frame-host';
@@ -53,12 +54,19 @@ import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 
 function channel() {
   const binary = new Set<(buffer: ArrayBuffer) => void>(), states = new Set<(state: string) => void>();
-  let state = 'disconnected';
-  return { get state() { return state; }, sessionEpoch: 1, connect: vi.fn(), disconnect: vi.fn(),
+  const sessions = new Set<(next: { state: string; epoch: number }) => void>();
+  let state = 'disconnected', epoch = 0;
+  function transition(next: string) {
+    if (next === 'connected' && state !== 'connected') epoch++;
+    state = next; for (const fn of states) fn(state);
+    for (const fn of sessions) fn({ state, epoch });
+  }
+  return { get state() { return state; }, get sessionEpoch() { return epoch; },
+    connect: vi.fn(() => transition('connecting')), disconnect: vi.fn(() => transition('disconnected')),
     onBinary: (fn: (buffer: ArrayBuffer) => void) => { binary.add(fn); return () => binary.delete(fn); },
     onStateChange: (fn: (value: string) => void) => { states.add(fn); return () => states.delete(fn); },
-    onSessionTransition: () => () => {},
-    connected() { state = 'connected'; for (const fn of states) fn(state); },
+    onSessionTransition: (fn: (next: { state: string; epoch: number }) => void) => { sessions.add(fn); return () => sessions.delete(fn); },
+    connected() { transition('connected'); },
     frame(receiver = 0) {
       const buffer = new ArrayBuffer(19), view = new DataView(buffer);
       view.setUint8(0, 1); view.setUint8(1, receiver); view.setUint32(3, 14_000_000, true);
@@ -130,6 +138,43 @@ afterEach(async () => {
 });
 
 describe('one managed scope owner through the real region and panel', () => {
+  it('appends only accepted receipts, including identical bins, and seeds recovery once', async () => {
+    const push = vi.spyOn(WaterfallRenderer.prototype, 'pushRow');
+    await render(); expect(push).toHaveBeenCalledTimes(1);
+    renew(10, true); expect(push).toHaveBeenCalledTimes(1);
+    expect(target.querySelector('.passband-freshness')!.textContent).toContain('◷');
+    renew(10); expect(push).toHaveBeenCalledTimes(1);
+    radio.current!.ptt = true; flushSync(); expect(push).toHaveBeenCalledTimes(1);
+    wire.frame(); expect(push).toHaveBeenCalledTimes(2);
+    const shared = h.resources.acquire('hardware-scope', 'independent');
+    toggle(); clear(); wire.frame(); expect(push).toHaveBeenCalledTimes(2);
+    toggle(); expect(push).toHaveBeenCalledTimes(3);
+    renew(11); expect(push).toHaveBeenCalledTimes(3);
+    vi.advanceTimersByTime(500); flushSync(); clear();
+    wire.frame(); expect(push).toHaveBeenCalledTimes(4);
+    h.resources.release(shared);
+  });
+  it('keeps freshness text readable without effective live-region semantics', async () => {
+    await render();
+    for (const stale of [true, false, true]) {
+      renew(10, stale);
+      const cue = target.querySelector('.passband-freshness')!;
+      const implicitLive = ({ status: 'polite', log: 'polite', alert: 'assertive' } as Record<string, string>)[cue.getAttribute('role') ?? ''];
+      expect(cue.getAttribute('aria-live') ?? implicitLive ?? 'off').toBe('off');
+      expect(cue.textContent?.includes('◷')).toBe(stale);
+      if (stale) expect(cue.getAttribute('aria-label')).toBeTruthy();
+    }
+  });
+  it('recovers when an independent hardware lease predates managed authority', async () => {
+    const shared = h.resources.acquire('hardware-scope', 'independent-before-host');
+    await Promise.resolve();
+    await render(); wire.frame();
+    expect(h.scope.hardwareScopeConnected).toBe(true);
+    expect(h.resources.snapshot('hardware-scope').demand).toBe(2);
+    expect(overlay()).not.toBeNull();
+    h.resources.release(shared);
+  });
+
   it.each(['desktop-v2', 'sdr-test'] as const)('%s clears local OFF under an independent healthy lease and fences replay', async skin => {
     await render(true, skin); const shared = h.resources.acquire('hardware-scope', 'independent');
     expect(overlay()).not.toBeNull(); expect(h.raw).not.toHaveBeenCalled(); expect(h.acquire).not.toHaveBeenCalled();
@@ -231,7 +276,7 @@ describe('one managed scope owner through the real region and panel', () => {
     expect(region!()!.projection?.passband.state).toBe('current');
     legacyComponent.$set({ regionContent: undefined }); flushSync();
     expect(managedWatch).toHaveBeenCalledOnce(); expect(readonlyWatch).toHaveBeenCalledOnce();
-    legacyComponent.$set({ regionContent: snippet }); flushSync(); wire.frame();
+    legacyComponent.$set({ regionContent: snippet }); flushSync(); await Promise.resolve(); wire.connected(); wire.frame();
     expect(managedWatch).toHaveBeenCalledTimes(2); expect(evidence).toHaveBeenCalledOnce();
     expect(region!()!.projection?.passband.state).toBe('unknown'); renew(11); wire.frame();
     expect(region!()!.projection?.passband.state).toBe('current');

--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -25,6 +25,7 @@
     toSpectrumAuthority,
     type SpectrumAuthority,
   } from '../../lib/runtime/adapters/scope-adapter';
+  import type { ScopeDisplayProjection } from '../../lib/runtime/adapters/scope-display-projection';
   import SpectrumToolbar from './SpectrumToolbar.svelte';
   import BandPlanOverlay from './BandPlanOverlay.svelte';
   import EiBiBrowser from './EiBiBrowser.svelte';
@@ -60,8 +61,11 @@
   // layouts that have no `applyModeDefault()` driver for the shared
   // tuning-step store. `MobileRadioLayout` passes `true`; `RadioLayout`
   // omits it (defaults `false`, toggle shown) because it owns the driver.
-  let { hideSourceControls = false, hideScopeControls = false, hideAutoStepToggle = false, scopeControls }: {
+  let { hideSourceControls = false, hideScopeControls = false, hideAutoStepToggle = false, scopeControls,
+    scopeProjection, scopeDemanded = true, onScopeDemandChange }: {
     hideSourceControls?: boolean; hideScopeControls?: boolean; hideAutoStepToggle?: boolean; scopeControls?: Snippet;
+    scopeProjection?: ScopeDisplayProjection | null;
+    scopeDemanded?: boolean; onScopeDemandChange?: (enabled: boolean) => void;
   } = $props();
 
   const vfoHandlers = getVfoHandlers();
@@ -72,10 +76,12 @@
   let filterWidthLifecycle = $derived(getFilterWidthCommandLifecycle());
   // --- Component state ---
   let audioFft = $derived(runtime.caps?.scopeSource === 'audio_fft');
-  let scopeConnected = $derived(audioFft
+  let scopeDemandOn = $state(true);
+  let managed = $derived(scopeProjection !== undefined);
+  let managedUnavailable = $derived(managed && (!scopeDemandOn || scopeProjection === null));
+  let scopeConnected = $derived(managed ? !managedUnavailable : audioFft
     ? runtime.defaultScopeStatus.transport === 'connected'
     : runtime.scope.hardwareScopeConnected);
-  let scopeDemandOn = $state(true);
   let scopeLease: ReturnType<typeof runtime.acquireHardwareScope> | null = null;
   let scopePixels = $state<Uint8Array | null>(null);
   let enableAvg = $state(true);
@@ -140,15 +146,20 @@
   let scopeMode = $derived(frameScopeMode);
   // Tuning indicator: center for CTR/SCROLL-C, proportional for FIX/SCROLL-F
   let isFixedScope = $derived(isFixedScopeFn(scopeMode));
+  let displayTuple = $derived(!managedUnavailable && scopeProjection
+    && (scopeProjection.passband.state === 'current' || scopeProjection.passband.state === 'stale')
+    ? scopeProjection.passband.tuple : null);
+  let displayStale = $derived(displayTuple !== null && scopeProjection?.passband.state === 'stale');
+  let displayFrequencyHz = $derived(managed ? displayTuple?.frequencyHz : spectrumAuthority?.frequencyHz);
   let tuneVisible = $derived(
-    spectrumAuthority?.frequencyHz !== null
-      && spectrumAuthority?.frequencyHz !== undefined
+    displayFrequencyHz !== null
+      && displayFrequencyHz !== undefined
       && (!isFixedScope || (
-        spectrumAuthority.frequencyHz >= startFreq
-        && spectrumAuthority.frequencyHz <= endFreq
+        displayFrequencyHz >= startFreq
+        && displayFrequencyHz <= endFreq
       )),
   );
-  let tuneHz = $derived(tuneVisible ? spectrumAuthority!.frequencyHz! : 0);
+  let tuneHz = $derived(tuneVisible ? displayFrequencyHz! : 0);
   let confirmedPassband = $derived(
     tuneVisible
       && spectrumAuthority?.mode !== null
@@ -156,7 +167,7 @@
       && spectrumAuthority.filterWidthHz !== null
       && spectrumAuthority.ifShiftHz !== null,
   );
-  let rxMode = $derived(confirmedPassband ? spectrumAuthority!.mode! : '');
+  let rxMode = $derived(managed ? displayTuple?.mode ?? '' : confirmedPassband ? spectrumAuthority!.mode! : '');
   let lifecyclePassbandHz = $derived(
     resizeCapture === null
       && filterWidthLifecycle.busy
@@ -180,13 +191,14 @@
   // the command lifecycle's busy target may hold that projection; confirmed
   // radio state remains the source of truth for every other state.
   let passbandHz = $derived(
-    confirmedPassband
-      ? (activeResizePassbandHz ?? lifecyclePassbandHz ?? spectrumAuthority!.filterWidthHz!)
-      : 0,
+    managed
+      ? displayTuple ? ((!displayStale && confirmedPassband
+        ? activeResizePassbandHz ?? lifecyclePassbandHz : null) ?? displayTuple.widthHz) : 0
+      : confirmedPassband ? (activeResizePassbandHz ?? lifecyclePassbandHz ?? spectrumAuthority!.filterWidthHz!) : 0,
   );
-  let passbandShiftHz = $derived(confirmedPassband ? spectrumAuthority!.ifShiftHz! : 0);
+  let passbandShiftHz = $derived(managed ? displayTuple?.shiftHz ?? 0 : confirmedPassband ? spectrumAuthority!.ifShiftHz! : 0);
   let canResizePassband = $derived(
-    confirmedPassband
+    confirmedPassband && !displayStale
       && spectrumAuthority !== null
       && spectrumAuthority.rule !== null
       && canResizeFromRightEdge(spectrumAuthority.mode!),
@@ -253,6 +265,7 @@
 
   function completeGestureAuthority(requireRule: boolean): SpectrumAuthority | null {
     const current = readAuthority();
+    if (managed && (managedUnavailable || scopeProjection?.passband.state !== 'current')) return null;
     if (!current || current.frequencyHz === null || current.mode === null
       || current.filterWidthHz === null || current.ifShiftHz === null
       || (requireRule && current.rule === null)) return null;
@@ -272,6 +285,7 @@
   }
 
   function readSampleGeometry(element: HTMLElement): SampleGeometry | null {
+    if (managedUnavailable) return null;
     const { width } = element.getBoundingClientRect();
     if (!Number.isFinite(width) || width <= 0 || !Number.isFinite(startFreq)
       || !Number.isFinite(endFreq) || endFreq <= startFreq
@@ -362,7 +376,7 @@
     const capture = resizeCapture;
     if (!capture || capture.pointerId !== event.pointerId || !waterfallContent) return;
     const candidate = resizeCandidate;
-    const stable = captureStillCurrent(capture, waterfallContent);
+    const stable = completeGestureAuthority(true) !== null && captureStillCurrent(capture, waterfallContent);
     resizeCapture = null;
     resizeCandidate = null;
     if (!stable || candidate === null || candidate === capture.authority.filterWidthHz) return;
@@ -380,7 +394,7 @@
   }
 
   function acquireScopeDemand(): void {
-    if (scopeLease) return;
+    if (managed || scopeLease) return;
     scopeLease = audioFft
       ? presentationResources.acquire('audio-fft', 'SpectrumPanel')
       : runtime.acquireHardwareScope('SpectrumPanel');
@@ -396,6 +410,11 @@
   function setScopeDemand(enabled: boolean): void {
     if (scopeDemandOn === enabled) return;
     scopeDemandOn = enabled;
+    if (managed) {
+      if (!enabled) clearSample();
+      onScopeDemandChange?.(enabled);
+      return;
+    }
     if (enabled) acquireScopeDemand();
     else releaseScopeDemand();
   }
@@ -409,6 +428,7 @@
   }
 
   function handleTune(hz: number): void {
+    if (managedUnavailable) return;
     const current = readAuthority();
     const frequency = snapFrequency(Math.round(hz));
     if (current?.frequencyHz === null || current?.frequencyHz === undefined || frequency === null) return;
@@ -418,6 +438,7 @@
   // --- Scroll-to-tune (mouse wheel on spectrum/waterfall) ---
   function handleWheel(event: WheelEvent): void {
     event.preventDefault();
+    if (managedUnavailable) return;
     const current = readAuthority();
     const step = getTuningStep();
     if (current?.frequencyHz === null || current?.frequencyHz === undefined
@@ -491,21 +512,47 @@
   const AUDIO_FFT_AMPLITUDE_MAX = 160;
   const CENTRAL_SCOPE_AMPLITUDE_MAX = 80;
 
+  function clearSample(): void {
+    scopePixels = null;
+    startFreq = 0;
+    endFreq = 0;
+    frameScopeMode = 0;
+    resizeCapture = null;
+    resizeCandidate = null;
+    dragCapture = null;
+    dragSurface = null;
+    dragCandidate = null;
+    dragging = false;
+    dxSpots = [];
+    if (managed) { spectrumPush = null; waterfallPush = null; }
+  }
+
+  $effect(() => { if (managed) scopeDemandOn = scopeDemanded; });
+  $effect(() => {
+    if (!managed) return;
+    const projection = scopeProjection;
+    const unavailable = managedUnavailable;
+    untrack(() => {
+      if (unavailable || !projection) { clearSample(); return; }
+      frameScopeMode = projection.frameMode;
+      startFreq = projection.frame.startHz;
+      endFreq = projection.frame.endHz;
+      scopePixels = Uint8Array.from(projection.frame.normalizedBins, sample => Math.round(sample * 255));
+      spectrumPush?.(scopePixels);
+      waterfallPush?.(scopePixels);
+      if (projection.passband.state !== 'current') { resizeCapture = null; resizeCandidate = null; }
+    });
+  });
+
   $effect(() => {
     const sourceIsAudio = audioFft;
+    const sourceIsManaged = managed;
     return untrack(() => {
       fullscreen = false;
-      scopePixels = null;
-      startFreq = 0;
-      endFreq = 0;
-      frameScopeMode = 0;
-      resizeCapture = null;
-      dragCapture = null;
-      dragging = false;
-      dxSpots = [];
+      if (!sourceIsManaged) clearSample();
       if (sourceIsAudio) runtime.scope.registerPresentationDriver(presentationResources);
       const receive = (frame: Parameters<Parameters<typeof runtime.scope.subscribe>[0]>[0]) => {
-        if (!scopeDemandOn) return;
+        if (managed || !scopeDemandOn) return;
         if (sourceIsAudio && (frame.pixels.length < 3 || frame.pixels.length % 2 === 0
           || frame.endFreq <= frame.startFreq)) return;
         const pixels = sourceIsAudio
@@ -520,11 +567,12 @@
         spectrumPush?.(pixels);
         waterfallPush?.(pixels);
       };
-      const unsubscribe = sourceIsAudio
+      const unsubscribe = sourceIsManaged ? () => {} : sourceIsAudio
         ? runtime.scope.subscribe(receive)
         : runtime.scope.subscribeHardware(receive);
       if (scopeDemandOn) acquireScopeDemand();
       const unsubDx = sourceIsAudio ? () => {} : runtime.subscribeDx((msg) => {
+        if (managedUnavailable) return;
         if (msg.type === 'dx_spot') {
           const spot = (msg as unknown as { spot: DxSpot }).spot;
           if (spot) dxSpots = [...dxSpots.slice(-49), spot];
@@ -560,7 +608,7 @@
   other `g <key>` targets, which land on a real form control that was already
   in the tab order.
 -->
-{#key audioFft}
+{#key `${audioFft}:${managed}`}
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <div class="spectrum-panel" class:audio-fft={audioFft} class:fullscreen data-waterfall tabindex="-1" onwheel={handleWheel}>
   {#if audioFft}
@@ -572,6 +620,11 @@
     </div>
   {:else}
   <SpectrumToolbar bind:enableAvg bind:enablePeakHold bind:brtLevel bind:colorScheme bind:fullscreen bind:showBandPlan bind:hiddenLayers bind:showEiBi {scopeDemandOn} onScopeDemandChange={setScopeDemand} {hideSourceControls} {hideScopeControls} {hideAutoStepToggle} {scopeControls} />
+  {/if}
+  {#if managed}
+    <div class="passband-freshness" role="status" aria-label={displayStale ? t('core.rxTx.target.reason.stale') : undefined}>
+      {displayStale ? `◷ ${t('core.rxTx.target.reason.stale')}` : ''}
+    </div>
   {/if}
   <div class="spectrum-with-scales">
     <div class="db-scale">
@@ -586,7 +639,9 @@
         <div class="scope-disconnected-overlay">{t('core.overlay.scopeDisconnected')}</div>
       {/if}
       {#if !audioFft}<BandPlanOverlay {startFreq} {endFreq} visible={showBandPlan} {hiddenLayers} />{/if}
-      <SpectrumCanvas data={scopePixels} options={spectrumOptions} {spanHz} {enableAvg} {enablePeakHold} onRegisterPush={(fn) => spectrumPush = fn} />
+      {#if !managedUnavailable}
+      <SpectrumCanvas data={scopePixels} options={spectrumOptions} {spanHz} {enableAvg} {enablePeakHold} onRegisterPush={(fn) => { spectrumPush = fn; if (managed && scopePixels) fn(scopePixels); }} />
+      {/if}
       {#if tuneVisible && spanHz > 0 && pbWidthPct > 0 && canResizePassband}
         <button
           type="button"
@@ -610,7 +665,9 @@
   <div class="waterfall-area">
     <div class="waterfall-scale"></div>
     <div class="waterfall-content" class:panning={dragging} class:draggable={canPan} bind:this={waterfallContent} onpointerdown={handleDragStart} role="presentation">
-      <WaterfallCanvas options={waterfallOptions} onFreqClick={audioFft ? undefined : handleTune} onRegisterPush={(fn) => waterfallPush = fn} />
+      {#if !managedUnavailable}
+      <WaterfallCanvas options={waterfallOptions} onFreqClick={audioFft ? undefined : handleTune} onRegisterPush={(fn) => { waterfallPush = fn; if (managed && scopePixels) fn(scopePixels); }} />
+      {/if}
       {#if !audioFft}<DxOverlay spots={dxSpots} {startFreq} {endFreq} onTune={handleTune} />{/if}
       <!-- Tuning + passband indicator overlays the waterfall -->
       {#if tuneVisible && spanHz > 0}
@@ -638,6 +695,7 @@
 {/key}
 
 <style>
+  .passband-freshness { min-height: 1.4em; padding: 0 8px; font-size: 11px; color: var(--text-muted); }
   .audio-source-label { display: flex; align-items: center; justify-content: space-between; padding: 6px 12px; color: var(--text-muted); font-size: 12px; }
   .audio-fft :global(canvas) { cursor: default; }
   .spectrum-panel {

--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -84,6 +84,7 @@
     : runtime.scope.hardwareScopeConnected);
   let scopeLease: ReturnType<typeof runtime.acquireHardwareScope> | null = null;
   let scopePixels = $state<Uint8Array | null>(null);
+  let sampledReceipt: number | null = null;
   let enableAvg = $state(true);
   let enablePeakHold = $state(true);
   let brtLevel = $state(0);
@@ -513,6 +514,7 @@
   const CENTRAL_SCOPE_AMPLITUDE_MAX = 80;
 
   function clearSample(): void {
+    sampledReceipt = null;
     scopePixels = null;
     startFreq = 0;
     endFreq = 0;
@@ -537,9 +539,12 @@
       frameScopeMode = projection.frameMode;
       startFreq = projection.frame.startHz;
       endFreq = projection.frame.endHz;
-      scopePixels = Uint8Array.from(projection.frame.normalizedBins, sample => Math.round(sample * 255));
-      spectrumPush?.(scopePixels);
-      waterfallPush?.(scopePixels);
+      if (sampledReceipt !== projection.acceptedSequence) {
+        sampledReceipt = projection.acceptedSequence;
+        scopePixels = Uint8Array.from(projection.frame.normalizedBins, sample => Math.round(sample * 255));
+        spectrumPush?.(scopePixels);
+        waterfallPush?.(scopePixels);
+      }
       if (projection.passband.state !== 'current') { resizeCapture = null; resizeCandidate = null; }
     });
   });
@@ -622,7 +627,7 @@
   <SpectrumToolbar bind:enableAvg bind:enablePeakHold bind:brtLevel bind:colorScheme bind:fullscreen bind:showBandPlan bind:hiddenLayers bind:showEiBi {scopeDemandOn} onScopeDemandChange={setScopeDemand} {hideSourceControls} {hideScopeControls} {hideAutoStepToggle} {scopeControls} />
   {/if}
   {#if managed}
-    <div class="passband-freshness" role="status" aria-label={displayStale ? t('core.rxTx.target.reason.stale') : undefined}>
+    <div class="passband-freshness" aria-label={displayStale ? t('core.rxTx.target.reason.stale') : undefined}>
       {displayStale ? `◷ ${t('core.rxTx.target.reason.stale')}` : ''}
     </div>
   {/if}

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -8,6 +8,7 @@ import { createRawSnippet, mount, unmount, flushSync } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import type { ScopeDisplayProjection } from '$lib/runtime/adapters/scope-display-projection';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
 
 // ---------------------------------------------------------------------------
@@ -370,6 +371,7 @@ vi.mock('$lib/runtime/props/panel-props', async (importOriginal) => ({
 // Import component after mocks
 // ---------------------------------------------------------------------------
 
+import { WaterfallRenderer } from '$lib/renderers/waterfall-renderer';
 import SpectrumPanel from '../SpectrumPanel.svelte';
 import spectrumPanelSource from '../SpectrumPanel.svelte?raw';
 import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
@@ -1385,5 +1387,188 @@ describe('opaque semantic scope snippet forwarding (MOR-2358)', () => {
     const viewer = target.querySelector<HTMLButtonElement>('[aria-label="Scope viewer"]')!;
     expect(viewer.textContent).toContain('Viewer ON'); viewer.click(); flushSync(); expect(viewer.textContent).toContain('Viewer OFF');
     expect(mockRuntime.scope.subscribeHardware).not.toHaveBeenCalled();
+  });
+});
+
+describe('managed scope projection (MOR-2367)', () => {
+  function projection(state: 'current' | 'stale' | 'unknown' | 'unsupported' = 'current'): ScopeDisplayProjection {
+    return Object.freeze({
+      frame: Object.freeze({ source: 'hardware', receiver: 'MAIN', freshness: 'fresh',
+        startHz: 14_000_000, endHz: 14_100_000, normalizedBins: Object.freeze([0, 0.5, 1]) }),
+      frameMode: 0,
+      passband: state === 'current' || state === 'stale'
+        ? Object.freeze({ state, tuple: Object.freeze({ frequencyHz: 14_050_250, mode: 'USB',
+          widthHz: 2_400, shiftHz: 0, frameMode: 0, startHz: 14_000_000, endHz: 14_100_000 }) })
+        : { state, reason: 'not-observed' },
+    });
+  }
+  function managed(initial: ReturnType<typeof projection> | null | undefined) {
+    const props = new SvelteMap<string, unknown>([['projection', initial], ['demanded', true]]);
+    const onScopeDemandChange = vi.fn((enabled: boolean) => props.set('demanded', enabled));
+    const target = mountPanel({
+      get scopeProjection() { return props.get('projection'); },
+      get scopeDemanded() { return props.get('demanded'); }, onScopeDemandChange,
+    });
+    return { target, props, onScopeDemandChange };
+  }
+  function cleared(target: HTMLElement) {
+    for (const selector of ['canvas', '.freq-axis', '.tune-line', '.passband-overlay', '.passband-resize-zone', '.draggable']) {
+      expect(target.querySelector(selector), selector).toBeNull();
+    }
+  }
+  it.each([null, 'current'] as const)('never acquires or subscribes raw scope for managed %s', (kind) => {
+    const { target } = managed(kind === null ? null : projection());
+    expect(mockRuntime.acquireHardwareScope).not.toHaveBeenCalled();
+    expect(mockRuntime.scope.subscribeHardware).not.toHaveBeenCalled();
+    emitFrame();
+    if (kind === null) cleared(target);
+    else expect(target.querySelector('.passband-overlay')).not.toBeNull();
+    expect(handlerHarness.vfo.onFreqChange).not.toHaveBeenCalled();
+  });
+  it('keeps omitted and explicit undefined projections on the legacy acquisition path', () => {
+    mountPanel(); mountPanel({ scopeProjection: undefined });
+    expect(mockRuntime.acquireHardwareScope).toHaveBeenCalledTimes(2);
+    expect(mockRuntime.scope.subscribeHardware).toHaveBeenCalledTimes(2);
+  });
+  it('clears after legacy-to-managed null and rejects a captured late raw callback', () => {
+    const { target, props } = managed(undefined);
+    emitFrame(); const oldCallback = runtimeHarness.state.capturedHardwareFrame!;
+    expect(target.querySelector('.passband-overlay')).not.toBeNull();
+    props.set('projection', null); flushSync(); cleared(target);
+    oldCallback({ receiver: 0, mode: 0, startFreq: 14_000_000, endFreq: 14_100_000, pixels: new Uint8Array([90, 90]) });
+    flushSync(); cleared(target);
+    expect(runtimeHarness.state.hardwareUnsubscribe).toHaveBeenCalledOnce();
+    expect(mockRuntime.releaseHardwareScope).toHaveBeenCalledOnce();
+  });
+  it.each(['null', 'off'] as const)('clears pixels, coordinates and active captures on %s while shared health stays true', async (boundary) => {
+    const shared = mockRuntime.acquireHardwareScope();
+    const { target, props, onScopeDemandChange } = managed(projection());
+    await vi.waitFor(() => expect(spectrumRendererHarness.render).toHaveBeenCalled());
+    expect([...spectrumRendererHarness.render.mock.calls.at(-1)![1]]).toEqual([0, 128, 255]);
+    const { waterfall } = prepareGeometry(target);
+    const zone = waterfall.querySelector('.passband-resize-zone')!;
+    pointer(zone, 'pointerdown', 80, 100); pointer(waterfall, 'pointermove', 80, 130);
+    const oldCanvas = target.querySelector('canvas');
+    if (boundary === 'null') props.set('projection', null);
+    else target.querySelector<HTMLButtonElement>('.scope-demand-toggle')!.click();
+    flushSync(); cleared(target);
+    expect(oldCanvas?.isConnected).toBe(false);
+    expect(runtimeHarness.state.mockScopeConnected).toBe(true);
+    expect(mockRuntime.acquireHardwareScope).toHaveBeenCalledOnce();
+    expect(mockRuntime.releaseHardwareScope).not.toHaveBeenCalled();
+    pointer(window, 'pointerup', 80, 130);
+    const { spectrum } = prepareGeometry(target);
+    pointer(spectrum, 'pointerdown', 81, 100); pointer(spectrum, 'pointermove', 81, 130); pointer(spectrum, 'pointerup', 81, 130);
+    target.querySelector('.spectrum-panel')!.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: 1 }));
+    emitFrame(); cleared(target);
+    expect(handlerHarness.vfo.onFreqChange).not.toHaveBeenCalled();
+    expect(handlerHarness.filter.onFilterWidthCommit).not.toHaveBeenCalled();
+    if (boundary === 'off') {
+      expect(onScopeDemandChange).toHaveBeenCalledWith(false);
+      props.set('projection', null); flushSync();
+      target.querySelector<HTMLButtonElement>('.scope-demand-toggle')!.click(); flushSync();
+      expect(onScopeDemandChange).toHaveBeenLastCalledWith(true); cleared(target);
+    }
+    props.set('projection', projection()); flushSync();
+    expect(target.querySelector('.passband-overlay')).not.toBeNull();
+    mockRuntime.releaseHardwareScope(shared);
+  });
+  it.each(['unknown', 'unsupported'] as const)('keeps the managed sample plane without raw RF fallback for %s passband', (state) => {
+    const { target } = managed(projection(state));
+    expect(target.querySelector('canvas')).not.toBeNull();
+    expect(target.querySelector('.freq-axis')).not.toBeNull();
+    expect(target.querySelector('.tune-line')).toBeNull();
+    expect(target.querySelector('.passband-overlay')).toBeNull();
+    expect(target.querySelector('.passband-resize-zone')).toBeNull();
+  });
+  it('retains whole stale geometry with a non-color cue while strict fresh frequency still pans', () => {
+    const { target, props } = managed(projection()); const original = target.querySelector('.passband-overlay')!.getAttribute('style');
+    authorityHarness.state.current = authority({ filterWidthHz: null, ifShiftHz: null }); refreshSpectrumAuthority();
+    props.set('projection', projection('stale')); flushSync();
+    expect(target.querySelector('.passband-overlay')!.getAttribute('style')).toBe(original);
+    const cue = target.querySelector('.passband-freshness')!;
+    expect(cue.textContent?.trim()).not.toBe(''); expect(cue.getAttribute('aria-label')).toBeTruthy();
+    expect(target.querySelector('.passband-resize-zone')).toBeNull();
+    const { spectrum } = prepareGeometry(target);
+    pointer(spectrum, 'pointerdown', 82, 100); pointer(spectrum, 'pointermove', 82, 120); pointer(spectrum, 'pointerup', 82, 120);
+    expect(handlerHarness.vfo.onFreqChange).toHaveBeenCalledOnce();
+    expect(handlerHarness.vfo.onFreqChange).toHaveBeenCalledWith(14_040_000, 0);
+    authorityHarness.state.current = authority({ frequencyHz: null }); refreshSpectrumAuthority(); flushSync();
+    pointer(spectrum, 'pointerdown', 83, 100); pointer(spectrum, 'pointermove', 83, 120); pointer(spectrum, 'pointerup', 83, 120);
+    expect(handlerHarness.vfo.onFreqChange).toHaveBeenCalledOnce();
+    props.set('projection', projection()); flushSync();
+    expect(target.querySelector('.passband-freshness')!.textContent?.trim()).toBe('');
+  });
+  it('does not grant stale resize even if a separate strict snapshot is current', () => {
+    const { target, props } = managed(projection()); const { waterfall } = prepareGeometry(target);
+    const zone = waterfall.querySelector('.passband-resize-zone')!;
+    pointer(zone, 'pointerdown', 84, 100); pointer(waterfall, 'pointermove', 84, 130);
+    props.set('projection', projection('stale')); flushSync();
+    pointer(window, 'pointerup', 84, 130);
+    expect(target.querySelector('.passband-resize-zone')).toBeNull();
+    expect(handlerHarness.filter.onFilterWidthCommit).not.toHaveBeenCalled();
+  });
+  it('pushes normalized managed frames through existing waterfall registrations on mount and recovery', () => {
+    const push = vi.spyOn(WaterfallRenderer.prototype, 'pushRow');
+    try {
+      const { target, props } = managed(projection());
+      expect([...push.mock.calls.at(-1)![0]]).toEqual([0, 128, 255]);
+      const firstCanvas = target.querySelector('.waterfall-content canvas');
+      props.set('projection', null); flushSync(); const afterClear = push.mock.calls.length;
+      emitFrame(); expect(push).toHaveBeenCalledTimes(afterClear);
+      props.set('projection', projection()); flushSync();
+      expect(target.querySelector('.waterfall-content canvas')).not.toBe(firstCanvas);
+      expect([...push.mock.calls.at(-1)![0]]).toEqual([0, 128, 255]);
+      expect(push.mock.calls.length).toBeGreaterThan(afterClear);
+    } finally { push.mockRestore(); }
+  });
+  it('preserves raw waterfall push delivery in legacy mode', () => {
+    const push = vi.spyOn(WaterfallRenderer.prototype, 'pushRow');
+    try {
+      mountPanel(); const frame = emitFrame();
+      expect(push).toHaveBeenCalledWith(frame.pixels);
+    } finally { push.mockRestore(); }
+  });
+  it.each(['tap', 'pan'] as const)('cancels an in-flight %s and DX coordinates when managed projection becomes null', (gesture) => {
+    const { target, props } = managed(projection()); const { spectrum, waterfall } = prepareGeometry(target);
+    const surface = gesture === 'tap' ? waterfall.querySelector('canvas')! : spectrum;
+    const spot = { spotter: 'N0CALL', freq: 14_075_410, call: 'K1ABC', comment: 'test', time_utc: '1200', timestamp: 1 };
+    runtimeHarness.state.capturedDxMessage?.({ type: 'dx_spot', spot }); flushSync();
+    expect(target.querySelector('.dx-badge')).not.toBeNull();
+    pointer(surface, 'pointerdown', 86, 100);
+    if (gesture === 'pan') pointer(surface, 'pointermove', 86, 120);
+    props.set('projection', null); flushSync();
+    pointer(surface, 'pointerup', 86, 120);
+    runtimeHarness.state.capturedDxMessage?.({ type: 'dx_spot', spot }); flushSync();
+    expect(target.querySelector('.dx-badge')).toBeNull(); cleared(target);
+    expect(handlerHarness.vfo.onFreqChange).not.toHaveBeenCalled();
+  });
+  it('routes current managed waterfall tap and wheel through canonical handlers', () => {
+    const { target } = managed(projection()); const { waterfall } = prepareGeometry(target);
+    const canvas = waterfall.querySelector('canvas')!;
+    pointer(canvas, 'pointerdown', 87, 150); pointer(canvas, 'pointerup', 87, 150);
+    expect(handlerHarness.vfo.onFreqChange).toHaveBeenCalledWith(14_050_000, 0);
+    target.querySelector('.spectrum-panel')!.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: 1 }));
+    expect(handlerHarness.vfo.onFreqChange).toHaveBeenCalledTimes(2);
+    expect(handlerHarness.vfo.onFreqChange).toHaveBeenLastCalledWith(14_049_000, 0, 'step');
+  });
+  it('obeys an external demanded=false even if the supplied projection is still live', () => {
+    const { target, props } = managed(projection());
+    props.set('demanded', false); flushSync(); cleared(target);
+    props.set('projection', projection()); flushSync(); cleared(target);
+    expect(mockRuntime.acquireHardwareScope).not.toHaveBeenCalled();
+    props.set('demanded', true); flushSync();
+    expect(target.querySelector('.passband-overlay')).not.toBeNull();
+  });
+  it.each(['failed', 'cancelled'] as const)('keeps pending resize temporary and returns to the qualified tuple after %s', (phase) => {
+    const input = projection(); const { target } = managed(input); const { waterfall } = prepareGeometry(target);
+    const zone = waterfall.querySelector('.passband-resize-zone')!;
+    pointer(zone, 'pointerdown', 85, 100); pointer(waterfall, 'pointermove', 85, 130); pointer(waterfall, 'pointerup', 85, 130);
+    expect(handlerHarness.filter.onFilterWidthCommit).toHaveBeenCalledWith(2_700, 0, 17);
+    setFilterWidthLifecycle(pendingFilterWidthLifecycle(2_700)); flushSync();
+    expect(target.querySelector<HTMLElement>('.passband-overlay')!.style.width).toBe('27%');
+    setFilterWidthLifecycle({ outcome: { phase } }); flushSync();
+    expect(target.querySelector<HTMLElement>('.passband-overlay')!.style.width).toBe('24%');
+    expect(input.passband).toEqual(projection().passband);
   });
 });

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -1395,7 +1395,7 @@ describe('managed scope projection (MOR-2367)', () => {
     return Object.freeze({
       frame: Object.freeze({ source: 'hardware', receiver: 'MAIN', freshness: 'fresh',
         startHz: 14_000_000, endHz: 14_100_000, normalizedBins: Object.freeze([0, 0.5, 1]) }),
-      frameMode: 0,
+      frameMode: 0, acceptedSequence: 1,
       passband: state === 'current' || state === 'stale'
         ? Object.freeze({ state, tuple: Object.freeze({ frequencyHz: 14_050_250, mode: 'USB',
           widthHz: 2_400, shiftHz: 0, frameMode: 0, startHz: 14_000_000, endHz: 14_100_000 }) })
@@ -1512,6 +1512,7 @@ describe('managed scope projection (MOR-2367)', () => {
     const push = vi.spyOn(WaterfallRenderer.prototype, 'pushRow');
     try {
       const { target, props } = managed(projection());
+      expect(push).toHaveBeenCalledTimes(1);
       expect([...push.mock.calls.at(-1)![0]]).toEqual([0, 128, 255]);
       const firstCanvas = target.querySelector('.waterfall-content canvas');
       props.set('projection', null); flushSync(); const afterClear = push.mock.calls.length;
@@ -1519,7 +1520,7 @@ describe('managed scope projection (MOR-2367)', () => {
       props.set('projection', projection()); flushSync();
       expect(target.querySelector('.waterfall-content canvas')).not.toBe(firstCanvas);
       expect([...push.mock.calls.at(-1)![0]]).toEqual([0, 128, 255]);
-      expect(push.mock.calls.length).toBeGreaterThan(afterClear);
+      expect(push).toHaveBeenCalledTimes(afterClear + 1);
     } finally { push.mockRestore(); }
   });
   it('preserves raw waterfall push delivery in legacy mode', () => {

--- a/frontend/src/lib/runtime/adapters/scope-display-projection.ts
+++ b/frontend/src/lib/runtime/adapters/scope-display-projection.ts
@@ -4,6 +4,8 @@ import type { ScopePassbandDisplay } from './scope-passband-display';
 export type ScopeDisplayProjection = Readonly<{
   frame: LcdSpectrumFrame;
   frameMode: number;
+  /** Existing controller-lifetime receipt identity, unchanged by metadata refresh. */
+  acceptedSequence: number;
   passband: ScopePassbandDisplay;
 }>;
 

--- a/frontend/src/lib/runtime/adapters/scope-display-projection.ts
+++ b/frontend/src/lib/runtime/adapters/scope-display-projection.ts
@@ -1,0 +1,14 @@
+import type { LcdSpectrumFrame } from '../../../skins/segmentline/lcd-display-contract';
+import type { ScopePassbandDisplay } from './scope-passband-display';
+
+export type ScopeDisplayProjection = Readonly<{
+  frame: LcdSpectrumFrame;
+  frameMode: number;
+  passband: ScopePassbandDisplay;
+}>;
+
+export type ManagedScopeRegion = Readonly<{
+  projection: ScopeDisplayProjection | null;
+  demanded: boolean;
+  setDemand(enabled: boolean): void;
+}>;


### PR DESCRIPTION
Managed hardware scope now receives one qualified frame and coherent passband display tuple from the existing selected-hardware host. Viewer OFF immediately clears its samples, axes, overlay and gestures even while another lease keeps transport healthy. Stale geometry stays tied to the same context, with a reserved localized cue; strict pan/resize authority and pending-command handling remain separate.

The passive region preserves the toolbar as snippet argument one and adds projection/demand as argument two. RadioLayout forwards the trinary projection: undefined retains legacy acquisition, null is managed unavailable, and a managed object uses no panel-owned hardware lease or raw subscription. The existing controller acceptedSequence travels with the projection, so metadata/freshness updates do not append waterfall rows; an actual new receipt with identical bins appends once. The cue has no implicit live-region announcements. Existing readonly and audio FFT paths retain their configured contracts.

The merged MOR-2373 controller prerequisite (#3228, main `7fa432810`) is integrated. The actual host/resource/controller/panel composition now recovers when an independent lease predates authority; that case is an ordinary passing test, not an outstanding limitation or skipped case. No new controller, manager, timer, receipt-floor map or pixel history is added here. The host's raw Uint8Array remains writable; deep pixel immutability is not claimed.

Validation at `07f69fe1e506a0e38292928608cb7efebd0e628e`:

- 356 focused tests pass without filters/skips across 6 files, including all 55 existing RadioLayout routing tests, 23 actual composition tests, 108 panel, 152 reducer, 14 host and 4 readonly compatibility tests.
- Types: svelte-check 0 errors / 0 warnings and node/harness TypeScript pass. ESLint passes for all 7 changed paths; diff check passes.
- Receipt/freshness/duplicate-delivery/live-semantics mutants fail; equivalent receipt guard control passes. Real composition covers shared-lease OFF, receipt/marker replay and recovery, 499/500 ms expiry, one host/subscription teardown, configuration forwarding, canonical receiver/slot startup, provider transitions, strict frequency-only pan and pending-target exclusion.

Scope: 7 files, 746 additions / 55 deletions (801 changed lines) relative to merged main. No full local suite, baseline regeneration, actual radio/UI validation or release was performed in this builder pass. Independent exact-head review and required PR checks remain merge gates.

Owner: [MOR-2367](https://linear.app/morozsm/issue/MOR-2367). The seven-file,801-line scope is one selected-receiver display contract: passive adapter, existing wiring/layout/panel integration and their real composition/routing regression proof. This explains the600-line soft threshold. Final squash text will describe the integrated356-pass candidate and omit the intermediate dependency checkpoint's historical355-pass/1-RED validation; that development state is superseded.
