### PR TITLE
fix(MOR-2373): rebind scope authority while preserving shared resource handles

### DIFF
--- a/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
+++ b/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
@@ -20,6 +20,7 @@ function makeMockChannel() {
   const sessionHandlers = new Set<(transition: { state: string; epoch: number }) => void>();
   const binaryHistory: Array<(buf: ArrayBuffer) => void> = [];
   const stateHistory: Array<(state: string) => void> = [];
+  const sessionHistory: Array<(transition: { state: string; epoch: number }) => void> = [];
   let state = 'disconnected';
   let sessionEpoch = 1;
   return {
@@ -39,6 +40,7 @@ function makeMockChannel() {
     }),
     onSessionTransition: vi.fn((handler: (transition: { state: string; epoch: number }) => void) => {
       sessionHandlers.add(handler);
+      sessionHistory.push(handler);
       return () => { sessionHandlers.delete(handler); };
     }),
     /** Fire a binary message to all registered handlers. */
@@ -51,7 +53,7 @@ function makeMockChannel() {
       for (const h of stateHandlers) h(next);
       for (const h of sessionHandlers) h({ state: next, epoch: sessionEpoch });
     },
-    _binaryHistory: binaryHistory, _stateHistory: stateHistory,
+    _binaryHistory: binaryHistory, _stateHistory: stateHistory, _sessionHistory: sessionHistory,
     _handlerCount() { return binaryHandlers.size; },
     _stateHandlerCount() { return stateHandlers.size; },
     _sessionHandlerCount() { return sessionHandlers.size; },
@@ -752,4 +754,205 @@ describe('ScopeController', () => {
     expect([local._handlerCount(), local._stateHandlerCount(), local._sessionHandlerCount()])
       .toEqual([0, 0, 0]);
   });
+});
+
+
+describe.each([
+  ['hardware', 'hardwareScopeDriver', 'hardware-scope', '/api/v1/scope'],
+  ['audio_fft', 'audioFftDriver', 'audio-fft', '/api/v1/audio-scope'],
+] as const)('authority rebind: %s', (source, driverName, resource, endpoint) => {
+  function rig() {
+    const channel = makeMockChannel();
+    channel.disconnect.mockImplementation(() => channel._setState('disconnected'));
+    channel.connect.mockImplementation(() => channel._setState('connecting'));
+    const controller = new ScopeController(() => channel as never, makeTiming().timing);
+    const driver = controller[driverName];
+    const stop = vi.spyOn(driver, 'stop');
+    const start = vi.spyOn(driver, 'start');
+    const host = new PresentationResourceHost(`rebind-${source}`);
+    host.configure(resource, { available: true, selected: true, driver });
+    const authority = (providerGeneration: number, receiver: 0 | 1 = 0) =>
+      controller.setFrameAuthority({ source, receiver, providerGeneration });
+    const raw = vi.fn();
+    if (source === 'hardware') controller.subscribeHardware(raw);
+    else controller.subscribe(raw);
+    const latest = () => source === 'hardware' ? controller.scopeFrame : controller.audioScopeFrame;
+    const retain = () => {
+      const binary = channel._binaryHistory.at(-1)!;
+      const state = channel._stateHistory.at(-1)!;
+      const session = channel._sessionHistory.at(-1)!;
+      return () => {
+        binary(makeScopeFrameBuffer());
+        binary(new ArrayBuffer(16));
+        state('connected');
+        state('disconnected');
+        session({ state: 'disconnected', epoch: 999 });
+        session({ state: 'connected', epoch: 999 });
+      };
+    };
+    const counts = () => [channel._handlerCount(), channel._stateHandlerCount(), channel._sessionHandlerCount()];
+    return { channel, controller, host, authority, raw, latest, retain, counts, start, stop };
+  }
+
+  it('recovers demand two under the original handle and fences every retired callback', async () => {
+    const r = rig();
+    const independent = r.host.acquire(resource, 'independent-before-authority')!;
+    await vi.waitFor(() => expect(r.host.snapshot(resource).pending).toBeUndefined());
+    const originalHandle = r.host.snapshot(resource).activeHandle;
+    r.channel._setState('connected');
+    r.channel._fire(makeScopeFrameBuffer());
+    expect(r.latest()).not.toBeNull();
+    expect(r.controller.snapshotFrameEvidence().envelope).toBeNull();
+    let retired = r.retain();
+    let epoch = r.channel.sessionEpoch;
+    for (const generation of [1, 2]) {
+      r.authority(generation);
+      const managed = r.host.acquire(resource, `managed-${generation}`)!;
+      await vi.waitFor(() => expect(r.host.snapshot(resource).pending).toBeUndefined());
+      expect(r.host.snapshot(resource)).toMatchObject({ demand: 2, activeHandle: originalHandle });
+      expect(r.host.snapshot(resource).activeHandle).toBe(originalHandle);
+      expect(r.start).toHaveBeenCalledTimes(1);
+      expect(r.stop).not.toHaveBeenCalled();
+      expect(r.channel.connect).toHaveBeenCalledTimes(generation + 1);
+      expect(r.channel.connect).toHaveBeenLastCalledWith(endpoint);
+      expect(r.channel.disconnect).toHaveBeenCalledTimes(generation);
+      expect(r.counts()).toEqual([1, 1, 1]);
+      expect(r.latest()).toBeNull();
+      expect(r.controller.snapshotHealth(source)).toEqual({ demanded: true, transport: 'connecting', frameSeen: false });
+      const evidence = vi.fn();
+      const unsubscribe = r.controller.subscribeFrameEvidence(evidence);
+      const rawCount = r.raw.mock.calls.length;
+      retired();
+      r.channel._fire(makeScopeFrameBuffer());
+      expect(r.raw).toHaveBeenCalledTimes(rawCount);
+      expect(evidence).not.toHaveBeenCalled();
+      expect(r.controller.snapshotFrameEvidence().envelope).toBeNull();
+      r.channel._setState('connected');
+      expect(r.channel.sessionEpoch).toBeGreaterThan(epoch);
+      r.channel._fire(makeScopeFrameBuffer());
+      const current = r.controller.snapshotFrameEvidence();
+      expect(current.envelope).toMatchObject({ providerGeneration: generation, transportEpoch: r.channel.sessionEpoch, acceptedSequence: generation + 1 });
+      expect(r.raw).toHaveBeenCalledTimes(rawCount + 1);
+      evidence.mockClear();
+      retired();
+      expect(r.controller.snapshotFrameEvidence()).toEqual(current);
+      expect(r.controller.snapshotHealth(source)).toEqual({ demanded: true, transport: 'connected', frameSeen: true });
+      expect(r.raw).toHaveBeenCalledTimes(rawCount + 1);
+      expect(evidence).not.toHaveBeenCalled();
+      unsubscribe();
+      epoch = r.channel.sessionEpoch;
+      retired = r.retain();
+      r.host.release(managed);
+      await vi.waitFor(() => expect(r.host.snapshot(resource).pending).toBeUndefined());
+      expect(r.channel.disconnect).toHaveBeenCalledTimes(generation);
+    }
+    r.host.release(independent);
+    await vi.waitFor(() => expect(r.host.snapshot(resource).pending).toBeUndefined());
+    expect(r.stop).toHaveBeenCalledExactlyOnceWith(originalHandle);
+    expect(r.host.snapshot(resource).demand).toBe(0);
+    expect(r.channel.disconnect).toHaveBeenCalledTimes(3);
+    expect(r.counts()).toEqual([0, 0, 0]);
+    const final = r.controller.snapshotFrameEvidence();
+    const rawCount = r.raw.mock.calls.length;
+    retired();
+    expect(r.controller.snapshotFrameEvidence()).toEqual(final);
+    expect(r.latest()).toBeNull();
+    expect(r.raw).toHaveBeenCalledTimes(rawCount);
+    expect(r.controller.snapshotHealth(source)).toEqual({ demanded: false, transport: 'disconnected', frameSeen: false });
+  });
+
+  it('keeps fresh, receiver-only and null authority streams running; restores valid authority once', async () => {
+    const r = rig();
+    r.authority(1);
+    const lease = r.host.acquire(resource, 'foreign')!;
+    await vi.waitFor(() => expect(r.host.snapshot(resource).pending).toBeUndefined());
+    r.channel._setState('connected');
+    r.authority(1);
+    r.authority(1, 1);
+    r.channel._fire(makeScopeFrameBuffer());
+    expect(r.controller.snapshotFrameEvidence().envelope).toBeNull();
+    r.authority(1);
+    r.channel._fire(makeScopeFrameBuffer());
+    expect(r.controller.snapshotFrameEvidence().envelope).not.toBeNull();
+    r.controller.setFrameAuthority(null);
+    r.controller.setFrameAuthority({ source, receiver: null, providerGeneration: 2 });
+    r.controller.setFrameAuthority({ source, receiver: 0, providerGeneration: null });
+    r.channel._fire(makeScopeFrameBuffer());
+    expect(r.latest()).not.toBeNull();
+    expect(r.raw).toHaveBeenCalledTimes(3);
+    expect(r.controller.snapshotFrameEvidence().envelope).toBeNull();
+    expect(r.channel.disconnect).not.toHaveBeenCalled();
+    expect(r.channel.connect).toHaveBeenCalledTimes(1);
+    expect(r.host.snapshot(resource).demand).toBe(1);
+    r.authority(1);
+    expect(r.channel.disconnect).toHaveBeenCalledTimes(1);
+    expect(r.latest()).toBeNull();
+    r.host.release(lease);
+    await vi.waitFor(() => expect(r.host.snapshot(resource).pending).toBeUndefined());
+  });
+
+  it.each(['onBinary', 'onStateChange', 'onSessionTransition', 'connect'] as const)('cleans failed %s while retaining original-handle final cleanup', async (failurePoint) => {
+    const r = rig();
+    const lease = r.host.acquire(resource, 'foreign')!;
+    await vi.waitFor(() => expect(r.host.snapshot(resource).pending).toBeUndefined());
+    const originalHandle = r.host.snapshot(resource).activeHandle;
+    r.channel._setState('connected');
+    const retired = r.retain();
+    const failure = new Error(`rebind ${failurePoint}`);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    r.channel[failurePoint].mockImplementationOnce(() => { throw failure; });
+    expect(() => r.authority(1)).not.toThrow();
+    expect(warn).toHaveBeenCalledWith('Scope authority rebind failed', failure);
+    expect(r.counts()).toEqual([0, 0, 0]);
+    r.retain()(); // Also reject callbacks installed before the failed registration/connect.
+    expect(r.controller.snapshotHealth(source)).toEqual({ demanded: true, transport: 'disconnected', frameSeen: false });
+    expect(r.host.snapshot(resource).activeHandle).toBe(originalHandle);
+    retired();
+    expect(r.latest()).toBeNull();
+    expect(r.controller.snapshotFrameEvidence().envelope).toBeNull();
+    r.host.release(lease);
+    await vi.waitFor(() => expect(r.host.snapshot(resource).pending).toBeUndefined());
+    expect(r.stop).toHaveBeenCalledExactlyOnceWith(originalHandle);
+    expect(r.counts()).toEqual([0, 0, 0]);
+    expect(r.channel.disconnect).toHaveBeenCalledTimes(3);
+    expect(r.controller.snapshotHealth(source).demanded).toBe(false);
+    warn.mockRestore();
+  });
+});
+
+
+it('rebinds only the stale selected source while foreign demand and fresh source bindings survive', async () => {
+  const channels = { scope: makeMockChannel(), 'audio-scope': makeMockChannel() };
+  for (const channel of Object.values(channels)) {
+    channel.disconnect.mockImplementation(() => channel._setState('disconnected'));
+    channel.connect.mockImplementation(() => channel._setState('connecting'));
+  }
+  const factory = vi.fn((name: string) => channels[name as keyof typeof channels] as never);
+  const controller = new ScopeController(factory, makeTiming().timing);
+  const host = new PresentationResourceHost('both');
+  host.configure('hardware-scope', { available: true, selected: true, driver: controller.hardwareScopeDriver });
+  host.configure('audio-fft', { available: true, selected: true, driver: controller.audioFftDriver });
+  host.acquire('hardware-scope', 'foreign-hardware');
+  host.acquire('audio-fft', 'foreign-audio');
+  await vi.waitFor(() => expect(host.snapshot('audio-fft').activeHandle).toBeDefined());
+  channels.scope._setState('connected');
+  channels['audio-scope']._setState('connected');
+  const select = (source: 'hardware' | 'audio_fft') =>
+    controller.setFrameAuthority({ source, receiver: 0, providerGeneration: 1 });
+  select('hardware');
+  expect(channels.scope.disconnect).toHaveBeenCalledTimes(1);
+  expect(channels['audio-scope'].disconnect).not.toHaveBeenCalled();
+  channels['audio-scope']._fire(makeScopeFrameBuffer());
+  expect(controller.audioScopeFrame).not.toBeNull();
+  expect(controller.snapshotFrameEvidence().envelope).toBeNull();
+  select('audio_fft');
+  expect(channels['audio-scope'].disconnect).toHaveBeenCalledTimes(1);
+  select('hardware');
+  select('audio_fft');
+  expect(channels.scope.disconnect).toHaveBeenCalledTimes(1);
+  expect(channels['audio-scope'].disconnect).toHaveBeenCalledTimes(1);
+  expect(host.snapshot('hardware-scope').demand).toBe(1);
+  expect(host.snapshot('audio-fft').demand).toBe(1);
+  expect(factory).toHaveBeenCalledTimes(2);
+  await host.teardown();
 });

