### PR TITLE
refactor: bind DSP and RF discrete instruments (MOR-2387)

### DIFF
--- a/frontend/src/semantic/DspSurface.svelte
+++ b/frontend/src/semantic/DspSurface.svelte
@@ -36,7 +36,7 @@
 
   PENDING AFFORDANCE (MOR-1441 leg 2). `pendingNb`/`pendingNr` are plain,
   command-bus-blind display props, same "read at the wiring seam" precedent
-  as leg 1's `pendingFrequencyHz`. `toggle()` keeps computing the flipped
+  as leg 1's `pendingFrequencyHz`. The toggle bindings keep computing the flipped
   value from `dsp[field].reading.value` — the CONFIRMED reading — exclusively
   (see below); pending never becomes the arithmetic base, the same class of
   defect leg 1's `FrequencyDisplayInteractive` fix closed for the frequency
@@ -47,7 +47,6 @@
   import { buildAgcOptions } from '../components-v2/panels/agc-utils';
   import { NOTCH_WIDTH_LABELS, formatAgcTime } from '../components-v2/panels/dsp-panel-logic';
   import { rawToPercentDisplay } from '../primitives/scalar/value-control-core';
-  import { pressedOf } from './pressed-of';
 
   /** On/off controls, `[field, label]`. */
   export const DSP_TOGGLES = [['nrActive', 'NR'], ['nbActive', 'NB']] as const;
@@ -133,6 +132,10 @@
 <script lang="ts">
   import { t } from '$lib/i18n';
   import type { RadioViewModel } from './radio-view-model';
+  import {
+    bindChoiceInstrument,
+    bindToggleInstrument,
+  } from '../primitives/control-instruments/control-instrument-behavior';
 
   interface Props {
     view: RadioViewModel;
@@ -169,10 +172,27 @@
     nbLevelPercent ? (v: number) => rawToPercentDisplay(v, 0, nbLevelMax) : undefined,
   );
 
-  function toggle(field: DspToggleField): void {
-    const f = dsp?.[field];
-    if (f && usable(f) && f.reading.status === 'known') onToggle?.(field, !f.reading.value);
-  }
+  const toggleBehaviors = {
+    nrActive: bindToggleInstrument(() => ({
+      field: dsp?.nrActive,
+      invoke: (next) => onToggle?.('nrActive', next),
+    })),
+    nbActive: bindToggleInstrument(() => ({
+      field: dsp?.nbActive,
+      invoke: (next) => onToggle?.('nbActive', next),
+    })),
+  } satisfies Record<DspToggleField, ReturnType<typeof bindToggleInstrument>>;
+  const notchBehavior = bindChoiceInstrument(() => ({
+    field: dsp?.notchMode,
+    choices: NOTCH_MODES,
+    invoke: (mode) => onNotchModeChange?.(mode),
+  }));
+  const agcBehavior = bindChoiceInstrument<number>(() => ({
+    field: dsp?.agcMode,
+    choices: agcOptions.map((option) => option.value),
+    invoke: (mode) => onAgcModeChange?.(mode),
+  }));
+
   function level(field: DspLevelField, value: number): void {
     if (!dsp) return;
     if (field === 'nrLevel') {
@@ -184,12 +204,6 @@
     }
     if (usable(dsp[field])) onLevelChange?.(field, value);
   }
