### PR TITLE
docs: archive MOR-2393 instrument audits

### DIFF
--- a/.claude/audits/2026-09-06-mechanism-audit-finite-choice.md
+++ b/.claude/audits/2026-09-06-mechanism-audit-finite-choice.md
@@ -1,0 +1,174 @@
+# Mechanism audit: finite-choice instruments
+
+Audited revision: `f2e7969708d5c93890cf1b24d833ce820b36dc15`, 2026-09-06.
+
+Method: `.claude/skills/mechanism-audit/SKILL.md`, read in full from the audited repository, and `.claude/agents/auditor.md`. Repository guidance and live owner acceptance were read. This is the bounded finite-choice decision tract: shared behavior plus antenna, band and RX-audio choices. It is not a final integrated whole-path audit. Inspection used immutable Git objects. No audited-tree edits, Git writes, tests, builds, installs, browser work, service changes or hardware operations occurred. Publication remains a separate reviewed operation.
+
+## Steps 0-3a: evidence before judgement
+
+### Definitions and consumers
+
+| Capability | Actual definition site | Per-implementation consumers |
+| --- | --- | --- |
+| Known-field choice binding | `frontend/src/primitives/control-instruments/control-instrument-behavior.ts:bindChoiceInstrument,canInvoke` | `frontend/src/semantic/CwKeyerSurface.svelte:apfChoice`; `DspSurface.svelte:notchBehavior,agcBehavior`; `FilterSurface.svelte` choice factories; `RfFrontEndSurface.svelte:preampBehavior,attenuatorBehavior`; `ScopeControlsSurface.svelte` choice factory. Paths abbreviated in this cell are under `frontend/src/semantic/`. Direct behavior/render tests also consume it. |
+| Offered membership and selection | Same primitive: closure-local `offered`, returned `selected,isSelected,invoke` | The binding instances above. These are actual definitions, not imports. |
+| Antenna port and RX-ANT | `frontend/src/semantic/AntennaSurface.svelte:ANTENNA_PORTS,selectPort,toggleRxAnt,antennaSwitchBlocks,tunerIdle,valueOf` | Port and RX-ANT controls in its template; production antenna snippet in `frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte`; surface and wiring tests. |
+| Band choice | `frontend/src/semantic/BandSurface.svelte:isCurrent,selectBand,receiverKnown` | Capability-derived `bandChoices` buttons; production band snippet in SemanticRadioSurfaces; surface and wiring tests. Frequency entry shares the module but is not a finite-choice implementation. |
+| Audio monitor and routing | `frontend/src/semantic/RxAudioSurface.svelte:MONITOR_MODES,FOCUS_CHOICES,SPLIT_CHOICES,isValue,liveOffered,linkLost` | Monitor/focus/split controls and loss annotation; production RX-audio snippet in SemanticRadioSurfaces; surface and wiring tests. |
+| MOD-input selection | Same RX-audio surface: `modInputValue,modInputUsable,changeModInput` | Native select in its template and existing `mode.onModInputChange` callback. Vocabulary is imported from `frontend/src/lib/radio/mod-input.ts:MOD_INPUT_SOURCES`, not redefined. |
+| Command and audio execution | `frontend/src/lib/runtime/commands/panel-commands.ts:makeAntennaHandlers,makeBandHandlers,makeModeHandlers,makeRxAudioHandlers,makeAudioRoutingHandlers` | Existing runtime adapter bindings supplied to SemanticRadioSurfaces and other panel consumers. These are downstream owners, not extra semantic-surface implementations. |
+
+Observation: all four scoped implementation modules were independently read, including complete semantic scripts/templates. Existing binding imports/calls, production mounts, relevant wiring callbacks, downstream handlers and targeted test bodies were inspected. The collection supplies the broader test and adapter census. Other adopted semantic families were checked as consumers, not independently audited in full.
+
+### Dated rulings and accepted target
+
+- `docs/plans/2026-07-25-ui-composition-architecture-v3.md` (2026-07-25): "Adapters are pure and depend only on runtime/domain contracts." Semantic presentation does not gain transport or truth ownership.
+- `frontend/src/semantic/AntennaSurface.svelte:selectPort` and its comments, introduced in commit `9da14cc25` (2026-08-06), preserve absolute port selection without observing the current TX port. `antennaSwitchBlocks` limits RF blockers and adds the ATU constraint. `docs/validation/desktop-v2-v3-parity.md:P11` and antenna tests preserve that narrowed gate.
+- `frontend/src/semantic/BandSurface.svelte:selectBand` and comments, introduced in commit `6c2a99364` (2026-08-06), treat TX permit as information for tuning, not permission to tune. The parity document's active-receiver correction and actual wiring preserve the independent known-receiver gate.
+- `frontend/src/semantic/RxAudioSurface.svelte:linkLost`, commit `cacd12d4e` (2026-08-06), and `docs/validation/desktop-v2-v3-parity.md:P6` require the loss annotation only when live is structurally offered, selected, and nonoperational. The test preserves live as selectable while the link is down because selecting it opens the link.
+- `docs/plans/2026-04-12-target-frontend-architecture.md:Addendum 2026-09-02` places common instruments in primitives and treats appearance as presentation. Live acceptance read on 2026-09-06 requires stable semantic behavior with replaceable geometry, permits distinct internal algorithms and forbids new truth/confirmation/transport owners.
+- The accepted target already exists: `bindChoiceInstrument` has five production semantic-family consumers at the pin. RIT/scan/CW adoption is landed; RIT uses action/toggle bindings, not a choice binding. Older tracking prose calling that adoption unfinished does not supersede the landed source. Antenna, band and RX audio are not consumers at this pin. Prior remaining-adoption design notes are candidate explanations, not accepted decisions.
+
+### Systematic sweep and limits
+
+The collection's per-name inventory contains 64 rows: 5 shared-behavior functions, 16 antenna names, 27 band names and 16 RX-audio names. It separates source and test lexical occurrences and includes module constants, exported helpers, local handlers and Svelte state. Its declaration/manual-assignment column is not a semantic write count; its project-wide token counts include comments and same-name collisions. These are not 64 independently resolved read/write proofs.
+
+Independent declaration enumeration of the full pinned modules supplements that inventory:
+
+| Module | Named function declarations | const/let/var declaration lines |
+| --- | ---: | ---: |
+| control-instrument-behavior.ts | 3 | 7 |
+| AntennaSurface.svelte | 4 | 15 |
+| BandSurface.svelte | 8 | 28 |
+| RxAudioSurface.svelte | 2 | 17 |
+
+Arrow-valued helpers occur in the declaration-line column. Destructured props are one declaration line, not one binding. The shared module additionally implements 12 object getters/methods across its returned action/toggle/choice objects; their consumers are property accesses through the behavior interfaces, not necessarily same-name direct calls. Type-only interfaces/signatures are not executable methods.
+
+The original 64-row inventory omits ordinary nested locals and does not separately enumerate returned object methods. Full-source inspection checked those omissions: antenna `atu,blocks`; band `text,value,asKhz,match,whole,frac,hz,hit,key`; RX-audio `value,source`; and shared binding `input,field` locals and behavior methods. They all feed return values, guards, calls or templates in their respective lexical scopes. The props are read by handlers/markup. Band entry state is read by parsing/readiness/hints and is assigned by input/cancel; it is not dead merely because frequency entry is excluded from the choice comparison.
+
+One important counterexample to lexical counting is antenna `sequence`: its same-line `++sequence` is a read/write feeding the live `blockedId`; one project token line does not make it dead. Several helpers the inventory casually labels private, including antenna `valueOf` and semantic `usable` exports, are actually exported from module scripts. They cannot be declared dead from an absent external literal match.
+
+No dead or constant-guard-unreachable candidate was established. Literal checks include dynamic indexed label maps, `ANTENNA_PORT_INTENT[port]`, dynamically chosen MOD-input command names and the local-extension boundary. Public imports and unavailable downstream/private consumers remain guards, not evidence of absence. Tests are positive consumers; no tests-only implementation was proposed for deletion. This is a bounded lexical/manual sweep, not complete binding-resolved data flow or clearance of every public API.
+
+### Observed policy and execution paths
+
+Observation: `control-instrument-behavior.ts:canInvoke` requires a present, structural, operational, known field and no blocker. `bindChoiceInstrument.selected` additionally requires current-value membership; `invoke` requires target membership. A known but unoffered current value yields no selection yet does not itself prevent invocation of an offered target. Optional `feedback` is forwarded unchanged; the binding owns no command lifecycle or confirmation store.
+
+Observation: antenna ports are the two command-addressable values `[1,2]`, not an enumeration from arbitrary `antennaCount`. `selectPort` requires the antenna group and no RF/ATU blockers, not a known current TX port. `toggleRxAnt` additionally needs usable observed RX-ANT because it inverts a current value. Downstream `makeAntennaHandlers.onSelectAnt1/2` still requires at least two antennas and the corresponding observed boolean RX override. Thus unknown current TX port is allowed at the surface, but an entirely unobserved antenna state does not guarantee a radio command. The existing indexed wiring maps the offered port to the shipped command handler.
+
+Observation: `BandSurface.selectBand` requires known active receiver, not known current band or allowed TX permit. `SemanticRadioSurfaces.selectBand` repeats the receiver guard. BSR choices use `band.onBandSelect`; bandless choices use the existing per-receiver `tuneFrequency(..., 'jump')`, bypassing the old MAIN-only fallback. `isCurrent` returns false for unread current band, and the pinned surface test explicitly expects `aria-pressed="false"` on every offered choice in that state. The separate current-band readout remains unknown.
+
+Observation: RX focus and split are absolute choices available while their current preference is unread or degraded. Monitor `live` is omitted only if `liveAudio.structural` is false; link-down does not disable selection. `makeAudioRoutingHandlers` updates the audio manager and saved preferences. `makeRxAudioHandlers.onMonitorModeChange` owns live/mute runtime behavior and can issue AF changes/restoration. It is therefore neither a single radio-confirmed field nor entirely free of radio side effects.
+
+Observation: RX MOD-input requires `usable(rx.modInputSource)` and a recognized current source. `changeModInput` resolves the offered target through `MOD_INPUT_SOURCES`, restores the DOM select to the observed value, and only then emits if usable. Tests cover unknown, degraded and unrecognized current sources. `makeModeHandlers.onModInputChange` independently obtains known active DATA group, validates it and selects the existing group-specific command. That command routing belongs below the renderer.
+
+## Step 4: steelman
+
+The strongest case for the existing arrangement is that these controls do not have the same authorization rule. A relative toggle cannot invert an unknown bit. An absolute antenna port can be chosen without observing the current port, but relay safety and preservation of the relevant RX override still matter. A band change needs an honest receiver target, not TX permission. Restoring an unread local routing preference is useful and does not pretend that its old value was known. A live-audio action must remain usable while the link is down. Applying the current known-field gate uniformly would remove intended behavior.
+
+The shared binding already solves the known-field form and owns offered membership and current selection. Its real adopters disprove a claim that all choice behavior lacks a shared home. The optional blocker can express extra family restrictions, and feedback forwarding is not another truth store. The three remaining surfaces contain little gesture machinery: some duplication is simple markup and callback wiring, not competing complex state machines.
+
+Canonical selection is distinct from requested target. No offered choice selected while the current value is unread is not a relative toggle reporting a known false state. The band test deliberately asserts false per-button selection alongside an unknown field readout. It must not be silently rewritten on the assumption that every boolean ARIA attribute means a known boolean radio fact.
+
+These arguments clear the family gates, command handlers, local preference domain and rendering details. They do not supply a common choice interface capable of representing independent observed selection and absolute invocation eligibility. The accepted replaceable-instrument goal makes that narrower coverage gap actionable; it does not select a helper name, internal topology or universal policy.
+
+## Deletions
+
+None established. No zero-consumer or vestigial-fork verdict is supported by this tract. Exported helpers, dynamic maps, binding methods and frequency-entry neighbors remain live or externally guarded. Do not turn the lexical inventory into a deletion list.
+
+## Consolidations
+
+### F1 - Absolute choices need independent observation and invocation semantics
+
+Verdict: B - missing shared-interface coverage, not evidence for one universal choice policy.
+Rank: displaced.
+Elements / definition sites: `frontend/src/primitives/control-instruments/control-instrument-behavior.ts:ChoiceInput,ChoiceInstrumentBehavior,canInvoke,bindChoiceInstrument`; `frontend/src/semantic/AntennaSurface.svelte:selectPort,currentPort`; `frontend/src/semantic/BandSurface.svelte:selectBand,isCurrent`; `frontend/src/semantic/RxAudioSurface.svelte:isValue,liveOffered` and monitor/focus/split callbacks.
+Consumers: shared binding serves the five semantic families enumerated above. Antenna implementation serves port buttons; band implementation serves capability-derived band buttons; RX implementation serves monitor/focus/split controls. All three remaining surfaces have production mounts and test consumers, not abandoned twins.
+Divergence: observation: known-field invocation is inseparable from current reading in the existing binding, while these absolute choices intentionally permit some unread states and use different eligibility facts. Inference: reusing that interface unchanged either rejects allowed actions or requires fabricated field evidence; neither satisfies truthful replaceable instruments. The current family differences themselves are not a regression.
+Prior ruling: 2026-08-06 antenna/band/audio decisions and parity entries above; 2026-09-02 primitive ownership addendum; 2026-09-06 accepted semantic-interface goal.
+In-flight: bindChoiceInstrument already exists with real adopters. No scoped absolute-choice adoption exists at the pin; unaccepted design notes do not establish an accepted replacement.
+Required surface: a finite offered vocabulary and target membership, canonical selected/unknown evidence independent from invocation eligibility, fresh input evaluation, supplied family blockers/eligibility and existing callbacks, plus preservation of supplied feedback without manufacturing confirmation. It must support existing known-only adopters and these genuinely absolute consumers without weakening relative-toggle semantics or changing runtime command gates. Distinct internal strategies remain permitted; no new owner/store is required by this finding.
+Depends on: none to adjudicate the missing surface; adoption depends on accepting that surface and preserving F3/F4 policies.
+Confidence: high on the interface mismatch; medium on the eventual breadth of a common interface.
+Falsifier: an existing supported common choice interface at this pin that represents unknown selection and independently permitted invocation without synthetic known fields, or a superseding accepted decision withdrawing those absolute behaviors.
+Fix class: design.
+Actionable: yes for the bounded interface gap and subsequent adoption; not authorization for a universal gate, new state machine or command vocabulary.
+
+### F2 - MOD-input can adopt the existing known-field behavior with its explicit blocker
+
+Verdict: A - incomplete adoption of an existing shared capability; no new primitive required for this element.
+Rank: parallel.
+Elements / definition sites: `frontend/src/semantic/RxAudioSurface.svelte:modInputValue,modInputUsable,changeModInput`; `frontend/src/primitives/control-instruments/control-instrument-behavior.ts:bindChoiceInstrument,canInvoke`; `frontend/src/lib/radio/mod-input.ts:MOD_INPUT_SOURCES`.
+Consumers: local selection/guard serves the RX native select; shared known-field guard/membership serves the five existing semantic families; MOD_INPUT_SOURCES serves this select and its existing radio-domain consumers.
+Divergence: observation: MOD-input additionally forbids invocation when the known current value is outside the vocabulary. The shared binding's selected value becomes undefined in that situation but its available/invoke gate remains open. Inference: the existing explicit blocker can preserve that extra restriction; merely passing the field and choices would regress it. String-to-vocabulary decoding and DOM restoration remain renderer adaptation.
+Prior ruling: known/current and requested target remain separate under the live 2026-09-06 acceptance; the 2026-09-02 addendum locates reusable instrument behavior in primitives. Source/tests pin MOD-input's unknown/degraded/unrecognized restrictions; no ruling was found requiring a private membership mechanism.
+In-flight: bindChoiceInstrument is the existing target with production consumers. RX MOD-input has not adopted it at the pin.
+Required surface: exists, including optional blocked and offered membership. Preserve the recognized-current-source blocker, canonical selected state, DOM reset, current DATA-group command routing and existing remedy callback. No generic command selection inside the primitive.
+Depends on: none; does not need F1's absolute-choice coverage decision.
+Confidence: high on capability fit; medium on the marginal value of adopting such a small client.
+Falsifier: a tested MOD-input interaction or observation requirement that cannot be represented by current field/choices/blocked/callback semantics without changing its behavior.
+Fix class: consolidate.
+Actionable: yes as narrow adoption under the accepted instrument goal; no standalone abstraction expansion is justified.
+
+### F3 - Safety, receiver identity and audio availability are legitimate family policies
+
+Verdict: C - correctly located domain policy supplied around common interaction.
+Rank: diverged (intentional policy variation, not a divergence defect).
+Elements / definition sites: `frontend/src/semantic/AntennaSurface.svelte:antennaSwitchBlocks,tunerIdle,toggleRxAnt`; `frontend/src/semantic/BandSurface.svelte:receiverKnown,selectBand`; `frontend/src/semantic/RxAudioSurface.svelte:liveOffered,linkLost`; `frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte:selectBand,tuneFrequency`; `frontend/src/lib/runtime/commands/panel-commands.ts:makeAntennaHandlers,makeModeHandlers,makeRxAudioHandlers,makeAudioRoutingHandlers`.
+Consumers: antenna controls consume RF/ATU restrictions; band buttons and wiring consume known receiver; monitor UI consumes structural offering/link state; existing runtime handlers consume these callbacks and perform their own validated command/audio operations. Relative RX-ANT has its separate known-bit consumer.
+Divergence: observation: relay switching requires RF/ATU conditions, tuning does not require TX permit, live selection can initiate a down link, routing writes absolute preferences, and MOD command selection depends on active DATA group. Inference: collapsing these into known/operational-current or TX-permitted gates would change accepted behavior.
+Prior ruling: dated antenna/band commits and audio parity record from 2026-08-06; pure-adapter architecture on 2026-07-25; current accepted no-new-transport/truth-owner constraint.
+In-flight: shared keyBlockedReasons and existing runtime handlers already exist; common choice behavior must consume the supplied outcomes, not replace those authorities.
+Required surface: preserve these policies as real semantic/runtime inputs and callbacks; shared interaction needs no knowledge of relay commands, BSR fallback, DATA vocabulary, audio storage or connection opening.
+Depends on: none. F1/F2 must preserve these constraints.
+Confidence: high.
+Falsifier: a newer accepted domain contract requiring the same authorization semantics across these families, supported by corresponding command and observation changes.
+Fix class: none.
+Actionable: no consolidation of the policies themselves; preservation is required during adoption.
+
+### F4 - Choice selection is not a boolean observation, and feedback forwarding is not confirmation
+
+Verdict: C for canonical per-choice selection and distinct audio preference ownership; undetermined for each family's missing end-to-end feedback projection.
+Rank: diverged (different evidence domains, not a proven duplicate lifecycle).
+Elements / definition sites: `frontend/src/semantic/BandSurface.svelte:isCurrent`; `frontend/src/semantic/AntennaSurface.svelte:currentPort`; `frontend/src/semantic/RxAudioSurface.svelte:isValue,modInputValue`; `frontend/src/primitives/control-instruments/control-instrument-behavior.ts:ChoiceInstrumentBehavior.feedback,bindChoiceInstrument.selected`; `frontend/src/lib/runtime/commands/panel-commands.ts:makeRxAudioHandlers,makeAudioRoutingHandlers,makeModeHandlers`.
+Consumers: the respective buttons/select consume canonical or preference state; binding users receive optional caller-supplied feedback; radio-command execution and audio preference/runtime handlers serve their own downstream consumers. The three remaining surfaces do not currently consume a ControlFeedback binding/envelope.
+Divergence: observation: unread band/antenna/routing gives no selected offered option, and band tests assert false per-button aria-pressed. Requested target is not substituted. Radio commands and audio preferences have different confirmation authorities; monitor may additionally have AF side effects. Inference: absence of an envelope in these surfaces is not proof of an absent command tracker, nor permission to present preference writes as radio confirmation.
+Prior ruling: 2026-09-06 acceptance requires canonical truth and requested target to remain distinct; dated band/antenna/audio behavior above. No scoped accepted feedback descriptor contract was found for all of these families.
+In-flight: feedback pass-through already exists in the shared binding; downstream command tracking already exists. Passing a generic feedback type does not implement field confirmation or prove adoption.
+Required surface: preserve observed-selection knowledge independently from requested target and lifecycle. Where real field-specific feedback is supplied, carry it through unchanged and expose it separately. Before authorizing new feedback projection, establish the actual field identity, observation matching and authority for antenna/band/MOD and the distinct local/composite audio cases. No invented confirmation floor, truth store or merged audio/radio lifecycle.
+Depends on: field-specific observation/command contracts for any new feedback adoption; selection preservation itself has no dependency.
+Confidence: high on current source semantics; medium on completeness of the bounded feedback-contract evidence.
+Falsifier: an existing scoped feedback projection/accepted descriptor proving these full paths already supply the required evidence, or an accepted selection contract superseding the pinned unknown-state tests.
+Fix class: none pending evidence for additional feedback work.
+Actionable: no blanket feedback architecture change from this tract; yes as a preservation constraint for choice adoption.
+
+### F5 - Existing shared mechanism and renderer adaptation are not competing systems
+
+Verdict: already shared for known-field eligibility, offered membership and feedback pass-through; C for finite markup, value decoding and readout formatting.
+Rank: parallel.
+Elements / definition sites: `frontend/src/primitives/control-instruments/control-instrument-behavior.ts:canInvoke,bindChoiceInstrument`; `frontend/src/lib/radio/mod-input.ts:MOD_INPUT_SOURCES`; `frontend/src/semantic/BandSurface.svelte:defaultPermitLabel,txDeniedReason,interpretFrequencyEntry`; `frontend/src/semantic/RxAudioSurface.svelte:changeModInput`; `frontend/src/semantic/AntennaSurface.svelte:ANTENNA_BLOCKED_LABEL`.
+Consumers: shared eligibility serves action/toggle/choice bindings; choice membership serves its production consumers; MOD vocabulary serves RX and radio-domain code. Local formatting and parsing serve their own semantic templates/handlers; frequency entry is not another finite-choice owner.
+Divergence: observation: select DOM restoration, label maps, permit hints and typed-frequency parsing differ from choice-button markup. Inference: common naming or nearby placement does not make these competing implementations of selection lifetime.
+Prior ruling: 2026-07-25 pure presentation/adapters and 2026-09-02 primitive ownership; 2026-09-06 acceptance allows different geometry and internal strategies.
+In-flight: these shared primitives and vocabulary are actual code at the pin; no replacement is warranted by their imports.
+Required surface: exists for the shared parts; keep renderer-specific adaptation and informative labels local. F1 is the bounded missing semantic coverage, not a reason to extract every helper.
+Depends on: none.
+Confidence: high.
+Falsifier: another live independent definition of the same domain vocabulary or eligibility mechanism, or a concrete second consumer requiring the supposedly renderer-local behavior unchanged.
+Fix class: none.
+Actionable: no; cleared except for the explicitly isolated F1/F2 adoption work.
+
+## Weakest link
+
+F4's feedback scope is the least settled conclusion. The source proves absent scoped envelope consumption and distinct runtime domains, not a complete census of every accepted field-specific feedback requirement. Check antenna/band/MOD observation identities and audio preference/composite completion contracts first. Do not convert that uncertainty into a new confirmation owner. F1's exact internal shape also remains deliberately undecided: the gap is proven, but neither one helper nor one algorithm is selected.
+
+## Cleared
+
+- Existing bindChoiceInstrument ownership, offered membership, current-value selection and stateless feedback pass-through.
+- Production liveness of antenna, band and RX-audio surfaces and the already-landed choice adopters.
+- Narrow antenna RF/ATU rules, observed RX-ANT inversion and existing downstream RX-override preservation.
+- Known-receiver band routing, informational TX permit, BSR dispatch and per-receiver absolute jump fallback.
+- Structurally offered live audio while disconnected, explicit link-loss annotation and absolute unread routing choices.
+- Separate canonical selection and requested target, including the tested unread-band per-option false attributes.
+- Existing MOD vocabulary/DATA command owner; local select decoding/reset and family-specific current-source blocker.
+- Local labels, informative permit presentation and live frequency-entry neighbors. No deletion, universal choice gate, new truth store or integrated-product completion is authorized.

