### PR TITLE
refactor: share meter ballistics lifecycle (MOR-1374 phase A)

### DIFF
--- a/frontend/src/components-v2/meters/BarGauge.svelte
+++ b/frontend/src/components-v2/meters/BarGauge.svelte
@@ -5,6 +5,10 @@
     prefersReducedMotion,
     onReducedMotionChange,
   } from '$lib/utils/smoothing.svelte';
+  import {
+    createElapsedEnvelopePeakStrategy,
+    createMeterBallistics,
+  } from '../../primitives/meters/meter-ballistics.svelte';
   import { DEFAULT_ZONES, valueToSegments, getSegmentZone, dimColor, valueFontSize } from './bar-gauge-utils';
   import type { Zone } from './bar-gauge-utils';
   import { updatePeakHold, peakHoldDisplay, PEAK_DECAY_MS, type PeakHoldState } from '../panels/meter-utils';
@@ -59,73 +63,53 @@
 
   // ── Smoother ────────────────────────────────────────────────────────────────
   const smoother = createSmoother(0.08, 0.2);
+  const ballistics = createMeterBallistics(smoother, {
+    now: () => Date.now(),
+    requestFrame: (callback) => requestAnimationFrame(callback),
+    cancelFrame: (id) => cancelAnimationFrame(id),
+    setInterval: (callback, milliseconds) => setInterval(callback, milliseconds),
+    clearInterval: (id) => clearInterval(id),
+    prefersReducedMotion,
+    onReducedMotionChange,
+  }, {
+    peakSource: 'sample',
+    ticker: { kind: 'interval', milliseconds: 100 },
+    peak: createElapsedEnvelopePeakStrategy<PeakHoldState>({
+      decayMilliseconds: PEAK_DECAY_MS,
+      updatePeakHold,
+      peakHoldDisplay,
+    }),
+  });
 
   $effect(() => {
-    if (value === null) smoother.reset(0);
-    else smoother.update(valueToSegments(value, SEG_COUNT));
+    const smoothTarget = value === null ? null : valueToSegments(value, SEG_COUNT);
+    untrack(() => ballistics.sync({ sample: value, smoothTarget, peakEnabled: showPeak }));
   });
 
   onMount(() => {
-    smoother.start();
-    return () => smoother.stop();
+    ballistics.start();
+    return () => ballistics.stop();
   });
 
   // ── Peak-hold marker (MOR-1282) ─────────────────────────────────────────────
-  // Reuses `updatePeakHold`/`peakHoldDisplay` — the single MOR-1252 semantics
-  // implementation MetersDockPanel already channels through — so this gauge
-  // never disagrees with the dock about hold/decay/reduced-motion behaviour.
-  // MetersSurface stays loop-free (R9): all ballistics live here.
-  let peakState = $state<PeakHoldState | undefined>(undefined);
-  let peakNow = $state(Date.now());
-
-  // Latches on every live sample. Reads `peakState` (to compare against the
-  // new sample) as well as writing it, so the read must be untracked —
-  // otherwise `resetPeak()`'s write below would re-trigger this same effect
-  // and immediately re-latch from the still-live `value` (mirrors the dock's
-  // own `untrack(() => stepAllPeaks())` pattern for the identical hazard).
-  $effect(() => {
-    if (value === null) { peakState = undefined; return; }
-    if (!showPeak) return;
-    const v = value;
-    const t = Date.now();
-    untrack(() => {
-      peakState = updatePeakHold(peakState, v, t, PEAK_DECAY_MS);
-      peakNow = t;
-    });
-  });
-
-  // Drives the decay display forward. No ticking (and no rAF) while reduced
-  // motion is preferred — the marker is a static hold instead (MOR-1249/1252).
-  $effect(() => {
-    if (!showPeak) return;
-    let intervalId: ReturnType<typeof setInterval> | null = null;
-    const start = () => { intervalId ??= setInterval(() => { peakNow = Date.now(); }, 100); };
-    const stop = () => { if (intervalId) { clearInterval(intervalId); intervalId = null; } };
-
-    if (!prefersReducedMotion()) start();
-    const unsubscribe = onReducedMotionChange((reduced) => {
-      if (reduced) stop(); else start();
-    });
-
-    return () => { stop(); unsubscribe(); };
-  });
-
   let peakPct = $derived.by(() => {
-    if (value === null || !showPeak || peakState === undefined) return undefined;
-    const level = prefersReducedMotion()
-      ? peakState.latchedPeak
-      : peakHoldDisplay(peakState, value, peakNow, PEAK_DECAY_MS);
+    const level = ballistics.view.peakValue;
+    if (level === null) return undefined;
     return Math.max(0, Math.min(100, level * 100));
   });
 
   function resetPeak() {
-    if (showPeak) peakState = undefined;
+    if (showPeak) ballistics.resetPeak();
   }
 
   // ── Reactive display values ─────────────────────────────────────────────────
   const measuredFault = $derived(value !== null && fault);
