### PR TITLE
refactor: share Dock meter ballistics lifecycle (MOR-1374 phase B)

### DIFF
--- a/frontend/src/components-v2/panels/MetersDockPanel.svelte
+++ b/frontend/src/components-v2/panels/MetersDockPanel.svelte
@@ -2,6 +2,10 @@
   import { onMount, untrack } from 'svelte';
   import { createSmoother, onReducedMotionChange, prefersReducedMotion } from '$lib/utils/smoothing.svelte';
   import {
+    createElapsedEnvelopePeakStrategy,
+    createMeterBallisticsGroup,
+  } from '../../primitives/meters/meter-ballistics.svelte';
+  import {
     alcLevel,
     compLevel,
     formatAlc,
@@ -59,7 +63,8 @@
     txActive,
   }: Props = $props();
 
-  type PeakKey = 'po' | 'swr' | 'alc' | 'id';
+  const PEAK_KEYS = ['po', 'swr', 'alc', 'id'] as const;
+  type PeakKey = (typeof PEAK_KEYS)[number];
 
   interface Tile {
     key: 'po' | 'swr' | 'alc' | 's' | 'id' | 'vd' | 'comp';
@@ -75,160 +80,53 @@
     fault?: boolean;
   }
 
-  // TX-meter display ballistics (MOR-498): a real analog Po/ALC/SWR/Id meter
-  // peaks on each voice syllable and decays slowly, so the operator reads the
-  // peak rather than the instantaneous trough. The web meters previously showed
-  // the INSTANTANEOUS sample, so the Po number collapsed to ~1 W in the gaps
-  // between syllables even though the radio's own needle held ~50 W.
-  //
-  // Fix: peak-hold the RAW meter value (fast attack, ~1.5 s linear decay) and
-  // derive BOTH the formatted number and the bar fill from that single held raw
-  // value, so the digits and the fill stay consistent. On RX the raw values are
-  // 0, so the held peak naturally decays to 0 within the window (no stale TX
-  // peak bleed). Vd (steady supply rail), COMP (not requested) and S (the RX
-  // indicator) keep instantaneous display. `PEAK_DECAY_MS` is the shared
-  // decay window (MOR-1282) imported from `./meter-utils` above — BarGauge
-  // imports the same binding so the window can never drift between surfaces.
+  const peakGroup = createMeterBallisticsGroup(PEAK_KEYS, {
+    now: () => Date.now(),
+    requestFrame: (callback) => requestAnimationFrame(callback),
+    cancelFrame: (id) => cancelAnimationFrame(id),
+    setInterval: (callback, milliseconds) => setInterval(callback, milliseconds),
+    clearInterval: (id) => clearInterval(id),
+    prefersReducedMotion,
+    onReducedMotionChange,
+  }, {
+    ticker: { kind: 'interval', milliseconds: 100 },
+    peak: createElapsedEnvelopePeakStrategy<PeakHoldState>({
+      decayMilliseconds: PEAK_DECAY_MS,
+      updatePeakHold,
+      peakHoldDisplay,
+    }),
+  });
 
-  // Peak-hold state for Po/SWR/ALC/Id, latched on the RAW meter value. Stores
-  // the latched peak + timestamp only; the decayed value is recomputed per
-  // render from `now` so it stays linear across the decay window instead of
-  // compounding tick-by-tick.
-  let peaks = $state<Partial<Record<PeakKey, PeakHoldState>>>({});
-  let now = $state(Date.now());
+  const peakSamples: Readonly<Record<PeakKey, number | null>> = {
+    get po() { return powerMeter ?? null; },
+    get swr() { return swrMeter ?? null; },
+    get alc() { return alcMeter ?? null; },
+    get id() { return idMeter ?? null; },
+  };
 
-  function steppeak(key: PeakKey, current: number | undefined, t: number) {
-    if (current === undefined) {
-      if (peaks[key] !== undefined) peaks[key] = undefined;
-      return;
-    }
-    const next = updatePeakHold(peaks[key], current, t, PEAK_DECAY_MS);
-    // Only write back on a re-latch / anchor reset — otherwise skip to avoid
-    // flagging a reactive read-then-write cycle. The display recomputes from
-    // `now` regardless.
-    if (peaks[key] !== next) peaks[key] = next;
-  }
+  $effect(() => {
+    void powerMeter;
+    void swrMeter;
+    void alcMeter;
+    void idMeter;
+    untrack(() => peakGroup.sync(peakSamples));
+  });
 
-  function stepAllPeaks() {
-    const t = Date.now();
-    now = t;
-    // Latch on the RAW meter value so the held value drives both the number
-    // (formatter) and the fill (level fn) coherently.
-    steppeak('po', powerMeter, t);
-    steppeak('swr', swrMeter, t);
-    steppeak('alc', alcMeter, t);
-    steppeak('id', idMeter, t);
-  }
+  onMount(() => {
+    peakGroup.start();
+    return () => peakGroup.stop();
+  });
 
