### PR TITLE
Share committed scalar CW behavior (MOR-2379)

### DIFF
--- a/frontend/src/components-v2/panels/CwPanel.svelte
+++ b/frontend/src/components-v2/panels/CwPanel.svelte
@@ -76,6 +76,7 @@
         breakInDelayFeedback.sessionEpoch,
         breakInDelayFeedback.scope.control,
         breakInDelayFeedback.scope.receiver,
+        breakInDelayFeedback.scope.slot ?? null,
       ]),
     }),
     {

--- a/frontend/src/components-v2/panels/CwPanel.svelte
+++ b/frontend/src/components-v2/panels/CwPanel.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import '../controls/control-button.css';
   import { HardwareButton } from '$lib/Button';
-  import { ValueControl, rawToPercentDisplay } from '../controls/value-control';
-  import { getLocale } from '$lib/i18n';
   import {
-    projectControlFeedbackPresentation,
-    type PresentationPhase,
-  } from '../../primitives/control-feedback/control-feedback-presentation';
+    ValueControl, clamp, rawToPercentDisplay, snapToStep,
+  } from '../controls/value-control';
+  import { getLocale } from '$lib/i18n';
+  import type { PresentationPhase } from '../../primitives/control-feedback/control-feedback-presentation';
+  import { createCommittedScalar } from '../../primitives/scalar/committed-scalar.svelte';
 
   import { isApfActive } from './cw-panel-logic';
   import {
@@ -63,50 +63,30 @@
     ? candidateBreakInDelayFeedback : { ...candidateBreakInDelayFeedback,
       confirmed: null, target: null, requestedTarget: null, phase: 'unavailable' as const,
       busy: false, availability: 'unavailable' as const, outcome: null, transitionId: null });
-  let breakInDelayAvailable = $derived(
+  let breakInDelayEditable = $derived(
     breakInDelayFeedback.availability === 'available'
       && breakInDelayFeedback.confirmed !== null,
   );
-  let breakInDelayTruth = $derived(
-    breakInDelayFeedback.busy && breakInDelayFeedback.target !== null
-      ? breakInDelayFeedback.target
-      : breakInDelayFeedback.confirmed,
-  );
-  let breakInDelayDraft = $state(0);
-  let breakInDelayEditing = $state(false);
-  let breakInDelayCancelled = $state(false);
-  let breakInDelayDraftAuthority = $state('');
-  let breakInDelayAnnouncement = $state<string | null>(null);
-  const announcedBreakInDelayTransitions = new Set<string>();
   const feedbackIntegratedRange = { 'feedback-policy': 'feedback-integrated' } as const;
-  let breakInDelayPresentation = $derived(projectControlFeedbackPresentation(
-    breakInDelayFeedback,
-    { announcedTransitionIds: [] },
-    rawToPercentDisplay,
-  ));
-  let breakInDelayAuthority = $derived(JSON.stringify([
-    breakInDelayFeedback.sessionEpoch, breakInDelayFeedback.transitionId,
-    breakInDelayFeedback.phase, breakInDelayFeedback.confirmed,
-  ]));
-  $effect(() => {
-    const truth = breakInDelayTruth, authority = breakInDelayAuthority;
-    if (breakInDelayEditing && breakInDelayDraftAuthority !== authority) {
-      breakInDelayCancelled = true;
-      breakInDelayEditing = false;
-    }
-    if (!breakInDelayEditing && truth !== null) breakInDelayDraft = truth;
-  });
-  $effect(() => {
-    const transition = breakInDelayPresentation.politeAnnouncement;
-    if (transition && !announcedBreakInDelayTransitions.has(transition.transitionId)) {
-      announcedBreakInDelayTransitions.add(transition.transitionId);
-      breakInDelayAnnouncement = breakInDelayMessage(
-        transition.phase,
-        breakInDelayFeedback.requestedTarget,
-        breakInDelayFeedback.confirmed,
-      );
-    }
-  });
+  const breakInDelayScalar = createCommittedScalar(
+    () => ({
+      feedback: breakInDelayFeedback,
+      editable: breakInDelayEditable,
+      contextKey: JSON.stringify([
+        breakInDelayFeedback.sessionEpoch,
+        breakInDelayFeedback.scope.control,
+        breakInDelayFeedback.scope.receiver,
+      ]),
+    }),
+    {
+      accepts: validDelay,
+      normalize: (value) => snapToStep(clamp(value, 0, 255), 1, 0),
+      draftPolicy: 'normalize',
+      describeTarget: rawToPercentDisplay,
+    },
+    onBreakInDelayChange,
+  );
+  let breakInDelayView = $derived(breakInDelayScalar.view);
   const delayText = (value: number | null): string =>
     value === null ? '—' : rawToPercentDisplay(value);
   const delayLabel = (): string =>
@@ -129,50 +109,41 @@
     if (phase === 'idle' || phase === 'confirmed') return `${label}: ${canonical}`;
     return `${label} ${delayText(target)}; ${ru ? 'подтверждено' : 'confirmed'} ${canonical}`;
   }
+  let retainedBreakInDelayAnnouncement: string | null = null;
+  let breakInDelayAnnouncement = $derived.by(() => {
+    const transition = breakInDelayView.presentation.politeAnnouncement;
+    if (transition !== null) {
+      retainedBreakInDelayAnnouncement = breakInDelayMessage(
+        transition.phase,
+        breakInDelayView.feedback.requestedTarget,
+        breakInDelayView.confirmed,
+      );
+    }
+    return retainedBreakInDelayAnnouncement;
+  });
   let breakInDelayValueText = $derived(
-    !breakInDelayAvailable
+    !breakInDelayView.editable
       ? breakInDelayMessage('unavailable', null, null)
-      : breakInDelayEditing
-        ? `${getLocale() === 'ru-RU' ? 'Черновик' : 'Draft'} ${delayText(breakInDelayDraft)}; ${getLocale() === 'ru-RU' ? 'подтверждено' : 'last confirmed'} ${delayText(breakInDelayFeedback.confirmed)}`
+      : breakInDelayView.editing
+        ? `${getLocale() === 'ru-RU' ? 'Черновик' : 'Draft'} ${delayText(breakInDelayView.draft)}; ${getLocale() === 'ru-RU' ? 'подтверждено' : 'last confirmed'} ${delayText(breakInDelayView.confirmed)}`
         : breakInDelayMessage(
-          breakInDelayFeedback.phase,
-          breakInDelayFeedback.target ?? breakInDelayFeedback.requestedTarget,
-          breakInDelayFeedback.confirmed,
+          breakInDelayView.feedback.phase,
+          breakInDelayView.feedback.target ?? breakInDelayView.feedback.requestedTarget,
+          breakInDelayView.confirmed,
         ),
   );