-  let fullSegs = $derived(value === null ? 0 : Math.floor(smoother.value));
-  let fracSeg  = $derived(value === null ? 0 : smoother.value - Math.floor(smoother.value));
+  let fullSegs = $derived(value === null ? 0 : Math.floor(ballistics.view.smoothedValue));
+  let fracSeg  = $derived(
+    value === null
+      ? 0
+      : ballistics.view.smoothedValue - Math.floor(ballistics.view.smoothedValue),
+  );
 </script>
 
 <svg

--- a/frontend/src/components-v2/meters/LinearSMeter.svelte
+++ b/frontend/src/components-v2/meters/LinearSMeter.svelte
@@ -44,6 +44,10 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
   import { createSmoother, prefersReducedMotion, onReducedMotionChange } from '$lib/utils/smoothing.svelte';
+  import {
+    createFrameStepPeakStrategy,
+    createMeterBallistics,
+  } from '../../primitives/meters/meter-ballistics.svelte';
   import type { MeterDisplay } from '../../presentation/languages/contract';
   import { DEFAULT_METER_DISPLAY } from './meter-display';
   import {
@@ -166,7 +170,7 @@
       return i < s9SegmentIndex ? display.toneBelowS9 : display.toneAboveS9;
     }
     const denom = SEG_COUNT - 1;
-    const fraction = denom === 0 ? Math.min(1, Math.max(0, smoother.value / SEG_COUNT)) : i / denom;
+    const fraction = denom === 0 ? Math.min(1, Math.max(0, smoothedSegs / SEG_COUNT)) : i / denom;
     return ACTIVE_COLORS[Math.round(fraction * (ACTIVE_COLORS.length - 1))];
   }
 
@@ -324,111 +328,42 @@
   // downward steps. The previous 0.25 (~250 ms) release was visibly behind the
   // number; AmberSmeter already uses a comparably snappy 0.15 release.
   const smoother = createSmoother(0.06, 0.1);
-
-  $effect(() => {
-    if (value === null || !mainPresent) smoother.reset(0);
-    else smoother.update((calibratedToSegments(value) / RAW_SEGMENT_DOMAIN) * SEG_COUNT);
-  });
-
-  onMount(() => {
-    smoother.start();
-    return () => smoother.stop();
-  });
-
-  // ── Peak hold ───────────────────────────────────────────────────────────────
-  const PEAK_HOLD_MS = 1000;   // hold at peak for 1 second
-  // Fraction of full scale to drop per frame once the hold window expires
-  // (~30% faster), scaled by SEG_COUNT below — peakSegs lives on the
-  // SEG_COUNT-wide visual domain (fed by the rescaled smoother.update()
-  // above), not the fixed RAW_SEGMENT_DOMAIN.
   const PEAK_DECAY_FRACTION = 0.0195 / RAW_SEGMENT_DOMAIN;
-
-  let peakSegs   = $state(0);  // peak position in segments (0-SEG_COUNT)
-  let peakTime   = $state(0);  // timestamp when peak was set
-  let peakFrameId = 0;
+  const ballistics = createMeterBallistics(smoother, {
+    now: () => performance.now(),
+    requestFrame: (callback) => requestAnimationFrame(callback),
+    cancelFrame: (id) => cancelAnimationFrame(id),
+    setInterval: (callback, milliseconds) => setInterval(callback, milliseconds),
+    clearInterval: (id) => clearInterval(id),
+    prefersReducedMotion,
+    onReducedMotionChange,
+  }, {
+    peakSource: 'smoothed',
+    ticker: { kind: 'animation-frame' },
+    peak: createFrameStepPeakStrategy({
+      holdMilliseconds: 1000,
+      decrementPerFrame: () => PEAK_DECAY_FRACTION * SEG_COUNT * 16.67,
+    }),
+  });
 
   $effect(() => {
-    if (value === null || !mainPresent) { peakSegs = 0; peakTime = 0; return; }
-    const current = smoother.value;
-
-    if (prefersReducedMotion()) {
-      // MOR-1252: static hold under reduced motion — the peak marker
-      // latches at the highest observed value and stays put (no glide)
-      // until either a higher value arrives or the hold window elapses, at
-      // which point it resets INSTANTLY to the current value (a single
-      // jump computed here, not a decay). This effect only re-runs when
-      // `smoother.value` actually changes — MOR-1233 already makes that a
-      // direct snap-to-target under reduce, so no rAF loop or interval is
-      // scheduled to drive this hold/reset.
-      //
-      // J2: the condition/write below both reads and writes peakSegs and
-      // peakTime, so it must run inside untrack() — otherwise the effect
-      // depends on its own writes and self-invalidates (it still converges
-      // today because the re-seat is idempotent and `||` short-circuits,
-      // but that's incidental, not guaranteed; matches the untrack()
-      // pattern MetersDockPanel's own latch-freshness effect already uses).
-      untrack(() => {
-        if (current >= peakSegs || performance.now() - peakTime > PEAK_HOLD_MS) {
-          peakSegs = current;
-          peakTime = performance.now();
-        }
-      });
-      return;
-    }
-
-    if (current >= peakSegs) {
-      // New peak — capture it (the decay-toward-current glide for an
-      // expired hold is handled by the rAF loop below).
-      peakSegs = current;
-      peakTime = performance.now();
-    }
+    const current = value === null || !mainPresent
+      ? null
+      : (calibratedToSegments(value) / RAW_SEGMENT_DOMAIN) * SEG_COUNT;
+    untrack(() => ballistics.sync({ sample: current, smoothTarget: current, peakEnabled: true }));
   });
 
   onMount(() => {
-    const tickPeak = (now: number) => {
-      const current = smoother.value;
-      const elapsed = now - peakTime;
-
-      if (current >= peakSegs) {
-        // Signal is at or above peak — update peak
-        peakSegs = current;
-        peakTime = now;
-      } else if (elapsed > PEAK_HOLD_MS) {
-        // Hold expired — decay toward current level
-        peakSegs = Math.max(current, peakSegs - PEAK_DECAY_FRACTION * SEG_COUNT * 16.67); // ~1 seg/sec at 60fps
-      }
-      // else: holding — do nothing
-
-      peakFrameId = requestAnimationFrame(tickPeak);
-    };
-
-    // MOR-1233: the hold/decay ballistics above are exactly the animation
-    // prefers-reduced-motion asks us to skip — don't schedule the loop while
-    // the preference is active. Fix cycle 1: react to it changing mid-
-    // session too (start/stop alone only decide once, at mount).
-    if (!prefersReducedMotion()) peakFrameId = requestAnimationFrame(tickPeak);
-
-    const unsubscribe = onReducedMotionChange((reduced) => {
-      if (reduced) {
-        if (peakFrameId) {
-          cancelAnimationFrame(peakFrameId);
-          peakFrameId = 0;
-        }
-      } else if (!peakFrameId) {
-        peakFrameId = requestAnimationFrame(tickPeak);
-      }
-    });
-
-    return () => {
-      if (peakFrameId) cancelAnimationFrame(peakFrameId);
-      unsubscribe();
-    };
+    ballistics.start();
+    return () => ballistics.stop();
   });
 