-  // Returns the peak-held RAW value for a TX meter for the current render
-  // frame, decayed linearly toward the live raw sample across PEAK_DECAY_MS.
-  function heldRaw(key: PeakKey, liveRaw: number): number {
-    return peakHoldDisplay(peaks[key], liveRaw, now, PEAK_DECAY_MS);
-  }
-
-  // MOR-1252: the NUMBER (and, coupled to it, the bar FILL) always render
-  // the raw live sample under reduced motion — never the held/decaying
-  // value — so freezing the peak marker never freezes the readout. Under
-  // full motion this is unchanged: both still derive from the held+decaying
-  // raw value (MOR-498/1249 ballistics stand).
   function displayRaw(key: PeakKey, liveRaw: number): number {
-    return prefersReducedMotion() ? liveRaw : heldRaw(key, liveRaw);
+    return peakGroup.view(key).displayedValue ?? liveRaw;
   }
 
-  // MOR-1252: fill-% position for the peak MARKER. Under full motion this
-  // matches `fillPct` exactly (the marker rides the held/decaying bar tip,
-  // unchanged from MOR-498/1249). Under reduced motion it instead reflects
-  // the STATIC latch (`peaks[key].latchedPeak`), independent of the live
-  // `raw` driving the number/fill — undefined (no marker) while unlatched.
   function peakFillPctFor(
     key: PeakKey,
-    raw: number,
     levelFn: (raw: number) => number,
   ): number | undefined {
-    const peakState = peaks[key];
-    if (peakState === undefined) return undefined;
-    return levelFn(prefersReducedMotion() ? peakState.latchedPeak : raw) * 100;
-  }
-
-  // A 100ms interval drives both the decay and the latch from fresh
-  // prop samples. Driving everything off a timer (not a reactive $effect)
-  // avoids the read-then-write cycle on `peaks` that Svelte 5 flags.
-  //
-  // MOR-1249/MOR-1252: mirrors the MOR-1233 fix shipped for LinearSMeter's
-  // own rAF peak-hold loop — under `prefers-reduced-motion` there is no
-  // hold-then-decay animation, so this interval is not scheduled at all (no
-  // ticks). Unlike the interim MOR-1249 fix, the latch itself is NOT
-  // cleared here: per the MOR-1252 owner decision the peak MARKER is a
-  // static hold (latch at the highest observed value, instant reset on
-  // expiry) while the NUMBER/FILL stay live via `displayRaw` above. The
-  // reduced-motion branch below is kept only for the ticking
-  // interval's own start/stop lifecycle; the latch's static-hold semantics
-  // are owned by the prop-reactive effect further down (no timer needed —
-  // see meter-utils.ts's `updatePeakHold`, which already holds statically
-  // and re-seats instantly on expiry rather than gliding).
-  //
-  // Reacts to the OS preference flipping mid-session in both directions
-  // (fix cycle 1 precedent: deciding once at mount is not enough).
-  $effect(() => {
-    let intervalId: ReturnType<typeof setInterval> | null = null;
-
-    function startTicking() {
-      if (intervalId) return;
-      intervalId = setInterval(() => untrack(() => stepAllPeaks()), 100);
-    }
-
-    function stopTicking() {
-      if (intervalId) {
-        clearInterval(intervalId);
-        intervalId = null;
-      }
-    }
-
-    if (!prefersReducedMotion()) {
-      untrack(() => stepAllPeaks());
-      startTicking();
-    }
-
-    const unsubscribe = onReducedMotionChange((reduced) => {
-      if (reduced) {
-        stopTicking();
-      } else if (!intervalId) {
-        untrack(() => stepAllPeaks());
-        startTicking();
-      }
-    });
-
-    return () => {
-      stopTicking();
-      unsubscribe();
-    };
-  });
-
-  // MOR-1252: keeps the static-hold latch fresh under reduced motion. This
-  // is ordinary prop-reactive Svelte tracking — it re-runs only when a raw
-  // meter value actually changes (a genuine data update) — not a scheduled
-  // loop, so it does not reintroduce the animation prefers-reduced-motion
-  // disables. `updatePeakHold` (see meter-utils.ts) already implements
-  // exactly the desired semantics: hold the latch unchanged while within
-  // the decay window, or re-seat it to the current sample (a single jump,
-  // no glide) once the window has elapsed.
-  $effect(() => {
-    const po = powerMeter;
-    const swr = swrMeter;
-    const alc = alcMeter;
-    const id = idMeter;
-    if (!prefersReducedMotion()) return;
-    const t = Date.now();
-    untrack(() => {
-      steppeak('po', po, t);
-      steppeak('swr', swr, t);
-      steppeak('alc', alc, t);
-      steppeak('id', id, t);
-    });
-  });
-
-  function resetPeak(key: PeakKey) {
-    peaks[key] = undefined;
+    const peakValue = peakGroup.view(key).peakValue;
+    return peakValue === null ? undefined : levelFn(peakValue) * 100;
   }
 
   // Priority order (plan §3): Po → SWR → ALC → S. Tiles with undefined