--- a/.claude/audits/2026-09-06-mechanism-audit-meter-context.md
+++ b/.claude/audits/2026-09-06-mechanism-audit-meter-context.md
@@ -1,0 +1,220 @@
+# Mechanism audit: meter source and context
+
+Audited revision: `f2e7969708d5c93890cf1b24d833ce820b36dc15`, 2026-09-06.
+
+Method: `.claude/skills/mechanism-audit/SKILL.md`, read in full from the audited repository, and `.claude/agents/auditor.md`. Repository guidance and live owner acceptance were read. This is the bounded meter source/context decision tract. It does not accept all alternate meter implementations, scopes, the integrated product, or the final whole-path audit. Source inspection used immutable Git objects; no audited-tree edits, Git writes, tests, builds, installs, browser work or hardware operations occurred.
+
+## Steps 0-3a: evidence before judgement
+
+### Actual definitions and consumer edges
+
+| Capability | Definition | Actual consumers |
+| --- | --- | --- |
+| Display observation qualification | `frontend/src/lib/runtime/adapters/display-observation.ts:qualifyDisplayObservation,qualifyRadioDisplayObservation,qualifyEvidence` | Radio view-model adapter and scope-passband display adapter; qualifier tests |
+| Active receiver identity | `frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts:activeReceiverId` | `toRadioViewModel`; single receiver is MAIN by topology, multiple receivers require observed active identity |
+| Canonical meters | Same adapter: `deriveMeters,meterField,displayTxMeter` | `frontend/src/semantic/MetersSurface.svelte`; `frontend/src/semantic/radio-display-model.ts:projectPeerSplitDisplay` for six telemetry fields |
+| Receiver indicator S-meter | Same adapter: `deriveReceiverIndicators` | `frontend/src/semantic/VfoIndicatorRow.svelte`; Standard `frontend/src/semantic/VfoSurface.svelte:standardInstrument` passes its S-meter to `frontend/src/components-v2/vfo/VfoPanel.svelte` |
+| Semantic meter projection | `frontend/src/semantic/MetersSurface.svelte:observed,signalDisplay,txPresentation,swrLowerScale` | One MetersSurface mount in SemanticRadioSurfaces, placed through three zone paths; root consumers include desktop, mobile, LCD and alternative skin compositions |
+| TX presentation semantics | `frontend/src/semantic/tx-meter-display.ts:projectTxMeterDisplay` | MetersSurface and radio-display-model's TX telemetry projection |
+| PBT continuity | `frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte:pbtEvidence,pbtFloorKey,pbtObservationFloors` | Local PBT retained/canonical overlay; no meter consumer of this state |
+| Shared ballistics | `frontend/src/primitives/meters/meter-ballistics.svelte.ts:createMeterBallistics,createMeterBallisticsGroup,createTickerLifecycle,createPeakChannel` | LinearSMeter, BarGauge, and MetersDockPanel respectively; direct lifecycle tests |
+| Peak algorithms | Same primitive: `createFrameStepPeakStrategy,createElapsedEnvelopePeakStrategy` | Frame strategy: LinearSMeter. Elapsed envelope: BarGauge and dock group |
+| Imported math | `frontend/src/lib/utils/smoothing.svelte.ts:createSmoother`; `frontend/src/components-v2/panels/meter-utils.ts:updatePeakHold,peakHoldDisplay`; meter scale/calibration helpers | Imported into ballistics consumers; imports are not additional definitions |
+
+Observation: qualifier, relevant adapter ranges, receiver-indicator derivation, semantic meter surface, both shared renderer scripts/templates, complete ballistics module, PBT continuity range, TX display projector, peer-split projection and Standard VFO mount were independently read. Backend observation admission and public field-status schema were also read. The independent collection supplies the broader layout importer census and imported math definition locations; this tract did not reopen every alternate layout or every math body.
+
+Observation: Standard's `standardInstrument` now directly mounts VfoPanel with `indicator.sMeter` reading and availability. The meter implementation files being unchanged across a merge does not make the consumer graph unchanged. VfoPanel is not a dead legacy consumer. The legacy adapter paths and dock fallback remain additional consumers in the collection; no deletion of either component follows from accepted layouts preferring semantic meters.
+
+### Dated rulings and accepted work
+
+- `docs/plans/2026-07-25-ui-composition-architecture-v3.md` (2026-07-25): "Adapters are pure and depend only on runtime/domain contracts." Pure transient presentation semantics are allowed; capabilities stay authoritative below presentation.
+- `docs/architecture/level-meter-calibrated-domain.md`, accepted calibrated-domain decision: "the DOMAIN, the unit vocabulary, and the interpolation ALGORITHM are GLOBAL"; correction curves are per rig. Its acceptance is recorded in that ADR; no new acceptance date is inferred here.
+- `.claude/audits/2026-08-30-mechanism-audit-state-feedback.md` distinguishes governed migration from duplicate truth stores, clears the shared loose availability helper, and records legitimate local visual grammar. Its old findings are a point-in-time record, not proof of the current tree.
+- `docs/plans/2026-04-12-target-frontend-architecture.md:Addendum 2026-09-02` locates common instruments under primitives and makes display models/geometry presentation inputs.
+- Source and collection identify accepted radio-wide P/SWR/ALC display qualification and PBT fenced retention on 2026-09-05. Accepted shared ballistics and dock adoption followed on 2026-09-06. These mechanisms exist in the pin and are not proposals to rebuild.
+- Live acceptance read on 2026-09-06 permits different internal algorithms, requires honest source/context behavior and reserves a later full-path audit. Prior meter context notes are unaccepted proposals and do not select the result below.
+
+### Systematic sweep coverage
+
+The collection enumerates named functions, constants, mutable/assigned locals, component props and method names across seven modules. For the two large modules it bounds definitions to active selection/meter helpers and session/PBT context, respectively; their other control/scope families are excluded. Source and test lexical counts are separated, with exported API consumer tables.
+
+Independent declaration-line checks over those same scopes give the following reproducible coverage counts. Function declarations and declaration lines are distinct categories; the latter includes constants, mutable bindings and arrow-valued declarations, not an AST total of bindings:
+
+| Module or bounded range at the pin | Named function declarations | const/let/var declaration lines |
+| --- | ---: | ---: |
+| display-observation.ts | 6 | 7 |
+| radio-view-model-adapter.ts, lines 121-195 and 269-339 | 10 | 20 |
+| MetersSurface.svelte, before stylesheet | 2 | 15 |
+| SemanticRadioSurfaces.svelte, lines 473-477 and 598-696 | 0 | 30 |
+| meter-ballistics.svelte.ts | 13 | 29 |
+| LinearSMeter.svelte, before stylesheet | 10 | 78 |
+| BarGauge.svelte, before stylesheet | 2 | 21 |
+
+The counts were obtained from pinned source text with anchored function and declaration patterns. The collection's per-name lists supplement these counts with markup references and object methods. Method signatures are not executable method implementations. Broad names such as `state`, `view`, `sample` and `now` collide across closures; ballistics aggregate counts and local assignment totals use different denominators and must not be summed or interpreted as data flow. Source/test absence in a lexical row is not proof of an absent interface consumer.
+
+The only independently established dead candidates are D1/D2. Reproduction:
+
+```sh
+git grep -n -w -e DBM_Y -e S_UNIT_Y f2e7969708d5c93890cf1b24d833ce820b36dc15 -- frontend/src frontend/tests src tests
+```
+
+Exactly two declaration hits were returned. Full LinearSMeter script/template inspection found actual readout positions expressed directly using TRACK_Y/TRACK_H. No runtime export, dynamic lookup, serialization, or public prop exposes either local. An available sibling source tree had no literal hits. Unknown external consumers remain a guard for public APIs, but cannot reach these component lexical locals through their public interface. No tests-only deletion and no additional constant-guard unreachable branch was established.
+
+This sweep is systematic but bounded and partly lexical. It does not clear all alternate meter paths or prove all remaining local bindings live.
+
+### Source and time contracts
+
+Observation: `display-observation.ts:validIdentity` requires matching safe nonnegative state/caps provider generations and contract version 1. Receiver qualification also validates topology/receiver object/path consistency. `qualifyEvidence` checks the leaf, any present ancestors, finite nonnegative field markers, availability/freshness and valid scalar values. Its return value exposes current/stale/unknown/unsupported plus value, not reusable provider/receiver/path/session/marker context.
+
+Observation: `radio-view-model-adapter.ts:deriveMeters` chooses SUB only from raw `state.active === 'SUB'` and otherwise MAIN. It does not consume the `activeId` already computed by `toRadioViewModel`. `meterField` combines finite numeric values with the loose `topFieldAvailable` gate. `deriveReceiverIndicators` uses canonical structural/operational receivers and strict per-field observation gates. P/SWR/ALC additionally carry qualified `display`; signal, compression, voltage and current do not have that display path.
+
+Observation: `src/rigplane/core/state_store.py:StateStore._strictly_older_than_entry,_strictly_older_than_observation` compares markers only when provider generation and non-null clock domain match, using strict `<`. `StateStore._apply_one` accepts an equal marker and increments observation sequence. Therefore marker equality is not a deduplication contract. `src/rigplane/web/state_schema.py:FieldStatusPublic` and `frontend/src/lib/types/state.ts:FieldStatusPublic` expose lastObservedMonotonic, but no typed clock-domain field. An open-ended `source` object is not a documented equivalent clock identity.
+
+Observation: LinearSMeter supplies `performance.now()`/animation-frame time to frame ballistics; BarGauge supplies `Date.now()` to interval ballistics. Both are local animation clocks. No backend-to-browser epoch conversion is established. Comparing a backend marker directly with either clock would invent a contract.
+
+## Step 4: steelman
+
+The strongest case for the current arrangement is that a station dock and a receiver strip answer different presentation questions. A dock chooses an active receiver, applies TX relevance and combines telemetry. A receiver strip has a fixed receiver identity and preserves a shell for each structural receiver. Those differences justify distinct projections and structural policies. The old loose field-availability helper also has an explicit compatibility history; tightening it globally would affect many unrelated controls.
+
+Display evidence and editable/current readings need not be identical. Stale information may remain available as marked display evidence while interaction and current meter motion are unavailable. The accepted P/SWR/ALC projector already distinguishes idle, relevant and indeterminate RF state. Flattening everything to one known/unknown number would erase that policy.
+
+Ballistics is already shared, with deliberately different peak algorithms. Frame-step behavior and elapsed envelopes need not become one formula. A design-language segment-count or calibration change can change the smooth target without another radio observation; an observation-only update gate would freeze valid visual remapping. A marker's equality also does not imply no new sample under the backend contract.
+
+PBT has real retention requirements and a local floor mechanism. But it has no meter consumers, its policy is field-specific, and lifting its strict marker floor wholesale would import a monotonic uniqueness assumption the meter source contract does not supply. Its existence proves that real session evidence is accessible at composition, not that PBT's whole retention algorithm is the generic meter solution.
+
+These arguments clear presentation differences and existing shared mechanisms. They do not justify a canonical signal meter selecting a receiver when canonical active identity is unknown, nor do they supply a way for a persistent ballistics instance to distinguish a new provider/session/receiver from the old one. Those narrower gaps are the findings.
+
+## Deletions
+
+### D1 - LinearSMeter S_UNIT_Y: dead
+
+Verdict: dead.
+Elements / definition site: `frontend/src/components-v2/meters/LinearSMeter.svelte:S_UNIT_Y`.
+Consumers: none; actual readout positioning uses inline TRACK_Y expressions.
+Written / read: one declaration, zero further writes, zero source reads, zero test reads/writes, using the exact whole-word search above and full component inspection.
+Guards checked: no local dynamic access or exposure, no export/prop/serialization path, no sibling literal consumer, no tests-only consumer. External renderer consumers cannot access the lexical binding.
+Collateral: none; keep S_UNIT_FS and TRACK_Y.
+Prior ruling: no retention requirement found for this coordinate; collection traces its introduction to 2026-03-17.
+In-flight: none found.
+Required surface: none.
+Depends on: none.
+Confidence: high.
+Falsifier: a live template/reference or explicit component exposure of this binding.
+Fix class: delete.
+Actionable: yes.
+
+### D2 - LinearSMeter DBM_Y: dead
+
+Verdict: dead.
+Elements / definition site: `frontend/src/components-v2/meters/LinearSMeter.svelte:DBM_Y`.
+Consumers: none; actual readout positioning uses TRACK_Y/TRACK_H directly.
+Written / read: one declaration, zero further writes, zero source reads, zero test reads/writes, same exact search as D1.
+Guards checked: dynamic, external, public and tests-only guards as D1; no binding exposure exists.
+Collateral: none; keep DBM_FS and TRACK_H.
+Prior ruling: none found requiring this local; collection traces introduction to 2026-03-17.
+In-flight: none found.
+Required surface: none.
+Depends on: none; independent of D1.
+Confidence: high.
+Falsifier: an actual reader or exposure mechanism.
+Fix class: delete.
+Actionable: yes.
+
+## Consolidations
+
+### F1 - Meter source qualification: shared predicates exist, consumer coverage is inconsistent
+
+Verdict: B - a consistent meter source/context projection is missing; not a missing global availability helper.
+Rank: diverged.
+Elements / definition sites: `frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts:deriveMeters,meterField,deriveReceiverIndicators,activeReceiverId`; `frontend/src/lib/runtime/adapters/display-observation.ts:qualifyDisplayObservation,qualifyRadioDisplayObservation`.
+Consumers: deriveMeters feeds MetersSurface and peer-split telemetry. Receiver indicators feed VfoIndicatorRow and the now-mounted Standard VfoPanel. The existing qualifiers serve P/SWR/ALC and other display families, plus scope-passband qualification; signal/current/voltage/compression use the older reading path.
+Divergence: observation: raw active selection and loose availability can yield a known canonical meter while strict receiver indicators remain unknown; state/caps identity mismatch is checked by qualified display, not by meterField. Inference: two presentation questions legitimately differ in placement/relevance, but qualification of a value as belonging to a known source must not be silently selected by that placement.
+Prior ruling: 2026-07-25 pure adapter contract; strict multi-receiver identity and single-receiver MAIN rule recorded in adapter history on 2026-08-11; 2026-08-30 audit clears the shared loose helper rather than mandating global tightening; 2026-09-06 full instrument acceptance requires source/context honesty.
+In-flight: existing qualifiers and canonical active identity are available; qualified P/SWR/ALC is accepted. No all-meter source/context contract is present at this pin.
+Required surface: a read-only meter projection using actual matching provider identity, actual canonical receiver selection for active-receiver meters, appropriate radio-wide identity for telemetry, field/path observation evidence and explicit current/stale/unknown/unsupported semantics. It must make qualified continuity context available without persisting another truth store. Preserve each consumer's structural shell/relevance policy and distinguish stale display from current reading. Existing qualifiers/identity derivation remain the source of admission rules.
+Depends on: none for qualification; F2 consumes continuity evidence. Any global availability semantic change is outside this finding.
+Confidence: high on inconsistent qualification; medium on the precise scope of the shared context return type.
+Falsifier: an upstream guarantee or actual common projection making these raw/strict paths equivalent for all admitted provider, active-identity and freshness states.
+Fix class: design.
+Actionable: yes for bounded qualification/context coverage; not authorization to merge all adapters or silently rewrite unrelated legacy availability behavior.
+
+### F2 - Shared ballistics cannot represent a change of source
+
+Verdict: B - continuity input gap in an already-shared lifecycle.
+Rank: displaced (missing shared surface would otherwise force client reset mechanisms).
+Elements / definition sites: `frontend/src/primitives/meters/meter-ballistics.svelte.ts:MeterBehaviorInput,createMeterBallistics.sync,createMeterBallisticsGroup.sync`; `frontend/src/components-v2/meters/LinearSMeter.svelte:ballistics` and sync effect; `frontend/src/components-v2/meters/BarGauge.svelte:ballistics` and sync effect.
+Consumers: LinearSMeter uses frame-step/smoothed input; BarGauge uses sample/envelope input; MetersDockPanel uses the group. Semantic meter props pass values/presence/display, and Standard's VfoPanel passes a numeric S-meter. None supplies a meter stream identity to ballistics.
+Divergence: observation: null input resets smoother and peak, but changing source with a non-null value has no identity input and can retain the old peak/smooth history. A session/receiver/provider-only change can leave a component's numeric dependency unchanged. Inference: the shared owner cannot enforce continuity boundaries it is never told about; relocating another copy of peak math would not solve this.
+Prior ruling: accepted shared ballistics on 2026-09-06; same-day instrument acceptance includes reconnect/context changes. The calibrated-domain ADR preserves existing math ownership.
+In-flight: `createMeterBallistics` and group are actual accepted mechanisms, not replacements to invent.
+Required surface: supplied, qualified source identity and invalidation semantics sufficient for the existing shared lifecycle to reset/reseed on real provider/session/receiver/field changes and unavailable evidence. Observation progression and visual smooth-target remapping must remain distinct inputs/semantics: geometry/calibration changes can need remapping without a new observation. If an observation marker is used, its clock domain/order/uniqueness must come from a real contract; equal markers cannot automatically suppress updates. Preserve existing frame/envelope/reduced-motion policies.
+Depends on: F1's qualified context for production adoption. Any stronger sequencing promise requires evidence covered by F5.
+Confidence: high on absent input and possible retained cross-source state; medium on precisely which local remap/reset policy preserves each visual strategy.
+Falsifier: every actual source change always unmounts the meter or delivers a guaranteed null/reset before any non-null replacement, with explicit production contracts covering provider and session changes as well as receiver switches.
+Fix class: design.
+Actionable: yes at the shared lifecycle input boundary. No second smoother, new poller or client-specific duplicated reset owner is earned.
+
+### F3 - Current versus stale TX display: intentional distinct projection
+
+Verdict: C - legitimately distinct display semantics, using an already-shared projector.
+Rank: name-collision (related facts are not interchangeable).
+Elements / definition sites: `frontend/src/semantic/tx-meter-display.ts:projectTxMeterDisplay`; `frontend/src/semantic/MetersSurface.svelte:txPresentation,swrLowerScale`; `frontend/src/semantic/radio-display-model.ts:txTelemetry,projectPeerSplitDisplay`; adapter `displayTxMeter`.
+Consumers: MetersSurface P/ALC bars and SWR overlay; peer-split TX telemetry. Separate ordinary reading/availability remains available to other consumers.
+Divergence: observation: P/SWR/ALC display qualification can produce stale/unknown while the older reading projection differs. The shared TX projector respects an explicit display value first, with a reading fallback only when display is absent. MetersSurface turns stale/idle into marked text and null motion input, preserving RF relevance cues. Inference: retaining marked display evidence is not duplicate confirmation truth.
+Prior ruling: accepted radio-wide TX display qualification on 2026-09-05; 2026-07-25 allowance for pure transient display semantics.
+In-flight: exists and is consumed by both projections.
+Required surface: exists; F1 must preserve display/current-reading distinctions and avoid upgrading stale display to current motion or editable truth.
+Depends on: none.
+Confidence: high.
+Falsifier: a consumer treats marked stale/unknown display as a current measurement or substitutes it for command confirmation.
+Fix class: none.
+Actionable: no consolidation of these distinct meanings; no clearance of all fallback consumers outside C1.
+
+### F4 - Peak algorithms and renderer geometry: already shared or correctly local
+
+Verdict: already-shared for lifetime and imported math; C for explicit peak policy and geometry.
+Rank: parallel (candidate cleared).
+Elements / definition sites: `frontend/src/primitives/meters/meter-ballistics.svelte.ts:createTickerLifecycle,createPeakChannel,createFrameStepPeakStrategy,createElapsedEnvelopePeakStrategy`; `frontend/src/components-v2/meters/LinearSMeter.svelte:SEG_COUNT,segX,generateTicks`; `frontend/src/components-v2/meters/BarGauge.svelte:segX`.
+Consumers: frame strategy in LinearSMeter; envelope in BarGauge and dock group. Renderer geometry serves the respective gauge; imported smoothing/peak math has the definition sites listed above.
+Divergence: frame-step decay and elapsed-time envelope are deliberately different algorithms behind the shared lifecycle. LinearSMeter smooth targets are scaled by dynamic segment count; BarGauge uses its own segment normalization. Different visual grammar does not imply duplicate radio truth.
+Prior ruling: accepted ballistics adoption on 2026-09-06; 2026-09-02 display-model geometry ruling; calibrated-domain ADR reserves global interpolation math.
+In-flight: exists and consumed; C1 context work is a bounded addition, not unfinished peak-math consolidation.
+Required surface: exists for current algorithms; F2 supplies continuity without erasing their policy differences or freezing visual remaps.
+Depends on: none.
+Confidence: high.
+Falsifier: independent peak lifetime/math definitions bypassing the cited owner in these exact scoped consumers, or an undeclared numeric-domain conversion mismatch.
+Fix class: none.
+Actionable: no algorithm unification or copied smoother implementation.
+
+### F5 - Marker deduplication and reconnect floors: evidence insufficient for a universal rule
+
+Verdict: undetermined for proposed universal ordering/deduplication; C for retaining PBT's bounded existing policy pending separate evidence.
+Rank: diverged (potentially drops valid observations if generalized).
+Elements / definition sites: `src/rigplane/core/state_store.py:StateStore._apply_one,_strictly_older_than_entry,_strictly_older_than_observation`; `src/rigplane/web/state_schema.py:FieldStatusPublic`; `frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte:pbtEvidence,pbtObservationFloors`; `frontend/src/primitives/meters/meter-ballistics.svelte.ts:MeterMotionHost`.
+Consumers: backend admission accepts field observations; frontend field status feeds qualifiers. PBT floor state serves its local overlay only; ballistics consumes local animation clocks, not backend clock identity.
+Divergence: observation: backend accepts equal markers and only compares ordered markers inside matching generation/clock domain. Public frontend field status lacks typed clock-domain identity. PBT's strict greater-than floor is not consumed by meters. Inference: neither that floor nor Date.now/performance.now proves a generic meter deduplication or post-reconnect freshness contract. A newer global observation sequence also does not alone prove a particular unchanged field was reobserved.
+Prior ruling: PBT retained-display acceptance on 2026-09-05; backend/public contracts at the audited pin. No universal field-marker uniqueness ruling found.
+In-flight: actual control session/epoch is already available at composition and used by PBT/scope. No proven universal meter floor/sequence contract exists.
+Required surface: explicit evidence for field-specific ordering, clock comparability and reconnect admission before any strict marker filter is applied to meters. Local animation timing stays separate from radio observation identity. Until then, context invalidation can be specified honestly without fabricating per-field freshness or suppressing equal-marker observations.
+Depends on: none to reject an unsupported assumption; F1/F2 may use only the context promises actually available.
+Confidence: high that stronger guarantees are unestablished.
+Falsifier: a published producer/transport contract guaranteeing field-specific unique progress and comparable marker clocks across the exact reset boundaries, with actual consumer evidence.
+Fix class: none for unproven generalization.
+Actionable: no universal floor/deduplication implementation from the present evidence; no deletion or wholesale extraction of PBT state.
+
+## Weakest link
+
+F2's production continuity guarantee is the weakest link. The missing identity input is certain, but the exact policy for geometry remapping versus reseeding, and for admitting an old-looking field after reconnect, needs a real consumer/producer contract. First trace one persistent canonical S-meter through an active-receiver change with equal numeric values, then a provider/session change with unchanged field markers, and finally a segment-count change without a radio observation. A solution must not carry old-source peaks, invent new observation evidence, or discard a valid visual remap. No runtime test was performed in this read-only audit.
+
+## Cleared
+
+- Display qualification and canonical active-receiver derivation already exist and must be reused.
+- Single-receiver MAIN by valid topology is legitimate; raw MAIN fallback on unresolved multiple receivers is a different condition.
+- Shared meter ballistics, ticker lifecycle, smoother and peak strategies are not duplicate implementations merely because multiple renderers import them.
+- Frame-step and elapsed-envelope strategies, reduced-motion behavior and visual geometry may legitimately differ.
+- Current readings and marked stale TX display evidence are distinct valid contracts.
+- Standard VfoPanel is an actual current consumer; unchanged meter bytes do not establish unchanged liveness.
+- PBT continuity is live, bounded behavior, not proven dead and not a ready-made universal meter mechanism.
+- Equal backend markers are permitted; frontend animation clocks do not define backend observation time.
+
+Implementation, alternate meter/scope tracts, public archive review and the final integrated whole-path audit remain separate work.

