### PR TITLE
refactor: share exact Icom filter width preflight (MOR-2378)

### DIFF
--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -12,7 +12,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal, Never, NotRequired, Required, TypedDict
 
+from rigplane.commands._codec import bcd_encode_value, filter_hz_to_index
 from rigplane.commands.command_map import CommandMap, ReverseCommandIndex
+from rigplane.core.exceptions import CommandError
 from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
 from rigplane.core.tx_interlock_contract import (
     TxInterlockCommandFamily,
@@ -538,6 +540,40 @@ class RadioProfile:
             if rule is not None:
                 return rule
         return None
+
+    def encode_filter_width(
+        self, width_hz: int, mode: str | None, *, data_mode: int = 0
+    ) -> bytes:
+        """Encode a width using the resolved segmented CI-V filter rule."""
+        rule = self.resolve_filter_rule(mode, data_mode=data_mode)
+
+        min_hz = self.filter_width_min
+        max_hz = self.filter_width_max
+        if rule is not None:
+            if rule.fixed:
+                raise CommandError(
+                    f"set_filter_width is unsupported for fixed-width mode {mode}"
+                )
+            if rule.min_hz is not None:
+                min_hz = rule.min_hz
+            if rule.max_hz is not None:
+                max_hz = rule.max_hz
+        if not min_hz <= width_hz <= max_hz:
+            raise CommandError(
+                f"set_filter_width value must be {min_hz}-{max_hz} Hz "
+                f"for {mode}, got {width_hz}"
+            )
+
+        if rule is None or not rule.segments:
+            raise CommandError(
+                f"set_filter_width has no filter-width mapping for mode {mode}"
+            )
+        try:
+            payload_value = filter_hz_to_index(width_hz, segments=rule.segments)
+        except ValueError as exc:
+            raise CommandError(str(exc)) from exc
+
+        return bcd_encode_value(payload_value, byte_count=1)
 
 
 # ── TOML-driven profile registry ──────────────────────────────────

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -96,9 +96,7 @@ from rigplane.commands import (
     CONTROLLER_ADDR,
     RECEIVER_MAIN,
     _level_bcd_decode,
-    bcd_encode_value,
     build_civ_frame,
-    filter_hz_to_index,
     filter_index_to_hz,
     get_acc1_mod_level,
     get_af_mute,
@@ -2000,35 +1998,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         target = self._radio_state.receiver("SUB" if receiver else "MAIN")
         mode_name = getattr(target, "mode", None)
         data_mode = int(getattr(target, "data_mode", 0) or 0)
-        rule = self._profile.resolve_filter_rule(mode_name, data_mode=data_mode)
-
-        min_hz = self._profile.filter_width_min
-        max_hz = self._profile.filter_width_max
-        if rule is not None:
-            if rule.fixed:
-                raise CommandError(
-                    f"set_filter_width is unsupported for fixed-width mode {mode_name}"
-                )
-            if rule.min_hz is not None:
-                min_hz = rule.min_hz
-            if rule.max_hz is not None:
-                max_hz = rule.max_hz
-        if not min_hz <= width_hz <= max_hz:
-            raise CommandError(
-                f"set_filter_width value must be {min_hz}-{max_hz} Hz "
-                f"for {mode_name}, got {width_hz}"
-            )
-
-        if rule is None or not rule.segments:
-            raise CommandError(
-                f"set_filter_width has no filter-width mapping for mode {mode_name}"
-            )
-        try:
-            payload_value = filter_hz_to_index(width_hz, segments=rule.segments)
-        except ValueError as exc:
-            raise CommandError(str(exc)) from exc
-
-        bcd_index_byte = bcd_encode_value(payload_value, byte_count=1)
+        bcd_index_byte = self._profile.encode_filter_width(
+            width_hz, mode_name, data_mode=data_mode
+        )
         # CI-V 1A 03: 1-byte BCD index (wfview-confirmed). cmd29-wrapped
         # for receiver routing on dual-RX rigs (IC-7610), direct on single-RX
         # (IC-705) and on MAIN for dual-RX rigs without cmd29 support

--- a/tests/test_dsp_filter_family.py
+++ b/tests/test_dsp_filter_family.py
@@ -10,9 +10,10 @@ Covers:
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -23,7 +24,13 @@ from rigplane.commands._codec import (
     hz_to_table_index,
     table_index_to_hz,
 )
-from rigplane.profiles import resolve_radio_profile
+from rigplane.core.exceptions import CommandError
+from rigplane.profiles import (
+    FilterWidthRule,
+    FilterWidthSegment,
+    RadioProfile,
+    resolve_radio_profile,
+)
 from rigplane.radio import IcomRadio
 from rigplane.radio_protocol import DspControlCapable
 from rigplane.rig_loader import load_rig
@@ -640,3 +647,242 @@ async def test_rigctld_filter_width_passband_round_trip() -> None:
     assert get_resp.ok
     assert get_resp.values[0] == "USB"
     assert get_resp.values[1] == "2400"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["IC-7610", "IC-705", "IC-9700", "IC-7300"])
+async def test_filter_preflight_shipped_rules_match_setter_bytes(model: str) -> None:
+    radio = _connected_icom(model=model)
+    radio.send_civ = AsyncMock()
+    profile = radio._profile
+    assert profile.filter_config
+    for mode, rule in profile.filter_config.items():
+        radio._radio_state.main.mode = mode
+        if rule.fixed:
+            with pytest.raises(CommandError) as error:
+                profile.encode_filter_width(2400, mode)
+            assert str(error.value) == (
+                f"set_filter_width is unsupported for fixed-width mode {mode}"
+            )
+            with pytest.raises(CommandError, match="unsupported for fixed-width mode"):
+                await radio.set_filter_width(2400)
+            radio.send_civ.assert_not_awaited()
+            continue
+        examples = (
+            [(200, b"\x00"), (6000, b"\x29"), (10000, b"\x49")]
+            if mode == "AM"
+            else [(50, b"\x00"), (500, b"\x09"), (600, b"\x10"), (2400, b"\x28")]
+            + ([(2700, b"\x31")] if mode.startswith("RTTY") else [(3600, b"\x40")])
+        )
+        for width, expected in examples:
+            assert profile.encode_filter_width(width, mode) == expected
+            await radio.set_filter_width(width)
+            if model == "IC-7610":
+                radio.send_civ.assert_awaited_once_with(
+                    0x29, data=b"\x00\x1a\x03" + expected, wait_response=False
+                )
+            else:
+                radio.send_civ.assert_awaited_once_with(
+                    0x1A, sub=0x03, data=expected, wait_response=False
+                )
+            radio.send_civ.reset_mock()
+
+
+@pytest.mark.parametrize(
+    ("keys", "mode", "data_mode", "expected"),
+    [
+        (("USB", "USB-D", "SSB", "SSB-D"), "usb", 0, b"\x00"),
+        (("USB", "USB-D", "SSB", "SSB-D"), "usb", 3, b"\x01"),
+        (("USB", "SSB-D"), "USB", 1, b"\x00"),
+        (("SSB", "SSB-D"), "LSB", 0, b"\x00"),
+        (("SSB", "SSB-D"), "LSB", 2, b"\x01"),
+        (("CW", "CW-R"), "CW-R", 0, b"\x01"),
+        (("CW",), "CW-R", 0, b"\x00"),
+        (("RTTY",), "RTTY-R", 0, b"\x00"),
+    ],
+)
+def test_filter_preflight_preserves_mode_data_resolution(
+    keys: tuple[str, ...], mode: str, data_mode: int, expected: bytes
+) -> None:
+    profile = replace(
+        resolve_radio_profile(model="IC-7610"),
+        filter_config={
+            key: FilterWidthRule(segments=(FilterWidthSegment(50, 50, 50, index),))
+            for index, key in enumerate(keys)
+        },
+    )
+    assert profile.encode_filter_width(50, mode, data_mode=data_mode) == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("rule", "width", "error_type", "message"),
+    [
+        (
+            FilterWidthRule(fixed=True),
+            20,
+            CommandError,
+            "set_filter_width is unsupported for fixed-width mode USB",
+        ),
+        (
+            FilterWidthRule(
+                min_hz=100, max_hz=200, segments=(FilterWidthSegment(50, 500, 50, 0),)
+            ),
+            50,
+            CommandError,
+            "set_filter_width value must be 100-200 Hz for USB, got 50",
+        ),
+        (
+            FilterWidthRule(
+                min_hz=100, max_hz=200, segments=(FilterWidthSegment(50, 500, 50, 0),)
+            ),
+            250,
+            CommandError,
+            "set_filter_width value must be 100-200 Hz for USB, got 250",
+        ),
+        (
+            None,
+            20,
+            CommandError,
+            "set_filter_width value must be 50-9999 Hz for USB, got 20",
+        ),
+        (
+            None,
+            2400,
+            CommandError,
+            "set_filter_width has no filter-width mapping for mode USB",
+        ),
+        (
+            FilterWidthRule(),
+            2400,
+            CommandError,
+            "set_filter_width has no filter-width mapping for mode USB",
+        ),
+        (
+            FilterWidthRule(segments=(FilterWidthSegment(50, 500, 50, 0),)),
+            75,
+            CommandError,
+            "Filter width 75 is not aligned to 50 Hz steps",
+        ),
+        (
+            FilterWidthRule(
+                segments=(
+                    FilterWidthSegment(50, 500, 50, 0),
+                    FilterWidthSegment(600, 3600, 100, 10),
+                )
+            ),
+            550,
+            CommandError,
+            "Filter width 550 is outside the configured segments",
+        ),
+        (
+            FilterWidthRule(segments=(FilterWidthSegment(50, 500, 50, 100),)),
+            50,
+            ValueError,
+            "BCD value must fit in 1 byte(s), got 100",
+        ),
+        (
+            FilterWidthRule(segments=(FilterWidthSegment(50, 500, 50, -1),)),
+            50,
+            ValueError,
+            "BCD value must be non-negative, got -1",
+        ),
+    ],
+)
+async def test_filter_preflight_preserves_refusal_before_any_wire_write(
+    rule: FilterWidthRule | None, width: int, error_type: type[Exception], message: str
+) -> None:
+    radio = _connected_icom()
+    radio._profile = replace(
+        radio._profile, filter_config={} if rule is None else {"USB": rule}
+    )
+    radio._radio_state.sub.mode = "USB"
+    radio.send_civ = AsyncMock()
+    radio._send_civ_expect = AsyncMock()
+    with pytest.raises(error_type) as pure_error:
+        radio._profile.encode_filter_width(width, "USB")
+    with pytest.raises(error_type) as setter_error:
+        await radio.set_filter_width(width, receiver=1)
+    for error in (pure_error, setter_error):
+        assert type(error.value) is error_type
+        assert str(error.value) == message
+    assert type(pure_error.value.__cause__) is type(setter_error.value.__cause__)
+    radio.send_civ.assert_not_awaited()
+    radio._send_civ_expect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("width", [2400.0, 2400.5, "2400", None, True])
+async def test_filter_preflight_does_not_coerce_previous_width_domain(
+    width: object,
+) -> None:
+    radio = _connected_icom()
+    radio._radio_state.main.mode = "USB"
+    radio.send_civ = AsyncMock()
+    with pytest.raises((CommandError, TypeError, ValueError)) as pure_error:
+        radio._profile.encode_filter_width(width, "USB")  # type: ignore[arg-type]
+    with pytest.raises(type(pure_error.value)) as setter_error:
+        await radio.set_filter_width(width)  # type: ignore[arg-type]
+    assert str(pure_error.value) == str(setter_error.value)
+    radio.send_civ.assert_not_awaited()
+
+
+@pytest.mark.parametrize("width", [50, 250])
+def test_filter_preflight_uses_profile_bounds_when_rule_omits_them(width: int) -> None:
+    profile = replace(
+        resolve_radio_profile(model="IC-7610"),
+        filter_width_min=100,
+        filter_width_max=200,
+        filter_config={
+            "USB": FilterWidthRule(segments=(FilterWidthSegment(50, 500, 50, 0),))
+        },
+    )
+    with pytest.raises(CommandError) as error:
+        profile.encode_filter_width(width, "USB")
+    assert (
+        str(error.value)
+        == f"set_filter_width value must be 100-200 Hz for USB, got {width}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("receiver", [0, 1])
+async def test_filter_preflight_setter_delegates_selected_context_and_payload(
+    receiver: int,
+) -> None:
+    radio = _connected_icom()
+    radio._radio_state.main.mode = "USB"
+    radio._radio_state.sub.mode = "RTTY"
+    radio._radio_state.main.data_mode = 1
+    radio._radio_state.sub.data_mode = 3
+    radio.send_civ = AsyncMock()
+    with patch.object(
+        RadioProfile, "encode_filter_width", autospec=True, return_value=b"\x77"
+    ) as encode:
+        await radio.set_filter_width(2400, receiver=receiver)
+    encode.assert_called_once_with(
+        radio._profile,
+        2400,
+        "RTTY" if receiver else "USB",
+        data_mode=3 if receiver else 1,
+    )
+    radio.send_civ.assert_awaited_once_with(
+        0x29, data=bytes([receiver, 0x1A, 0x03, 0x77]), wait_response=False
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("admission", ["connection", "receiver", "support"])
+async def test_filter_preflight_remains_after_runtime_admission(admission: str) -> None:
+    radio = _connected_icom()
+    radio.send_civ = AsyncMock()
+    receiver = 2 if admission == "receiver" else 0
+    if admission == "connection":
+        radio._check_connected = Mock(side_effect=CommandError("disconnected"))
+    elif admission == "support":
+        radio._profile = replace(radio._profile, command_names=frozenset())
+    with patch.object(RadioProfile, "encode_filter_width", autospec=True) as encode:
+        with pytest.raises(CommandError):
+            await radio.set_filter_width(2400, receiver=receiver)
+        encode.assert_not_called()
+    radio.send_civ.assert_not_awaited()


### PR DESCRIPTION
`IcomRadio.set_filter_width` previously owned the complete fixed-mode, range, segmented mapping and one-byte BCD validation sequence. `RadioProfile.encode_filter_width(width_hz, mode, *, data_mode=0)` now performs that same sequence and returns the validated payload; the ordinary setter delegates after its existing connection, receiver and command-support admission, then uses its existing cmd29/direct/VFO route.

This is the pure preflight prerequisite [MOR-2378](https://linear.app/morozsm/issue/MOR-2378/filter-preflight-share-exact-icom-width-validation-before-ordered) under MOR-2377. It adds a profile method without changing the ordinary setter's width domain, error messages/types, mode/DATA resolution or routing. The mapping `ValueError` is still wrapped as `CommandError`; BCD encoding `ValueError` remains unwrapped. No ordered operation, queue, UI, capability, calibration or hardware implementation is included.

Validation on local Python 3.13:
- Before editing, `uv run pytest tests/test_dsp_filter_family.py -q --tb=short --timeout=300 --timeout-method=thread`: 31 passed. New tests were RED before the helper existed (34 failed / 31 passed); the restored final file has 65 passed.
- The focused command adding `tests/test_profiles_runtime.py`, `tests/test_profiles_routing.py`, `tests/test_receiver_command_admission.py` and `tests/test_icom_receiver_tier.py` passed all 268 tests across 5 files.
- Tests cover shipped Icom rules, literal payload boundaries and segment transitions, mode/DATA alias precedence including DATA 3, invalid-width refusal without wire writes, selected-receiver delegation and runtime admission ordering.
- Harmful mutations bypassing fixed/range checks, coercing the width lattice, truncating unencodable indices and restoring divergent setter conversion failed 5/5/3/2/2 tests respectively. An equivalent copy of the encoded bytes passed all 34 new tests; the restored focused file passed afterward.
- `uv run ruff check` and `uv run ruff format --check` on the three changed paths passed; `uv run lint-imports` kept all 5 architecture contracts; `git diff --check` passed.

No local full suite was run. The natural Ready PR quick run supplies Python 3.11 full-suite evidence; CI and independent exact-head review remain merge gates.