@@ -241,10 +139,7 @@
     // MOR-483 part-1 hide-on-RX). The S tile (RX indicator) and Vd tile
     // (continuous supply rail) likewise stay rendered in both states.
     // Po/SWR/ALC/Id are peak-held: the formatted number and the bar fill both
-    // derive from the SAME held raw value (`heldRaw(...)`), so they stay in
-    // lockstep through the decay. Read `now` so the derived recomputes each
-    // 100 ms tick as the held peak decays.
-    void now;
+    // derive from the same grouped held raw value, so they stay in lockstep.
     if (powerMeter !== undefined) {
       const raw = displayRaw('po', powerMeter);
       out.push({
@@ -252,7 +147,7 @@
         label: 'Po',
         display: formatPowerWatts(raw),
         fillPct: normalizePower(raw) * 100,
-        peakFillPct: peakFillPctFor('po', raw, normalizePower),
+        peakFillPct: peakFillPctFor('po', normalizePower),
         fill: 'var(--v2-meter-power-fill)',
         track: 'var(--v2-meter-power-track)',
         relevant: txActive,
@@ -265,7 +160,7 @@
         label: 'SWR',
         display: formatSwr(raw),
         fillPct: swrLevel(raw) * 100,
-        peakFillPct: peakFillPctFor('swr', raw, swrLevel),
+        peakFillPct: peakFillPctFor('swr', swrLevel),
         fill: 'var(--v2-meter-swr-fill)',
         track: 'var(--v2-meter-swr-track)',
         relevant: txActive,
@@ -279,7 +174,7 @@
         label: 'ALC',
         display: formatAlc(raw),
         fillPct: alcLevel(raw) * 100,
-        peakFillPct: peakFillPctFor('alc', raw, alcLevel),
+        peakFillPct: peakFillPctFor('alc', alcLevel),
         fill: 'var(--v2-meter-alc-fill)',
         track: 'var(--v2-meter-alc-track)',
         relevant: txActive,
@@ -293,7 +188,7 @@
         label: 'Id',
         display: formatAmps(raw),
         fillPct: idLevel(raw) * 100,
-        peakFillPct: peakFillPctFor('id', raw, idLevel),
+        peakFillPct: peakFillPctFor('id', idLevel),
         fill: 'var(--v2-meter-id-fill)',
         track: 'var(--v2-meter-id-track)',
         relevant: txActive,
@@ -340,10 +235,10 @@
   // Issue #938 — per-tile rAF-driven bar smoothing. Smoothers are keyed by
   // tile.key and reused across renders so the bar carries fractional state
   // between updates. Peak-hold (`peakFillPct`) and digit text
-  // (`tile.display`) continue to read raw props; only the bar-fill width is
-  // smoothed. Each smoother is seeded with the tile's current fillPct on
-  // first creation so the initial synchronous render matches the raw target
-  // (no flash from 0).
+  // (`tile.display`) continue to read the group's displayed raw values; only
+  // the bar-fill width is smoothed. Each smoother is seeded with the tile's
+  // current fillPct on first creation so the initial synchronous render
+  // matches the raw target (no flash from 0).
   type Smoother = ReturnType<typeof createSmoother>;
   const smoothers = new Map<Tile['key'], Smoother>();
 
@@ -405,7 +300,7 @@
             tile.key === 'alc' ||
             tile.key === 'id'
           ) {
-            resetPeak(tile.key);
+            peakGroup.resetPeak(tile.key);
           }
         }}
       >

--- a/frontend/src/components-v2/panels/__tests__/MetersDockPanel.peakhold.svelte.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MetersDockPanel.peakhold.svelte.test.ts
@@ -99,6 +99,15 @@ function poNumber(t: HTMLElement): string | null | undefined {
   return t.querySelector('[data-meter="po"] .tile-value')?.textContent;
 }
 
