### PR TITLE
feat: add shared DATA selection and resolved filter configuration

### DIFF
--- a/frontend/fixtures/stubs/panel-adapters.ts
+++ b/frontend/fixtures/stubs/panel-adapters.ts
@@ -63,3 +63,7 @@ export function getPendingNbOn(_receiver: 0 | 1): boolean | null {
 export function getPendingNrOn(_receiver: 0 | 1): boolean | null {
   return null;
 }
+
+export function getDataModeArmed(): { armed: false; value: null } {
+  return { armed: false, value: null };
+}

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -27,7 +27,7 @@
   import {
     bindSemanticSurfaceHandlers, getBreakInDelayControlFeedback, getPendingFrequencyHz,
     getPendingFilterSelection, getPendingNbOn, getPendingNrOn, getPendingPreampLevel,
-    getSystemHandlers,
+    getSystemHandlers, getDataModeArmed,
   } from '$lib/runtime/adapters/panel-adapters';
   import { toRitXitProps } from '$lib/runtime/props/panel-props';
   import type { SemanticSurfaceName } from '../../presentation/layouts/contract';
@@ -715,6 +715,8 @@
   let pendingFilter = $derived(
     activeReceiverIndex === null ? null : getPendingFilterSelection(activeReceiverIndex),
   );
+  let dataModeArmed = $derived(getDataModeArmed());
+  let pendingDataMode = $derived(dataModeArmed.armed ? dataModeArmed.value : null);
   let pendingPreamp = $derived(
     activeReceiverIndex === null ? null : getPendingPreampLevel(activeReceiverIndex),
   );
@@ -1148,8 +1150,7 @@
     both renders the pre-1304 element shape exactly.
 
     UNLIKE `txAuxSurface`/`metersSurface` it is control-bearing (fix round,
-    verify-MOR-1304 F1). `FilterSurface` renders up to 14 focusable controls
-    (mode/filter/shape buttons, width and passband-level sliders), and the
+    verify-MOR-1304 F1). `FilterSurface` renders focusable controls, and the
     DUAL COCKPIT manifest (`dual-receiver-cockpit.ts`) declares no `filter`
     zone, so a bare mount there would put every one of those controls outside
     every declared zone and after the `rx-tx` zone that MOR-1069 requires to
@@ -1178,6 +1179,8 @@
       <FilterSurface
         {view}
         {pendingFilter}
+        {pendingDataMode}
+        onDataModeChange={filterIntents.onDataModeChange}
         onModeChange={filterIntents.onModeChange}
         onFilterChange={filterIntents.onFilterChange}
         onFilterWidthChange={filterIntents.onFilterWidthChange}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-discrete-pending-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-discrete-pending-wiring.component.test.ts
@@ -64,6 +64,7 @@ import { setCapabilities, clearCapabilities } from '$lib/stores/capabilities.sve
 import { setRadioState, resetRadioState } from '$lib/stores/radio.svelte';
 import { acknowledgeCommand, getCommandLifecycles, resetCommandLifecycle } from '$lib/stores/commands.svelte';
 import { dispatchRadioIntent } from '$lib/runtime/commands/radio-intents';
+import { sendCommand } from '$lib/transport/ws-client';
 import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
 
 const PROVIDER_GENERATION = 0;