+  let smoothedSegs = $derived(ballistics.view.smoothedValue);
+  let peakSegs = $derived(ballistics.view.peakValue ?? 0);
   // Peak X position for the vertical indicator line
   let peakX = $derived(BAR_X + peakSegs * (SEG_W + SEG_GAP));
   // Only show peak line if it's meaningfully ahead of current bar
-  let showPeak = $derived(value !== null && mainPresent && peakSegs - smoother.value > 0.3);
+  let showPeak = $derived(value !== null && mainPresent && peakSegs - smoothedSegs > 0.3);
 
   // Peak-line color zones as fractions of the raw 20-segment domain — 15/20
   // and 18/20 are visual gradient stops with no calibration anchor (unlike
@@ -440,8 +375,8 @@
   let peakColor = $derived(peakSegs <= s9SegmentIndex ? 'var(--v2-accent-cyan-bright)' : peakSegs <= peakZoneYellow ? 'var(--v2-accent-yellow)' : peakSegs <= peakZoneOrange ? 'var(--v2-accent-orange-alt)' : 'var(--v2-accent-red-alt)');
 
   // ── Reactive display values ─────────────────────────────────────────────────
-  let fullSegs = $derived(value === null ? 0 : Math.floor(smoother.value));
-  let fracSeg  = $derived(value === null ? 0 : smoother.value - Math.floor(smoother.value));
+  let fullSegs = $derived(value === null ? 0 : Math.floor(smoothedSegs));
+  let fracSeg  = $derived(value === null ? 0 : smoothedSegs - Math.floor(smoothedSegs));
 
   let displaySUnit = $derived(value === null ? 'S ?' : calibratedToSUnit(value));
   let displayDbm   = $derived(value === null ? '' : formatDbm(calibratedToDbm(value)));

