### PR TITLE
feat: add control instrument behaviors (MOR-2380)

### DIFF
--- a/frontend/src/primitives/control-instruments/__tests__/ControlInstrumentRenderHarness.svelte
+++ b/frontend/src/primitives/control-instruments/__tests__/ControlInstrumentRenderHarness.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import {
+    bindChoiceInstrument, bindToggleInstrument, type InstrumentField,
+  } from '../control-instrument-behavior';
+
+  interface Props {
+    toggle: InstrumentField<boolean>;
+    choice: InstrumentField<string>;
+    choices: readonly string[];
+    onToggle: (next: boolean) => void;
+    onChoice: (value: string) => void;
+  }
+
+  let { toggle, choice, choices, onToggle, onChoice }: Props = $props();
+  const toggleBehavior = bindToggleInstrument(() => ({ field: toggle, invoke: onToggle }));
+  const choiceBehavior = bindChoiceInstrument(() => ({ field: choice, choices, invoke: onChoice }));
+</script>
+
+<button
+  type="button" role="checkbox" data-testid="alternate-toggle"
+  aria-checked={toggleBehavior.confirmed}
+  disabled={!toggleBehavior.available}
+  onclick={() => toggleBehavior.invoke()}
+>Toggle</button>
+
+<div role="grid" aria-label="Alternative choices">
+  {#each choices as choice (choice)}
+    <button
+      type="button" role="radio" data-testid={`alternate-choice-${choice}`}
+      aria-checked={choiceBehavior.isSelected(choice)}
+      disabled={!choiceBehavior.available}
+      onclick={() => choiceBehavior.invoke(choice)}
+    >{choice}</button>
+  {/each}
+</div>

--- a/frontend/src/primitives/control-instruments/__tests__/ControlInstrumentRenderHarness.svelte
+++ b/frontend/src/primitives/control-instruments/__tests__/ControlInstrumentRenderHarness.svelte
@@ -18,12 +18,15 @@
 
 <button
   type="button" role="checkbox" data-testid="alternate-toggle"
-  aria-checked={toggleBehavior.confirmed}
+  aria-checked={toggleBehavior.confirmed ?? 'mixed'}
   disabled={!toggleBehavior.available}
   onclick={() => toggleBehavior.invoke()}
 >Toggle</button>
 
-<div role="grid" aria-label="Alternative choices">
+<div
+  class="alternate-choice-grid" role="radiogroup" aria-label="Alternative choices"
+  data-testid="alternate-choices" style:display="grid"
+>
   {#each choices as choice (choice)}
     <button
       type="button" role="radio" data-testid={`alternate-choice-${choice}`}
@@ -33,3 +36,7 @@
     >{choice}</button>
   {/each}
 </div>
+
+<style>
+  .alternate-choice-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.5rem; }
+</style>

--- a/frontend/src/primitives/control-instruments/__tests__/control-instrument-behavior.test.ts
+++ b/frontend/src/primitives/control-instruments/__tests__/control-instrument-behavior.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  bindActionInstrument, bindChoiceInstrument, bindToggleInstrument,
+  type InstrumentField,
+} from '../control-instrument-behavior';
+
+const usable = <T>(value: T): InstrumentField<T> => ({
+  availability: { structural: true, operational: true }, reading: { status: 'known', value },
+});
+const unavailable = <T>(value: T): InstrumentField<T> => ({
+  availability: { structural: true, operational: false }, reading: { status: 'known', value },
+});
+const unknown = <T>(): InstrumentField<T> => ({
+  availability: { structural: true, operational: true }, reading: { status: 'unknown' },
+});
+
+describe('control-instrument behavior bindings', () => {
+  it('re-checks an action field and blocker at invocation time', () => {
+    let field = usable(1);
+    let blocked = false;
+    const invoke = vi.fn();
+    const behavior = bindActionInstrument(() => ({ field, blocked, invoke }));
+
+    field = unavailable(1);
+    behavior.invoke();
+    blocked = true;
+    field = usable(1);
+    behavior.invoke();
+    blocked = false;
+    behavior.invoke();
+
+    expect(invoke).toHaveBeenCalledOnce();
+  });
+
+  it('derives a toggle target from the current confirmed boolean', () => {
+    let field = usable(false);
+    const invoke = vi.fn();
+    const behavior = bindToggleInstrument(() => ({ field, invoke }));
+
+    expect(behavior.confirmed).toBe(false);
+    field = usable(true);
+    behavior.invoke();
+    expect(invoke).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  it('omits unknown toggle state and does not invoke it', () => {
+    const invoke = vi.fn();
+    const behavior = bindToggleInstrument(() => ({ field: unknown<boolean>(), invoke }));
+
+    expect(behavior.confirmed).toBeUndefined();
+    behavior.invoke();
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('keeps a supplied feedback envelope unchanged and does not invent one', () => {
+    const feedback = { phase: 'submitted', target: true } as const;
+    const present = bindToggleInstrument(() => ({ field: usable(true), invoke: vi.fn(), feedback }));
+    const absent = bindToggleInstrument(() => ({ field: usable(true), invoke: vi.fn() }));
+
+    expect(present.feedback).toBe(feedback);
+    expect(absent.feedback).toBeUndefined();
+  });
+
+  it('only selects and invokes values in the current offered finite choice set', () => {
+    let field = usable(9);
+    let choices = [1, 2] as readonly number[];
+    const invoke = vi.fn();
+    const behavior = bindChoiceInstrument(() => ({ field, choices, invoke }));
+
+    expect(behavior.selected).toBeUndefined();
+    expect(behavior.isSelected(1)).toBe(false);
+    behavior.invoke(9);
+    expect(invoke).not.toHaveBeenCalled();
+
+    field = usable(2);
+    choices = [2, 3];
+    expect(behavior.selected).toBe(2);
+    behavior.invoke(3);
+    expect(invoke).toHaveBeenCalledExactlyOnceWith(3);
+  });
+});

--- a/frontend/src/primitives/control-instruments/__tests__/control-instrument-renderers.component.test.ts
+++ b/frontend/src/primitives/control-instruments/__tests__/control-instrument-renderers.component.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import ControlInstrumentRenderHarness from './ControlInstrumentRenderHarness.svelte';
+import type { InstrumentField } from '../control-instrument-behavior';
+
+const usable = <T>(value: T): InstrumentField<T> => ({
+  availability: { structural: true, operational: true }, reading: { status: 'known', value },
+});
+const unknown = <T>(): InstrumentField<T> => ({
+  availability: { structural: true, operational: true }, reading: { status: 'unknown' },
+});
+
+let target: HTMLDivElement;
+beforeEach(() => { target = document.createElement('div'); document.body.appendChild(target); });
+afterEach(() => { target.remove(); });
+
+function render(toggle: InstrumentField<boolean>, choice: InstrumentField<string>, choices = ['A', 'B'] as const) {
+  const onToggle = vi.fn();
+  const onChoice = vi.fn();
+  const component = mount(ControlInstrumentRenderHarness, { target, props: { toggle, choice, choices, onToggle, onChoice } });
+  flushSync();
+  return {
+    checkbox: () => target.querySelector<HTMLButtonElement>('[data-testid="alternate-toggle"]')!,
+    radio: (value: string) => target.querySelector<HTMLButtonElement>(`[data-testid="alternate-choice-${value}"]`)!,
+    onToggle, onChoice, dispose: () => unmount(component),
+  };
+}
+
+describe('control-instrument renderer independence', () => {
+  it('renders confirmed state through checkbox and grid radio semantics', () => {
+    const r = render(usable(true), usable('B'));
+    expect(r.checkbox().getAttribute('aria-checked')).toBe('true');
+    expect(r.radio('A').getAttribute('aria-checked')).toBe('false');
+    expect(r.radio('B').getAttribute('aria-checked')).toBe('true');
+    r.dispose();
+  });
+
+  it('omits unknown checkbox state and leaves an out-of-list observed choice unselected', () => {
+    const r = render(unknown<boolean>(), usable('outside'));
+    expect(r.checkbox().hasAttribute('aria-checked')).toBe(false);
+    expect(r.radio('A').getAttribute('aria-checked')).toBe('false');
+    expect(r.radio('B').getAttribute('aria-checked')).toBe('false');
+    r.dispose();
+  });
+
+  it('sends toggle and explicit grid values through the same bindings', () => {
+    const r = render(usable(false), usable('A'));
+    r.checkbox().click();
+    r.radio('B').click();
+    flushSync();
+    expect(r.onToggle).toHaveBeenCalledExactlyOnceWith(true);
+    expect(r.onChoice).toHaveBeenCalledExactlyOnceWith('B');
+    r.dispose();
+  });
+});

--- a/frontend/src/primitives/control-instruments/__tests__/control-instrument-renderers.component.test.ts
+++ b/frontend/src/primitives/control-instruments/__tests__/control-instrument-renderers.component.test.ts
@@ -21,29 +21,35 @@ function render(toggle: InstrumentField<boolean>, choice: InstrumentField<string
   flushSync();
   return {
     checkbox: () => target.querySelector<HTMLButtonElement>('[data-testid="alternate-toggle"]')!,
+    choiceGroup: () => target.querySelector<HTMLElement>('[data-testid="alternate-choices"]')!,
     radio: (value: string) => target.querySelector<HTMLButtonElement>(`[data-testid="alternate-choice-${value}"]`)!,
     onToggle, onChoice, dispose: () => unmount(component),
   };
 }
 
 describe('control-instrument renderer independence', () => {
-  it('renders confirmed state through checkbox and grid radio semantics', () => {
+  it('renders confirmed state through checkbox and CSS-grid radio semantics', () => {
     const r = render(usable(true), usable('B'));
     expect(r.checkbox().getAttribute('aria-checked')).toBe('true');
+    expect(r.choiceGroup().getAttribute('role')).toBe('radiogroup');
+    expect(r.choiceGroup().getAttribute('aria-label')).toBe('Alternative choices');
+    expect(getComputedStyle(r.choiceGroup()).display).toBe('grid');
     expect(r.radio('A').getAttribute('aria-checked')).toBe('false');
     expect(r.radio('B').getAttribute('aria-checked')).toBe('true');
+    expect(r.radio('A').closest('[role="radiogroup"]')).toBe(r.choiceGroup());
+    expect(r.radio('B').closest('[role="radiogroup"]')).toBe(r.choiceGroup());
     r.dispose();
   });
 
-  it('omits unknown checkbox state and leaves an out-of-list observed choice unselected', () => {
+  it('renders unknown checkbox as mixed and leaves an out-of-list observed choice unselected', () => {
     const r = render(unknown<boolean>(), usable('outside'));
-    expect(r.checkbox().hasAttribute('aria-checked')).toBe(false);
+    expect(r.checkbox().getAttribute('aria-checked')).toBe('mixed');
     expect(r.radio('A').getAttribute('aria-checked')).toBe('false');
     expect(r.radio('B').getAttribute('aria-checked')).toBe('false');
     r.dispose();
   });
 
-  it('sends toggle and explicit grid values through the same bindings', () => {
+  it('sends toggle and explicit radio values through the same bindings', () => {
     const r = render(usable(false), usable('A'));
     r.checkbox().click();
     r.radio('B').click();

--- a/frontend/src/primitives/control-instruments/control-instrument-behavior.ts
+++ b/frontend/src/primitives/control-instruments/control-instrument-behavior.ts
@@ -1,0 +1,111 @@
+/** Stateless current-input behavior bindings for control renderers. */
+
+export interface InstrumentAvailability {
+  readonly structural: boolean;
+  readonly operational: boolean;
+}
+
+export type InstrumentReading<T> =
+  | Readonly<{ status: 'known'; value: T }>
+  | Readonly<{ status: 'unknown' }>;
+
+/** Structural subset shared by semantic field facts without owning them. */
+export interface InstrumentField<T> {
+  readonly availability: InstrumentAvailability;
+  readonly reading: InstrumentReading<T>;
+}
+
+interface BindingInput<T, Feedback> {
+  readonly field: InstrumentField<T> | undefined;
+  readonly blocked?: boolean;
+  readonly feedback?: Feedback;
+}
+
+interface ActionInput<T, Feedback> extends BindingInput<T, Feedback> {
+  readonly invoke: () => void;
+}
+
+interface ToggleInput<Feedback> extends BindingInput<boolean, Feedback> {
+  readonly invoke: (next: boolean) => void;
+}
+
+interface ChoiceInput<T, Feedback> extends BindingInput<T, Feedback> {
+  readonly choices: readonly T[];
+  readonly invoke: (value: T) => void;
+}
+
+const canInvoke = <T>(input: BindingInput<T, unknown>): input is BindingInput<T, unknown> & {
+  readonly field: InstrumentField<T> & { readonly reading: Readonly<{ status: 'known'; value: T }> };
+} => input.blocked !== true
+  && input.field !== undefined
+  && input.field.availability.structural
+  && input.field.availability.operational
+  && input.field.reading.status === 'known';
+
+export interface ActionInstrumentBehavior<Feedback> {
+  readonly available: boolean;
+  readonly feedback: Feedback | undefined;
+  invoke(): void;
+}
+
+export function bindActionInstrument<T, Feedback = never>(
+  current: () => ActionInput<T, Feedback>,
+): ActionInstrumentBehavior<Feedback> {
+  return {
+    get available() { return canInvoke(current()); },
+    get feedback() { return current().feedback; },
+    invoke() {
+      const input = current();
+      if (canInvoke(input)) input.invoke();
+    },
+  };
+}
+
+export interface ToggleInstrumentBehavior<Feedback> extends ActionInstrumentBehavior<Feedback> {
+  readonly confirmed: boolean | undefined;
+}
+
+export function bindToggleInstrument<Feedback = never>(
+  current: () => ToggleInput<Feedback>,
+): ToggleInstrumentBehavior<Feedback> {
+  return {
+    get available() { return canInvoke(current()); },
+    get confirmed() {
+      const field = current().field;
+      return field?.reading.status === 'known' ? field.reading.value : undefined;
+    },
+    get feedback() { return current().feedback; },
+    invoke() {
+      const input = current();
+      if (canInvoke(input)) input.invoke(!input.field.reading.value);
+    },
+  };
+}
+
+export interface ChoiceInstrumentBehavior<T, Feedback> {
+  readonly available: boolean;
+  readonly feedback: Feedback | undefined;
+  readonly selected: T | undefined;
+  isSelected(value: T): boolean;
+  invoke(value: T): void;
+}
+
+export function bindChoiceInstrument<T, Feedback = never>(
+  current: () => ChoiceInput<T, Feedback>,
+): ChoiceInstrumentBehavior<T, Feedback> {
+  const offered = (choices: readonly T[], value: T): boolean => choices.some(choice => Object.is(choice, value));
+  return {
+    get available() { return canInvoke(current()); },
+    get selected() {
+      const input = current();
+      return input.field?.reading.status === 'known' && offered(input.choices, input.field.reading.value)
+        ? input.field.reading.value : undefined;
+    },
+    get feedback() { return current().feedback; },
+    isSelected(value) { return this.selected !== undefined && Object.is(this.selected, value); },
+    invoke(value) {
+      const input = current();
+      if (canInvoke(input) && offered(input.choices, value)) input.invoke(value);
+    },
+  };
+}

--- a/frontend/src/semantic/FilterSurface.svelte
+++ b/frontend/src/semantic/FilterSurface.svelte
@@ -90,14 +90,11 @@
   const numberOf = (f: DisplayObservedField<number>, fallback: number): number =>
     f.display?.state === 'current' || f.display?.state === 'stale' ? f.display.value
       : f.reading.status === 'known' ? f.reading.value : fallback;
-  /** Never fabricates a selection: `usable` alone cannot narrow `reading` for
-   *  the `===` comparison below, so the known-check is repeated explicitly. */
-  const isSelected = (f: TxAuxField<unknown>, value: unknown): boolean =>
-    usable(f) && f.reading.status === 'known' && f.reading.value === value;
 </script>
 
 <script lang="ts">
   import { t } from '$lib/i18n';
+  import { bindChoiceInstrument } from '../primitives/control-instruments/control-instrument-behavior';
   import type { RadioViewModel } from './radio-view-model';
 
   interface Props {
@@ -127,23 +124,35 @@
   let modeFilter = $derived(view.modeFilter);
   let filterPassband = $derived(view.filterPassband);
 
-  function selectMode(mode: string): void {
-    if (modeFilter && usable(modeFilter.currentMode)) onModeChange?.(mode);
-  }
-  function selectFilter(filter: number): void {
-    if (modeFilter && usable(modeFilter.currentFilter)) onFilterChange?.(filter);
-  }
   function changeWidth(value: number): void {
     if (modeFilter && usable(modeFilter.filterWidth)) onFilterWidthChange?.(value);
   }
-  function selectShape(shape: number): void {
-    if (filterPassband && usable(filterPassband.filterShape)) onFilterShapeChange?.(shape);
+  function modeInstrument() {
+    return bindChoiceInstrument(() => ({
+      field: modeFilter?.currentMode, choices: modeFilter?.modeChoices ?? [],
+      invoke: (value) => onModeChange?.(value),
+    }));
   }
-  function selectDataMode(mode: number): void {
-    if (!filterPassband || !usable(filterPassband.dataMode)
-      || filterPassband.dataModeChoices.length < 2
-      || !filterPassband.dataModeChoices.some(choice => choice.value === mode)) return;
-    onDataModeChange?.(mode);
+  function filterInstrument() {
+    return bindChoiceInstrument(() => ({
+      field: modeFilter?.currentFilter,
+      choices: (modeFilter?.filterChoices ?? []).map((_choice, index) => index + 1),
+      invoke: (value) => onFilterChange?.(value),
+    }));
+  }
+  function shapeInstrument() {
+    return bindChoiceInstrument(() => ({
+      field: filterPassband?.filterShape, choices: FILTER_SHAPES.map(([value]) => value),
+      invoke: (value) => onFilterShapeChange?.(value),
+    }));
+  }
+  function dataModeInstrument() {
+    return bindChoiceInstrument(() => ({
+      field: filterPassband?.dataMode,
+      choices: filterPassband?.dataModeChoices.map(choice => choice.value) ?? [],
+      blocked: (filterPassband?.dataModeChoices.length ?? 0) < 2,
+      invoke: (value) => onDataModeChange?.(value),
+    }));
   }
   /** One guarded entry point for all three passband sliders — each still
    *  reads and disables on its OWN field's availability (see the file
@@ -161,6 +170,7 @@
   <section class="filter-surface" data-testid="filter-surface" aria-label="Mode and filter controls">
     {#if modeFilter}
       {#if modeFilter.currentMode.availability.structural}
+        {@const behavior = modeInstrument()}
         <div
           class="filter-choice-group" data-testid="filter-mode"
           data-disabled-reason={reasonOf(modeFilter.currentMode)}
@@ -168,14 +178,15 @@
           {#each modeFilter.modeChoices as choice (choice)}
             <button
               type="button" class="filter-choice" data-testid={`filter-mode-${choice}`}
-              aria-pressed={isSelected(modeFilter.currentMode, choice)}
-              disabled={!usable(modeFilter.currentMode)}
-              onclick={() => selectMode(choice)}
+              aria-pressed={behavior.available && behavior.isSelected(choice)}
+              disabled={!behavior.available}
+              onclick={() => behavior.invoke(choice)}
             >{choice}</button>
           {/each}
         </div>
       {/if}
       {#if modeFilter.currentFilter.availability.structural}
+        {@const behavior = filterInstrument()}
         <div
           class="filter-choice-group" data-testid="filter-select"
           data-disabled-reason={reasonOf(modeFilter.currentFilter)}
@@ -185,10 +196,10 @@
           {#each modeFilter.filterChoices as choice, index (choice)}
             <button
               type="button" class="filter-choice" data-testid={`filter-select-${index + 1}`}
-              aria-pressed={isSelected(modeFilter.currentFilter, index + 1)}
+              aria-pressed={behavior.available && behavior.isSelected(index + 1)}
               data-pending={pendingFilter === index + 1}
-              disabled={!usable(modeFilter.currentFilter)}
-              onclick={() => selectFilter(index + 1)}
+              disabled={!behavior.available}
+              onclick={() => behavior.invoke(index + 1)}
             >{choice}</button>
           {/each}
           {#if pendingFilter !== null}
@@ -225,6 +236,7 @@
         {/key}
       {/snippet}
       {#if filterPassband.filterShapeControlStructural}
+        {@const behavior = shapeInstrument()}
         <div
           class="filter-choice-group" data-testid="filter-shape"
           data-disabled-reason={reasonOf(filterPassband.filterShape)}
@@ -232,9 +244,9 @@
           {#each FILTER_SHAPES as [value, label] (value)}
             <button
               type="button" class="filter-choice" data-testid={`filter-shape-${value}`}
-              aria-pressed={isSelected(filterPassband.filterShape, value)}
-              disabled={!usable(filterPassband.filterShape)}
-              onclick={() => selectShape(value)}
+              aria-pressed={behavior.available && behavior.isSelected(value)}
+              disabled={!behavior.available}
+              onclick={() => behavior.invoke(value)}
             >{label}</button>
           {/each}
         </div>
@@ -280,6 +292,7 @@
         {/if}
       {/each}
       {#if filterPassband.dataMode.availability.structural}
+        {@const behavior = dataModeInstrument()}
         <div
           class={filterPassband.dataModeChoices.length > 1 ? 'filter-choice-group' : 'filter-readout'} data-testid="filter-data-mode"
           role="group" aria-label={t('core.mobile.sheet.dataMode')}
@@ -293,10 +306,10 @@
             {#each filterPassband.dataModeChoices as choice (choice.value)}
               <button
                 type="button" class="filter-choice" data-testid={`filter-data-mode-${choice.value}`}
-                aria-pressed={isSelected(filterPassband.dataMode, choice.value)}
+                aria-pressed={behavior.available && behavior.isSelected(choice.value)}
                 data-pending={pendingDataMode === choice.value}
-                disabled={!usable(filterPassband.dataMode)}
-                onclick={() => selectDataMode(choice.value)}
+                disabled={!behavior.available}
+                onclick={() => behavior.invoke(choice.value)}
               >{choice.label ?? (choice.value === 0 ? 'OFF' : `D${choice.value}`)}</button>
             {/each}
           {/if}

--- a/frontend/src/semantic/ScopeControlsSurface.svelte
+++ b/frontend/src/semantic/ScopeControlsSurface.svelte
@@ -30,8 +30,8 @@
 
   Two-level availability (MOR-977/1256): `structural: false` renders
   NOTHING; a present-but-unusable control stays visible and disabled rather
-  than guessing a value. `aria-pressed`/`aria-checked` are OMITTED (never
-  `"false"`) on an unread field — `TxAuxSurface.svelte`'s `pressedOf` shape.
+  than guessing a value. An unread toggle omits `aria-pressed`; unselected
+  radio choices expose `aria-checked="false"`.
 -->
 <script module lang="ts">
   import type { ScopeControlsField } from './radio-view-model';

--- a/frontend/src/semantic/ScopeControlsSurface.svelte
+++ b/frontend/src/semantic/ScopeControlsSurface.svelte
@@ -39,7 +39,6 @@
     MODE_BUTTONS, SPAN_LABELS, SPEED_LABELS,
     isSpanApplicable, isEdgeApplicable, clampSpan, clampSpeed, clampRef,
   } from '../components/spectrum/spectrum-toolbar-logic';
-  import { pressedOf } from './pressed-of';
 
   /** On/off leaves, `[field, label]`. */
   export const TOGGLES = [
@@ -68,6 +67,9 @@
 </script>
 
 <script lang="ts">
+  import {
+    bindActionInstrument, bindChoiceInstrument, bindToggleInstrument,
+  } from '../primitives/control-instruments/control-instrument-behavior';
   import type { RadioViewModel } from './radio-view-model';
 
   interface Props {
@@ -90,34 +92,48 @@
   let spanApplicable = $derived(isSpanApplicable(modeKnown));
   let edgeApplicable = $derived(isEdgeApplicable(modeKnown));
 
-  function toggle(field: ScopeToggleField): void {
-    const f = sc?.[field];
-    if (f && usable(f) && f.reading.status === 'known') onToggleChange?.(field, !f.reading.value);
+  function toggleInstrument(field: ScopeToggleField) {
+    return bindToggleInstrument(() => ({
+      field: sc?.[field],
+      invoke: (next) => onToggleChange?.(field, next),
+    }));
   }
-  function choice(field: ScopeChoiceField, value: number): void {
-    const f = sc?.[field];
-    if (f && usable(f)) onChoiceChange?.(field, value);
+  function choiceInstrument(field: ScopeChoiceField, choices: readonly number[]) {
+    return bindChoiceInstrument(() => ({
+      field: sc?.[field], choices,
+      invoke: (value) => onChoiceChange?.(field, value),
+    }));
   }
-  function span(delta: -1 | 1): void {
-    if (sc && usable(sc.span)) onSpanChange?.(clampSpan(numberOf(sc.span, 3), delta));
+  function spanInstrument(delta: -1 | 1) {
+    return bindActionInstrument(() => {
+      const field = sc?.span;
+      return { field, invoke: () => onSpanChange?.(clampSpan(numberOf(field!, 3), delta)) };
+    });
   }
-  function speed(delta: -1 | 1): void {
-    if (sc && usable(sc.speed)) onSpeedChange?.(clampSpeed(numberOf(sc.speed, 1), delta));
+  function speedInstrument(delta: -1 | 1) {
+    return bindActionInstrument(() => {
+      const field = sc?.speed;
+      return { field, invoke: () => onSpeedChange?.(clampSpeed(numberOf(field!, 1), delta)) };
+    });
   }
-  function ref(delta: -5 | 5): void {
-    if (sc && usable(sc.refDb)) onRefChange?.(clampRef(numberOf(sc.refDb, 0), delta));
+  function refInstrument(delta: -5 | 5) {
+    return bindActionInstrument(() => {
+      const field = sc?.refDb;
+      return { field, invoke: () => onRefChange?.(clampRef(numberOf(field!, 0), delta)) };
+    });
   }
 </script>
 
 {#if sc}
   <section class="scope-controls-surface" data-testid="scope-controls-surface" aria-label="Scope controls">
     {#if sc.mode.availability.structural}
+      {@const behavior = choiceInstrument('mode', MODE_BUTTONS.map(([value]) => value))}
       <div class="scope-row" role="radiogroup" aria-label="Scope mode" data-testid="scope-mode">
         {#each MODE_BUTTONS as [v, label] (v)}
           <button
             type="button" role="radio" class="scope-choice" data-testid={`scope-mode-${v}`}
-            aria-checked={sc.mode.reading.status === 'known' && sc.mode.reading.value === v}
-            disabled={!usable(sc.mode)} onclick={() => choice('mode', v)}
+            aria-checked={behavior.isSelected(v)}
+            disabled={!behavior.available} onclick={() => behavior.invoke(v)}
           >{label}</button>
         {/each}
       </div>
@@ -125,12 +141,13 @@
 
     {#each CHOICES as [field, label, options] (field)}
       {#if (field !== 'edge' || edgeApplicable) && sc[field].availability.structural}
+        {@const behavior = choiceInstrument(field, options.map(([value]) => value))}
         <div class="scope-row" role="radiogroup" aria-label={label} data-testid={`scope-${field}`}>
           {#each options as [v, optLabel] (v)}
             <button
               type="button" role="radio" class="scope-choice" data-testid={`scope-${field}-${v}`}
-              aria-checked={sc[field].reading.status === 'known' && sc[field].reading.value === v}
-              disabled={!usable(sc[field])} onclick={() => choice(field, v)}
+              aria-checked={behavior.isSelected(v)}
+              disabled={!behavior.available} onclick={() => behavior.invoke(v)}
             >{optLabel}</button>
           {/each}
         </div>
@@ -138,42 +155,49 @@
     {/each}
 
     {#if spanApplicable && sc.span.availability.structural}
+      {@const decrement = spanInstrument(-1)}
+      {@const increment = spanInstrument(1)}
       <div class="scope-stepper" data-testid="scope-span">
         <span class="scope-name">SPAN</span>
-        <button type="button" disabled={!usable(sc.span)} onclick={() => span(-1)}>-</button>
+        <button type="button" disabled={!decrement.available} onclick={() => decrement.invoke()}>-</button>
         <output data-testid="scope-span-value">
           {usable(sc.span) ? (SPAN_LABELS[numberOf(sc.span, 3)] ?? '?') : UNKNOWN_TEXT}
         </output>
-        <button type="button" disabled={!usable(sc.span)} onclick={() => span(1)}>+</button>
+        <button type="button" disabled={!increment.available} onclick={() => increment.invoke()}>+</button>
       </div>
     {/if}
 
     {#if sc.speed.availability.structural}
+      {@const decrement = speedInstrument(-1)}
+      {@const increment = speedInstrument(1)}
       <div class="scope-stepper" data-testid="scope-speed">
         <span class="scope-name">SPEED</span>
-        <button type="button" disabled={!usable(sc.speed)} onclick={() => speed(-1)}>-</button>
+        <button type="button" disabled={!decrement.available} onclick={() => decrement.invoke()}>-</button>
         <output data-testid="scope-speed-value">
           {usable(sc.speed) ? (SPEED_LABELS[numberOf(sc.speed, 1)] ?? '?') : UNKNOWN_TEXT}
         </output>
-        <button type="button" disabled={!usable(sc.speed)} onclick={() => speed(1)}>+</button>
+        <button type="button" disabled={!increment.available} onclick={() => increment.invoke()}>+</button>
       </div>
     {/if}
 
     {#if sc.refDb.availability.structural}
+      {@const decrement = refInstrument(-5)}
+      {@const increment = refInstrument(5)}
       <div class="scope-stepper" data-testid="scope-ref">
         <span class="scope-name">REF</span>
-        <button type="button" disabled={!usable(sc.refDb)} onclick={() => ref(-5)}>-</button>
+        <button type="button" disabled={!decrement.available} onclick={() => decrement.invoke()}>-</button>
         <output data-testid="scope-ref-value">{textOf(sc.refDb)}</output>
-        <button type="button" disabled={!usable(sc.refDb)} onclick={() => ref(5)}>+</button>
+        <button type="button" disabled={!increment.available} onclick={() => increment.invoke()}>+</button>
       </div>
     {/if}
 
     {#each TOGGLES as [field, label] (field)}
       {#if sc[field].availability.structural}
+        {@const behavior = toggleInstrument(field)}
         <button
           type="button" class="scope-toggle" data-testid={`scope-${field}`}
-          aria-pressed={pressedOf(sc[field])} disabled={!usable(sc[field])}
-          onclick={() => toggle(field)}
+          aria-pressed={behavior.confirmed} disabled={!behavior.available}
+          onclick={() => behavior.invoke()}
         >{label}: {textOf(sc[field])}</button>
       {/if}
     {/each}

--- a/frontend/src/semantic/__tests__/FilterSurface.test.ts
+++ b/frontend/src/semantic/__tests__/FilterSurface.test.ts
@@ -510,25 +510,10 @@ describe('choice fields emit the caller intent only when usable', () => {
     });
   });
 
-  /**
-   * MOR-1304 fix round (verify-MOR-1304 F3) — `HTMLElement.click()` is a
-   * no-op on a `disabled` button in jsdom (and in every real browser): the
-   * click-activation steps never run, so the handler's OWN guard
-   * (`usable(...)` in `selectMode`/`selectFilter`/`selectShape`) is never
-   * actually exercised — `disabled` alone would satisfy an assertion that
-   * `onXChange` was never called, even with the guard deleted. Dispatching
-   * the `MouseEvent` directly bypasses that suppression and reaches the
-   * `onclick` handler regardless of `disabled`, so these tests can tell
-   * "the button is disabled" apart from "the guard inside the handler holds"
-   * — MF3/MF12/MF13 in the verify report, each SURVIVED under `.click()`.
-   */
   function forceClick(button: HTMLButtonElement): void {
     button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
   }
 
-  // MUTATION KILLED (MF3): `selectMode`'s `usable(modeFilter.currentMode)`
-  // guard dropped — clicking would arm a guess rather than a confirmed
-  // selection.
   it('emits nothing when the mode is clicked on an unobserved reading', () => {
     const onModeChange = vi.fn();
     const view = withModeFilterField(base(), 'currentMode', { unknown: true });
@@ -539,8 +524,6 @@ describe('choice fields emit the caller intent only when usable', () => {
     }, { onModeChange });
   });
 
-  // MUTATION KILLED (MF12): `selectFilter`'s `usable(modeFilter.currentFilter)`
-  // guard dropped.
   it('emits nothing when a filter is clicked on an unobserved reading', () => {
     const onFilterChange = vi.fn();
     const view = withModeFilterField(base(), 'currentFilter', { unknown: true });
@@ -551,8 +534,6 @@ describe('choice fields emit the caller intent only when usable', () => {
     }, { onFilterChange });
   });
 
-  // MUTATION KILLED (MF13): `selectShape`'s `usable(filterPassband.filterShape)`
-  // guard dropped.
   it('emits nothing when a shape is clicked on an unobserved reading', () => {
     const onFilterShapeChange = vi.fn();
     const view = withPassbandField(base(), 'filterShape', { unknown: true });

--- a/frontend/src/semantic/__tests__/FilterSurface.test.ts
+++ b/frontend/src/semantic/__tests__/FilterSurface.test.ts
@@ -826,6 +826,20 @@ describe('pending-target affordance (MOR-1441 leg 2)', () => {
       expect(onFilterChange).toHaveBeenCalledExactlyOnceWith(3);
     }, { onFilterChange }, { pendingFilter: 3 });
   });
+
+  it('keeps an observed out-of-list filter unselected without changing clicked intent', () => {
+    const onFilterChange = vi.fn();
+    const view = base();
+    view.modeFilter!.currentFilter = {
+      availability: { structural: true, operational: true }, reading: { status: 'known', value: 99 },
+    };
+    withSurface(view, (s) => {
+      for (const value of [1, 2, 3]) expect(s.button('filter-select', value)!.getAttribute('aria-pressed')).toBe('false');
+      s.button('filter-select', 2)!.click();
+      flushSync();
+      expect(onFilterChange).toHaveBeenCalledExactlyOnceWith(2);
+    }, { onFilterChange });
+  });
 });
 
 // ── 9. No re-derivation — facts only (carry-forwards 1 and 5) ───────────────

--- a/frontend/src/semantic/__tests__/ScopeControlsSurface.test.ts
+++ b/frontend/src/semantic/__tests__/ScopeControlsSurface.test.ts
@@ -144,6 +144,12 @@ describe('unread leaves render honestly, never fabricated', () => {
     expect(r.el('scope-ref-value')!.textContent).toBe(UNKNOWN_TEXT);
     r.dispose();
   });
+
+  it('does not coerce an observed out-of-list choice into a selected option', () => {
+    const r = render(withSc({ centerType: known(99) }));
+    for (const value of [0, 1, 2]) expect(r.el(`scope-centerType-${value}`)!.getAttribute('aria-checked')).toBe('false');
+    r.dispose();
+  });
 });
 
 describe('handler guards are pinned independently of `disabled` (MOR-1304 F3)', () => {

--- a/frontend/src/semantic/__tests__/ScopeControlsSurface.test.ts
+++ b/frontend/src/semantic/__tests__/ScopeControlsSurface.test.ts
@@ -180,14 +180,6 @@ describe('handler guards are pinned independently of `disabled` (MOR-1304 F3)', 
     r.dispose();
   });
 
-  /**
-   * The `usable()` gate is structural && operational && known — a field can
-   * be `reading.status === 'known'` (a stale, previously-observed value)
-   * while `operational: false` (unwritable right now). These three pin THAT
-   * half specifically: a guard that checks only `status === 'known'` (a
-   * plausible partial mutation) still passes the tests above but must fail
-   * these, since none of them is unread.
-   */
   const STALE: Availability = { structural: true, operational: false };
 
   it('refuses a choice click on a KNOWN but operationally-stale field', () => {


### PR DESCRIPTION
## Summary

- Add stateless action, toggle, and finite-choice behavior bindings that re-read current inputs when invoked.
- Adopt the bindings in ScopeControlsSurface and FilterSurface without changing presentation, localization, pending markers, or clamp functions.
- Render an unknown alternate checkbox as `aria-checked="mixed"`, and render alternate choices as a CSS grid with valid `radiogroup`/`radio` semantics.
- Remove stale verification and ARIA comments without changing executable behavior or test assertions.

Linear: [MOR-2380](https://linear.app/morozsm/issue/MOR-2380)

## Scope

This is one behavior-binding adoption slice. The PR changes the eight leased files and 491 lines (408 additions, 83 deletions), measured with `git diff --numstat 669923b7e9839a7fbd458bd13147cdefb13292e4..6dbf86943aa3f432763845208dbc93f7dabba265`. They remain one unit because the common binding, its renderer proof, and both first production consumers form one bounded contract.

## Validation

- `npm run test -- --run src/primitives/control-instruments/__tests__/control-instrument-behavior.test.ts src/primitives/control-instruments/__tests__/control-instrument-renderers.component.test.ts src/semantic/__tests__/ScopeControlsSurface.test.ts src/semantic/__tests__/FilterSurface.test.ts` — 115 passed at `6dbf86943aa3f432763845208dbc93f7dabba265`.
- `npm run check` — 0 errors and 0 warnings.
- `npm run lint -- --quiet` — passed.
- `git diff --check` — passed.
- The cleanup commit changes comments only; no new tests or mutation were added. The finite-choice offered-value mutation was previously proven before this prose-only correction.

Full quick CI remains the required suite owner.