@@ -198,6 +199,7 @@ function render(): void {
 const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
 
 beforeEach(() => {
+  vi.mocked(sendCommand).mockClear();
   txHarness = new ManagedAppTxHarness();
   h.txController = txHarness.controller;
   // Assert acceptance, not just call it — a rejected fixture would leave
@@ -220,6 +222,70 @@ afterEach(() => {
 });
 
 describe('discrete pending markers reach the mounted DOM over the real wiring path (MOR-1488, closes MOR-1473)', () => {
+  function seedData(active: 'MAIN' | 'SUB' = 'SUB', unavailable?: 'active' | 'dataMode' | 'staleDataMode'): ServerState {
+    resetRadioState();
+    clearCapabilities();
+    expect(setCapabilities({ ...liveCaps(), receivers: 2, vfoScheme: 'main_sub',
+      capabilities: [...liveCaps().capabilities, 'data_mode'], dataModeCount: 1,
+      dataModeLabels: { '0': 'OFF', '1': 'DATA' },
+    })).toBe(true);
+    const state = liveState();
+    const fieldStatus: NonNullable<ServerState['fieldStatus']> = { ...state.fieldStatus, 'main.dataMode': fresh,
+      ...Object.fromEntries(Object.entries(state.fieldStatus!).filter(([key]) => key.startsWith('main.'))
+        .map(([key, value]) => [key.replace('main.', 'sub.'), value])), 'sub.dataMode': fresh,
+    };
+    if (unavailable) fieldStatus[unavailable === 'active' ? 'active' : `${active.toLowerCase()}.dataMode`] = {
+      ...fresh, ...(unavailable === 'staleDataMode' ? { freshness: 'stale' as const } : { observed: false }),
+    };
+    const dataState = { ...state, active, sub: { ...state.main, dataMode: 0 }, fieldStatus };
+    expect(setRadioState(dataState)).toBe(true);
+    return dataState;
+  }
+
+  it.each(['MAIN', 'SUB'] as const)('DATA click emits one receiver-specific frame for %s and pending never becomes confirmed', active => {
+    const state = seedData(active);
+    render();
+    expect(sendCommand).not.toHaveBeenCalled();
+    const off = q<HTMLButtonElement>('[data-testid="filter-data-mode-0"]')!;
+    const on = q<HTMLButtonElement>('[data-testid="filter-data-mode-1"]')!;
+    expect(on).not.toBeNull();
+    on.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_data_mode',
+      { mode: 1, receiver: active === 'MAIN' ? 0 : 1 }, expect.any(String));
+    expect(on.dataset.pending).toBe('true');
+    expect(off.dataset.pending).toBe('false');
+    expect(off.getAttribute('aria-pressed')).toBe('true');
+    expect(on.getAttribute('aria-pressed')).toBe('false');
+    const commands = getCommandLifecycles().filter(command => command.name === 'set_data_mode');
+    expect(commands).toHaveLength(1);
+    acknowledgeCommand(commands[0].id, commands[0].originalEpoch, commands[0].originalEpoch);
+    flushSync();
+    expect(on.dataset.pending).toBe('true');
+    const receiver = active === 'MAIN' ? 'main' : 'sub';
+    expect(setRadioState({ ...state, revision: 2, stateRevision: 2, freshnessRevision: 2, observationSeq: 2,
+      [receiver]: { ...state[receiver], dataMode: 1 },
+    })).toBe(true);
+    flushSync();
+    expect(on.dataset.pending).toBe('false');
+    expect(off.getAttribute('aria-pressed')).toBe('false');
+    expect(on.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it.each(['active', 'dataMode', 'staleDataMode'] as const)('DATA with unavailable %s emits nothing on mount or forced click', unavailable => {
+    seedData('SUB', unavailable);
+    render();
+    const on = q<HTMLButtonElement>('[data-testid="filter-data-mode-1"]')!;
+    expect(on).not.toBeNull();
+    expect(on.disabled).toBe(true);
+    expect(on.getAttribute('aria-pressed')).toBe('false');
+    on.disabled = false;
+    on.click();
+    flushSync();
+    expect(sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
   it('marks the clicked filter choice pending while set_filter is in flight (FilterSurface)', () => {
     render();
     expect(q('[data-testid="filter-select"]')!.dataset.filterStatus).toBe('confirmed');

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -42,6 +42,7 @@ vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
     } as Record<PropertyKey, unknown>)[handler] ?? h.noop })
     : group }),
   getSystemHandlers: () => ({ onSpeak: h.speak }),
+  getDataModeArmed: () => ({ armed: false, value: null }),
   getBreakInDelayControlFeedback: () => null, getPendingFrequencyHz: () => null,
   getPendingFilterSelection: () => null, getPendingNbOn: () => null,
   getPendingNrOn: () => null, getPendingPreampLevel: () => null,

--- a/frontend/src/lib/i18n/locales/ja-JP.json
+++ b/frontend/src/lib/i18n/locales/ja-JP.json
@@ -167,6 +167,7 @@
   "core.mobile.closeStepPicker": "ステップ選択を閉じる",
 
   "core.modePanel.modInputLabel": "MOD IN",
+  "core.modePanel.dataMode.pendingAnnouncement": "保留中、まだ確認されていません",
   "core.modePanel.modInputAria": "変調入力ソース",
 
   "core.vfo.groupLabel": "VFO",

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts
@@ -646,7 +646,7 @@ describe('PBT display observations (MOR-1692)', () => {
     const { display: outerDisplay, ...strictOuter } = result.pbtOuter;
     const absent = { reading: { status: 'unknown' }, availability: { structural: false, operational: false } };
     expect({ ...result, pbtInner: strict, pbtOuter: strictOuter }).toEqual({
-      filterShape: absent, filterShapeControlStructural: false, ifShiftControlStructural: false, dataMode: absent,
+      filterShape: absent, filterShapeControlStructural: false, ifShiftControlStructural: false, dataMode: absent, dataModeChoices: [],
       ifShift: { reading: freshness === 'fresh' ? { status: 'known', value: 225 } : { status: 'unknown' }, availability: { structural: true, operational: freshness === 'fresh' } },
       pbtInner: strict,
       pbtOuter: { reading: { status: 'known', value: 0 }, availability: { structural: true, operational: true } },

--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -21,7 +21,7 @@ import {
   validateRadioViewModel, type RadioViewModel,
 } from '../../../../semantic/radio-view-model';
 import { topologyFixtures } from '../../../../semantic/fixtures/topologies';
-import { toMemoryPanelProps } from '../../props/panel-props';
+import { resolveFilterModeConfig, toMemoryPanelProps } from '../../props/panel-props';
 import {
   toRadioViewModel, type MetersTxAuthority,
 } from '../radio-view-model-adapter';
@@ -1040,9 +1040,9 @@ describe('RF gain additive display observation', () => {
     };
     return state;
   }
-  it.each([false, true])('preserves every strict model member for stale=%s', (stale) => {
+  it.each([false, true])('preserves legacy strict model members for stale=%s', (stale) => {
     const view = toRadioViewModel(displayState(stale), displayCaps, RECEIVING)!;
-    const strictJson = JSON.stringify(view, (key, value) => key === 'display' ? undefined : value);
+    const strictJson = JSON.stringify(view, (key, value) => ['display', 'activeFilterConfiguration', 'dataModeChoices'].includes(key) ? undefined : value);
     const digest = createHash('sha256').update(strictJson).digest('hex');
     expect(digest).toBe(stale ? 'b4b5cff2b85557e39baa48e4d73c756e12ff026488ffa05a1ef558ca0b3f0507' : '379a5f00e3bebae780e4215af4e014351df2a07fc067d412f97df6aeadca840f');
   });
@@ -1061,5 +1061,114 @@ describe('RF gain additive display observation', () => {
     const view = model(state, { ...displayCaps, capabilities: displayCaps.capabilities.filter((cap) => cap !== 'dual_rx') }, RECEIVING);
     expect(view.receiverIndicators![1].rfGain.availability.operational).toBe(false);
     expect(view.receiverIndicators![1].rfGain.display).toEqual({ state: 'current', value: 0.75 });
+  });
+});
+
+
+describe('MOR-2374 shared DATA and filter configuration', () => {
+  const config = {
+    defaults: [2400], fixed: false, minHz: 50, maxHz: 3600, stepHz: 50,
+    segments: [{ hzMin: 50, hzMax: 500, stepHz: 50, indexMin: 0 }], table: [50, 100, 500],
+  };
+  const dataCaps = (extra: Partial<Capabilities> = {}) => caps({
+    capabilities: [...DUAL, 'data_mode'], modes: ['USB'], filters: ['FIL1', 'FIL2'],
+    dataModeCount: 3, filterConfig: { USB: config }, ...extra,
+  });
+  function state() {
+    const s = observedState();
+    s.fieldStatus = { ...s.fieldStatus, 'main.dataMode': fresh, 'sub.dataMode': fresh };
+    return s;
+  }
+  it.each([0, 1, 3])('offers exactly 0..%i with canonical labels', (count) => {
+    const model = toRadioViewModel(state(), dataCaps({ dataModeCount: count,
+      dataModeLabels: { '0': 'OFF label', '1': 'Digital', '2': '  ', '9': 'stray' } }))!;
+    expect(model.filterPassband!.dataModeChoices).toEqual(Array.from({ length: count + 1 }, (_, value) =>
+      ({ value, label: value === 0 ? 'OFF label' : value === 1 ? 'Digital' : null })));
+    expect(validateRadioViewModel(model)).toEqual(model);
+  });
+  it.each([undefined, -1, 1.5, 4, 1e12, Number.MAX_SAFE_INTEGER + 1, NaN, Infinity, '3'])
+    ('rejects malformed or oversized DATA count %s', (dataModeCount) => {
+      expect(toRadioViewModel(state(), dataCaps({ dataModeCount } as Partial<Capabilities>))!
+        .filterPassband!.dataModeChoices).toEqual([]);
+    });
+  it('leaves fallback presentation to the component and does not infer DATA support', () => {
+    expect(toRadioViewModel(state(), dataCaps({ dataModeLabels: undefined }))!.filterPassband!.dataModeChoices)
+      .toEqual([0, 1, 2, 3].map(value => ({ value, label: null })));
+    const fp = toRadioViewModel(state(), dataCaps({ capabilities: DUAL }))!.filterPassband!;
+    expect(fp.dataModeChoices).toEqual([]);
+    expect(fp.dataMode.availability.structural).toBe(false);
+  });
+  it('uses SUB observations for DATA and configuration', () => {
+    const s = state(); s.active = 'SUB'; s.sub!.dataMode = 2;
+    const model = toRadioViewModel(s, dataCaps({ filterConfig: { USB: config,
+      'USB-D': { defaults: [500], fixed: true } } }))!;
+    expect(model.filterPassband!.dataMode.reading).toEqual({ status: 'known', value: 2 });
+    expect(model.modeFilter!.activeFilterConfiguration!.slots[0].factoryWidthHz).toBe(500);
+  });
+  it.each(['active', 'main.dataMode', 'main.mode'])('requires current evidence for %s', (path) => {
+    for (const status of [undefined, stale, { ...fresh, observed: false }]) {
+      const s = state(); s.fieldStatus = { ...s.fieldStatus, [path]: status } as ServerState['fieldStatus'];
+      const model = toRadioViewModel(s, dataCaps())!;
+      expect(model.modeFilter!.activeFilterConfiguration).toBeNull();
+      if (path !== 'main.mode') {
+        expect(model.filterPassband!.dataMode.reading.status).toBe('unknown');
+        expect(model.filterPassband!.dataMode.availability.operational).toBe(false);
+        expect(model.filterPassband!.dataModeChoices).toHaveLength(4);
+      }
+    }
+  });
+  it.each([
+    ['USB', 0, 'USB'], ['USB', 1, 'USB-D'], ['LSB', 0, 'SSB'], ['LSB', 1, 'SSB-D'],
+    ['CW-R', 0, 'CW'], ['RTTY-R', 0, 'RTTY'], ['FM', 0, null],
+  ] as const)('resolves %s DATA %i via the shipped resolver', (mode, dataMode, key) => {
+    const entries = ['USB', 'USB-D', 'SSB', 'SSB-D', 'CW', 'RTTY'];
+    const c = dataCaps({ filterConfig: Object.fromEntries(entries.map((name, i) =>
+      [name, { ...config, defaults: [100 * (i + 1)] }])) });
+    const s = state(); s.main.mode = mode; s.main.dataMode = dataMode;
+    const resolved = resolveFilterModeConfig(c, mode, dataMode);
+    const result = toRadioViewModel(s, c)!.modeFilter!.activeFilterConfiguration;
+    expect(resolved).toBe(key ? c.filterConfig![key] : null);
+    expect(result).toEqual(resolved ? { slots: [
+      { filter: 1, label: 'FIL1', factoryWidthHz: resolved.defaults[0] },
+      { filter: 2, label: 'FIL2', factoryWidthHz: null },
+    ], fixed: resolved.fixed, minHz: resolved.minHz, maxHz: resolved.maxHz, stepHz: resolved.stepHz,
+    segments: resolved.segments, table: resolved.table } : null);
+  });
+  it('copies nested configuration and never fills missing defaults from current width', () => {
+    const c = dataCaps({ filterConfig: { USB: structuredClone(config) } });
+    const s = state(); s.main.filterWidth = 999;
+    const projected = toRadioViewModel(s, c)!.modeFilter!.activeFilterConfiguration!;
+    const saved = structuredClone(projected);
+    expect(projected.slots[1].factoryWidthHz).toBeNull();
+    c.filterConfig!.USB.defaults[0] = 999; c.filterConfig!.USB.segments![0].stepHz = 25;
+    c.filterConfig!.USB.table![0] = 25; c.filters[0] = 'changed';
+    expect(projected).toEqual(saved);
+  });
+  it.each([undefined, NaN, Infinity, -1, 0.5, 4])('withholds missing or invalid observed DATA value %s', (value) => {
+    const s = state(); Object.assign(s.main, { dataMode: value });
+    const model = toRadioViewModel(s, dataCaps())!;
+    expect(model.modeFilter!.activeFilterConfiguration).toBeNull();
+    expect(model.filterPassband!.dataMode.reading.status).toBe('unknown');
+  });
+  it.each([[1, 2], [0, 1]])('preserves observed DATA independently of advertised count %i', (count, value) => {
+    const s = state(); s.main.dataMode = value;
+    const model = toRadioViewModel(s, dataCaps({ dataModeCount: count, filterConfig: { USB: config,
+      'USB-D': { defaults: [500], fixed: true } } }))!;
+    expect(model.filterPassband!.dataMode.reading).toEqual({ status: 'known', value });
+    expect(model.filterPassband!.dataMode.availability.operational).toBe(true);
+    expect(model.modeFilter!.activeFilterConfiguration!.slots[0].factoryWidthHz).toBe(500);
+  });
+  it('permits observed non-DATA mode configuration without DATA evidence', () => {
+    const s = state(); delete s.fieldStatus!['main.dataMode'];
+    expect(toRadioViewModel(s, dataCaps({ capabilities: DUAL }))!.modeFilter!.activeFilterConfiguration).not.toBeNull();
+  });
+  it.each([
+    null, {}, { ...config, fixed: 'yes' }, { ...config, defaults: [-1] },
+    { ...config, minHz: NaN }, { ...config, maxHz: 1 }, { ...config, stepHz: 0 },
+    { ...config, table: [100, 50] }, { ...config, table: [Infinity] },
+    { ...config, segments: [{ hzMin: 50, hzMax: 10, stepHz: 0, indexMin: -1 }] },
+  ])('withholds malformed filter configuration %#', (bad) => {
+    const c = dataCaps({ filterConfig: { USB: bad } } as unknown as Partial<Capabilities>);
+    expect(toRadioViewModel(state(), c)!.modeFilter!.activeFilterConfiguration).toBeNull();
   });
 });

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -29,7 +29,7 @@ import type {
   RadioViewModel, TxAuxField, TxAuxViewModel, AtuStatus,
   MeterField, MeterRfState, MetersViewModel,
   AudioFocus, MonitorMode, RxAudioViewModel, ModeFilterViewModel,
-  FilterPassbandViewModel, DspViewModel, RfFrontEndViewModel,
+  ActiveFilterConfiguration, FilterPassbandViewModel, DspViewModel, RfFrontEndViewModel,
   BandChoice, BandViewModel, RitXitViewModel, AntennaViewModel, ScanViewModel,
   BreakInMode, CwKeyerViewModel, ScopeControlsViewModel,
   ScopeDisplayViewModel, ScopeSourceKind, ScopeHealthState,
@@ -338,6 +338,40 @@ function deriveMeters(
   };
 }
 
+function isDataModeValue(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 && value <= 3;
+}
+
+function copyFilterConfiguration(
+  config: unknown, labels: readonly string[],
+): ActiveFilterConfiguration | null {
+  if (typeof config !== 'object' || config === null) return null;
+  const c = config as Record<string, unknown>;
+  const hz = (n: unknown): n is number => typeof n === 'number' && Number.isFinite(n) && n > 0;
+  if (!Array.isArray(c.defaults) || c.defaults.some(n => !hz(n)) || typeof c.fixed !== 'boolean'
+    || labels.some(label => typeof label !== 'string' || !label.trim())) return null;
+  const minHz = c.minHz ?? null, maxHz = c.maxHz ?? null, stepHz = c.stepHz ?? null;
+  if ([minHz, maxHz, stepHz].some(n => n !== null && !hz(n))
+    || (typeof minHz === 'number' && typeof maxHz === 'number' && minHz > maxHz)) return null;
+  const table = c.table ?? [], segments = c.segments ?? [];
+  if (!Array.isArray(table) || table.some((n, i) => !hz(n) || (i > 0 && n <= table[i - 1]))
+    || !Array.isArray(segments)) return null;
+  const copiedSegments: { hzMin: number; hzMax: number; stepHz: number; indexMin: number }[] = [];
+  for (const raw of segments) {
+    if (typeof raw !== 'object' || raw === null) return null;
+    const { hzMin, hzMax, stepHz, indexMin } = raw;
+    if (!hz(hzMin) || !hz(hzMax) || hzMin > hzMax || !hz(stepHz)
+      || !Number.isSafeInteger(indexMin) || indexMin < 0) return null;
+    copiedSegments.push({ hzMin, hzMax, stepHz, indexMin });
+  }
+  const defaults = c.defaults;
+  return {
+    slots: labels.map((label, i) => ({ filter: i + 1, label, factoryWidthHz: defaults[i] ?? null })),
+    fixed: c.fixed, minHz: minHz as number | null, maxHz: maxHz as number | null,
+    stepHz: stepHz as number | null, segments: copiedSegments, table: [...table],
+  };
+}
+
 /**
  * Mode/filter facts (MOR-1262 decomposition slice 4A, MOR-1280): current
  * mode, capability-derived mode choice set, current filter selection,
@@ -360,7 +394,7 @@ function deriveMeters(
  * an additional consumer, not a migration (that is slice 4B).
  */
 function deriveModeFilter(
-  state: ServerState | null, caps: Capabilities | null,
+  state: ServerState | null, caps: Capabilities | null, activeId: ReceiverId | null,
 ): ModeFilterViewModel | undefined {
   if (!caps) return undefined;
   const modeChoices = caps.modes ?? [];
@@ -377,11 +411,19 @@ function deriveModeFilter(
   // The active mode-keyed filter config, resolved by the ONE shipped
   // derivation (`resolveFilterModeConfig`) — see the doc comment above.
   const filterConfig = resolveFilterModeConfig(caps, rx?.mode, rx?.dataMode);
+  const activeBase = activeId === 'SUB' ? 'sub' : 'main';
+  const activeRx = activeId === null ? undefined : state?.[activeBase];
+  const dataValue = activeRx?.dataMode;
+  const configObserved = activeId !== null && strictFieldAvailable(state, activeBase + '.mode')
+    && (!hasCap(caps, 'data_mode') || (isDataModeValue(dataValue) && strictFieldAvailable(state, activeBase + '.dataMode')));
+  const activeFilterConfiguration = configObserved
+    ? copyFilterConfiguration(resolveFilterModeConfig(caps, activeRx?.mode, activeRx?.dataMode), filterChoices) : null;
   const widthMin = filterConfig?.minHz ?? filterConfig?.table?.[0] ?? caps.filterWidthMin;
   const widthMax = filterConfig?.maxHz
     ?? (filterConfig?.table?.length ? filterConfig.table[filterConfig.table.length - 1] : undefined)
     ?? caps.filterWidthMax;
   return {
+    activeFilterConfiguration,
     currentMode: txAuxField(hasModes, modeObserved, rx?.mode),
     modeChoices,
     currentFilter: txAuxField(hasFilters, filterObserved, numOrUndef(rx?.filter ?? undefined)),
@@ -443,7 +485,7 @@ function deriveModeFilter(
  *    field's ` ?? 128` fallback the way `toFilterProps` does.
  */
 function deriveFilterPassband(
-  state: ServerState | null, caps: Capabilities | null,
+  state: ServerState | null, caps: Capabilities | null, activeId: ReceiverId | null,
 ): FilterPassbandViewModel | undefined {
   if (!caps) return undefined;
   const hasFilters = (caps.filters ?? []).length > 0;
@@ -458,7 +500,15 @@ function deriveFilterPassband(
   const base = onSub ? 'sub.' : 'main.';
 
   const filterShapeObserved = topFieldAvailable(state, `${base}filterShape`);
-  const dataModeObserved = topFieldAvailable(state, `${base}dataMode`);
+  const dataRx = activeId === null ? undefined : state?.[RECEIVER_KEY[activeId]];
+  const dataValue = dataRx?.dataMode;
+  const dataModeObserved = activeId !== null && isDataModeValue(dataValue) && strictFieldAvailable(state, RECEIVER_KEY[activeId] + '.dataMode');
+  const count = caps.dataModeCount;
+  const dataModeChoices = hasDataModeCap && typeof count === 'number' && Number.isSafeInteger(count) && count >= 0 && count <= 3
+    ? Array.from({ length: count + 1 }, (_, value) => {
+      const label = caps.dataModeLabels?.[String(value)];
+      return { value, label: typeof label === 'string' && label.trim() ? label : null };
+    }) : [];
   const pbtInnerObserved = topFieldAvailable(state, `${base}pbtInner`);
   const pbtOuterObserved = topFieldAvailable(state, `${base}pbtOuter`);
   const ifShiftRawObserved = topFieldAvailable(state, `${base}ifShift`);
@@ -568,7 +618,8 @@ function deriveFilterPassband(
         structural: hasPbtCap && hasPbtRange, value: pbtOuterHz,
       }),
     },
-    dataMode: txAuxField(hasDataModeCap, dataModeObserved, numOrUndef(rx?.dataMode)),
+    dataModeChoices,
+    dataMode: txAuxField(hasDataModeCap, dataModeObserved, numOrUndef(dataRx?.dataMode)),
   };
 }
 
@@ -1647,8 +1698,8 @@ export function toRadioViewModel(
   const txAux = deriveTxAux(state, caps);
   const meters = deriveMeters(state, caps, tx);
   const rxAudio = deriveRxAudio(state, caps, facts, modInputSource, rxAudioSnapshot);
-  const modeFilter = deriveModeFilter(state, caps);
-  const filterPassband = deriveFilterPassband(state, caps);
+  const modeFilter = deriveModeFilter(state, caps, activeId);
+  const filterPassband = deriveFilterPassband(state, caps, activeId);
   const dsp = deriveDsp(state, caps);
   const rfFrontEnd = deriveRfFrontEnd(state, caps);
   const band = deriveBand(state, caps, activeId);

--- a/frontend/src/semantic/FilterSurface.svelte
+++ b/frontend/src/semantic/FilterSurface.svelte
@@ -106,6 +106,8 @@
      *  active receiver, DISPLAY ONLY (see the file header). `null` when
      *  nothing is pending. */
     pendingFilter?: number | null;
+    pendingDataMode?: number | null;
+    onDataModeChange?: (mode: number) => void;
     onModeChange?: (mode: string) => void;
     onFilterChange?: (filter: number) => void;
     onFilterWidthChange?: (width: number) => void;
@@ -115,11 +117,12 @@
     onPbtOuterChange?: (value: number) => void;
   }
   let {
-    view, pendingFilter = null, onModeChange, onFilterChange, onFilterWidthChange,
+    view, pendingFilter = null, pendingDataMode = null, onDataModeChange, onModeChange, onFilterChange, onFilterWidthChange,
     onFilterShapeChange, onIfShiftChange, onPbtInnerChange, onPbtOuterChange,
   }: Props = $props();
 
   const pendingFilterId = $props.id();
+  const pendingDataModeId = `${pendingFilterId}-data-mode`;
 
   let modeFilter = $derived(view.modeFilter);
   let filterPassband = $derived(view.filterPassband);
@@ -135,6 +138,12 @@
   }
   function selectShape(shape: number): void {
     if (filterPassband && usable(filterPassband.filterShape)) onFilterShapeChange?.(shape);
+  }
+  function selectDataMode(mode: number): void {
+    if (!filterPassband || !usable(filterPassband.dataMode)
+      || filterPassband.dataModeChoices.length < 2
+      || !filterPassband.dataModeChoices.some(choice => choice.value === mode)) return;
+    onDataModeChange?.(mode);
   }
   /** One guarded entry point for all three passband sliders — each still
    *  reads and disables on its OWN field's availability (see the file
@@ -272,10 +281,28 @@
       {/each}
       {#if filterPassband.dataMode.availability.structural}
         <div
-          class="filter-readout" data-testid="filter-data-mode"
+          class={filterPassband.dataModeChoices.length > 1 ? 'filter-choice-group' : 'filter-readout'} data-testid="filter-data-mode"
+          role="group" aria-label={t('core.mobile.sheet.dataMode')}
           data-disabled-reason={reasonOf(filterPassband.dataMode)}
+          data-data-mode-status={pendingDataMode !== null ? 'pending' : presentationOf(filterPassband.dataMode)}
+          aria-describedby={pendingDataMode !== null ? pendingDataModeId : undefined}
         >
-          <span class="filter-level-name">DATA</span><output>{textOf(filterPassband.dataMode)}</output>
+          <span class="filter-level-name">{filterPassband.dataModeChoices.length > 1 ? t('core.mobile.sheet.dataMode') : 'DATA'}</span>
+          <output>{textOf(filterPassband.dataMode)}</output>
+          {#if filterPassband.dataModeChoices.length > 1}
+            {#each filterPassband.dataModeChoices as choice (choice.value)}
+              <button
+                type="button" class="filter-choice" data-testid={`filter-data-mode-${choice.value}`}
+                aria-pressed={isSelected(filterPassband.dataMode, choice.value)}
+                data-pending={pendingDataMode === choice.value}
+                disabled={!usable(filterPassband.dataMode)}
+                onclick={() => selectDataMode(choice.value)}
+              >{choice.label ?? (choice.value === 0 ? 'OFF' : `D${choice.value}`)}</button>
+            {/each}
+          {/if}
+          {#if pendingDataMode !== null}
+            <span id={pendingDataModeId} class="sr-only">{t('core.modePanel.dataMode.pendingAnnouncement')}</span>
+          {/if}
         </div>
       {/if}
     {/if}

--- a/frontend/src/semantic/__tests__/FilterSurface.test.ts
+++ b/frontend/src/semantic/__tests__/FilterSurface.test.ts
@@ -11,6 +11,7 @@
 import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
+import { getLocale, setLocale } from '$lib/i18n';
 import FilterSurface, {
   FILTER_PASSBAND_LEVELS, FILTER_SHAPES, type FilterPassbandLevelField,
 } from '../FilterSurface.svelte';
@@ -94,6 +95,7 @@ beforeEach(() => { target = document.createElement('div'); document.body.appendC
 afterEach(() => { target.remove(); });
 
 type Handlers = {
+  onDataModeChange?: (mode: number) => void;
   onModeChange?: (mode: string) => void;
   onFilterChange?: (filter: number) => void;
   onFilterWidthChange?: (width: number) => void;
@@ -103,7 +105,8 @@ type Handlers = {
   onPbtOuterChange?: (value: number) => void;
 };
 
-function render(view: RadioViewModel, handlers: Handlers = {}, extra: { pendingFilter?: number | null } = {}) {
+type PendingProps = { pendingFilter?: number | null; pendingDataMode?: number | null };
+function render(view: RadioViewModel, handlers: Handlers = {}, extra: PendingProps = {}) {
   const component = mount(FilterSurface, { target, props: { view, ...extra, ...handlers } });
   flushSync();
   const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
@@ -121,11 +124,116 @@ function render(view: RadioViewModel, handlers: Handlers = {}, extra: { pendingF
 
 function withSurface(
   view: RadioViewModel, fn: (s: ReturnType<typeof render>) => void, handlers: Handlers = {},
-  extra: { pendingFilter?: number | null } = {},
+  extra: PendingProps = {},
 ): void {
   const s = render(view, handlers, extra);
   try { fn(s); } finally { s.dispose(); }
 }
+
+describe('DATA choices and evidence (MOR-2374)', () => {
+  function dataView(values = [0, 1]): RadioViewModel {
+    const view = base();
+    return { ...view, filterPassband: { ...view.filterPassband!,
+      dataMode: { availability: { structural: true, operational: true }, reading: { status: 'known', value: 0 } },
+      dataModeChoices: values.map(value => ({ value, label: value === 0 ? 'OFF' : `DATA${value}` })),
+    } };
+  }
+
+  it.each([{ values: [0, 1] }, { values: [0, 1, 2, 3] }])('renders capability labels and dispatches explicit choices for $values', ({ values }) => {
+    const onDataModeChange = vi.fn();
+    withSurface(dataView(values), s => {
+      expect(onDataModeChange).not.toHaveBeenCalled();
+      for (const value of values) {
+        const button = s.button('filter-data-mode', value)!;
+        expect(button.textContent).toBe(value === 0 ? 'OFF' : `DATA${value}`);
+        expect(button.getAttribute('aria-pressed')).toBe(String(value === 0));
+        button.click();
+      }
+      expect(onDataModeChange.mock.calls).toEqual(values.map(value => [value]));
+    }, { onDataModeChange });
+  });
+
+  it.each([{ values: [] }, { values: [0] }])('keeps $values readout-only', ({ values }) => {
+    withSurface(dataView(values), s => {
+      expect(s.group('filter-data-mode')!.classList.contains('filter-readout')).toBe(true);
+      expect(s.group('filter-data-mode')!.querySelector('.filter-level-name')!.textContent).toBe('DATA');
+      expect(s.group('filter-data-mode')!.querySelectorAll('button')).toHaveLength(0);
+      expect(s.output('filter-data-mode')!.textContent).toBe('0');
+    });
+  });
+
+  it.each(['unknown', 'stale'] as const)('disables %s DATA without a confirmed selection or forced callback', state => {
+    const onDataModeChange = vi.fn();
+    const view = withPassbandField(dataView(), 'dataMode', state === 'unknown'
+      ? { unknown: true } : { availability: { structural: true, operational: false } });
+    withSurface(view, s => {
+      for (const value of [0, 1]) {
+        const button = s.button('filter-data-mode', value)!;
+        expect(button.disabled).toBe(true);
+        expect(button.getAttribute('aria-pressed')).toBe('false');
+        button.disabled = false;
+        button.click();
+      }
+      expect(onDataModeChange).not.toHaveBeenCalled();
+    }, { onDataModeChange }, { pendingDataMode: 1 });
+  });
+
+  it('preserves current DATA outside the choices while dispatching only explicit destinations', () => {
+    const view = dataView(), onDataModeChange = vi.fn();
+    view.filterPassband!.dataMode.reading = { status: 'known', value: 2 };
+    withSurface(view, s => {
+      expect(s.output('filter-data-mode')!.textContent).toBe('2');
+      for (const value of [0, 1]) {
+        const button = s.button('filter-data-mode', value)!;
+        expect(button.disabled).toBe(false);
+        expect(button.getAttribute('aria-pressed')).toBe('false');
+        button.click();
+      }
+      expect(onDataModeChange.mock.calls).toEqual([[0], [1]]);
+    }, { onDataModeChange });
+  });
+
+  it('renders OFF and Dn when capability labels are absent', () => {
+    const baseView = dataView();
+    const view = { ...baseView, filterPassband: { ...baseView.filterPassband!, dataModeChoices: [0, 1].map(value => ({ value, label: null })) } };
+    withSurface(view, s => {
+      expect(s.button('filter-data-mode', 0)!.textContent).toBe('OFF');
+      expect(s.button('filter-data-mode', 1)!.textContent).toBe('D1');
+    });
+  });
+
+  it('rejects a removed choice even if its old DOM callback is invoked', () => {
+    const view = dataView([0, 1, 2, 3]);
+    const onDataModeChange = vi.fn();
+    withSurface(view, s => {
+      const choices = view.filterPassband!.dataModeChoices as { value: number; label: string }[];
+      choices.pop();
+      s.button('filter-data-mode', 3)!.click();
+      expect(onDataModeChange).not.toHaveBeenCalled();
+      choices.push({ value: 3, label: 'DATA3' });
+      s.button('filter-data-mode', 3)!.click();
+      expect(onDataModeChange).toHaveBeenCalledExactlyOnceWith(3);
+    }, { onDataModeChange });
+  });
+
+  it('keeps pending separate from confirmed with a Japanese accessible announcement', () => {
+    const locale = getLocale();
+    setLocale('ja-JP');
+    try {
+      withSurface(dataView([0, 1, 2, 3]), s => {
+        const group = s.group('filter-data-mode')!;
+        expect(group.getAttribute('aria-label')).toBe('DATA MODE');
+        expect(group.dataset.dataModeStatus).toBe('pending');
+        expect(s.button('filter-data-mode', 0)!.getAttribute('aria-pressed')).toBe('true');
+        expect(s.button('filter-data-mode', 2)!.getAttribute('aria-pressed')).toBe('false');
+        expect(s.button('filter-data-mode', 2)!.dataset.pending).toBe('true');
+        expect(s.button('filter-data-mode', 0)!.dataset.pending).toBe('false');
+        expect(document.getElementById(group.getAttribute('aria-describedby')!)!.textContent)
+          .toBe('保留中、まだ確認されていません');
+      }, {}, { pendingDataMode: 2 });
+    } finally { setLocale(locale); }
+  });
+});
 
 // ── 1. Whole-group gating ───────────────────────────────────────────────────
 
@@ -635,7 +743,7 @@ describe('filterShape renders honest unknown rather than a fabricated default', 
   });
 });
 
-// ── 8. dataMode is an honest readout, never a control ───────────────────────
+// ── 8. DATA readout ────────────────────────────────────────────────────────
 
 describe('dataMode renders as a readout', () => {
   it('shows the known value', () => {
@@ -651,8 +759,9 @@ describe('dataMode renders as a readout', () => {
     });
   });
 
-  it('carries no button or input — it is read-only', () => {
-    withSurface(base(), (s) => {
+  it('carries no button or input when no DATA choices are available', () => {
+    const view = base();
+    withSurface({ ...view, filterPassband: { ...view.filterPassband!, dataModeChoices: [] } }, (s) => {
       const readout = s.group('filter-data-mode')!;
       expect(readout.querySelector('button')).toBeNull();
       expect(readout.querySelector('input')).toBeNull();

--- a/frontend/src/semantic/__tests__/radio-display-model.test.ts
+++ b/frontend/src/semantic/__tests__/radio-display-model.test.ts
@@ -89,6 +89,7 @@ function view(): RadioViewModel {
       tuneMinHz: 30_000, tuneMaxHz: 74_800_000,
     },
     filterPassband: {
+      dataModeChoices: [],
       filterShape: known(1), filterShapeControlStructural: false,
       ifShift: known(250), ifShiftControlStructural: false,
       pbtInner: known(400), pbtOuter: known(-400), dataMode: unknown(false),

--- a/frontend/src/semantic/__tests__/radio-view-model.test.ts
+++ b/frontend/src/semantic/__tests__/radio-view-model.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { validateRadioViewModel, type RadioViewModel } from '../radio-view-model';
+import { withModeFilter, withFilterPassband } from '../fixtures/topologies';
 
 function valid(): RadioViewModel {
   return {
@@ -462,5 +463,52 @@ describe('receiver RF gain display facet validation', () => {
     const view = withDisplay({ state: 'current', value: 0 });
     Object.assign(view.receiverIndicators![0].sMeter, { display: { state: 'stale', value: 0 } });
     expect(() => validateRadioViewModel(view)).toThrow();
+  });
+});
+
+
+describe('MOR-2374 strict filter contract', () => {
+  const configuration = {
+    slots: [{ filter: 1, label: 'FIL1', factoryWidthHz: 2400 }, { filter: 2, label: 'FIL2', factoryWidthHz: null }],
+    fixed: false, minHz: 50, maxHz: 3600, stepHz: 50,
+    segments: [{ hzMin: 50, hzMax: 500, stepHz: 50, indexMin: 0 }], table: [50, 100],
+  };
+  const model = () => {
+    const v = withFilterPassband(withModeFilter(valid()));
+    return { ...v, modeFilter: { ...v.modeFilter!, activeFilterConfiguration: configuration },
+      filterPassband: { ...v.filterPassband!, dataModeChoices: [{ value: 0, label: 'OFF' }, { value: 1, label: 'D1' }] } };
+  };
+  it('accepts populated and unavailable forms', () => {
+    expect(validateRadioViewModel(model())).toEqual(model());
+    const unlabeled = model();
+    const metadata = { ...unlabeled, filterPassband: { ...unlabeled.filterPassband, dataModeChoices: [{ value: 0, label: null }] } };
+    expect(validateRadioViewModel(metadata)).toEqual(metadata);
+    const v = model();
+    const unavailable = { ...v, modeFilter: { ...v.modeFilter, activeFilterConfiguration: null },
+      filterPassband: { ...v.filterPassband, dataModeChoices: [] } };
+    expect(validateRadioViewModel(unavailable)).toEqual(unavailable);
+  });
+  it.each([
+    undefined, null, [{ value: 1, label: 'D1' }], [{ value: 0, label: '' }],
+    [{ value: 0, label: 'OFF', raw: true }], [{ value: 0, label: 'OFF' }, { value: 0, label: 'D1' }],
+    [{ value: -1, label: 'OFF' }], [{ value: NaN, label: 'OFF' }],
+    [0, 1, 2, 3, 4].map(value => ({ value, label: 'D' + value })),
+  ])('rejects malformed DATA vocabulary %#', (dataModeChoices) => {
+    const v = model();
+    expect(() => validateRadioViewModel({ ...v, filterPassband: { ...v.filterPassband, dataModeChoices } })).toThrow(TypeError);
+  });
+  it.each([
+    undefined, {}, { ...configuration, raw: true }, { ...configuration, fixed: 1 },
+    { ...configuration, slots: [{ filter: 0, label: 'FIL1', factoryWidthHz: 1 }] },
+    { ...configuration, slots: [{ filter: 1, label: ' ', factoryWidthHz: 1 }] },
+    { ...configuration, slots: [{ filter: 1, label: 'FIL1', factoryWidthHz: -1 }] },
+    { ...configuration, minHz: NaN }, { ...configuration, maxHz: Infinity },
+    { ...configuration, minHz: 4000 }, { ...configuration, stepHz: 0 },
+    { ...configuration, table: [100, 100] }, { ...configuration, table: [-1] },
+    { ...configuration, segments: [{ hzMin: 100, hzMax: 50, stepHz: 10, indexMin: 0 }] },
+    { ...configuration, segments: [{ hzMin: 50, hzMax: 100, stepHz: 10, indexMin: 0, raw: true }] },
+  ])('rejects malformed configuration %#', (activeFilterConfiguration) => {
+    const v = model();
+    expect(() => validateRadioViewModel({ ...v, modeFilter: { ...v.modeFilter, activeFilterConfiguration } })).toThrow(TypeError);
   });
 });

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -261,6 +261,7 @@ export function withModeFilter(fixture: RadioViewModel): RadioViewModel {
   const avail: Availability = { structural: true, operational: true };
   const known = <T>(value: T): ModeFilterField<T> => ({ reading: { status: 'known', value }, availability: avail });
   const modeFilter: ModeFilterViewModel = {
+    activeFilterConfiguration: null,
     currentMode: known('USB'),
     modeChoices: ['USB', 'LSB', 'CW', 'RTTY', 'FM'],
     currentFilter: known(1),
@@ -300,6 +301,7 @@ export function withFilterPassband(fixture: RadioViewModel): RadioViewModel {
     pbtInner: known(0),
     pbtOuter: known(0),
     dataMode: known(0),
+    dataModeChoices: [{ value: 0, label: 'OFF' }, { value: 1, label: 'D1' }],
   };
   return { ...fixture, filterPassband };
 }

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -289,6 +289,16 @@ export interface RxAudioViewModel {
  */
 export type ModeFilterField<T> = TxAuxField<T>;
 
+export interface ActiveFilterConfiguration {
+  readonly slots: readonly { readonly filter: number; readonly label: string; readonly factoryWidthHz: number | null }[];
+  readonly fixed: boolean;
+  readonly minHz: number | null;
+  readonly maxHz: number | null;
+  readonly stepHz: number | null;
+  readonly segments: readonly { readonly hzMin: number; readonly hzMax: number; readonly stepHz: number; readonly indexMin: number }[];
+  readonly table: readonly number[];
+}
+
 /**
  * Mode/filter facts (MOR-1262 decomposition slice 4A). Facts only — no
  * command emission; choosing a mode or dragging the filter-width control
@@ -301,14 +311,9 @@ export type ModeFilterField<T> = TxAuxField<T>;
  * selection and the width bounds ARE readings, and degrade to `unknown`
  * rather than to `toFilterProps`'s fabricated defaults ('USB', 2400 Hz,
  * 50..9999 Hz) — see `radio-view-model-adapter.ts`'s `deriveModeFilter`.
- *
- * `filterWidthMin`/`filterWidthMax` are the ONE remaining consumer of
- * `resolveFilterModeConfig`'s per-mode table lookup that this slice adds;
- * the X6200 CAT-audit lesson (filter-width codecs are radio-specific) is why
- * this group never re-derives that table itself — it reads the shipped
- * resolver's own output, like `modInputReadiness` reads `deriveTxCapabilities`.
  */
 export interface ModeFilterViewModel {
+  readonly activeFilterConfiguration: ActiveFilterConfiguration | null;
   currentMode: ModeFilterField<string>;
   modeChoices: readonly string[];
   currentFilter: ModeFilterField<number>;
@@ -399,6 +404,7 @@ export interface FilterPassbandViewModel {
   pbtInner: DisplayObservedField<number>;
   pbtOuter: DisplayObservedField<number>;
   dataMode: FilterPassbandField<number>;
+  readonly dataModeChoices: readonly { readonly value: number; readonly label: string | null }[];
 }
 
 /**
@@ -1619,15 +1625,66 @@ function numArray(value: unknown, path: string): number[] {
   return value.map((item, i) => num(item, `${path}[${i}]`));
 }
 
-/** N4 again: exactly the seven facts the adapter reads, no speculative keys.
- *  See `radio-view-model-adapter.ts::deriveModeFilter`. */
+function positiveHz(value: unknown, path: string): number {
+  const n = num(value, path);
+  if (n <= 0) invalid(path, 'positive Hz');
+  return n;
+}
+
+function nonBlank(value: unknown, path: string): string {
+  const label = str(value, path);
+  if (!label.trim()) invalid(path, 'a non-empty label');
+  return label;
+}
+
+function validateFilterConfiguration(value: unknown, path: string): ActiveFilterConfiguration | null {
+  if (value === null) return null;
+  const v = record(value, path);
+  exactKeys(v, ['slots', 'fixed', 'minHz', 'maxHz', 'stepHz', 'segments', 'table'], path);
+  if (!Array.isArray(v.slots) || !Array.isArray(v.segments) || !Array.isArray(v.table)) invalid(path, 'configuration arrays');
+  const nullableHz = (n: unknown, p: string) => n === null ? null : positiveHz(n, p);
+  const minHz = nullableHz(v.minHz, path + '.minHz');
+  const maxHz = nullableHz(v.maxHz, path + '.maxHz');
+  if (minHz !== null && maxHz !== null && minHz > maxHz) invalid(path, 'ordered bounds');
+  const table = v.table.map((n, i) => positiveHz(n, path + '.table[' + i + ']'));
+  if (table.some((n, i) => i > 0 && n <= table[i - 1])) invalid(path, 'increasing table widths');
+  return {
+    slots: v.slots.map((item, i) => {
+      const slot = record(item, path + '.slots[' + i + ']');
+      exactKeys(slot, ['filter', 'label', 'factoryWidthHz'], path);
+      if (slot.filter !== i + 1) invalid(path, 'contiguous filter slots from one');
+      return { filter: i + 1, label: nonBlank(slot.label, path), factoryWidthHz: nullableHz(slot.factoryWidthHz, path) };
+    }),
+    fixed: bool(v.fixed, path + '.fixed'), minHz, maxHz, stepHz: nullableHz(v.stepHz, path + '.stepHz'),
+    segments: v.segments.map((item) => {
+      const segment = record(item, path + '.segments');
+      exactKeys(segment, ['hzMin', 'hzMax', 'stepHz', 'indexMin'], path);
+      const hzMin = positiveHz(segment.hzMin, path), hzMax = positiveHz(segment.hzMax, path);
+      const indexMin = num(segment.indexMin, path);
+      if (hzMin > hzMax || !Number.isSafeInteger(indexMin) || indexMin < 0) invalid(path, 'valid segment bounds and index');
+      return { hzMin, hzMax, stepHz: positiveHz(segment.stepHz, path), indexMin };
+    }), table,
+  };
+}
+
+function validateDataModeChoices(value: unknown, path: string): FilterPassbandViewModel['dataModeChoices'] {
+  if (!Array.isArray(value) || value.length > 4) invalid(path, 'DATA choices in 0..3');
+  return value.map((item, i) => {
+    const choice = record(item, path + '[' + i + ']');
+    exactKeys(choice, ['value', 'label'], path);
+    if (choice.value !== i) invalid(path, 'contiguous DATA choices from zero');
+    return { value: i, label: choice.label === null ? null : nonBlank(choice.label, path) };
+  });
+}
+
 function validateModeFilter(value: unknown, path: string): ModeFilterViewModel {
   const v = record(value, path);
   exactKeys(v, [
     'currentMode', 'modeChoices', 'currentFilter', 'filterChoices',
-    'filterWidth', 'filterWidthMin', 'filterWidthMax',
+    'filterWidth', 'filterWidthMin', 'filterWidthMax', 'activeFilterConfiguration',
   ], path);
   return {
+    activeFilterConfiguration: validateFilterConfiguration(v.activeFilterConfiguration, `${path}.activeFilterConfiguration`),
     currentMode: validateTxAuxField(v.currentMode, `${path}.currentMode`, str),
     modeChoices: strArray(v.modeChoices, `${path}.modeChoices`),
     currentFilter: validateTxAuxField(v.currentFilter, `${path}.currentFilter`, num),
@@ -1638,15 +1695,13 @@ function validateModeFilter(value: unknown, path: string): ModeFilterViewModel {
   };
 }
 
-/** N4 again: exactly the six facts the adapter reads, no speculative keys.
- *  See `radio-view-model-adapter.ts::deriveFilterPassband`. */
 function validateFilterPassband(value: unknown, path: string): FilterPassbandViewModel {
   const v = record(value, path);
   exactKeys(
     v,
     [
       'filterShape', 'filterShapeControlStructural', 'ifShift', 'ifShiftControlStructural',
-      'pbtInner', 'pbtOuter', 'dataMode',
+      'pbtInner', 'pbtOuter', 'dataMode', 'dataModeChoices',
     ],
     path,
   );
@@ -1657,6 +1712,7 @@ function validateFilterPassband(value: unknown, path: string): FilterPassbandVie
     ifShiftControlStructural: bool(v.ifShiftControlStructural, `${path}.ifShiftControlStructural`),
     pbtInner: validateDisplayObservedField(v.pbtInner, `${path}.pbtInner`, num),
     pbtOuter: validateDisplayObservedField(v.pbtOuter, `${path}.pbtOuter`, num),
+    dataModeChoices: validateDataModeChoices(v.dataModeChoices, `${path}.dataModeChoices`),
     dataMode: validateTxAuxField(v.dataMode, `${path}.dataMode`, num),
   };
 }


### PR DESCRIPTION
14 code + 0 regenerated baselines = 14 files

The coordinator grants the delegated file-count exception for this single shared semantic contract and its required fixture migrations. DATA selection and resolved filter configuration share the adapter, schema, and verification matrix; the change totals 546 added/deleted lines.

The common filter surface previously exposed DATA only as a numeric readout. It now renders advertised choices and sends selections through the existing mode handler, with pending feedback separate from observed selection. Fresh DATA2 with an advertised OFF/DATA1 set remains visible as 2; neither button is falsely selected, and choosing OFF sends the explicit target 0.

The internal semantic contract now requires `filterPassband.dataModeChoices` and `modeFilter.activeFilterConfiguration` whenever their groups are present. Choices contain capability values and nullable label metadata; the component supplies OFF/Dn fallback text. The copied filter configuration comes from the existing resolver and preserves missing factory widths as null. Fixtures and the offline pending accessor were updated for the required contract. Wire commands are unchanged. Preset editing and legacy-panel suppression remain outside this change.

Independent review identified one omitted `getDataModeArmed` export in a closed receiver-indicator test mock. The correction adds that explicit fixture fact without changing production code. On corrected head `4173adffa50573f2d98c5f119c6ee8d74ba2b8d4`, all 13 receiver-indicator and 18 DATA-wiring tests pass; `npm run check` and `npm run lint` pass.

Before that fixture-only correction, 667 tests passed across 11 focused/affected suites, including 321 primary and 65 mobile tests. Type/lint/i18n/build checks passed. Eight Chromium cases verified containment, exact commands, pending state, and observed DATA2/count1 at 375px and 1280px, including one explicit OFF target 0. Sixteen harmful mutants were killed and two equivalent implementation controls passed; the independent verifier reproduced those mutation results. These are prior-head results for unchanged production code, not a new full-suite claim.

Prior-head natural CI: quick run 33998675756 failed with 9924 passed / 13 failed, matching the corrected mock omission; visual run 33998675701 passed. The two earlier local image comparisons remain unresolved observations, with no baseline regeneration. Corrected-head required CI and fresh independent exact-head review remain merge gates.

Tracks [MOR-2374](https://linear.app/morozsm/issue/MOR-2374/lcd-shared-controls-add-data-selection-and-resolved-filter).
