### PR TITLE
fix: remove fabricated AF activity without FFT bins

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberAfScope.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberAfScope.svelte
@@ -277,6 +277,12 @@
     slopeExtra: number,
     passbandHz: number,
   ): void {
+    if (!pixels || pixels.length === 0) {
+      smoothed = null;
+      runningMax = null;
+      return;
+    }
+
     const maxVal = 160;
     const barW = 2;
     const gap = 1;
@@ -310,22 +316,17 @@
       const barCenterX = x + barW / 2;
 
       // Get raw amplitude — map bar position to passband FFT bins only
-      let rawAmp: number;
-      if (pixels && pixels.length > 0) {
-        // pixels[] is symmetric: [-Nyquist ... DC ... +Nyquist]
-        // DC is at center (pixels.length / 2), positive freqs are right half
-        const dcIdx = Math.floor(pixels.length / 2);
-        const positiveLen = pixels.length - dcIdx; // DC → Nyquist
+      // pixels[] is symmetric: [-Nyquist ... DC ... +Nyquist]
+      // DC is at center (pixels.length / 2), positive freqs are right half
+      const dcIdx = Math.floor(pixels.length / 2);
+      const positiveLen = pixels.length - dcIdx; // DC → Nyquist
 
-        // Bar position 0→1 within trapezoid
-        const barFrac = (barCenterX - startX) / (endX - startX);
-        // Map to positive-side FFT bin within passband only
-        const pixIdx = dcIdx + Math.floor(barFrac * passbandFrac * positiveLen);
-        const clamped = Math.max(dcIdx, Math.min(pixels.length - 1, pixIdx));
-        rawAmp = Math.min(pixels[clamped], maxVal) / maxVal;
-      } else {
-        rawAmp = Math.random() * 0.06 + 0.02;
-      }
+      // Bar position 0→1 within trapezoid
+      const barFrac = (barCenterX - startX) / (endX - startX);
+      // Map to positive-side FFT bin within passband only
+      const pixIdx = dcIdx + Math.floor(barFrac * passbandFrac * positiveLen);
+      const clamped = Math.max(dcIdx, Math.min(pixels.length - 1, pixIdx));
+      const rawAmp = Math.min(pixels[clamped], maxVal) / maxVal;
 
       // Smooth
       const prev = smoothed[i];

--- a/frontend/src/components-v2/panels/lcd/__tests__/AmberAfScope.honesty.component.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/AmberAfScope.honesty.component.test.ts
@@ -1,0 +1,146 @@
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import AmberAfScope from '../AmberAfScope.svelte';
+
+type Mode = 'compact' | 'fill' | 'dominant';
+type Point = [number, number];
+const width = 320;
+const height = 160;
+let component: ReturnType<typeof mount> | undefined;
+let target: HTMLDivElement;
+let nextFrame: FrameRequestCallback | undefined;
+let path: Point[];
+let strokes: Point[][];
+let bars: number[][];
+let labels: string[];
+
+beforeEach(() => {
+  path = [];
+  strokes = [];
+  bars = [];
+  labels = [];
+  nextFrame = undefined;
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  vi.spyOn(Math, 'random').mockReturnValue(0.9);
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    nextFrame = callback;
+    return 1;
+  });
+  vi.stubGlobal('cancelAnimationFrame', () => { nextFrame = undefined; });
+  vi.stubGlobal('ResizeObserver', class {
+    constructor(private callback: ResizeObserverCallback) {}
+    observe() {
+      this.callback([{ contentRect: { width, height } } as ResizeObserverEntry], this as unknown as ResizeObserver);
+    }
+    disconnect() {}
+  });
+  const context = {
+    clearRect: () => { strokes = []; bars = []; labels = []; },
+    setTransform: () => {},
+    measureText: (text: string) => ({ width: text.length * 8 }),
+    fillText: (text: string) => { labels.push(text); },
+    beginPath: () => { path = []; },
+    moveTo: (x: number, y: number) => { path.push([x, y]); },
+    lineTo: (x: number, y: number) => { path.push([x, y]); },
+    stroke: () => { strokes.push([...path]); },
+    fillRect: (...rect: number[]) => { bars.push(rect); },
+  } as unknown as CanvasRenderingContext2D;
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(context);
+});
+
+afterEach(async () => {
+  if (component) await unmount(component);
+  component = undefined;
+  target.remove();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function renderFrame() {
+  const callback = nextFrame;
+  expect(callback).toBeTypeOf('function');
+  nextFrame = undefined;
+  callback!(0);
+}
+
+function setup(mode: Mode, initial: Uint8Array | null) {
+  let data = initial;
+  let push: ((pixels: Uint8Array) => void) | undefined;
+  component = mount(AmberAfScope, {
+    target,
+    props: {
+      get data() { return data; },
+      mode,
+      filterWidth: 2400,
+      filterWidthMax: 3600,
+      onRegisterPush: (callback) => { push = callback; },
+    },
+  });
+  flushSync();
+  renderFrame();
+  return {
+    setData(pixels: Uint8Array | null) { data = pixels; renderFrame(); },
+    push(pixels: Uint8Array) { expect(push).toBeTypeOf('function'); push!(pixels); renderFrame(); },
+  };
+}
+
+function expectFrameOnly() {
+  expect(bars).toEqual([]);
+  expect(strokes).toHaveLength(1);
+  expect(strokes[0]).toHaveLength(6);
+  expect(strokes[0].some(([, y]) => y === 40)).toBe(true);
+  expect(labels).toEqual(['Shift: ', '+0000', 'Hz', 'Filter: ', '2400', 'Hz']);
+}
+
+function expectZeroActivity() {
+  expect(bars).toEqual([]);
+  expect(strokes.slice(1).flat().every(([, y]) => y === height)).toBe(true);
+}
+
+function expectActivity(mode: Mode) {
+  expect(bars.length).toBeGreaterThan(0);
+  expect(bars.some(([, y, , h]) => y < height && h > 0)).toBe(true);
+  if (mode === 'dominant') {
+    expect(strokes.slice(1).flat().some(([, y]) => y < height)).toBe(true);
+  }
+}
+
+describe.each<Mode>(['compact', 'fill', 'dominant'])('Amber AF %s input honesty', (mode) => {
+  it.each([null, new Uint8Array()])('keeps only the instrument frame without bins (%s)', (pixels) => {
+    setup(mode, pixels);
+    expectFrameOnly();
+    for (let i = 0; i < 5; i++) renderFrame();
+    expectFrameOnly();
+  });
+
+  it('does not invent activity for measured zero bins', () => {
+    setup(mode, new Uint8Array(256));
+    expectZeroActivity();
+    for (let i = 0; i < 5; i++) renderFrame();
+    expectZeroActivity();
+  });
+
+  it.each([null, new Uint8Array()])('clears smoothing and peaks after explicit prop input (%s)', (empty) => {
+    const scope = setup(mode, new Uint8Array(256).fill(160));
+    expectActivity(mode);
+    scope.setData(empty);
+    expectFrameOnly();
+    scope.setData(new Uint8Array(256));
+    expectZeroActivity();
+    scope.setData(new Uint8Array(256).fill(80));
+    expectActivity(mode);
+  });
+
+  it('clears pushed empty bins and resumes with real bins', () => {
+    const scope = setup(mode, null);
+    scope.push(new Uint8Array(256).fill(160));
+    expectActivity(mode);
+    scope.push(new Uint8Array());
+    expectFrameOnly();
+    scope.push(new Uint8Array(256));
+    expectZeroActivity();
+    scope.push(new Uint8Array(256).fill(80));
+    expectActivity(mode);
+  });
+});


### PR DESCRIPTION
When the Amber AF renderer had no FFT bins, it generated random amplitudes and could show bars or a dominant-mode peak trace. `AmberAfScope.drawFft` now clears its smoothing/peak buffers and returns for null or empty input. The existing instrument labels and trapezoid remain; nonempty bins keep their rendering path.

Closes [MOR-2376](https://linear.app/morozsm/issue/MOR-2376/lcd-audio-honesty-remove-fabricated-af-activity-when-no-fft-bins-exist), a bounded prerequisite under MOR-2320. The existing `latestPixels ?? data` source selection remains unchanged: source expiry and invalidation of previously pushed data require the separately tracked consumer lifecycle migration. This does not complete LCD/audio acceptance or change public API, transport, or hardware behavior.

Validation:
- Focused Vitest command covering `AmberAfScope.honesty.component`, `audio-fft-demand.isolated`, LCD `scope-frame`, runtime `scope-frame-host`, and `RadioLayout.audio-fft.component`: 53 passed across 5 files.
- `npm run check`: zero Svelte errors/warnings; both subsequent TypeScript checks passed. ESLint on the two changed paths and `git diff --cached --check` passed.
- Mounted canvas/RAF tests cover compact, fill, and dominant modes. Reinstating fabrication failed 15 cases; retaining smoothing failed 9; retaining peaks failed 3. A legitimate bar-width/attack/decay variation passed all 18 component cases. The restored candidate passed the focused checks above.
- A bounded Chromium probe mounted the actual component in all three modes: positive bins changed canvas pixels, an empty push restored the initial canvas exactly, and fresh bins resumed activity. No page errors. No visual baselines were changed; required natural PR CI and independent exact-head review remain pending.