-  function restoreBreakInDelay(): void {
-    breakInDelayEditing = false;
-    breakInDelayDraft = breakInDelayTruth ?? 0;
-  }
   function updateBreakInDelayDraft(event: Event): void {
-    if (!breakInDelayAvailable) return;
-    if (!breakInDelayEditing) breakInDelayDraftAuthority = breakInDelayAuthority;
-    breakInDelayCancelled = false;
-    breakInDelayEditing = true;
-    breakInDelayDraft = Math.min(255, Math.max(0, Math.round(
-      (event.currentTarget as HTMLInputElement).valueAsNumber,
-    )));
+    breakInDelayScalar.input((event.currentTarget as HTMLInputElement).valueAsNumber);
   }
   function commitBreakInDelay(event: Event): void {
-    if (breakInDelayCancelled) {
-      breakInDelayCancelled = false;
-      restoreBreakInDelay();
-      (event.currentTarget as HTMLInputElement).value = String(breakInDelayDraft);
-      return;
-    }
-    const candidate = (event.currentTarget as HTMLInputElement).valueAsNumber;
-    if (breakInDelayAvailable && Number.isFinite(candidate)) {
-      const bounded = Math.min(255, Math.max(0, Math.round(candidate)));
-      breakInDelayDraft = bounded;
-      onBreakInDelayChange(bounded);
-    }
-    breakInDelayEditing = false;
+    const target = event.currentTarget as HTMLInputElement;
+    const restored = breakInDelayScalar.commit(target.valueAsNumber);
+    if (restored !== null) target.value = String(restored);
   }
   function cancelBreakInDelay(event?: Event): void {
-    breakInDelayCancelled = true;
-    restoreBreakInDelay();
+    const restored = breakInDelayScalar.cancel();
     if (event?.currentTarget instanceof HTMLInputElement) {
-      event.currentTarget.value = String(breakInDelayDraft);
+      if (restored !== null) event.currentTarget.value = String(restored);
     }
   }
   function handleBreakInDelayKeydown(event: KeyboardEvent): void {
@@ -263,26 +234,26 @@
         <span class="break-in-delay-header">
           <span>{delayLabel()}</span>
           <output data-testid="cw-break-in-delay-value">
-            {breakInDelayAvailable ? delayText(breakInDelayDraft) : '—'}
+            {breakInDelayView.editable ? delayText(breakInDelayView.displayed) : '—'}
           </output>
         </span>
         <input
           data-testid="cw-break-in-delay"
-          type="range" min="0" max="255" step="1" value={breakInDelayDraft}
+          type="range" min="0" max="255" step="1" value={breakInDelayView.displayed ?? undefined}
           {...feedbackIntegratedRange}
-          disabled={!breakInDelayAvailable}
+          disabled={!breakInDelayView.editable}
           aria-label={delayLabel()}
-          aria-valuenow={breakInDelayAvailable ? breakInDelayDraft : undefined}
+          aria-valuenow={breakInDelayView.displayed ?? undefined}
           aria-valuetext={breakInDelayValueText}
-          aria-busy={breakInDelayPresentation.attributes['aria-busy']}
-          data-command-phase={breakInDelayPresentation.attributes['data-command-phase']}
+          aria-busy={breakInDelayView.presentation.attributes['aria-busy']}
+          data-command-phase={breakInDelayView.presentation.attributes['data-command-phase']}
           oninput={updateBreakInDelayDraft}
           onchange={commitBreakInDelay}
           onpointercancel={cancelBreakInDelay}
           onkeydown={handleBreakInDelayKeydown}
         />
         <span class="break-in-delay-phase" aria-hidden="true">
-          ● {breakInDelayFeedback.phase}
+          ● {breakInDelayView.feedback.phase}
         </span>
         {#if breakInDelayAnnouncement}
           <span

--- a/frontend/src/components-v2/panels/__tests__/CwPanel.feedback-wiring.svelte.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/CwPanel.feedback-wiring.svelte.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
   component = null; target?.remove(); setLocale('en-US');
   Object.assign(feedback, { confirmed: 64, target: null, requestedTarget: null, phase: 'idle',
     busy: false, availability: 'available', outcome: null, lifecycleId: null, transitionId: null,
-    sessionEpoch: 1 });
+    sessionEpoch: 1, scope: { control: 'break-in-delay', receiver: 0 } });
 });
 function render() {
   target = document.createElement('div'); document.body.appendChild(target);
@@ -127,12 +127,15 @@ describe('fallback CwPanel ControlFeedback wiring (MOR-1754)', () => {
     r.input().value = '111'; r.input().dispatchEvent(new Event('change', { bubbles: true }));
     expect(handlers.onBreakInDelayChange).not.toHaveBeenCalled();
   });
-  it('preserves equal reprojection but invalidates a changed session context', () => {
+  it.each([
+    ['session epoch', { sessionEpoch: 2 }],
+    ['feedback scope', { scope: { control: 'break-in-delay', receiver: 1 } }],
+  ] as const)('preserves equal reprojection but invalidates changed %s', (_case, changedContext) => {
     handlers.onBreakInDelayChange.mockClear(); const r = render();
     r.input().value = '111'; r.input().dispatchEvent(new Event('input', { bubbles: true }));
     Object.assign(feedback, { confirmed: 64, sessionEpoch: 1 }); flushSync();
     expect(r.input().value).toBe('111');
-    Object.assign(feedback, { sessionEpoch: 2 }); flushSync();
+    Object.assign(feedback, changedContext); flushSync();
     r.input().dispatchEvent(new Event('change', { bubbles: true }));
     expect([r.input().value, handlers.onBreakInDelayChange.mock.calls]).toEqual(['64', []]);
   });

--- a/frontend/src/components-v2/panels/__tests__/CwPanel.feedback-wiring.svelte.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/CwPanel.feedback-wiring.svelte.test.ts
@@ -31,7 +31,8 @@ afterEach(() => {
   if (component) unmount(component);
   component = null; target?.remove(); setLocale('en-US');
   Object.assign(feedback, { confirmed: 64, target: null, requestedTarget: null, phase: 'idle',
-    busy: false, availability: 'available', outcome: null, lifecycleId: null, transitionId: null });
+    busy: false, availability: 'available', outcome: null, lifecycleId: null, transitionId: null,
+    sessionEpoch: 1 });
 });
 function render() {
   target = document.createElement('div'); document.body.appendChild(target);
@@ -41,6 +42,25 @@ function render() {
   return { input, live };
 }
 describe('fallback CwPanel ControlFeedback wiring (MOR-1754)', () => {
+  it('keeps normalized input local until one native change commits it', () => {
+    handlers.onBreakInDelayChange.mockClear(); const r = render();
+    Object.defineProperty(r.input(), 'valueAsNumber', { configurable: true, value: 111.4 });
+    r.input().dispatchEvent(new Event('input', { bubbles: true })); flushSync();
+    expect([handlers.onBreakInDelayChange.mock.calls, r.input().value])
+      .toEqual([[], '111']);
+    r.input().dispatchEvent(new Event('change', { bubbles: true }));
+    expect(handlers.onBreakInDelayChange).toHaveBeenCalledExactlyOnceWith(111);
+  });
+  it.each(['Escape', 'pointercancel'] as const)('%s cancels and suppresses a delayed change', (route) => {
+    handlers.onBreakInDelayChange.mockClear(); const r = render();
+    r.input().value = '111'; r.input().dispatchEvent(new Event('input', { bubbles: true }));
+    const cancel = route === 'Escape'
+      ? new KeyboardEvent('keydown', { key: route, bubbles: true })
+      : new Event(route, { bubbles: true });
+    r.input().dispatchEvent(cancel);
+    r.input().dispatchEvent(new Event('change', { bubbles: true }));
+    expect([r.input().value, handlers.onBreakInDelayChange.mock.calls]).toEqual(['64', []]);
+  });
   it('projects pending and every terminal phase without replacing canonical truth', () => {
     const r = render();
     for (const [phase, busy] of [
@@ -106,5 +126,14 @@ describe('fallback CwPanel ControlFeedback wiring (MOR-1754)', () => {
       .toEqual([true, 'Control unavailable', '—']);
     r.input().value = '111'; r.input().dispatchEvent(new Event('change', { bubbles: true }));
     expect(handlers.onBreakInDelayChange).not.toHaveBeenCalled();
+  });
+  it('preserves equal reprojection but invalidates a changed session context', () => {
+    handlers.onBreakInDelayChange.mockClear(); const r = render();
+    r.input().value = '111'; r.input().dispatchEvent(new Event('input', { bubbles: true }));
+    Object.assign(feedback, { confirmed: 64, sessionEpoch: 1 }); flushSync();
+    expect(r.input().value).toBe('111');
+    Object.assign(feedback, { sessionEpoch: 2 }); flushSync();
+    r.input().dispatchEvent(new Event('change', { bubbles: true }));
+    expect([r.input().value, handlers.onBreakInDelayChange.mock.calls]).toEqual(['64', []]);
   });
 });

--- a/frontend/src/primitives/scalar/__tests__/committed-scalar.test.ts
+++ b/frontend/src/primitives/scalar/__tests__/committed-scalar.test.ts
@@ -1,0 +1,157 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import type { ControlFeedbackPresentationInput } from '../../control-feedback/control-feedback-presentation';
+import {
+  createCommittedScalar,
+  type CommittedScalarInput,
+  type CommittedScalarPolicy,
+} from '../committed-scalar.svelte';
+
+const feedback = (
+  phase: ControlFeedbackPresentationInput<number>['phase'] = 'idle',
+  over: Partial<ControlFeedbackPresentationInput<number>> = {},
+): Readonly<ControlFeedbackPresentationInput<number>> => ({
+  confirmed: 64, target: null, requestedTarget: null, phase,
+  transitionId: null, outcome: null, ...over,
+});
+
+const rejectPolicy: Readonly<CommittedScalarPolicy> = {
+  accepts: (value) => Number.isSafeInteger(value) && value >= 0 && value <= 255,
+  normalize: (value) => Math.min(255, Math.max(0, Math.round(value))),
+  draftPolicy: 'reject-invalid',
+  describeTarget: String,
+};
+const normalizePolicy: Readonly<CommittedScalarPolicy> = {
+  ...rejectPolicy,
+  draftPolicy: 'normalize',
+};
+
+function setup(
+  policy = rejectPolicy,
+  initial: Readonly<ControlFeedbackPresentationInput<number>> = feedback(),
+) {
+  let current: CommittedScalarInput = { feedback: initial, editable: true, contextKey: 'receiver:0' };
+  const request = vi.fn();
+  const scalar = createCommittedScalar(() => current, policy, request);
+  return { scalar, request, update: (over: Partial<CommittedScalarInput>) => {
+    current = { ...current, ...over };
+  } };
+}
+
+describe('createCommittedScalar', () => {
+  it('owns no timer or upper-layer import', () => {
+    const source = readFileSync('src/primitives/scalar/committed-scalar.svelte.ts', 'utf8');
+    expect(source).not.toMatch(/setTimeout|setInterval|semantic\/|components-v2\/|runtime\//);
+  });
+
+  it('keeps input local and dispatches one normalized commit', () => {
+    const { scalar, request } = setup(normalizePolicy);
+    scalar.input(111.4);
+    expect(request).not.toHaveBeenCalled();
+    expect(scalar.view).toMatchObject({ confirmed: 64, draft: 111, displayed: 111, editing: true });
+    expect(scalar.commit(111.4)).toBeNull();
+    expect(request).toHaveBeenCalledExactlyOnceWith(111);
+    expect(scalar.view).toMatchObject({ confirmed: 64, draft: null, displayed: 64, editing: false });
+  });
+
+  it('preserves the full requested-versus-confirmed feedback envelope', () => {
+    const pending = feedback('awaiting-confirmation', {
+      target: 111, requestedTarget: 111, transitionId: 'pending-1',
+    });
+    const { scalar, request } = setup(rejectPolicy, pending);
+    expect(scalar.view).toMatchObject({
+      feedback: pending, confirmed: 64, draft: null, displayed: 111, editable: true,
+      presentation: { attributes: { 'aria-busy': 'true' } },
+    });
+    scalar.input(112);
+    scalar.commit(112);
+    expect(request).toHaveBeenCalledExactlyOnceWith(112);
+  });
+
+  it.each(['failed', 'cancelled', 'timed-out'] as const)(
+    'keeps %s outcome and error inspectable', (phase) => {
+      const terminal = feedback(phase, {
+        requestedTarget: 111, transitionId: `${phase}-1`, outcome: { phase, error: 'radio rejected' },
+      });
+      const { scalar } = setup(rejectPolicy, terminal);
+      expect(scalar.view.feedback).toBe(terminal);
+      expect(scalar.view.feedback.outcome).toEqual({ phase, error: 'radio rejected' });
+      expect(scalar.view.announcement).toContain('111');
+    },
+  );
+
+  it('keeps unavailable truth unknown instead of inventing zero', () => {
+    const unknown = feedback('unavailable', { confirmed: null });
+    const { scalar, request } = setup(rejectPolicy, unknown);
+    expect(scalar.view).toMatchObject({ confirmed: null, draft: null, displayed: null, editable: false });
+    expect(scalar.commit(0)).toBeNull();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid drafts under the reject policy', () => {
+    const { scalar } = setup();
+    scalar.input(64.5); scalar.input(-1);
+    expect(scalar.view.draft).toBeNull();
+  });
+
+  it('cancels without dispatch and suppresses the trailing native change', () => {
+    const { scalar, request } = setup();
+    scalar.input(111);
+    expect(scalar.cancel()).toBe(64);
+    expect(scalar.commit(111)).toBe(64);
+    expect(request).not.toHaveBeenCalled();
+    scalar.input(99);
+    scalar.commit(99);
+    expect(request).toHaveBeenCalledExactlyOnceWith(99);
+  });
+
+  it.each([
+    ['context', { contextKey: 'receiver:1' }],
+    ['authority', { feedback: feedback('failed', {
+      confirmed: 72, requestedTarget: 111, transitionId: 'failed-1', outcome: { phase: 'failed' },
+    }) }],
+    ['editability', { editable: false }],
+  ] as const)('invalidates a draft on %s change and rejects its stale release', (_name, change) => {
+    const { scalar, request, update } = setup();
+    scalar.input(111);
+    update(change);
+    expect(scalar.view.draft).toBeNull();
+    expect(scalar.commit(111)).not.toBeNull();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('preserves a draft across an equivalent feedback clone', () => {
+    const current = feedback('awaiting-confirmation', {
+      target: 80, requestedTarget: 80, transitionId: 'pending-1',
+    });
+    const { scalar, request, update } = setup(rejectPolicy, current);
+    scalar.input(111);
+    update({ feedback: { ...current } });
+    expect(scalar.view.draft).toBe(111);
+    scalar.commit(111);
+    expect(request).toHaveBeenCalledExactlyOnceWith(111);
+  });
+
+  it('supports no-input changes and repeated accepted requests while busy', () => {
+    const { scalar, request } = setup(rejectPolicy, feedback('submitted', {
+      target: 80, requestedTarget: 80, transitionId: 'submitted-1',
+    }));
+    scalar.commit(90);
+    scalar.input(91);
+    scalar.commit(91);
+    expect(request.mock.calls).toEqual([[90], [91]]);
+  });
+
+  it('keeps draft and announcement memory per instance', () => {
+    const current = feedback('failed', {
+      requestedTarget: 111, transitionId: 'shared-transition', outcome: { phase: 'failed' },
+    });
+    const first = setup(rejectPolicy, current).scalar;
+    const second = setup(rejectPolicy, current).scalar;
+    first.input(90);
+    expect(first.view.draft).toBe(90);
+    expect(second.view.draft).toBeNull();
+    expect(first.view.announcement).not.toBeNull();
+    expect(second.view.announcement).not.toBeNull();
+  });
+});

--- a/frontend/src/primitives/scalar/committed-scalar.svelte.ts
+++ b/frontend/src/primitives/scalar/committed-scalar.svelte.ts
@@ -1,0 +1,190 @@
+import {
+  projectControlFeedbackPresentation,
+  type ControlFeedbackPresentation,
+  type ControlFeedbackPresentationInput,
+  type ControlFeedbackPresentationState,
+  type PresentationOutcome,
+} from '../control-feedback/control-feedback-presentation';
+export type ScalarFeedback = Readonly<ControlFeedbackPresentationInput<number>>;
+export interface CommittedScalarInput {
+  readonly feedback: ScalarFeedback;
+  readonly editable: boolean;
+  readonly contextKey: string;
+}
+export interface CommittedScalarPolicy {
+  accepts(value: number): boolean;
+  normalize(value: number): number | null;
+  readonly draftPolicy: 'reject-invalid' | 'normalize';
+  describeTarget(value: number): string;
+}
+export interface CommittedScalarView {
+  readonly feedback: ScalarFeedback;
+  readonly confirmed: number | null;
+  readonly draft: number | null;
+  readonly displayed: number | null;
+  readonly editable: boolean;
+  readonly editing: boolean;
+  readonly presentation: Readonly<ControlFeedbackPresentation>;
+  readonly announcement: string | null;
+}
+export interface CommittedScalar {
+  readonly view: Readonly<CommittedScalarView>;
+  input(value: number): void;
+  commit(value: number): number | null;
+  cancel(): number | null;
+}
+
+type DraftIdentity = {
+  contextKey: string;
+  editable: boolean;
+  confirmed: number | null;
+  target: number | null;
+  requestedTarget: number | null;
+  phase: ScalarFeedback['phase'];
+  transitionId: string | null;
+  outcomePhase: PresentationOutcome | null;
+  outcomeError: string | undefined;
+};
+function identityOf(input: Readonly<CommittedScalarInput>): DraftIdentity {
+  return Object.freeze({
+    contextKey: input.contextKey,
+    editable: input.editable,
+    confirmed: input.feedback.confirmed,
+    target: input.feedback.target,
+    requestedTarget: input.feedback.requestedTarget,
+    phase: input.feedback.phase,
+    transitionId: input.feedback.transitionId,
+    outcomePhase: input.feedback.outcome?.phase ?? null,
+    outcomeError: input.feedback.outcome?.error,
+  });
+}
+
+function sameIdentity(left: DraftIdentity, right: DraftIdentity): boolean {
+  return left.contextKey === right.contextKey
+    && left.editable === right.editable
+    && Object.is(left.confirmed, right.confirmed)
+    && Object.is(left.target, right.target)
+    && Object.is(left.requestedTarget, right.requestedTarget)
+    && left.phase === right.phase
+    && left.transitionId === right.transitionId
+    && left.outcomePhase === right.outcomePhase
+    && left.outcomeError === right.outcomeError;
+}
+
+export function createCommittedScalar(
+  read: () => Readonly<CommittedScalarInput>,
+  policy: Readonly<CommittedScalarPolicy>,
+  request: (value: number) => void,
+): CommittedScalar {
+  let draft = $state<number | null>(null);
+  let draftIdentity: DraftIdentity | null = null;
+  let suppressCommit = false;
+  let presentationState: Readonly<ControlFeedbackPresentationState> = { announcedTransitionIds: [] };
+  let announcement: string | null = null;
+
+  function isEditable(input: Readonly<CommittedScalarInput>): boolean {
+    return input.editable && input.feedback.phase !== 'unavailable';
+  }
+
+  function authoritativeDisplayed(
+    input: Readonly<CommittedScalarInput>,
+    presentation: Readonly<ControlFeedbackPresentation>,
+  ): number | null {
+    if (input.feedback.phase === 'unavailable') return null;
+    if (presentation.attributes['aria-busy'] === 'true') {
+      return input.feedback.target ?? input.feedback.requestedTarget ?? input.feedback.confirmed;
+    }
+    return input.feedback.confirmed;
+  }
+
+  function reconcile(input: Readonly<CommittedScalarInput>): void {
+    if (draft === null || draftIdentity === null) return;
+    if (sameIdentity(draftIdentity, identityOf(input))) return;
+    draftIdentity = null;
+    suppressCommit = true;
+  }
+
+  function activeDraft(input: Readonly<CommittedScalarInput>): number | null {
+    if (draft === null || draftIdentity === null) return null;
+    return sameIdentity(draftIdentity, identityOf(input)) ? draft : null;
+  }
+
+  function project(input: Readonly<CommittedScalarInput>): Readonly<ControlFeedbackPresentation> {
+    const presentation = projectControlFeedbackPresentation(
+      input.feedback,
+      presentationState,
+      policy.describeTarget,
+    );
+    presentationState = presentation.state;
+    if (presentation.politeAnnouncement !== null) {
+      announcement = presentation.politeAnnouncement.message;
+    }
+    return presentation;
+  }
+
+  function normalize(value: number): number | null {
+    const normalized = policy.normalize(value);
+    return normalized !== null && Number.isFinite(normalized) && policy.accepts(normalized)
+      ? normalized : null;
+  }
+
+  function viewOf(input: Readonly<CommittedScalarInput>): Readonly<CommittedScalarView> {
+    reconcile(input);
+    const presentation = project(input);
+    const confirmed = input.feedback.phase === 'unavailable' ? null : input.feedback.confirmed;
+    const currentDraft = activeDraft(input);
+    return Object.freeze({
+      feedback: input.feedback,
+      confirmed,
+      draft: currentDraft,
+      displayed: currentDraft ?? authoritativeDisplayed(input, presentation),
+      editable: isEditable(input),
+      editing: currentDraft !== null,
+      presentation,
+      announcement,
+    });
+  }
+  function restore(input: Readonly<CommittedScalarInput>): number | null {
+    return authoritativeDisplayed(input,
+      projectControlFeedbackPresentation(input.feedback, presentationState, policy.describeTarget));
+  }
+
+  return {
+    get view() { return viewOf(read()); },
+    input(value: number): void {
+      const current = read();
+      reconcile(current);
+      suppressCommit = false;
+      if (!isEditable(current)) return;
+      const candidate = policy.draftPolicy === 'normalize'
+        ? normalize(value)
+        : Number.isFinite(value) && policy.accepts(value) ? value : null;
+      if (candidate === null) return;
+      draft = candidate;
+      draftIdentity = identityOf(current);
+    },
+    commit(value: number): number | null {
+      const current = read();
+      reconcile(current);
+      if (suppressCommit) {
+        suppressCommit = false;
+        return restore(current);
+      }
+      if (!isEditable(current)) return restore(current);
+      const candidate = normalize(activeDraft(current) ?? value);
+      draft = null;
+      draftIdentity = null;
+      if (candidate === null) return restore(current);
+      request(candidate);
+      return null;
+    },
+    cancel(): number | null {
+      const current = read();
+      reconcile(current);
+      draft = null;
+      draftIdentity = null;
+      suppressCommit = true;
+      return restore(current);
+    },
+  };
+}

--- a/frontend/src/semantic/CwKeyerSurface.svelte
+++ b/frontend/src/semantic/CwKeyerSurface.svelte
@@ -131,6 +131,11 @@
   import { clamp, snapToStep } from '../components-v2/controls/value-control/value-control-core';
   import type { RadioViewModel } from './radio-view-model';
 
+  type BreakInDelayFeedback = ControlFeedbackPresentationInput<number> & {
+    readonly sessionEpoch?: number;
+    readonly scope?: Readonly<{ control: string; receiver: number; slot?: string }>;
+  };
+
   interface Props {
     view: RadioViewModel;
     onBreakInMode?: (mode: number) => void;
@@ -138,7 +143,7 @@
     onApfOn?: (on: boolean) => void;
     onTwinPeakToggle?: () => void;
     onReversePaddleToggle?: () => void;
-    breakInDelayFeedback?: Readonly<ControlFeedbackPresentationInput<number>>;
+    breakInDelayFeedback?: Readonly<BreakInDelayFeedback>;
     autoTuneAvailable?: boolean;
     onAutoTune?: () => void;
   }
@@ -203,8 +208,8 @@
     return target === null && requestedTarget !== null && outcome?.phase === phase
       && typeof transitionId === 'string' && transitionId.length > 0;
   }
-  let effectiveBreakInDelayFeedback = $derived.by<Readonly<ControlFeedbackPresentationInput<number>>>(() => {
-    let candidate: Readonly<ControlFeedbackPresentationInput<number>>;
+  let effectiveBreakInDelayFeedback = $derived.by<Readonly<BreakInDelayFeedback>>(() => {
+    let candidate: Readonly<BreakInDelayFeedback>;
     if (breakInDelayFeedback !== undefined) candidate = breakInDelayFeedback;
     else {
       const field = cw?.breakInDelay;
@@ -219,6 +224,13 @@
     catch { return unavailableFeedback; }
   });
   let hasBreakInDelayFeedback = $derived(breakInDelayFeedback !== undefined);
+  let breakInDelayContextKey = $derived(JSON.stringify([
+    'cw-keyer.break-in-delay',
+    breakInDelayFeedback?.sessionEpoch ?? null,
+    breakInDelayFeedback?.scope?.control ?? null,
+    breakInDelayFeedback?.scope?.receiver ?? null,
+    breakInDelayFeedback?.scope?.slot ?? null,
+  ]));
   const INTEGRATED_RANGE_POLICY = { 'feedback-policy': 'feedback-integrated' } as const;
   const RADIO_BACKED_RANGE_POLICY = { 'feedback-policy': 'radio-backed' } as const;
   let breakInDelayEditable = $derived(
@@ -229,7 +241,7 @@
     () => ({
       feedback: effectiveBreakInDelayFeedback,
       editable: breakInDelayEditable,
-      contextKey: 'cw-keyer.break-in-delay',
+      contextKey: breakInDelayContextKey,
     }),
     {
       accepts: validLevel,

--- a/frontend/src/semantic/CwKeyerSurface.svelte
+++ b/frontend/src/semantic/CwKeyerSurface.svelte
@@ -124,12 +124,11 @@
 
 <script lang="ts">
   import {
-    projectControlFeedbackPresentation,
-    type ControlFeedbackPresentation,
     type ControlFeedbackPresentationInput,
-    type ControlFeedbackPresentationState,
     type PresentationPhase,
   } from '../primitives/control-feedback/control-feedback-presentation';
+  import { createCommittedScalar } from '../primitives/scalar/committed-scalar.svelte';
+  import { clamp, snapToStep } from '../components-v2/controls/value-control/value-control-core';
   import type { RadioViewModel } from './radio-view-model';
 
   interface Props {
@@ -220,111 +219,65 @@
     catch { return unavailableFeedback; }
   });
   let hasBreakInDelayFeedback = $derived(breakInDelayFeedback !== undefined);
-  let breakInDelayPresentationMemory: Readonly<{
-    state: ControlFeedbackPresentationState; announcement: string | null;
-  }> = { state: { announcedTransitionIds: [] }, announcement: null };
-  let breakInDelayPresentation = $derived.by<Readonly<ControlFeedbackPresentation> & {
-    readonly announcement: string | null;
-  }>(() => {
-    const next = projectControlFeedbackPresentation(
-      effectiveBreakInDelayFeedback,
-      breakInDelayPresentationMemory.state,
-      (target) => String(target),
-    );
-    const announcement = next.politeAnnouncement?.message
-      ?? breakInDelayPresentationMemory.announcement;
-    breakInDelayPresentationMemory = { state: next.state, announcement };
-    return Object.freeze({ ...next, announcement });
-  });
-
   const INTEGRATED_RANGE_POLICY = { 'feedback-policy': 'feedback-integrated' } as const;
   const RADIO_BACKED_RANGE_POLICY = { 'feedback-policy': 'radio-backed' } as const;
-  let breakInDelayBusy = $derived(BUSY_BREAK_IN_DELAY_PHASES.has(effectiveBreakInDelayFeedback.phase));
   let breakInDelayEditable = $derived(
     cw !== undefined && usable(cw.breakInDelay)
       && effectiveBreakInDelayFeedback.phase !== 'unavailable',
   );
-  let breakInDelayAuthority = $derived(JSON.stringify([
-    effectiveBreakInDelayFeedback.transitionId, effectiveBreakInDelayFeedback.phase,
-    effectiveBreakInDelayFeedback.confirmed, effectiveBreakInDelayFeedback.target,
-    effectiveBreakInDelayFeedback.requestedTarget, effectiveBreakInDelayFeedback.outcome?.phase ?? null,
-  ]));
-  let breakInDelayDraft: number | null = $state(null);
-  let breakInDelayDraftAuthority: string | null = $state(null);
-  let activeBreakInDelayDraft = $derived(
-    breakInDelayDraftAuthority === breakInDelayAuthority ? breakInDelayDraft : null,
+  const breakInDelayScalar = createCommittedScalar(
+    () => ({
+      feedback: effectiveBreakInDelayFeedback,
+      editable: breakInDelayEditable,
+      contextKey: 'cw-keyer.break-in-delay',
+    }),
+    {
+      accepts: validLevel,
+      normalize: (value) => snapToStep(clamp(
+        value, breakInDelayDomain[2], breakInDelayDomain[3],
+      ), breakInDelayDomain[4], breakInDelayDomain[2]),
+      draftPolicy: 'reject-invalid',
+      describeTarget: String,
+    },
+    (value) => setLevel('breakInDelay', value),
   );
-  let breakInDelayDisplayed = $derived(
-    activeBreakInDelayDraft
-      ?? (breakInDelayBusy
-        ? (effectiveBreakInDelayFeedback.target
-          ?? effectiveBreakInDelayFeedback.requestedTarget
-          ?? effectiveBreakInDelayFeedback.confirmed)
-        : effectiveBreakInDelayFeedback.confirmed),
+  let breakInDelayView = $derived(breakInDelayScalar.view);
+  let breakInDelayBusy = $derived(
+    breakInDelayView.presentation.attributes['aria-busy'] === 'true',
   );
   let breakInDelayPhaseLabel = $derived(
-    activeBreakInDelayDraft !== null
+    breakInDelayView.editing
       ? 'draft'
-      : effectiveBreakInDelayFeedback.phase.replaceAll('-', ' '),
+      : breakInDelayView.feedback.phase.replaceAll('-', ' '),
   );
   let breakInDelayValueText = $derived.by(() => {
-    const confirmed = effectiveBreakInDelayFeedback.confirmed;
-    if (effectiveBreakInDelayFeedback.phase === 'unavailable' || confirmed === null) {
+    const confirmed = breakInDelayView.confirmed;
+    if (confirmed === null) {
       return 'Break-in delay unavailable';
     }
-    if (activeBreakInDelayDraft !== null) {
-      return `Draft ${activeBreakInDelayDraft}; last confirmed ${confirmed}`;
+    if (breakInDelayView.draft !== null) {
+      return `Draft ${breakInDelayView.draft}; last confirmed ${confirmed}`;
     }
     if (breakInDelayBusy) {
-      return `Requested ${breakInDelayDisplayed}; last confirmed ${confirmed}`;
+      return `Requested ${breakInDelayView.displayed}; last confirmed ${confirmed}`;
     }
-    const requested = effectiveBreakInDelayFeedback.requestedTarget;
-    if (effectiveBreakInDelayFeedback.outcome !== null && requested !== null
-      && effectiveBreakInDelayFeedback.outcome.phase !== 'confirmed') {
-      return `Confirmed ${confirmed}; request ${requested} ${effectiveBreakInDelayFeedback.outcome.phase}`;
+    const requested = breakInDelayView.feedback.requestedTarget;
+    if (breakInDelayView.feedback.outcome !== null && requested !== null
+      && breakInDelayView.feedback.outcome.phase !== 'confirmed') {
+      return `Confirmed ${confirmed}; request ${requested} ${breakInDelayView.feedback.outcome.phase}`;
     }
     return `Confirmed ${confirmed}`;
   });
-  let breakInDelayCancelled = false;
-  function restoreBreakInDelay(target: HTMLInputElement): void {
-    target.value = String(effectiveBreakInDelayFeedback.confirmed ?? Number(target.min));
-  }
   function noteBreakInDelayInput(target: HTMLInputElement): void {
-    breakInDelayCancelled = false;
-    const candidate = target.valueAsNumber;
-    if (breakInDelayEditable && validLevel(candidate)) {
-      breakInDelayDraft = candidate;
-      breakInDelayDraftAuthority = breakInDelayAuthority;
-    }
+    breakInDelayScalar.input(target.valueAsNumber);
   }
   function commitBreakInDelay(target: HTMLInputElement): void {
-    if (breakInDelayCancelled) {
-      breakInDelayCancelled = false;
-      restoreBreakInDelay(target);
-      return;
-    }
-    if (breakInDelayDraft !== null && breakInDelayDraftAuthority !== breakInDelayAuthority) {
-      breakInDelayDraft = null;
-      breakInDelayDraftAuthority = null;
-      restoreBreakInDelay(target);
-      return;
-    }
-    const candidate = activeBreakInDelayDraft ?? target.valueAsNumber;
-    const min = Number(target.min);
-    const max = Number(target.max);
-    if (Number.isFinite(candidate) && Number.isFinite(min) && Number.isFinite(max)) {
-      if (breakInDelayEditable) {
-        setLevel('breakInDelay', Math.min(max, Math.max(min, Math.round(candidate))));
-      }
-    }
-    breakInDelayDraft = null;
-    breakInDelayDraftAuthority = null;
+    const restored = breakInDelayScalar.commit(target.valueAsNumber);
+    if (restored !== null) target.value = String(restored);
   }
   function cancelBreakInDelay(target: HTMLInputElement): void {
-    breakInDelayCancelled = true;
-    breakInDelayDraft = null;
-    breakInDelayDraftAuthority = null;
-    restoreBreakInDelay(target);
+    const restored = breakInDelayScalar.cancel();
+    if (restored !== null) target.value = String(restored);
   }
   function keyBreakInDelay(event: KeyboardEvent & { currentTarget: HTMLInputElement }): void {
     if (event.key !== 'Escape') return;
@@ -388,14 +341,14 @@
           {#if field === 'breakInDelay'}
             <input
               {...INTEGRATED_RANGE_POLICY} type="range" {min} {max} {step}
-              value={breakInDelayDisplayed ?? (hasBreakInDelayFeedback ? undefined : min)}
-              disabled={hasBreakInDelayFeedback ? !breakInDelayEditable : !usable(f)}
+              value={breakInDelayView.displayed ?? (hasBreakInDelayFeedback ? undefined : min)}
+              disabled={hasBreakInDelayFeedback ? !breakInDelayView.editable : !usable(f)}
               data-command-phase={hasBreakInDelayFeedback
-                ? breakInDelayPresentation.attributes['data-command-phase'] : undefined}
+                ? breakInDelayView.presentation.attributes['data-command-phase'] : undefined}
               aria-busy={hasBreakInDelayFeedback
-                ? breakInDelayPresentation.attributes['aria-busy'] : undefined}
-              aria-valuenow={hasBreakInDelayFeedback && breakInDelayDisplayed !== null
-                ? breakInDelayDisplayed : undefined}
+                ? breakInDelayView.presentation.attributes['aria-busy'] : undefined}
+              aria-valuenow={hasBreakInDelayFeedback && breakInDelayView.displayed !== null
+                ? breakInDelayView.displayed : undefined}
               aria-valuetext={hasBreakInDelayFeedback ? breakInDelayValueText : undefined}
               oninput={(event) => noteBreakInDelayInput(event.currentTarget)}
               onchange={(event) => commitBreakInDelay(event.currentTarget)}
@@ -405,16 +358,15 @@
             {#if hasBreakInDelayFeedback}
             <output
               data-testid="cw-keyer-breakInDelay-value"
-              data-command-phase={effectiveBreakInDelayFeedback.phase}
-            >{effectiveBreakInDelayFeedback.phase === 'unavailable'
-              || breakInDelayDisplayed === null ? UNKNOWN_TEXT : breakInDelayDisplayed}
+              data-command-phase={breakInDelayView.feedback.phase}
+            >{breakInDelayView.displayed === null ? UNKNOWN_TEXT : breakInDelayView.displayed}
               <span class:command-pending={breakInDelayBusy}>{breakInDelayPhaseLabel}</span>
             </output>
-            {#if breakInDelayPresentation.announcement !== null}
+            {#if breakInDelayView.announcement !== null}
               <span
                 class="sr-only" role="status" aria-live="polite" aria-atomic="true"
                 data-control-feedback-status
-              >{breakInDelayPresentation.announcement}</span>
+              >{breakInDelayView.announcement}</span>
             {/if}
             {:else}
               <output data-testid="cw-keyer-breakInDelay-value">{textOf(f)} {unit}</output>

--- a/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
@@ -43,6 +43,11 @@ import type {
   ControlFeedbackPresentationInput, PresentationPhase,
 } from '../../primitives/control-feedback/control-feedback-presentation';
 
+type BreakInDelayFeedback = ControlFeedbackPresentationInput<number> & {
+  readonly sessionEpoch?: number;
+  readonly scope?: Readonly<{ control: string; receiver: number; slot?: string }>;
+};
+
 const SOURCE = readFileSync('src/semantic/CwKeyerSurface.svelte', 'utf8');
 /** Comments stripped, so the file's own doctrine prose can never be what a
  *  source-scanning test matches. */
@@ -78,7 +83,7 @@ type Handlers = {
   onApfOn?: (on: boolean) => void;
   onTwinPeakToggle?: () => void;
   onReversePaddleToggle?: () => void;
-  breakInDelayFeedback?: Readonly<ControlFeedbackPresentationInput<number>>;
+  breakInDelayFeedback?: Readonly<BreakInDelayFeedback>;
   onAutoTune?: () => void;
 };
 
@@ -97,7 +102,7 @@ function render(view: RadioViewModel, handlers: Handlers = {}) {
   };
 }
 
-function renderReactiveFeedback(initial: ControlFeedbackPresentationInput<number>) {
+function renderReactiveFeedback(initial: BreakInDelayFeedback) {
   const onLevelChange = vi.fn();
   const props = proxy({ view: base(), onLevelChange, breakInDelayFeedback: initial });
   const component = mount(CwKeyerSurface, { target, props });
@@ -121,8 +126,8 @@ const slide = (el: HTMLInputElement, value: number) => {
 };
 const feedback = (
   phase: PresentationPhase,
-  over: Partial<ControlFeedbackPresentationInput<number>> = {},
-): Readonly<ControlFeedbackPresentationInput<number>> => ({
+  over: Partial<BreakInDelayFeedback> = {},
+): Readonly<BreakInDelayFeedback> => ({
   confirmed: 64, target: null, requestedTarget: null, phase,
   transitionId: null, outcome: null, ...over,
 });
@@ -418,6 +423,21 @@ describe('Break-in Delay separates draft, submitted target and confirmed truth',
     expect(r.input().value).toBe('111');
     r.input().dispatchEvent(new Event('change', { bubbles: true }));
     expect(r.onLevelChange).toHaveBeenCalledExactlyOnceWith('breakInDelay', 111);
+    r.dispose();
+  });
+
+  it('invalidates a stale draft when an equal projection moves to a new session context', () => {
+    const context = { control: 'break-in-delay', receiver: 0 } as const;
+    const r = renderReactiveFeedback(feedback('idle', { sessionEpoch: 1, scope: context }));
+    r.input().value = '111';
+    r.input().dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(r.input().value).toBe('111');
+    r.props.breakInDelayFeedback = feedback('idle', { sessionEpoch: 2, scope: { ...context } });
+    flushSync();
+    const restored = r.input().value;
+    r.input().dispatchEvent(new Event('change', { bubbles: true }));
+    expect([restored, r.onLevelChange.mock.calls]).toEqual(['64', []]);
     r.dispose();
   });
 

--- a/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
@@ -141,7 +141,7 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
    *  This check regexes THIS file's specifiers only, so that premise is
    *  pinned one level down by `pressed-of.test.ts`'s `'has no runtime
    *  import'` case (verify-MOR-1358 F1) — the two together are the closure. */
-  it('imports nothing but the fact contract and the shared pressedOf helper', () => {
+  it('imports only the allow-listed fact, presentation and numeric dependencies', () => {
     const specifiers = [...CODE.matchAll(/from\s+'([^']+)'/g)].map((m) => m[1]);
     expect(specifiers.length).toBeGreaterThan(0);
     // MOR-1474: `$lib/i18n` added for the operator-legible `t()` catalog
@@ -152,6 +152,8 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
     expect([...new Set(specifiers)]).toEqual([
       '$lib/i18n', './radio-view-model', './pressed-of',
       '../primitives/control-feedback/control-feedback-presentation',
+      '../primitives/scalar/committed-scalar.svelte',
+      '../components-v2/controls/value-control/value-control-core',
     ]);
   });
 
@@ -417,6 +419,32 @@ describe('Break-in Delay separates draft, submitted target and confirmed truth',
     r.input().dispatchEvent(new Event('change', { bubbles: true }));
     expect(r.onLevelChange).toHaveBeenCalledExactlyOnceWith('breakInDelay', 111);
     r.dispose();
+  });
+
+  it('keeps draft and announcement state independent across mounted instances', () => {
+    const secondTarget = document.createElement('div'); document.body.appendChild(secondTarget);
+    const current = feedback('failed', {
+      requestedTarget: 111, transitionId: 'shared-transition', outcome: { phase: 'failed' },
+    });
+    const first = mount(CwKeyerSurface, {
+      target, props: { view: base(), breakInDelayFeedback: current },
+    });
+    const second = mount(CwKeyerSurface, {
+      target: secondTarget, props: { view: base(), breakInDelayFeedback: { ...current } },
+    });
+    flushSync();
+    const firstInput = target.querySelector<HTMLInputElement>(
+      '[data-testid="cw-keyer-breakInDelay"] input',
+    )!;
+    firstInput.value = '90'; firstInput.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    const secondInput = secondTarget.querySelector<HTMLInputElement>(
+      '[data-testid="cw-keyer-breakInDelay"] input',
+    )!;
+    expect([firstInput.value, secondInput.value]).toEqual(['90', '64']);
+    expect(target.querySelector('[data-control-feedback-status]')?.textContent).toContain('111');
+    expect(secondTarget.querySelector('[data-control-feedback-status]')?.textContent).toContain('111');
+    unmount(first); unmount(second); secondTarget.remove();
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- add an appearance-independent committed scalar binding with the full validated feedback envelope, explicit numeric/draft policy, structural edit identity, and per-instance transition memory
- adopt the binding in both production break-in-delay compositions while retaining each component's existing markup, copy, validation boundary, numeric policy, and command callback
- preserve local draft versus requested versus confirmed presentation, unknown state, cancellation, stale native-change suppression, equal reprojection, and repeated requests while busy
- include the live feedback session epoch and complete scope in both consumers' draft identity, so the old draft is discarded, the confirmed value is restored, and the trailing native change is suppressed after a context transition
- retain compatible behavior for omitted legacy context: one stable fallback identity, with no invented session source

## Scope

Implements the accepted first slice of [MOR-2379](https://linear.app/morozsm/issue/MOR-2379), child of [MOR-2215](https://linear.app/morozsm/issue/MOR-2215). This does not complete the remaining scalar variants or MOR-2215.

This is one behavior unit across 6 files and 739 changed lines (551 additions, 188 deletions). It exceeds the 600-line soft threshold because the shared behavior, both real consumers, the review correction, and discriminating tests must land together to prove that neither visual retains separate draft, cancellation, announcement, or session-context authority.

## Verification

- `npx vitest run src/primitives/scalar/__tests__/committed-scalar.test.ts src/__tests__/control-feedback-presentation.test.ts src/semantic/__tests__/CwKeyerSurface.test.ts src/components-v2/panels/__tests__/CwPanel.component.test.ts src/components-v2/panels/__tests__/CwPanel.feedback-wiring.svelte.test.ts` — 5 files passed, 172 tests passed
- `npm run check` — 0 errors and 0 warnings
- `npx eslint src/primitives/scalar/committed-scalar.svelte.ts src/primitives/scalar/__tests__/committed-scalar.test.ts src/semantic/CwKeyerSurface.svelte src/semantic/__tests__/CwKeyerSurface.test.ts src/components-v2/panels/CwPanel.svelte src/components-v2/panels/__tests__/CwPanel.feedback-wiring.svelte.test.ts` — passed
- `git diff --check` — passed
- review mutation: restoring the constant semantic context key made the new epoch regression fail with `111` and one stale `breakInDelay: 111` dispatch instead of `64` and no dispatch
- input mutation: temporarily dispatching from `input()` was killed by 8 of 15 primitive tests
- both mutations were removed before the final focused run

## Baseline

The coordinator supplied frontend baseline `quick.yml` run `34000478807` on `34fb`, valid at base `669923b7e9839a7fbd458bd13147cdefb13292e4`; `main` run `34002301446` succeeded. No full local suite was run.