### PR TITLE
feat: add RF SQL continuous pair binding (MOR-2392)

### DIFF
--- a/frontend/src/primitives/scalar/__tests__/continuous-pair.test.ts
+++ b/frontend/src/primitives/scalar/__tests__/continuous-pair.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createContinuousPair,
+  createLegacyContinuousPairPolicy,
+  nativeRangeContinuousPairPolicy,
+  type ContinuousPairInput,
+} from '../continuous-pair.svelte';
+import type { CommandScalarFeedback, ScalarDomain } from '../continuous-scalar.svelte';
+
+const DOMAIN: ScalarDomain = {
+  min: 0, max: 1, step: 0.01, defaultValue: null, fineStepDivisor: 10,
+};
+
+const feedback = (
+  control: string,
+  confirmed: number | null,
+  over: Partial<CommandScalarFeedback> = {},
+): Readonly<CommandScalarFeedback> => ({
+  confirmed, target: null, requestedTarget: null, phase: 'idle', busy: false,
+  availability: 'available', outcome: null, lifecycleId: null, transitionId: null,
+  sessionEpoch: 7, scope: { control, receiver: 0 }, repeatPolicy: 'latest-target-wins',
+  ...over,
+});
+
+function readingSetup(
+  policy = nativeRangeContinuousPairPolicy,
+  over: Partial<Extract<ContinuousPairInput, { evidence: 'reading' }>> = {},
+) {
+  const requestRf = vi.fn<(value: number) => void>();
+  const requestSql = vi.fn<(value: number) => void>();
+  let current: Extract<ContinuousPairInput, { evidence: 'reading' }> = {
+    evidence: 'reading', domain: DOMAIN, enabled: true, ownerKey: 'rf-sql:main',
+    rf: { reading: { status: 'known', value: 1 }, availability: 'available' },
+    sql: { reading: { status: 'known', value: 0 }, availability: 'available' },
+    requestRf, requestSql, ...over,
+  };
+  const pair = createContinuousPair(() => current, policy);
+  return {
+    pair, requestRf, requestSql,
+    update: (next: Partial<typeof current>) => { current = { ...current, ...next }; },
+  };
+}
+
+function commandSetup() {
+  const requestRf = vi.fn<(value: number) => void>();
+  const requestSql = vi.fn<(value: number) => void>();
+  let current: Extract<ContinuousPairInput, { evidence: 'command-feedback' }> = {
+    evidence: 'command-feedback', domain: DOMAIN, enabled: true,
+    rf: { command: 'set_rf_gain', feedback: feedback('rf-gain', 1) },
+    sql: { command: 'set_squelch', feedback: feedback('squelch', 0) },
+    requestRf, requestSql,
+  };
+  const pair = createContinuousPair(
+    () => current,
+    createLegacyContinuousPairPolicy({ keyboardDebounceMs: 50 }),
+  );
+  return {
+    pair, requestRf, requestSql, read: () => current,
+    update: (next: Partial<typeof current>) => { current = { ...current, ...next }; },
+  };
+}
+
+describe('continuous pair evidence and geometry', () => {
+  it('preserves both supplied lanes when invalid geometry disables editing', () => {
+    const { pair } = readingSetup(undefined, {
+      domain: { ...DOMAIN, max: Number.NaN },
+      rf: { reading: { status: 'known', value: 0.4 }, availability: 'available' },
+      sql: { reading: { status: 'known', value: 0.2 }, availability: 'available' },
+    });
+    expect(pair.view).toMatchObject({
+      canonical: { rf: 0.4, sql: 0.2 }, position: null, axisDraft: null,
+      domainValid: false, editable: false,
+      lanes: { rf: { canonical: 0.4 }, sql: { canonical: 0.2 } },
+    });
+  });
+
+  it('keeps off-axis facts intact while projecting their geometry', () => {
+    const { pair } = readingSetup(undefined, {
+      rf: { reading: { status: 'known', value: 0.4 }, availability: 'available' },
+      sql: { reading: { status: 'known', value: 0.2 }, availability: 'available' },
+    });
+    expect(pair.view.canonical).toEqual({ rf: 0.4, sql: 0.2 });
+    expect(pair.view.position).toBeCloseTo(0.632, 3);
+    expect(pair.view.lanes.rf.canonical).toBe(0.4);
+  });
+
+  it.each([
+    [{ status: 'unknown' } as const, { status: 'known', value: 0 } as const],
+    [{ status: 'known', value: Number.NaN } as const, { status: 'known', value: 0 } as const],
+  ])('makes pair geometry unknown when either lane is not finite and known', (rf, sql) => {
+    const { pair } = readingSetup(undefined, {
+      rf: { reading: rf, availability: 'available' },
+      sql: { reading: sql, availability: 'available' },
+    });
+    expect(pair.view).toMatchObject({ position: null, editable: false });
+    const lane = pair.view.lanes.rf;
+    expect(lane.evidence).toBe('reading');
+    if (lane.evidence === 'reading') expect(lane.reading).toBe(rf);
+  });
+
+  it('does not re-quantize a fine lane step through the inverse axis', () => {
+    vi.useFakeTimers();
+    const { pair, requestSql } = readingSetup(
+      createLegacyContinuousPairPolicy({ keyboardDebounceMs: 50 }),
+    );
+    const lease = pair.attachRenderer();
+    expect(lease.key({ key: 'ArrowRight', fine: true })).toBe(true);
+    vi.advanceTimersByTime(50);
+    expect(requestSql).toHaveBeenCalledExactlyOnceWith(0.001);
+    expect(pair.view.lanes.sql.localRequested).toBe(0.001);
+    vi.useRealTimers();
+  });
+});
+
+describe('continuous pair request reconciliation', () => {
+  it('calls RF then SQL only for lanes changed from effective requested state', () => {
+    const order: string[] = [];
+    const requestRf = vi.fn(() => order.push('rf'));
+    const requestSql = vi.fn(() => order.push('sql'));
+    const { pair } = readingSetup(undefined, { requestRf, requestSql });
+    const lease = pair.attachRenderer();
+    lease.nativeInput(0);
+    expect(order).toEqual(['rf']);
+    lease.nativeInput(1);
+    expect(order).toEqual(['rf', 'rf', 'sql']);
+  });
+
+  it('dispatches a canonical reversal after a different local request and deduplicates repeats', () => {
+    const { pair, requestSql } = readingSetup();
+    const lease = pair.attachRenderer();
+    lease.nativeInput(1);
+    lease.nativeInput(0.5);
+    lease.nativeInput(0.5);
+    expect(requestSql.mock.calls).toEqual([[1], [0]]);
+    expect(pair.view.lanes.sql.localRequested).toBe(0);
+  });
+
+  it('prefers supplied command targets over local records', () => {
+    vi.useFakeTimers();
+    const { pair, requestSql, read, update } = commandSetup();
+    const lease = pair.attachRenderer();
+    lease.key({ key: 'ArrowRight', fine: false });
+    vi.advanceTimersByTime(50);
+    expect(requestSql).toHaveBeenCalledExactlyOnceWith(0.01);
+    update({ sql: { ...read().sql, feedback: feedback('squelch', 0, {
+      target: 0.02, requestedTarget: 0.02, phase: 'submitted', busy: true,
+      lifecycleId: 'sql-1', transitionId: 'sql-submitted',
+    }) } });
+    lease.key({ key: 'ArrowLeft', fine: false });
+    vi.advanceTimersByTime(50);
+    expect(requestSql).toHaveBeenLastCalledWith(0.01);
+    vi.useRealTimers();
+  });
+
+  it('keeps staggered lane outcomes and announcements independent', () => {
+    const { pair, read, update } = commandSetup();
+    update({
+      rf: { ...read().rf, feedback: feedback('rf-gain', 0.8, {
+        requestedTarget: 0.8, phase: 'confirmed', outcome: { phase: 'confirmed' },
+        lifecycleId: 'rf-1', transitionId: 'rf-confirmed',
+      }) },
+      sql: { ...read().sql, feedback: feedback('squelch', 0, {
+        requestedTarget: 0.3, phase: 'failed', outcome: { phase: 'failed', error: 'rejected' },
+        lifecycleId: 'sql-1', transitionId: 'sql-failed',
+      }) },
+    });
+    const first = pair.view;
+    expect(first.lanes.rf).toMatchObject({ phase: 'confirmed', error: null });
+    expect(first.lanes.sql).toMatchObject({ phase: 'failed', error: 'rejected' });
+    expect(first.lanes.rf.announcement).toBe('Confirmed: 0.8');
+    expect(first.lanes.sql.announcement).toBe('Failed: 0.3');
+    const second = pair.view;
+    expect(second.lanes.rf.announcement).toBeNull();
+    expect(second.lanes.sql.announcement).toBeNull();
+  });
+
+  it('preserves known command readings but disables editing across availability replacement', () => {
+    const { pair, read, update } = commandSetup();
+    update({ sql: { ...read().sql, feedback: feedback('squelch', 0.2, {
+      availability: 'unavailable', phase: 'unavailable',
+    }) } });
+    expect(pair.view).toMatchObject({
+      canonical: { rf: 1, sql: 0.2 }, editable: false,
+      lanes: { sql: { availability: 'unavailable', canonical: 0.2 } },
+    });
+  });
+});
+
+describe('continuous pair delegates one scalar lifetime', () => {
+  it('keeps native input immediate and omits legacy wheel, key and reset behavior', () => {
+    const { pair, requestRf, requestSql } = readingSetup();
+    const lease = pair.attachRenderer();
+    lease.nativeInput(0);
+    expect(requestRf).toHaveBeenCalledExactlyOnceWith(0);
+    expect(lease.key({ key: 'ArrowRight', fine: false })).toBe(false);
+    lease.wheel({ direction: 1, fine: false });
+    lease.reset();
+    expect(requestRf).toHaveBeenCalledTimes(1);
+    expect(requestSql).not.toHaveBeenCalled();
+  });
+
+  it('uses immediate pointer, wheel and reset but debounces legacy keyboard', () => {
+    vi.useFakeTimers();
+    const { pair, requestRf, requestSql } = readingSetup(
+      createLegacyContinuousPairPolicy({ keyboardDebounceMs: 50 }),
+    );
+    const lease = pair.attachRenderer();
+    const token = lease.beginPointer()!;
+    lease.pointer(token, 0);
+    lease.wheel({ direction: 1, fine: false });
+    lease.reset();
+    expect(requestRf).toHaveBeenCalledTimes(3);
+    expect(requestSql).not.toHaveBeenCalled();
+    lease.key({ key: 'ArrowRight', fine: false });
+    expect(requestSql).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(50);
+    expect(requestSql).toHaveBeenCalledExactlyOnceWith(0.01);
+    vi.useRealTimers();
+  });
+
+  it('expires wheel draft and cancels debounced work on a terminal lane outcome', () => {
+    vi.useFakeTimers();
+    const { pair, requestSql, read, update } = commandSetup();
+    const lease = pair.attachRenderer();
+    lease.wheel({ direction: 1, fine: false });
+    expect(pair.view.interaction).toBe('wheel');
+    vi.advanceTimersByTime(300);
+    expect(pair.view).toMatchObject({ interaction: 'idle', axisDraft: null });
+    lease.key({ key: 'ArrowRight', fine: false });
+    update({ rf: { ...read().rf, feedback: feedback('rf-gain', 1, {
+      requestedTarget: 0.5, phase: 'failed', outcome: { phase: 'failed', error: 'no' },
+      lifecycleId: 'rf-failed', transitionId: 'rf-failed',
+    }) } });
+    void pair.view;
+    vi.advanceTimersByTime(50);
+    expect(requestSql).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it('invalidates old renderer leases and current work on authority replacement', () => {
+    vi.useFakeTimers();
+    const { pair, requestSql, update } = readingSetup(
+      createLegacyContinuousPairPolicy({ keyboardDebounceMs: 50 }),
+    );
+    const stale = pair.attachRenderer();
+    stale.key({ key: 'ArrowRight', fine: false });
+    update({ ownerKey: 'rf-sql:sub' });
+    void pair.view;
+    vi.advanceTimersByTime(50);
+    expect(requestSql).not.toHaveBeenCalled();
+    const current = pair.attachRenderer();
+    stale.nativeInput(1);
+    expect(requestSql).not.toHaveBeenCalled();
+    current.nativeInput(1);
+    expect(requestSql).toHaveBeenCalledExactlyOnceWith(1);
+    vi.useRealTimers();
+  });
+
+  it('cancels pending work when command receiver authority changes', () => {
+    vi.useFakeTimers();
+    const { pair, requestSql, read, update } = commandSetup();
+    const lease = pair.attachRenderer();
+    lease.key({ key: 'ArrowRight', fine: false });
+    update({ sql: { ...read().sql, feedback: feedback('squelch', 0, {
+      sessionEpoch: 8, scope: { control: 'squelch', receiver: 1 },
+    }) } });
+    void pair.view;
+    vi.advanceTimersByTime(50);
+    expect(requestSql).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('keeps lane announcement identity when appearance leases are replaced', () => {
+    const { pair, read, update } = commandSetup();
+    update({ rf: { ...read().rf, feedback: feedback('rf-gain', 0.8, {
+      requestedTarget: 0.8, phase: 'confirmed', outcome: { phase: 'confirmed' },
+      lifecycleId: 'rf-appearance', transitionId: 'rf-appearance-confirmed',
+    }) } });
+    const first = pair.attachRenderer();
+    expect(first.view.lanes.rf.announcement).toBe('Confirmed: 0.8');
+    const replacement = pair.attachRenderer();
+    expect(replacement.view.lanes.rf.announcement).toBeNull();
+    first.nativeInput(0);
+    expect(pair.view.axisDraft).toBeNull();
+  });
+
+  it('drops cancelled pointer draft without retracting emitted requests and destroys ownership', () => {
+    const { pair, requestRf } = readingSetup(
+      createLegacyContinuousPairPolicy({ keyboardDebounceMs: 50 }),
+    );
+    const lease = pair.attachRenderer();
+    const token = lease.beginPointer()!;
+    lease.pointer(token, 0);
+    expect(requestRf).toHaveBeenCalledExactlyOnceWith(0);
+    lease.cancelPointer(token);
+    expect(pair.view.axisDraft).toBeNull();
+    pair.destroy();
+    lease.nativeInput(0.2);
+    expect(requestRf).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/primitives/scalar/continuous-pair.svelte.ts
+++ b/frontend/src/primitives/scalar/continuous-pair.svelte.ts
@@ -1,0 +1,522 @@
+import {
+  projectControlFeedbackPresentation,
+  type ControlFeedbackPresentation,
+  type ControlFeedbackPresentationState,
+} from '../control-feedback/control-feedback-presentation';
+import {
+  createContinuousScalar,
+  type CommandScalarFeedback,
+  type ContinuousScalarBinding,
+  type ContinuousScalarPolicy,
+  type ContinuousScalarRendererLease,
+  type ScalarDomain,
+  type ScalarKeyInput,
+  type ScalarPhase,
+  type ScalarReading,
+  type ScalarSource,
+  type ScalarStepInput,
+} from './continuous-scalar.svelte';
+import {
+  clamp,
+  dualParamNormXFromValues,
+  dualParamStepAlongAxis,
+  dualParamValuesFromNormX,
+} from './value-control-core';
+
+export interface ContinuousPairValues {
+  readonly rf: number;
+  readonly sql: number;
+}
+
+export interface PairReadingLane {
+  readonly reading: ScalarReading;
+  readonly availability: 'available' | 'unavailable';
+}
+
+export interface PairCommandLane {
+  readonly command: string;
+  readonly feedback: Readonly<CommandScalarFeedback>;
+}
+
+interface ContinuousPairInputBase {
+  readonly domain: ScalarDomain;
+  readonly enabled: boolean;
+  readonly requestRf: (value: number) => void;
+  readonly requestSql: (value: number) => void;
+}
+
+export interface ReadingContinuousPairInput extends ContinuousPairInputBase {
+  readonly evidence: 'reading';
+  readonly ownerKey: string;
+  readonly rf: Readonly<PairReadingLane>;
+  readonly sql: Readonly<PairReadingLane>;
+}
+
+export interface CommandFeedbackContinuousPairInput extends ContinuousPairInputBase {
+  readonly evidence: 'command-feedback';
+  readonly rf: Readonly<PairCommandLane>;
+  readonly sql: Readonly<PairCommandLane>;
+}
+
+export type ContinuousPairInput =
+  | ReadingContinuousPairInput
+  | CommandFeedbackContinuousPairInput;
+
+export interface ContinuousPairPolicy {
+  readonly name: string;
+  readonly preview: 'optimistic' | 'confirmed';
+  wheel(
+    current: Readonly<ContinuousPairValues>,
+    event: ScalarStepInput,
+    domain: ScalarDomain,
+  ): Readonly<ContinuousPairValues> | null;
+  key(
+    current: Readonly<ContinuousPairValues>,
+    event: ScalarKeyInput,
+    domain: ScalarDomain,
+  ): Readonly<ContinuousPairValues> | null;
+  reset(domain: ScalarDomain): Readonly<ContinuousPairValues> | null;
+  dispatch(source: ScalarSource): 'immediate' | Readonly<{ debounceMs: number }>;
+  readonly wheelIdleMs: 0 | 300;
+}
+
+const nativePolicy: ContinuousPairPolicy = {
+  name: 'native-range-pair',
+  preview: 'optimistic',
+  wheel: () => null,
+  key: () => null,
+  reset: () => null,
+  dispatch: () => 'immediate',
+  wheelIdleMs: 0,
+};
+export const nativeRangeContinuousPairPolicy: Readonly<ContinuousPairPolicy> =
+  Object.freeze(nativePolicy);
+
+export function createLegacyContinuousPairPolicy(
+  options: Readonly<{ keyboardDebounceMs: number }>,
+): Readonly<ContinuousPairPolicy> {
+  const keyboardDispatch = options.keyboardDebounceMs > 0
+    ? Object.freeze({ debounceMs: options.keyboardDebounceMs })
+    : 'immediate';
+  const legacyPolicy: ContinuousPairPolicy = {
+    name: 'legacy-rf-sql-pair',
+    preview: 'optimistic' as const,
+    wheel: (current, event, domain) => {
+      const adaptive = Math.max(1, Math.ceil((domain.max - domain.min) / 255));
+      const step = event.fine
+        ? domain.step / domain.fineStepDivisor
+        : domain.step * 4 * adaptive;
+      return dualParamStepAlongAxis(
+        current.rf, current.sql, event.direction, step, domain.fineStepDivisor,
+        domain.min, domain.max, false,
+      );
+    },
+    key: (current, event, domain) => {
+      if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return null;
+      return dualParamStepAlongAxis(
+        current.rf, current.sql, event.key === 'ArrowRight' ? 1 : -1,
+        domain.step, domain.fineStepDivisor, domain.min, domain.max, event.fine,
+      );
+    },
+    reset: (domain) => ({ rf: domain.max, sql: domain.min }),
+    dispatch: (source) => source === 'keyboard' ? keyboardDispatch : 'immediate',
+    wheelIdleMs: 300,
+  };
+  return Object.freeze(legacyPolicy);
+}
+
+interface PairReadingLaneView {
+  readonly evidence: 'reading';
+  readonly reading: ScalarReading;
+  readonly availability: 'available' | 'unavailable';
+  readonly canonical: number | null;
+  readonly localRequested: number | null;
+  readonly feedback: null;
+  readonly phase: null;
+  readonly error: null;
+  readonly presentation: null;
+  readonly announcement: null;
+}
+
+interface PairCommandLaneView {
+  readonly evidence: 'command-feedback';
+  readonly command: string;
+  readonly feedback: Readonly<CommandScalarFeedback>;
+  readonly availability: 'available' | 'unavailable';
+  readonly canonical: number | null;
+  readonly localRequested: number | null;
+  readonly phase: ScalarPhase;
+  readonly error: string | null;
+  readonly presentation: Readonly<ControlFeedbackPresentation>;
+  readonly announcement: string | null;
+}
+
+export type ContinuousPairLaneView = Readonly<PairReadingLaneView | PairCommandLaneView>;
+
+export interface ContinuousPairView {
+  readonly evidence: ContinuousPairInput['evidence'];
+  readonly domain: Readonly<ScalarDomain>;
+  readonly domainValid: boolean;
+  readonly canonical: Readonly<{ rf: number | null; sql: number | null }>;
+  readonly position: number | null;
+  readonly axisDraft: number | null;
+  readonly draft: Readonly<ContinuousPairValues> | null;
+  readonly displayedPosition: number | null;
+  readonly editable: boolean;
+  readonly busy: boolean;
+  readonly interaction: 'idle' | ScalarSource;
+  readonly lanes: Readonly<{ rf: ContinuousPairLaneView; sql: ContinuousPairLaneView }>;
+}
+
+export interface ContinuousPairRendererLease {
+  readonly view: Readonly<ContinuousPairView>;
+  beginPointer(): number | null;
+  pointer(token: number, candidate: number): void;
+  endPointer(token: number): void;
+  cancelPointer(token: number): void;
+  nativeInput(candidate: number): void;
+  wheel(event: ScalarStepInput): void;
+  key(event: ScalarKeyInput): boolean;
+  reset(): void;
+  dispose(): void;
+}
+
+export interface ContinuousPairBinding {
+  readonly view: Readonly<ContinuousPairView>;
+  attachRenderer(): ContinuousPairRendererLease;
+  cancel(reason: 'authority' | 'availability' | 'terminal' | 'owner-dispose'): void;
+  destroy(): void;
+}
+
+type Identity = readonly unknown[];
+type LaneName = 'rf' | 'sql';
+interface LocalRequest {
+  readonly value: number;
+  readonly observation: Identity;
+}
+interface ProjectedCandidate {
+  readonly axis: number;
+  readonly values: Readonly<ContinuousPairValues>;
+  readonly authority: number;
+  readonly source: 'wheel' | 'keyboard' | 'reset';
+}
+
+const sameIdentity = (left: Identity | null, right: Identity): boolean =>
+  left !== null && left.length === right.length
+  && left.every((value, index) => Object.is(value, right[index]));
+const finiteValue = (value: number | null | undefined): number | null =>
+  value !== null && value !== undefined && Number.isFinite(value) ? value : null;
+
+function canonicalLane(input: Readonly<ContinuousPairInput>, lane: LaneName): number | null {
+  return input.evidence === 'reading'
+    ? input[lane].reading.status === 'known' ? finiteValue(input[lane].reading.value) : null
+    : finiteValue(input[lane].feedback.confirmed);
+}
+
+function laneAvailable(input: Readonly<ContinuousPairInput>, lane: LaneName): boolean {
+  return input.evidence === 'reading'
+    ? input[lane].availability === 'available'
+    : input[lane].feedback.availability === 'available';
+}
+
+function laneObservation(input: Readonly<ContinuousPairInput>, lane: LaneName): Identity {
+  if (input.evidence === 'reading') {
+    return Object.freeze([
+      input[lane].availability, input[lane].reading.status, canonicalLane(input, lane),
+    ]);
+  }
+  const feedback = input[lane].feedback;
+  return Object.freeze([
+    feedback.confirmed, feedback.target, feedback.requestedTarget, feedback.phase,
+    feedback.lifecycleId, feedback.transitionId, feedback.outcome?.phase, feedback.outcome?.error,
+  ]);
+}
+
+function authorityOf(input: Readonly<ContinuousPairInput>): Identity {
+  const domain = input.domain;
+  const shared = [
+    input.evidence, input.enabled, domain.min, domain.max, domain.step,
+    domain.defaultValue, domain.fineStepDivisor, domain.keyboardStep,
+  ];
+  if (input.evidence === 'reading') {
+    return Object.freeze([
+      ...shared, input.ownerKey, input.rf.availability, input.rf.reading.status,
+      input.sql.availability, input.sql.reading.status,
+    ]);
+  }
+  return Object.freeze([
+    ...shared,
+    input.rf.command, input.rf.feedback.sessionEpoch, input.rf.feedback.availability,
+    input.rf.feedback.scope.control, input.rf.feedback.scope.receiver, input.rf.feedback.scope.slot,
+    input.sql.command, input.sql.feedback.sessionEpoch, input.sql.feedback.availability,
+    input.sql.feedback.scope.control, input.sql.feedback.scope.receiver, input.sql.feedback.scope.slot,
+  ]);
+}
+
+const TERMINAL_PHASES: ReadonlySet<ScalarPhase> = new Set([
+  'failed', 'timed-out', 'cancelled', 'superseded',
+]);
+
+function terminalOf(input: Readonly<ContinuousPairInput>): Identity | null {
+  if (input.evidence === 'reading') return null;
+  const identities = (['rf', 'sql'] as const).flatMap((lane) => {
+    const feedback = input[lane].feedback;
+    const phase = feedback.outcome !== null && TERMINAL_PHASES.has(feedback.outcome.phase)
+      ? feedback.outcome.phase : TERMINAL_PHASES.has(feedback.phase) ? feedback.phase : null;
+    return phase === null ? [] : [
+      lane, feedback.lifecycleId, feedback.transitionId, phase,
+    ];
+  });
+  return identities.length === 0 ? null : Object.freeze(identities);
+}
+
+function axisDomain(domain: ScalarDomain): ScalarDomain {
+  const min = Number.isFinite(domain.min) ? 0 : domain.min;
+  const max = Number.isFinite(domain.max) && domain.max >= domain.min ? 1 : domain.max - domain.min;
+  return {
+    min, max, step: domain.step, fineStepDivisor: domain.fineStepDivisor,
+    defaultValue: domain.defaultValue === null ? null
+      : Number.isFinite(domain.defaultValue) ? 0.5 : domain.defaultValue,
+    ...(domain.keyboardStep === undefined ? {} : { keyboardStep: domain.keyboardStep }),
+  };
+}
+
+function snapshotDomain(domain: ScalarDomain): Readonly<ScalarDomain> {
+  return Object.freeze({
+    min: domain.min, max: domain.max, step: domain.step,
+    defaultValue: domain.defaultValue, fineStepDivisor: domain.fineStepDivisor,
+    ...(domain.keyboardStep === undefined ? {} : { keyboardStep: domain.keyboardStep }),
+  });
+}
+
+function validCommandLane(lane: Readonly<PairCommandLane>): boolean {
+  const feedback = lane.feedback;
+  return Number.isFinite(feedback.sessionEpoch)
+    && (feedback.scope.receiver === 0 || feedback.scope.receiver === 1)
+    && (feedback.target === null || Number.isFinite(feedback.target))
+    && (feedback.requestedTarget === null || Number.isFinite(feedback.requestedTarget));
+}
+
+export function createContinuousPair(
+  read: () => Readonly<ContinuousPairInput>,
+  policy: Readonly<ContinuousPairPolicy>,
+): ContinuousPairBinding {
+  let localRf = $state<LocalRequest | null>(null);
+  let localSql = $state<LocalRequest | null>(null);
+  let lastAuthority: Identity | null = null;
+  let handledTerminal: Identity | null = null;
+  let authorityGeneration = 0;
+  let projectedCandidate: ProjectedCandidate | null = null;
+  let rfPresentation: Readonly<ControlFeedbackPresentationState> = { announcedTransitionIds: [] };
+  let sqlPresentation: Readonly<ControlFeedbackPresentationState> = { announcedTransitionIds: [] };
+  let scalar: ContinuousScalarBinding;
+
+  const localOf = (lane: LaneName): LocalRequest | null => lane === 'rf' ? localRf : localSql;
+  const setLocal = (lane: LaneName, value: LocalRequest | null): void => {
+    if (lane === 'rf') localRf = value;
+    else localSql = value;
+  };
+
+  function reconcile(input: Readonly<ContinuousPairInput>): void {
+    const authority = authorityOf(input);
+    if (lastAuthority !== null && !sameIdentity(lastAuthority, authority)) {
+      authorityGeneration += 1;
+      localRf = null;
+      localSql = null;
+      projectedCandidate = null;
+      rfPresentation = { announcedTransitionIds: [] };
+      sqlPresentation = { announcedTransitionIds: [] };
+      scalar?.cancel('authority');
+      handledTerminal = null;
+    }
+    lastAuthority = authority;
+    for (const lane of ['rf', 'sql'] as const) {
+      const local = localOf(lane);
+      if (local !== null && !sameIdentity(local.observation, laneObservation(input, lane))) {
+        setLocal(lane, null);
+      }
+    }
+    const terminal = terminalOf(input);
+    if (terminal !== null && !sameIdentity(handledTerminal, terminal)) {
+      projectedCandidate = null;
+      scalar?.cancel('terminal');
+      handledTerminal = terminal;
+    }
+  }
+
+  function current(): Readonly<ContinuousPairInput> {
+    const input = read();
+    reconcile(input);
+    return input;
+  }
+
+  function pairEditable(input: Readonly<ContinuousPairInput>): boolean {
+    if (!input.enabled || canonicalLane(input, 'rf') === null || canonicalLane(input, 'sql') === null
+      || !laneAvailable(input, 'rf') || !laneAvailable(input, 'sql')) return false;
+    return input.evidence === 'reading'
+      || (validCommandLane(input.rf) && validCommandLane(input.sql));
+  }
+
+  function effectiveLane(input: Readonly<ContinuousPairInput>, lane: LaneName): number | null {
+    if (input.evidence === 'command-feedback') {
+      const target = finiteValue(input[lane].feedback.target);
+      if (target !== null) return target;
+    }
+    return localOf(lane)?.value ?? canonicalLane(input, lane);
+  }
+
+  function effectivePair(input: Readonly<ContinuousPairInput>): ContinuousPairValues | null {
+    const rf = effectiveLane(input, 'rf');
+    const sql = effectiveLane(input, 'sql');
+    return rf === null || sql === null ? null : { rf, sql };
+  }
+
+  function rememberCandidate(
+    values: Readonly<ContinuousPairValues>,
+    input: Readonly<ContinuousPairInput>,
+    source: ProjectedCandidate['source'],
+  ): number {
+    const axis = dualParamNormXFromValues(
+      values.rf, values.sql, input.domain.min, input.domain.max,
+    );
+    projectedCandidate = {
+      axis, values: Object.freeze({ ...values }), authority: authorityGeneration, source,
+    };
+    return axis;
+  }
+
+  function requestAxis(axis: number): void {
+    const input = current();
+    const exact = projectedCandidate !== null
+      && projectedCandidate.authority === authorityGeneration
+      && projectedCandidate.source === scalar.view.interaction
+      && Object.is(projectedCandidate.axis, axis)
+      ? projectedCandidate.values : null;
+    const values = exact ?? dualParamValuesFromNormX(
+      axis, input.domain.min, input.domain.max, input.domain.step,
+    );
+    const changeRf = !Object.is(values.rf, effectiveLane(input, 'rf'));
+    const changeSql = !Object.is(values.sql, effectiveLane(input, 'sql'));
+    if (changeRf) {
+      localRf = { value: values.rf, observation: laneObservation(input, 'rf') };
+      input.requestRf(values.rf);
+    }
+    if (changeSql) {
+      localSql = { value: values.sql, observation: laneObservation(input, 'sql') };
+      input.requestSql(values.sql);
+    }
+  }
+
+  const scalarPolicy: ContinuousScalarPolicy = {
+    name: policy.name,
+    preview: policy.preview,
+    normalize: (value) => Number.isFinite(value) ? clamp(value, 0, 1) : null,
+    wheel: (_axis, event) => {
+      const input = current();
+      const pair = effectivePair(input);
+      const values = pair === null ? null : policy.wheel(pair, event, input.domain);
+      return values === null ? null : rememberCandidate(values, input, 'wheel');
+    },
+    key: (_axis, event) => {
+      const input = current();
+      const pair = effectivePair(input);
+      const values = pair === null ? null : policy.key(pair, event, input.domain);
+      return values === null ? null : rememberCandidate(values, input, 'keyboard');
+    },
+    reset: () => {
+      const input = current();
+      const values = policy.reset(input.domain);
+      return values === null ? null : rememberCandidate(values, input, 'reset');
+    },
+    dispatch: (source) => policy.dispatch(source),
+    dispatchesCanonical: () => true,
+    wheelIdleMs: policy.wheelIdleMs,
+    describeTarget: String,
+  };
+
+  scalar = createContinuousScalar(() => {
+    const input = current();
+    const rf = canonicalLane(input, 'rf');
+    const sql = canonicalLane(input, 'sql');
+    return {
+      evidence: 'reading', ownerKey: `continuous-pair:${authorityGeneration}`,
+      domain: axisDomain(input.domain), enabled: pairEditable(input), request: requestAxis,
+      reading: rf === null || sql === null
+        ? { status: 'unknown' }
+        : { status: 'known', value: dualParamNormXFromValues(
+          rf, sql, input.domain.min, input.domain.max,
+        ) },
+    };
+  }, scalarPolicy);
+
+  function laneView(input: Readonly<ContinuousPairInput>, lane: LaneName): ContinuousPairLaneView {
+    const canonical = canonicalLane(input, lane);
+    const localRequested = localOf(lane)?.value ?? null;
+    if (input.evidence === 'reading') {
+      return Object.freeze({
+        evidence: 'reading' as const, reading: input[lane].reading,
+        availability: input[lane].availability, canonical, localRequested,
+        feedback: null, phase: null, error: null, presentation: null, announcement: null,
+      });
+    }
+    const feedback = input[lane].feedback;
+    const prior = lane === 'rf' ? rfPresentation : sqlPresentation;
+    const presentation = projectControlFeedbackPresentation(feedback, prior, String);
+    if (lane === 'rf') rfPresentation = presentation.state;
+    else sqlPresentation = presentation.state;
+    return Object.freeze({
+      evidence: 'command-feedback' as const, command: input[lane].command,
+      feedback, availability: feedback.availability, canonical, localRequested,
+      phase: feedback.phase, error: feedback.outcome?.error ?? null, presentation,
+      announcement: presentation.politeAnnouncement?.message ?? null,
+    });
+  }
+
+  function viewOf(): Readonly<ContinuousPairView> {
+    const input = current();
+    const axis = scalar.view;
+    const rf = canonicalLane(input, 'rf');
+    const sql = canonicalLane(input, 'sql');
+    const position = axis.domainValid && rf !== null && sql !== null ? axis.canonical : null;
+    const exactDraft = projectedCandidate !== null
+      && projectedCandidate.authority === authorityGeneration
+      && projectedCandidate.source === axis.interaction
+      && axis.draft !== null && Object.is(projectedCandidate.axis, axis.draft)
+      ? projectedCandidate.values : null;
+    const draft = axis.draft === null ? null : exactDraft ?? Object.freeze(dualParamValuesFromNormX(
+      axis.draft, input.domain.min, input.domain.max, input.domain.step,
+    ));
+    return Object.freeze({
+      evidence: input.evidence,
+      domain: snapshotDomain(input.domain), domainValid: axis.domainValid,
+      canonical: Object.freeze({ rf, sql }), position, axisDraft: axis.draft,
+      draft, displayedPosition: axis.domainValid ? axis.displayed : null,
+      editable: axis.editable, busy: input.evidence === 'command-feedback'
+        ? input.rf.feedback.busy || input.sql.feedback.busy : false,
+      interaction: axis.interaction,
+      lanes: Object.freeze({ rf: laneView(input, 'rf'), sql: laneView(input, 'sql') }),
+    });
+  }
+
+  function wrapLease(lease: ContinuousScalarRendererLease): ContinuousPairRendererLease {
+    return {
+      get view() { void lease.view; return viewOf(); },
+      beginPointer: () => lease.beginPointer(),
+      pointer: (token, candidate) => lease.pointer(token, candidate),
+      endPointer: (token) => lease.endPointer(token),
+      cancelPointer: (token) => lease.cancelPointer(token),
+      nativeInput: (candidate) => lease.nativeInput(candidate),
+      wheel: (event) => lease.wheel(event),
+      key: (event) => lease.key(event),
+      reset: () => lease.reset(),
+      dispose: () => lease.dispose(),
+    };
+  }
+
+  return {
+    get view() { return viewOf(); },
+    attachRenderer: () => wrapLease(scalar.attachRenderer()),
+    cancel: (reason) => scalar.cancel(reason),
+    destroy: () => scalar.destroy(),
+  };
+}

--- a/frontend/src/semantic/RfFrontEndSurface.svelte
+++ b/frontend/src/semantic/RfFrontEndSurface.svelte
@@ -190,7 +190,10 @@
       field?.availability.structural && field.availability.operational
         ? 'available' as const : 'unavailable' as const;
     return {
-      evidence: 'reading', ownerKey: 'semantic-rf-sql',
+      evidence: 'reading', ownerKey: JSON.stringify([
+        view.topologyId, view.activeReceiver.status,
+        view.activeReceiver.status === 'known' ? view.activeReceiver.receiver : null,
+      ]),
       domain: {
         min: RF_SQL_MIN, max: RF_SQL_MAX, step: RF_SQL_STEP,
         defaultValue: null, fineStepDivisor: 10,
@@ -219,6 +222,7 @@
   $effect(() => {
     rfSqlView = rfSqlLease === null ? rfSqlPair.view : rfSqlLease.view;
   });
+  let combinedNormX = $derived(rfSqlView.displayedPosition ?? RF_SQL_MIN);
   onDestroy(() => rfSqlPair.destroy());
 </script>
 
@@ -279,7 +283,7 @@
         <span class="rf-front-end-name">RF/SQL</span>
         <input
           type="range" min={RF_SQL_MIN} max={RF_SQL_MAX} step={RF_SQL_STEP}
-          value={rfSqlView.displayedPosition ?? RF_SQL_MIN}
+          value={combinedNormX}
           disabled={!rfSqlView.editable}
           data-pair-evidence={rfSqlView.evidence}
           oninput={(event) => rfSqlLease?.nativeInput(event.currentTarget.valueAsNumber)}

--- a/frontend/src/semantic/RfFrontEndSurface.svelte
+++ b/frontend/src/semantic/RfFrontEndSurface.svelte
@@ -4,8 +4,9 @@
   Presentation only. It renders the MOR-1262 decomposition family 11
   `rfFrontEnd` fact group (MOR-1292/MOR-1293) — preamp, attenuator, RF gain,
   squelch, DIGI-SEL, IP+ — and emits control intents as callbacks. It holds
-  no state, consults no controller and issues no command directly (v3 ADR
-  invariant 11), same doctrine as `TxAuxSurface`/`RxAudioSurface`.
+  only primitive-owned local interaction state, consults no controller and
+  issues no command directly (v3 ADR invariant 11), same doctrine as
+  `TxAuxSurface`/`RxAudioSurface`.
 
   CARRY-FORWARDS (binding, from the MOR-1292/MOR-1293 review rulings — see
   `radio-view-model.ts`'s `RfFrontEndViewModel` doc comment for the fact-layer
@@ -41,9 +42,9 @@
 
   PENDING AFFORDANCE (MOR-1441 leg 2). `pendingPreamp` is a plain, command-
   bus-blind display prop, same "read at the wiring seam" precedent as leg
-  1's `pendingFrequencyHz`. It never touches the MOR-1447 combined-knob/
-  change-guard machinery above (`combinedNormX`/`changeCombined` read only
-  confirmed `rf.rfGain`/`rf.squelch`) — preamp is a disjoint field. Marks the
+  1's `pendingFrequencyHz`. It never touches the MOR-1447 combined pair
+  binding, whose reading evidence comes only from `rf.rfGain`/`rf.squelch` —
+  preamp is a disjoint field. Marks the
   targeted preamp CHOICE distinctly; the preamp binding's `aria-checked` keeps reading
   `rf.preamp`'s CONFIRMED reading exclusively, so a click while pending still
   dispatches the CLICKED (explicit) value.
@@ -103,12 +104,13 @@
 </script>
 
 <script lang="ts">
+  import { onDestroy, untrack } from 'svelte';
   import { t } from '$lib/i18n';
   import type { RadioViewModel } from './radio-view-model';
   import {
-    dualParamValuesFromNormX,
-    dualParamNormXFromValues,
-  } from '../primitives/scalar/value-control-core';
+    createContinuousPair, nativeRangeContinuousPairPolicy,
+    type ContinuousPairInput, type ContinuousPairRendererLease, type ContinuousPairView,
+  } from '../primitives/scalar/continuous-pair.svelte';
   import {
     bindChoiceInstrument,
     bindToggleInstrument,
@@ -183,51 +185,41 @@
     && !!rf?.rfGain.availability.structural
     && !!rf?.squelch.availability.structural,
   );
-  const knownOr = (f: RfFrontEndField<number> | undefined, fallback: number): number =>
-    f && f.reading.status === 'known' ? f.reading.value : fallback;
-  /** Readback projection (MOR-1447 leg 2): the honest inverse of the
-   *  hardware knob. Ported verbatim from `dualParamNormXFromValues`
-   *  (`primitives/scalar/value-control-core.ts`) — the
-   *  same math `DualParamRenderer.svelte` already draws with. Ambiguity
-   *  handling is inherited from that function: if SQL reads above its
-   *  minimum, the knob is projected to the right leg (RF forced to max) —
-   *  the physical knob genuinely cannot express "RF below max AND SQL above
-   *  min" at once, so this is the one honest reading, not a guess.
-   */
-  let combinedNormX = $derived(
-    dualParamNormXFromValues(
-      knownOr(rf?.rfGain, RF_SQL_MIN),
-      knownOr(rf?.squelch, RF_SQL_MIN),
-      RF_SQL_MIN,
-      RF_SQL_MAX,
-    ),
-  );
-  function changeCombined(normX: number): void {
-    // Both halves must be independently usable, not merely structurally
-    // present (mirrors carry-forward 2/3's "the handler itself refuses to
-    // emit, independent of `disabled`" discipline): one physical knob must
-    // not silently half-write the pair — e.g. move RF while SQL is degraded
-    // and stays untouched, desyncing what looks like a single control.
-    if (!rf || !usable(rf.rfGain) || !usable(rf.squelch)) return;
-    const { rf: nextRf, sql: nextSql } = dualParamValuesFromNormX(
-      normX, RF_SQL_MIN, RF_SQL_MAX, RF_SQL_STEP,
-    );
-    // Per-field change guard, mirroring `DualParamRenderer.svelte`'s
-    // `emitPair` (`primitives/scalar/value-control-core.ts`'s companion component — only emits
-    // a field that actually moved). Without this, every input event
-    // unconditionally re-sends BOTH fields — a left-leg drag spams redundant
-    // `set_squelch(0)` and a right-leg drag spams redundant `set_rf_gain(255)`
-    // on every tick, roughly doubling the CI-V write rate versus both the
-    // real hardware knob and the leg-1 two-slider path. On the live serial
-    // IC-7300 gate radio that write-rate doubling is the queue-lag/"Commander
-    // stopped" hazard shape.
-    if (rf.rfGain.reading.status === 'known' && nextRf !== rf.rfGain.reading.value) {
-      changeLevel('rfGain', nextRf);
-    }
-    if (rf.squelch.reading.status === 'known' && nextSql !== rf.squelch.reading.value) {
-      changeLevel('squelch', nextSql);
-    }
+  function rfSqlInput(): Readonly<ContinuousPairInput> {
+    const availability = (field: RfFrontEndField<number> | undefined) =>
+      field?.availability.structural && field.availability.operational
+        ? 'available' as const : 'unavailable' as const;
+    return {
+      evidence: 'reading', ownerKey: 'semantic-rf-sql',
+      domain: {
+        min: RF_SQL_MIN, max: RF_SQL_MAX, step: RF_SQL_STEP,
+        defaultValue: null, fineStepDivisor: 10,
+      },
+      enabled: controlModel === 'combined',
+      rf: {
+        reading: rf?.rfGain.reading ?? { status: 'unknown' },
+        availability: availability(rf?.rfGain),
+      },
+      sql: {
+        reading: rf?.squelch.reading ?? { status: 'unknown' },
+        availability: availability(rf?.squelch),
+      },
+      requestRf: (value) => changeLevel('rfGain', value),
+      requestSql: (value) => changeLevel('squelch', value),
+    };
   }
+  const rfSqlPair = createContinuousPair(rfSqlInput, nativeRangeContinuousPairPolicy);
+  let rfSqlLease: ContinuousPairRendererLease | null = $state(null);
+  let rfSqlView: Readonly<ContinuousPairView> = $state(untrack(() => rfSqlPair.view));
+  $effect(() => {
+    const lease = rfSqlPair.attachRenderer();
+    rfSqlLease = lease;
+    return () => lease.dispose();
+  });
+  $effect(() => {
+    rfSqlView = rfSqlLease === null ? rfSqlPair.view : rfSqlLease.view;
+  });
+  onDestroy(() => rfSqlPair.destroy());
 </script>
 
 {#if rf}
@@ -287,9 +279,10 @@
         <span class="rf-front-end-name">RF/SQL</span>
         <input
           type="range" min={RF_SQL_MIN} max={RF_SQL_MAX} step={RF_SQL_STEP}
-          value={combinedNormX}
-          disabled={!usable(rf.rfGain) || !usable(rf.squelch)}
-          oninput={(event) => changeCombined(event.currentTarget.valueAsNumber)}
+          value={rfSqlView.displayedPosition ?? RF_SQL_MIN}
+          disabled={!rfSqlView.editable}
+          data-pair-evidence={rfSqlView.evidence}
+          oninput={(event) => rfSqlLease?.nativeInput(event.currentTarget.valueAsNumber)}
         />
         <output
           >{levelTextOf(rf.rfGain, RF_SQL_MIN, RF_SQL_MAX)} / {levelTextOf(rf.squelch, RF_SQL_MIN, RF_SQL_MAX)}</output

--- a/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
@@ -371,6 +371,23 @@ describe('the combined RF/SQL knob (controlModel="combined")', () => {
     r.dispose();
   });
 
+  it('uses the pair binding to dispatch a canonical reversal after an unconfirmed request', () => {
+    const onLevelChange = vi.fn();
+    const r = render(base(), { controlModel: 'combined', onLevelChange });
+    const input = r.el('rf-sql')!.querySelector('input')!;
+    expect(input.dataset.pairEvidence).toBe('reading');
+    input.value = '1';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.value = '0.5';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onLevelChange.mock.calls).toEqual([
+      ['squelch', 1],
+      ['squelch', 0],
+    ]);
+    r.dispose();
+  });
+
   it('a hard-right drag emits ONLY squelch — RF is already at max, unchanged (owner semantics: "hard right = SQL max (RF max)")', () => {
     const onLevelChange = vi.fn();
     const r = render(base(), { controlModel: 'combined', onLevelChange });

--- a/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
@@ -14,6 +14,7 @@
  */
 import { describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
 import RfFrontEndSurface, {
   DISABLED_REASON_LABEL, RF_FRONT_END_LEVELS, RF_FRONT_END_TOGGLES, UNKNOWN_TEXT,
 } from '../RfFrontEndSurface.svelte';
@@ -386,6 +387,39 @@ describe('the combined RF/SQL knob (controlModel="combined")', () => {
       ['squelch', 0],
     ]);
     r.dispose();
+  });
+
+  it('clears identical lane draft and request state when receiver topology is replaced', () => {
+    const views = new SvelteMap([['current', base()]]);
+    const onLevelChange = vi.fn();
+    target = document.createElement('div');
+    document.body.appendChild(target);
+    const component = mount(RfFrontEndSurface, {
+      target,
+      props: {
+        get view() { return views.get('current')!; },
+        controlModel: 'combined', onLevelChange,
+      },
+    });
+    flushSync();
+    const input = target.querySelector<HTMLInputElement>('[data-testid="rf-front-end-rf-sql"] input')!;
+    input.value = '1';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(input.valueAsNumber).toBe(1);
+
+    views.set('current', withRfFrontEnd(topologyFixtures['2/ab_shared']));
+    flushSync();
+    expect(input.valueAsNumber).toBe(0.5);
+    input.value = '1';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onLevelChange.mock.calls).toEqual([
+      ['squelch', 1],
+      ['squelch', 1],
+    ]);
+    unmount(component);
+    target.remove();
   });
 
   it('a hard-right drag emits ONLY squelch — RF is already at max, unchanged (owner semantics: "hard right = SQL max (RF max)")', () => {


### PR DESCRIPTION
## Linear

- [MOR-2392](https://linear.app/morozsm/issue/MOR-2392/add-rfsql-pair-binding-through-the-existing-scalar-lifetime-and-adopt)

## Summary

- Add the public ContinuousPairInput, ContinuousPairView, ContinuousPairBinding, renderer lease, and explicit native and legacy pair policies.
- Delegate the single axis gesture, renderer token, debounce, wheel expiry, authority invalidation, and disposal lifetime to one existing ContinuousScalarBinding in reading-evidence mode.
- Retain only pair-specific lane evidence, presentation cursors, exact lane projections, and local request reconciliation.
- Adopt the binding in the real semantic RF/SQL combined native range.
- Bind reading authority to topology and known or unknown active-receiver identity so equivalent lane facts cannot retain state from a replaced context.

## Behavior

RF and SQL callbacks remain independent and are invoked RF first, only when that lane differs from its effective requested state. Effective state prefers live feedback target, then a local dispatched request, then canonical evidence.

This intentionally corrects the prior confirmed-only reversal behavior: returning from an unconfirmed target to canonical dispatches once, while repeating the same target is suppressed. Pointer cancellation drops scalar transient work but does not retract already emitted lane requests. Terminal or authority replacement cancels the joint scalar transient without inventing aggregate pair confirmation or erasing independent lane outcomes.

The reading-only native range keeps the frozen combinedNormX debt identity as an alias of the pair projected display. No feedback baseline or production feedback claim changes here.

## Public surface and limits

The public pair view preserves original canonical lanes, local requested lanes, command envelopes, per-lane presentations and announcements, projected axis position, and transient axis draft. Geometry never rewrites off-axis supplied facts, and exact lane projections prevent fine steps from being quantized again through the inverse axis.

This is honest P1 reading-only production adoption. P2 still owns RF/SQL state-backed descriptors and projections plus legacy renderer and panel adoption. This PR does not claim RF/SQL family completion or MOR-2215/MOR-1686 completion.

## Scope

- 4 files
- 925 additions, 54 deletions
- 979 additions plus deletions

## Verification

- Focused baseline: 3 files, 166 tests passed
- Discriminating RED: missing continuous-pair interface
- Original final focused matrix: 4 files, 184 tests passed
- Correction baseline reproduced the frozen debt failure while pair and surface tests passed
- Corrected pair, semantic surface, and debt inventory: 3 files, 84 tests passed
- Changed-scope ESLint passed
- npm run check passed with 0 errors and 0 warnings
- git diff --check passed
- Negative control: removing local-request precedence failed canonical reversal
- Negative control: removing exact projected lane candidate failed the 0.001 fine-step case
- Correction negative control: restoring the static semantic owner key retained the stale 1.0 draft after receiver/topology replacement instead of canonical 0.5