--- a/frontend/src/components-v2/meters/__tests__/LinearSMeter.reduced-motion.svelte.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/LinearSMeter.reduced-motion.svelte.test.ts
@@ -321,12 +321,31 @@ describe('LinearSMeter — prefers-reduced-motion (MOR-1233)', () => {
 });
 
 describe('LinearSMeter — runtime prefers-reduced-motion flips (MOR-1233 fix cycle 1, F1/F2)', () => {
+  it('holds a pending high sample when reduced motion turns ON before its first frame', () => {
+    const { setMatches, restore } = mockReducedMotion(false);
+    try {
+      const { target, state } = mountReactive({ value: 20 });
+      flushSync();
+
+      setMatches(true);
+      state.value = 0;
+      flushSync();
+
+      expect(peakLineCount(target)).toBe(1);
+      expect(rafSpy).toHaveBeenCalledTimes(2);
+      expect(cafSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      restore();
+    }
+  });
+
   it('KILL F1: stops both live loops when reduced motion turns ON mid-session', () => {
     const { setMatches, restore } = mockReducedMotion(false);
     try {
       mountReactive({ value: 20 });
       flushSync();
       rafSpy.mockClear();
+      cafSpy.mockClear();
 
       // OS preference flips to "reduce" while both loops (ballistics +
       // peak-hold) are already scheduled.

--- a/frontend/src/primitives/meters/__tests__/meter-ballistics.test.ts
+++ b/frontend/src/primitives/meters/__tests__/meter-ballistics.test.ts
@@ -74,6 +74,29 @@ function createFakeSmoother(initial = 0): MeterSmoother & { set(value: number): 
   };
 }
 
+function createMotionAwareSmoother(host: TestHost): MeterSmoother {
+  let current = 0;
+  let target = 0;
+  let unsubscribe: (() => void) | undefined;
+  return {
+    get value() { return current; },
+    update(value) {
+      target = value;
+      if (host.prefersReducedMotion()) current = target;
+    },
+    reset(value) { current = target = value; },
+    start() {
+      unsubscribe = host.onReducedMotionChange((reduced) => {
+        if (reduced) current = target;
+      });
+    },
+    stop() {
+      unsubscribe?.();
+      unsubscribe = undefined;
+    },
+  };
+}
+
 function frameSetup(options: { reduced?: boolean; decrement?: () => number } = {}) {
   const host = createHost(options.reduced);
   const smoother = createFakeSmoother();
@@ -173,6 +196,30 @@ describe('createMeterBallistics frame-step strategy', () => {
     meter.sync({ sample: 2, smoothTarget: 2, peakEnabled: true });
     expect(meter.view.peakValue).toBe(2);
   });
+
+  it('captures the smoother snap when reduced motion turns on before the next frame', () => {
+    const host = createHost(false);
+    const smoother = createMotionAwareSmoother(host);
+    const meter = createMeterBallistics(smoother, host, {
+      peakSource: 'smoothed',
+      ticker: { kind: 'animation-frame' },
+      peak: createFrameStepPeakStrategy({
+        holdMilliseconds: 1000,
+        decrementPerFrame: () => 1,
+      }),
+    });
+    meter.sync({ sample: 10, smoothTarget: 10, peakEnabled: true });
+    meter.start();
+    expect(meter.view).toEqual({ smoothedValue: 0, peakValue: 0 });
+
+    host.setReduced(true);
+    expect(meter.view).toEqual({ smoothedValue: 10, peakValue: 10 });
+    meter.sync({ sample: 2, smoothTarget: 2, peakEnabled: true });
+    expect(meter.view).toEqual({ smoothedValue: 2, peakValue: 10 });
+    expect(host.activeFrames).toBe(0);
+    meter.stop();
+    expect(host.listenerCount).toBe(0);
+  });
 });
 
 describe('createMeterBallistics elapsed-envelope strategy', () => {
@@ -222,6 +269,17 @@ describe('createMeterBallistics elapsed-envelope strategy', () => {
     expect(meter.view.peakValue).toBe(1);
     meter.sync({ sample: 0.2, smoothTarget: 2, peakEnabled: true });
     expect(meter.view.peakValue).toBe(0.2);
+  });
+
+  it('does not observe Bar sample state on preference flips', () => {
+    const { host, meter, update } = elapsedSetup();
+    meter.sync({ sample: 1, smoothTarget: 10, peakEnabled: true });
+    meter.start();
+    update.mockClear();
+    host.setReduced(true);
+    host.setReduced(false);
+    expect(update).not.toHaveBeenCalled();
+    expect(host.activeIntervals).toBe(1);
   });
 });
 

--- a/frontend/src/primitives/meters/__tests__/meter-ballistics.test.ts
+++ b/frontend/src/primitives/meters/__tests__/meter-ballistics.test.ts
@@ -1,0 +1,260 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createElapsedEnvelopePeakStrategy,
+  createFrameStepPeakStrategy,
+  createMeterBallistics,
+  type MeterMotionHost,
+  type MeterSmoother,
+} from '../meter-ballistics.svelte';
+
+interface TestHost extends MeterMotionHost {
+  advance(milliseconds: number): void;
+  flushFrame(milliseconds?: number): void;
+  flushIntervals(): void;
+  setReduced(reduced: boolean): void;
+  readonly activeFrames: number;
+  readonly activeIntervals: number;
+  readonly listenerCount: number;
+}
+
+function createHost(initialReduced = false): TestHost {
+  let now = 0;
+  let reduced = initialReduced;
+  let nextId = 1;
+  const frames = new Map<number, FrameRequestCallback>();
+  const intervals = new Map<number, () => void>();
+  const listeners = new Set<(value: boolean) => void>();
+  return {
+    now: () => now,
+    requestFrame: (callback) => {
+      const id = nextId++;
+      frames.set(id, callback);
+      return id;
+    },
+    cancelFrame: (id) => { frames.delete(id); },
+    setInterval: (callback) => {
+      const id = nextId++;
+      intervals.set(id, callback);
+      return id as unknown as ReturnType<typeof setInterval>;
+    },
+    clearInterval: (id) => { intervals.delete(id as unknown as number); },
+    prefersReducedMotion: () => reduced,
+    onReducedMotionChange: (callback) => {
+      listeners.add(callback);
+      return () => { listeners.delete(callback); };
+    },
+    advance: (milliseconds) => { now += milliseconds; },
+    flushFrame: (milliseconds = 16.67) => {
+      now += milliseconds;
+      const pending = [...frames.values()];
+      frames.clear();
+      pending.forEach((callback) => callback(now));
+    },
+    flushIntervals: () => { intervals.forEach((callback) => callback()); },
+    setReduced: (value) => {
+      reduced = value;
+      listeners.forEach((callback) => callback(value));
+    },
+    get activeFrames() { return frames.size; },
+    get activeIntervals() { return intervals.size; },
+    get listenerCount() { return listeners.size; },
+  };
+}
+
+function createFakeSmoother(initial = 0): MeterSmoother & { set(value: number): void } {
+  let current = initial;
+  return {
+    get value() { return current; },
+    update: vi.fn((value: number) => { current = value; }),
+    reset: vi.fn((value: number) => { current = value; }),
+    start: vi.fn(),
+    stop: vi.fn(),
+    set: (value) => { current = value; },
+  };
+}
+
+function frameSetup(options: { reduced?: boolean; decrement?: () => number } = {}) {
+  const host = createHost(options.reduced);
+  const smoother = createFakeSmoother();
+  const meter = createMeterBallistics(smoother, host, {
+    peakSource: 'smoothed',
+    ticker: { kind: 'animation-frame' },
+    peak: createFrameStepPeakStrategy({
+      holdMilliseconds: 1000,
+      decrementPerFrame: options.decrement ?? (() => 1),
+    }),
+  });
+  return { host, smoother, meter };
+}
+
+function elapsedSetup(reduced = false) {
+  const host = createHost(reduced);
+  const smoother = createFakeSmoother();
+  const update = vi.fn((state: { latchedPeak: number; latchedAt: number } | undefined, value: number, now: number) => (
+    state === undefined || value > state.latchedPeak || now - state.latchedAt > 1500
+      ? { latchedPeak: value, latchedAt: now }
+      : state
+  ));
+  const display = vi.fn((state: { latchedPeak: number; latchedAt: number }, value: number, now: number) => (
+    Math.max(value, state.latchedPeak * (1 - (now - state.latchedAt) / 1500))
+  ));
+  const meter = createMeterBallistics(smoother, host, {
+    peakSource: 'sample',
+    ticker: { kind: 'interval', milliseconds: 100 },
+    peak: createElapsedEnvelopePeakStrategy({
+      decayMilliseconds: 1500,
+      updatePeakHold: update,
+      peakHoldDisplay: display,
+    }),
+  });
+  return { host, smoother, meter, update, display };
+}
+
+describe('createMeterBallistics frame-step strategy', () => {
+  it('is the shared owner without importing renderer or smoother implementations', () => {
+    const primitive = readFileSync('src/primitives/meters/meter-ballistics.svelte.ts', 'utf8');
+    expect(primitive).not.toMatch(/components-v2|createSmoother|Math\.exp|calibrated|SEG_COUNT|runtime\//);
+    for (const component of ['LinearSMeter.svelte', 'BarGauge.svelte']) {
+      const source = readFileSync(`src/components-v2/meters/${component}`, 'utf8');
+      expect(source.match(/createMeterBallistics\(/g)).toHaveLength(1);
+      expect(source.match(/createSmoother\(/g)).toHaveLength(1);
+    }
+  });
+
+  it('delegates smoothing and clears both outputs when either coordinate is absent', () => {
+    const { meter, smoother } = frameSetup();
+    meter.sync({ sample: 8, smoothTarget: 12, peakEnabled: true });
+    expect(smoother.update).toHaveBeenCalledExactlyOnceWith(12);
+    expect(meter.view).toEqual({ smoothedValue: 12, peakValue: 12 });
+
+    meter.sync({ sample: null, smoothTarget: 12, peakEnabled: true });
+    expect(smoother.reset).toHaveBeenLastCalledWith(0);
+    expect(meter.view).toEqual({ smoothedValue: 0, peakValue: null });
+    meter.sync({ sample: 8, smoothTarget: null, peakEnabled: true });
+    expect(meter.view).toEqual({ smoothedValue: 0, peakValue: null });
+  });
+
+  it('relatches equality, holds after separation, then decrements once per delivered frame', () => {
+    const { host, meter, smoother } = frameSetup();
+    meter.sync({ sample: 10, smoothTarget: 10, peakEnabled: true });
+    meter.start();
+    host.advance(900);
+    host.flushFrame(0);
+    smoother.set(8);
+    host.flushFrame(900);
+    expect(meter.view.peakValue).toBe(10);
+    host.flushFrame(101);
+    expect(meter.view.peakValue).toBe(9);
+    host.flushFrame(400);
+    expect(meter.view.peakValue).toBe(8);
+  });
+
+  it('uses the current caller decrement and never falls below the smoother', () => {
+    let decrement = 1;
+    const { host, meter, smoother } = frameSetup({ decrement: () => decrement });
+    meter.sync({ sample: 12, smoothTarget: 12, peakEnabled: true });
+    meter.start();
+    smoother.set(3);
+    host.flushFrame(1001);
+    expect(meter.view.peakValue).toBe(11);
+    decrement = 20;
+    host.flushFrame();
+    expect(meter.view.peakValue).toBe(3);
+  });
+
+  it('keeps a static reduced-motion peak and re-seats it on the next expired sync', () => {
+    const { host, meter } = frameSetup({ reduced: true });
+    meter.sync({ sample: 10, smoothTarget: 10, peakEnabled: true });
+    meter.start();
+    expect(host.activeFrames).toBe(0);
+    host.advance(1001);
+    expect(meter.view.peakValue).toBe(10);
+    meter.sync({ sample: 2, smoothTarget: 2, peakEnabled: true });
+    expect(meter.view.peakValue).toBe(2);
+  });
+});
+
+describe('createMeterBallistics elapsed-envelope strategy', () => {
+  it('delegates observe and projection to the injected envelope functions', () => {
+    const { meter, update, display } = elapsedSetup();
+    meter.sync({ sample: 0.8, smoothTarget: 6, peakEnabled: true });
+    expect(update).toHaveBeenCalledExactlyOnceWith(undefined, 0.8, 0, 1500);
+    expect(meter.view).toEqual({ smoothedValue: 6, peakValue: 0.8 });
+    expect(display).toHaveBeenCalledExactlyOnceWith({ latchedPeak: 0.8, latchedAt: 0 }, 0.8, 0, 1500);
+  });
+
+  it('advances wall time without observing or resampling input', () => {
+    const { host, meter, update, display } = elapsedSetup();
+    meter.sync({ sample: 1, smoothTarget: 10, peakEnabled: true });
+    meter.sync({ sample: 0.1, smoothTarget: 1, peakEnabled: true });
+    meter.start();
+    expect(host.activeIntervals).toBe(1);
+    update.mockClear();
+    display.mockClear();
+    host.advance(750);
+    host.flushIntervals();
+    expect(update).not.toHaveBeenCalled();
+    expect(meter.view.peakValue).toBe(0.5);
+    expect(display).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides without clearing state and reset remains clear until a new sync', () => {
+    const { meter } = elapsedSetup();
+    meter.sync({ sample: 1, smoothTarget: 10, peakEnabled: true });
+    meter.sync({ sample: 0.2, smoothTarget: 2, peakEnabled: false });
+    expect(meter.view.peakValue).toBeNull();
+    meter.sync({ sample: 0.2, smoothTarget: 2, peakEnabled: true });
+    expect(meter.view.peakValue).toBe(1);
+    meter.resetPeak();
+    expect(meter.view.peakValue).toBeNull();
+    expect(meter.view.peakValue).toBeNull();
+    meter.sync({ sample: 0.2, smoothTarget: 2, peakEnabled: true });
+    expect(meter.view.peakValue).toBe(0.2);
+  });
+
+  it('uses static reduced-motion projection and re-seats only on genuine sync', () => {
+    const { host, meter } = elapsedSetup(true);
+    meter.sync({ sample: 1, smoothTarget: 10, peakEnabled: true });
+    meter.start();
+    expect(host.activeIntervals).toBe(0);
+    host.advance(2000);
+    expect(meter.view.peakValue).toBe(1);
+    meter.sync({ sample: 0.2, smoothTarget: 2, peakEnabled: true });
+    expect(meter.view.peakValue).toBe(0.2);
+  });
+});
+
+describe('createMeterBallistics scheduling lifecycle', () => {
+  it.each([
+    ['frame', frameSetup, 'activeFrames'],
+    ['interval', elapsedSetup, 'activeIntervals'],
+  ] as const)('keeps one %s schedule across preference flips and tears down once', (_name, setup, count) => {
+    const { host, meter, smoother } = setup();
+    meter.sync({ sample: 1, smoothTarget: 1, peakEnabled: true });
+    meter.start();
+    expect(smoother.start).toHaveBeenCalledTimes(1);
+    expect(host[count]).toBe(1);
+    expect(host.listenerCount).toBe(1);
+    host.setReduced(true);
+    expect(host[count]).toBe(0);
+    host.setReduced(false);
+    expect(host[count]).toBe(1);
+    host.setReduced(false);
+    expect(host[count]).toBe(1);
+    meter.stop();
+    expect(host[count]).toBe(0);
+    expect(host.listenerCount).toBe(0);
+    expect(smoother.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops an interval while peak is hidden and resumes it on re-enable', () => {
+    const { host, meter } = elapsedSetup();
+    meter.sync({ sample: 1, smoothTarget: 10, peakEnabled: true });
+    meter.start();
+    meter.sync({ sample: 0.5, smoothTarget: 5, peakEnabled: false });
+    expect(host.activeIntervals).toBe(0);
+    meter.sync({ sample: 0.5, smoothTarget: 5, peakEnabled: true });
+    expect(host.activeIntervals).toBe(1);
+  });
+});

--- a/frontend/src/primitives/meters/meter-ballistics.svelte.ts
+++ b/frontend/src/primitives/meters/meter-ballistics.svelte.ts
@@ -1,0 +1,204 @@
+export type MeterBehaviorInput = Readonly<{
+  sample: number | null;
+  smoothTarget: number | null;
+  peakEnabled: boolean;
+}>;
+
+export interface MeterBallisticsView {
+  readonly smoothedValue: number;
+  readonly peakValue: number | null;
+}
+
+export interface MeterSmoother {
+  readonly value: number;
+  update(value: number): void;
+  reset(value: number): void;
+  start(): void;
+  stop(): void;
+}
+
+export type MeterTicker =
+  | Readonly<{ kind: 'animation-frame' }>
+  | Readonly<{ kind: 'interval'; milliseconds: number }>;
+
+type MeterIntervalId = ReturnType<typeof setInterval>;
+
+export interface MeterMotionHost {
+  now(): number;
+  requestFrame(callback: FrameRequestCallback): number;
+  cancelFrame(id: number): void;
+  setInterval(callback: () => void, milliseconds: number): MeterIntervalId;
+  clearInterval(id: MeterIntervalId): void;
+  prefersReducedMotion(): boolean;
+  onReducedMotionChange(callback: (reduced: boolean) => void): () => void;
+}
+
+export interface MeterPeakStrategy<State> {
+  seed(current: number, now: number): State;
+  observe(state: State, current: number, now: number, reduced: boolean): State;
+  advance(state: State, current: number, now: number): State;
+  project(state: State, current: number, now: number, reduced: boolean): number;
+}
+
+export interface MeterBallisticsPolicy<State> {
+  readonly peakSource: 'sample' | 'smoothed';
+  readonly ticker: MeterTicker;
+  readonly peak: MeterPeakStrategy<State>;
+}
+
+export interface MeterBallistics {
+  readonly view: Readonly<MeterBallisticsView>;
+  sync(input: MeterBehaviorInput): void;
+  resetPeak(): void;
+  start(): void;
+  stop(): void;
+}
+
+type FrameStepPeak = Readonly<{ value: number; latchedAt: number }>;
+
+export function createFrameStepPeakStrategy(options: Readonly<{
+  holdMilliseconds: number;
+  decrementPerFrame: () => number;
+}>): MeterPeakStrategy<FrameStepPeak> {
+  const latch = (current: number, now: number): FrameStepPeak => ({ value: current, latchedAt: now });
+  return {
+    seed: latch,
+    observe(state, current, now, reduced) {
+      if (current >= state.value || (reduced && now - state.latchedAt > options.holdMilliseconds)) {
+        return latch(current, now);
+      }
+      return state;
+    },
+    advance(state, current, now) {
+      if (current >= state.value) return latch(current, now);
+      if (now - state.latchedAt <= options.holdMilliseconds) return state;
+      return { ...state, value: Math.max(current, state.value - options.decrementPerFrame()) };
+    },
+    project: (state) => state.value,
+  };
+}
+
+export function createElapsedEnvelopePeakStrategy<State extends { readonly latchedPeak: number }>(
+  options: Readonly<{
+    decayMilliseconds: number;
+    updatePeakHold(state: State | undefined, current: number, now: number, decayMilliseconds: number): State;
+    peakHoldDisplay(state: State, current: number, now: number, decayMilliseconds: number): number;
+  }>,
+): MeterPeakStrategy<State> {
+  return {
+    seed: (current, now) => options.updatePeakHold(undefined, current, now, options.decayMilliseconds),
+    observe: (state, current, now) => (
+      options.updatePeakHold(state, current, now, options.decayMilliseconds)
+    ),
+    advance: (state) => state,
+    project: (state, current, now, reduced) => (
+      reduced
+        ? state.latchedPeak
+        : options.peakHoldDisplay(state, current, now, options.decayMilliseconds)
+    ),
+  };
+}
+
+export function createMeterBallistics<State>(
+  smoother: MeterSmoother,
+  host: MeterMotionHost,
+  policy: Readonly<MeterBallisticsPolicy<State>>,
+): MeterBallistics {
+  let peakState = $state<State | undefined>(undefined);
+  let sample = $state(0);
+  let peakEnabled = $state(false);
+  let projectionNow = $state(host.now());
+  let reduced = $state(host.prefersReducedMotion());
+  let started = false;
+  let scheduleId: number | MeterIntervalId | undefined;
+  let unsubscribe: (() => void) | undefined;
+
+  function peakCurrent(): number {
+    return policy.peakSource === 'sample' ? sample : smoother.value;
+  }
+
+  function clearSchedule(): void {
+    if (scheduleId === undefined) return;
+    if (policy.ticker.kind === 'animation-frame') host.cancelFrame(scheduleId as number);
+    else host.clearInterval(scheduleId as MeterIntervalId);
+    scheduleId = undefined;
+  }
+
+  function advance(now: number): void {
+    projectionNow = now;
+    if (peakState !== undefined) {
+      peakState = policy.peak.advance(peakState, peakCurrent(), now);
+    }
+  }
+
+  function ensureSchedule(): void {
+    if (!started || reduced || !peakEnabled || scheduleId !== undefined) return;
+    if (policy.ticker.kind === 'animation-frame') {
+      scheduleId = host.requestFrame((now) => {
+        scheduleId = undefined;
+        if (!started || reduced || !peakEnabled) return;
+        advance(now);
+        ensureSchedule();
+      });
+      return;
+    }
+    scheduleId = host.setInterval(() => advance(host.now()), policy.ticker.milliseconds);
+  }
+
+  function reconcileSchedule(): void {
+    if (!started || reduced || !peakEnabled) clearSchedule();
+    else ensureSchedule();
+  }
+
+  return {
+    get view() {
+      const peakValue = peakEnabled && peakState !== undefined
+        ? policy.peak.project(peakState, peakCurrent(), projectionNow, reduced)
+        : null;
+      return { smoothedValue: smoother.value, peakValue };
+    },
+    sync(input) {
+      peakEnabled = input.peakEnabled;
+      projectionNow = host.now();
+      if (input.sample === null || input.smoothTarget === null) {
+        sample = 0;
+        smoother.reset(0);
+        peakState = undefined;
+        reconcileSchedule();
+        return;
+      }
+      sample = input.sample;
+      smoother.update(input.smoothTarget);
+      if (peakEnabled) {
+        const current = peakCurrent();
+        peakState = peakState === undefined
+          ? policy.peak.seed(current, projectionNow)
+          : policy.peak.observe(peakState, current, projectionNow, reduced);
+      }
+      reconcileSchedule();
+    },
+    resetPeak() {
+      peakState = undefined;
+      projectionNow = host.now();
+    },
+    start() {
+      if (started) return;
+      started = true;
+      smoother.start();
+      reduced = host.prefersReducedMotion();
+      unsubscribe = host.onReducedMotionChange((nextReduced) => {
+        reduced = nextReduced;
+        reconcileSchedule();
+      });
+      ensureSchedule();
+    },
+    stop() {
+      if (!started) return;
+      started = false;
+      clearSchedule();
+      unsubscribe?.();
+      unsubscribe = undefined;
+      smoother.stop();
+    },
+  };
+}

--- a/frontend/src/primitives/meters/meter-ballistics.svelte.ts
+++ b/frontend/src/primitives/meters/meter-ballistics.svelte.ts
@@ -188,6 +188,10 @@ export function createMeterBallistics<State>(
       reduced = host.prefersReducedMotion();
       unsubscribe = host.onReducedMotionChange((nextReduced) => {
         reduced = nextReduced;
+        if (nextReduced && peakEnabled && peakState !== undefined && policy.peakSource === 'smoothed') {
+          projectionNow = host.now();
+          peakState = policy.peak.observe(peakState, smoother.value, projectionNow, true);
+        }
         reconcileSchedule();
       });
       ensureSchedule();


### PR DESCRIPTION
5 code + 0 regenerated baselines = 5 files.

## Scope

Implements [MOR-1374 phase A](https://linear.app/morozsm/issue/MOR-1374/linearsmeter-has-its-own-peak-hold-reimplementation-bypassing-meter) only.

- Adds one headless single-channel meter lifecycle with injected smoother and motion host.
- Adopts it in both LinearSMeter and BarGauge.
- Preserves Linear frame-step hold/decay and dynamic segment units.
- Preserves BarGauge elapsed envelope by injecting the existing meter-utils functions.
- Leaves renderer props, markup, geometry, CSS, and image baselines unchanged.

Measured change: 611 additions + 147 deletions = 758 A+D. This is one semantic unit because the shared lifecycle is earned by both production adopters; splitting either adopter out would leave phase A incomplete.

## First Review Correction

The shared owner now observes the smoother value after a runtime reduced-motion ON transition for smoothed-source policies. This preserves a pending Linear high-water peak when the smoother snaps before its next frame. Sample-source policies do not observe or relatch on preference flips, preserving BarGauge behavior.

## Verification

- Focused meter tests: 10 files, 142 tests passed.
- Frontend type checks: 0 errors, 0 warnings.
- Changed-file ESLint: passed.
- Frontend boundary lint: passed.
- RED/GREEN: the headless and actual Linear component transition cases failed before the correction and pass on the corrected head.
- Unaffected controls: Bar sample-source transition, zero/one scheduling, OFF resume, and listener cleanup pass.

## Remaining Work

MOR-1374 remains In Progress. Phase B must adopt the lifecycle in MetersDockPanel while preserving one ticker for four channels and held-raw projection order. Phase C remains sequenced after MOR-2385 for real provider and receiver context.