-  function notch(mode: (typeof NOTCH_MODES)[number]): void {
-    if (dsp && usable(dsp.notchMode)) onNotchModeChange?.(mode);
-  }
-  function agc(mode: number): void {
-    if (dsp && usable(dsp.agcMode)) onAgcModeChange?.(mode);
-  }
 </script>
 
 {#if dsp}
@@ -199,12 +213,13 @@
         {#if dsp[field].availability.structural}
           {@const pending = pendingOf(field)}
           {@const pendingId = `${pendingToggleIdBase}-${field}`}
+          {@const behavior = toggleBehaviors[field]}
           <button
             type="button" class="dsp-toggle" data-testid={`dsp-${field}`} data-field={field}
-            data-disabled-reason={reasonOf(dsp[field])} aria-pressed={pressedOf(dsp[field])}
+            data-disabled-reason={reasonOf(dsp[field])} aria-pressed={behavior.confirmed}
             data-pending-status={pending !== null ? 'pending' : 'confirmed'}
             aria-describedby={pending !== null ? pendingId : undefined}
-            disabled={!usable(dsp[field])} onclick={() => toggle(field)}
+            disabled={!behavior.available} onclick={() => behavior.invoke()}
           >{label}: {fmt(dsp[field])}</button>
           {#if pending !== null}
             <span id={pendingId} class="sr-only">{t('core.dsp.pendingAnnouncement')}</span>
@@ -249,8 +264,8 @@
         {#each NOTCH_MODES as mode (mode)}
           <button
             type="button" class="dsp-choice" data-testid={`dsp-notchMode-${mode}`}
-            aria-pressed={dsp.notchMode.reading.status === 'known' && dsp.notchMode.reading.value === mode}
-            disabled={!usable(dsp.notchMode)} onclick={() => notch(mode)}
+            aria-pressed={notchBehavior.selected === undefined ? undefined : notchBehavior.isSelected(mode)}
+            disabled={!notchBehavior.available} onclick={() => notchBehavior.invoke(mode)}
           >{mode}</button>
         {/each}
       </div>
@@ -261,8 +276,8 @@
         {#each agcOptions as option (option.value)}
           <button
             type="button" class="dsp-choice" data-testid={`dsp-agcMode-${option.value}`}
-            aria-pressed={dsp.agcMode.reading.status === 'known' && dsp.agcMode.reading.value === option.value}
-            disabled={!usable(dsp.agcMode)} onclick={() => agc(option.value)}
+            aria-pressed={agcBehavior.selected === undefined ? undefined : agcBehavior.isSelected(option.value)}
+            disabled={!agcBehavior.available} onclick={() => agcBehavior.invoke(option.value)}
           >{option.label}</button>
         {/each}
       </div>

--- a/frontend/src/semantic/RfFrontEndSurface.svelte
+++ b/frontend/src/semantic/RfFrontEndSurface.svelte
@@ -44,13 +44,12 @@
   1's `pendingFrequencyHz`. It never touches the MOR-1447 combined-knob/
   change-guard machinery above (`combinedNormX`/`changeCombined` read only
   confirmed `rf.rfGain`/`rf.squelch`) — preamp is a disjoint field. Marks the
-  targeted preamp CHOICE distinctly; `isValue`/`aria-checked` keep reading
+  targeted preamp CHOICE distinctly; the preamp binding's `aria-checked` keeps reading
   `rf.preamp`'s CONFIRMED reading exclusively, so a click while pending still
   dispatches the CLICKED (explicit) value.
 -->
 <script module lang="ts">
   import type { DisabledReasonCode, RfFrontEndField } from './radio-view-model';
-  import { pressedOf } from './pressed-of';
   import { formatKnownLevel } from './format-level';
 
   /** The one rendering of "not read". Never 0, never the last value. */
@@ -67,8 +66,6 @@
    *  `String()`-ing the raw wire fraction. */
   const levelTextOf = (f: RfFrontEndField<number>, min: number, max: number): string =>
     f.reading.status === 'known' ? formatKnownLevel(f.reading.value, min, max) : UNKNOWN_TEXT;
-  const isValue = (f: RfFrontEndField<unknown>, value: unknown): boolean =>
-    f.reading.status === 'known' && f.reading.value === value;
 
   /** `[field, label, min, max, step]`. The radio's own normalized 0..1
    *  reading (a wire-protocol FRACTION, not the raw 0-255 wire unit) — same
@@ -112,6 +109,10 @@
     dualParamValuesFromNormX,
     dualParamNormXFromValues,
   } from '../primitives/scalar/value-control-core';
+  import {
+    bindChoiceInstrument,
+    bindToggleInstrument,
+  } from '../primitives/control-instruments/control-instrument-behavior';
 
   interface Props {
     view: RadioViewModel;
@@ -145,12 +146,28 @@
     view.disabledReasons.find((reason) => reason.field === 'rfFrontEnd.preamp') ?? null,
   );
 
-  function changePreamp(level: number): void {
-    if (rf && usable(rf.preamp) && preMutex === null) onPreampChange?.(level);
-  }
-  function changeAttenuator(db: number): void {
-    if (rf && usable(rf.attenuator)) onAttenuatorChange?.(db);
-  }
+  const preampBehavior = bindChoiceInstrument<number>(() => ({
+    field: rf?.preamp,
+    choices: rf?.preValues ?? [],
+    blocked: preMutex !== null,
+    invoke: (level) => onPreampChange?.(level),
+  }));
+  const attenuatorBehavior = bindChoiceInstrument<number>(() => ({
+    field: rf?.attenuator,
+    choices: rf?.attValues ?? [],
+    invoke: (db) => onAttenuatorChange?.(db),
+  }));
+  const toggleBehaviors = {
+    digiSel: bindToggleInstrument(() => ({
+      field: rf?.digiSel,
+      invoke: (next) => onToggle?.('digiSel', next),
+    })),
+    ipPlus: bindToggleInstrument(() => ({
+      field: rf?.ipPlus,
+      invoke: (next) => onToggle?.('ipPlus', next),
+    })),
+  } satisfies Record<RfFrontEndToggleField, ReturnType<typeof bindToggleInstrument>>;
+
   function changeLevel(field: RfFrontEndLevelField, value: number): void {
     if (rf && usable(rf[field])) onLevelChange?.(field, value);
   }
@@ -211,10 +228,6 @@
       changeLevel('squelch', nextSql);
     }
   }
-  function toggle(field: RfFrontEndToggleField): void {
-    const f = rf?.[field];
-    if (f && usable(f) && f.reading.status === 'known') onToggle?.(field, !f.reading.value);
-  }
 </script>
 
 {#if rf}
@@ -232,10 +245,10 @@
           <button
             type="button" role="radio" class="rf-front-end-choice"
             data-testid={`rf-front-end-preamp-${value}`}
-            aria-checked={isValue(rf.preamp, value)}
+            aria-checked={preampBehavior.isSelected(value)}
             data-pending={pendingPreamp === value}
-            disabled={!usable(rf.preamp) || preMutex !== null}
-            onclick={() => changePreamp(value)}
+            disabled={!preampBehavior.available}
+            onclick={() => preampBehavior.invoke(value)}
           >{value}</button>
         {/each}
         <output data-testid="rf-front-end-preamp-value">{textOf(rf.preamp)}</output>
@@ -257,9 +270,9 @@
           <button
             type="button" role="radio" class="rf-front-end-choice"
             data-testid={`rf-front-end-attenuator-${value}`}
-            aria-checked={isValue(rf.attenuator, value)}
-            disabled={!usable(rf.attenuator)}
-            onclick={() => changeAttenuator(value)}
+            aria-checked={attenuatorBehavior.isSelected(value)}
+            disabled={!attenuatorBehavior.available}
+            onclick={() => attenuatorBehavior.invoke(value)}
           >{value} dB</button>
         {/each}
         <output data-testid="rf-front-end-attenuator-value">{textOf(rf.attenuator)}</output>
@@ -304,12 +317,13 @@
 
     {#each RF_FRONT_END_TOGGLES as [field, label] (field)}
       {#if rf[field].availability.structural}
+        {@const behavior = toggleBehaviors[field]}
         <button
           type="button" class="rf-front-end-toggle"
           data-testid={`rf-front-end-${field}`} data-observed={usable(rf[field])}
-          aria-pressed={pressedOf(rf[field])}
-          disabled={!usable(rf[field])}
-          onclick={() => toggle(field)}
+          aria-pressed={behavior.confirmed}
+          disabled={!behavior.available}
+          onclick={() => behavior.invoke()}
         >{label}: {textOf(rf[field])}</button>
       {/if}
     {/each}

--- a/frontend/src/semantic/__tests__/DspSurface.test.ts
+++ b/frontend/src/semantic/__tests__/DspSurface.test.ts
@@ -187,7 +187,7 @@ describe('operational availability decides whether a control is USABLE', () => {
     });
   });
 
-  // MOR-1304/1305 N1/MD7: `pressedOf` must return `undefined` — never `false`
+  // MOR-1304/1305 N1/MD7: the toggle binding must return `undefined` — never `false`
   // — for an unobserved toggle reading, so Svelte OMITS `aria-pressed`
   // entirely. `aria-pressed="false"` is not the absence of a claim, it is the
   // claim "this control is OFF" about a reading the radio never reported —
@@ -219,6 +219,14 @@ describe('operational availability decides whether a control is USABLE', () => {
     withSurface(view, (s) => {
       expect(s.notchButton('off')!.disabled).toBe(true);
       expect(s.agcButton(1)!.disabled).toBe(true);
+    });
+  });
+
+  it('omits pressed state for unobserved DSP choices', () => {
+    const view = withField(withField(base(), 'notchMode', { unknown: true }), 'agcMode', { unknown: true });
+    withSurface(view, (s) => {
+      expect(s.notchButton('off')!.getAttribute('aria-pressed')).toBeNull();
+      expect(s.agcButton(1)!.getAttribute('aria-pressed')).toBeNull();
     });
   });
 });
@@ -485,10 +493,30 @@ describe('notchMode renders as a three-way choice', () => {
     }, { onNotchModeChange });
   });
 
+  it('does not select an offered mode for a known out-of-offered reading', () => {
+    const onNotchModeChange = vi.fn();
+    const view = {
+      ...base(),
+      dsp: {
+        ...base().dsp!,
+        notchMode: { ...base().dsp!.notchMode, reading: { status: 'known' as const, value: 'other' } },
+      },
+    } as unknown as RadioViewModel;
+    withSurface(view, (s) => {
+      for (const mode of ['off', 'auto', 'manual']) {
+        expect(s.notchButton(mode)!.getAttribute('aria-pressed')).toBeNull();
+      }
+      s.notchButton('manual')!.click();
+      flushSync();
+      expect(onNotchModeChange).toHaveBeenCalledExactlyOnceWith('manual');
+      expect(s.notchButton('manual')!.getAttribute('aria-pressed')).toBeNull();
+    }, { onNotchModeChange });
+  });
+
   /**
    * MOR-1304/1305 F3: `.click()` on a disabled button never reaches its
    * `onclick` handler at all — a no-op that would pass this assertion even
-   * with the `notch()` guard deleted. Dispatching the click event directly
+   * with the choice binding's guard deleted. Dispatching the click event directly
    * proves the GUARD rejects it, not merely that `disabled` suppressed the
    * interaction.
    */
@@ -538,7 +566,7 @@ describe('agcMode renders the capability-derived choice set with caps-echoed lab
 
   /**
    * MOR-1304/1305 F3: same bypass discipline as notchMode's guard test — the
-   * event is dispatched directly so a deleted `agc()` guard is what this
+   * event is dispatched directly so a deleted choice-binding guard is what this
    * assertion catches, not merely `disabled` suppressing a plain `.click()`.
    */
   it('emits nothing when clicked on an unobserved reading, even bypassing disabled', () => {
@@ -583,7 +611,7 @@ describe('pending-target affordance (MOR-1441 leg 2)', () => {
   });
 
   // THE seam test — the exact class of defect leg 1's runaway bug belonged
-  // to, applied to a toggle: `toggle()` computes the NEXT boolean from
+  // to, applied to a toggle: the toggle binding computes the NEXT boolean from
   // `dsp[field].reading.value` (CONFIRMED), never from the pending prop. If
   // it instead read pending, an in-flight "turn NR on" (confirmed still
   // false, pending true) would compute `!true = false` and dispatch a

--- a/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
@@ -132,6 +132,17 @@ describe('carry-forward 1: a stale/unread reading renders unknown, never its las
     expect(onAttenuatorChange).not.toHaveBeenCalled();
     r.dispose();
   });
+
+  it('keeps every radio unchecked for unread choices while exposing unknown output', () => {
+    const r = render(
+      withRf({ preamp: unread<number>(DEGRADED), attenuator: unread<number>(DEGRADED) }),
+    );
+    for (const value of [0, 1, 2]) expect(r.el(`preamp-${value}`)!.getAttribute('aria-checked')).toBe('false');
+    for (const value of [0, 6, 12, 18]) expect(r.el(`attenuator-${value}`)!.getAttribute('aria-checked')).toBe('false');
+    expect(r.text('preamp-value')).toBe(UNKNOWN_TEXT);
+    expect(r.text('attenuator-value')).toBe(UNKNOWN_TEXT);
+    r.dispose();
+  });
 });
 
 /* ── (2)+(3) the PREAMP/DIGI-SEL mutex ──────────────────────────── */
@@ -222,6 +233,18 @@ describe('preamp and attenuator render as choice groups from the capability-deri
     r.el('preamp-2')!.click();
     flushSync();
     expect(onPreampChange).toHaveBeenCalledExactlyOnceWith(2);
+    r.dispose();
+  });
+
+  it('does not select an offered radio for a known out-of-offered preamp value', () => {
+    const onPreampChange = vi.fn();
+    const r = render(withRf({ preamp: known(3) }), { onPreampChange });
+    for (const value of [0, 1, 2]) expect(r.el(`preamp-${value}`)!.getAttribute('aria-checked')).toBe('false');
+    expect(r.text('preamp-value')).toBe('3');
+    r.el('preamp-1')!.click();
+    flushSync();
+    expect(onPreampChange).toHaveBeenCalledExactlyOnceWith(1);
+    expect(r.el('preamp-1')!.getAttribute('aria-checked')).toBe('false');
     r.dispose();
   });
 


### PR DESCRIPTION
## Summary
- adopt shared toggle and choice behavior for DSP NR/NB, notch/AGC, and RF DIGI-SEL/IP+, preamp/attenuator
- preserve existing mounted renderers, ARIA roles, unknown output, mutex explanation, and target-only pending markers
- add mounted regression coverage for unknown/out-of-offered selection states

## Limits
This does not add MOR-1686 full lifecycle feedback: NR/NB/preamp pending values remain display-only targets and never confirm local state.

## Validation
- `npm exec vitest run src/semantic/__tests__/DspSurface.test.ts src/semantic/__tests__/RfFrontEndSurface.test.ts` (141 passed)
- `npm run check`
- changed-path ESLint
- `npm run lint:boundaries`
- `git diff --check`

Linear: MOR-2387, MOR-2187, MOR-2215