### PR TITLE
feat: adopt Bipolar controls through scalar binding

### DIFF
--- a/frontend/src/components-v2/controls/value-control/BipolarRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/BipolarRenderer.svelte
@@ -1,30 +1,28 @@
 <script lang="ts">
-  import { untrack } from 'svelte';
+  import { onDestroy, untrack } from 'svelte';
+  import type {
+    ContinuousScalarBinding,
+    ContinuousScalarRendererLease,
+    ContinuousScalarView,
+  } from '../../../primitives/scalar/continuous-scalar.svelte';
   import './value-control.css';
   import {
     getCenterPercent,
     getBipolarFill,
     calculateClickValue,
-    handleKeyboardStep,
-    handleWheelStep,
-    debounce,
     formatBipolarValue,
-    clamp,
-    snapToStep,
     valueToPosition,
   } from '../../../primitives/scalar/value-control-core';
+  import {
+    projectScalarRenderPresentation,
+    type LegacyReadingPresentation,
+  } from './scalar-render-presentation';
 
   interface Props {
-    value: number;
-    min: number;
-    max: number;
-    step: number;
-    /** Larger increment for keyboard gestures; step remains the radio value lattice. */
-    keyboardStep?: number;
-    defaultValue?: number;
-    fineStepDivisor?: number;
+    binding: ContinuousScalarBinding;
     label: string;
     displayFn?: (v: number) => string;
+    unknownDisplay?: string;
     fillColor?: string;
     fillGradient?: string[];
     trackColor?: string;
@@ -33,24 +31,17 @@
     showLabel?: boolean;
     compact?: boolean;
     variant?: 'modern' | 'hardware' | 'hardware-illuminated';
-    onChange: (value: number) => void;
-    debounceMs?: number;
-    disabled?: boolean;
     unit?: string;
     shortcutHint?: string | null;
     title?: string | null;
+    legacy?: LegacyReadingPresentation;
   }
 
   let {
-    value,
-    min,
-    max,
-    step,
-    keyboardStep,
-    defaultValue = 0,
-    fineStepDivisor = 10,
+    binding,
     label,
     displayFn,
+    unknownDisplay,
     fillColor,
     fillGradient,
     trackColor = 'var(--v2-bg-gradient-start)',
@@ -59,188 +50,137 @@
     showLabel = true,
     compact = false,
     variant = 'modern',
-    onChange,
-    debounceMs = 0,
-    disabled = false,
     unit = '',
     shortcutHint = null,
     title = null,
+    legacy,
   }: Props = $props();
 
+  const feedbackDescriptionId = $props.id();
+
   let containerEl: HTMLDivElement | null = $state(null);
-  let isDragging = $state(false);
-  let wheelLocked = $state(false);
-  let wheelUnlockTimer: ReturnType<typeof setTimeout> | null = null;
-  let localValue = $state(untrack(() => value));
+  let activePointer: { id: number; token: number; target: HTMLElement } | null = null;
+  const initialBinding = untrack(() => binding);
+  let attachedBinding = initialBinding;
+  let lease: ContinuousScalarRendererLease = $state(initialBinding.attachRenderer());
 