--- a/frontend/src/lib/runtime/__tests__/scope-frame-host.test.ts
+++ b/frontend/src/lib/runtime/__tests__/scope-frame-host.test.ts
@@ -10,10 +10,16 @@ function channel() {
   const sessions = new Set<(value: { state: string; epoch: number }) => void>();
   let state = 'disconnected';
   let epoch = 0;
+  function transition(next: string) {
+    if (next === 'connected' && state !== 'connected') epoch += 1;
+    state = next;
+    for (const handler of [...states]) handler(next);
+    for (const handler of [...sessions]) handler({ state: next, epoch });
+  }
   return {
     get state() { return state; },
     get sessionEpoch() { return epoch; },
-    connect: vi.fn(), disconnect: vi.fn(),
+    connect: vi.fn(() => transition('connecting')), disconnect: vi.fn(() => transition('disconnected')),
     onBinary(handler: (buffer: ArrayBuffer) => void) {
       binary.add(handler); return () => { binary.delete(handler); };
     },
@@ -24,12 +30,8 @@ function channel() {
       sessions.add(handler); return () => { sessions.delete(handler); };
     },
     fire(buffer: ArrayBuffer) { for (const handler of [...binary]) handler(buffer); },
-    transition(next: string) {
-      if (next === 'connected' && state !== 'connected') epoch += 1;
-      state = next;
-      for (const handler of [...states]) handler(next);
-      for (const handler of [...sessions]) handler({ state: next, epoch });
-    },
+    transition,
+    retainBinary: () => [...binary][0],
     counts: () => [binary.size, states.size, sessions.size],
   };
 }
