### PR TITLE
Adopt discrete controls through shared scalar binding

### DIFF
--- a/frontend/src/components-v2/controls/value-control/DiscreteRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/DiscreteRenderer.svelte
@@ -1,26 +1,28 @@
 <script lang="ts">
-  import { untrack } from 'svelte';
+  import { onDestroy, untrack } from 'svelte';
+  import type {
+    ContinuousScalarBinding,
+    ContinuousScalarRendererLease,
+    ContinuousScalarView,
+  } from '../../../primitives/scalar/continuous-scalar.svelte';
   import './value-control.css';
   import {
     getFillPercent,
     calculateClickValue,
-    handleKeyboardStep,
-    clamp,
     snapToStep,
-    debounce,
     valueToPosition,
     enumerateDiscreteValues,
   } from '../../../primitives/scalar/value-control-core';
+  import {
+    projectScalarRenderPresentation,
+    type LegacyReadingPresentation,
+  } from './scalar-render-presentation';
 
   interface Props {
-    value: number;
-    min: number;
-    max: number;
-    step: number;
-    defaultValue?: number;
-    fineStepDivisor?: number;
+    binding: ContinuousScalarBinding;
     label: string;
     displayFn?: (v: number) => string;
+    unknownDisplay?: string;
     fillColor?: string;
     fillGradient?: string[];
     trackColor?: string;
@@ -29,9 +31,6 @@
     showLabel?: boolean;
     compact?: boolean;
     variant?: 'modern' | 'hardware' | 'hardware-illuminated';
-    onChange: (value: number) => void;
-    debounceMs?: number;
-    disabled?: boolean;
     unit?: string;
     shortcutHint?: string | null;
     title?: string | null;
@@ -40,17 +39,14 @@
     showAllTicks?: boolean;
     /** Visual style for discrete step marks. */
     tickStyle?: 'ruler' | 'led' | 'notch';
+    legacy?: LegacyReadingPresentation;
   }
 
   let {
-    value,
-    min,
-    max,
-    step,
-    defaultValue,
-    fineStepDivisor = 10,
+    binding,
     label,
     displayFn,
+    unknownDisplay,
     fillColor,
     fillGradient,
     trackColor = 'var(--v2-bg-gradient-start)',
@@ -59,50 +55,69 @@
     showLabel = true,
     compact = false,
     variant = 'modern',
-    onChange,
-    debounceMs = 0,
-    disabled = false,
     unit = '',
     shortcutHint = null,
     title = null,
     tickLabels = [],
     showAllTicks = true,
     tickStyle = 'notch',
+    legacy,
   }: Props = $props();
 
-  let containerEl: HTMLDivElement | null = $state(null);
-  let isDragging = $state(false);
-  let wheelLocked = $state(false);
-  let wheelUnlockTimer: ReturnType<typeof setTimeout> | null = null;
-  let localValue = $state(untrack(() => value));
+  const feedbackDescriptionId = $props.id();
 
