### PR TITLE
feat: add continuous scalar behavior foundation (MOR-2383)

### DIFF
--- a/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
+++ b/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
@@ -207,6 +207,33 @@ describe('continuous scalar source policies', () => {
     expect(confirmed.request).toHaveBeenLastCalledWith(2_410);
   });
 
+  it('suppresses HBar pointer, key, and reset at canonical but still sends boundary wheel', () => {
+    const policy = createHBarContinuousScalarPolicy({ preview: 'optimistic', debounceMs: 0 });
+    const atMax = readingSetup(policy, {
+      domain: { ...DOMAIN, defaultValue: 5_000 },
+      reading: { status: 'known', value: 5_000 },
+    });
+    const lease = atMax.scalar.attachRenderer();
+    const token = lease.beginPointer()!;
+    lease.pointer(token, 5_000);
+    expect(lease.key({ key: 'ArrowRight', fine: false })).toBe(true);
+    lease.reset();
+    expect(atMax.request).not.toHaveBeenCalled();
+    lease.wheel({ direction: 1, fine: false });
+    expect(atMax.request).toHaveBeenCalledExactlyOnceWith(5_000);
+    lease.dispose();
+
+    const pending = commandSetup(policy, { feedback: feedback('submitted', {
+      target: 2_700, requestedTarget: 2_700, lifecycleId: 'pending-target',
+    }) });
+    const pendingLease = pending.scalar.attachRenderer();
+    const pendingToken = pendingLease.beginPointer()!;
+    pendingLease.pointer(pendingToken, 2_700);
+    pendingLease.pointer(pendingToken, 2_700);
+    expect(pending.request.mock.calls).toEqual([[2_700], [2_700]]);
+    pendingLease.dispose();
+  });
+
   it('uses caller debounce for HBar keys and reset but not pointer or wheel', () => {
     vi.useFakeTimers();
     const { scalar, request } = commandSetup();
@@ -224,7 +251,7 @@ describe('continuous scalar source policies', () => {
     vi.advanceTimersByTime(49);
     expect(request).toHaveBeenCalledTimes(2);
     vi.advanceTimersByTime(1);
-    expect(request).toHaveBeenLastCalledWith(2_400);
+    expect(request).toHaveBeenLastCalledWith(2_800);
     vi.useRealTimers();
   });
 });