@@ -156,24 +158,26 @@ describe('ScopeFrameHost MOR-2326 lifecycle', () => {
     host.dispose();
   });
 
-  it('retires provider receipts, rejects old callbacks, and recovers on re-acquisition', async () => {
+  it('retires provider receipts, rejects old callbacks, and recovers under the original handle', async () => {
     const { channels, controller, host } = rig();
     host.updateAuthority({ source: 'hardware', receiver: 'MAIN', providerGeneration: 1 });
-    let handle = await controller.hardwareScopeDriver.start();
+    const handle = await controller.hardwareScopeDriver.start();
     channels.scope.transition('connected');
     const updates = vi.fn();
     host.subscribePresentation(updates);
     channels.scope.fire(frame());
     const original = updates.mock.lastCall![0];
+    const retired = channels.scope.retainBinary();
     host.updateAuthority({ source: 'hardware', receiver: 'MAIN', providerGeneration: 2 });
     expect(updates.mock.lastCall![0]).toMatchObject({
       envelope: null, authority: { providerGeneration: 2 }, resolution: { state: 'ghost' },
     });
     channels.scope.fire(frame());
     expect(host.snapshotPresentation().envelope).toBeNull();
-    await controller.hardwareScopeDriver.stop(handle);
-    handle = await controller.hardwareScopeDriver.start();
-    channels.scope.transition('reconnecting');
+    retired(frame());
+    expect(host.snapshotPresentation().envelope).toBeNull();
+    expect(channels.scope.connect).toHaveBeenCalledTimes(2);
+    expect(channels.scope.disconnect).toHaveBeenCalledTimes(1);
     channels.scope.transition('connected');
     channels.scope.fire(frame());
     const renewed = updates.mock.lastCall![0];
@@ -181,6 +185,8 @@ describe('ScopeFrameHost MOR-2326 lifecycle', () => {
     expect(renewed.envelope.providerGeneration).toBe(2);
     expect(renewed.envelope.acceptedSequence).toBeGreaterThan(original.envelope.acceptedSequence);
     expect(renewed.envelope.transportEpoch).toBeGreaterThan(original.envelope.transportEpoch);
+    retired(frame());
+    expect(host.snapshotPresentation()).toEqual(renewed);
     channels.scope.fire(new ArrayBuffer(16));
     expect(updates.mock.lastCall![0].resolution.state).toBe('ghost');
     expect(original.resolution.state).toBe('live');

--- a/frontend/src/lib/runtime/scope-controller.svelte.ts
+++ b/frontend/src/lib/runtime/scope-controller.svelte.ts
@@ -161,8 +161,8 @@ export class ScopeController {
   /**
    * Installs the one canonical display identity. Changing any identity member
    * retires the prior envelope synchronously. A provider-generation change
-   * also retires the channel revision: its callbacks may still serve legacy
-   * raw subscribers but cannot revive display facts under the new provider.
+   * also retires the channel revision and rebinds the selected demanded source
+   * without changing the resource host's handle or adopting old-provider pixels.
    */
   setFrameAuthority(authority: ScopeFrameCanonicalAuthority | null): void {
     const normalized = authority
@@ -181,6 +181,13 @@ export class ScopeController {
     this._frameAuthority = normalized;
     this._frameEnvelope = null;
     this._notifyEvidence();
+    if (normalized?.receiver != null && normalized.providerGeneration != null) {
+      if (normalized.source === 'hardware') {
+        this._rebind('hardware', this._hardwareBindings, this._activeHardwareHandle);
+      } else {
+        this._rebind('audio_fft', this._bindings, this._activeHandle);
+      }
+    }
   }
 
   snapshotFrameEvidence(): ScopeFrameEvidence {
@@ -228,58 +235,91 @@ export class ScopeController {
   }
 
   private _connect(): AudioFftHandle {
-    const ch = this._getChannel('audio-scope');
+    const channel = this._getChannel('audio-scope');
     const handle = Object.freeze({ token: Symbol('audio-fft') });
-    const authorityRevision = this._authorityRevision;
-    let unsubscribeBinary = () => {}, unsubscribeState = () => {}, unsubscribeSession = () => {};
     this._activeHandle = handle;
-    this._invalidateSource('audio_fft');
-    this._setHealth('audio_fft', {
-      demanded: true, transport: ch.state, frameSeen: false,
-    });
+    return this._installBinding('audio_fft', this._bindings, handle, channel);
+  }
+
+  private _rebind<H extends AudioFftHandle | HardwareHandle>(
+    source: ScopeSource, bindings: Map<H, ChannelBinding>, handle: H | null,
+  ): void {
+    const old = handle && bindings.get(handle);
+    if (!handle || !old || old.authorityRevision === this._authorityRevision) return;
+    this._invalidateSource(source);
+    bindings.delete(handle); // Retained callbacks lose authority before transport teardown.
     try {
-      unsubscribeState = ch.onStateChange((state) => {
-        if (this._activeHandle !== handle) return;
-        if (state !== 'connected') this._invalidateSource('audio_fft');
-        this._setHealth('audio_fft', {
-          demanded: true, transport: state,
-          frameSeen: state === 'connected' && this._arrivalIsLive('audio_fft'),
-        });
-      });
-      unsubscribeSession = this._subscribeSession(ch, (transition) => {
-        this._sessionTransition('audio_fft', handle, transition);
-      });
-      unsubscribeBinary = ch.onBinary((buf: ArrayBuffer) => {
-        if (this._activeHandle !== handle || this._readHealth('audio_fft').transport !== 'connected') return;
+      try { this._unsubscribeBinding(old); } finally { old.channel.disconnect(); }
+      this._setHealth(source, { demanded: true, transport: 'disconnected', frameSeen: false });
+      this._installBinding(source, bindings, handle, old.channel, true);
+    } catch (error) {
+      // The host still owns this exact handle, including after failed registration/connect.
+      if (!bindings.has(handle)) bindings.set(handle, this._emptyBinding(old.channel, old.authorityRevision));
+      this._setHealth(source, { demanded: true, transport: 'disconnected', frameSeen: false });
+      console.warn('Scope authority rebind failed', error);
+    }
+  }
+
+  private _emptyBinding(channel: WsChannel, authorityRevision: number): ChannelBinding {
+    return { channel, authorityRevision, unsubscribeBinary: () => {}, unsubscribeState: () => {}, unsubscribeSession: () => {} };
+  }
+
+  private _unsubscribeBinding(binding: ChannelBinding): void {
+    try { binding.unsubscribeBinary(); } finally {
+      try { binding.unsubscribeState(); } finally { binding.unsubscribeSession(); }
+    }
+  }
+
+  private _installBinding<H extends AudioFftHandle | HardwareHandle>(
+    source: ScopeSource, bindings: Map<H, ChannelBinding>, handle: H,
+    channel: WsChannel, preserveDemand = false,
+  ): H {
+    const authorityRevision = this._authorityRevision;
+    const binding = this._emptyBinding(channel, authorityRevision);
+    const current = () => bindings.get(handle) === binding
+      && (source === 'hardware' ? this._activeHardwareHandle : this._activeHandle) === handle;
+    bindings.set(handle, binding);
+    this._invalidateSource(source);
+    this._setHealth(source, { demanded: true, transport: channel.state, frameSeen: false });
+    try {
+      binding.unsubscribeBinary = channel.onBinary((buf) => {
+        if (!current() || this._readHealth(source).transport !== 'connected') return;
         const frame = parseScopeFrame(buf);
         if (!frame) {
-          this._invalidateSource('audio_fft', authorityRevision === this._authorityRevision);
+          this._invalidateSource(source, authorityRevision === this._authorityRevision);
           return;
         }
-        if (this._acceptFrame('audio_fft', ch, authorityRevision, frame, buf)) {
-          for (const h of this._subscribers.values()) h(frame);
+        if (this._acceptFrame(source, channel, authorityRevision, frame, buf)) {
+          const subscribers = source === 'hardware' ? this._hardwareSubscribers : this._subscribers;
+          for (const subscriber of subscribers.values()) subscriber(frame);
         }
       });
-      this._bindings.set(handle, {
-        channel: ch, authorityRevision, unsubscribeBinary, unsubscribeState, unsubscribeSession,
+      binding.unsubscribeState = channel.onStateChange((state) => {
+        if (!current()) return;
+        if (state !== 'connected') this._invalidateSource(source);
+        this._setHealth(source, {
+          demanded: true, transport: state,
+          frameSeen: state === 'connected' && this._arrivalIsLive(source),
+        });
       });
-      ch.connect('/api/v1/audio-scope');
+      binding.unsubscribeSession = this._subscribeSession(channel, (transition) => {
+        if (current()) this._sessionTransition(source, handle, transition);
+      });
+      channel.connect(source === 'hardware' ? '/api/v1/scope' : '/api/v1/audio-scope');
       return handle;
     } catch (error) {
-      this._bindings.delete(handle);
-      try { unsubscribeBinary(); } finally {
-        try { unsubscribeState(); } finally { unsubscribeSession(); }
+      bindings.delete(handle);
+      this._unsubscribeBinding(binding);
+      const active = source === 'hardware' ? this._activeHardwareHandle : this._activeHandle;
+      if (active === handle) {
+        if (!preserveDemand) {
+          if (source === 'hardware') this._activeHardwareHandle = null;
+          else this._activeHandle = null;
+        }
+        this._invalidateSource(source);
+        this._setHealth(source, { demanded: preserveDemand, transport: 'disconnected', frameSeen: false });
       }
-      if (this._activeHandle === handle) {
-        this._activeHandle = null;
-        this._invalidateSource('audio_fft');
-        this._setHealth('audio_fft', {
-          demanded: false, transport: 'disconnected', frameSeen: false,
-        });
-      }
-      if (![...this._bindings.values()].some((binding) => binding.channel === ch)) {
-        ch.disconnect();
-      }
+      if (![...bindings.values()].some((item) => item.channel === channel)) channel.disconnect();
       throw error;
     }
   }
@@ -314,61 +354,8 @@ export class ScopeController {
   private _connectHardware(): HardwareHandle {
     const channel = this._getChannel('scope');
     const handle = Object.freeze({ generation: ++this._hardwareGeneration });
-    const authorityRevision = this._authorityRevision;
-    let unsubscribeBinary = () => {}, unsubscribeState = () => {}, unsubscribeSession = () => {};
     this._activeHardwareHandle = handle;
-    this._invalidateSource('hardware');
-    this._setHealth('hardware', {
-      demanded: true, transport: channel.state, frameSeen: false,
-    });
-    try {
-      unsubscribeBinary = channel.onBinary((buf) => {
-        if (
-          this._activeHardwareHandle !== handle
-          || this._readHealth('hardware').transport !== 'connected'
-        ) return;
-        const frame = parseScopeFrame(buf);
-        if (!frame) {
-          this._invalidateSource('hardware', authorityRevision === this._authorityRevision);
-          return;
-        }
-        if (this._acceptFrame('hardware', channel, authorityRevision, frame, buf)) {
-          for (const subscriber of this._hardwareSubscribers.values()) subscriber(frame);
-        }
-      });
-      unsubscribeState = channel.onStateChange((state: ConnectionState) => {
-        if (this._activeHardwareHandle !== handle) return;
-        if (state !== 'connected') this._invalidateSource('hardware');
-        this._setHealth('hardware', {
-          demanded: true, transport: state,
-          frameSeen: state === 'connected' && this._arrivalIsLive('hardware'),
-        });
-      });
-      unsubscribeSession = this._subscribeSession(channel, (transition) => {
-        this._sessionTransition('hardware', handle, transition);
-      });
-      this._hardwareBindings.set(handle, {
-        channel, authorityRevision, unsubscribeBinary, unsubscribeState, unsubscribeSession,
-      });
-      channel.connect('/api/v1/scope');
-    } catch (error) {
-      this._hardwareBindings.delete(handle);
-      try { unsubscribeBinary(); } finally {
-        try { unsubscribeState(); } finally { unsubscribeSession(); }
-      }
-      if (this._activeHardwareHandle === handle) {
-        this._activeHardwareHandle = null;
-        this._invalidateSource('hardware');
-        this._setHealth('hardware', {
-          demanded: false, transport: 'disconnected', frameSeen: false,
-        });
-      }
-      if (![...this._hardwareBindings.values()].some((item) => item.channel === channel)) {
-        channel.disconnect();
-      }
-      throw error;
-    }
-    return handle;
+    return this._installBinding('hardware', this._hardwareBindings, handle, channel);
   }
 
   private _disconnectHardware(handle: HardwareHandle): void {


### PR DESCRIPTION
3 code + 0 regenerated baselines = 3 files

A scope resource acquired before canonical authority could keep its old callback revision indefinitely while shared demand remained active. The managed display then stayed blank despite receiving raw frames. ScopeController now replaces the selected source's stale binding under the same resource-host-owned handle and reconnects the existing named channel for a fresh transport epoch. Demand and final-release ownership remain intact.

The authority-revision fence remains, and binary/state/session callbacks also verify current binding identity. Both hardware and audio recover; null/incomplete authority, receiver-only changes and already-current bindings do not restart transport. Synchronous registration/connect failures leave factual demanded/disconnected health and a cleanup-only binding under the original handle. No retry scheduler or new ownership layer is added.

Owner: [MOR-2373](https://linear.app/morozsm/issue/MOR-2373), prerequisite for consumer PR3227 / MOR-2367. The three-file scope includes the existing host test's migration from manual reacquisition to actual disconnect/connecting/new-epoch behavior; host production, resource host and WebSocket implementation are unchanged. Total412 changed lines.

Validation at9c15e802f0b8fcfa701b12aeac4a7e5025e716c6:57 controller/host tests pass;3 existing targeted WebSocket tests pass; types and changed-path lint pass. Parameterized tests use the real resource host, preserve the adopted handle through demand-two recovery and final release, reject retained callbacks, isolate the other source and cover registration/connect failure boundaries. Seven harmful mutations are detected, including replacing the handle, rewriting the revision without transport replacement, removing binding identity and unnecessary restart; an equivalent identity control passes. No local full suite was run.

Natural exact-head CI and independent review are required before merge. Consumer integration will then prove its committed external pre-authority regression against the combined heads. This prerequisite does not claim live provider timing, installed browser or operator acceptance. No radio, deployment or release action is included.