-  function markWheelActive() {
-    wheelLocked = true;
-    if (wheelUnlockTimer) clearTimeout(wheelUnlockTimer);
-    wheelUnlockTimer = setTimeout(() => {
-      wheelLocked = false;
-      wheelUnlockTimer = null;
-    }, 300);
-  }
+  let containerEl: HTMLDivElement | null = $state(null);
+  let activePointer: { id: number; token: number; target: HTMLElement } | null = null;
+  const initialBinding = untrack(() => binding);
+  let attachedBinding = initialBinding;
+  let lease: ContinuousScalarRendererLease = $state(initialBinding.attachRenderer());
 
   $effect(() => {
-    if (!isDragging && !wheelLocked) {
-      localValue = value;
+    if (binding === attachedBinding) return;
+    if (activePointer?.target.hasPointerCapture?.(activePointer.id)) {
+      activePointer.target.releasePointerCapture(activePointer.id);
     }
+    activePointer = null;
+    lease.dispose();
+    attachedBinding = binding;
+    lease = binding.attachRenderer();
+  });
+  onDestroy(() => {
+    if (activePointer?.target.hasPointerCapture?.(activePointer.id)) {
+      activePointer.target.releasePointerCapture(activePointer.id);
+    }
+    activePointer = null;
+    lease.dispose();
   });
 
-  let fillPercent = $derived(getFillPercent(localValue, min, max));
-  let effectiveDefault = $derived(defaultValue ?? min);
+  let view = $state<ContinuousScalarView>(untrack(() => lease.view));
+  let skipViewAssignment = true;
+  $effect(() => {
+    const next = lease.view;
+    if (skipViewAssignment) {
+      skipViewAssignment = false;
+    } else {
+      view = next;
+    }
+  });
+  let renderedValue = $derived(view.displayed);
+  let fillPercent = $derived(!view.domainValid || renderedValue === null
+    ? 0
+    : getFillPercent(renderedValue, view.domain.min, view.domain.max));
   let effectiveFill = $derived(
     fillGradient
       ? `linear-gradient(90deg, ${fillGradient.join(', ')})`
       : (fillColor ?? accentColor),
   );
-  let displayValue = $derived(
-    displayFn ? displayFn(localValue) : `${localValue}${unit ? '\u00a0' + unit : ''}`,
-  );
+  let displayValue = $derived(renderedValue === null
+    ? unknownDisplay ?? (displayFn ? displayFn(Number.NaN) : '—')
+    : displayFn ? displayFn(renderedValue)
+      : `${renderedValue}${unit ? '\u00a0' + unit : ''}`);
+  let renderPresentation = $derived(projectScalarRenderPresentation(view, legacy));
 
   let tickItems = $derived.by(() => {
+    if (!view.domainValid) return [];
+    const { min, max, step } = view.domain;
     const steps = enumerateDiscreteValues(min, max, step);
     if (showAllTicks) {
       return steps.map((v, i) => ({
@@ -140,102 +155,70 @@
 
   let hasTickLabels = $derived(tickItems.some((t) => t.label.length > 0));
 
-  let debouncedOnChange = $derived.by<(...args: unknown[]) => void>(() => {
-    if (debounceMs > 0) {
-      return debounce((v: number) => onChange(v), debounceMs) as (...args: unknown[]) => void;
-    }
-    return ((v: number) => onChange(v)) as (...args: unknown[]) => void;
-  });
-
-  function emitChange(newValue: number, immediate = false) {
-    if (newValue !== localValue) {
-      localValue = newValue;
-    }
-    if (newValue !== value) {
-      if (immediate) {
-        onChange(newValue);
-      } else {
-        debouncedOnChange(newValue);
-      }
-    }
-  }
-
   function handlePointerDown(e: PointerEvent) {
-    if (disabled || !containerEl) return;
+    if (!containerEl) return;
+    const token = lease.beginPointer();
+    if (token === null) return;
 
     e.preventDefault();
     const target = e.currentTarget as HTMLElement;
     target.setPointerCapture(e.pointerId);
-
-    isDragging = true;
+    activePointer = { id: e.pointerId, token, target };
 
     const rect = containerEl.getBoundingClientRect();
-    const newValue = calculateClickValue(e.clientX, rect.left, rect.width, min, max, step);
-    emitChange(newValue, true);
+    const domain = view.domain;
+    const newValue = calculateClickValue(
+      e.clientX, rect.left, rect.width, domain.min, domain.max, domain.step,
+    );
+    lease.pointer(token, newValue);
   }
 
   function handlePointerMove(e: PointerEvent) {
-    if (!isDragging || disabled || !containerEl) return;
+    if (!activePointer || activePointer.id !== e.pointerId || !containerEl) return;
 
     const rect = containerEl.getBoundingClientRect();
-    const newValue = calculateClickValue(e.clientX, rect.left, rect.width, min, max, step);
-    emitChange(newValue, true);
+    const domain = view.domain;
+    const newValue = calculateClickValue(
+      e.clientX, rect.left, rect.width, domain.min, domain.max, domain.step,
+    );
+    lease.pointer(activePointer.token, newValue);
   }
 
   function handlePointerUp(e: PointerEvent) {
-    if (!isDragging) return;
+    if (!activePointer || activePointer.id !== e.pointerId) return;
+    if (activePointer.target.hasPointerCapture?.(e.pointerId)) {
+      activePointer.target.releasePointerCapture(e.pointerId);
+    }
+    lease.endPointer(activePointer.token);
+    activePointer = null;
+  }
 
-    const target = e.currentTarget as HTMLElement;
-    target.releasePointerCapture(e.pointerId);
-    isDragging = false;
+  function handlePointerCancel(e: PointerEvent) {
+    if (!activePointer || activePointer.id !== e.pointerId) return;
+    if (activePointer.target.hasPointerCapture?.(e.pointerId)) {
+      activePointer.target.releasePointerCapture(e.pointerId);
+    }
+    lease.cancelPointer(activePointer.token);
+    activePointer = null;
   }
 
   function handleWheel(e: WheelEvent) {
-    if (disabled) return;
+    if (!view.editable) return;
     e.preventDefault();
-
-    const fine = e.shiftKey && fineStepDivisor > 0;
-    const effectiveStep = fine ? step / fineStepDivisor : step;
-    const direction = e.deltaY > 0 ? -1 : 1;
-    const newValue = clamp(
-      snapToStep(localValue + direction * effectiveStep, effectiveStep, min),
-      min,
-      max,
-    );
-    localValue = newValue;
-    markWheelActive();
-    onChange(newValue);
+    lease.wheel({ direction: e.deltaY > 0 ? -1 : 1, fine: e.shiftKey });
   }
 
   function handleKeyDown(e: KeyboardEvent) {
-    if (disabled) return;
-
-    const newValue = handleKeyboardStep(
-      localValue,
-      e.key,
-      step,
-      fineStepDivisor,
-      min,
-      max,
-      e.shiftKey,
-    );
-    if (newValue !== null) {
-      e.preventDefault();
-      emitChange(newValue);
-    }
+    if (lease.key({ key: e.key, fine: e.shiftKey })) e.preventDefault();
   }
 
-  function handleDoubleClick() {
-    if (disabled) return;
-    if (defaultValue === undefined) return;
-    emitChange(effectiveDefault);
-  }
+  function handleDoubleClick() { lease.reset(); }
 </script>
 
 <div
   class="vc-hbar vc-discrete"
   class:compact
-  class:disabled
+  class:disabled={!view.editable}
   class:hardware={variant === 'hardware'}
   class:hw-illum={variant === 'hardware-illuminated'}
   bind:this={containerEl}
@@ -260,16 +243,19 @@
   <div
     class="vc-track-container"
     role="slider"
-    tabindex={disabled ? -1 : 0}
+    tabindex={view.editable ? 0 : -1}
     aria-label={label}
-    aria-valuemin={min}
-    aria-valuemax={max}
-    aria-valuenow={value}
-    aria-disabled={disabled}
+    aria-valuemin={view.domainValid ? view.domain.min : undefined}
+    aria-valuemax={view.domainValid ? view.domain.max : undefined}
+    aria-valuenow={view.domainValid ? view.canonical ?? undefined : undefined}
+    aria-disabled={!view.editable}
+    aria-busy={renderPresentation.attributes['aria-busy']}
+    aria-describedby={renderPresentation.description !== null ? feedbackDescriptionId : undefined}
+    data-command-phase={renderPresentation.attributes['data-command-phase'] ?? undefined}
     onpointerdown={handlePointerDown}
     onpointermove={handlePointerMove}
     onpointerup={handlePointerUp}
-    onpointercancel={handlePointerUp}
+    onpointercancel={handlePointerCancel}
     onwheel={handleWheel}
     onkeydown={handleKeyDown}
     ondblclick={handleDoubleClick}
@@ -282,7 +268,7 @@
               {#each tickItems as t (t.value)}
                 <div
                   class="vc-discrete-led-segment"
-                  class:active={t.value <= localValue + 1e-9}
+                  class:active={renderedValue !== null && t.value <= renderedValue + 1e-9}
                 ></div>
               {/each}
             </div>
@@ -308,7 +294,7 @@
           {#each tickItems as t (t.value)}
             <div
               class="vc-discrete-ruler-tick"
-              class:active={t.value <= localValue + 1e-9}
+              class:active={renderedValue !== null && t.value <= renderedValue + 1e-9}
               class:major={t.rulerMajor}
               style:left="{t.percent}%"
             ></div>
@@ -322,7 +308,7 @@
             {#each tickItems as t (t.value)}
               <div
                 class="vc-discrete-led-segment"
-                class:active={t.value <= localValue + 1e-9}
+                class:active={renderedValue !== null && t.value <= renderedValue + 1e-9}
               ></div>
             {/each}
           </div>
@@ -345,7 +331,7 @@
           {#each tickItems as t (t.value)}
             <div
               class="vc-discrete-ruler-tick"
-              class:active={t.value <= localValue + 1e-9}
+              class:active={renderedValue !== null && t.value <= renderedValue + 1e-9}
               class:major={t.rulerMajor}
               style:left="{t.percent}%"
             ></div>
@@ -360,7 +346,7 @@
             {#each tickItems as t (t.value)}
               <div
                 class="vc-discrete-led-segment"
-                class:active={t.value <= localValue + 1e-9}
+                class:active={renderedValue !== null && t.value <= renderedValue + 1e-9}
               ></div>
             {/each}
           </div>
@@ -382,7 +368,7 @@
           {#each tickItems as t (t.value)}
             <div
               class="vc-discrete-ruler-tick"
-              class:active={t.value <= localValue + 1e-9}
+              class:active={renderedValue !== null && t.value <= renderedValue + 1e-9}
               class:major={t.rulerMajor}
               style:left="{t.percent}%"
             ></div>
@@ -394,6 +380,19 @@
       {/if}
     {/if}
   </div>
+
+  {#if renderPresentation.description !== null}
+    <span id={feedbackDescriptionId} class="sr-only">{renderPresentation.description}</span>
+  {/if}
+  {#if renderPresentation.status !== null}
+    <span
+      class="sr-only"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-control-feedback-status
+    >{renderPresentation.status}{renderPresentation.error === null ? '' : `: ${renderPresentation.error}`}</span>
+  {/if}
 
   {#if hasTickLabels}
     <div class="vc-discrete-label-row" aria-hidden="true">
@@ -435,6 +434,11 @@
   .vc-value {
     color: var(--vc-text-value, var(--v2-text-bright));
     font-family: 'Roboto Mono', monospace;
+  }
+
+  .sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
   }
 
   .disabled {

--- a/frontend/src/components-v2/controls/value-control/DiscreteRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/DiscreteRenderer.svelte
@@ -39,6 +39,7 @@
     showAllTicks?: boolean;
     /** Visual style for discrete step marks. */
     tickStyle?: 'ruler' | 'led' | 'notch';
+    dimmed?: boolean;
     legacy?: LegacyReadingPresentation;
   }
 
@@ -61,6 +62,7 @@
     tickLabels = [],
     showAllTicks = true,
     tickStyle = 'notch',
+    dimmed,
     legacy,
   }: Props = $props();
 
@@ -114,6 +116,7 @@
     : displayFn ? displayFn(renderedValue)
       : `${renderedValue}${unit ? '\u00a0' + unit : ''}`);
   let renderPresentation = $derived(projectScalarRenderPresentation(view, legacy));
+  let effectiveDimmed = $derived(dimmed ?? !view.editable);
 
   let tickItems = $derived.by(() => {
     if (!view.domainValid) return [];
@@ -218,7 +221,8 @@
 <div
   class="vc-hbar vc-discrete"
   class:compact
-  class:disabled={!view.editable}
+  class:interaction-disabled={!view.editable}
+  class:dimmed={effectiveDimmed}
   class:hardware={variant === 'hardware'}
   class:hw-illum={variant === 'hardware-illuminated'}
   bind:this={containerEl}
@@ -441,8 +445,11 @@
     overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
   }
 
-  .disabled {
+  .dimmed {
     opacity: 0.4;
+  }
+
+  .interaction-disabled {
     pointer-events: none;
   }
 

--- a/frontend/src/components-v2/controls/value-control/ValueControl.svelte
+++ b/frontend/src/components-v2/controls/value-control/ValueControl.svelte
@@ -166,7 +166,7 @@
         reading: Number.isFinite(value)
           ? { status: 'known' as const, value }
           : { status: 'unknown' as const },
-        ownerKey: `${mountId}:${optimistic}:${debounceMs}`,
+        ownerKey: `${mountId}:${scalarPolicy.name}:${debounceMs}`,
       }),
       adapterPolicy,
     );

--- a/frontend/src/components-v2/controls/value-control/ValueControl.svelte
+++ b/frontend/src/components-v2/controls/value-control/ValueControl.svelte
@@ -9,6 +9,7 @@
   import {
     createBipolarContinuousScalarPolicy,
     createContinuousScalar,
+    createDiscreteContinuousScalarPolicy,
     createHBarContinuousScalarPolicy,
     type ContinuousScalarBinding,
     type ContinuousScalarPolicy,
@@ -59,7 +60,7 @@
 
   interface BoundContinuousProps {
     binding: ContinuousScalarBinding;
-    renderer: 'hbar' | 'bipolar';
+    renderer: 'hbar' | 'bipolar' | 'discrete';
     value?: undefined;
     min?: undefined;
     max?: undefined;
@@ -124,7 +125,10 @@
     debounceMs,
   }));
   let bipolarPolicy = $derived(createBipolarContinuousScalarPolicy({ debounceMs }));
-  let scalarPolicy = $derived(renderer === 'bipolar' ? bipolarPolicy : hbarPolicy);
+  let discretePolicy = $derived(createDiscreteContinuousScalarPolicy({ debounceMs }));
+  let scalarPolicy = $derived(renderer === 'bipolar'
+    ? bipolarPolicy
+    : renderer === 'discrete' ? discretePolicy : hbarPolicy);
   const adapterPolicy: ContinuousScalarPolicy = {
     get name() { return scalarPolicy.name; },
     get preview() { return scalarPolicy.preview; },
@@ -219,7 +223,6 @@
     title,
   });
   let knobProps = $derived({ ...commonProps, arcAngle, tickCount, tickLabels });
-  let discreteProps = $derived({ ...commonProps, tickLabels, showAllTicks, tickStyle });
   let legacy = $derived<LegacyReadingPresentation>({
     phase: feedbackPhase,
     busy: feedbackBusy,
@@ -265,5 +268,10 @@
 {:else if renderer === 'knob'}
   <KnobRenderer {...knobProps} />
 {:else if renderer === 'discrete'}
-  <DiscreteRenderer {...discreteProps} />
+  <DiscreteRenderer
+    binding={scalarBinding} {label} {displayFn} {unknownDisplay}
+    {fillColor} {fillGradient} {trackColor}
+    {accentColor} {showValue} {showLabel} {compact} {variant} {unit} {shortcutHint} {title}
+    {tickLabels} {showAllTicks} {tickStyle} {legacy}
+  />
 {/if}

--- a/frontend/src/components-v2/controls/value-control/ValueControl.svelte
+++ b/frontend/src/components-v2/controls/value-control/ValueControl.svelte
@@ -270,6 +270,7 @@
 {:else if renderer === 'discrete'}
   <DiscreteRenderer
     binding={scalarBinding} {label} {displayFn} {unknownDisplay}
+    dimmed={externalBinding === undefined ? disabled : undefined}
     {fillColor} {fillGradient} {trackColor}
     {accentColor} {showValue} {showLabel} {compact} {variant} {unit} {shortcutHint} {title}
     {tickLabels} {showAllTicks} {tickStyle} {legacy}

--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
@@ -647,6 +647,39 @@ describe('ValueControl controlled Bipolar rendering', () => {
 });
 
 describe('ValueControl controlled Discrete rendering', () => {
+  it.each([
+    ['optimistic', false],
+    ['keyboardStep', 5],
+  ] as const)('keeps a pending Discrete request when ignored raw %s changes', (prop, next) => {
+    vi.useFakeTimers();
+    try {
+      const onChange = vi.fn();
+      const { state, target } = mountReactive({
+        value: 20,
+        min: 0,
+        max: 100,
+        step: 10,
+        keyboardStep: 40,
+        optimistic: true,
+        label: 'Ignored authority input',
+        renderer: 'discrete',
+        debounceMs: 50,
+        onChange,
+      });
+
+      slider(target).dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+      );
+      state[prop] = next;
+      flushSync();
+      vi.advanceTimersByTime(50);
+
+      expect(onChange).toHaveBeenCalledExactlyOnceWith(30);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('cancels a Discrete pointer draft and reconciles rejected wheel state at expiry', () => {
     vi.useFakeTimers();
     const onChange = vi.fn();
@@ -774,5 +807,61 @@ describe('ValueControl controlled Discrete rendering', () => {
     flushSync();
     expect(visibleValue(target)).toBe('UNKNOWN');
     expect(slider(target).getAttribute('aria-disabled')).toBe('true');
+  });
+});
+
+describe('ValueControl raw effective behavior authority', () => {
+  it('keeps a pending Bipolar request when ignored raw optimistic changes', () => {
+    vi.useFakeTimers();
+    try {
+      const onChange = vi.fn();
+      const { state, target } = mountReactive({
+        value: 0,
+        min: -100,
+        max: 100,
+        step: 5,
+        optimistic: true,
+        label: 'Ignored Bipolar preview',
+        renderer: 'bipolar',
+        debounceMs: 50,
+        onChange,
+      });
+
+      slider(target).dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+      );
+      state.optimistic = false;
+      flushSync();
+      vi.advanceTimersByTime(50);
+
+      expect(onChange).toHaveBeenCalledExactlyOnceWith(5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cancels a pending HBar request when raw optimistic changes effective preview', () => {
+    vi.useFakeTimers();
+    try {
+      const onChange = vi.fn();
+      const { state, target } = mountReactive({
+        ...baseProps,
+        optimistic: true,
+        debounceMs: 50,
+        onChange,
+      });
+
+      slider(target).dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+      );
+      state.optimistic = false;
+      flushSync();
+      vi.advanceTimersByTime(50);
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(visibleValue(target)).toContain('20');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
@@ -4,6 +4,7 @@ import ValueControl from '../ValueControl.svelte';
 import {
   createBipolarContinuousScalarPolicy,
   createContinuousScalar,
+  createDiscreteContinuousScalarPolicy,
   createHBarContinuousScalarPolicy,
   type CommandScalarFeedback,
   type ContinuousScalarBinding,
@@ -129,6 +130,20 @@ function bipolarBinding(value: number, request: (value: number) => void): Contin
       request,
     }),
     createBipolarContinuousScalarPolicy({ debounceMs: 0 }),
+  );
+}
+
+function discreteBinding(value: number, request: (value: number) => void): ContinuousScalarBinding {
+  return createContinuousScalar(
+    () => ({
+      evidence: 'reading',
+      reading: { status: 'known', value },
+      ownerKey: `external-discrete-${value}`,
+      domain: { min: 0, max: 10, step: 1, defaultValue: null, fineStepDivisor: 10 },
+      enabled: true,
+      request,
+    }),
+    createDiscreteContinuousScalarPolicy({ debounceMs: 0 }),
   );
 }
 
@@ -495,8 +510,10 @@ describe('ValueControl controlled Bipolar rendering', () => {
     });
     const control = slider(target) as HTMLElement & {
       setPointerCapture?: (pointerId: number) => void;
+      releasePointerCapture?: (pointerId: number) => void;
     };
     control.setPointerCapture = vi.fn();
+    control.releasePointerCapture = vi.fn();
     vi.spyOn(target.querySelector('.vc-bipolar') as HTMLElement, 'getBoundingClientRect')
       .mockReturnValue({ left: 0, width: 100 } as DOMRect);
 
@@ -621,6 +638,137 @@ describe('ValueControl controlled Bipolar rendering', () => {
     });
 
     expect(visibleValue(target)).toBe('KNOWN:25');
+    expect(slider(target).getAttribute('aria-valuenow')).toBeNull();
+    state.value = Number.NaN;
+    flushSync();
+    expect(visibleValue(target)).toBe('UNKNOWN');
+    expect(slider(target).getAttribute('aria-disabled')).toBe('true');
+  });
+});
+
+describe('ValueControl controlled Discrete rendering', () => {
+  it('cancels a Discrete pointer draft and reconciles rejected wheel state at expiry', () => {
+    vi.useFakeTimers();
+    const onChange = vi.fn();
+    const { target } = mountReactive({
+      value: 4,
+      min: 0,
+      max: 10,
+      step: 1,
+      label: 'Discrete lifecycle',
+      renderer: 'discrete',
+      debounceMs: 0,
+      onChange,
+    });
+    const control = slider(target) as HTMLElement & {
+      setPointerCapture?: (pointerId: number) => void;
+      releasePointerCapture?: (pointerId: number) => void;
+    };
+    control.setPointerCapture = vi.fn();
+    control.releasePointerCapture = vi.fn();
+    vi.spyOn(target.querySelector('.vc-discrete') as HTMLElement, 'getBoundingClientRect')
+      .mockReturnValue({ left: 0, width: 100 } as DOMRect);
+
+    control.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true, clientX: 80, pointerId: 1,
+    }));
+    control.dispatchEvent(new PointerEvent('pointercancel', { bubbles: true, pointerId: 1 }));
+    control.dispatchEvent(new PointerEvent('pointermove', {
+      bubbles: true, clientX: 100, pointerId: 1,
+    }));
+    flushSync();
+    expect(onChange.mock.calls).toEqual([[8]]);
+    expect(visibleValue(target)).toBe('4');
+
+    control.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true, cancelable: true }));
+    flushSync();
+    expect(onChange).toHaveBeenLastCalledWith(5);
+    expect(visibleValue(target)).toBe('5');
+    vi.advanceTimersByTime(300);
+    flushSync();
+    expect(visibleValue(target)).toBe('4');
+    vi.useRealTimers();
+  });
+
+  it('replaces HBar with Discrete on the same external owner and revokes retained callbacks', () => {
+    const request = vi.fn();
+    const binding = discreteBinding(4, request);
+    const { state, target } = mountReactive({ binding, label: 'Replaceable', renderer: 'hbar' });
+    const retainedHBar = slider(target);
+
+    state.renderer = 'discrete';
+    flushSync();
+    expect(target.querySelector('.vc-discrete')).not.toBeNull();
+    expect(visibleValue(target)).toBe('4');
+
+    retainedHBar.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(request).not.toHaveBeenCalled();
+    slider(target).dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(request).toHaveBeenCalledExactlyOnceWith(5);
+
+    const retainedLease = binding.attachRenderer();
+    expect(retainedLease.beginPointer()).not.toBeNull();
+    retainedLease.dispose();
+    binding.destroy();
+  });
+
+  it('preserves full command feedback and one-shot announcement identity in Discrete', () => {
+    const binding = commandBinding(vi.fn(), {
+      phase: 'failed',
+      busy: false,
+      outcome: { phase: 'failed', error: 'radio rejected' },
+      transitionId: 'failed-discrete',
+    });
+    const { state, target } = mountReactive({ binding, label: 'Feedback', renderer: 'hbar' });
+    expect(target.querySelector('[data-control-feedback-status]')?.textContent)
+      .toBe('Failed: 30 Hz: radio rejected');
+
+    state.renderer = 'discrete';
+    flushSync();
+    const replacement = slider(target);
+    expect(replacement.getAttribute('data-command-phase')).toBe('failed');
+    expect(replacement.getAttribute('aria-busy')).toBe('false');
+    const descriptionId = replacement.getAttribute('aria-describedby');
+    expect(target.querySelector(`#${descriptionId}`)?.textContent).toBe('30 Hz');
+    expect(target.querySelector('[data-control-feedback-status]')).toBeNull();
+    binding.destroy();
+  });
+
+  it.each([
+    [Number.POSITIVE_INFINITY, '+INF'],
+    [Number.NEGATIVE_INFINITY, '-INF'],
+    [Number.NaN, 'NAN'],
+  ] as const)('keeps exact legacy formatting for nonfinite Discrete input %s', (value, expected) => {
+    const { target } = mountReactive({
+      value,
+      min: 0,
+      max: 10,
+      step: 1,
+      label: 'Nonfinite',
+      renderer: 'discrete',
+      onChange: vi.fn(),
+      displayFn: (candidate: number) => Number.isNaN(candidate) ? 'NAN'
+        : candidate === Number.POSITIVE_INFINITY ? '+INF' : '-INF',
+    });
+
+    expect(visibleValue(target)).toBe(expected);
+    expect(slider(target).getAttribute('aria-valuenow')).toBeNull();
+    expect(slider(target).getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('distinguishes known invalid-domain Discrete evidence from an unknown reading', () => {
+    const { state, target } = mountReactive({
+      value: 4,
+      min: 0,
+      max: Number.NaN,
+      step: 1,
+      label: 'Domain',
+      renderer: 'discrete',
+      onChange: vi.fn(),
+      displayFn: (candidate: number) => Number.isNaN(candidate) ? 'UNKNOWN' : `KNOWN:${candidate}`,
+    });
+
+    expect(visibleValue(target)).toBe('KNOWN:4');
     expect(slider(target).getAttribute('aria-valuenow')).toBeNull();
     state.value = Number.NaN;
     flushSync();

--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import ValueControl from '../ValueControl.svelte';
+import DiscreteRenderer from '../DiscreteRenderer.svelte';
 import {
   createBipolarContinuousScalarPolicy,
   createContinuousScalar,
@@ -647,6 +648,120 @@ describe('ValueControl controlled Bipolar rendering', () => {
 });
 
 describe('ValueControl controlled Discrete rendering', () => {
+  it('keeps a raw unknown reading undimmed but noninteractive without numeric value ARIA', () => {
+    const onChange = vi.fn();
+    const { target } = mountReactive({
+      value: Number.NaN,
+      min: 0,
+      max: 100,
+      step: 10,
+      disabled: false,
+      label: 'Unknown raw Discrete',
+      renderer: 'discrete',
+      onChange,
+    });
+    const wrapper = target.querySelector('.vc-discrete')!;
+    const control = slider(target);
+
+    expect(wrapper.classList.contains('dimmed')).toBe(false);
+    expect(wrapper.classList.contains('disabled')).toBe(false);
+    expect(wrapper.classList.contains('interaction-disabled')).toBe(true);
+    expect(control.getAttribute('aria-valuenow')).toBeNull();
+    expect(control.getAttribute('aria-disabled')).toBe('true');
+    expect(control.getAttribute('tabindex')).toBe('-1');
+    control.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    control.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('dims an explicitly disabled raw Discrete without changing owner editability', () => {
+    const { target } = mountReactive({
+      value: 20,
+      min: 0,
+      max: 100,
+      step: 10,
+      disabled: true,
+      label: 'Disabled raw Discrete',
+      renderer: 'discrete',
+      onChange: vi.fn(),
+    });
+
+    expect(target.querySelector('.vc-discrete')?.classList.contains('dimmed')).toBe(true);
+    expect(target.querySelector('.vc-discrete')?.classList.contains('interaction-disabled')).toBe(true);
+    expect(slider(target).getAttribute('aria-disabled')).toBe('true');
+    expect(slider(target).getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('retains default noneditable dimming for a direct external binding', () => {
+    const binding = createContinuousScalar(
+      () => ({
+        evidence: 'reading',
+        reading: { status: 'unknown' },
+        ownerKey: 'external-unknown-discrete',
+        domain: { min: 0, max: 100, step: 10, defaultValue: null, fineStepDivisor: 10 },
+        enabled: true,
+        request: vi.fn(),
+      }),
+      createDiscreteContinuousScalarPolicy({ debounceMs: 0 }),
+    );
+    const { target } = mountReactive({
+      binding,
+      label: 'External unknown Discrete',
+      renderer: 'discrete',
+    });
+
+    expect(target.querySelector('.vc-discrete')?.classList.contains('dimmed')).toBe(true);
+    expect(target.querySelector('.vc-discrete')?.classList.contains('interaction-disabled')).toBe(true);
+    expect(slider(target).getAttribute('aria-disabled')).toBe('true');
+    binding.destroy();
+  });
+
+  it('keeps pending owner work intact when direct renderer dimming changes', () => {
+    vi.useFakeTimers();
+    const request = vi.fn();
+    const binding = createContinuousScalar(
+      () => ({
+        evidence: 'reading',
+        reading: { status: 'known', value: 20 },
+        ownerKey: 'direct-cosmetic-discrete',
+        domain: { min: 0, max: 100, step: 10, defaultValue: null, fineStepDivisor: 10 },
+        enabled: true,
+        request,
+      }),
+      createDiscreteContinuousScalarPolicy({ debounceMs: 50 }),
+    );
+    const state = $state({
+      binding,
+      label: 'Direct cosmetic Discrete',
+      dimmed: false,
+    });
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    roots.push(target);
+    const component = mount(DiscreteRenderer, { target, props: state });
+    components.push(component);
+    flushSync();
+
+    try {
+      slider(target).dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+      );
+      state.dimmed = true;
+      flushSync();
+      expect(target.querySelector('.vc-discrete')?.classList.contains('dimmed')).toBe(true);
+      expect(target.querySelector('.vc-discrete')?.classList.contains('interaction-disabled')).toBe(false);
+      expect(slider(target).getAttribute('aria-disabled')).toBe('false');
+      expect(slider(target).getAttribute('tabindex')).toBe('0');
+      expect(visibleValue(target)).toBe('30');
+
+      vi.advanceTimersByTime(50);
+      expect(request).toHaveBeenCalledExactlyOnceWith(30);
+    } finally {
+      binding.destroy();
+      vi.useRealTimers();
+    }
+  });
+
   it.each([
     ['optimistic', false],
     ['keyboardStep', 5],

--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.test.ts
@@ -5,6 +5,7 @@ import ValueControl from '../ValueControl.svelte';
 import {
   createBipolarContinuousScalarPolicy,
   createContinuousScalar,
+  createDiscreteContinuousScalarPolicy,
   createHBarContinuousScalarPolicy,
 } from '../../../../primitives/scalar/continuous-scalar.svelte';
 
@@ -84,6 +85,31 @@ describe('ValueControl wrapper', () => {
     expect(getSlider(target).getAttribute('aria-valuemax')).toBe('100');
     expect(target.querySelector('.vc-bipolar')?.getAttribute('style'))
       .toContain('--vc-current: 37.5%');
+    binding.destroy();
+  });
+
+  it('renders a caller-owned Discrete binding synchronously without raw bounds', () => {
+    const binding = createContinuousScalar(
+      () => ({
+        evidence: 'reading' as const,
+        reading: { status: 'known' as const, value: 4 },
+        ownerKey: 'direct-discrete',
+        domain: { min: 0, max: 8, step: 1, defaultValue: null, fineStepDivisor: 10 },
+        enabled: true,
+        request: vi.fn(),
+      }),
+      createDiscreteContinuousScalarPolicy({ debounceMs: 0 }),
+    );
+
+    const target = mountControl({
+      binding, label: 'Direct discrete', renderer: 'discrete', tickStyle: 'led',
+    });
+
+    expect(getValueDisplay(target)?.textContent).toBe('4');
+    expect(getSlider(target).getAttribute('aria-valuemin')).toBe('0');
+    expect(getSlider(target).getAttribute('aria-valuemax')).toBe('8');
+    expect(target.querySelector('.vc-discrete')?.getAttribute('style'))
+      .toContain('--vc-fill-percent: 50%');
     binding.destroy();
   });
 

--- a/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
@@ -99,6 +99,19 @@ describe('CwPanel component rendering', () => {
     const t = mountPanel();
     const labels = Array.from(t.querySelectorAll('.vc-label'));
     expect(labels.some((el) => el.textContent === 'Key Speed')).toBe(true);
+    expect(t.querySelector('.vc-discrete')).not.toBeNull();
+  });
+
+  it('dispatches Key Speed through its Discrete facade binding', () => {
+    vi.useFakeTimers();
+    const t = mountPanel({ keySpeed: 12 });
+    const control = t.querySelector<HTMLElement>('[aria-label="Key Speed"]')!;
+
+    control.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    vi.advanceTimersByTime(50);
+
+    expect(mockHandlers.onKeySpeedChange).toHaveBeenCalledExactlyOnceWith(13);
+    vi.useRealTimers();
   });
 
   it('renders SEMI break-in button', () => {

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
@@ -93,6 +93,22 @@ function mountPanel(overrides?: Partial<typeof mockProps>) {
   return t;
 }
 
+function openLongPressModal(t: HTMLElement, buttonPrefix: string): void {
+  vi.useFakeTimers();
+  const button = Array.from(t.querySelectorAll<HTMLButtonElement>('.dsp-btn-wrap button')).find(
+    (candidate) => candidate.textContent?.trim().startsWith(buttonPrefix),
+  );
+  if (buttonPrefix === 'AGC-T') {
+    button?.click();
+    flushSync();
+    return;
+  }
+  button?.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+  vi.advanceTimersByTime(600);
+  flushSync();
+  vi.useRealTimers();
+}
+
 beforeEach(() => {
   resetCommandLifecycle();
   components = [];
@@ -171,6 +187,29 @@ describe('DspPanel component rendering', () => {
     unmount(comp);
     expect(t.innerHTML).toBe('');
   });
+});
+
+describe('DspPanel Discrete facade mounts', () => {
+  it.each([
+    ['NR', 'Noise reduction settings', 'NR Level', 'onNrLevelChange', 6],
+    ['NB', 'Noise blanker settings', 'NB Depth', 'onNbDepthChange', 1],
+    ['AGC-T', 'AGC time settings', 'AGC Time', 'onAgcTimeChange', 1],
+  ] as const)(
+    'renders and dispatches the %s Discrete mount',
+    (button, dialogLabel, controlLabel, handler, expected) => {
+      const t = mountPanel({ nbActive: true });
+      openLongPressModal(t, button);
+      const dialog = t.querySelector<HTMLElement>(`[aria-label="${dialogLabel}"]`)!;
+      const control = dialog.querySelector<HTMLElement>(`[aria-label="${controlLabel}"]`)!;
+
+      expect(control.closest('.vc-discrete')).not.toBeNull();
+      vi.useFakeTimers();
+      control.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+      vi.advanceTimersByTime(50);
+      expect(mockHandlers[handler]).toHaveBeenCalledExactlyOnceWith(expected);
+      vi.useRealTimers();
+    },
+  );
 });
 
 describe('DspPanel NB modal depth/width gating (MOR-502)', () => {

--- a/frontend/src/components-v2/panels/__tests__/VoxPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/VoxPanel.component.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import VoxPanel from '../VoxPanel.svelte';
+
+const components: ReturnType<typeof mount>[] = [];
+
+afterEach(() => {
+  components.splice(0).forEach((component) => unmount(component));
+  vi.useRealTimers();
+  document.body.innerHTML = '';
+});
+
+function mountPanel(overrides: Record<string, unknown> = {}) {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  components.push(mount(VoxPanel, { target, props: {
+    voxOn: true,
+    voxGain: 128,
+    antiVoxGain: 64,
+    voxDelay: 7,
+    onVoxToggle: vi.fn(),
+    onVoxGainChange: vi.fn(),
+    onAntiVoxGainChange: vi.fn(),
+    onVoxDelayChange: vi.fn(),
+    ...overrides,
+  } }));
+  flushSync();
+  return target;
+}
+
+describe('VoxPanel Discrete delay mount', () => {
+  it('renders the delay through Discrete with the established seconds formatter', () => {
+    const target = mountPanel();
+    const control = target.querySelector<HTMLElement>('[aria-label="VOX Delay"]')!;
+
+    expect(control.closest('.vc-discrete')).not.toBeNull();
+    expect(control.closest('.vc-discrete')?.querySelector('.vc-value')?.textContent).toBe('0.7s');
+  });
+
+  it('dispatches one declared delay step through the facade binding', () => {
+    vi.useFakeTimers();
+    const onVoxDelayChange = vi.fn();
+    const target = mountPanel({ onVoxDelayChange });
+    const control = target.querySelector<HTMLElement>('[aria-label="VOX Delay"]')!;
+
+    control.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    flushSync();
+    expect(control.closest('.vc-discrete')?.querySelector('.vc-value')?.textContent).toBe('0.8s');
+    vi.advanceTimersByTime(50);
+
+    expect(onVoxDelayChange).toHaveBeenCalledExactlyOnceWith(8);
+  });
+});

--- a/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
+++ b/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
@@ -3,6 +3,7 @@ import type { ControlFeedback } from '$lib/runtime/adapters/panel-adapters';
 import {
   createBipolarContinuousScalarPolicy,
   createContinuousScalar,
+  createDiscreteContinuousScalarPolicy,
   createHBarContinuousScalarPolicy,
   nativeRangeContinuousScalarPolicy,
   type CommandScalarFeedback,
@@ -216,6 +217,55 @@ describe('continuous scalar contract', () => {
 });
 
 describe('continuous scalar source policies', () => {
+  it('keeps Discrete ordinary and fine wheel increments distinct from HBar', () => {
+    const policy = createDiscreteContinuousScalarPolicy({ debounceMs: 0 });
+    const domain = { min: 0, max: 10, step: 2, defaultValue: null, fineStepDivisor: 4 };
+
+    expect(policy.wheel(4, { direction: 1, fine: false }, domain)).toBe(6);
+    expect(policy.wheel(4, { direction: -1, fine: true }, domain)).toBe(3.5);
+    expect(createHBarContinuousScalarPolicy({ preview: 'optimistic', debounceMs: 0 })
+      .wheel(4, { direction: 1, fine: false }, domain)).toBe(10);
+  });
+
+  it('ignores Discrete keyboardStep while preserving declared-step keyboard behavior', () => {
+    const policy = createDiscreteContinuousScalarPolicy({ debounceMs: 0 });
+    const { scalar, request } = readingSetup(policy, {
+      domain: { min: 0, max: 10, step: 2, defaultValue: null, fineStepDivisor: 4, keyboardStep: Infinity },
+      reading: { status: 'known', value: 4 },
+    });
+
+    expect(scalar.view.domainValid).toBe(true);
+    expect('keyboardStep' in scalar.view.domain).toBe(false);
+    scalar.attachRenderer().key({ key: 'ArrowRight', fine: false });
+    expect(request).toHaveBeenCalledExactlyOnceWith(6);
+  });
+
+  it('keeps absent Discrete reset inert while HBar resets to min', () => {
+    const domain = { min: 0, max: 10, step: 1, defaultValue: null, fineStepDivisor: 10 };
+    const discrete = readingSetup(createDiscreteContinuousScalarPolicy({ debounceMs: 0 }), {
+      domain, reading: { status: 'known', value: 5 },
+    });
+    const hbar = readingSetup(createHBarContinuousScalarPolicy({ preview: 'optimistic', debounceMs: 0 }), {
+      domain, reading: { status: 'known', value: 5 },
+    });
+
+    discrete.scalar.attachRenderer().reset();
+    hbar.scalar.attachRenderer().reset();
+    expect(discrete.request).not.toHaveBeenCalled();
+    expect(hbar.request).toHaveBeenCalledExactlyOnceWith(0);
+  });
+
+  it('dispatches a Discrete wheel at the canonical boundary', () => {
+    const policy = createDiscreteContinuousScalarPolicy({ debounceMs: 0 });
+    const { scalar, request } = readingSetup(policy, {
+      domain: { min: 0, max: 10, step: 1, defaultValue: null, fineStepDivisor: 10 },
+      reading: { status: 'known', value: 10 },
+    });
+
+    scalar.attachRenderer().wheel({ direction: 1, fine: false });
+    expect(request).toHaveBeenCalledExactlyOnceWith(10);
+  });
+
   it.each([0, -50, Number.NaN, 2.5, Number.POSITIVE_INFINITY])(
     'adapts invalid Bipolar keyboard hint %s without weakening the radio domain',
     (keyboardStep) => {

--- a/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
+++ b/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
@@ -191,6 +191,43 @@ export function createHBarContinuousScalarPolicy(
   return Object.freeze(policy);
 }
 
+export function createDiscreteContinuousScalarPolicy(
+  options: Readonly<{
+    debounceMs: number;
+    describeTarget?: (value: number) => string;
+  }>,
+): Readonly<ContinuousScalarPolicy> {
+  const debounce = options.debounceMs > 0
+    ? Object.freeze({ debounceMs: options.debounceMs })
+    : 'immediate';
+  const policy: ContinuousScalarPolicy = {
+    name: 'discrete',
+    preview: 'optimistic',
+    resolveKeyboardStep: () => undefined,
+    normalize: (value, domain) => Number.isFinite(value)
+      ? clamp(value, domain.min, domain.max) : null,
+    wheel: (current, event, domain) => {
+      const quantum = event.fine ? domain.step / domain.fineStepDivisor : domain.step;
+      return snap(current + event.direction * quantum, domain, quantum);
+    },
+    key: (current, event, domain) => handleKeyboardStep(
+      current,
+      event.key,
+      domain.step,
+      domain.fineStepDivisor,
+      domain.min,
+      domain.max,
+      event.fine,
+    ),
+    reset: (domain) => domain.defaultValue,
+    dispatch: (source) => source === 'keyboard' || source === 'reset' ? debounce : 'immediate',
+    dispatchesCanonical: (source) => source === 'wheel',
+    wheelIdleMs: 300,
+    describeTarget: options.describeTarget ?? String,
+  };
+  return Object.freeze(policy);
+}
+
 function bipolarLatticeCompatible(increment: number, domain: ScalarDomain): boolean {
   return Number.isFinite(increment)
     && increment > 0


### PR DESCRIPTION
## Scope

- Linked Linear issue: [MOR-2394](https://linear.app/morozsm/issue/MOR-2394/adopt-all-five-discrete-control-mounts-through-the-shared-scalar)
- Adopt the five existing Discrete mounts (CW Key Speed; DSP NR Level, NB Depth, AGC Time; VOX Delay) through the shared continuous-scalar binding without editing panel production sources.
- Add the Discrete interaction policy: optimistic drafts, immediate absolute pointer input, one-step/fine-step wheel behavior, canonical-boundary wheel dispatch, 300 ms wheel reconciliation, declared-step debounced keyboard input, and explicit-default-only reset.
- Preserve ruler/LED/notch ticks, compact layout, hardware variants, legacy decoration, and exact raw nonfinite formatting.
- Compatibility impact: **API**. The direct `DiscreteRenderer` component API now requires `binding` and no longer accepts raw value/domain/callback props. `ValueControl renderer="discrete"` remains raw-compatible and now also supports caller-owned bindings. Historical raw semantics remain: `keyboardStep` and `optimistic` do not alter Discrete behavior.
- Size: 842 added/deleted lines across the exact nine-file lease, within the expected 650-900 range and below the 1,000-line hard cap.

## First Review Correction

- Addressed BLOCKED review on `3ab8cf3c7cffefbbfde291ed852acced25e8fbf2`.
- Raw authority uses effective policy identity plus debounce. Ignored `optimistic` changes no longer cancel pending Discrete or Bipolar requests; HBar preview changes remain authority-changing.
- Reactive coverage also proves ignored Discrete `keyboardStep` changes preserve pending work.
- Restoring the old raw key made both ignored-`optimistic` witnesses fail with zero requests, while the ignored-`keyboardStep` and HBar invalidation witnesses passed.

## Visual Parity Correction

- Addressed the repeated 4/36 visual failure on `1fc403edab1fffce1ece0309d5350814bd0ca225`, independently localized to unintended 40% opacity on unavailable raw Key Speed.
- Discrete now separates `interaction-disabled` pointer blocking from cosmetic `dimmed` opacity.
- Raw ValueControl passes its explicit raw `disabled` value as the dimming override. Thus an unknown raw reading remains undimmed but noneditable, unfocusable, and without numeric value ARIA; explicit disabled remains dimmed.
- Caller-owned external bindings retain the prior default: a noneditable view is dimmed when no override is supplied.
- Direct cosmetic dimming changes do not alter editability, ARIA, focus, pending drafts, or request delivery.
- Restoring the old combined `.disabled` coupling made all four visual/authority witnesses fail.
- No baseline, PNG, threshold, primitive view, owner, callback, panel source, or skin change.

## Verification

- [x] Focused Vitest slice: 7 files, 203 tests passed
- [x] `npm run check`: zero Svelte/TypeScript diagnostics
- [x] ESLint on all nine leased paths
- [x] `git diff --check`
- [x] Existing `control-feedback-debt-inventory.test.ts` passed read-only; no baseline or debt inventory edits
- [x] Original reset and canonical-boundary wheel mutation controls failed their targeted tests
- [x] First-correction restored-key control failed the two ignored-`optimistic` witnesses
- [x] Second-correction restored opacity/editability coupling failed all four focused witnesses
- [x] Public/open-core boundary checked
- [x] No release, CLI, config, wire, or documentation impact
- Full/quick/visual suites were not run locally; required Ready-PR automation is the final suite evidence.

## Agent Review

- [x] Fresh independent exact-head review comment posted before merge
- Result: PASS at 5e323b39b8484720a9f6cb78027c1f151658b47d; https://github.com/rigplane/rigplane-core/pull/3248#issuecomment-5557887990

## Notes

- The five existing raw panel mounts gain the shared binding mechanism, but they remain reading-backed decorations and do not gain command-feedback evidence.
- A caller-supplied command binding receives full feedback presentation in Discrete.
- Prior heads passed natural quick but failed four near-threshold visual frames. No baseline or threshold change was made; this source parity repair receives one fresh natural visual run.
- Out of scope: S4 skins/Knob work, source panel changes, baseline changes, and proprietary workflows.

Coordinator acceptance: corrected the required PR-body size claim to the measured 716 additions + 126 deletions = 842 A+D. Natural quick 34020432157 and visual 34020432131 passed, and the actual exact-head Agent Review Gate is PASS. The nine files form one shared policy/facade/renderer migration with its contract and five production-adoption witnesses.