+function peakMarkerCount(t: HTMLElement, meterKey = 'po'): number {
+  return t.querySelectorAll(`[data-meter="${meterKey}"] [data-testid="peak-marker"]`).length;
+}
+
+function fillWidth(t: HTMLElement, meterKey = 'po'): number {
+  const fill = t.querySelector(`[data-meter="${meterKey}"] .tile-bar-fill`) as HTMLElement | null;
+  return parseFloat(fill?.style.width ?? '0');
+}
+
 describe('MetersDockPanel TX peak-hold ballistics (MOR-498)', () => {
   it('holds the Po NUMBER near a prior peak through the inter-syllable gap', () => {
     // 100 W (a voice peak); 2 W (an inter-syllable trough) — engineering
@@ -183,5 +192,47 @@ describe('MetersDockPanel TX peak-hold ballistics (MOR-498)', () => {
     vi.advanceTimersByTime(100);
     flushSync();
     expect(t.querySelector('[data-meter="vd"] .tile-value')?.textContent).toBe('13.8 V');
+  });
+
+  it('clears a removed channel immediately and reappears without its stale peak or smoother', () => {
+    const { t, state } = mountReactive({ powerMeter: 100, txActive: true });
+    vi.advanceTimersByTime(100);
+    flushSync();
+    expect(poNumber(t)).toBe('100W');
+    expect(peakMarkerCount(t)).toBe(1);
+
+    state.powerMeter = undefined;
+    flushSync();
+    expect(t.querySelector('[data-meter="po"]')).toBeNull();
+    state.powerMeter = 2;
+    flushSync();
+    expect(poNumber(t)).toBe('2W');
+    expect(peakMarkerCount(t)).toBe(0);
+    expect(fillWidth(t)).toBeLessThan(10);
+  });
+
+  it('resets only Po and relatches it on the next shared tick', () => {
+    const { t } = mountReactive({
+      powerMeter: 100,
+      swrMeter: 3,
+      alcMeter: 60,
+      idMeter: 25,
+      txActive: true,
+    });
+    vi.advanceTimersByTime(100);
+    flushSync();
+    for (const key of ['po', 'swr', 'alc', 'id']) expect(peakMarkerCount(t, key)).toBe(1);
+
+    t.querySelector('[data-meter="po"]')?.dispatchEvent(new Event('dblclick', { bubbles: true }));
+    flushSync();
+    expect(peakMarkerCount(t, 'po')).toBe(0);
+    for (const key of ['swr', 'alc', 'id']) expect(peakMarkerCount(t, key)).toBe(1);
+
+    vi.advanceTimersByTime(99);
+    flushSync();
+    expect(peakMarkerCount(t, 'po')).toBe(0);
+    vi.advanceTimersByTime(1);
+    flushSync();
+    expect(peakMarkerCount(t, 'po')).toBe(1);
   });
 });

--- a/frontend/src/components-v2/panels/__tests__/MetersDockPanel.reduced-motion.svelte.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MetersDockPanel.reduced-motion.svelte.test.ts
@@ -9,9 +9,8 @@ import MetersDockPanel from '../MetersDockPanel.svelte';
 // while the peak marker glided. These tests pin the fix, mirroring the
 // MOR-1233 precedent already shipped for LinearSMeter's own rAF peak-hold
 // loop: under reduced motion the decay interval is not scheduled at all (no
-// ticks), any already-latched peak snaps to the live raw value (never
-// freezes at a stale position), and the preference is honored on RUNTIME
-// flips in both directions.
+// ticks), the number and fill follow live raw values while the marker remains
+// static, and the preference is honored on RUNTIME flips in both directions.
 //
 // The MatchMediaMock + mockReducedMotion() helper is duplicated from
 // smoothing.isolated.test.ts / LinearSMeter.reduced-motion.svelte.test.ts,
@@ -187,6 +186,23 @@ describe('MetersDockPanel — prefers-reduced-motion (MOR-1249)', () => {
     }
   });
 
+  it('uses one interval for all four peak-capable channels', () => {
+    const { restore } = mockReducedMotion(false);
+    try {
+      mountReactive({
+        powerMeter: 100,
+        swrMeter: 3,
+        alcMeter: 60,
+        idMeter: 25,
+        txActive: true,
+      });
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+      expect(netActiveIntervals()).toBe(1);
+    } finally {
+      restore();
+    }
+  });
+
   it('snaps the Po NUMBER directly to the live raw sample when reduced motion is preferred (no glide)', () => {
     const { restore } = mockReducedMotion(true);
     try {
@@ -280,10 +296,31 @@ describe('MetersDockPanel — prefers-reduced-motion (MOR-1249)', () => {
       restore();
     }
   });
+
+  it('keeps a reset peak clear until a genuine reduced-motion sample update', () => {
+    const { restore } = mockReducedMotion(true);
+    try {
+      const { t, state } = mountReactive({ powerMeter: 100, txActive: true });
+      expect(peakMarkerCount(t)).toBe(1);
+      t.querySelector('[data-meter="po"]')?.dispatchEvent(new Event('dblclick', { bubbles: true }));
+      flushSync();
+      expect(peakMarkerCount(t)).toBe(0);
+
+      vi.advanceTimersByTime(2000);
+      flushSync();
+      expect(peakMarkerCount(t)).toBe(0);
+      state.powerMeter = 2;
+      flushSync();
+      expect(peakMarkerCount(t)).toBe(1);
+      expect(poNumber(t)).toBeLessThan(10);
+    } finally {
+      restore();
+    }
+  });
 });
 
 describe('MetersDockPanel — runtime prefers-reduced-motion flips (MOR-1249, mirrors MOR-1233 F1/F2)', () => {
-  it('KILL F1: stops the live decay interval and snaps the peak to current when reduced motion turns ON mid-session', () => {
+  it('KILL F1: stops the live decay interval while the readout follows current when reduced motion turns ON', () => {
     const { setMatches, restore } = mockReducedMotion(false);
     try {
       const { t, state } = mountReactive({ powerMeter: 100, txActive: true });
@@ -298,8 +335,7 @@ describe('MetersDockPanel — runtime prefers-reduced-motion flips (MOR-1249, mi
       expect(netActiveIntervals()).toBe(0); // the interval was torn down
 
       // Drop the raw signal; without any timer advancing, the number must
-      // reflect the live trough immediately — proving the held peak was
-      // cleared (snapped), not merely paused mid-decay (frozen).
+      // reflect the live trough immediately while the marker stays static.
       state.powerMeter = 2;
       flushSync();
       expect(poNumber(t)).toBeLessThan(10);

--- a/frontend/src/primitives/meters/__tests__/meter-ballistics.test.ts
+++ b/frontend/src/primitives/meters/__tests__/meter-ballistics.test.ts
@@ -4,6 +4,7 @@ import {
   createElapsedEnvelopePeakStrategy,
   createFrameStepPeakStrategy,
   createMeterBallistics,
+  createMeterBallisticsGroup,
   type MeterMotionHost,
   type MeterSmoother,
 } from '../meter-ballistics.svelte';
@@ -132,6 +133,32 @@ function elapsedSetup(reduced = false) {
     }),
   });
   return { host, smoother, meter, update, display };
+}
+
+const GROUP_KEYS = ['po', 'swr', 'alc', 'id'] as const;
+
+function groupSetup(reduced = false) {
+  const host = createHost(reduced);
+  const update = vi.fn((state: { latchedPeak: number; latchedAt: number } | undefined, value: number, now: number) => (
+    state === undefined || value > state.latchedPeak || now - state.latchedAt > 1500
+      ? { latchedPeak: value, latchedAt: now }
+      : state
+  ));
+  const display = vi.fn((state: { latchedPeak: number; latchedAt: number }, value: number, now: number) => (
+    Math.max(value, state.latchedPeak * (1 - (now - state.latchedAt) / 1500))
+  ));
+  const group = createMeterBallisticsGroup(GROUP_KEYS, host, {
+    ticker: { kind: 'interval', milliseconds: 100 },
+    peak: createElapsedEnvelopePeakStrategy({
+      decayMilliseconds: 1500,
+      updatePeakHold: update,
+      peakHoldDisplay: display,
+    }),
+  });
+  const sync = (over: Partial<Record<(typeof GROUP_KEYS)[number], number | null>> = {}) => {
+    group.sync({ po: 100, swr: 3, alc: 60, id: 25, ...over });
+  };
+  return { host, group, update, display, sync };
 }
 
 describe('createMeterBallistics frame-step strategy', () => {
@@ -280,6 +307,98 @@ describe('createMeterBallistics elapsed-envelope strategy', () => {
     host.setReduced(false);
     expect(update).not.toHaveBeenCalled();
     expect(host.activeIntervals).toBe(1);
+  });
+});
+
+describe('createMeterBallisticsGroup', () => {
+  it('observes four channels at one time through one interval and listener', () => {
+    const { host, group, update, sync } = groupSetup();
+    sync();
+    expect(update).not.toHaveBeenCalled();
+    group.start();
+    expect(host.activeIntervals).toBe(1);
+    expect(host.listenerCount).toBe(1);
+    expect(update).toHaveBeenCalledTimes(4);
+    expect(new Set(update.mock.calls.map((call) => call[2]))).toEqual(new Set([0]));
+
+    update.mockClear();
+    host.advance(100);
+    host.flushIntervals();
+    expect(update).toHaveBeenCalledTimes(4);
+    expect(new Set(update.mock.calls.map((call) => call[2]))).toEqual(new Set([100]));
+  });
+
+  it('stores normal sync, resets one channel, and relatches only on the next tick', () => {
+    const { host, group, update, sync } = groupSetup();
+    sync();
+    group.start();
+    update.mockClear();
+    sync({ po: 2, swr: 1.2 });
+    expect(update).not.toHaveBeenCalled();
+    group.resetPeak('po');
+    expect(group.view('po')).toEqual({ liveValue: 2, displayedValue: 2, peakValue: null });
+    expect(group.view('swr').peakValue).toBe(3);
+    expect(update).not.toHaveBeenCalled();
+
+    host.advance(100);
+    host.flushIntervals();
+    expect(group.view('po').peakValue).toBe(2);
+    expect(group.view('swr').peakValue).toBeGreaterThan(1.2);
+    expect(update).toHaveBeenCalledTimes(4);
+  });
+
+  it('clears absence immediately and reappears live without stale peak state', () => {
+    const { host, group, sync } = groupSetup();
+    sync();
+    group.start();
+    sync({ po: null });
+    expect(group.view('po')).toEqual({ liveValue: null, displayedValue: null, peakValue: null });
+    sync({ po: 2 });
+    expect(group.view('po')).toEqual({ liveValue: 2, displayedValue: 2, peakValue: null });
+    host.advance(100);
+    host.flushIntervals();
+    expect(group.view('po').peakValue).toBe(2);
+  });
+
+  it('delegates normal projection while reduced motion keeps live display and static peak', () => {
+    const { host, group, display, sync } = groupSetup();
+    sync();
+    group.start();
+    sync({ po: 2 });
+    host.advance(750);
+    host.flushIntervals();
+    display.mockClear();
+    expect(group.view('po').displayedValue).toBe(50);
+    expect(group.view('po').peakValue).toBe(50);
+    expect(display).toHaveBeenCalledTimes(2);
+
+    host.setReduced(true);
+    sync({ po: 1 });
+    expect(group.view('po')).toEqual({ liveValue: 1, displayedValue: 1, peakValue: 100 });
+    expect(host.activeIntervals).toBe(0);
+  });
+
+  it('uses only genuine reduced-motion sync and resumes one immediate-sampling ticker', () => {
+    const { host, group, update, sync } = groupSetup(true);
+    sync();
+    group.start();
+    expect(host.activeIntervals).toBe(0);
+    expect(update).toHaveBeenCalledTimes(4);
+    update.mockClear();
+    host.advance(2000);
+    expect(update).not.toHaveBeenCalled();
+    sync({ po: 2 });
+    expect(group.view('po').peakValue).toBe(2);
+
+    update.mockClear();
+    host.setReduced(false);
+    expect(update).toHaveBeenCalledTimes(4);
+    expect(host.activeIntervals).toBe(1);
+    host.setReduced(false);
+    expect(host.activeIntervals).toBe(1);
+    group.stop();
+    expect(host.activeIntervals).toBe(0);
+    expect(host.listenerCount).toBe(0);
   });
 });
 

--- a/frontend/src/primitives/meters/meter-ballistics.svelte.ts
+++ b/frontend/src/primitives/meters/meter-ballistics.svelte.ts
@@ -54,6 +54,21 @@ export interface MeterBallistics {
   stop(): void;
 }
 
+export interface MeterPeakGroupChannelView {
+  readonly liveValue: number | null;
+  readonly displayedValue: number | null;
+  readonly peakValue: number | null;
+}
+
+export interface MeterBallisticsGroup<Key extends PropertyKey> {
+  readonly reducedMotion: boolean;
+  view(key: Key): Readonly<MeterPeakGroupChannelView>;
+  sync(samples: Readonly<Record<Key, number | null>>): void;
+  resetPeak(key: Key): void;
+  start(): void;
+  stop(): void;
+}
+
 type FrameStepPeak = Readonly<{ value: number; latchedAt: number }>;
 
 export function createFrameStepPeakStrategy(options: Readonly<{
@@ -99,61 +114,154 @@ export function createElapsedEnvelopePeakStrategy<State extends { readonly latch
   };
 }
 
-export function createMeterBallistics<State>(
-  smoother: MeterSmoother,
+interface PeakChannel<State> {
+  readonly hasPeak: boolean;
+  observe(current: number, now: number, reduced: boolean): void;
+  advance(current: number, now: number): void;
+  project(current: number, now: number, reduced: boolean): number | null;
+  reset(): void;
+}
+
+function createPeakChannel<State>(strategy: MeterPeakStrategy<State>): PeakChannel<State> {
+  let state = $state<State | undefined>(undefined);
+  return {
+    get hasPeak() { return state !== undefined; },
+    observe(current, now, reduced) {
+      state = state === undefined
+        ? strategy.seed(current, now)
+        : strategy.observe(state, current, now, reduced);
+    },
+    advance(current, now) {
+      if (state !== undefined) state = strategy.advance(state, current, now);
+    },
+    project(current, now, reduced) {
+      return state === undefined ? null : strategy.project(state, current, now, reduced);
+    },
+    reset() { state = undefined; },
+  };
+}
+
+interface TickerLifecycle {
+  readonly reducedMotion: boolean;
+  reconcile(): void;
+  start(): void;
+  stop(): void;
+}
+
+interface PeakGroupSlot<State> {
+  liveValue: number | null;
+  readonly channel: PeakChannel<State>;
+}
+
+function createPeakGroupSlot<State>(strategy: MeterPeakStrategy<State>): PeakGroupSlot<State> {
+  let liveValue = $state<number | null>(null);
+  const channel = createPeakChannel(strategy);
+  return {
+    get liveValue() { return liveValue; },
+    set liveValue(value) { liveValue = value; },
+    channel,
+  };
+}
+
+function createTickerLifecycle(
   host: MeterMotionHost,
-  policy: Readonly<MeterBallisticsPolicy<State>>,
-): MeterBallistics {
-  let peakState = $state<State | undefined>(undefined);
-  let sample = $state(0);
-  let peakEnabled = $state(false);
-  let projectionNow = $state(host.now());
+  ticker: MeterTicker,
+  enabled: () => boolean,
+  hooks: Readonly<{
+    onTick(now: number): void;
+    onStart?(reduced: boolean): void;
+    onReducedMotionChange?(reduced: boolean): void;
+  }>,
+): TickerLifecycle {
   let reduced = $state(host.prefersReducedMotion());
   let started = false;
   let scheduleId: number | MeterIntervalId | undefined;
   let unsubscribe: (() => void) | undefined;
 
-  function peakCurrent(): number {
-    return policy.peakSource === 'sample' ? sample : smoother.value;
-  }
-
   function clearSchedule(): void {
     if (scheduleId === undefined) return;
-    if (policy.ticker.kind === 'animation-frame') host.cancelFrame(scheduleId as number);
+    if (ticker.kind === 'animation-frame') host.cancelFrame(scheduleId as number);
     else host.clearInterval(scheduleId as MeterIntervalId);
     scheduleId = undefined;
   }
 
-  function advance(now: number): void {
-    projectionNow = now;
-    if (peakState !== undefined) {
-      peakState = policy.peak.advance(peakState, peakCurrent(), now);
-    }
-  }
-
   function ensureSchedule(): void {
-    if (!started || reduced || !peakEnabled || scheduleId !== undefined) return;
-    if (policy.ticker.kind === 'animation-frame') {
+    if (!started || reduced || !enabled() || scheduleId !== undefined) return;
+    if (ticker.kind === 'animation-frame') {
       scheduleId = host.requestFrame((now) => {
         scheduleId = undefined;
-        if (!started || reduced || !peakEnabled) return;
-        advance(now);
+        if (!started || reduced || !enabled()) return;
+        hooks.onTick(now);
         ensureSchedule();
       });
       return;
     }
-    scheduleId = host.setInterval(() => advance(host.now()), policy.ticker.milliseconds);
+    scheduleId = host.setInterval(() => hooks.onTick(host.now()), ticker.milliseconds);
   }
 
-  function reconcileSchedule(): void {
-    if (!started || reduced || !peakEnabled) clearSchedule();
+  function reconcile(): void {
+    if (!started || reduced || !enabled()) clearSchedule();
     else ensureSchedule();
   }
 
   return {
+    get reducedMotion() { return reduced; },
+    reconcile,
+    start() {
+      if (started) return;
+      started = true;
+      reduced = host.prefersReducedMotion();
+      hooks.onStart?.(reduced);
+      unsubscribe = host.onReducedMotionChange((nextReduced) => {
+        const changed = nextReduced !== reduced;
+        reduced = nextReduced;
+        if (changed) hooks.onReducedMotionChange?.(nextReduced);
+        reconcile();
+      });
+      reconcile();
+    },
+    stop() {
+      if (!started) return;
+      started = false;
+      clearSchedule();
+      unsubscribe?.();
+      unsubscribe = undefined;
+    },
+  };
+}
+
+export function createMeterBallistics<State>(
+  smoother: MeterSmoother,
+  host: MeterMotionHost,
+  policy: Readonly<MeterBallisticsPolicy<State>>,
+): MeterBallistics {
+  const channel = createPeakChannel(policy.peak);
+  let sample = $state(0);
+  let peakEnabled = $state(false);
+  let projectionNow = $state(host.now());
+  let started = false;
+
+  function peakCurrent(): number {
+    return policy.peakSource === 'sample' ? sample : smoother.value;
+  }
+
+  const lifecycle = createTickerLifecycle(host, policy.ticker, () => peakEnabled, {
+    onTick(now) {
+      projectionNow = now;
+      channel.advance(peakCurrent(), now);
+    },
+    onReducedMotionChange(nextReduced) {
+      if (nextReduced && peakEnabled && channel.hasPeak && policy.peakSource === 'smoothed') {
+        projectionNow = host.now();
+        channel.observe(smoother.value, projectionNow, true);
+      }
+    },
+  });
+
+  return {
     get view() {
-      const peakValue = peakEnabled && peakState !== undefined
-        ? policy.peak.project(peakState, peakCurrent(), projectionNow, reduced)
+      const peakValue = peakEnabled
+        ? channel.project(peakCurrent(), projectionNow, lifecycle.reducedMotion)
         : null;
       return { smoothedValue: smoother.value, peakValue };
     },
@@ -163,46 +271,113 @@ export function createMeterBallistics<State>(
       if (input.sample === null || input.smoothTarget === null) {
         sample = 0;
         smoother.reset(0);
-        peakState = undefined;
-        reconcileSchedule();
+        channel.reset();
+        lifecycle.reconcile();
         return;
       }
       sample = input.sample;
       smoother.update(input.smoothTarget);
       if (peakEnabled) {
-        const current = peakCurrent();
-        peakState = peakState === undefined
-          ? policy.peak.seed(current, projectionNow)
-          : policy.peak.observe(peakState, current, projectionNow, reduced);
+        channel.observe(peakCurrent(), projectionNow, lifecycle.reducedMotion);
       }
-      reconcileSchedule();
+      lifecycle.reconcile();
     },
     resetPeak() {
-      peakState = undefined;
+      channel.reset();
       projectionNow = host.now();
     },
     start() {
       if (started) return;
       started = true;
       smoother.start();
-      reduced = host.prefersReducedMotion();
-      unsubscribe = host.onReducedMotionChange((nextReduced) => {
-        reduced = nextReduced;
-        if (nextReduced && peakEnabled && peakState !== undefined && policy.peakSource === 'smoothed') {
-          projectionNow = host.now();
-          peakState = policy.peak.observe(peakState, smoother.value, projectionNow, true);
-        }
-        reconcileSchedule();
-      });
-      ensureSchedule();
+      lifecycle.start();
     },
     stop() {
       if (!started) return;
       started = false;
-      clearSchedule();
-      unsubscribe?.();
-      unsubscribe = undefined;
+      lifecycle.stop();
       smoother.stop();
     },
+  };
+}
+
+export function createMeterBallisticsGroup<Key extends PropertyKey, State>(
+  keys: readonly Key[],
+  host: MeterMotionHost,
+  policy: Readonly<{
+    ticker: Extract<MeterTicker, { kind: 'interval' }>;
+    peak: MeterPeakStrategy<State>;
+  }>,
+): MeterBallisticsGroup<Key> {
+  const slots = new Map<Key, PeakGroupSlot<State>>();
+  for (const key of keys) {
+    slots.set(key, createPeakGroupSlot(policy.peak));
+  }
+  let projectionNow = $state(host.now());
+  let sampleSource: Readonly<Record<Key, number | null>> | undefined;
+
+  function slotFor(key: Key) {
+    const slot = slots.get(key);
+    if (slot === undefined) throw new Error(`Unknown meter peak channel: ${String(key)}`);
+    return slot;
+  }
+
+  function sampleAll(now: number): void {
+    projectionNow = now;
+    for (const key of keys) {
+      const slot = slotFor(key);
+      if (sampleSource !== undefined) slot.liveValue = sampleSource[key];
+      if (slot.liveValue === null) {
+        slot.channel.reset();
+        continue;
+      }
+      slot.channel.observe(slot.liveValue, now, false);
+      slot.channel.advance(slot.liveValue, now);
+    }
+  }
+
+  const lifecycle = createTickerLifecycle(host, policy.ticker, () => true, {
+    onTick: sampleAll,
+    onStart(reduced) {
+      if (!reduced) sampleAll(host.now());
+    },
+    onReducedMotionChange(reduced) {
+      if (!reduced) sampleAll(host.now());
+    },
+  });
+
+  return {
+    get reducedMotion() { return lifecycle.reducedMotion; },
+    view(key) {
+      const slot = slotFor(key);
+      const liveValue = slot.liveValue;
+      if (liveValue === null) return { liveValue: null, displayedValue: null, peakValue: null };
+      const peakValue = slot.channel.project(
+        liveValue,
+        projectionNow,
+        lifecycle.reducedMotion,
+      );
+      return {
+        liveValue,
+        displayedValue: lifecycle.reducedMotion ? liveValue : (peakValue ?? liveValue),
+        peakValue,
+      };
+    },
+    sync(samples) {
+      sampleSource = samples;
+      const reduced = lifecycle.reducedMotion;
+      const now = reduced ? host.now() : projectionNow;
+      for (const key of keys) {
+        const slot = slotFor(key);
+        const liveValue = samples[key];
+        slot.liveValue = liveValue;
+        if (liveValue === null) slot.channel.reset();
+        else if (reduced) slot.channel.observe(liveValue, now, true);
+      }
+      if (reduced) projectionNow = now;
+    },
+    resetPeak(key) { slotFor(key).channel.reset(); },
+    start: lifecycle.start,
+    stop: lifecycle.stop,
   };
 }


### PR DESCRIPTION
5 code + 0 regenerated baselines = 5 files.

## Summary
- Add the source-compatible `createMeterBallisticsGroup` facade while keeping channel transitions and ticker lifecycle private and shared with `createMeterBallistics`.
- Move Po/SWR/ALC/Id onto one 100 ms ticker and one reduced-motion listener, preserving held raw -> existing formatter/level/fault -> existing tile smoother ordering.
- Intentionally clear a channel as soon as absence is observed, so a quick remove/reappear cannot resurrect a stale marker or smoother.

## Why this is one unit
The 704 A+D candidate exceeds the soft line threshold because the private lifecycle extraction, grouped API, Dock adoption, and discriminating component/headless coverage form one contract. Splitting them would either publish an unused abstraction or duplicate lifecycle ownership. Size was measured from `git diff --numstat 8eda79286aa96193414482542864a98f69a33829..b1a289ed6`.

## Verification
- RED on the accepted phase-A base: the grouped API tests failed before the API existed; the quick removal/reappearance component case retained `93W` instead of showing the fresh `2W` sample.
- Correction control during adoption: omitting shared-tick refresh of current component inputs left the existing decay case at `87W`; the final candidate passes it.
- GREEN: `npx vitest run` over grouped/single ballistics, Dock peak/reduced/isolated, meter-utils, BarGauge peak/reduced, Linear reduced, and MetersSurface: 9 files, 348 tests passed.
- `npm run check`: 0 errors and 0 warnings.
- Changed-file ESLint, `npm run lint:boundaries`, and `git diff --check` passed.

Linear: https://linear.app/morozsm/issue/MOR-1374/linearsmeter-has-its-own-peak-hold-reimplementation-bypassing-meter

This PR completes MOR-1374 phase B only. Provider-context phase C and the MOR-2215 final mechanism audit remain separate.