### PR TITLE
Refactor seven non-TX semantic controls

### DIFF
--- a/frontend/src/semantic/CwKeyerSurface.svelte
+++ b/frontend/src/semantic/CwKeyerSurface.svelte
@@ -129,6 +129,10 @@
   } from '../primitives/control-feedback/control-feedback-presentation';
   import { createCommittedScalar } from '../primitives/scalar/committed-scalar.svelte';
   import { clamp, snapToStep } from '../primitives/scalar/value-control-core';
+  import {
+    bindChoiceInstrument,
+    bindToggleInstrument,
+  } from '../primitives/control-instruments/control-instrument-behavior';
   import type { RadioViewModel } from './radio-view-model';
 
   type BreakInDelayFeedback = ControlFeedbackPresentationInput<number> & {
@@ -164,6 +168,33 @@
   );
   const mutexed = (field: 'apf' | 'twinPeak'): boolean =>
     view.disabledReasons.some((r) => r.field === `cwKeyer.${field}`);
+  const reversePaddleToggle = bindToggleInstrument(() => ({
+    field: cw?.reversePaddle,
+    // The handler owns its zero-argument inversion; the binding's next value
+    // is intentionally not forwarded.
+    invoke: () => onReversePaddleToggle?.(),
+  }));
+  const twinPeakToggle = bindToggleInstrument(() => ({
+    field: cw?.twinPeak,
+    blocked: mutexed('twinPeak'),
+    // The handler owns its zero-argument inversion; the binding's next value
+    // is intentionally not forwarded.
+    invoke: () => onTwinPeakToggle?.(),
+  }));
+  const apfChoice = bindChoiceInstrument(() => {
+    const field = cw?.apf;
+    return {
+      field: field === undefined ? undefined : {
+        availability: field.availability,
+        reading: field.reading.status === 'known'
+          ? { status: 'known' as const, value: field.reading.value > 0 }
+          : { status: 'unknown' as const },
+      },
+      blocked: mutexed('apf'),
+      choices: APF_CHOICES.map(([, on]) => on),
+      invoke: (on: boolean) => onApfOn?.(on),
+    };
+  });
 
   /** The handler half of every gate. `disabled` alone is not enough: a design
    *  language may restyle these controls, and a programmatic click must not
@@ -296,15 +327,6 @@
     event.preventDefault();
     cancelBreakInDelay(event.currentTarget);
   }
-  function setApf(on: boolean): void {
-    if (cw && usable(cw.apf) && !mutexed('apf')) onApfOn?.(on);
-  }
-  function toggleTwinPeak(): void {
-    if (cw && usable(cw.twinPeak) && !mutexed('twinPeak')) onTwinPeakToggle?.();
-  }
-  function toggleReversePaddle(): void {
-    if (cw && usable(cw.reversePaddle)) onReversePaddleToggle?.();
-  }
   function requestRxFrequencyCorrection(): void {
     if (autoTuneAvailable) onAutoTune?.();
   }
@@ -407,8 +429,8 @@
       <button
         type="button" class="cw-keyer-toggle" data-testid="cw-keyer-reverse-paddle"
         aria-pressed={pressedOf(cw.reversePaddle)}
-        disabled={!usable(cw.reversePaddle)}
-        onclick={toggleReversePaddle}
+        disabled={!reversePaddleToggle.available}
+        onclick={() => reversePaddleToggle.invoke()}
       >Reverse paddle: {textOf(cw.reversePaddle)}</button>
     {/if}
 
@@ -426,10 +448,9 @@
           <button
             type="button" role="radio" class="cw-keyer-choice"
             data-testid={`cw-keyer-apf-${label}`}
-            aria-checked={cw.apf.reading.status === 'known'
-              && (cw.apf.reading.value > 0) === on}
-            disabled={!usable(cw.apf) || mutexed('apf')}
-            onclick={() => setApf(on)}
+            aria-checked={apfChoice.isSelected(on)}
+            disabled={!apfChoice.available}
+            onclick={() => apfChoice.invoke(on)}
           >APF {label}</button>
         {/each}
         <output data-testid="cw-keyer-apf-value">{textOf(cw.apf)}</output>
@@ -445,8 +466,8 @@
         <button
           type="button" class="cw-keyer-toggle" data-testid="cw-keyer-twin-peak-toggle"
           aria-pressed={pressedOf(cw.twinPeak)}
-          disabled={!usable(cw.twinPeak) || mutexed('twinPeak')}
-          onclick={toggleTwinPeak}
+          disabled={!twinPeakToggle.available}
+          onclick={() => twinPeakToggle.invoke()}
         >TPF: {textOf(cw.twinPeak)}</button>
         {#if mutexed('twinPeak')}
           <!-- Rule 4: RTTY is named, so a permanently-disabled control in a

--- a/frontend/src/semantic/RitXitScanSurface.svelte
+++ b/frontend/src/semantic/RitXitScanSurface.svelte
@@ -78,6 +78,10 @@
   import { decodeControlDomain, encodeControlDomain } from '$lib/radio/control-domain';
   import { exactDecimalNumber } from '$lib/types/exact-decimal';
   import type { ControlDomain } from '$lib/types/capabilities';
+  import {
+    bindActionInstrument,
+    bindToggleInstrument,
+  } from '../primitives/control-instruments/control-instrument-behavior';
   import type { RadioViewModel } from './radio-view-model';
 
   interface Props {
@@ -127,13 +131,34 @@
    *  gate: it is honest about what it is from the moment it exists. */
   let selectedType = $state(DEFAULT_SCAN_TYPE);
 