--- a/.claude/audits/2026-09-06-mechanism-audit-scalar-pair.md
+++ b/.claude/audits/2026-09-06-mechanism-audit-scalar-pair.md
@@ -1,0 +1,280 @@
+# Mechanism audit: scalar and RF/SQL pair
+
+Audited revision: `f2e7969708d5c93890cf1b24d833ce820b36dc15` (2026-09-06, `feat: unify HBar scalar ownership (#3244)`).
+
+Method: `.claude/skills/mechanism-audit/SKILL.md`, read in full from the audited repository, with `.claude/agents/auditor.md`. `AGENTS.md`, `CLAUDE.md`, and the live acceptance criteria were also read. This is a decision audit of the bounded scalar/pair tract, not the final integrated whole-path audit. Source conclusions use immutable Git objects at the full revision above. HEAD and checkout status were inspected at entry; subsequent conclusions do not depend on the mutable checkout. No audited-tree edits, Git writes, tests, builds, installs, browser work, or hardware operations were performed.
+
+## Steps 0-3a: evidence before judgement
+
+### Definitions and consumers
+
+All paths below are repository-relative. In the tables, `controls/` means `frontend/src/components-v2/controls/value-control/`; `scalar/` means `frontend/src/primitives/scalar/`. These abbreviations do not denote additional modules.
+
+| Capability | Actual definition | Consumers per implementation |
+| --- | --- | --- |
+| Continuous scalar lifetime and feedback | `scalar/continuous-scalar.svelte.ts:createContinuousScalar` | `controls/ValueControl.svelte:createRawBinding` for built-in HBar; `frontend/src/semantic/FilterSurface.svelte:filterWidthScalar` as collected; HBar consumes a renderer lease |
+| Committed scalar editing | `scalar/committed-scalar.svelte.ts:createCommittedScalar` | `frontend/src/components-v2/panels/CwPanel.svelte:breakInDelayScalar` and `frontend/src/semantic/CwKeyerSurface.svelte:breakInDelayScalar` as collected |
+| Feedback presentation | `frontend/src/primitives/control-feedback/control-feedback-presentation.ts:projectControlFeedbackPresentation` | Both scalar factories; their renderers consume the result |
+| Scalar local interaction | `controls/BipolarRenderer.svelte:emitChange,markWheelActive,handleKeyDown`; `controls/DiscreteRenderer.svelte:emitChange,markWheelActive`; `controls/KnobRenderer.svelte:emitChange,handlePointerMove` | Bipolar: ValueControl routes in FilterPanel and RitXitPanel; Discrete: CwPanel, DspPanel, VoxPanel; Knob: ValueControl demo and lab routes and tests. No production Knob adoption is established by those demo routes |
+| Custom knob behavior | `controls/skins/ProfessionalKnob.svelte:emit,onMove,onWheel,onKey` | Three direct demo mounts in `frontend/src/components-v2/controls/ControlButtonDemo.svelte`; public registry and barrel exports. `frontend/src/App.svelte` dynamically loads that demo |
+| Combined axis math | `scalar/value-control-core.ts:dualParamValuesFromNormX,dualParamNormXFromValues,dualParamStepAlongAxis` | Forward/inverse: semantic RF/SQL and DualParamRenderer, with thumb/deviation wrappers for the latter; stepping: DualParamRenderer; direct math tests |
+| Pair interaction and lane dispatch | `frontend/src/semantic/RfFrontEndSurface.svelte:changeCombined`; `controls/DualParamRenderer.svelte:emitPair,handleWheel,handleKeyDown` | SemanticRadioSurfaces mounts the semantic surface; legacy RfFrontEnd mounts DualParamRenderer. RfFrontEnd has mount sites in LeftSidebar, MobileRadioLayout and RadioLayout |
+| RF/SQL command dispatch | `frontend/src/lib/runtime/commands/panel-commands.ts:makeRfFrontEndHandlers`; `frontend/src/lib/runtime/commands/radio-intents.ts:dispatchRadioIntentWithResult` | Legacy normalized adapter, semantic handler binder/wiring, keyboard intent path. Each actual intent calls `beginCommand` and `sendCommand` |
+| State-backed command confirmation and projection | `frontend/src/lib/stores/commands.svelte.ts:STATE_BACKED_COMMAND_DESCRIPTORS,reconcileStateBackedCommands`; `frontend/src/lib/runtime/adapters/panel-adapters.ts:projectControlFeedback` | Registered Filter Width and Break-in Delay. No RF gain or squelch descriptor or corresponding full-feedback accessor at this revision |
+
+Observation: the core factories, four remaining renderer scripts, custom knob script, pair implementations, ValueControl, skin contracts, feedback projector, command descriptors/reconciliation, RF handler factory and dispatch envelope were opened. Source searches verified the named mount sites and public exports. The Filter/CW adopter sites above are collection-backed; their whole component bodies were not independently reopened for this tract. Imports and interface method signatures are not counted as independent implementations.
+
+### Prior rulings and accepted target
+
+- The architecture addendum of 2026-09-02, `docs/plans/2026-04-12-target-frontend-architecture.md:Addendum 2026-09-02`, records: "the single home going forward is `frontend/src/primitives/`" and "the skin composes." Its instrument conformance criteria require honest unknown and externally supplied appearance. The document identifier and dated section are the public ruling reference.
+- `docs/internals/skins-presentation-boundary-gate.md` (2026-08-31) protects custom instruments and explicitly bounds the meter census to its directory. A custom visual implementation is permitted; shared radio truth remains below presentation.
+- `docs/release-notes/2026-beta-known-limitations.md`, combined RF/SQL limitation, records the absence of local gesture tracking on the semantic path. This is evidence of a difference, not a prescribed remedy.
+- `frontend/src/semantic/RfFrontEndSurface.svelte:changeCombined` and `frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte:RF_FRONT_END_LEVEL_INTENT` preserve the combined profile mode, independently usable lanes and per-lane change guards. The collection dates the original change to 2026-08-11; current source independently establishes the contract, not that historical date.
+- The live owner acceptance, read on 2026-09-06, requires a stable instrument model/intent interface with replaceable rendering, permits materially different algorithms behind it, and requires decision adjudication before pair architectural implementation. Earlier scalar/pair plans are not premises here.
+
+Observation: the accepted revision already contains `ContinuousScalarBinding`, HBar's lease adoption and the HBar render-presentation projection. This is an existing migration target, not a proposed foundation. A pair binding does not exist at this revision. Full feedback exists for Filter Width and Break-in Delay, not RF/SQL. No proposed implementation outside the pin is counted as accepted source.
+
+### Sweep coverage and limits
+
+The repaired systematic inventory enumerates 833 executable entries over 18 implementation files, plus the interface-only `controls/skin.ts`: 157 functions, 274 constants, 351 mutable bindings and 51 object methods. It separates source, source-tree tests, other test files, browser-test paths and fixtures. Interfaces/type signatures and import/re-export declarations are excluded from executable definitions. Counts below are enumeration coverage, not proof of liveness:
+
+| Module | Named entries |
+| --- | ---: |
+| value-control-core | 89 |
+| continuous-scalar | 95 |
+| committed-scalar | 29 |
+| control-feedback-presentation | 11 |
+| ValueControl | 60 |
+| HBarRenderer | 45 |
+| BipolarRenderer | 64 |
+| DiscreteRenderer | 65 |
+| KnobRenderer | 69 |
+| ProfessionalKnob | 51 |
+| DualParamRenderer | 64 |
+| scalar-render-presentation | 2 |
+| skins/index | 2 |
+| RfFrontEndSurface | 34 |
+| RfFrontEnd | 33 |
+| SemanticRadioSurfaces, RF range only | 7 |
+| panel-adapters, RF/feedback ranges only | 28 |
+| commands.svelte | 85 |
+
+This supersedes the earlier 352-entry extraction, which omitted closure state/object methods and misclassified test references. Repaired positive witnesses include `clamp` with 31 resolved source reads and 4 test reads, `snapToStep` with 24/7, and separately enumerated scalar drafts and timers. These are collector measurements, not rerun tests. There are 403 entries with unresolved source attribution, especially shadowed identifiers and Svelte markup. Object properties also require manual tracing: nominal zero-count methods such as policy `wheel` and lease `pointer` are called through interfaces, as the opened owner and HBar code show. Public functions such as `confirmCommand` and `getCommandLifecycleHold` likewise cannot be deleted from direct-import counts. The repaired inventory improves systematic coverage; it does not authorize a blanket zero-read or exhaustive dead-code verdict.
+
+The zero-read candidate `KnobRenderer:indicatorPos` was independently checked with:
+
+```sh
+git grep -n -w -e indicatorPos -e indicatorLength f2e7969708d5c93890cf1b24d833ce820b36dc15 -- frontend/src frontend/tests src tests
+```
+
+It returns exactly the two declarations and the one `indicatorLength` use embedded in the `indicatorPos` declaration. The full KnobRenderer template was inspected; it uses `indicatorEnd`. Literal public/export/dynamic checks and an available sibling source search found no exposure of either local binding. The sibling search is a limited literal check, not a census of all downstream code.
+
+Public functions such as `calculateDragValue`, or exported skin registry entries, do not become dead merely because an in-repository production call was not established. Public, dynamic and external-consumer guards prevent that verdict. No tests-only behavior is authorized for deletion by this report. No constant-return guard was established to make an additional scoped branch unreachable.
+
+## Step 4: steelman
+
+The strongest case for retaining the arrangement is substantial. A horizontal pointer position, vertical relative knob drag and browser-native range input need different geometry. Bipolar keyboard increments have a default-centered lattice; Discrete intentionally has its own notch presentation, reset opt-in and wheel increment; Knob reads incoming values rather than providing the bars' optimistic preview. HBar and native Filter already share a lifecycle while selecting different policies. There is no reason to make these algorithms identical merely because all edit numbers.
+
+RF/SQL is not an ordinary scalar truth value. Its axis maps onto two independent radio fields, and the inverse loses information when both fields are away from the physical knob's compatible state. A projected thumb therefore cannot serve as both lanes' confirmed state. Separate commands can have separate availability, pending, failure and confirmation outcomes. Keeping lane truth independent is the strongest case against imposing a single command-feedback scalar. Conversely, native range movement and the legacy axis's wheel/key stepping need not share one numerical stepping algorithm.
+
+A skin can legitimately own its graphics and pointer geometry. ProfessionalKnob is a real reachable demonstration of that facility, although it is not evidence of production adoption. A public registry is also a valid extension point with unknown external users. These facts defeat a vestigial-fork verdict.
+
+The strongest case for change is narrower: renderer-owned debounce, local drafts and late callback validity are behavior, while appearance selection currently replaces those mechanisms and can omit the full feedback contract. The scalar owner already supplies most of this lifetime. Pair math is already shared, but no accepted contract combines a gesture with independently preserved lane evidence. The missing RF/SQL descriptors are separate from that instrument contract and cannot be replaced by draft state. The following per-element decisions preserve those distinctions.
+
+## Deletions
+
+### D1 - KnobRenderer indicatorPos: dead
+
+Verdict: dead.
+Elements / definition site: `frontend/src/components-v2/controls/value-control/KnobRenderer.svelte:indicatorPos`.
+Consumers: none. Rendered indicator geometry uses `indicatorEnd`.
+Written / read: one declaration assignment, zero subsequent writes, zero source reads, zero test reads/writes. Established by the exact literal whole-word search above and inspection of the full component.
+Guards checked: dynamic access absent in the component; no export, prop or serialization path exposes this lexical local; the available sibling literal search has no hit; no tests-only consumer. Unknown external component consumers cannot access this unexported local through the declared component interface.
+Collateral: D2 is its sole supporting calculation. Keep `calculateIndicatorPosition`, which has live callers.
+Prior ruling: none found for this local.
+In-flight: none found.
+Required surface: none.
+Depends on: none.
+Confidence: high.
+Falsifier: a template or executable local access to `indicatorPos`, or an explicit exposure mechanism in this pinned component.
+Fix class: delete.
+Actionable: yes.
+
+### D2 - KnobRenderer indicatorLength: dead after D1
+
+Verdict: dead, dependent calculation.
+Elements / definition site: `frontend/src/components-v2/controls/value-control/KnobRenderer.svelte:indicatorLength`.
+Consumers: only D1's initializer; none after D1.
+Written / read: one declaration assignment, one source read solely in D1, zero test reads/writes. Same exact search as D1.
+Guards checked: same lexical-local, dynamic, public, sibling and tests-only checks as D1.
+Collateral: none; `radius` and `trackWidth` remain live.
+Prior ruling: none found.
+In-flight: none found.
+Required surface: none.
+Depends on: D1; deleting this alone would leave a reference.
+Confidence: high.
+Falsifier: another live reader or exposed binding.
+Fix class: delete.
+Actionable: yes, together with or after D1.
+
+## Consolidations
+
+### F1 - Remaining scalar lifetime: migration incomplete with diverged local behavior
+
+Verdict: A - displaced behavior; existing shared target is only partly adopted.
+Rank: diverged.
+Elements / definition sites: `frontend/src/components-v2/controls/value-control/BipolarRenderer.svelte:emitChange,markWheelActive`; `DiscreteRenderer.svelte:emitChange,markWheelActive`; `KnobRenderer.svelte:emitChange`; `skins/ProfessionalKnob.svelte:emit`; target `frontend/src/primitives/scalar/continuous-scalar.svelte.ts:createContinuousScalar`.
+Consumers: Bipolar reaches FilterPanel/RitXitPanel; Discrete reaches CW/DSP/Vox panels through ValueControl. Knob reaches demo/lab; ProfessionalKnob reaches its direct demo and public registry. Target reaches HBar and native Filter. These are not four established production knob paths.
+Divergence: observation: local bar drafts and 300 ms wheel locks differ from Knob's incoming-value display. Old debounced callbacks have no renderer lease or authority-generation check; the shared owner checks both. Pointer cancellation is handled as pointer-up on old renderers. Inference: late-input validity and feedback consistency currently depend on chosen appearance; those lifetime responsibilities belong behind the instrument interface.
+Prior ruling: 2026-09-02 architecture addendum, "single home going forward" under primitives; 2026-09-06 acceptance permits explicit differing policies.
+In-flight: accepted `createContinuousScalar` with HBar/Filter consumers; remaining listed paths do not consume it. This is not a missing scalar foundation.
+Required surface: the existing continuous scalar lifetime and full evidence view, with explicit policies capable of preserving each live consumer's normalization, preview, dispatch, keyboard and reset behavior. Renderer attachment, cancellation and authority invalidation must survive appearance replacement. Geometry remains an input to that behavior.
+Depends on: F1a for preserving Bipolar's invalid keyboard-hint fallback; F4 for the public custom-skin contract. Legitimate policies in F6 must remain explicit during adoption.
+Confidence: high on displacement; the exact existing domain contract is insufficient for unchanged Bipolar keyboard hints, as F1a establishes.
+Falsifier: an existing nonlocal owner already controls these renderer timers/drafts, or source proof that their callbacks are invalidated outside the renderer across replacement/context changes.
+Fix class: consolidate.
+Actionable: yes for behavior migration; no blanket instruction to copy HBar policy into all renderers or claim production migration through demo changes.
+
+### F1a - Invalid keyboard hint versus invalid radio domain: policy compatibility gap
+
+Verdict: B - gap in the accepted surface's ability to preserve a live policy unchanged.
+Rank: diverged.
+Elements / definition sites: `frontend/src/components-v2/controls/value-control/BipolarRenderer.svelte:getKeyboardIncrement,isLatticeCompatible`; `frontend/src/primitives/scalar/continuous-scalar.svelte.ts:ScalarDomain,validDomain,editable`.
+Consumers: Bipolar's keyboard handlers in Filter/RIT routes and `frontend/src/components-v2/controls/value-control/__tests__/ValueControl.test.ts` invalid-keyboardStep cases; shared validation currently serves HBar and Filter.
+Divergence: observation: Bipolar falls back to the radio step for hints 0, -50, NaN, 2.5 on a step-5 lattice, and Infinity. The named tests were opened and assert this fallback, including emission of 5 for Infinity. Shared `validDomain` rejects nonpositive/nonfinite keyboardStep before policy invocation, disabling the scalar; it accepts positive 2.5 regardless of lattice compatibility. Inference: copying these hint values into the current shared domain cannot preserve Bipolar behavior merely by changing its key policy.
+Prior ruling: 2026-09-06 acceptance requires preservation of existing input behavior and permits task-dependent policies; these executable test cases are the specific compatibility evidence.
+In-flight: accepted domain validation exists for HBar/Filter; no Bipolar-compatible hint boundary is present.
+Required surface: preserve valid canonical min/max/step independently of an invalid optional keyboard interaction hint, and permit the existing Bipolar fallback policy without weakening canonical-domain honesty or silently changing HBar's accepted behavior. This names the required distinction, not an implementation topology.
+Depends on: none; F1's Bipolar adoption depends on resolving it.
+Confidence: high.
+Falsifier: an already-consumed adapter/policy boundary that normalizes or separates these hints before shared validation while preserving all cited cases.
+Fix class: design.
+Actionable: yes, as a bounded compatibility requirement for scalar migration.
+
+### F2 - RF/SQL gesture plus two-lane evidence: a bounded shared surface is missing
+
+Verdict: B - gap.
+Rank: diverged.
+Elements / definition sites: `frontend/src/semantic/RfFrontEndSurface.svelte:combinedNormX,changeCombined`; `frontend/src/components-v2/controls/value-control/DualParamRenderer.svelte:localRf,localSql,emitPair,handleWheel,handleKeyDown`; existing `frontend/src/primitives/scalar/continuous-scalar.svelte.ts:ContinuousScalarInput,ContinuousScalarView,createContinuousScalar`.
+Consumers: semantic path is mounted by SemanticRadioSurfaces; legacy pair is mounted by RfFrontEnd in the layout paths named above. Existing scalar owner serves HBar/Filter, not either pair implementation.
+Divergence: observation: semantic input projects readings and has no owned draft; legacy retains local lane drafts and custom wheel/key behavior. Both use existing pair math and independently suppress unchanged lanes. The current scalar feedback variant carries one command, one scope and one lifecycle. Inference: neither moving the whole renderer nor representing the pair by one synthetic confirmed axis supplies independent two-lane truth.
+Prior ruling: combined-control source contract and dated 2026-08-11 change evidence; current known-limitations entry records gesture-retention difference. 2026-09-06 acceptance permits distinct algorithms behind a stable interface.
+In-flight: accepted scalar gesture lifetime and shared RF/SQL math exist; no pair contract exists at the pin.
+Required surface: one replaceable pair-instrument interface that retains each lane's domain, known/unknown, availability, confirmed reading, requested/target, lifecycle phase and failure independently; represents the combined axis as a projection/draft; accepts native and explicit axis gestures with declared policies; preserves per-lane write guards and invalidates transient work when authority changes. Reading-only input must remain explicitly reading-only until F3 is available. The existing scalar lifecycle, feedback presentation and pair math must be accounted for before adding any new lifetime mechanism.
+Depends on: F3 for full state-backed RF/SQL evidence, but not for an honestly labeled reading-only interface. F6's numerical/geometry distinctions are constraints.
+Confidence: high that the surface is missing; medium on internal reuse topology.
+Falsifier: an existing binding, consumed by both pair paths, already exposes independently scoped lane evidence and controls combined gesture lifetime.
+Fix class: design.
+Actionable: yes for the required surface. This finding does not select one scalar axis plus coordinator, two scalar owners, or a wholly independent pair owner. Their internal topology is undetermined by consumer evidence; a second confirmation owner is not earned.
+
+### F3 - RF/SQL full feedback: descriptor and projection adoption gap
+
+Verdict: B - gap in field coverage of an existing shared mechanism.
+Rank: displaced (shared ownership pressure, not duplicate transport).
+Elements / definition sites: `frontend/src/lib/stores/commands.svelte.ts:STATE_BACKED_COMMAND_DESCRIPTORS,reconcileStateBackedCommands`; `frontend/src/lib/runtime/adapters/panel-adapters.ts:projectControlFeedback`; `frontend/src/lib/runtime/commands/panel-commands.ts:makeRfFrontEndHandlers`; `frontend/src/lib/runtime/commands/radio-intents.ts:dispatchRadioIntentWithResult`.
+Consumers: Filter Width and Break-in Delay use descriptor reconciliation and projection. RF/SQL handlers use the actual tracked command dispatch, reached independently from legacy, semantic and keyboard paths; neither RF/SQL surface consumes a full per-lane feedback accessor.
+Divergence: observation: RF/SQL commands already have real IDs, epochs, pending/delivery/failure lifecycle tracking. Their absence from the descriptor map means the descriptor-driven state confirmation/projector path used by Filter/CW is not provided to RF/SQL. Local drafts and changed readings are not that lifecycle evidence.
+Prior ruling: 2026-09-06 instrument acceptance requires honest confirmed/requested/error information and reuse of command ownership; current shared descriptor/projector is the accepted source target.
+In-flight: `projectControlFeedback` and descriptor-based reconciliation exist with the two named adopters; RF/SQL registrations/accessors do not.
+Required surface: qualified per-field descriptors and read-only feedback projections for RF gain and squelch, using actual command receiver/session scope, normalized observation versus integer target semantics, and real field observation boundaries. Preserve two independent outcomes; no synthetic pair confirmation, new transport, queue or lifecycle store.
+Depends on: none for descriptor/projection coverage; F2 consumes it. Actual RF/SQL confirmation matching and observation contracts must be verified in implementation review.
+Confidence: high on missing coverage; exact numeric matching policy remains unadjudicated here.
+Falsifier: existing registered descriptors and wired per-lane accessors at the pinned revision.
+Fix class: design.
+Actionable: yes, bounded to existing confirmation/projection extension; not proof that RF/SQL commands are currently untracked.
+
+### F4 - ValueControl skin substitution: behavioral contract is part of the override
+
+Verdict: B - missing appearance-level contract adoption.
+Rank: displaced.
+Elements / definition sites: `frontend/src/components-v2/controls/value-control/skin.ts:SkinRendererProps,KnobSkinRendererProps,Skin`; `ValueControl.svelte:skinComponent,commonProps`; `skins/ProfessionalKnob.svelte:emit,onWheel,onKey`; existing `HBarRenderer.svelte:lease` and `scalar-render-presentation.ts:projectScalarRenderPresentation`.
+Consumers: built-in HBar takes a binding. Custom renderer dispatch takes raw props; ProfessionalKnob is a direct demo consumer plus the exported registry's knob component. No production registry adoption was established.
+Divergence: observation: custom skin props include onChange and debounceMs but no scalar evidence view; ValueControl's full binding variant is HBar-only and prohibits a skin. Raw skin routes do not receive the HBar feedback projection. Inference: the current override replaces behavior, not merely appearance, so it cannot meet behavior-preserving substitution as currently typed.
+Prior ruling: 2026-09-02 "the skin composes"; 2026-08-31 boundary document permits custom instruments; 2026-09-06 acceptance forbids appearance selection from dropping feedback or changing policy.
+In-flight: scalar binding/view and HBar render projection already exist. No need for a second feedback presentation helper has been demonstrated.
+Required surface: custom and built-in renderers must consume the same instrument evidence/lifetime interface and receive the presentation inputs needed for their declared geometry. The public override must preserve confirmed/target/unknown/availability/feedback and command policy. Whether this requires any new helper beyond the existing view/projector is undetermined.
+Depends on: agreement on the shared behavioral contract identified in F1, not completion of F1's renderer migration. This skin-boundary decision and F1a's hint policy precede that migration; no dependency on deleting public skin exports.
+Confidence: high.
+Falsifier: a public custom-renderer route accepting the existing complete binding and preserving its feedback, with actual consumer evidence.
+Fix class: design.
+Actionable: yes for contract adoption; no for inventing a separate generic skin behavior helper solely from this finding.
+
+### F5 - Pair math, scalar lifetime and feedback projection: already shared
+
+Verdict: already-shared.
+Rank: parallel (candidate cleared).
+Elements / definition sites: `frontend/src/primitives/scalar/value-control-core.ts:dualParamValuesFromNormX,dualParamNormXFromValues,dualParamStepAlongAxis`; `continuous-scalar.svelte.ts:createContinuousScalar`; `frontend/src/primitives/control-feedback/control-feedback-presentation.ts:projectControlFeedbackPresentation`.
+Consumers: pair math has semantic and legacy renderer consumers as listed above; scalar lifetime has HBar and Filter; feedback projection is called by continuous and committed scalars.
+Divergence: their clients choose different policies, but imports are not additional definitions. The nonlinear pair inverse and stepping are distinct operations in one shared module.
+Prior ruling: 2026-09-02 primitives home; accepted HBar adoption on 2026-09-06.
+In-flight: exists and consumed.
+Required surface: exists; F2/F3 add consumer contracts, not replacement math/confirmation implementations.
+Depends on: none.
+Confidence: high.
+Falsifier: a separately defined equivalent pair formula or feedback projector in one of the cited client paths.
+Fix class: none.
+Actionable: no consolidation of already-shared definitions.
+
+### F6 - Scalar policies, pair stepping and visual grammar: legitimately distinct
+
+Verdict: C - legitimately local geometry and explicit task policy.
+Rank: name-collision (same family name is not algorithm identity).
+Elements / definition sites: `BipolarRenderer.svelte:getKeyboardIncrement,handleBipolarKeyboardStep,handleWheel`; `DiscreteRenderer.svelte:handleDoubleClick,handleWheel,tickItems,notchPercents`; `KnobRenderer.svelte:handlePointerMove`; `ProfessionalKnob.svelte:onMove`; `DualParamRenderer.svelte:handleKeyDown,handleWheel`; `frontend/src/primitives/scalar/continuous-scalar.svelte.ts:createHBarContinuousScalarPolicy,nativeRangeContinuousScalarPolicy` (renderer paths use the controls prefix defined above).
+Consumers: respective renderer routes in the consumer table; native range policy is consumed by Filter. Pair custom stepping serves DualParamRenderer; semantic RF/SQL uses native input.
+Divergence: observation: Bipolar wheel uses one step unless the range exceeds 500 steps; HBar uses four times an adaptive multiplier. Bipolar's explicit keyboard increment validates lattice compatibility and snaps around default. Discrete's reset requires an explicit default. Knob uses relative vertical movement with distinct fine sensitivity and incoming-value preview. Pair step advances lane values directly, while pointer/native input maps a normalized position through the center dead zone. Ticks, arcs, fills, dimensions and pointer coordinates are visual/input grammar.
+Prior ruling: 2026-09-06 acceptance explicitly permits materially different algorithms and gesture geometry; 2026-09-02 look/layout ruling separates display model and composition.
+In-flight: HBar/native policies already demonstrate explicit differences under one owner.
+Required surface: exists conceptually in the policy and input-geometry boundary; migration must carry these distinctions explicitly. Identical family names do not require identical stepping.
+Depends on: none to retain; F1/F2 must preserve the declared distinctions.
+Confidence: high on observed difference and valid ownership distinction; this is not a blanket endorsement of every historical edge case.
+Falsifier: a consumer contract requiring the same policy that these implementations demonstrably violate, or radio truth/confirmation hidden inside a claimed geometric calculation.
+Fix class: none.
+Actionable: no consolidation of visual grammar or forced algorithm unification.
+
+### F7 - Normalized-to-wire RF conversion: correctly located adapter work
+
+Verdict: C - legitimately local boundary adaptation.
+Rank: parallel (small identical conversion, cleared as an architectural defect).
+Elements / definition sites: `frontend/src/lib/runtime/adapters/panel-adapters.ts:withNormalizedRfLevels`; `frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte:RF_FRONT_END_LEVEL_INTENT`.
+Consumers: legacy RfFrontEnd handler accessor; semantic RfFrontEndSurface callback respectively. Both call the same raw `makeRfFrontEndHandlers` factory.
+Divergence: none in the `Math.round(value * 255)` conversion. The semantic binder preserves the raw factory object's identity; source comments and named binder tests document why wrapping it there is not interchangeable.
+Prior ruling: combined-control conversion recorded in source with the 2026-08-11 historical reference; conversion occurs at wiring, not presentation.
+In-flight: common raw handlers and typed intent contract already exist.
+Required surface: exists. Sharing a tiny pure conversion is optional maintenance, not a prerequisite for an instrument owner and not evidence for a new pair mechanism.
+Depends on: none.
+Confidence: high.
+Falsifier: divergent conversions for identical domains or an existing canonical domain converter whose omission violates a required policy.
+Fix class: none.
+Actionable: no required architectural consolidation.
+
+### F8 - Public/demo-only renderer and helper deletion: not established
+
+Verdict: undetermined for alleged dead public API; ProfessionalKnob itself is demonstrably reachable.
+Rank: name-collision (no established dead fork).
+Elements / definition sites: `frontend/src/components-v2/controls/value-control/skins/index.ts:professionalSkin,skins`; `skin.ts:Skin`; `skins/ProfessionalKnob.svelte`; `frontend/src/primitives/scalar/value-control-core.ts:calculateDragValue` and other exported helpers with weak inventory counts.
+Consumers: ProfessionalKnob has direct demo mounts; registry has public barrel exposure. External consumers of exported helpers/registry are unknown. Test counts from the collection are not authoritative.
+Divergence: production adoption, demo reachability and public availability are different facts.
+Prior ruling: 2026-08-31 boundary gate preserves legitimate custom instruments; no public retirement ruling found for these symbols.
+In-flight: none that removes their public consumers.
+Required surface: evidence of public retirement and reliable symbol-resolved source/test/external consumer census before deletion.
+Depends on: none; does not block D1/D2 because their locals are inaccessible through this API.
+Confidence: high that deletion is not presently justified.
+Falsifier: explicit accepted API retirement plus verified absent consumers, or newly located real consumers settling the liveness question positively.
+Fix class: none.
+Actionable: no deletion.
+
+## Weakest link
+
+F2's internal reuse topology is the weakest decision boundary. The evidence earns an interface retaining two lane outcomes and one combined gesture, but does not choose how many internal scalar owners implement it. First check discriminating cases: one lane confirms while the other fails, receiver/session changes during a gesture, both observed lane values lie outside the single-axis image, and a policy change replaces the renderer. Any proposed topology that synthesizes a pair confirmation or duplicates accepted lifecycle ownership fails the required surface. The incomplete lexical sweep also prevents a claim that all dead code in the tract has been cleared.
+
+## Cleared
+
+- Shared RF/SQL axis mapping and step helpers are actual shared definitions.
+- ContinuousScalarBinding is the accepted scalar lifetime target; HBar is an adopter, not an independent lifetime copy.
+- The existing feedback presentation projector is shared by continuous and committed scalar mechanisms.
+- Committed editing and continuous gestures have distinct actual contracts; their coexistence does not itself justify merging them.
+- Relative knob geometry, native range input, bipolar lattice policy, discrete reset policy and visual grammar may legitimately differ.
+- Normalized RF/SQL conversion at adapter/wiring boundaries is correctly located.
+- ProfessionalKnob is demo/public reachable; it is neither proven dead nor proof of production migration.
+
+This report completes the bounded decision adjudication only. Implementation, independent verification, public archive review and the final integrated whole-path audit remain separate work.

