### PR TITLE
refactor: extract shared frequency readout instruments (MOR-2381)

### DIFF
--- a/frontend/src/components-v2/display/FrequencyDisplay.svelte
+++ b/frontend/src/components-v2/display/FrequencyDisplay.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { formatFrequency } from './frequency-format';
+  import StandardFrequencyReadout from '../../primitives/frequency/StandardFrequencyReadout.svelte';
+  import { projectFrequencyReadout } from '../../primitives/frequency/frequency-readout';
 
   interface Props {
     freq: number;       // frequency in Hz (e.g. 14235000)
@@ -9,39 +10,7 @@
 
   let { freq, compact = false, active = true }: Props = $props();
 
-  let parts = $derived(formatFrequency(freq));
+  let model = $derived(projectFrequencyReadout({ confirmedHz: freq }));
 </script>
 
-<div class="freq" class:compact class:inactive={!active}>
-  <span class="digits">{parts.mhz}</span><span class="sep">.</span><span
-    class="digits">{parts.khz}</span><span class="sep">.</span><span
-    class="digits">{parts.hz}</span>
-</div>
-
-<style>
-  .freq {
-    display: inline-flex;
-    align-items: baseline;
-    font-family: 'Roboto Mono', monospace;
-    font-weight: 700;
-    font-size: 24px;
-    line-height: 1;
-    letter-spacing: 0.035em;
-    color: var(--v2-accent-cyan-bright);
-    white-space: nowrap;
-    user-select: none;
-  }
-
-  .freq.compact {
-    font-size: 14px;
-  }
-
-  .freq.inactive {
-    color: var(--v2-text-muted);
-  }
-
-  .sep {
-    opacity: 0.5;
-    margin: 0 0.02em;
-  }
-</style>
+<StandardFrequencyReadout {model} presentation="passive" {compact} {active} />

--- a/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
+++ b/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { splitFrequencyToDigits, groupDigitsForDisplay, adjustFreqByDigit, type DigitInfo } from './frequency-tuning';
+  import StandardFrequencyReadout from './StandardFrequencyReadout.svelte';
+  import { createFrequencyInteraction } from './frequency-interaction.svelte';
+  import { projectFrequencyReadout } from './frequency-readout';
 
   interface Props {
     /**
@@ -78,226 +80,30 @@
     vfoFreqHook = true,
   }: Props = $props();
 
-  const pendingId = $props.id();
-
-  // Receiver-aware CSS custom properties
-  let cssVars = $derived({
-    '--freq-active-color': `var(--v2-vfo-${receiver}-freq-active)`,
-    '--freq-inactive-color': `var(--v2-vfo-${receiver}-freq-inactive)`,
-    '--freq-hover-color': `var(--v2-vfo-${receiver}-freq-hover)`,
-    '--freq-selected-bg': `var(--v2-vfo-${receiver}-freq-selected-bg)`,
-    '--freq-selected-text': `var(--v2-vfo-${receiver}-freq-selected-text)`,
-    '--freq-glow': `var(--v2-vfo-${receiver}-freq-glow)`,
-    '--freq-font-family': `var(--v2-vfo-font-family)`,
-    '--freq-font-weight': `var(--v2-vfo-font-weight)`,
+  let model = $derived(projectFrequencyReadout({
+    confirmedHz: freq,
+    displayHz,
+    pendingDisplayHz,
+    pendingAnnouncement,
+  }));
+  const interaction = createFrequencyInteraction({
+    get confirmedHz() { return freq; },
+    get digits() { return model.digits; },
+    get disabled() { return disabled; },
+    get contextKey() { return contextKey; },
+    get receiver() { return receiver; },
+    get minFreq() { return minFreq; },
+    get maxFreq() { return maxFreq; },
+    get onFreqChange() { return onFreqChange; },
   });
-
-  let selectedDigitIndex = $state<number | null>(null);
-  let hoveredDigitIndex = $state<number | null>(null);
-  let inert = $derived(disabled || freq === null || !Number.isFinite(freq));
-  $effect(() => {
-    void inert;
-    void contextKey;
-    void receiver;
-    selectedDigitIndex = null;
-    hoveredDigitIndex = null;
-  });
-
-  let pending = $derived(pendingDisplayHz !== null);
-  // Pending and historical readouts never replace the strict arithmetic input.
-  let shownFrequency = $derived(pendingDisplayHz ?? (displayHz === undefined ? freq : displayHz));
-  let allDigits = $derived(shownFrequency === null ? [] : splitFrequencyToDigits(shownFrequency));
-  let groups = $derived(groupDigitsForDisplay(allDigits));
-
-  function handleWheel(digit: DigitInfo, event: WheelEvent) {
-    if (inert || freq === null) return;
-    // MOR-1639: scrolling over a VFO readout is ordinary page navigation
-    // until the operator deliberately picks THIS digit. Do not consume an
-    // unarmed event: that both preserves page scrolling and guarantees no
-    // frequency intent reaches the command path by accident.
-    if (selectedDigitIndex !== digit.digitIndex) return;
-    event.preventDefault();
-    const direction = event.deltaY > 0 ? -1 : 1;
-    const newFreq = adjustFreqByDigit(freq, digit.multiplier, direction, minFreq, maxFreq);
-    if (newFreq !== freq && onFreqChange) {
-      onFreqChange(newFreq);
-    }
-  }
-
-  function handleDigitClick(digit: DigitInfo, event: MouseEvent) {
-    if (inert) return;
-    event.stopPropagation();
-    selectedDigitIndex = digit.digitIndex;
-  }
-
-  function handleKeyDown(event: KeyboardEvent) {
-    if (inert || freq === null) return;
-    if (selectedDigitIndex === null) return;
-    const digit = allDigits.find(d => d.digitIndex === selectedDigitIndex);
-    if (!digit) return;
-    if (event.key === 'ArrowUp') {
-      event.preventDefault();
-      const newFreq = adjustFreqByDigit(freq, digit.multiplier, 1, minFreq, maxFreq);
-      if (newFreq !== freq && onFreqChange) onFreqChange(newFreq);
-    } else if (event.key === 'ArrowDown') {
-      event.preventDefault();
-      const newFreq = adjustFreqByDigit(freq, digit.multiplier, -1, minFreq, maxFreq);
-      if (newFreq !== freq && onFreqChange) onFreqChange(newFreq);
-    }
-  }
-
-  function handleDigitEnter(digit: DigitInfo) {
-    if (inert) return;
-    hoveredDigitIndex = digit.digitIndex;
-  }
-
-  function handleDigitLeave() {
-    hoveredDigitIndex = null;
-  }
-
-  function isSelected(digit: DigitInfo): boolean {
-    return selectedDigitIndex === digit.digitIndex;
-  }
-
-  function isHovered(digit: DigitInfo): boolean {
-    return hoveredDigitIndex === digit.digitIndex;
-  }
 </script>
 
-<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-<div
-  class="freq" class:compact class:inactive={!active}
-  data-freq-status={pending ? 'pending' : 'confirmed'}
-  data-vfo-freq={vfoFreqHook ? '' : undefined}
-  data-vfo-active={vfoFreqHook ? active : undefined}
-  aria-describedby={pending && pendingAnnouncement ? pendingId : undefined}
-  aria-disabled={inert}
-  style={Object.entries(cssVars).map(([k, v]) => `${k}:${v}`).join(';')}
-  tabindex={inert ? -1 : 0} role="group" aria-label="Frequency display" onkeydown={handleKeyDown}
->
-  {#if shownFrequency === null}
-    <span>—</span>
-  {:else}
-  {#each groups.mhz as digit}
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <span
-      class="digit"
-      class:selected={isSelected(digit)}
-      class:hovered={isHovered(digit)}
-      onwheel={(e) => handleWheel(digit, e)}
-      onclick={(e) => handleDigitClick(digit, e)}
-      onmouseenter={() => handleDigitEnter(digit)}
-      onmouseleave={handleDigitLeave}
-    >{digit.char}</span>
-  {/each}
-  <span class="sep">.</span>
-  {#each groups.khz as digit}
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <span
-      class="digit"
-      class:selected={isSelected(digit)}
-      class:hovered={isHovered(digit)}
-      onwheel={(e) => handleWheel(digit, e)}
-      onclick={(e) => handleDigitClick(digit, e)}
-      onmouseenter={() => handleDigitEnter(digit)}
-      onmouseleave={handleDigitLeave}
-    >{digit.char}</span>
-  {/each}
-  <span class="sep">.</span>
-  {#each groups.hz as digit}
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <span
-      class="digit"
-      class:selected={isSelected(digit)}
-      class:hovered={isHovered(digit)}
-      onwheel={(e) => handleWheel(digit, e)}
-      onclick={(e) => handleDigitClick(digit, e)}
-      onmouseenter={() => handleDigitEnter(digit)}
-      onmouseleave={handleDigitLeave}
-    >{digit.char}</span>
-  {/each}
-  {/if}
-  {#if pending && pendingAnnouncement}
-    <span id={pendingId} class="sr-only">{pendingAnnouncement}</span>
-  {/if}
-</div>
-
-<style>
-  .freq {
-    display: inline-flex;
-    align-items: baseline;
-    font-family: var(--freq-font-family, 'Roboto Mono', monospace);
-    font-weight: var(--freq-font-weight, 700);
-    font-size: 24px;
-    line-height: 1;
-    letter-spacing: 0.035em;
-    color: var(--freq-active-color, var(--v2-accent-cyan-bright));
-    text-shadow: var(--freq-glow, none);
-    white-space: nowrap;
-    user-select: none;
-  }
-
-  .freq.compact {
-    font-size: 14px;
-  }
-
-  .freq.inactive {
-    color: var(--freq-inactive-color, var(--v2-text-muted));
-  }
-
-  /* MOR-1441 — a pending (unconfirmed) target never renders identically to
-     confirmed radio truth. Structural (italic + reduced opacity), never a
-     color-only tell, same doctrine as the `data-observed` convention. */
-  .freq[data-freq-status='pending'] {
-    font-style: italic;
-    opacity: 0.75;
-  }
-
-  .digit {
-    cursor: ns-resize;
-    position: relative;
-    transition: color 0.1s ease, background 0.1s ease;
-  }
-
-  .digit:hover {
-    color: var(--freq-hover-color, var(--v2-text-white, #ffffff));
-  }
-
-  .freq[aria-disabled='true'] .digit { cursor: default; }
-
-  .digit.hovered::after {
-    content: '';
-    position: absolute;
-    bottom: -2px;
-    left: 0;
-    right: 0;
-    height: 2px;
-    background: var(--freq-active-color, var(--v2-accent-cyan-bright));
-    opacity: 0.5;
-  }
-
-  .digit.selected {
-    color: var(--freq-selected-text, var(--v2-text-white, #ffffff));
-    background: var(--freq-selected-bg, var(--v2-accent-cyan, #00b4d8));
-    border-radius: 2px;
-    padding: 0 1px;
-  }
-
-  .sep {
-    opacity: 0.5;
-    margin: 0 0.02em;
-    pointer-events: none;
-  }
-
-  /* MOR-1441 (B2) — the visual pending marker's assistive-tech twin: a
-     rendered word, not just italic/opacity (which convey nothing to a
-     screen reader). Same convention as `TxAuxSurface.svelte`'s `.sr-only`. */
-  .sr-only {
-    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
-    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
-  }
-</style>
+<StandardFrequencyReadout
+  {model}
+  presentation="interactive"
+  {interaction}
+  {compact}
+  {active}
+  {receiver}
+  {vfoFreqHook}
+/>

--- a/frontend/src/primitives/frequency/StandardFrequencyReadout.svelte
+++ b/frontend/src/primitives/frequency/StandardFrequencyReadout.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+  import type { FrequencyInteraction } from './frequency-interaction.svelte';
+  import type { FrequencyReadoutModel } from './frequency-readout';
+
+  export type FrequencyReadoutPresentation = 'interactive' | 'passive';
+
+  interface Props {
+    model: FrequencyReadoutModel;
+    presentation: FrequencyReadoutPresentation;
+    interaction?: FrequencyInteraction;
+    compact?: boolean;
+    active?: boolean;
+    receiver?: 'main' | 'sub';
+    vfoFreqHook?: boolean;
+  }
+
+  let {
+    model,
+    presentation,
+    interaction,
+    compact = false,
+    active = true,
+    receiver = 'main',
+    vfoFreqHook = true,
+  }: Props = $props();
+
+  const pendingId = $props.id();
+  let interactive = $derived(presentation === 'interactive');
+  let cssVars = $derived(interactive ? {
+    '--freq-active-color': `var(--v2-vfo-${receiver}-freq-active)`,
+    '--freq-inactive-color': `var(--v2-vfo-${receiver}-freq-inactive)`,
+    '--freq-hover-color': `var(--v2-vfo-${receiver}-freq-hover)`,
+    '--freq-selected-bg': `var(--v2-vfo-${receiver}-freq-selected-bg)`,
+    '--freq-selected-text': `var(--v2-vfo-${receiver}-freq-selected-text)`,
+    '--freq-glow': `var(--v2-vfo-${receiver}-freq-glow)`,
+    '--freq-font-family': 'var(--v2-vfo-font-family)',
+    '--freq-font-weight': 'var(--v2-vfo-font-weight)',
+  } : undefined);
+  let style = $derived(cssVars
+    ? Object.entries(cssVars).map(([key, value]) => `${key}:${value}`).join(';')
+    : undefined);
+</script>
+
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<div
+  class="freq" class:compact class:inactive={!active} class:interactive
+  data-freq-status={interactive ? model.status : undefined}
+  data-vfo-freq={interactive && vfoFreqHook ? '' : undefined}
+  data-vfo-active={interactive && vfoFreqHook ? active : undefined}
+  aria-describedby={interactive && model.status === 'pending' && model.pendingAnnouncement ? pendingId : undefined}
+  aria-disabled={interactive ? interaction?.inert ?? true : undefined}
+  {style}
+  tabindex={interactive ? interaction?.inert === false ? 0 : -1 : undefined}
+  role={interactive ? 'group' : undefined}
+  aria-label={interactive ? 'Frequency display' : undefined}
+  onkeydown={interactive ? interaction?.handleKeyDown : undefined}
+>
+  {#if !model.known}
+    {#if interactive}
+      <span>—</span>
+    {:else}
+      <span class="digits">{model.textGroups.mhz}</span><span class="sep">.</span><span
+        class="digits">{model.textGroups.khz}</span><span class="sep">.</span><span
+        class="digits">{model.textGroups.hz}</span>
+    {/if}
+  {:else if interactive}
+    {#each model.groups.mhz as digit}
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <span
+        class="digit"
+        class:selected={interaction?.isSelected(digit)}
+        class:hovered={interaction?.isHovered(digit)}
+        onwheel={(event) => interaction?.handleWheel(digit, event)}
+        onclick={(event) => interaction?.handleDigitClick(digit, event)}
+        onmouseenter={() => interaction?.handleDigitEnter(digit)}
+        onmouseleave={() => interaction?.handleDigitLeave()}
+      >{digit.char}</span>
+    {/each}
+    <span class="sep">.</span>
+    {#each model.groups.khz as digit}
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <span
+        class="digit"
+        class:selected={interaction?.isSelected(digit)}
+        class:hovered={interaction?.isHovered(digit)}
+        onwheel={(event) => interaction?.handleWheel(digit, event)}
+        onclick={(event) => interaction?.handleDigitClick(digit, event)}
+        onmouseenter={() => interaction?.handleDigitEnter(digit)}
+        onmouseleave={() => interaction?.handleDigitLeave()}
+      >{digit.char}</span>
+    {/each}
+    <span class="sep">.</span>
+    {#each model.groups.hz as digit}
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <span
+        class="digit"
+        class:selected={interaction?.isSelected(digit)}
+        class:hovered={interaction?.isHovered(digit)}
+        onwheel={(event) => interaction?.handleWheel(digit, event)}
+        onclick={(event) => interaction?.handleDigitClick(digit, event)}
+        onmouseenter={() => interaction?.handleDigitEnter(digit)}
+        onmouseleave={() => interaction?.handleDigitLeave()}
+      >{digit.char}</span>
+    {/each}
+  {:else}
+    <span class="digits">{model.textGroups.mhz}</span><span class="sep">.</span><span
+      class="digits">{model.textGroups.khz}</span><span class="sep">.</span><span
+      class="digits">{model.textGroups.hz}</span>
+  {/if}
+  {#if interactive && model.status === 'pending' && model.pendingAnnouncement}
+    <span id={pendingId} class="sr-only">{model.pendingAnnouncement}</span>
+  {/if}
+</div>
+
+<style>
+  .freq {
+    display: inline-flex;
+    align-items: baseline;
+    font-family: 'Roboto Mono', monospace;
+    font-weight: 700;
+    font-size: 24px;
+    line-height: 1;
+    letter-spacing: 0.035em;
+    color: var(--v2-accent-cyan-bright);
+    white-space: nowrap;
+    user-select: none;
+  }
+
+  .freq.interactive {
+    font-family: var(--freq-font-family, 'Roboto Mono', monospace);
+    font-weight: var(--freq-font-weight, 700);
+    color: var(--freq-active-color, var(--v2-accent-cyan-bright));
+    text-shadow: var(--freq-glow, none);
+  }
+
+  .freq.compact { font-size: 14px; }
+
+  .freq.inactive { color: var(--v2-text-muted); }
+
+  .freq.interactive.inactive { color: var(--freq-inactive-color, var(--v2-text-muted)); }
+
+  .freq[data-freq-status='pending'] {
+    font-style: italic;
+    opacity: 0.75;
+  }
+
+  .digit {
+    cursor: ns-resize;
+    position: relative;
+    transition: color 0.1s ease, background 0.1s ease;
+  }
+
+  .digit:hover { color: var(--freq-hover-color, var(--v2-text-white, #ffffff)); }
+
+  .freq[aria-disabled='true'] .digit { cursor: default; }
+
+  .digit.hovered::after {
+    content: '';
+    position: absolute;
+    bottom: -2px;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--freq-active-color, var(--v2-accent-cyan-bright));
+    opacity: 0.5;
+  }
+
+  .digit.selected {
+    color: var(--freq-selected-text, var(--v2-text-white, #ffffff));
+    background: var(--freq-selected-bg, var(--v2-accent-cyan, #00b4d8));
+    border-radius: 2px;
+    padding: 0 1px;
+  }
+
+  .sep {
+    opacity: 0.5;
+    margin: 0 0.02em;
+  }
+
+  .freq.interactive .sep { pointer-events: none; }
+
+  .sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+  }
+</style>

--- a/frontend/src/primitives/frequency/__tests__/AlternateFrequencyReadoutHarness.svelte
+++ b/frontend/src/primitives/frequency/__tests__/AlternateFrequencyReadoutHarness.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { projectFrequencyReadout } from '../frequency-readout';
+  import { createFrequencyInteraction } from '../frequency-interaction.svelte';
+
+  interface Props {
+    confirmedHz: number | null;
+    displayHz?: number | null;
+    pendingDisplayHz?: number | null;
+    disabled?: boolean;
+    contextKey?: string;
+    onFreqChange?: (frequencyHz: number) => void;
+  }
+
+  let {
+    confirmedHz,
+    displayHz,
+    pendingDisplayHz = null,
+    disabled = false,
+    contextKey,
+    onFreqChange,
+  }: Props = $props();
+
+  let readout = $derived(projectFrequencyReadout({
+    confirmedHz,
+    displayHz,
+    pendingDisplayHz,
+  }));
+  const interaction = createFrequencyInteraction({
+    get confirmedHz() { return confirmedHz; },
+    get digits() { return readout.digits; },
+    get disabled() { return disabled; },
+    get contextKey() { return contextKey; },
+    minFreq: 0,
+    maxFreq: 999_000_000,
+    get onFreqChange() { return onFreqChange; },
+  });
+</script>
+
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<div
+  role="group"
+  tabindex="0"
+  data-alternate-frequency-readout
+  data-source={readout.source}
+  aria-disabled={interaction.inert}
+  onkeydown={interaction.handleKeyDown}
+>
+  {#each readout.digits as digit}
+    <button
+      type="button"
+      data-multiplier={digit.multiplier}
+      aria-pressed={interaction.isSelected(digit)}
+      onclick={(event) => interaction.handleDigitClick(digit, event)}
+      onwheel={(event) => interaction.handleWheel(digit, event)}
+    >{digit.char}</button>
+  {/each}
+</div>

--- a/frontend/src/primitives/frequency/__tests__/StandardFrequencyReadout.isolated.test.ts
+++ b/frontend/src/primitives/frequency/__tests__/StandardFrequencyReadout.isolated.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { ComponentProps } from 'svelte';
+import StandardFrequencyReadout from '../StandardFrequencyReadout.svelte';
+import AlternateFrequencyReadoutHarness from './AlternateFrequencyReadoutHarness.svelte';
+import { projectFrequencyReadout } from '../frequency-readout';
+import FrequencyDisplay from '../../../components-v2/display/FrequencyDisplay.svelte';
+
+const mounted: ReturnType<typeof mount>[] = [];
+
+function mountReadout(props: ComponentProps<typeof StandardFrequencyReadout>): HTMLElement {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  mounted.push(mount(StandardFrequencyReadout, { target, props }));
+  flushSync();
+  return target;
+}
+
+afterEach(() => {
+  mounted.forEach((component) => unmount(component));
+  mounted.length = 0;
+  document.body.innerHTML = '';
+});
+
+describe('frequency readout projection', () => {
+  it('keeps confirmed, historical display, and pending values distinct', () => {
+    const model = projectFrequencyReadout({
+      confirmedHz: 14_250_000,
+      displayHz: 7_100_000,
+      pendingDisplayHz: 14_260_000,
+      pendingAnnouncement: 'Pending, not yet confirmed',
+    });
+
+    expect(model).toMatchObject({
+      confirmedHz: 14_250_000,
+      displayHz: 7_100_000,
+      pendingDisplayHz: 14_260_000,
+      shownHz: 14_260_000,
+      source: 'pending',
+      status: 'pending',
+      pendingAnnouncement: 'Pending, not yet confirmed',
+    });
+    expect(model.digits.map((digit) => digit.char).join('')).toBe('14260000');
+  });
+
+  it('preserves an explicit null display and valid zero', () => {
+    expect(projectFrequencyReadout({ confirmedHz: 14_250_000, displayHz: null })).toMatchObject({
+      displayHz: null,
+      shownHz: null,
+      source: 'display',
+    });
+    expect(projectFrequencyReadout({ confirmedHz: 0 })).toMatchObject({
+      shownHz: 0,
+      textGroups: { mhz: '0', khz: '000', hz: '000' },
+    });
+  });
+});
+
+describe('StandardFrequencyReadout', () => {
+  it('keeps the passive FrequencyDisplay facade grouped and non-interactive', () => {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    mounted.push(mount(FrequencyDisplay, {
+      target,
+      props: { freq: 14_235_000, compact: true, active: false },
+    }));
+    flushSync();
+    const root = target.querySelector<HTMLElement>('.freq')!;
+
+    expect(root.textContent?.replace(/\s/g, '')).toBe('14.235.000');
+    expect(root.classList.contains('compact')).toBe(true);
+    expect(root.classList.contains('inactive')).toBe(true);
+    expect(root.querySelectorAll('.digits')).toHaveLength(3);
+    expect(root.hasAttribute('aria-disabled')).toBe(false);
+    expect(root.hasAttribute('data-vfo-freq')).toBe(false);
+  });
+
+  it('renders the passive presentation with its grouped zero and appearance classes', () => {
+    const target = mountReadout({
+      model: projectFrequencyReadout({ confirmedHz: 0 }),
+      presentation: 'passive',
+      compact: true,
+      active: false,
+    });
+    const root = target.querySelector<HTMLElement>('.freq')!;
+
+    expect(root.textContent?.replace(/\s/g, '')).toBe('0.000.000');
+    expect(root.classList.contains('compact')).toBe(true);
+    expect(root.classList.contains('inactive')).toBe(true);
+    expect(root.querySelectorAll('.digits')).toHaveLength(3);
+    expect(root.hasAttribute('tabindex')).toBe(false);
+    expect(root.hasAttribute('data-freq-status')).toBe(false);
+  });
+
+  it('renders interactive pending text, status, and linked announcement from the model', () => {
+    const target = mountReadout({
+      model: projectFrequencyReadout({
+        confirmedHz: 14_250_000,
+        pendingDisplayHz: 14_260_000,
+        pendingAnnouncement: 'Pending, not yet confirmed',
+      }),
+      presentation: 'interactive',
+      active: true,
+    });
+    const root = target.querySelector<HTMLElement>('.freq')!;
+    const descriptionId = root.getAttribute('aria-describedby');
+
+    expect(root.dataset.freqStatus).toBe('pending');
+    expect(Array.from(root.querySelectorAll('.digit')).map((digit) => digit.textContent).join('')).toBe('14260000');
+    expect(descriptionId).toBeTruthy();
+    expect(target.querySelector(`#${descriptionId}`)?.textContent).toBe('Pending, not yet confirmed');
+  });
+
+  it('renders the presentation-specific unknown text', () => {
+    const unknown = projectFrequencyReadout({ confirmedHz: null });
+    expect(mountReadout({ model: unknown, presentation: 'interactive' }).textContent?.trim()).toBe('—');
+    expect(mountReadout({ model: unknown, presentation: 'passive' }).textContent?.replace(/\s/g, '')).toBe('--.---.---');
+  });
+});
+
+describe('alternate frequency renderer', () => {
+  it('uses the shared behavior while keeping pending display out of arithmetic', () => {
+    const onFreqChange = vi.fn();
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    mounted.push(mount(AlternateFrequencyReadoutHarness, {
+      target,
+      props: {
+        confirmedHz: 14_250_000,
+        pendingDisplayHz: 14_260_000,
+        onFreqChange,
+      },
+    }));
+    flushSync();
+
+    const root = target.querySelector<HTMLElement>('[data-alternate-frequency-readout]')!;
+    const oneKhz = target.querySelector<HTMLButtonElement>('[data-multiplier="1000"]')!;
+    expect(root.dataset.source).toBe('pending');
+    expect(Array.from(target.querySelectorAll('button')).map((digit) => digit.textContent).join('')).toBe('14260000');
+
+    oneKhz.click();
+    oneKhz.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true, cancelable: true }));
+    flushSync();
+
+    expect(onFreqChange).toHaveBeenCalledExactlyOnceWith(14_251_000);
+    expect(onFreqChange).not.toHaveBeenCalledWith(14_261_000);
+  });
+});

--- a/frontend/src/primitives/frequency/frequency-interaction.svelte.ts
+++ b/frontend/src/primitives/frequency/frequency-interaction.svelte.ts
@@ -1,0 +1,93 @@
+import { adjustFreqByDigit, type DigitInfo } from './frequency-tuning';
+
+export interface FrequencyInteractionInput {
+  readonly confirmedHz: number | null;
+  readonly digits: readonly DigitInfo[];
+  readonly disabled: boolean;
+  readonly contextKey?: string;
+  readonly receiver?: 'main' | 'sub';
+  readonly minFreq: number;
+  readonly maxFreq: number;
+  readonly onFreqChange?: (frequencyHz: number) => void;
+}
+
+export interface FrequencyInteraction {
+  readonly inert: boolean;
+  readonly selectedDigitIndex: number | null;
+  readonly hoveredDigitIndex: number | null;
+  handleWheel(digit: DigitInfo, event: WheelEvent): void;
+  handleDigitClick(digit: DigitInfo, event: MouseEvent): void;
+  handleKeyDown(event: KeyboardEvent): void;
+  handleDigitEnter(digit: DigitInfo): void;
+  handleDigitLeave(): void;
+  isSelected(digit: DigitInfo): boolean;
+  isHovered(digit: DigitInfo): boolean;
+}
+
+export function createFrequencyInteraction(
+  current: FrequencyInteractionInput,
+): FrequencyInteraction {
+  let selectedDigitIndex = $state<number | null>(null);
+  let hoveredDigitIndex = $state<number | null>(null);
+  let inert = $derived.by(() => {
+    const { confirmedHz, disabled } = current;
+    return disabled || confirmedHz === null || !Number.isFinite(confirmedHz);
+  });
+
+  $effect(() => {
+    const { contextKey, receiver } = current;
+    void inert;
+    void contextKey;
+    void receiver;
+    selectedDigitIndex = null;
+    hoveredDigitIndex = null;
+  });
+
+  function emitStep(digit: DigitInfo, direction: 1 | -1): void {
+    const { confirmedHz, minFreq, maxFreq, onFreqChange } = current;
+    if (inert || confirmedHz === null) return;
+    const nextHz = adjustFreqByDigit(confirmedHz, digit.multiplier, direction, minFreq, maxFreq);
+    if (nextHz !== confirmedHz) onFreqChange?.(nextHz);
+  }
+
+  function handleWheel(digit: DigitInfo, event: WheelEvent): void {
+    if (inert || selectedDigitIndex !== digit.digitIndex) return;
+    event.preventDefault();
+    emitStep(digit, event.deltaY > 0 ? -1 : 1);
+  }
+
+  function handleDigitClick(digit: DigitInfo, event: MouseEvent): void {
+    if (inert) return;
+    event.stopPropagation();
+    selectedDigitIndex = digit.digitIndex;
+  }
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    if (inert || selectedDigitIndex === null) return;
+    const digit = current.digits.find((candidate) => candidate.digitIndex === selectedDigitIndex);
+    if (!digit || (event.key !== 'ArrowUp' && event.key !== 'ArrowDown')) return;
+    event.preventDefault();
+    emitStep(digit, event.key === 'ArrowUp' ? 1 : -1);
+  }
+
+  function handleDigitEnter(digit: DigitInfo): void {
+    if (!inert) hoveredDigitIndex = digit.digitIndex;
+  }
+
+  function handleDigitLeave(): void {
+    hoveredDigitIndex = null;
+  }
+
+  return {
+    get inert() { return inert; },
+    get selectedDigitIndex() { return selectedDigitIndex; },
+    get hoveredDigitIndex() { return hoveredDigitIndex; },
+    handleWheel,
+    handleDigitClick,
+    handleKeyDown,
+    handleDigitEnter,
+    handleDigitLeave,
+    isSelected: (digit) => selectedDigitIndex === digit.digitIndex,
+    isHovered: (digit) => hoveredDigitIndex === digit.digitIndex,
+  };
+}

--- a/frontend/src/primitives/frequency/frequency-readout.ts
+++ b/frontend/src/primitives/frequency/frequency-readout.ts
@@ -1,0 +1,66 @@
+import {
+  groupDigitsForDisplay,
+  splitFrequencyToDigits,
+  type DigitInfo,
+} from './frequency-tuning';
+
+export type FrequencyReadoutSource = 'confirmed' | 'display' | 'pending';
+export type FrequencyReadoutStatus = 'confirmed' | 'pending';
+
+export interface FrequencyReadoutInput {
+  confirmedHz: number | null;
+  displayHz?: number | null;
+  pendingDisplayHz?: number | null;
+  pendingAnnouncement?: string;
+}
+
+export interface FrequencyReadoutModel {
+  readonly confirmedHz: number | null;
+  readonly displayHz: number | null;
+  readonly pendingDisplayHz: number | null;
+  readonly shownHz: number | null;
+  readonly source: FrequencyReadoutSource;
+  readonly status: FrequencyReadoutStatus;
+  readonly known: boolean;
+  readonly digits: readonly DigitInfo[];
+  readonly groups: Readonly<{
+    mhz: readonly DigitInfo[];
+    khz: readonly DigitInfo[];
+    hz: readonly DigitInfo[];
+  }>;
+  readonly textGroups: Readonly<{ mhz: string; khz: string; hz: string }>;
+  readonly pendingAnnouncement?: string;
+}
+
+export function projectFrequencyReadout(input: FrequencyReadoutInput): FrequencyReadoutModel {
+  const explicitDisplay = input.displayHz !== undefined;
+  const displayHz = explicitDisplay ? input.displayHz ?? null : input.confirmedHz;
+  const pendingDisplayHz = input.pendingDisplayHz ?? null;
+  const source: FrequencyReadoutSource = pendingDisplayHz !== null
+    ? 'pending'
+    : explicitDisplay ? 'display' : 'confirmed';
+  const shownHz = pendingDisplayHz ?? displayHz;
+  const known = shownHz !== null && Number.isFinite(shownHz);
+  const digits = known ? splitFrequencyToDigits(shownHz) : [];
+  const groups = groupDigitsForDisplay(digits);
+
+  return {
+    confirmedHz: input.confirmedHz,
+    displayHz,
+    pendingDisplayHz,
+    shownHz,
+    source,
+    status: source === 'pending' ? 'pending' : 'confirmed',
+    known,
+    digits,
+    groups,
+    textGroups: known
+      ? {
+          mhz: groups.mhz.map((digit) => digit.char).join('') || '0',
+          khz: groups.khz.map((digit) => digit.char).join(''),
+          hz: groups.hz.map((digit) => digit.char).join(''),
+        }
+      : { mhz: '--', khz: '---', hz: '---' },
+    pendingAnnouncement: input.pendingAnnouncement,
+  };
+}


### PR DESCRIPTION
## Summary

- Extract the frequency readout projection, digit interaction controller, and Standard renderer from `FrequencyDisplayInteractive`.
- Keep `FrequencyDisplayInteractive` as the existing interactive facade and route the passive mobile `FrequencyDisplay` facade through the same renderer.
- Add a test-only alternate renderer that consumes the exported projection and interaction binding without importing runtime, store, or wiring code.

Linear owner: [MOR-2381](https://linear.app/morozsm/issue/MOR-2381)

This is the bounded frequency-instrument slice under MOR-2215; it does not complete the umbrella architecture.

## Behavior preserved

- Confirmed Hz remains the only arithmetic input for wheel and arrow-key tuning.
- Pending and explicit display values remain presentation-only.
- Unknown, zero, compact, inactive, pending announcement, focus hooks, digit selection, hover, and context reset remain represented.
- Existing `VfoSurface`, `VfoPanel`, `MobileRadioLayout`, keyboard routing, runtime, store, and command-owner files are unchanged, as established by `git diff --name-only origin/main...HEAD`.

## Verification

- Focused Vitest matrix: 8 files passed, 342 tests passed.
- `npm run check`: 0 errors and 0 warnings.
- `npm run lint`: passed.
- `git diff --check origin/main...HEAD`: passed.
- Mutation: changed the interactive facade's confirmed-Hz getter to `model.shownHz`; 4 of 20 focused tests failed, including pending wheel and arrow arithmetic. Restoring the getter to `freq` returned the focused matrix to 342/342.

The accepted frontend baseline is quick run 34000478807 on the unchanged frontend tree described in the MOR-2381 specification. No full local suite or macOS visual-baseline regeneration was run; required PR CI remains owned by the coordinator after Ready transition.

## Size

The exact head changes 7 files and 842 lines: 586 additions and 256 deletions, measured with `git diff --numstat origin/main...HEAD`.

This exceeds the 6-file/600-line soft threshold because the typed projection, stateful controller, preserved renderer, two compatibility facades, and renderer-independent mounted proof are one behavior-preserving extraction contract. Splitting them would leave either an unconsumed abstraction or an unverified compatibility seam.