-  function markWheelActive() {
-    wheelLocked = true;
-    if (wheelUnlockTimer) clearTimeout(wheelUnlockTimer);
-    wheelUnlockTimer = setTimeout(() => {
-      wheelLocked = false;
-      wheelUnlockTimer = null;
-    }, 300);
-  }
-
-  // Sync from parent value ONLY when idle (no drag, no wheel)
-  let prevValue = untrack(() => value);
   $effect(() => {
-    const v = value;
-    if (v !== prevValue) {
-      prevValue = v;
-      if (!isDragging && !wheelLocked) {
-        localValue = v;
-      }
+    if (binding === attachedBinding) return;
+    if (activePointer?.target.hasPointerCapture?.(activePointer.id)) {
+      activePointer.target.releasePointerCapture(activePointer.id);
     }
+    activePointer = null;
+    lease.dispose();
+    attachedBinding = binding;
+    lease = binding.attachRenderer();
+  });
+  onDestroy(() => {
+    if (activePointer?.target.hasPointerCapture?.(activePointer.id)) {
+      activePointer.target.releasePointerCapture(activePointer.id);
+    }
+    activePointer = null;
+    lease.dispose();
   });
 
-  // Derived values
-  let centerPercent = $derived(getCenterPercent(min, max));
-  let currentPercent = $derived(valueToPosition(localValue, min, max) * 100);
-  let bipolarFill = $derived(getBipolarFill(localValue, min, max));
+  let view = $state<ContinuousScalarView>(untrack(() => lease.view));
+  let skipViewAssignment = true;
+  $effect(() => {
+    const next = lease.view;
+    if (skipViewAssignment) {
+      skipViewAssignment = false;
+    } else {
+      view = next;
+    }
+  });
+  let renderedValue = $derived(view.displayed);
+  let centerPercent = $derived(view.domainValid
+    ? getCenterPercent(view.domain.min, view.domain.max) : 0);
+  let currentPercent = $derived(view.domainValid && renderedValue !== null
+    ? valueToPosition(renderedValue, view.domain.min, view.domain.max) * 100 : 0);
+  let bipolarFill = $derived(view.domainValid && renderedValue !== null
+    ? getBipolarFill(renderedValue, view.domain.min, view.domain.max)
+    : { fillStart: 0, fillEnd: 0 });
   let effectiveFill = $derived(fillGradient
     ? `linear-gradient(90deg, ${fillGradient.join(', ')})`
     : (fillColor ?? accentColor));
-  let displayValue = $derived(displayFn
-    ? displayFn(localValue)
-    : `${formatBipolarValue(localValue)}${unit ? '\u00a0' + unit : ''}`);
-  
-  // Absolute deviation from center for illuminated variant
-  // 0 at center, 1.0 at either extreme
-  let absDeviationRatio = $derived(Math.abs(localValue - defaultValue) / Math.max(Math.abs(max - defaultValue), Math.abs(min - defaultValue)));
-  
-  // Bipolar wheel: 1 step per tick by default (fine control).
-  // Only scale up for very large ranges (>500 steps) to stay usable.
-  let stepsInRange = $derived(Math.max(1, (max - min) / step));
-  let adaptiveWheelMultiplier = $derived(stepsInRange > 500 ? Math.round(stepsInRange / 240) : 1);
-
-  // Debounced change handler
-  let debouncedOnChange = $derived.by<(...args: unknown[]) => void>(() => {
-    if (debounceMs > 0) {
-      return debounce((v: number) => onChange(v), debounceMs) as (...args: unknown[]) => void;
-    }
-    return ((v: number) => onChange(v)) as (...args: unknown[]) => void;
+  let displayValue = $derived(renderedValue === null
+    ? unknownDisplay ?? (displayFn ? displayFn(Number.NaN) : '—')
+    : displayFn ? displayFn(renderedValue)
+      : `${formatBipolarValue(renderedValue)}${unit ? '\u00a0' + unit : ''}`);
+  let absDeviationRatio = $derived.by(() => {
+    if (!view.domainValid || renderedValue === null) return 0;
+    const center = view.domain.defaultValue ?? 0;
+    const extent = Math.max(
+      Math.abs(view.domain.max - center), Math.abs(view.domain.min - center),
+    );
+    return extent > 0 ? Math.abs(renderedValue - center) / extent : 0;
   });
-
-  function emitChange(newValue: number, immediate = false, emitWhenLocalValueChanges = false) {
-    const localValueChanged = newValue !== localValue;
-    if (localValueChanged) {
-      localValue = newValue;
-    }
-    if (newValue !== value || (emitWhenLocalValueChanges && localValueChanged)) {
-      if (immediate) {
-        onChange(newValue);
-      } else {
-        debouncedOnChange(newValue);
-      }
-    }
-  }
+  let renderPresentation = $derived(projectScalarRenderPresentation(view, legacy));
 
   function handlePointerDown(e: PointerEvent) {
-    if (disabled || !containerEl) return;
+    if (!containerEl) return;
+    const token = lease.beginPointer();
+    if (token === null) return;
 
     e.preventDefault();
     const target = e.currentTarget as HTMLElement;
     target.setPointerCapture(e.pointerId);
+    activePointer = { id: e.pointerId, token, target };
 
-    isDragging = true;
-
-    // Calculate value from click position
     const rect = containerEl.getBoundingClientRect();
-    const newValue = calculateClickValue(e.clientX, rect.left, rect.width, min, max, step);
-    emitChange(newValue, true);
+    const domain = view.domain;
+    const newValue = calculateClickValue(
+      e.clientX, rect.left, rect.width, domain.min, domain.max, domain.step,
+    );
+    lease.pointer(token, newValue);
   }
 
   function handlePointerMove(e: PointerEvent) {
-    if (!isDragging || disabled || !containerEl) return;
+    if (!activePointer || activePointer.id !== e.pointerId || !containerEl) return;
 
     const rect = containerEl.getBoundingClientRect();
-    const newValue = calculateClickValue(e.clientX, rect.left, rect.width, min, max, step);
-    emitChange(newValue, true);
+    const domain = view.domain;
+    const newValue = calculateClickValue(
+      e.clientX, rect.left, rect.width, domain.min, domain.max, domain.step,
+    );
+    lease.pointer(activePointer.token, newValue);
   }
 
   function handlePointerUp(e: PointerEvent) {
-    if (!isDragging) return;
+    if (!activePointer || activePointer.id !== e.pointerId) return;
+    if (activePointer.target.hasPointerCapture?.(e.pointerId)) {
+      activePointer.target.releasePointerCapture(e.pointerId);
+    }
+    lease.endPointer(activePointer.token);
+    activePointer = null;
+  }
 
-    const target = e.currentTarget as HTMLElement;
-    target.releasePointerCapture(e.pointerId);
-    isDragging = false;
+  function handlePointerCancel(e: PointerEvent) {
+    if (!activePointer || activePointer.id !== e.pointerId) return;
+    if (activePointer.target.hasPointerCapture?.(e.pointerId)) {
+      activePointer.target.releasePointerCapture(e.pointerId);
+    }
+    lease.cancelPointer(activePointer.token);
+    activePointer = null;
   }
 
   function handleWheel(e: WheelEvent) {
-    if (disabled) return;
+    if (!view.editable) return;
     e.preventDefault();
-
-    // Use adaptive multiplier for consistent scroll speed across ranges
-    const wheelMultiplier = e.shiftKey ? 1 : adaptiveWheelMultiplier;
-    const effectiveStep = e.shiftKey ? step / fineStepDivisor : step * wheelMultiplier;
-    const direction = e.deltaY > 0 ? -1 : 1;
-    const newValue = clamp(
-      snapToStep(localValue + direction * effectiveStep, effectiveStep, min),
-      min,
-      max,
-    );
-    localValue = newValue;
-    markWheelActive();
-    onChange(newValue);
+    lease.wheel({ direction: e.deltaY > 0 ? -1 : 1, fine: e.shiftKey });
   }
 
   function handleKeyDown(e: KeyboardEvent) {
-    if (disabled) return;
-
-    const keyboardIncrement = getKeyboardIncrement(e.shiftKey);
-    const newValue = keyboardIncrement === null
-      ? handleKeyboardStep(localValue, e.key, step, fineStepDivisor, min, max, e.shiftKey)
-      : handleBipolarKeyboardStep(localValue, e.key, keyboardIncrement);
-    if (newValue !== null) {
-      e.preventDefault();
-      emitChange(newValue, false, keyboardIncrement !== null);
-    }
+    if (lease.key({ key: e.key, fine: e.shiftKey })) e.preventDefault();
   }
 
-  function getKeyboardIncrement(shiftKey: boolean): number | null {
-    if (keyboardStep === undefined) return null;
-    if (!isLatticeCompatible(keyboardStep)) return isLatticeCompatible(step) ? step : null;
-
-    const increment = shiftKey ? keyboardStep / fineStepDivisor : keyboardStep;
-    return isLatticeCompatible(increment) ? increment : step;
-  }
-
-  function isLatticeCompatible(increment: number): boolean {
-    return Number.isFinite(increment)
-      && increment > 0
-      && Number.isFinite(step)
-      && step > 0
-      && Number.isInteger(increment / step);
-  }
-
-  function handleBipolarKeyboardStep(currentValue: number, key: string, increment: number): number | null {
-    switch (key) {
-      case 'ArrowRight':
-      case 'ArrowUp':
-        return clamp(defaultValue + Math.round((currentValue + increment - defaultValue) / increment) * increment, min, max);
-      case 'ArrowLeft':
-      case 'ArrowDown':
-        return clamp(defaultValue + Math.round((currentValue - increment - defaultValue) / increment) * increment, min, max);
-      case 'Home':
-        return min;
-      case 'End':
-        return max;
-      default:
-        return null;
-    }
-  }
-
-  function handleDoubleClick() {
-    if (disabled) return;
-    emitChange(defaultValue);
-  }
+  function handleDoubleClick() { lease.reset(); }
 </script>
 
 <div
   class="vc-bipolar"
   class:compact
-  class:disabled
+  class:disabled={!view.editable}
   class:hardware={variant === 'hardware'}
   class:hw-illum={variant === 'hardware-illuminated'}
   bind:this={containerEl}
@@ -262,16 +202,19 @@
   <div
     class="vc-track-container"
     role="slider"
-    tabindex={disabled ? -1 : 0}
+    tabindex={view.editable ? 0 : -1}
     aria-label={label}
-    aria-valuemin={min}
-    aria-valuemax={max}
-    aria-valuenow={value}
-    aria-disabled={disabled}
+    aria-valuemin={view.domainValid ? view.domain.min : undefined}
+    aria-valuemax={view.domainValid ? view.domain.max : undefined}
+    aria-valuenow={view.domainValid ? view.canonical ?? undefined : undefined}
+    aria-disabled={!view.editable}
+    aria-busy={renderPresentation.attributes['aria-busy']}
+    aria-describedby={renderPresentation.description !== null ? feedbackDescriptionId : undefined}
+    data-command-phase={renderPresentation.attributes['data-command-phase'] ?? undefined}
     onpointerdown={handlePointerDown}
     onpointermove={handlePointerMove}
     onpointerup={handlePointerUp}
-    onpointercancel={handlePointerUp}
+    onpointercancel={handlePointerCancel}
     onwheel={handleWheel}
     onkeydown={handleKeyDown}
     ondblclick={handleDoubleClick}
@@ -304,6 +247,19 @@
       <div class="vc-thumb" aria-hidden="true"></div>
     {/if}
   </div>
+
+  {#if renderPresentation.description !== null}
+    <span id={feedbackDescriptionId} class="sr-only">{renderPresentation.description}</span>
+  {/if}
+  {#if renderPresentation.status !== null}
+    <span
+      class="sr-only"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-control-feedback-status
+    >{renderPresentation.status}{renderPresentation.error === null ? '' : `: ${renderPresentation.error}`}</span>
+  {/if}
 
   <div class="vc-axis" aria-hidden="true">
     <span class="axis-negative">-</span>
@@ -341,6 +297,11 @@
   .vc-value {
     color: var(--vc-text-value, var(--v2-text-bright));
     font-family: 'Roboto Mono', monospace;
+  }
+
+  .sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
   }
 
   .disabled {

--- a/frontend/src/components-v2/controls/value-control/ValueControl.svelte
+++ b/frontend/src/components-v2/controls/value-control/ValueControl.svelte
@@ -7,6 +7,7 @@
   import type { LegacyReadingPresentation } from './scalar-render-presentation';
   import type { Skin } from './skin';
   import {
+    createBipolarContinuousScalarPolicy,
     createContinuousScalar,
     createHBarContinuousScalarPolicy,
     type ContinuousScalarBinding,
@@ -56,9 +57,9 @@
     disabled?: boolean;
   }
 
-  interface BoundHBarProps {
+  interface BoundContinuousProps {
     binding: ContinuousScalarBinding;
-    renderer: 'hbar';
+    renderer: 'hbar' | 'bipolar';
     value?: undefined;
     min?: undefined;
     max?: undefined;
@@ -74,7 +75,7 @@
     skin?: undefined;
   }
 
-  type Props = PresentationProps & (RawProps | BoundHBarProps);
+  type Props = PresentationProps & (RawProps | BoundContinuousProps);
 
   let {
     binding: externalBinding,
@@ -122,17 +123,26 @@
     preview: optimistic ? 'optimistic' : 'confirmed',
     debounceMs,
   }));
+  let bipolarPolicy = $derived(createBipolarContinuousScalarPolicy({ debounceMs }));
+  let scalarPolicy = $derived(renderer === 'bipolar' ? bipolarPolicy : hbarPolicy);
   const adapterPolicy: ContinuousScalarPolicy = {
-    get name() { return hbarPolicy.name; },
-    get preview() { return hbarPolicy.preview; },
-    normalize(candidate, domain) { return hbarPolicy.normalize(candidate, domain); },
-    wheel(current, event, domain) { return hbarPolicy.wheel(current, event, domain); },
-    key(current, event, domain) { return hbarPolicy.key(current, event, domain); },
-    reset(domain) { return hbarPolicy.reset(domain); },
-    dispatch(source) { return hbarPolicy.dispatch(source); },
-    dispatchesCanonical(source) { return hbarPolicy.dispatchesCanonical(source); },
-    get wheelIdleMs() { return hbarPolicy.wheelIdleMs; },
-    describeTarget(candidate) { return hbarPolicy.describeTarget(candidate); },
+    get name() { return scalarPolicy.name; },
+    get preview() { return scalarPolicy.preview; },
+    resolveKeyboardStep(domain) {
+      return scalarPolicy.resolveKeyboardStep === undefined
+        ? domain.keyboardStep
+        : scalarPolicy.resolveKeyboardStep(domain);
+    },
+    normalize(candidate, domain) { return scalarPolicy.normalize(candidate, domain); },
+    wheel(current, event, domain) { return scalarPolicy.wheel(current, event, domain); },
+    key(current, event, domain) { return scalarPolicy.key(current, event, domain); },
+    reset(domain) { return scalarPolicy.reset(domain); },
+    dispatch(source) { return scalarPolicy.dispatch(source); },
+    dispatchesCanonical(source, context, domain) {
+      return scalarPolicy.dispatchesCanonical(source, context, domain);
+    },
+    get wheelIdleMs() { return scalarPolicy.wheelIdleMs; },
+    describeTarget(candidate) { return scalarPolicy.describeTarget(candidate); },
   };
 
   function createRawBinding(): ContinuousScalarBinding {
@@ -143,7 +153,7 @@
           min,
           max,
           step,
-          defaultValue: defaultValue ?? null,
+          defaultValue: defaultValue ?? (renderer === 'bipolar' ? 0 : null),
           fineStepDivisor,
           keyboardStep,
         },
@@ -163,7 +173,7 @@
   let ownedBinding: ContinuousScalarBinding | null = initialExternalBinding === undefined
     ? createRawBinding()
     : null;
-  let hbarBinding = $state(initialExternalBinding ?? ownedBinding!);
+  let scalarBinding = $state(initialExternalBinding ?? ownedBinding!);
 
   $effect(() => {
     if (externalBinding === attachedExternalBinding) return;
@@ -171,10 +181,10 @@
     attachedExternalBinding = externalBinding;
     if (externalBinding === undefined) {
       ownedBinding = createRawBinding();
-      hbarBinding = ownedBinding;
+      scalarBinding = ownedBinding;
     } else {
       ownedBinding = null;
-      hbarBinding = externalBinding;
+      scalarBinding = externalBinding;
     }
     if (displacedOwnedBinding !== null) {
       queueMicrotask(() => displacedOwnedBinding.destroy());
@@ -240,13 +250,18 @@
   {/if}
 {:else if renderer === 'hbar'}
   <HBarRenderer
-    binding={hbarBinding} {label} {displayFn} {unknownDisplay}
+    binding={scalarBinding} {label} {displayFn} {unknownDisplay}
     {fillColor} {fillGradient} {trackColor}
     {accentColor} {showValue} {showLabel} {compact} {variant} {unit} {shortcutHint} {title}
     {legacy}
   />
 {:else if renderer === 'bipolar'}
-  <BipolarRenderer {...commonProps} />
+  <BipolarRenderer
+    binding={scalarBinding} {label} {displayFn} {unknownDisplay}
+    {fillColor} {fillGradient} {trackColor}
+    {accentColor} {showValue} {showLabel} {compact} {variant} {unit} {shortcutHint} {title}
+    {legacy}
+  />
 {:else if renderer === 'knob'}
   <KnobRenderer {...knobProps} />
 {:else if renderer === 'discrete'}

--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import ValueControl from '../ValueControl.svelte';
 import {
+  createBipolarContinuousScalarPolicy,
   createContinuousScalar,
   createHBarContinuousScalarPolicy,
   type CommandScalarFeedback,
@@ -114,6 +115,20 @@ function readingBinding(value: number, request: (value: number) => void): Contin
       request,
     }),
     createHBarContinuousScalarPolicy({ preview: 'optimistic', debounceMs: 0 }),
+  );
+}
+
+function bipolarBinding(value: number, request: (value: number) => void): ContinuousScalarBinding {
+  return createContinuousScalar(
+    () => ({
+      evidence: 'reading',
+      reading: { status: 'known', value },
+      ownerKey: `external-bipolar-${value}`,
+      domain: { min: -100, max: 100, step: 5, defaultValue: 0, fineStepDivisor: 10, keyboardStep: 50 },
+      enabled: true,
+      request,
+    }),
+    createBipolarContinuousScalarPolicy({ debounceMs: 0 }),
   );
 }
 
@@ -462,5 +477,154 @@ describe('ValueControl controlled HBar rendering', () => {
 
     expect(slider(target).getAttribute('aria-disabled')).toBe('true');
     expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('ValueControl controlled Bipolar rendering', () => {
+  it('cancels a Bipolar pointer draft and makes its retained move inert', () => {
+    const onChange = vi.fn();
+    const { target } = mountReactive({
+      value: 0,
+      min: -100,
+      max: 100,
+      step: 5,
+      label: 'Pointer',
+      renderer: 'bipolar',
+      debounceMs: 0,
+      onChange,
+    });
+    const control = slider(target) as HTMLElement & {
+      setPointerCapture?: (pointerId: number) => void;
+    };
+    control.setPointerCapture = vi.fn();
+    vi.spyOn(target.querySelector('.vc-bipolar') as HTMLElement, 'getBoundingClientRect')
+      .mockReturnValue({ left: 0, width: 100 } as DOMRect);
+
+    control.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true, clientX: 75, pointerId: 1,
+    }));
+    control.dispatchEvent(new PointerEvent('pointercancel', { bubbles: true, pointerId: 1 }));
+    control.dispatchEvent(new PointerEvent('pointermove', {
+      bubbles: true, clientX: 100, pointerId: 1,
+    }));
+    flushSync();
+
+    expect(onChange.mock.calls).toEqual([[50]]);
+    expect(visibleValue(target)).toBe('0');
+  });
+
+  it('reconciles a rejected raw wheel draft when the shared wheel lease expires', () => {
+    vi.useFakeTimers();
+    const onChange = vi.fn();
+    const { target } = mountReactive({
+      value: 0,
+      min: -100,
+      max: 100,
+      step: 5,
+      label: 'Rejected',
+      renderer: 'bipolar',
+      debounceMs: 0,
+      onChange,
+    });
+    const control = slider(target);
+
+    control.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true, cancelable: true }));
+    flushSync();
+    expect(onChange).toHaveBeenCalledExactlyOnceWith(5);
+    expect(visibleValue(target)).toBe('+5');
+
+    vi.advanceTimersByTime(300);
+    flushSync();
+    expect(visibleValue(target)).toBe('0');
+    expect(control.getAttribute('aria-valuenow')).toBe('0');
+    vi.useRealTimers();
+  });
+
+  it('replaces HBar with Bipolar on the same external owner and revokes retained callbacks', () => {
+    const request = vi.fn();
+    const binding = bipolarBinding(0, request);
+    const { state, target } = mountReactive({ binding, label: 'Replaceable', renderer: 'hbar' });
+    const retainedHBar = slider(target);
+
+    state.renderer = 'bipolar';
+    flushSync();
+    expect(target.querySelector('.vc-bipolar')).not.toBeNull();
+    expect(visibleValue(target)).toBe('0');
+
+    retainedHBar.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(request).not.toHaveBeenCalled();
+    slider(target).dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(request).toHaveBeenCalledExactlyOnceWith(50);
+
+    const retainedLease = binding.attachRenderer();
+    expect(retainedLease.beginPointer()).not.toBeNull();
+    retainedLease.dispose();
+    binding.destroy();
+  });
+
+  it('preserves command feedback and announcement identity across Bipolar appearance replacement', () => {
+    const binding = commandBinding(vi.fn(), {
+      phase: 'failed',
+      busy: false,
+      outcome: { phase: 'failed', error: 'radio rejected' },
+      transitionId: 'failed-bipolar',
+    });
+    const { state, target } = mountReactive({ binding, label: 'Feedback', renderer: 'hbar' });
+    const first = slider(target);
+    expect(first.getAttribute('data-command-phase')).toBe('failed');
+    expect(target.querySelector('[data-control-feedback-status]')?.textContent)
+      .toBe('Failed: 30 Hz: radio rejected');
+
+    state.renderer = 'bipolar';
+    flushSync();
+    const replacement = slider(target);
+    expect(replacement.getAttribute('data-command-phase')).toBe('failed');
+    expect(replacement.getAttribute('aria-busy')).toBe('false');
+    const descriptionId = replacement.getAttribute('aria-describedby');
+    expect(target.querySelector(`#${descriptionId}`)?.textContent).toBe('30 Hz');
+    expect(target.querySelector('[data-control-feedback-status]')).toBeNull();
+    binding.destroy();
+  });
+
+  it.each([
+    [Number.POSITIVE_INFINITY, '+INF'],
+    [Number.NEGATIVE_INFINITY, '-INF'],
+    [Number.NaN, 'NAN'],
+  ] as const)('keeps exact legacy formatting for nonfinite Bipolar input %s', (value, expected) => {
+    const { target } = mountReactive({
+      value,
+      min: -100,
+      max: 100,
+      step: 5,
+      label: 'Nonfinite',
+      renderer: 'bipolar',
+      onChange: vi.fn(),
+      displayFn: (candidate: number) => Number.isNaN(candidate) ? 'NAN'
+        : candidate === Number.POSITIVE_INFINITY ? '+INF' : '-INF',
+    });
+
+    expect(visibleValue(target)).toBe(expected);
+    expect(slider(target).getAttribute('aria-valuenow')).toBeNull();
+    expect(slider(target).getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('distinguishes a known invalid-domain Bipolar reading from an unknown reading', () => {
+    const { state, target } = mountReactive({
+      value: 25,
+      min: -100,
+      max: Number.NaN,
+      step: 5,
+      label: 'Domain',
+      renderer: 'bipolar',
+      onChange: vi.fn(),
+      displayFn: (candidate: number) => Number.isNaN(candidate) ? 'UNKNOWN' : `KNOWN:${candidate}`,
+    });
+
+    expect(visibleValue(target)).toBe('KNOWN:25');
+    expect(slider(target).getAttribute('aria-valuenow')).toBeNull();
+    state.value = Number.NaN;
+    flushSync();
+    expect(visibleValue(target)).toBe('UNKNOWN');
+    expect(slider(target).getAttribute('aria-disabled')).toBe('true');
   });
 });

--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.test.ts
@@ -3,6 +3,7 @@ import { mount, unmount, flushSync } from 'svelte';
 import type { ComponentProps } from 'svelte';
 import ValueControl from '../ValueControl.svelte';
 import {
+  createBipolarContinuousScalarPolicy,
   createContinuousScalar,
   createHBarContinuousScalarPolicy,
 } from '../../../../primitives/scalar/continuous-scalar.svelte';
@@ -60,6 +61,29 @@ describe('ValueControl wrapper', () => {
     expect(getSlider(target).getAttribute('aria-valuemax')).toBe('60');
     expect(target.querySelector('.vc-hbar')?.getAttribute('style'))
       .toContain('--vc-fill-percent: 50%');
+    binding.destroy();
+  });
+
+  it('renders a caller-owned Bipolar binding synchronously without raw bounds', () => {
+    const binding = createContinuousScalar(
+      () => ({
+        evidence: 'reading' as const,
+        reading: { status: 'known' as const, value: -25 },
+        ownerKey: 'direct-bipolar',
+        domain: { min: -100, max: 100, step: 5, defaultValue: 0, fineStepDivisor: 10 },
+        enabled: true,
+        request: vi.fn(),
+      }),
+      createBipolarContinuousScalarPolicy({ debounceMs: 0 }),
+    );
+
+    const target = mountControl({ binding, label: 'Direct', renderer: 'bipolar' });
+
+    expect(getValueDisplay(target)?.textContent).toBe('-25');
+    expect(getSlider(target).getAttribute('aria-valuemin')).toBe('-100');
+    expect(getSlider(target).getAttribute('aria-valuemax')).toBe('100');
+    expect(target.querySelector('.vc-bipolar')?.getAttribute('style'))
+      .toContain('--vc-current: 37.5%');
     binding.destroy();
   });
 

--- a/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
@@ -455,11 +455,13 @@ describe('PBT sliders visibility', () => {
   it('renders 3 sliders total when hasPbt=true', () => {
     const t = mountPanel({ hasPbt: true, pbtInner: 0, pbtOuter: 0 });
     expect(t.querySelectorAll('[role="slider"]').length).toBe(3);
+    expect(t.querySelectorAll('.vc-bipolar').length).toBe(3);
   });
 
   it('renders 1 slider total when hasPbt=false', () => {
     const t = mountPanel();
     expect(t.querySelectorAll('[role="slider"]').length).toBe(1);
+    expect(t.querySelectorAll('.vc-bipolar').length).toBe(1);
   });
 });
 

--- a/frontend/src/components-v2/panels/__tests__/RitXitPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/RitXitPanel.isolated.test.ts
@@ -219,6 +219,7 @@ describe('RitXitPanel component', () => {
     const target = mountPanel();
     const labels = Array.from(target.querySelectorAll('.vc-label')).map((el) => el.textContent);
     expect(labels).toContain('Offset');
+    expect(target.querySelectorAll('.vc-bipolar')).toHaveLength(1);
   });
 
   it('uses the shared offset constraints', () => {

--- a/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
+++ b/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { ControlFeedback } from '$lib/runtime/adapters/panel-adapters';
 import {
+  createBipolarContinuousScalarPolicy,
   createContinuousScalar,
   createHBarContinuousScalarPolicy,
   nativeRangeContinuousScalarPolicy,
@@ -215,6 +216,81 @@ describe('continuous scalar contract', () => {
 });
 
 describe('continuous scalar source policies', () => {
+  it.each([0, -50, Number.NaN, 2.5, Number.POSITIVE_INFINITY])(
+    'adapts invalid Bipolar keyboard hint %s without weakening the radio domain',
+    (keyboardStep) => {
+      const policy = createBipolarContinuousScalarPolicy({ debounceMs: 0 });
+      const { scalar, request } = readingSetup(policy, {
+        domain: {
+          min: -100,
+          max: 100,
+          step: 5,
+          defaultValue: 0,
+          fineStepDivisor: 10,
+          keyboardStep,
+        },
+        reading: { status: 'known', value: 0 },
+      });
+
+      expect(scalar.view).toMatchObject({
+        domainValid: true,
+        editable: true,
+        domain: { min: -100, max: 100, step: 5, keyboardStep: 5 },
+      });
+      scalar.attachRenderer().key({ key: 'ArrowRight', fine: false });
+      expect(request).toHaveBeenCalledExactlyOnceWith(5);
+    },
+  );
+
+  it('dispatches a center-anchored draft return but suppresses an untouched boundary', () => {
+    vi.useFakeTimers();
+    const policy = createBipolarContinuousScalarPolicy({ debounceMs: 50 });
+    const { scalar, request } = readingSetup(policy, {
+      domain: {
+        min: -100,
+        max: 100,
+        step: 5,
+        defaultValue: 0,
+        fineStepDivisor: 10,
+        keyboardStep: 50,
+      },
+      reading: { status: 'known', value: 0 },
+    });
+    const lease = scalar.attachRenderer();
+
+    lease.key({ key: 'ArrowRight', fine: false });
+    vi.advanceTimersByTime(50);
+    lease.key({ key: 'ArrowLeft', fine: false });
+    vi.advanceTimersByTime(50);
+    expect(request.mock.calls).toEqual([[50], [0]]);
+
+    const atBoundary = readingSetup(policy, {
+      domain: {
+        min: -100,
+        max: 100,
+        step: 5,
+        defaultValue: 0,
+        fineStepDivisor: 10,
+        keyboardStep: 50,
+      },
+      reading: { status: 'known', value: 100 },
+    });
+    expect(atBoundary.scalar.attachRenderer().key({ key: 'ArrowRight', fine: false })).toBe(true);
+    vi.advanceTimersByTime(50);
+    expect(atBoundary.request).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('keeps Bipolar wheel scaling and fine stepping explicit', () => {
+    const policy = createBipolarContinuousScalarPolicy({ debounceMs: 0 });
+    const compact = { min: -100, max: 100, step: 5, defaultValue: 0, fineStepDivisor: 10 };
+    const large = { min: -9_999, max: 9_999, step: 1, defaultValue: 0, fineStepDivisor: 10 };
+
+    expect(policy.wheel(0, { direction: 1, fine: false }, compact)).toBe(5);
+    expect(policy.wheel(0, { direction: 1, fine: false }, large)).toBe(44);
+    expect(policy.wheel(0, { direction: 1, fine: true }, compact)).toBe(0.5);
+  });
+
   it('makes native input immediate and tokenless without wheel or key reinterpretation', () => {
     const { scalar, request } = readingSetup(nativeRangeContinuousScalarPolicy, {
       reading: { status: 'known', value: 2_450 },
@@ -509,6 +585,23 @@ describe('continuous scalar deferred work', () => {
     vi.advanceTimersByTime(1);
     expect(scalar.view).toMatchObject({ interaction: 'idle', draft: null, displayed: 2_500 });
     expect(request.mock.calls).toEqual([[2_410], [2_420]]);
+    vi.useRealTimers();
+  });
+
+  it('reconciles a rejected Bipolar wheel draft to current canonical state at expiry', () => {
+    vi.useFakeTimers();
+    const policy = createBipolarContinuousScalarPolicy({ debounceMs: 50 });
+    const { scalar, request } = readingSetup(policy, {
+      domain: { min: -100, max: 100, step: 5, defaultValue: 0, fineStepDivisor: 10 },
+      reading: { status: 'known', value: 0 },
+    });
+    const lease = scalar.attachRenderer();
+
+    lease.wheel({ direction: 1, fine: false });
+    expect(request).toHaveBeenCalledExactlyOnceWith(5);
+    expect(scalar.view).toMatchObject({ interaction: 'wheel', draft: 5, displayed: 5 });
+    vi.advanceTimersByTime(300);
+    expect(scalar.view).toMatchObject({ interaction: 'idle', draft: null, displayed: 0 });
     vi.useRealTimers();
   });
 });

--- a/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
+++ b/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
@@ -54,16 +54,25 @@ export type ScalarSource = 'native-input' | 'pointer' | 'wheel' | 'keyboard' | '
 export type ScalarDispatchMode = 'immediate' | Readonly<{ debounceMs: number }>;
 export interface ScalarStepInput { readonly direction: -1 | 1; readonly fine: boolean }
 export interface ScalarKeyInput { readonly key: string; readonly fine: boolean }
+export interface ScalarDispatchContext {
+  readonly canonical: number;
+  readonly interactionBase: number;
+}
 
 export interface ContinuousScalarPolicy {
   readonly name: string;
   readonly preview: 'optimistic' | 'confirmed';
+  resolveKeyboardStep?(domain: ScalarDomain): number | undefined;
   normalize(value: number, domain: ScalarDomain): number | null;
   wheel(current: number, event: ScalarStepInput, domain: ScalarDomain): number | null;
   key(current: number, event: ScalarKeyInput, domain: ScalarDomain): number | null;
   reset(domain: ScalarDomain): number | null;
   dispatch(source: ScalarSource): ScalarDispatchMode;
-  dispatchesCanonical(source: ScalarSource): boolean;
+  dispatchesCanonical(
+    source: ScalarSource,
+    context?: Readonly<ScalarDispatchContext>,
+    domain?: ScalarDomain,
+  ): boolean;
   readonly wheelIdleMs: 0 | 300;
   describeTarget(value: number): string;
 }
@@ -176,6 +185,92 @@ export function createHBarContinuousScalarPolicy(
     reset: (domain) => domain.defaultValue ?? domain.min,
     dispatch: (source) => source === 'keyboard' || source === 'reset' ? debounce : 'immediate',
     dispatchesCanonical: (source) => source === 'wheel',
+    wheelIdleMs: 300,
+    describeTarget: options.describeTarget ?? String,
+  };
+  return Object.freeze(policy);
+}
+
+function bipolarLatticeCompatible(increment: number, domain: ScalarDomain): boolean {
+  return Number.isFinite(increment)
+    && increment > 0
+    && Number.isFinite(domain.step)
+    && domain.step > 0
+    && Number.isInteger(increment / domain.step);
+}
+
+function bipolarKeyboardStep(
+  current: number,
+  key: string,
+  increment: number,
+  domain: ScalarDomain,
+): number | null {
+  const center = domain.defaultValue ?? 0;
+  switch (key) {
+    case 'ArrowRight':
+    case 'ArrowUp':
+      return clamp(center + Math.round((current + increment - center) / increment) * increment,
+        domain.min, domain.max);
+    case 'ArrowLeft':
+    case 'ArrowDown':
+      return clamp(center + Math.round((current - increment - center) / increment) * increment,
+        domain.min, domain.max);
+    case 'Home':
+      return domain.min;
+    case 'End':
+      return domain.max;
+    default:
+      return null;
+  }
+}
+
+export function createBipolarContinuousScalarPolicy(
+  options: Readonly<{
+    debounceMs: number;
+    describeTarget?: (value: number) => string;
+  }>,
+): Readonly<ContinuousScalarPolicy> {
+  const debounce = options.debounceMs > 0
+    ? Object.freeze({ debounceMs: options.debounceMs })
+    : 'immediate';
+  const policy: ContinuousScalarPolicy = {
+    name: 'bipolar',
+    preview: 'optimistic',
+    resolveKeyboardStep: (domain) => domain.keyboardStep === undefined
+      || bipolarLatticeCompatible(domain.keyboardStep, domain)
+      || !Number.isFinite(domain.step) || domain.step <= 0
+      ? domain.keyboardStep
+      : domain.step,
+    normalize: (value, domain) => Number.isFinite(value)
+      ? clamp(value, domain.min, domain.max) : null,
+    wheel: (current, event, domain) => {
+      const stepsInRange = Math.max(1, (domain.max - domain.min) / domain.step);
+      const multiplier = stepsInRange > 500 ? Math.round(stepsInRange / 240) : 1;
+      const quantum = event.fine
+        ? domain.step / domain.fineStepDivisor
+        : domain.step * multiplier;
+      return clamp(snapToStep(current + event.direction * quantum, quantum, domain.min),
+        domain.min, domain.max);
+    },
+    key: (current, event, domain) => {
+      if (domain.keyboardStep === undefined) {
+        return handleKeyboardStep(
+          current, event.key, domain.step, domain.fineStepDivisor,
+          domain.min, domain.max, event.fine,
+        );
+      }
+      const requested = event.fine
+        ? domain.keyboardStep / domain.fineStepDivisor
+        : domain.keyboardStep;
+      const increment = bipolarLatticeCompatible(requested, domain) ? requested : domain.step;
+      return bipolarKeyboardStep(current, event.key, increment, domain);
+    },
+    reset: (domain) => domain.defaultValue ?? 0,
+    dispatch: (source) => source === 'keyboard' || source === 'reset' ? debounce : 'immediate',
+    dispatchesCanonical: (source, context, domain) => source === 'wheel'
+      || (source === 'keyboard' && domain?.keyboardStep !== undefined
+        && context !== undefined
+        && !Object.is(context.interactionBase, context.canonical)),
     wheelIdleMs: 300,
     describeTarget: options.describeTarget ?? String,
   };
@@ -332,7 +427,14 @@ export function createContinuousScalar(
   }
 
   function current(): Readonly<ContinuousScalarInput> {
-    const input = read();
+    const source = read();
+    const keyboardStep = policy.resolveKeyboardStep === undefined
+      ? source.domain.keyboardStep
+      : policy.resolveKeyboardStep(source.domain);
+    const domain = Object.is(keyboardStep, source.domain.keyboardStep)
+      ? source.domain
+      : { ...source.domain, keyboardStep };
+    const input = domain === source.domain ? source : { ...source, domain };
     reconcile(input);
     return input;
   }
@@ -357,10 +459,16 @@ export function createContinuousScalar(
       || normalized < input.domain.min || normalized > input.domain.max) return false;
     const authority = authorityOf(input);
     const generation = invalidationGeneration;
+    const canonical = canonicalOf(input);
+    const base = interactionBase(input);
+    if (canonical === null || base === null) return false;
     draft = normalized;
-    draftCanonical = canonicalOf(input);
+    draftCanonical = canonical;
     interaction = source;
-    if (!policy.dispatchesCanonical(source) && Object.is(normalized, draftCanonical)) {
+    if (!policy.dispatchesCanonical(source, {
+      canonical,
+      interactionBase: base,
+    }, input.domain) && Object.is(normalized, draftCanonical)) {
       draft = null;
       draftCanonical = null;
       if (source !== 'pointer') interaction = 'idle';
@@ -451,7 +559,7 @@ export function createContinuousScalar(
         if (activeGesture?.renderer !== renderer || activeGesture.token !== token) return;
         activeGesture = null;
         interaction = 'idle';
-        reconcile(read());
+        current();
       },
       cancelPointer(token: number): void {
         current();


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-2391/adopt-bipolar-controls-through-the-shared-scalar-binding-with-explicit

## Summary

- add an explicit Bipolar continuous-scalar policy for center-anchored keyboard input, adaptive wheel stepping, debounce, and invalid keyboard-hint fallback
- make BipolarRenderer binding-only and reuse the established renderer lease plus scalar feedback projection
- extend ValueControl raw and external binding modes to HBar and Bipolar while preserving the five existing panel mounts

## Public API and behavior

BipolarRenderer now accepts a ContinuousScalarBinding instead of raw value/domain/callback behavior props. ValueControl preserves existing raw caller compatibility and now accepts external bindings for either HBar or Bipolar. ContinuousScalarPolicy gains an optional keyboard-hint resolver and optional contextual arguments on dispatchesCanonical, so existing source-only policies remain compatible. Canonical min/max/step validation is unchanged.

Wheel expiry now reconciles rejected optimistic Bipolar state to the current canonical reading. Pointer cancellation, renderer replacement, authority changes, and owner disposal revoke unsent work without retracting already dispatched requests. No visual baselines were changed.

## Scope rationale

This crosses the six-file soft threshold because the scalar owner, ValueControl facade, Bipolar renderer, and all five production-mount witnesses form one coupled lifetime and compatibility contract. Splitting them would leave either an unadopted owner or an unverified public facade. Measured at the committed head: 8 files, 559 additions, 191 deletions, 750 changed lines.

## Verification

- focused baseline before edits: 5 files, 205 tests passed
- discriminating RED: 16 failures across policy, binding, expiry, feedback, and evidence witnesses
- final focused Vitest: 5 files, 222 tests passed
- changed-scope ESLint: passed
- npm run check: passed with 0 errors and 0 warnings
- git diff --check: passed
- mutation witnesses: source-only canonical dispatch, retained wheel draft, and stale renderer lease each failed their targeted tests

## Remaining limits

No broad/full local suite or local visual baseline run was performed, per MOR-2391. Required quick and path-selected visual evidence are left to the natural Ready PR workflows. Independent exact-head review and merge remain coordinator-owned.