--- a/.claude/audits/README.md
+++ b/.claude/audits/README.md
@@ -13,6 +13,19 @@ public repository** — never put session notes, baselines, or anything with
 internal identifiers here; untracked working notes belong in the ignored
 remainder of `.claude/`.
 
+## 2026-09-06 — instrument mechanism decision audits (source `f2e7969708d5c93890cf1b24d833ce820b36dc15`)
+
+Three independent, bounded mechanism-audit tracts at the pinned source. They
+record point-in-time evidence for scalar pairs, meter context, and finite
+choice controls; a final whole-path audit remains outstanding.
+
+- [2026-09-06-mechanism-audit-scalar-pair.md](2026-09-06-mechanism-audit-scalar-pair.md)
+  — scalar-pair ownership, lifecycle and interaction evidence.
+- [2026-09-06-mechanism-audit-meter-context.md](2026-09-06-mechanism-audit-meter-context.md)
+  — meter source/context and ballistics-continuity evidence.
+- [2026-09-06-mechanism-audit-finite-choice.md](2026-09-06-mechanism-audit-finite-choice.md)
+  — finite-choice observation, eligibility and feedback-boundary evidence.
+
 ## 2026-09-03 — Icom lower-executor lifetime (draft, source `4e4c1782`)
 
 - [2026-09-03-mechanism-audit-icom-lower-executor-lifetime.md](2026-09-03-mechanism-audit-icom-lower-executor-lifetime.md)


### PR DESCRIPTION
## Summary

Publishes the three completed independent instrument mechanism-audit reports for MOR-2393 and indexes them in `.claude/audits/README.md`.

## Evidence

- Source pin: `f2e7969708d5c93890cf1b24d833ce820b36dc15`
- Measured diff: 4 files, 687 insertions (674 report lines plus 13 README lines)
- Byte equality verified for each staged report against the final handoff artifact

## Limits

- Mechanical archive publication only; no audit findings were changed.
- Scope is bounded to scalar-pair, meter-context, and finite-choice tracts.
- The final whole-path audit remains outstanding.
- No private collection inventories, session ledgers, or plans were published.

Closes MOR-2393.