@@ -251,15 +278,17 @@ describe('continuous scalar authority and feedback reconciliation', () => {
   });
 
   it.each(['failed', 'timed-out', 'cancelled', 'superseded'] as const)(
-    'cancels draft and timers on %s while preserving outcome evidence', (phase) => {
+    'cancels pre-%s work once and permits a fresh pointer gesture', (phase) => {
       vi.useFakeTimers();
       const { scalar, request, update } = commandSetup();
       const lease = scalar.attachRenderer();
+      const staleToken = lease.beginPointer()!;
+      lease.pointer(staleToken, 2_600);
       expect(lease.key({ key: 'ArrowRight', fine: false })).toBe(true);
-      expect(scalar.view.draft).toBe(2_500);
+      expect(scalar.view.draft).toBe(2_700);
 
       const terminal = feedback(phase, {
-        requestedTarget: 2_500,
+        requestedTarget: 2_700,
         lifecycleId: 'life-1',
         transitionId: `${phase}-1`,
         outcome: { phase, error: 'radio rejected' },
@@ -272,11 +301,43 @@ describe('continuous scalar authority and feedback reconciliation', () => {
         error: 'radio rejected',
         phase,
       });
+      lease.pointer(staleToken, 2_900);
+      const freshToken = lease.beginPointer();
+      expect(freshToken).not.toBeNull();
+      lease.pointer(freshToken!, 2_800);
       vi.advanceTimersByTime(100);
-      expect(request).not.toHaveBeenCalled();
+      expect(request.mock.calls).toEqual([[2_600], [2_800]]);
       vi.useRealTimers();
     },
   );
+
+  it('keeps every intent path live when a handled terminal outcome survives a phase change', () => {
+    vi.useFakeTimers();
+    const terminal = feedback('failed', {
+      requestedTarget: 2_500,
+      lifecycleId: 'life-retained',
+      transitionId: 'failed-retained',
+      outcome: { phase: 'failed', error: 'retained' },
+    });
+    const { scalar, request, update } = commandSetup(undefined, {
+      domain: { ...DOMAIN, defaultValue: 2_700 }, feedback: terminal,
+    });
+    expect(scalar.view.error).toBe('retained');
+    update({ feedback: {
+      ...terminal, phase: 'idle', busy: false, transitionId: 'idle-after-retained',
+    } });
+    const lease = scalar.attachRenderer();
+    const token = lease.beginPointer()!;
+    lease.pointer(token, 2_600);
+    lease.nativeInput(2_650);
+    lease.wheel({ direction: 1, fine: true });
+    lease.key({ key: 'ArrowRight', fine: false });
+    vi.advanceTimersByTime(50);
+    lease.reset();
+    vi.advanceTimersByTime(50);
+    expect(request.mock.calls).toEqual([[2_600], [2_650], [2_660], [2_800], [2_700]]);
+    vi.useRealTimers();
+  });
 
   it('retires an optimistic draft when confirmation reaches it', () => {
     const { scalar, update } = commandSetup(nativeRangeContinuousScalarPolicy);

--- a/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
+++ b/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
@@ -277,14 +277,20 @@ describe('continuous scalar authority and feedback reconciliation', () => {
     expect(scalar.view.draft).toBe(2_900);
   });
 
-  it.each(['failed', 'timed-out', 'cancelled', 'superseded'] as const)(
-    'cancels pre-%s work once and permits a fresh pointer gesture', (phase) => {
+  it.each([
+    ['failed', 'key'], ['timed-out', 'reset'],
+    ['cancelled', 'key'], ['superseded', 'reset'],
+  ] as const)(
+    'cancels pre-%s %s work once and permits a fresh pointer gesture', (phase, source) => {
       vi.useFakeTimers();
-      const { scalar, request, update } = commandSetup();
+      const { scalar, request, update } = commandSetup(undefined, {
+        domain: { ...DOMAIN, defaultValue: 2_700 },
+      });
       const lease = scalar.attachRenderer();
       const staleToken = lease.beginPointer()!;
       lease.pointer(staleToken, 2_600);
-      expect(lease.key({ key: 'ArrowRight', fine: false })).toBe(true);
+      if (source === 'key') expect(lease.key({ key: 'ArrowRight', fine: false })).toBe(true);
+      else lease.reset();
       expect(scalar.view.draft).toBe(2_700);
 
       const terminal = feedback(phase, {
@@ -294,6 +300,8 @@ describe('continuous scalar authority and feedback reconciliation', () => {
         outcome: { phase, error: 'radio rejected' },
       });
       update({ feedback: terminal });
+      vi.advanceTimersByTime(50);
+      expect(request.mock.calls).toEqual([[2_600]]);
       expect(scalar.view).toMatchObject({
         feedback: terminal,
         draft: null,
@@ -305,7 +313,6 @@ describe('continuous scalar authority and feedback reconciliation', () => {
       const freshToken = lease.beginPointer();
       expect(freshToken).not.toBeNull();
       lease.pointer(freshToken!, 2_800);
-      vi.advanceTimersByTime(100);
       expect(request.mock.calls).toEqual([[2_600], [2_800]]);
       vi.useRealTimers();
     },
@@ -323,19 +330,20 @@ describe('continuous scalar authority and feedback reconciliation', () => {
       domain: { ...DOMAIN, defaultValue: 2_700 }, feedback: terminal,
     });
     expect(scalar.view.error).toBe('retained');
-    update({ feedback: {
-      ...terminal, phase: 'idle', busy: false, transitionId: 'idle-after-retained',
-    } });
     const lease = scalar.attachRenderer();
     const token = lease.beginPointer()!;
     lease.pointer(token, 2_600);
+    update({ feedback: {
+      ...terminal, phase: 'idle', busy: false, transitionId: 'idle-after-retained',
+    } });
+    lease.pointer(token, 2_620);
     lease.nativeInput(2_650);
     lease.wheel({ direction: 1, fine: true });
     lease.key({ key: 'ArrowRight', fine: false });
     vi.advanceTimersByTime(50);
     lease.reset();
     vi.advanceTimersByTime(50);
-    expect(request.mock.calls).toEqual([[2_600], [2_650], [2_660], [2_800], [2_700]]);
+    expect(request.mock.calls).toEqual([[2_600], [2_620], [2_650], [2_660], [2_800], [2_700]]);
     vi.useRealTimers();
   });
 

--- a/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
+++ b/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
@@ -1,0 +1,421 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ControlFeedback } from '$lib/runtime/adapters/panel-adapters';
+import {
+  createContinuousScalar,
+  createHBarContinuousScalarPolicy,
+  nativeRangeContinuousScalarPolicy,
+  type CommandScalarFeedback,
+  type ContinuousScalarInput,
+  type ReadingScalarInput,
+  type ScalarDomain,
+} from '../continuous-scalar.svelte';
+
+const ACTUAL_CONTRACT_FITS: ControlFeedback<number> extends CommandScalarFeedback ? true : false = true;
+
+const DOMAIN: ScalarDomain = {
+  min: 0,
+  max: 5_000,
+  step: 100,
+  defaultValue: 2_400,
+  fineStepDivisor: 10,
+};
+
+const feedback = (
+  phase: CommandScalarFeedback['phase'] = 'idle',
+  over: Partial<CommandScalarFeedback> = {},
+): Readonly<CommandScalarFeedback> => ({
+  confirmed: 2_400,
+  target: null,
+  requestedTarget: null,
+  phase,
+  busy: ['submitted', 'queued', 'dispatched', 'awaiting-confirmation'].includes(phase),
+  availability: phase === 'unavailable' ? 'unavailable' : 'available',
+  outcome: null,
+  lifecycleId: null,
+  transitionId: null,
+  sessionEpoch: 7,
+  scope: { control: 'filter-width', receiver: 0, slot: 'main' },
+  repeatPolicy: 'latest-target-wins',
+  ...over,
+});
+
+const commandInput = (
+  request: (value: number) => void,
+  over: Partial<Omit<Extract<ContinuousScalarInput, { evidence: 'command-feedback' }>, 'evidence'>> = {},
+): Extract<ContinuousScalarInput, { evidence: 'command-feedback' }> => ({
+  evidence: 'command-feedback',
+  domain: DOMAIN,
+  enabled: true,
+  request,
+  feedback: feedback(),
+  command: 'set_filter_width',
+  ...over,
+});
+
+const readingInput = (
+  request: (value: number) => void,
+  over: Partial<Omit<ReadingScalarInput, 'evidence'>> = {},
+): ReadingScalarInput => ({
+  evidence: 'reading',
+  domain: DOMAIN,
+  enabled: true,
+  request,
+  reading: { status: 'known', value: 2_400 },
+  ownerKey: 'filter-width:main',
+  ...over,
+});
+
+function commandSetup(
+  policy = createHBarContinuousScalarPolicy({ preview: 'optimistic', debounceMs: 50 }),
+  initial?: Partial<Omit<Extract<ContinuousScalarInput, { evidence: 'command-feedback' }>, 'evidence'>>,
+) {
+  const request = vi.fn<(value: number) => void>();
+  let current = commandInput(request, initial);
+  const scalar = createContinuousScalar(() => current, policy);
+  return {
+    scalar,
+    request,
+    read: () => current,
+    update: (
+      over: Partial<Omit<Extract<ContinuousScalarInput, { evidence: 'command-feedback' }>, 'evidence'>>,
+    ) => { current = { ...current, ...over }; },
+  };
+}
+
+function readingSetup(
+  policy = createHBarContinuousScalarPolicy({ preview: 'optimistic', debounceMs: 50 }),
+  initial?: Partial<Omit<ReadingScalarInput, 'evidence'>>,
+) {
+  const request = vi.fn<(value: number) => void>();
+  let current = readingInput(request, initial);
+  const scalar = createContinuousScalar(() => current, policy);
+  return {
+    scalar,
+    request,
+    read: () => current,
+    update: (over: Partial<Omit<ReadingScalarInput, 'evidence'>>) => {
+      current = { ...current, ...over };
+    },
+  };
+}
+
+describe('continuous scalar contract', () => {
+  it('keeps reading evidence honest for known, unknown, and non-finite values', () => {
+    const { scalar, request, update } = readingSetup();
+    const lease = scalar.attachRenderer();
+    expect(scalar.view).toMatchObject({
+      evidence: 'reading',
+      canonical: 2_400,
+      displayed: 2_400,
+      confirmed: null,
+      target: null,
+      requested: null,
+      phase: null,
+      presentation: null,
+      announcement: null,
+      editable: true,
+    });
+
+    update({ reading: { status: 'unknown' } });
+    expect(scalar.view).toMatchObject({ canonical: null, displayed: null, editable: false });
+    lease.nativeInput(1_500);
+    expect(request).not.toHaveBeenCalled();
+
+    update({ reading: { status: 'known', value: Number.NaN } });
+    expect(scalar.view).toMatchObject({ canonical: null, displayed: null, editable: false });
+    update({ enabled: false, reading: { status: 'known', value: 2_400 } });
+    lease.nativeInput(1_600);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('preserves the full command envelope while deriving fail-closed scalar fields', () => {
+    expect(ACTUAL_CONTRACT_FITS).toBe(true);
+    const pending = feedback('awaiting-confirmation', {
+      confirmed: 2_400,
+      target: 2_800,
+      requestedTarget: 2_800,
+      lifecycleId: 'life-1',
+      transitionId: 'transition-1',
+    });
+    const { scalar, update } = commandSetup(undefined, { feedback: pending });
+    expect(scalar.view).toMatchObject({
+      evidence: 'command-feedback',
+      feedback: pending,
+      canonical: 2_400,
+      confirmed: 2_400,
+      target: 2_800,
+      requested: 2_800,
+      phase: 'awaiting-confirmation',
+      busy: true,
+      presentation: { attributes: { 'aria-busy': 'true' } },
+      announcement: 'Awaiting confirmation: 2800',
+    });
+    expect(scalar.view.announcement).toBeNull();
+
+    const malformed = feedback('submitted', {
+      confirmed: Number.POSITIVE_INFINITY,
+      target: 2_900,
+      requestedTarget: 2_900,
+      transitionId: 'transition-2',
+    });
+    update({ feedback: malformed });
+    const malformedView = scalar.view;
+    expect(malformedView.evidence).toBe('command-feedback');
+    if (malformedView.evidence === 'command-feedback') expect(malformedView.feedback).toBe(malformed);
+    expect(malformedView).toMatchObject({ canonical: null, displayed: null, editable: false });
+  });
+});
+
+describe('continuous scalar source policies', () => {
+  it('makes native input immediate and tokenless without wheel or key reinterpretation', () => {
+    const { scalar, request } = readingSetup(nativeRangeContinuousScalarPolicy, {
+      reading: { status: 'known', value: 2_450 },
+    });
+    const lease = scalar.attachRenderer();
+    lease.nativeInput(2_561);
+    expect(request).toHaveBeenCalledExactlyOnceWith(2_600);
+    expect(scalar.view).toMatchObject({
+      interaction: 'native-input', canonical: 2_450, draft: 2_600, displayed: 2_600,
+    });
+    expect(lease.key({ key: 'ArrowRight', fine: false })).toBe(false);
+    lease.wheel({ direction: 1, fine: false });
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps optimistic and confirmed HBar display/base policies explicit', () => {
+    const optimisticPolicy = createHBarContinuousScalarPolicy({ preview: 'optimistic', debounceMs: 0 });
+    expect(optimisticPolicy.wheel(1_000, { direction: 1, fine: false }, DOMAIN)).toBe(5_000);
+    const optimistic = readingSetup(optimisticPolicy);
+    const confirmed = readingSetup(
+      createHBarContinuousScalarPolicy({ preview: 'confirmed', debounceMs: 0 }),
+    );
+    const optimisticLease = optimistic.scalar.attachRenderer();
+    const confirmedLease = confirmed.scalar.attachRenderer();
+
+    optimisticLease.wheel({ direction: 1, fine: true });
+    confirmedLease.wheel({ direction: 1, fine: true });
+    expect(optimistic.request).toHaveBeenCalledWith(2_410);
+    expect(confirmed.request).toHaveBeenCalledWith(2_410);
+    expect(optimistic.scalar.view.displayed).toBe(2_410);
+    expect(optimistic.scalar.view.interactionBase).toBe(2_410);
+    expect(confirmed.scalar.view.displayed).toBe(2_400);
+    expect(confirmed.scalar.view.interactionBase).toBe(2_400);
+
+    optimisticLease.key({ key: 'ArrowRight', fine: true });
+    confirmedLease.key({ key: 'ArrowRight', fine: true });
+    expect(optimistic.request).toHaveBeenLastCalledWith(2_420);
+    expect(confirmed.request).toHaveBeenLastCalledWith(2_410);
+  });
+
+  it('uses caller debounce for HBar keys and reset but not pointer or wheel', () => {
+    vi.useFakeTimers();
+    const { scalar, request } = commandSetup();
+    const lease = scalar.attachRenderer();
+    const token = lease.beginPointer();
+    expect(token).not.toBeNull();
+    lease.pointer(token!, 2_700);
+    lease.wheel({ direction: 1, fine: true });
+    expect(request.mock.calls).toEqual([[2_700], [2_710]]);
+
+    expect(lease.key({ key: 'ArrowRight', fine: false })).toBe(true);
+    expect(lease.key({ key: 'PageDown', fine: false })).toBe(false);
+    lease.reset();
+    expect(request).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(49);
+    expect(request).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(1);
+    expect(request).toHaveBeenLastCalledWith(2_400);
+    vi.useRealTimers();
+  });
+});
+
+describe('continuous scalar authority and feedback reconciliation', () => {
+  it('does not abort a live drag for changing same-authority pending feedback', () => {
+    const { scalar, request, update, read } = commandSetup();
+    const lease = scalar.attachRenderer();
+    const token = lease.beginPointer()!;
+    lease.pointer(token, 2_700);
+
+    update({ feedback: feedback('submitted', {
+      target: 2_700, requestedTarget: 2_700, lifecycleId: 'life-1', transitionId: 'submitted-1',
+    }) });
+    expect(scalar.view.draft).toBe(2_700);
+    update({ feedback: {
+      ...read().feedback,
+      phase: 'awaiting-confirmation',
+      transitionId: 'awaiting-1',
+    } });
+    lease.pointer(token, 2_900);
+    expect(request.mock.calls).toEqual([[2_700], [2_900]]);
+    expect(scalar.view.draft).toBe(2_900);
+  });
+
+  it.each(['failed', 'timed-out', 'cancelled', 'superseded'] as const)(
+    'cancels draft and timers on %s while preserving outcome evidence', (phase) => {
+      vi.useFakeTimers();
+      const { scalar, request, update } = commandSetup();
+      const lease = scalar.attachRenderer();
+      expect(lease.key({ key: 'ArrowRight', fine: false })).toBe(true);
+      expect(scalar.view.draft).toBe(2_500);
+
+      const terminal = feedback(phase, {
+        requestedTarget: 2_500,
+        lifecycleId: 'life-1',
+        transitionId: `${phase}-1`,
+        outcome: { phase, error: 'radio rejected' },
+      });
+      update({ feedback: terminal });
+      expect(scalar.view).toMatchObject({
+        feedback: terminal,
+        draft: null,
+        displayed: 2_400,
+        error: 'radio rejected',
+        phase,
+      });
+      vi.advanceTimersByTime(100);
+      expect(request).not.toHaveBeenCalled();
+      vi.useRealTimers();
+    },
+  );
+
+  it('retires an optimistic draft when confirmation reaches it', () => {
+    const { scalar, update } = commandSetup(nativeRangeContinuousScalarPolicy);
+    const lease = scalar.attachRenderer();
+    lease.nativeInput(2_700);
+    update({ feedback: feedback('confirmed', {
+      confirmed: 2_700,
+      requestedTarget: 2_700,
+      lifecycleId: 'life-1',
+      transitionId: 'confirmed-1',
+      outcome: { phase: 'confirmed' },
+    }) });
+    expect(scalar.view).toMatchObject({ canonical: 2_700, draft: null, displayed: 2_700, interaction: 'idle' });
+  });
+
+  it('reconciles reading updates as canonical values, not invented authority sessions', () => {
+    const { scalar, request, update } = readingSetup();
+    const lease = scalar.attachRenderer();
+    const token = lease.beginPointer()!;
+    lease.pointer(token, 2_700);
+    update({ reading: { status: 'known', value: 2_500 } });
+    expect(scalar.view).toMatchObject({ canonical: 2_500, draft: 2_700 });
+    lease.pointer(token, 2_800);
+    expect(request.mock.calls).toEqual([[2_700], [2_800]]);
+  });
+});
+
+describe('continuous scalar deferred work', () => {
+  it('dispatches a debounced candidate through the current request callback', () => {
+    vi.useFakeTimers();
+    const original = vi.fn<(value: number) => void>();
+    const replacement = vi.fn<(value: number) => void>();
+    let current = readingInput(original);
+    const scalar = createContinuousScalar(
+      () => current,
+      createHBarContinuousScalarPolicy({ preview: 'optimistic', debounceMs: 50 }),
+    );
+    const lease = scalar.attachRenderer();
+    lease.key({ key: 'ArrowRight', fine: false });
+    current = { ...current, request: replacement };
+    vi.advanceTimersByTime(50);
+    expect(original).not.toHaveBeenCalled();
+    expect(replacement).toHaveBeenCalledExactlyOnceWith(2_500);
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ['epoch', { feedback: feedback('idle', { sessionEpoch: 8 }) }],
+    ['receiver', { feedback: feedback('idle', { scope: { control: 'filter-width', receiver: 1, slot: 'main' } }) }],
+    ['control', { feedback: feedback('idle', { scope: { control: 'other', receiver: 0, slot: 'main' } }) }],
+    ['slot', { feedback: feedback('idle', { scope: { control: 'filter-width', receiver: 0, slot: 'sub' } }) }],
+    ['command', { command: 'set_other' }],
+    ['domain', { domain: { ...DOMAIN, max: 4_000 } }],
+    ['availability', { feedback: feedback('unavailable', { confirmed: null }) }],
+  ] as const)('drops command debounce after %s replacement', (_label, replacement) => {
+    vi.useFakeTimers();
+    const { scalar, request, update } = commandSetup();
+    const lease = scalar.attachRenderer();
+    lease.key({ key: 'ArrowRight', fine: false });
+    update(replacement);
+    vi.advanceTimersByTime(50);
+    expect(request).not.toHaveBeenCalled();
+    expect(scalar.view.draft).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ['owner', { ownerKey: 'filter-width:sub' }],
+    ['knownness', { reading: { status: 'unknown' as const } }],
+    ['domain', { domain: { ...DOMAIN, step: 50 } }],
+    ['enabled gate', { enabled: false }],
+  ] as const)('drops reading debounce after %s replacement', (_label, replacement) => {
+    vi.useFakeTimers();
+    const { scalar, request, update } = readingSetup();
+    const lease = scalar.attachRenderer();
+    lease.key({ key: 'ArrowRight', fine: false });
+    update(replacement);
+    vi.advanceTimersByTime(50);
+    expect(request).not.toHaveBeenCalled();
+    expect(scalar.view.draft).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it('restarts one wheel hold and actively reconciles at expiry', () => {
+    vi.useFakeTimers();
+    const { scalar, request, update } = readingSetup();
+    const lease = scalar.attachRenderer();
+    lease.wheel({ direction: 1, fine: true });
+    vi.advanceTimersByTime(200);
+    lease.wheel({ direction: 1, fine: true });
+    update({ reading: { status: 'known', value: 2_500 } });
+    vi.advanceTimersByTime(299);
+    expect(scalar.view).toMatchObject({ interaction: 'wheel', draft: 2_420, displayed: 2_420 });
+    vi.advanceTimersByTime(1);
+    expect(scalar.view).toMatchObject({ interaction: 'idle', draft: null, displayed: 2_500 });
+    expect(request.mock.calls).toEqual([[2_410], [2_420]]);
+    vi.useRealTimers();
+  });
+});
+
+describe('continuous scalar renderer leases and cleanup', () => {
+  it('makes replaced renderer callbacks and stale gesture tokens inert', () => {
+    vi.useFakeTimers();
+    const { scalar, request } = readingSetup();
+    const rendererA = scalar.attachRenderer();
+    const tokenA = rendererA.beginPointer()!;
+    rendererA.pointer(tokenA, 2_700);
+    rendererA.key({ key: 'ArrowRight', fine: false });
+
+    const rendererB = scalar.attachRenderer();
+    expect(scalar.view).toMatchObject({ draft: null, interaction: 'idle' });
+    rendererA.pointer(tokenA, 3_000);
+    rendererA.nativeInput(3_100);
+    rendererA.wheel({ direction: 1, fine: false });
+    rendererA.reset();
+    rendererA.dispose();
+    vi.advanceTimersByTime(100);
+    expect(request.mock.calls).toEqual([[2_700]]);
+
+    const tokenB = rendererB.beginPointer()!;
+    rendererB.pointer(tokenA, 3_200);
+    rendererB.pointer(tokenB, 2_900);
+    expect(request.mock.calls).toEqual([[2_700], [2_900]]);
+    vi.useRealTimers();
+  });
+
+  it('destroy clears timers and permanently forbids future intents', () => {
+    vi.useFakeTimers();
+    const { scalar, request } = readingSetup();
+    const lease = scalar.attachRenderer();
+    lease.key({ key: 'ArrowRight', fine: false });
+    lease.wheel({ direction: 1, fine: true });
+    scalar.destroy();
+    vi.advanceTimersByTime(1_000);
+    lease.nativeInput(3_000);
+    lease.wheel({ direction: 1, fine: true });
+    lease.reset();
+    expect(request.mock.calls).toEqual([[2_510]]);
+    expect(scalar.attachRenderer().beginPointer()).toBeNull();
+    vi.useRealTimers();
+  });
+});

--- a/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
+++ b/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
@@ -1,0 +1,477 @@
+import {
+  projectControlFeedbackPresentation,
+  type ControlFeedbackPresentation,
+  type ControlFeedbackPresentationInput,
+  type ControlFeedbackPresentationState,
+  type PresentationPhase,
+} from '../control-feedback/control-feedback-presentation';
+import { clamp, handleKeyboardStep, snapToStep } from './value-control-core';
+
+export type ScalarPhase = PresentationPhase;
+
+export interface ScalarDomain {
+  readonly min: number;
+  readonly max: number;
+  readonly step: number;
+  readonly defaultValue: number | null;
+  readonly fineStepDivisor: number;
+  readonly keyboardStep?: number;
+}
+
+export interface CommandScalarFeedback extends ControlFeedbackPresentationInput<number> {
+  readonly busy: boolean;
+  readonly availability: 'available' | 'unavailable';
+  readonly lifecycleId: string | null;
+  readonly sessionEpoch: number;
+  readonly scope: Readonly<{ control: string; receiver: 0 | 1; slot?: string }>;
+  readonly repeatPolicy: 'latest-target-wins';
+}
+
+export type ScalarReading =
+  | Readonly<{ status: 'known'; value: number }>
+  | Readonly<{ status: 'unknown' }>;
+
+interface ContinuousScalarInputBase {
+  readonly domain: ScalarDomain;
+  readonly enabled: boolean;
+  readonly request: (value: number) => void;
+}
+
+export interface CommandFeedbackScalarInput extends ContinuousScalarInputBase {
+  readonly evidence: 'command-feedback';
+  readonly feedback: Readonly<CommandScalarFeedback>;
+  readonly command: string;
+}
+
+export interface ReadingScalarInput extends ContinuousScalarInputBase {
+  readonly evidence: 'reading';
+  readonly reading: ScalarReading;
+  readonly ownerKey: string;
+}
+
+export type ContinuousScalarInput = CommandFeedbackScalarInput | ReadingScalarInput;
+export type ScalarSource = 'native-input' | 'pointer' | 'wheel' | 'keyboard' | 'reset';
+export type ScalarDispatchMode = 'immediate' | Readonly<{ debounceMs: number }>;
+export interface ScalarStepInput { readonly direction: -1 | 1; readonly fine: boolean }
+export interface ScalarKeyInput { readonly key: string; readonly fine: boolean }
+
+export interface ContinuousScalarPolicy {
+  readonly name: string;
+  readonly preview: 'optimistic' | 'confirmed';
+  normalize(value: number, domain: ScalarDomain): number | null;
+  wheel(current: number, event: ScalarStepInput, domain: ScalarDomain): number | null;
+  key(current: number, event: ScalarKeyInput, domain: ScalarDomain): number | null;
+  reset(domain: ScalarDomain): number | null;
+  dispatch(source: ScalarSource): ScalarDispatchMode;
+  readonly wheelIdleMs: 0 | 300;
+  describeTarget(value: number): string;
+}
+
+export interface ContinuousScalarViewBase {
+  readonly canonical: number | null;
+  readonly draft: number | null;
+  readonly displayed: number | null;
+  readonly interactionBase: number | null;
+  readonly editable: boolean;
+  readonly busy: boolean;
+  readonly interaction: 'idle' | ScalarSource;
+}
+
+export type ContinuousScalarView = Readonly<ContinuousScalarViewBase & (
+  | Readonly<{
+    evidence: 'command-feedback';
+    feedback: Readonly<CommandScalarFeedback>;
+    confirmed: number | null;
+    target: number | null;
+    requested: number | null;
+    phase: ScalarPhase;
+    error: string | null;
+    presentation: Readonly<ControlFeedbackPresentation>;
+    announcement: string | null;
+  }>
+  | Readonly<{
+    evidence: 'reading';
+    reading: ScalarReading;
+    confirmed: null;
+    target: null;
+    requested: null;
+    phase: null;
+    error: null;
+    presentation: null;
+    announcement: null;
+  }>
+)>;
+
+export interface ContinuousScalarRendererLease {
+  readonly view: Readonly<ContinuousScalarView>;
+  beginPointer(): number | null;
+  pointer(token: number, candidate: number): void;
+  endPointer(token: number): void;
+  cancelPointer(token: number): void;
+  nativeInput(candidate: number): void;
+  wheel(event: ScalarStepInput): void;
+  key(event: ScalarKeyInput): boolean;
+  reset(): void;
+  dispose(): void;
+}
+
+export interface ContinuousScalarBinding {
+  readonly view: Readonly<ContinuousScalarView>;
+  attachRenderer(): ContinuousScalarRendererLease;
+  cancel(reason: 'authority' | 'availability' | 'terminal' | 'owner-dispose'): void;
+  destroy(): void;
+}
+
+const finite = (value: number | null | undefined): boolean =>
+  value === null || value === undefined || Number.isFinite(value);
+
+function validDomain(domain: ScalarDomain): boolean {
+  return Number.isFinite(domain.min) && Number.isFinite(domain.max) && domain.max >= domain.min
+    && Number.isFinite(domain.step) && domain.step > 0
+    && Number.isFinite(domain.fineStepDivisor) && domain.fineStepDivisor > 0
+    && finite(domain.defaultValue)
+    && (domain.keyboardStep === undefined
+      || (Number.isFinite(domain.keyboardStep) && domain.keyboardStep > 0));
+}
+
+function snap(value: number, domain: ScalarDomain, quantum: number): number | null {
+  if (!validDomain(domain) || !Number.isFinite(value) || !Number.isFinite(quantum) || quantum <= 0) {
+    return null;
+  }
+  return clamp(snapToStep(value, quantum, domain.min), domain.min, domain.max);
+}
+
+export function createHBarContinuousScalarPolicy(
+  options: Readonly<{
+    preview: 'optimistic' | 'confirmed';
+    debounceMs: number;
+    describeTarget?: (value: number) => string;
+  }>,
+): Readonly<ContinuousScalarPolicy> {
+  const debounce = options.debounceMs > 0
+    ? Object.freeze({ debounceMs: options.debounceMs })
+    : 'immediate';
+  const policy: ContinuousScalarPolicy = {
+    name: `hbar-${options.preview}`,
+    preview: options.preview,
+    normalize: (value, domain) => snap(value, domain, domain.step / domain.fineStepDivisor),
+    wheel: (current, event, domain) => {
+      const quantum = event.fine
+        ? domain.step / domain.fineStepDivisor
+        : domain.step * 4 * Math.max(1, Math.ceil((domain.max - domain.min) / 255));
+      return snap(current + event.direction * quantum, domain, quantum);
+    },
+    key: (current, event, domain) => handleKeyboardStep(
+      current,
+      event.key,
+      domain.keyboardStep ?? domain.step,
+      domain.fineStepDivisor,
+      domain.min,
+      domain.max,
+      event.fine,
+    ),
+    reset: (domain) => domain.defaultValue ?? domain.min,
+    dispatch: (source) => source === 'keyboard' || source === 'reset' ? debounce : 'immediate',
+    wheelIdleMs: 300,
+    describeTarget: options.describeTarget ?? String,
+  };
+  return Object.freeze(policy);
+}
+
+const nativeRangePolicy: ContinuousScalarPolicy = {
+  name: 'native-range',
+  preview: 'optimistic',
+  normalize: (value, domain) => snap(value, domain, domain.step),
+  wheel: () => null,
+  key: () => null,
+  reset: (domain) => domain.defaultValue ?? domain.min,
+  dispatch: () => 'immediate',
+  wheelIdleMs: 0,
+  describeTarget: String,
+};
+export const nativeRangeContinuousScalarPolicy: Readonly<ContinuousScalarPolicy> =
+  Object.freeze(nativeRangePolicy);
+
+type AuthorityIdentity = readonly (string | number | boolean | null | undefined)[];
+
+function authorityOf(input: Readonly<ContinuousScalarInput>): AuthorityIdentity {
+  const domain = input.domain;
+  const shared = [
+    input.evidence, input.enabled, domain.min, domain.max, domain.step,
+    domain.defaultValue, domain.fineStepDivisor, domain.keyboardStep,
+  ] as const;
+  if (input.evidence === 'command-feedback') {
+    return Object.freeze([
+      ...shared, input.command, input.feedback.sessionEpoch, input.feedback.availability,
+      input.feedback.scope.control, input.feedback.scope.receiver, input.feedback.scope.slot,
+    ]);
+  }
+  return Object.freeze([...shared, input.ownerKey, input.reading.status]);
+}
+
+function sameAuthority(left: AuthorityIdentity | null, right: AuthorityIdentity): boolean {
+  return left !== null && left.length === right.length
+    && left.every((value, index) => Object.is(value, right[index]));
+}
+
+function canonicalOf(input: Readonly<ContinuousScalarInput>): number | null {
+  if (!validDomain(input.domain)) return null;
+  if (input.evidence === 'reading') {
+    return input.reading.status === 'known' && Number.isFinite(input.reading.value)
+      ? input.reading.value : null;
+  }
+  const value = input.feedback.confirmed;
+  return input.feedback.availability === 'available' && value !== null && Number.isFinite(value)
+    ? value : null;
+}
+
+function validCommandFeedback(feedback: Readonly<CommandScalarFeedback>): boolean {
+  return finite(feedback.target) && finite(feedback.requestedTarget)
+    && Number.isFinite(feedback.sessionEpoch)
+    && (feedback.scope.receiver === 0 || feedback.scope.receiver === 1);
+}
+
+function editable(input: Readonly<ContinuousScalarInput>): boolean {
+  if (!input.enabled || canonicalOf(input) === null) return false;
+  return input.evidence === 'reading' || validCommandFeedback(input.feedback);
+}
+
+const TERMINAL_FAILURES: ReadonlySet<ScalarPhase> = new Set([
+  'failed', 'timed-out', 'cancelled', 'superseded',
+]);
+
+export function createContinuousScalar(
+  read: () => Readonly<ContinuousScalarInput>,
+  policy: Readonly<ContinuousScalarPolicy>,
+): ContinuousScalarBinding {
+  let draft = $state<number | null>(null);
+  let interaction = $state<'idle' | ScalarSource>('idle');
+  let draftCanonical: number | null = null;
+  let lastAuthority: AuthorityIdentity | null = null;
+  let activeRenderer: number | null = null;
+  let rendererSequence = 0;
+  let gestureSequence = 0;
+  let activeGesture: { renderer: number; token: number } | null = null;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let wheelTimer: ReturnType<typeof setTimeout> | null = null;
+  let presentationState: Readonly<ControlFeedbackPresentationState> = {
+    announcedTransitionIds: [],
+  };
+  let destroyed = false;
+
+  function clearTimers(): void {
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    if (wheelTimer !== null) clearTimeout(wheelTimer);
+    debounceTimer = null;
+    wheelTimer = null;
+  }
+
+  function clearTransient(): void {
+    clearTimers();
+    draft = null;
+    draftCanonical = null;
+    interaction = 'idle';
+    activeGesture = null;
+  }
+
+  function reconcile(input: Readonly<ContinuousScalarInput>): void {
+    const authority = authorityOf(input);
+    if (lastAuthority !== null && !sameAuthority(lastAuthority, authority)) {
+      clearTransient();
+      presentationState = { announcedTransitionIds: [] };
+    }
+    lastAuthority = authority;
+    if (input.evidence === 'command-feedback') {
+      if (TERMINAL_FAILURES.has(input.feedback.phase)
+        || (input.feedback.outcome !== null && TERMINAL_FAILURES.has(input.feedback.outcome.phase))) {
+        clearTransient();
+      } else if (draft !== null && Object.is(canonicalOf(input), draft)) {
+        draft = null;
+        draftCanonical = null;
+        if (interaction !== 'pointer' && interaction !== 'wheel') interaction = 'idle';
+      }
+    } else if (draft !== null && interaction !== 'pointer' && interaction !== 'wheel'
+      && !Object.is(canonicalOf(input), draftCanonical)) {
+      draft = null;
+      draftCanonical = null;
+      interaction = 'idle';
+    }
+  }
+
+  function current(): Readonly<ContinuousScalarInput> {
+    const input = read();
+    reconcile(input);
+    return input;
+  }
+
+  function dispatch(candidate: number, authority: AuthorityIdentity): void {
+    const input = current();
+    if (!destroyed && sameAuthority(authority, authorityOf(input)) && editable(input)) {
+      input.request(candidate);
+    }
+  }
+
+  function applyCandidate(
+    renderer: number,
+    source: ScalarSource,
+    candidate: number | null,
+  ): boolean {
+    const input = current();
+    if (destroyed || renderer !== activeRenderer || !editable(input) || candidate === null) return false;
+    const normalized = policy.normalize(candidate, input.domain);
+    if (normalized === null || !Number.isFinite(normalized)
+      || normalized < input.domain.min || normalized > input.domain.max) return false;
+    const authority = authorityOf(input);
+    draft = normalized;
+    draftCanonical = canonicalOf(input);
+    interaction = source;
+    const mode = policy.dispatch(source);
+    if (mode === 'immediate') {
+      dispatch(normalized, authority);
+    } else {
+      if (debounceTimer !== null) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        if (renderer === activeRenderer) dispatch(normalized, authority);
+      }, mode.debounceMs);
+    }
+    return true;
+  }
+
+  function interactionBase(input: Readonly<ContinuousScalarInput>): number | null {
+    return policy.preview === 'optimistic' && draft !== null ? draft : canonicalOf(input);
+  }
+
+  function viewOf(input: Readonly<ContinuousScalarInput>): Readonly<ContinuousScalarView> {
+    const canonical = canonicalOf(input);
+    const displayed = policy.preview === 'optimistic' && draft !== null ? draft : canonical;
+    const common = {
+      canonical,
+      draft,
+      displayed,
+      interactionBase: interactionBase(input),
+      editable: editable(input),
+      busy: input.evidence === 'command-feedback' ? input.feedback.busy : false,
+      interaction,
+    } as const;
+    if (input.evidence === 'reading') {
+      return Object.freeze({
+        ...common,
+        evidence: 'reading' as const,
+        reading: input.reading,
+        confirmed: null,
+        target: null,
+        requested: null,
+        phase: null,
+        error: null,
+        presentation: null,
+        announcement: null,
+      });
+    }
+    const presentation = projectControlFeedbackPresentation(
+      input.feedback, presentationState, policy.describeTarget,
+    );
+    presentationState = presentation.state;
+    return Object.freeze({
+      ...common,
+      evidence: 'command-feedback' as const,
+      feedback: input.feedback,
+      confirmed: canonical,
+      target: input.feedback.target,
+      requested: input.feedback.requestedTarget,
+      phase: input.feedback.phase,
+      error: input.feedback.outcome?.error ?? null,
+      presentation,
+      announcement: presentation.politeAnnouncement?.message ?? null,
+    });
+  }
+
+  function makeLease(renderer: number): ContinuousScalarRendererLease {
+    return {
+      get view() { return viewOf(current()); },
+      beginPointer(): number | null {
+        const input = current();
+        if (destroyed || renderer !== activeRenderer || !editable(input)) return null;
+        const token = ++gestureSequence;
+        activeGesture = { renderer, token };
+        interaction = 'pointer';
+        return token;
+      },
+      pointer(token: number, candidate: number): void {
+        current();
+        if (activeGesture?.renderer === renderer && activeGesture.token === token) {
+          applyCandidate(renderer, 'pointer', candidate);
+        }
+      },
+      endPointer(token: number): void {
+        current();
+        if (activeGesture?.renderer !== renderer || activeGesture.token !== token) return;
+        activeGesture = null;
+        interaction = 'idle';
+        reconcile(read());
+      },
+      cancelPointer(token: number): void {
+        current();
+        if (activeGesture?.renderer === renderer && activeGesture.token === token) clearTransient();
+      },
+      nativeInput(candidate: number): void {
+        applyCandidate(renderer, 'native-input', candidate);
+      },
+      wheel(event: ScalarStepInput): void {
+        const input = current();
+        if (destroyed || renderer !== activeRenderer || !editable(input)) return;
+        const base = interactionBase(input);
+        if (base === null || !applyCandidate(renderer, 'wheel', policy.wheel(base, event, input.domain))) return;
+        if (policy.wheelIdleMs === 300) {
+          if (wheelTimer !== null) clearTimeout(wheelTimer);
+          const authority = authorityOf(input);
+          wheelTimer = setTimeout(() => {
+            wheelTimer = null;
+            const latest = current();
+            if (renderer === activeRenderer && sameAuthority(authority, authorityOf(latest))) {
+              draft = null;
+              draftCanonical = null;
+              interaction = 'idle';
+            }
+          }, policy.wheelIdleMs);
+        }
+      },
+      key(event: ScalarKeyInput): boolean {
+        const input = current();
+        if (destroyed || renderer !== activeRenderer || !editable(input)) return false;
+        const base = interactionBase(input);
+        if (base === null) return false;
+        const candidate = policy.key(base, event, input.domain);
+        if (candidate === null) return false;
+        return applyCandidate(renderer, 'keyboard', candidate);
+      },
+      reset(): void {
+        const input = current();
+        if (!destroyed && renderer === activeRenderer && editable(input))
+          applyCandidate(renderer, 'reset', policy.reset(input.domain));
+      },
+      dispose(): void {
+        if (renderer !== activeRenderer) return;
+        clearTransient();
+        activeRenderer = null;
+      },
+    };
+  }
+
+  return {
+    get view() { return viewOf(current()); },
+    attachRenderer(): ContinuousScalarRendererLease {
+      if (!destroyed && activeRenderer !== null) clearTransient();
+      const renderer = ++rendererSequence;
+      if (!destroyed) activeRenderer = renderer;
+      return makeLease(renderer);
+    },
+    cancel(): void { clearTransient(); },
+    destroy(): void {
+      if (destroyed) return;
+      destroyed = true;
+      clearTransient();
+      activeRenderer = null;
+    },
+  };
+}

--- a/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
+++ b/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
@@ -63,6 +63,7 @@ export interface ContinuousScalarPolicy {
   key(current: number, event: ScalarKeyInput, domain: ScalarDomain): number | null;
   reset(domain: ScalarDomain): number | null;
   dispatch(source: ScalarSource): ScalarDispatchMode;
+  dispatchesCanonical(source: ScalarSource): boolean;
   readonly wheelIdleMs: 0 | 300;
   describeTarget(value: number): string;
 }
@@ -172,6 +173,7 @@ export function createHBarContinuousScalarPolicy(
     ),
     reset: (domain) => domain.defaultValue ?? domain.min,
     dispatch: (source) => source === 'keyboard' || source === 'reset' ? debounce : 'immediate',
+    dispatchesCanonical: (source) => source === 'wheel',
     wheelIdleMs: 300,
     describeTarget: options.describeTarget ?? String,
   };
@@ -186,6 +188,7 @@ const nativeRangePolicy: ContinuousScalarPolicy = {
   key: () => null,
   reset: (domain) => domain.defaultValue ?? domain.min,
   dispatch: () => 'immediate',
+  dispatchesCanonical: () => true,
   wheelIdleMs: 0,
   describeTarget: String,
 };
@@ -240,6 +243,17 @@ const TERMINAL_FAILURES: ReadonlySet<ScalarPhase> = new Set([
   'failed', 'timed-out', 'cancelled', 'superseded',
 ]);
 
+function terminalIdentity(input: Readonly<ContinuousScalarInput>): AuthorityIdentity | null {
+  if (input.evidence === 'reading') return null;
+  const outcomePhase = input.feedback.outcome?.phase;
+  const phase = outcomePhase !== undefined && TERMINAL_FAILURES.has(outcomePhase)
+    ? outcomePhase
+    : TERMINAL_FAILURES.has(input.feedback.phase) ? input.feedback.phase : null;
+  return phase === null ? null : Object.freeze([
+    ...authorityOf(input), input.feedback.lifecycleId ?? input.feedback.transitionId, phase,
+  ]);
+}
+
 export function createContinuousScalar(
   read: () => Readonly<ContinuousScalarInput>,
   policy: Readonly<ContinuousScalarPolicy>,
@@ -248,6 +262,7 @@ export function createContinuousScalar(
   let interaction = $state<'idle' | ScalarSource>('idle');
   let draftCanonical: number | null = null;
   let lastAuthority: AuthorityIdentity | null = null;
+  let handledTerminal: AuthorityIdentity | null = null;
   let activeRenderer: number | null = null;
   let rendererSequence = 0;
   let gestureSequence = 0;
@@ -278,14 +293,16 @@ export function createContinuousScalar(
     const authority = authorityOf(input);
     if (lastAuthority !== null && !sameAuthority(lastAuthority, authority)) {
       clearTransient();
+      handledTerminal = null;
       presentationState = { announcedTransitionIds: [] };
     }
     lastAuthority = authority;
-    if (input.evidence === 'command-feedback') {
-      if (TERMINAL_FAILURES.has(input.feedback.phase)
-        || (input.feedback.outcome !== null && TERMINAL_FAILURES.has(input.feedback.outcome.phase))) {
-        clearTransient();
-      } else if (draft !== null && Object.is(canonicalOf(input), draft)) {
+    const terminal = terminalIdentity(input);
+    if (terminal !== null && !sameAuthority(handledTerminal, terminal)) {
+      clearTransient();
+      handledTerminal = terminal;
+    } else if (input.evidence === 'command-feedback') {
+      if (draft !== null && Object.is(canonicalOf(input), draft)) {
         draft = null;
         draftCanonical = null;
         if (interaction !== 'pointer' && interaction !== 'wheel') interaction = 'idle';
@@ -325,6 +342,12 @@ export function createContinuousScalar(
     draft = normalized;
     draftCanonical = canonicalOf(input);
     interaction = source;
+    if (!policy.dispatchesCanonical(source) && Object.is(normalized, draftCanonical)) {
+      draft = null;
+      draftCanonical = null;
+      if (source !== 'pointer') interaction = 'idle';
+      return true;
+    }
     const mode = policy.dispatch(source);
     if (mode === 'immediate') {
       dispatch(normalized, authority);

--- a/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
+++ b/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
@@ -269,6 +269,7 @@ export function createContinuousScalar(
   let activeGesture: { renderer: number; token: number } | null = null;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let wheelTimer: ReturnType<typeof setTimeout> | null = null;
+  let invalidationGeneration = 0;
   let presentationState: Readonly<ControlFeedbackPresentationState> = {
     announcedTransitionIds: [],
   };
@@ -282,6 +283,7 @@ export function createContinuousScalar(
   }
 
   function clearTransient(): void {
+    invalidationGeneration += 1;
     clearTimers();
     draft = null;
     draftCanonical = null;
@@ -321,9 +323,10 @@ export function createContinuousScalar(
     return input;
   }
 
-  function dispatch(candidate: number, authority: AuthorityIdentity): void {
+  function dispatch(candidate: number, authority: AuthorityIdentity, generation: number): void {
     const input = current();
-    if (!destroyed && sameAuthority(authority, authorityOf(input)) && editable(input)) {
+    if (!destroyed && generation === invalidationGeneration
+      && sameAuthority(authority, authorityOf(input)) && editable(input)) {
       input.request(candidate);
     }
   }
@@ -339,6 +342,7 @@ export function createContinuousScalar(
     if (normalized === null || !Number.isFinite(normalized)
       || normalized < input.domain.min || normalized > input.domain.max) return false;
     const authority = authorityOf(input);
+    const generation = invalidationGeneration;
     draft = normalized;
     draftCanonical = canonicalOf(input);
     interaction = source;
@@ -350,12 +354,12 @@ export function createContinuousScalar(
     }
     const mode = policy.dispatch(source);
     if (mode === 'immediate') {
-      dispatch(normalized, authority);
+      dispatch(normalized, authority, generation);
     } else {
       if (debounceTimer !== null) clearTimeout(debounceTimer);
       debounceTimer = setTimeout(() => {
         debounceTimer = null;
-        if (renderer === activeRenderer) dispatch(normalized, authority);
+        if (renderer === activeRenderer) dispatch(normalized, authority, generation);
       }, mode.debounceMs);
     }
     return true;


### PR DESCRIPTION
## Summary
- add one continuous scalar state owner with explicit optimistic/confirmed and native-range policies
- keep command feedback and reading evidence discriminated; reading data never fabricates command lifecycle fields
- make deferred dispatch, wheel hold, renderer replacement, stale gesture, and destroy behavior authority-safe
- handle each terminal transition once so pre-transition work is cancelled while fresh gestures remain usable
- invalidate deferred callbacks when their own current-state read discovers terminal or authority cancellation
- preserve HBar same-canonical suppression for pointer/key/reset while wheel remains dispatching at a boundary

## Scope
- H0 foundation only for [MOR-2383](https://linear.app/morozsm/issue/MOR-2383/share-continuous-scalar-lifecycle-with-explicit-policies-and-honest)
- supports the parent [MOR-2215](https://linear.app/morozsm/issue/MOR-2215/v3-acceptance-complete-existing-instrument-behaviorrender-separation)
- does not adopt HBar or FilterSurface; MOR-2384 and MOR-2385 remain required follow-through

## Size
- 2 files, 994 additions + deletions (490 test, 504 implementation)
- this exceeds the 600-line soft threshold because the additive public contract, one state machine, and its authority/timer/lease proof form one tested unit; splitting the tests from the owner would remove the H0 acceptance evidence
- the bounded extra correction remains below the repository hard ceiling of 1000 A+D

## Independent review corrections
- addresses BLOCKED comments 5556582562 and 5556655114 on prior immutable heads
- terminal cancellation is fingerprinted by structural authority plus lifecycle/transition identity and terminal outcome; retained terminal evidence is not re-applied on every read
- every transient cancellation advances an invalidation generation; deferred dispatch checks its captured generation after re-reading current state
- active fresh post-terminal drag survives retained-outcome phase and transition movement in the same lifecycle
- HBar policy explicitly selects which sources dispatch a canonical-equal candidate; native-range policy remains separate

## Verification
- `npx vitest run src/primitives/scalar/__tests__/continuous-scalar.test.ts src/__tests__/control-feedback-presentation.test.ts` — 48 passed
- `npm run check` — 0 errors, 0 warnings
- changed-path ESLint — passed
- staged diff check — passed
- structural-authority mutation: disabling value comparison failed epoch replacement while current-callback replacement remained green
- repeated-terminal mutation failed fresh post-terminal pointer while nonterminal pending drag remained green
- HBar canonical-dispatch mutation failed suppression/boundary behavior while ordinary noncanonical intents remained green
- deferred-generation mutation dispatched stale pre-terminal debounce while current-callback and retained fresh paths remained green
- moving-transition identity mutation dropped an active fresh-drag continuation while nonterminal pending drag remained green
- accepted base `003738a1e34bb1cd0a90169896466f004eed3914`: natural quick run 34007446342 succeeded
- prior-head `npm run lint:boundaries` passed; corrections do not change imports or package boundaries

## Compatibility
Additive public primitive API only. No existing runtime, renderer, hardware, or compatibility contract is changed in H0.