### PR TITLE
Refactor S-meter calibration into a pure primitive

### DIFF
--- a/frontend/src/components-v2/meters/smeter-scale.ts
+++ b/frontend/src/components-v2/meters/smeter-scale.ts
@@ -15,12 +15,20 @@
  */
 
 import { getSmeterCalibration, getSmeterRedline } from '$lib/stores/capabilities.svelte';
-
-interface CalPoint {
-  raw: number;
-  actual: number;
-  label: string;
-}
+import {
+  calibratedToDbm as calibratedToDbmForCalibration,
+  calibratedToRaw as calibratedToRawForCalibration,
+  calibratedToSegments as calibratedToSegmentsForCalibration,
+  calibratedToSUnit as calibratedToSUnitForCalibration,
+  formatDbm as formatDbmForCalibration,
+  getS9Raw as getS9RawForCalibration,
+  getScaleMaxRaw as getScaleMaxRawForCalibration,
+  isSmeterCalibrated as isSmeterCalibratedForCalibration,
+  rawToDbm as rawToDbmForCalibration,
+  rawToSegments as rawToSegmentsForCalibration,
+  rawToSUnit as rawToSUnitForCalibration,
+  type SmeterCalibrationPoint,
+} from '../../primitives/meters/s-meter-scale';
 
 export interface SmeterMark {
   raw: number;
@@ -29,10 +37,7 @@ export interface SmeterMark {
   color: string;
 }
 
-const MAX_RAW = 255;
-const S9_DBM = -73;
-
-function getCal(): CalPoint[] {
+function getCal(): SmeterCalibrationPoint[] {
   return getSmeterCalibration() ?? [];
 }
 
@@ -44,15 +49,13 @@ function getCal(): CalPoint[] {
  *  below must fall back to an honest raw-scale label instead of
  *  fabricating a reading against a borrowed curve (MOR-1451). */
 export function isSmeterCalibrated(): boolean {
-  return getCal().length >= 2;
+  return isSmeterCalibratedForCalibration(getCal());
 }
 
 /** Find S9 raw value from calibration; the raw-scale midpoint when
  *  uncalibrated — a neutral bar-geometry anchor, not a claimed threshold. */
 export function getS9Raw(): number {
-  const cal = getCal();
-  const s9 = cal.find(p => p.label === 'S9');
-  return s9?.raw ?? MAX_RAW / 2;
+  return getS9RawForCalibration(getCal());
 }
 
 /** Get redline raw value. */
@@ -62,108 +65,19 @@ export function getRedlineRaw(): number {
 
 /** Last calibration raw knot, used as the right edge of visual S-meter scales. */
 export function getScaleMaxRaw(): number {
-  const cal = getCal();
-  return cal[cal.length - 1]?.raw ?? MAX_RAW;
-}
-
-/** Piecewise linear interpolation over calibration table. */
-function interpolate(raw: number, table: CalPoint[], outKey: 'actual'): number;
-function interpolate(raw: number, table: CalPoint[], outKey: 'actual'): number {
-  const v = Math.max(0, Math.min(MAX_RAW, raw));
-  if (table.length === 0) return 0;
-  if (v <= table[0].raw) return table[0][outKey];
-  for (let i = 0; i < table.length - 1; i++) {
-    const p0 = table[i];
-    const p1 = table[i + 1];
-    if (v <= p1.raw) {
-      const t = (v - p0.raw) / (p1.raw - p0.raw);
-      return p0[outKey] + t * (p1[outKey] - p0[outKey]);
-    }
-  }
-  return table[table.length - 1][outKey];
-}
-
-/** Inverse interpolation from calibrated dB-rel-S9 back to the scale raw axis. */
-function interpolateActual(actual: number, table: CalPoint[]): number {
-  if (table.length === 0) return 0;
-  const minActual = table[0].actual;
-  const maxActual = table[table.length - 1].actual;
-  const v = Math.max(minActual, Math.min(maxActual, actual));
-  if (v <= minActual) return table[0].raw;
-  for (let i = 0; i < table.length - 1; i++) {
-    const p0 = table[i];
-    const p1 = table[i + 1];
-    if (v <= p1.actual) {
-      const span = p1.actual - p0.actual;
-      const t = span === 0 ? 0 : (v - p0.actual) / span;
-      return p0.raw + t * (p1.raw - p0.raw);
-    }
-  }
-  return table[table.length - 1].raw;
-}
-
-/** Map raw to fractional S-unit (0.0 - 9.0+ range). */
-function rawToSFloat(raw: number): number {
-  const cal = getCal();
-  const s9Raw = getS9Raw();
-  const v = Math.max(0, Math.min(MAX_RAW, raw));
-
-  // Find S-unit points (labels like S0..S9)
-  const sPoints = cal.filter(p => /^S\d$/.test(p.label));
-  if (sPoints.length < 2) {
-    // Fallback: linear
-    return (v / s9Raw) * 9;
-  }
-
-  // Interpolate through S-unit points
-  for (let i = 0; i < sPoints.length - 1; i++) {
-    const p0 = sPoints[i];
-    const p1 = sPoints[i + 1];
-    const s0 = parseInt(p0.label.slice(1));
-    const s1 = parseInt(p1.label.slice(1));
-    if (v <= p1.raw) {
-      const t = Math.max(0, (v - p0.raw) / (p1.raw - p0.raw));
-      return s0 + t * (s1 - s0);
-    }
-  }
-  return 9;
+  return getScaleMaxRawForCalibration(getCal());
 }
 
 /** Map raw 0-255 to fractional segment count 0-20. */
 export function rawToSegments(raw: number): number {
-  const s9Raw = getS9Raw();
-  const maxRaw = Math.max(s9Raw + 1, getScaleMaxRaw());
-  const v = Math.max(0, Math.min(maxRaw, raw));
-  if (v <= s9Raw) {
-    return (rawToSFloat(v) / 9) * 11;
-  }
-  return 11 + ((v - s9Raw) / (maxRaw - s9Raw)) * 9;
+  return rawToSegmentsForCalibration(raw, getCal());
 }
 
 /** Map raw 0-255 to S-unit string, e.g. "S7", "S9+20". Falls back to the
  *  plain raw number (no "S" claim) when the radio has no calibration table
  *  (MOR-1451) — never a reading borrowed from a different radio's curve. */
 export function rawToSUnit(raw: number): string {
-  const v = Math.max(0, Math.min(MAX_RAW, raw));
-  if (!isSmeterCalibrated()) return String(Math.round(v));
-
-  const s9Raw = getS9Raw();
-
-  if (v <= s9Raw) {
-    const s = Math.floor(rawToSFloat(v));
-    return `S${Math.min(9, s)}`;
-  }
-
-  // Over S9: an honest, continuous dB-over-S9 reading interpolated from
-  // the profile's own table (MOR-2024) — not a knot-snapped label. The
-  // previous version walked the declared over-S9 knots backwards and
-  // returned the first one at or below `v`, which silently under-reported
-  // any raw strictly between two knots, and fell through to the bare
-  // literal "S9+" with no number at all once `v` was short of every
-  // declared knot (e.g. a profile with a single over-point leaves a wide
-  // gap right above S9 where that used to happen).
-  const over = Math.round(interpolate(v, getCal(), 'actual'));
-  return over > 0 ? `S9+${over}` : 'S9';
+  return rawToSUnitForCalibration(raw, getCal());
 }
 
 /** Map raw 0-255 to dBm value (linear interpolation between calibration
@@ -171,25 +85,23 @@ export function rawToSUnit(raw: number): string {
  *  honest-fallback text functions below detect that state themselves and
  *  never present the passthrough as a real dBm reading (MOR-1451). */
 export function rawToDbm(raw: number): number {
-  if (!isSmeterCalibrated()) return Math.round(Math.max(0, Math.min(MAX_RAW, raw)));
-  return Math.round(interpolate(raw, getCal(), 'actual'));
+  return rawToDbmForCalibration(raw, getCal());
 }
 
 /** Map calibrated dB-rel-S9 from backend state to the raw axis used by the
  *  UI scale. Identity passthrough when uncalibrated, matching `rawToDbm`. */
 export function calibratedToRaw(actual: number): number {
-  if (!isSmeterCalibrated()) return Math.max(0, Math.min(MAX_RAW, actual));
-  return interpolateActual(actual, getCal());
+  return calibratedToRawForCalibration(actual, getCal());
 }
 
 /** Map calibrated dB-rel-S9 to fractional segment count 0-20 for the top S-meter. */
 export function calibratedToSegments(actual: number): number {
-  return rawToSegments(calibratedToRaw(actual));
+  return calibratedToSegmentsForCalibration(actual, getCal());
 }
 
 /** Map calibrated dB-rel-S9 to an S-unit label, e.g. "S7", "S9+20". */
 export function calibratedToSUnit(actual: number): string {
-  return rawToSUnit(calibratedToRaw(actual));
+  return calibratedToSUnitForCalibration(actual, getCal());
 }
 
 /** Map calibrated dB-rel-S9 to user-facing dBm referenced to S9=-73 dBm.
@@ -197,12 +109,7 @@ export function calibratedToSUnit(actual: number): string {
  *  would be a fabricated physical unit, not a passthrough (MOR-1451);
  *  `formatDbm` renders this as an explicit "uncalibrated" label. */
 export function calibratedToDbm(actual: number): number | null {
-  if (!isSmeterCalibrated()) return null;
-  const cal = getCal();
-  const minActual = cal[0].actual;
-  const maxActual = cal[cal.length - 1].actual;
-  const clamped = Math.max(minActual, Math.min(maxActual, actual));
-  return Math.round(S9_DBM + clamped);
+  return calibratedToDbmForCalibration(actual, getCal());
 }
 
 function colorForActual(actual: number): string {
@@ -231,12 +138,10 @@ export function getScaleMarks(): SmeterMark[] {
 
 /** Format dBm value as display string, e.g. "−67 dBm". Uses Unicode minus. */
 export function formatDbm(dbm: number | null): string {
-  if (dbm === null) return 'uncalibrated';
-  const sign = dbm < 0 ? '\u2212' : '+';
-  return `${sign}${Math.abs(dbm)} dBm`;
+  return formatDbmForCalibration(dbm);
 }
 
 /** Get full calibration table for rendering scale ticks. */
-export function getCalibrationPoints(): CalPoint[] {
+export function getCalibrationPoints(): SmeterCalibrationPoint[] {
   return getCal();
 }

--- a/frontend/src/components-v2/panels/meter-utils.test.ts
+++ b/frontend/src/components-v2/panels/meter-utils.test.ts
@@ -118,7 +118,8 @@ import {
   peakHoldDisplay,
   type PeakHoldState,
 } from './meter-utils';
-import { isSmeterCalibrated } from '../meters/smeter-scale';
+import { calibratedToRaw as calibratedToRawFromFacade, isSmeterCalibrated } from '../meters/smeter-scale';
+import { calibratedToSegments } from '../../primitives/meters/s-meter-scale';
 
 beforeEach(() => {
   setCapabilities(makeCaps({
@@ -664,6 +665,26 @@ describe('sLevel (calibrated bar)', () => {
   });
   it('returns the S9 marker position for a calibrated 0 dB-rel-S9 reading', () => {
     expect(sLevel(0)).toBeCloseTo(130 / 240);
+    expect(sLevel(0)).not.toBeCloseTo(calibratedToSegments(0, IC7610_LIKE_S_METER_CAL) / 20);
+  });
+});
+
+describe('S-meter live profile replacement', () => {
+  it('uses the current profile on each facade and panel-adapter call', () => {
+    setCapabilities(makeCaps({
+      meterCalibrations: { s_meter: IC7610_LIKE_S_METER_CAL },
+    }));
+    expect(calibratedToRawFromFacade(0)).toBe(130);
+    expect(sLevel(0)).toBeCloseTo(130 / 240);
+
+    const ic7300Calibration = [
+      { raw: 0, actual: -54, label: 'S0' },
+      { raw: 120, actual: 0, label: 'S9' },
+      { raw: 241, actual: 60, label: 'S9+60' },
+    ];
+    setCapabilities(makeCaps({ meterCalibrations: { s_meter: ic7300Calibration } }));
+    expect(calibratedToRawFromFacade(0)).toBe(120);
+    expect(sLevel(0)).toBeCloseTo(120 / 241);
   });
 });
 

--- a/frontend/src/components-v2/panels/meter-utils.ts
+++ b/frontend/src/components-v2/panels/meter-utils.ts
@@ -26,17 +26,12 @@ import {
   getMeterRedline,
 } from '$lib/runtime/adapters/capabilities-adapter';
 import type { MeterCalPoint } from '$lib/runtime/adapters/capabilities-adapter';
-// `formatSMeter`'s calibrated branch defers to the one table-driven S-unit
-// reader (MOR-2024) instead of keeping a second copy of that math here.
-// `isSmeterCalibrated` is reused from the same import instead of a second
-// local "is there a curve" check -- the two were never byte-for-byte
-// duplicates (this file's check went through `getSmeterKnots()`, gated at
-// `length >= 2`; the imported one tested `length > 0` directly), so the
-// swap silently loosened the gate to one knot until `smeter-scale.ts`'s
-// `isSmeterCalibrated` was fixed (MOR-2024) to also require `length >= 2`
-// -- interpolation needs two points to define a line, so a single knot
-// cannot support a calibrated reading.
-import { calibratedToSUnit, isSmeterCalibrated } from '../meters/smeter-scale';
+import {
+  calibratedToRaw,
+  calibratedToSUnit,
+  getCalibratedScaleMaxRaw,
+  isSmeterCalibrated,
+} from '../../primitives/meters/s-meter-scale';
 
 export type MeterSource = 'S' | 'SWR' | 'POWER' | 'po';
 
@@ -202,39 +197,6 @@ export function compLevel(value: number): number {
 
 // ---- S-meter (dB-rel-S9 when calibrated; MOR-1451) ----
 
-function getSmeterKnots(): [number, number][] {
-  const cal = getMeterCalibration('s_meter');
-  if (!cal || cal.length < 2) return [];
-  return cal.map((p) => [p.raw, p.actual] as [number, number]);
-}
-
-function getSmeterMaxRaw(): number {
-  const knots = getSmeterKnots();
-  return knots.length > 0 ? knots[knots.length - 1][0] : RAW_SCALE_MAX;
-}
-
-/** Identity passthrough when uncalibrated, matching `smeter-scale.ts`'s
- *  `calibratedToRaw`. */
-function calibratedSmeterToRaw(actual: number): number {
-  const knots = getSmeterKnots();
-  if (knots.length === 0) return Math.max(0, Math.min(RAW_SCALE_MAX, actual));
-  const minActual = knots[0][1];
-  const maxActual = knots[knots.length - 1][1];
-  const clamped = Math.max(minActual, Math.min(maxActual, actual));
-
-  for (let i = 0; i < knots.length - 1; i++) {
-    const [raw0, actual0] = knots[i];
-    const [raw1, actual1] = knots[i + 1];
-    if (clamped <= actual1) {
-      const span = actual1 - actual0;
-      const t = span === 0 ? 0 : (clamped - actual0) / span;
-      return raw0 + t * (raw1 - raw0);
-    }
-  }
-
-  return knots[knots.length - 1][0];
-}
-
 /**
  * Formats calibrated S-meter value (dB relative to S9) as an S-unit string.
  * Falls back to the honest raw-tagged reading (`formatRaw`, e.g. "53 raw";
@@ -250,16 +212,18 @@ function calibratedSmeterToRaw(actual: number): number {
  * FTX-1's real S0-S9 steps are 6/3/3/3/3/3/15/9/9 dB).
  */
 export function formatSMeter(actual: number): string {
-  if (!isSmeterCalibrated()) {
+  const calibration = getMeterCalibration('s_meter') ?? [];
+  if (!isSmeterCalibrated(calibration)) {
     return formatRaw(actual);
   }
-  return calibratedToSUnit(actual);
+  return calibratedToSUnit(actual, calibration);
 }
 
 /** Bar level for calibrated S-meter values relative to the UI scale full-scale. */
 export function sLevel(actual: number): number {
-  const scaleMaxRaw = getSmeterMaxRaw();
-  const scaled = calibratedSmeterToRaw(actual);
+  const calibration = getMeterCalibration('s_meter') ?? [];
+  const scaleMaxRaw = getCalibratedScaleMaxRaw(calibration);
+  const scaled = calibratedToRaw(actual, calibration);
   return scaleMaxRaw > 0 ? Math.max(0, Math.min(1, scaled / scaleMaxRaw)) : 0;
 }
 

--- a/frontend/src/primitives/meters/__tests__/s-meter-scale.test.ts
+++ b/frontend/src/primitives/meters/__tests__/s-meter-scale.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  calibratedToDbm,
+  calibratedToRaw,
+  calibratedToSegments,
+  calibratedToSUnit,
+  getCalibratedScaleMaxRaw,
+  formatDbm,
+  getS9Raw,
+  getScaleMaxRaw,
+  isSmeterCalibrated,
+  rawToSegments,
+  rawToSUnit,
+  type SmeterCalibrationPoint,
+} from '../s-meter-scale';
+
+const FTX1_CALIBRATION: readonly SmeterCalibrationPoint[] = [
+  { raw: 0, actual: -54, label: 'S0' },
+  { raw: 13, actual: -51, label: 'S0.5' },
+  { raw: 26, actual: -48, label: 'S1' },
+  { raw: 39, actual: -45, label: 'S2' },
+  { raw: 52, actual: -42, label: 'S3' },
+  { raw: 65, actual: -39, label: 'S4' },
+  { raw: 78, actual: -36, label: 'S5' },
+  { raw: 91, actual: -33, label: 'S6' },
+  { raw: 103, actual: -18, label: 'S7' },
+  { raw: 117, actual: -9, label: 'S8' },
+  { raw: 130, actual: 0, label: 'S9' },
+  { raw: 165, actual: 10, label: 'S9+10' },
+  { raw: 200, actual: 20, label: 'S9+20' },
+  { raw: 240, actual: 40, label: 'S9+40' },
+];
+
+describe('pure S-meter calibration', () => {
+  it('uses the nonuniform profile for inverse mapping, labels, and dBm', () => {
+    expect(calibratedToRaw(-33, FTX1_CALIBRATION)).toBe(91);
+    expect(calibratedToRaw(0, FTX1_CALIBRATION)).toBe(130);
+    expect(calibratedToRaw(40, FTX1_CALIBRATION)).toBe(240);
+    expect(calibratedToSUnit(-33, FTX1_CALIBRATION)).toBe('S6');
+    expect(formatDbm(calibratedToDbm(-33, FTX1_CALIBRATION))).toBe('\u2212106 dBm');
+  });
+
+  it('preserves both S-axis breakpoints and endpoints', () => {
+    expect(getS9Raw(FTX1_CALIBRATION)).toBe(130);
+    expect(getScaleMaxRaw(FTX1_CALIBRATION)).toBe(240);
+    expect(rawToSegments(129, FTX1_CALIBRATION)).toBeLessThan(11);
+    expect(rawToSegments(130, FTX1_CALIBRATION)).toBe(11);
+    expect(rawToSegments(131, FTX1_CALIBRATION)).toBeGreaterThan(11);
+    expect(rawToSegments(240, FTX1_CALIBRATION)).toBe(20);
+    expect(calibratedToSegments(0, FTX1_CALIBRATION)).toBe(11);
+    expect(calibratedToSegments(40, FTX1_CALIBRATION)).toBe(20);
+  });
+
+  it('keeps empty and single-knot profiles uncalibrated', () => {
+    const single = [{ raw: 130, actual: 0, label: 'S9' }] as const;
+
+    expect(isSmeterCalibrated([])).toBe(false);
+    expect(isSmeterCalibrated(single)).toBe(false);
+    expect(getCalibratedScaleMaxRaw(single)).toBe(255);
+    expect(calibratedToRaw(53, [])).toBe(53);
+    expect(calibratedToRaw(53, single)).toBe(53);
+    expect(rawToSUnit(53, single)).toBe('53');
+    expect(calibratedToDbm(53, single)).toBeNull();
+  });
+
+  it('retains input-order semantics for an unsorted profile', () => {
+    const unsorted = [FTX1_CALIBRATION[0], FTX1_CALIBRATION[10], FTX1_CALIBRATION[7]];
+
+    expect(calibratedToRaw(0, unsorted)).toBeCloseTo(130 * (21 / 54));
+  });
+});

--- a/frontend/src/primitives/meters/s-meter-scale.ts
+++ b/frontend/src/primitives/meters/s-meter-scale.ts
@@ -1,0 +1,128 @@
+export interface SmeterCalibrationPoint {
+  raw: number;
+  actual: number;
+  label: string;
+}
+
+const MAX_RAW = 255;
+const S9_DBM = -73;
+
+function clampRaw(raw: number): number {
+  return Math.max(0, Math.min(MAX_RAW, raw));
+}
+
+export function isSmeterCalibrated(calibration: readonly SmeterCalibrationPoint[]): boolean {
+  return calibration.length >= 2;
+}
+
+export function getS9Raw(calibration: readonly SmeterCalibrationPoint[]): number {
+  return calibration.find((point) => point.label === 'S9')?.raw ?? MAX_RAW / 2;
+}
+
+export function getScaleMaxRaw(calibration: readonly SmeterCalibrationPoint[]): number {
+  return calibration[calibration.length - 1]?.raw ?? MAX_RAW;
+}
+
+export function getCalibratedScaleMaxRaw(calibration: readonly SmeterCalibrationPoint[]): number {
+  return isSmeterCalibrated(calibration) ? getScaleMaxRaw(calibration) : MAX_RAW;
+}
+
+function interpolateRaw(raw: number, calibration: readonly SmeterCalibrationPoint[]): number {
+  const value = clampRaw(raw);
+  if (calibration.length === 0) return 0;
+  if (value <= calibration[0].raw) return calibration[0].actual;
+  for (let index = 0; index < calibration.length - 1; index += 1) {
+    const start = calibration[index];
+    const end = calibration[index + 1];
+    if (value <= end.raw) {
+      const t = (value - start.raw) / (end.raw - start.raw);
+      return start.actual + t * (end.actual - start.actual);
+    }
+  }
+  return calibration[calibration.length - 1].actual;
+}
+
+export function calibratedToRaw(actual: number, calibration: readonly SmeterCalibrationPoint[]): number {
+  if (!isSmeterCalibrated(calibration)) return clampRaw(actual);
+
+  const minActual = calibration[0].actual;
+  const maxActual = calibration[calibration.length - 1].actual;
+  const value = Math.max(minActual, Math.min(maxActual, actual));
+  if (value <= minActual) return calibration[0].raw;
+  for (let index = 0; index < calibration.length - 1; index += 1) {
+    const start = calibration[index];
+    const end = calibration[index + 1];
+    if (value <= end.actual) {
+      const span = end.actual - start.actual;
+      const t = span === 0 ? 0 : (value - start.actual) / span;
+      return start.raw + t * (end.raw - start.raw);
+    }
+  }
+  return calibration[calibration.length - 1].raw;
+}
+
+function rawToSFloat(raw: number, calibration: readonly SmeterCalibrationPoint[]): number {
+  const s9Raw = getS9Raw(calibration);
+  const value = clampRaw(raw);
+  const sPoints = calibration.filter((point) => /^S\d$/.test(point.label));
+  if (sPoints.length < 2) return (value / s9Raw) * 9;
+
+  for (let index = 0; index < sPoints.length - 1; index += 1) {
+    const start = sPoints[index];
+    const end = sPoints[index + 1];
+    const startUnit = parseInt(start.label.slice(1), 10);
+    const endUnit = parseInt(end.label.slice(1), 10);
+    if (value <= end.raw) {
+      const t = Math.max(0, (value - start.raw) / (end.raw - start.raw));
+      return startUnit + t * (endUnit - startUnit);
+    }
+  }
+  return 9;
+}
+
+export function rawToSegments(raw: number, calibration: readonly SmeterCalibrationPoint[]): number {
+  const s9Raw = getS9Raw(calibration);
+  const maxRaw = Math.max(s9Raw + 1, getScaleMaxRaw(calibration));
+  const value = Math.max(0, Math.min(maxRaw, raw));
+  if (value <= s9Raw) return (rawToSFloat(value, calibration) / 9) * 11;
+  return 11 + ((value - s9Raw) / (maxRaw - s9Raw)) * 9;
+}
+
+export function rawToSUnit(raw: number, calibration: readonly SmeterCalibrationPoint[]): string {
+  const value = clampRaw(raw);
+  if (!isSmeterCalibrated(calibration)) return String(Math.round(value));
+  const s9Raw = getS9Raw(calibration);
+  if (value <= s9Raw) return `S${Math.min(9, Math.floor(rawToSFloat(value, calibration)))}`;
+
+  const over = Math.round(interpolateRaw(value, calibration));
+  return over > 0 ? `S9+${over}` : 'S9';
+}
+
+export function rawToDbm(raw: number, calibration: readonly SmeterCalibrationPoint[]): number {
+  if (!isSmeterCalibrated(calibration)) return Math.round(clampRaw(raw));
+  return Math.round(interpolateRaw(raw, calibration));
+}
+
+export function calibratedToSegments(actual: number, calibration: readonly SmeterCalibrationPoint[]): number {
+  return rawToSegments(calibratedToRaw(actual, calibration), calibration);
+}
+
+export function calibratedToSUnit(actual: number, calibration: readonly SmeterCalibrationPoint[]): string {
+  return rawToSUnit(calibratedToRaw(actual, calibration), calibration);
+}
+
+export function calibratedToDbm(
+  actual: number,
+  calibration: readonly SmeterCalibrationPoint[],
+): number | null {
+  if (!isSmeterCalibrated(calibration)) return null;
+  const minActual = calibration[0].actual;
+  const maxActual = calibration[calibration.length - 1].actual;
+  return Math.round(S9_DBM + Math.max(minActual, Math.min(maxActual, actual)));
+}
+
+export function formatDbm(dbm: number | null): string {
+  if (dbm === null) return 'uncalibrated';
+  const sign = dbm < 0 ? '\u2212' : '+';
+  return `${sign}${Math.abs(dbm)} dBm`;
+}


### PR DESCRIPTION
## Summary
- extract deterministic S-meter calibration and inverse mapping into `primitives/meters/s-meter-scale.ts`
- retain live capability lookup in both higher adapters and remove the panel inverse duplicate
- preserve distinct `sLevel` raw/scale-max normalization and S-axis 20-segment geometry

Linear: MOR-2386 (child of MOR-2215).

## Verification
- `npx vitest run src/primitives/meters/__tests__/s-meter-scale.test.ts src/components-v2/panels/meter-utils.test.ts src/components-v2/meters/__tests__/smeter-no-double-conversion.test.ts src/components-v2/meters/__tests__/meter-contract.test.ts` (106 passed)
- `npm run check`
- changed-path ESLint
- `npm run lint:boundaries`
- `git diff --check`

No Svelte, CSS, baseline, or visual-output changes.

## Scope
One calibration extraction and its only duplicate inverse consumer are a single contract; the final diff is 5 files and 431 changed lines.