-  // F2 (fix round, verify-MOR-1308): gated on the field's OWN observation,
-  // not just the wrong-VFO guard — mirrors `TxAuxSurface.svelte`'s `toggle`.
-  // Firing over an unobserved reading arms a guess at the command bus
-  // (`makeRitXitHandlers().onRitToggle`'s `?? false` optimism), exactly the
-  // re-loosening the B-wave criterion forbids.
-  function toggleRit(): void { if (rx && activeKnown && usable(rx.ritActive)) onRitToggle?.(); }
-  function toggleXit(): void { if (rx && activeKnown && usable(rx.xitActive)) onXitToggle?.(); }
+  const ritToggle = bindToggleInstrument(() => ({
+    field: rx?.ritActive,
+    blocked: !activeKnown,
+    // The handler owns its zero-argument inversion; the binding's next value
+    // is intentionally not forwarded.
+    invoke: () => onRitToggle?.(),
+  }));
+  const xitToggle = bindToggleInstrument(() => ({
+    field: rx?.xitActive,
+    blocked: !activeKnown,
+    // The handler owns its zero-argument inversion; the binding's next value
+    // is intentionally not forwarded.
+    invoke: () => onXitToggle?.(),
+  }));
+  const scanToggle = bindToggleInstrument(() => ({
+    field: sc?.scanning,
+    invoke: (next) => {
+      if (next) onScanStart?.(selectedType);
+      else onScanStop?.();
+    },
+  }));
+  const resumeCycle = bindActionInstrument(() => ({
+    field: sc?.scanResumeMode,
+    invoke: () => {
+      if (sc?.scanResumeMode.reading.status !== 'known') return;
+      onResumeModeChange?.(0xD0 | ((sc.scanResumeMode.reading.value + 1) % 4));
+    },
+  }));
   function changeOffset(displayHz: number): void {
     if (!canAdjustOffset || !Number.isFinite(displayHz)) return;
     let raw = displayHz;
@@ -165,21 +190,6 @@
   // unlike the toggles, it never reads a guessed value to decide what to
   // send. Still gated on `activeKnown` (S3b — no receiver to attribute it to).
   function clear(): void { if (activeKnown) onClear?.(); }
-  function toggleScan(): void {
-    if (!sc || !usable(sc.scanning)) return;
-    if (scanningOn) { onScanStop?.(); return; }
-    // MOR-1495 review R2: START no longer depends on an OBSERVED scanType
-    // (see file header) — it always sends the operator/default selection.
-    onScanStart?.(selectedType);
-  }
-  function cycleResume(): void {
-    if (!sc || !usable(sc.scanResumeMode) || sc.scanResumeMode.reading.status !== 'known') return;
-    // F1 (fix round, verify-MOR-1308): the fact is the `& 0x0F` masked value
-    // (8A), but the wire wants the full CI-V byte — the backend validates
-    // `scan_set_resume: mode must be 0xD0-0xD3` (control.py:2283-2289). Same
-    // split `ScanPanel.svelte` makes between `rm.value` and `rm.value & 0x0F`.
-    onResumeModeChange?.(0xD0 | ((sc.scanResumeMode.reading.value + 1) % 4));
-  }
 </script>
 
 {#if rx || sc}
@@ -189,13 +199,13 @@
         {#if rx.ritActive.availability.structural}
           <button
             type="button" data-testid="ritxit-rit-toggle" aria-pressed={pressedOf(rx.ritActive)}
-            disabled={!activeKnown || !usable(rx.ritActive)} onclick={toggleRit}
+            disabled={!ritToggle.available} onclick={() => ritToggle.invoke()}
           >RIT</button>
         {/if}
         {#if rx.xitActive.availability.structural}
           <button
             type="button" data-testid="ritxit-xit-toggle" aria-pressed={pressedOf(rx.xitActive)}
-            disabled={!activeKnown || !usable(rx.xitActive)} onclick={toggleXit}
+            disabled={!xitToggle.available} onclick={() => xitToggle.invoke()}
           >XIT</button>
         {/if}
         <label class="offset" data-testid="ritxit-offset"
@@ -223,8 +233,8 @@
           <span data-testid="scan-status" data-observed={usable(sc.scanning)}>{textOf(sc.scanning)}</span>
           <button
             type="button" data-testid="scan-toggle" aria-pressed={pressedOf(sc.scanning)}
-            disabled={!usable(sc.scanning)}
-            onclick={toggleScan}
+            disabled={!scanToggle.available}
+            onclick={() => scanToggle.invoke()}
           >{scanningOn ? 'STOP' : 'START'}</button>
         {/if}
         {#if sc.scanType.availability.structural}
@@ -233,8 +243,8 @@
         {#if sc.scanResumeMode.availability.structural}
           <output data-testid="scan-resume-value">{textOf(sc.scanResumeMode)}</output>
           <button
-            type="button" data-testid="scan-resume-cycle" disabled={!usable(sc.scanResumeMode)}
-            onclick={cycleResume}
+            type="button" data-testid="scan-resume-cycle" disabled={!resumeCycle.available}
+            onclick={() => resumeCycle.invoke()}
           >RESUME ▶</button>
         {/if}
       </div>

--- a/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
@@ -159,7 +159,17 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
       '../primitives/control-feedback/control-feedback-presentation',
       '../primitives/scalar/committed-scalar.svelte',
       '../primitives/scalar/value-control-core',
+      '../primitives/control-instruments/control-instrument-behavior',
     ]);
+  });
+
+  it('uses current-input bindings for APF, Twin Peak and reverse paddle', () => {
+    expect(CODE).toContain('const apfChoice = bindChoiceInstrument');
+    expect(CODE).toContain('const twinPeakToggle = bindToggleInstrument');
+    expect(CODE).toContain('const reversePaddleToggle = bindToggleInstrument');
+    expect(CODE).toContain('value: field.reading.value > 0');
+    expect(CODE).toContain('invoke: () => onTwinPeakToggle?.()');
+    expect(CODE).toContain('invoke: () => onReversePaddleToggle?.()');
   });
 
   // Kills: `onMount(() => …)` and every relative of it, plus a dynamic import

--- a/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
@@ -15,6 +15,7 @@
  *   `scan` per-field partial-reporter gate — a radio that has only ever
  *        reported `scanning` surfaces exactly that field, no more.
  */
+import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import RitXitScanSurface, { OFFSET_MAX, OFFSET_MIN, OFFSET_STEP, UNKNOWN_TEXT } from '../RitXitScanSurface.svelte';
@@ -24,6 +25,7 @@ import type {
 } from '../radio-view-model';
 
 const ON: Availability = { structural: true, operational: true };
+const SOURCE = readFileSync('src/semantic/RitXitScanSurface.svelte', 'utf8');
 
 const base = (): RadioViewModel => withScan(withRitXit(topologyFixtures['1/single']));
 const withRx = (over: Partial<RitXitViewModel>): RadioViewModel => {
@@ -70,6 +72,21 @@ function render(view: RadioViewModel, handlers: Handlers = {}) {
 }
 /** MOR-1304 F3 recipe: bypasses jsdom's disabled-button `.click()` no-op. */
 const bypassClick = (el: HTMLElement) => el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+describe('current-input action bindings', () => {
+  it('uses toggles for RIT, XIT and scan, plus an action for the resume cycle', () => {
+    expect(SOURCE).toContain('bindToggleInstrument');
+    expect(SOURCE).toContain('const ritToggle = bindToggleInstrument');
+    expect(SOURCE).toContain('const xitToggle = bindToggleInstrument');
+    expect(SOURCE).toContain('const scanToggle = bindToggleInstrument');
+    expect(SOURCE).toContain('const resumeCycle = bindActionInstrument');
+  });
+
+  it('keeps RIT and XIT callbacks as zero-argument intents', () => {
+    expect(SOURCE).toContain('invoke: () => onRitToggle?.()');
+    expect(SOURCE).toContain('invoke: () => onXitToggle?.()');
+  });
+});
 
 describe('structural presence: absent groups render nothing extra', () => {
   it('renders nothing when neither ritXit nor scan is present', () => {


### PR DESCRIPTION
Linear: MOR-2389

Adopts existing current-input behavior bindings for RIT/XIT, scan start-stop and resume, CW APF, Twin Peak, and reverse paddle.

Preserves zero-argument toggle handlers, scan local default/start behavior and full resume bytes, APF ordinal display/selection, mutex guards, and existing non-scope controls.

Validation:
- `npx vitest run src/semantic/__tests__/RitXitScanSurface.test.ts src/semantic/__tests__/CwKeyerSurface.test.ts` (151 passed)
- `npm run check` (0 errors, 0 warnings)
- changed-path ESLint (passed)
- `git diff --check` (passed)

Mutation evidence: setting the APF mutex blocker to `false` made the APF mutex test fail; the implementation was restored before the final green run.