### PR TITLE
MOR-2395 Qualify canonical meter readings

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -213,6 +213,24 @@ function liveState(): unknown {
   };
 }
 
+function useQualifiedMainSMeter(rawState: unknown, value = 120): void {
+  const state = rawState as {
+    main: Record<string, unknown>;
+    fieldStatus: Record<string, unknown>;
+  };
+  h.state = {
+    ...state,
+    stateContractVersion: 1,
+    providerGeneration: 1,
+    main: { ...state.main, sMeter: value },
+    fieldStatus: {
+      ...state.fieldStatus,
+      'main.sMeter': { ...fresh, lastObservedMonotonic: 0 },
+    },
+  };
+  h.caps = { ...(h.caps as object), stateContractVersion: 1, providerGeneration: 1 };
+}
+
 /** One representative capability set per canonical topology fixture id. */
 function capsFor(id: TopologyFixtureId): Capabilities {
   const scheme = topologyFixtures[id].vfoScheme;
@@ -331,8 +349,7 @@ describe('the migrated desktop layout owns VFO/TX through the semantic surfaces'
   // `desktop-v2` block below for why a bare fixture (no meter fields at all)
   // would prove nothing about suppression.
   it('drops the legacy meters dock in favour of the semantic meters surface', () => {
-    const state = liveState() as { main: Record<string, unknown> };
-    h.state = { ...state, main: { ...state.main, sMeter: 120 } };
+    useQualifiedMainSMeter(liveState());
     const t = render('sdr-test');
     expect(t.querySelector('.bottom-dock')).toBeNull();
     expect(t.querySelector('[data-testid="meters-dock-panel"]')).toBeNull();
@@ -399,8 +416,7 @@ describe('desktop-v2 resolves through the v3 path (MOR-1313)', () => {
   // at all, so it would pass this assertion vacuously (both the dock and the
   // semantic surface self-gate away) and prove nothing about suppression.
   it('drops the legacy meters dock in favour of the semantic meters surface', () => {
-    const state = liveState() as { main: Record<string, unknown> };
-    h.state = { ...state, main: { ...state.main, sMeter: 120 } };
+    useQualifiedMainSMeter(liveState());
     const t = render('desktop-v2');
     expect(t.querySelector('.bottom-dock')).toBeNull();
     expect(t.querySelector('[data-testid="meters-dock-panel"]')).toBeNull();
@@ -1228,13 +1244,13 @@ describe("the SDR face's zones are placed as five regions (MOR-2231, batch 5)", 
         bands: [{ name: '20m', start: 14_000_000, end: 14_350_000, default: 14_225_000 }],
       }],
     } as Capabilities;
-    const state = liveState() as { main: Record<string, unknown> };
+    const state = liveState() as Record<string, unknown>;
     h.state = {
       ...state,
-      main: { ...state.main, sMeter: 120 },
       scanning: false, scanType: 0x34, scanResumeMode: 1,
       txAntenna: 1, rxAntenna1: 0, ritOn: false, ritTx: false, ritFreq: 0,
     };
+    useQualifiedMainSMeter(h.state);
   });
 
   it('uses the SDR region sequence while regions=false keeps the previous surface sequence', () => {

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -138,7 +138,10 @@ import {
 } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
 
 
-const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const fresh = {
+  storePath: 'x', observed: true, freshness: 'fresh', availability: 'available',
+  lastObservedMonotonic: 0,
+};
 const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
 
 /** Every raw meter the MOR-1269 adapter reads, all observed fresh. The
@@ -166,6 +169,7 @@ function liveState(withMeters: boolean, over: Partial<ServerState> = {}): Server
     ...(withMeters ? { sMeter: -12 } : {}),
   });
   return {
+    stateContractVersion: 1, providerGeneration: 1,
     active: 'MAIN', split: false, dualWatch: false, ptt: false,
     txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
     main: receiver(14250000), sub: receiver(14300000),
@@ -177,6 +181,7 @@ function liveState(withMeters: boolean, over: Partial<ServerState> = {}): Server
 
 const liveCaps = (withMeters: boolean): Capabilities => ({
   model: 'fixture', scope: false, audio: true, tx: true,
+  stateContractVersion: 1, providerGeneration: 1,
   capabilities: withMeters
     ? ['audio', 'tx', 'dual_rx', 'compressor']
     : ['audio', 'tx', 'dual_rx'],
@@ -290,6 +295,16 @@ describe('the meters surface mounts only when the view model carries the group',
     render({ strips });
     expect(target.querySelectorAll('[data-testid="meters-surface"]')).toHaveLength(1);
     expect(Object.keys(relevance())).toContain('power');
+    expect(q('[data-testid="meter-signal"]')!.dataset.observed).toBe('true');
+    expect(q('[data-testid="meter-drainVoltage"]')!.dataset.observed).toBe('true');
+  });
+
+  it('keeps mounted meter shells but clears readings across a provider generation mismatch', () => {
+    h.caps = { ...liveCaps(true), providerGeneration: 2 };
+    render();
+    expect(q('[data-testid="meters-surface"]')).not.toBeNull();
+    expect(q('[data-testid="meter-signal"]')!.dataset.observed).toBe('false');
+    expect(q('[data-testid="meter-drainVoltage"]')!.dataset.observed).toBe('false');
   });
 
   // MUTATION KILLED: giving the meters surface a `data-zone-id` of its own.

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -57,7 +57,10 @@ import {
   ManagedAppTxHarness, type ManagedAppTxServerSnapshot,
 } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
 
-const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const fresh = {
+  storePath: 'x', observed: true, freshness: 'fresh', availability: 'available',
+  lastObservedMonotonic: 0,
+};
 const slot = (frequency: number) => ({ freqHz: frequency, mode: 'USB', filterNum: 1, dataMode: 0 });
 function state(overrides: Partial<ServerState> = {}): ServerState {
   const paths = ['active', 'split', 'dualWatch', 'main.freqHz', 'main.mode', 'main.filter',
@@ -68,7 +71,8 @@ function state(overrides: Partial<ServerState> = {}): ServerState {
   }
   const receiver = (frequency: number) => ({ ...slot(frequency), filter: 1, activeSlot: 'A',
     vfoA: slot(frequency), vfoB: slot(frequency + 50_000), sMeter: -12 });
-  return { active: 'MAIN', split: false, dualWatch: false,
+  return { stateContractVersion: 1, providerGeneration: 1,
+    active: 'MAIN', split: false, dualWatch: false,
     tunerStatus: 0, ritOn: false, ritTx: true, ritFreq: 0, txAntenna: 1,
     main: receiver(14_200_000), sub: receiver(7_100_000),
     fieldStatus: Object.fromEntries(paths.map((path) => [path, fresh])),
@@ -77,6 +81,7 @@ function state(overrides: Partial<ServerState> = {}): ServerState {
 function caps(vfoScheme: Capabilities['vfoScheme'], receivers: number, dual = receivers === 2): Capabilities {
   const common = ['vfo_equalize', 'vfo_swap', 'split', 'speech', 'tuner', 'rit', 'xit'];
   return { model: 'fixture', scope: false, audio: false, tx: true,
+    stateContractVersion: 1, providerGeneration: 1,
     capabilities: dual ? ['dual_rx', 'dual_watch', ...common] : common, receivers, vfoScheme,
     antennas: 1,
     freqRanges: [], modes: [], filters: [], scopeSource: null, audioFftAvailable: false,
@@ -144,6 +149,9 @@ describe('production receiver-indicator partitioning', () => {
     for (const receiver of receivers) {
       expect(rowReceivers(target.querySelector(`[data-testid="channel-strip-${receiver}"]`)!))
         .toEqual([receiver]);
+      expect(target.querySelector(
+        `[data-indicator-receiver="${receiver}"] [data-testid="receiver-s-meter-unknown"]`,
+      )).toBeNull();
     }
     expect(rowReceivers(target.querySelector('[data-testid="cockpit-zone-global"]')!)).toEqual([]);
   });
@@ -154,6 +162,12 @@ describe('production receiver-indicator partitioning', () => {
     expect(rowReceivers(target)).toEqual(['MAIN', 'SUB']);
     expect(sub.dataset.indicatorOperational).toBe('false');
     expect(sub.querySelector('[data-testid="receiver-s-meter-unknown"]')).not.toBeNull();
+  });
+
+  it('keeps both S-meter shells mounted but unknown across a provider mismatch', () => {
+    render({ ...caps('main_sub', 2), providerGeneration: 2 });
+    expect(rowReceivers(target)).toEqual(['MAIN', 'SUB']);
+    expect(target.querySelectorAll('[data-testid="receiver-s-meter-unknown"]')).toHaveLength(2);
   });
 
   it('mounts one singleton shared row/block and maps each production-admitted button exactly once', () => {

--- a/frontend/src/lib/runtime/adapters/__tests__/meters-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/meters-adapter.test.ts
@@ -20,6 +20,7 @@ import { toRadioViewModel, type MetersTxAuthority } from '../radio-view-model-ad
 function caps(overrides: Partial<Capabilities> = {}): Capabilities {
   return {
     model: 'fixture', scope: true, audio: true, tx: true, capabilities: ['scope', 'audio', 'tx'],
+    stateContractVersion: 1, providerGeneration: 1,
     receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
     audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
     webrtc: { available: false, enabled: false },
@@ -28,8 +29,18 @@ function caps(overrides: Partial<Capabilities> = {}): Capabilities {
   } as Capabilities;
 }
 
-const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
-const stale: FieldStatus = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
+const fresh: FieldStatus = {
+  storePath: 'x', observed: true, freshness: 'fresh', availability: 'available',
+  lastObservedMonotonic: 0,
+};
+const stale: FieldStatus = {
+  storePath: 'x', observed: true, freshness: 'stale', availability: 'stale',
+  lastObservedMonotonic: 0,
+};
+const METER_PATHS = [
+  'main.sMeter', 'sub.sMeter', 'powerMeter', 'swrMeter', 'alcMeter',
+  'compMeter', 'vdMeter', 'idMeter',
+] as const;
 
 /** The RX authority: positively observed OFF with zero TX risk. */
 const RX: MetersTxAuthority = { radioTx: 'off', txRisk: 'none' };
@@ -38,6 +49,7 @@ const TX: MetersTxAuthority = { radioTx: 'on', txRisk: 'confirmed-on' };
 
 function meterState(overrides: Partial<ServerState> = {}): ServerState {
   return {
+    stateContractVersion: 1, providerGeneration: 1,
     active: 'MAIN', split: false, dualWatch: false, ptt: false,
     txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14195000 },
     main: {
@@ -48,6 +60,7 @@ function meterState(overrides: Partial<ServerState> = {}): ServerState {
     fieldStatus: {
       active: fresh, split: fresh, dualWatch: fresh, txTarget: fresh,
       'main.freqHz': fresh, 'main.mode': fresh, 'main.filter': fresh,
+      ...Object.fromEntries(METER_PATHS.map((path) => [path, fresh])),
     },
     ...overrides,
   } as ServerState;
@@ -114,10 +127,9 @@ describe('meters TX truth comes from the App TX authority (R9 / MOR-1235)', () =
 describe('target meter display provenance (MOR-2359)', () => {
   const targets = [['power', 'powerMeter'], ['swr', 'swrMeter'], ['alc', 'alcMeter']] as const;
   const observed = { ...fresh, lastObservedMonotonic: 310658.42975425 };
-  const capabilities = caps({ stateContractVersion: 1, providerGeneration: 1 });
+  const capabilities = caps();
   function stateWith(status: Partial<FieldStatus> = {}): ServerState {
     return meterState({
-      stateContractVersion: 1, providerGeneration: 1,
       fieldStatus: { ...meterState().fieldStatus,
         ...Object.fromEntries(targets.map(([, path]) => [path, { ...observed, ...status }])),
       },
@@ -168,7 +180,8 @@ describe('target meter display provenance (MOR-2359)', () => {
         for (const [meter, path] of targets) {
           const { display, ...strict } = meters[meter];
           expect(display).toBeDefined();
-          const operational = !('freshness' in status && status.freshness === 'stale');
+          const operational = status.observed !== false
+            && !('freshness' in status && status.freshness === 'stale');
           expect(strict).toEqual({
             reading: operational ? { status: 'known', value: state[path] } : { status: 'unknown' },
             availability: { structural: true, operational }, relevant,
@@ -241,22 +254,140 @@ describe('meters evidence gate and per-meter derivation (MOR-1262 slice 2A)', ()
     }), caps(), TX).meters!;
     expect(meters.swr).toEqual({
       reading: { status: 'unknown' }, availability: { structural: true, operational: false }, relevant: true,
-      display: { state: 'unknown', reason: 'identity-unresolved' },
+      display: { state: 'stale', value: 20 },
     });
   });
 
   it('follows the active receiver for the S-meter, with its own field status', () => {
+    const dualCaps = caps({
+      receivers: 2, vfoScheme: 'main_sub',
+      capabilities: ['scope', 'audio', 'tx', 'dual_rx'],
+    });
     const onSub = meterState({
       active: 'SUB',
       sub: { freqHz: 7100000, mode: 'LSB', filter: 1, sMeter: 60 } as ServerState['main'],
     });
-    expect(model(onSub, caps(), RX).meters!.signal.reading).toEqual({ status: 'known', value: 60 });
+    expect(model(onSub, dualCaps, RX).meters!.signal.reading).toEqual({ status: 'known', value: 60 });
     const staleSub = meterState({
       active: 'SUB',
       sub: { freqHz: 7100000, mode: 'LSB', filter: 1, sMeter: 60 } as ServerState['main'],
       fieldStatus: { ...meterState().fieldStatus, 'sub.sMeter': stale },
     });
-    expect(model(staleSub, caps(), RX).meters!.signal.reading).toEqual({ status: 'unknown' });
+    expect(model(staleSub, dualCaps, RX).meters!.signal.reading).toEqual({ status: 'unknown' });
+  });
+
+  it.each(METER_PATHS.filter((path) => path !== 'sub.sMeter'))(
+    'requires current leaf evidence for %s while preserving its structural shell', (path) => {
+      const state = meterState();
+      const fieldStatus = { ...state.fieldStatus };
+      delete fieldStatus[path];
+      const meters = model({ ...state, fieldStatus }, caps(), TX).meters!;
+      const field = path === 'main.sMeter' ? meters.signal
+        : path === 'powerMeter' ? meters.power
+          : path === 'swrMeter' ? meters.swr
+            : path === 'alcMeter' ? meters.alc
+              : path === 'compMeter' ? meters.compression
+                : path === 'vdMeter' ? meters.drainVoltage : meters.drainCurrent;
+      expect(field.reading).toEqual({ status: 'unknown' });
+      expect(field.availability).toEqual({ structural: true, operational: false });
+    },
+  );
+
+  it.each(METER_PATHS.filter((path) => path !== 'sub.sMeter'))(
+    'keeps stale %s structurally present but non-operational', (path) => {
+      const state = meterState({
+        fieldStatus: { ...meterState().fieldStatus, [path]: stale },
+      });
+      const meters = model(state, caps(), TX).meters!;
+      const field = path === 'main.sMeter' ? meters.signal
+        : path === 'powerMeter' ? meters.power
+          : path === 'swrMeter' ? meters.swr
+            : path === 'alcMeter' ? meters.alc
+              : path === 'compMeter' ? meters.compression
+                : path === 'vdMeter' ? meters.drainVoltage : meters.drainCurrent;
+      expect(field.reading).toEqual({ status: 'unknown' });
+      expect(field.availability).toEqual({ structural: true, operational: false });
+    },
+  );
+
+  it.each([
+    ['provider mismatch', { providerGeneration: 2 }],
+    ['contract mismatch', { stateContractVersion: 2 }],
+  ] as const)('%s fences every canonical reading without removing shells', (_label, capabilityOverride) => {
+    const meters = model(meterState(), caps(capabilityOverride), TX).meters!;
+    for (const field of [
+      meters.signal, meters.power, meters.swr, meters.alc, meters.compression,
+      meters.drainVoltage, meters.drainCurrent,
+    ]) {
+      expect(field.reading).toEqual({ status: 'unknown' });
+      expect(field.availability).toEqual({ structural: true, operational: false });
+    }
+  });
+
+  it.each([undefined, NaN, Infinity, -1])(
+    'rejects invalid observation marker %s for every canonical reading', (lastObservedMonotonic) => {
+      const state = meterState();
+      const fieldStatus = Object.fromEntries(METER_PATHS.map((path) => [
+        path, { ...fresh, lastObservedMonotonic },
+      ]));
+      const meters = model({ ...state, fieldStatus }, caps(), TX).meters!;
+      expect([
+        meters.signal, meters.power, meters.swr, meters.alc, meters.compression,
+        meters.drainVoltage, meters.drainCurrent,
+      ].every((field) => field.reading.status === 'unknown')).toBe(true);
+    },
+  );
+
+  it('preserves valid zero for all seven canonical readings', () => {
+    const state = meterState({
+      main: { ...meterState().main, sMeter: 0 },
+      powerMeter: 0, swrMeter: 0, alcMeter: 0, compMeter: 0, vdMeter: 0, idMeter: 0,
+    });
+    const meters = model(state, caps(), TX).meters!;
+    expect([
+      meters.signal, meters.power, meters.swr, meters.alc, meters.compression,
+      meters.drainVoltage, meters.drainCurrent,
+    ].map((field) => field.reading)).toEqual(Array(7).fill({ status: 'known', value: 0 }));
+  });
+
+  it('keeps an unresolved dual active receiver as an unknown supported signal shell', () => {
+    const state = meterState({
+      fieldStatus: { ...meterState().fieldStatus, active: { ...fresh, observed: false } },
+      sub: { ...meterState().main, sMeter: 60 },
+    });
+    const dualCaps = caps({
+      receivers: 2, vfoScheme: 'main_sub',
+      capabilities: ['scope', 'audio', 'tx', 'dual_rx'],
+    });
+    expect(model(state, dualCaps, RX).meters!.signal).toEqual({
+      reading: { status: 'unknown' },
+      availability: { structural: true, operational: false },
+      relevant: true,
+    });
+  });
+
+  it('does not select raw SUB signal when SUB is structurally non-operational', () => {
+    const state = meterState({
+      active: 'SUB',
+      sub: { ...meterState().main, sMeter: 60 },
+    });
+    const signal = model(state, caps({ receivers: 2, vfoScheme: 'main_sub' }), RX).meters!.signal;
+    expect(signal).toEqual({
+      reading: { status: 'unknown' },
+      availability: { structural: true, operational: false },
+      relevant: true,
+    });
+  });
+
+  it('ignores a stray raw SUB signal outside the canonical single-receiver topology', () => {
+    const state = meterState({
+      active: 'SUB',
+      main: { freqHz: 14195000, mode: 'USB', filter: 1 } as ServerState['main'],
+      sub: { ...meterState().main, sMeter: 60 },
+      powerMeter: undefined, swrMeter: undefined, alcMeter: undefined,
+      compMeter: undefined, vdMeter: undefined, idMeter: undefined,
+    });
+    expect(model(state, caps(), RX).meters).toBeUndefined();
   });
 
   it('degrades a malformed raw value (wrong JS type) to unknown rather than coercing', () => {

--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -265,6 +265,8 @@ function model(
 }
 
 const INDICATOR_CAPS = caps({
+  stateContractVersion: 1,
+  providerGeneration: 1,
   filters: ['FIL1'],
   agcLabels: { '2': 'SLOW' },
   capabilities: [
@@ -282,10 +284,16 @@ function indicatorState(overrides: Partial<ServerState> = {}): ServerState {
   const base = observedState();
   const fieldStatus = { ...base.fieldStatus } as Record<string, FieldStatus>;
   for (const receiverKey of ['main', 'sub'] as const) {
-    for (const leaf of INDICATOR_LEAVES) fieldStatus[`${receiverKey}.${leaf}`] = fresh;
+    for (const leaf of INDICATOR_LEAVES) {
+      fieldStatus[`${receiverKey}.${leaf}`] = leaf === 'sMeter'
+        ? { ...fresh, lastObservedMonotonic: 0 }
+        : fresh;
+    }
   }
   return {
     ...base,
+    stateContractVersion: 1,
+    providerGeneration: 1,
     main: {
       ...base.main, sMeter: 0, filterWidth: 2400, agc: 0, nb: false, nr: true,
       autoNotch: false, manualNotch: false, att: 0, preamp: 0, rfGain: 0,
@@ -377,6 +385,21 @@ describe('receiver indicators are structural-receiver addressed (MOR-2299 slice 
       .receiverIndicators?.find((indicator) => indicator.receiver === 'MAIN');
     expect(main?.sMeter.reading).toEqual({ status: 'unknown' });
     expect(main?.sMeter.availability.operational).toBe(false);
+  });
+
+  it.each([
+    ['provider mismatch', { providerGeneration: 2 }],
+    ['invalid marker', { lastObservedMonotonic: NaN }],
+  ] as const)('%s fences only the receiver S-meter qualification path', (kind, override) => {
+    const state = indicatorState();
+    const fieldStatus = { ...state.fieldStatus } as Record<string, FieldStatus>;
+    if (kind === 'invalid marker') fieldStatus['main.sMeter'] = { ...fresh, ...override };
+    const capabilities = kind === 'provider mismatch' ? { ...INDICATOR_CAPS, ...override } : INDICATOR_CAPS;
+    const main = model({ ...state, fieldStatus }, capabilities as Capabilities, RECEIVING)
+      .receiverIndicators?.find((indicator) => indicator.receiver === 'MAIN')!;
+    expect(main.sMeter.reading).toEqual({ status: 'unknown' });
+    expect(main.sMeter.availability.operational).toBe(false);
+    expect(main.nbActive.reading).toEqual({ status: 'known', value: false });
   });
 
   it('uses one App-authority RF fact only: ptt and assignment cannot override it', () => {

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -816,11 +816,11 @@ function deriveRfFrontEnd(
  * groups above: those groups answer a different question and would mirror
  * MAIN onto SUB when the active receiver changes.
  *
- * Admission is the owner-recorded leaf rule exactly: the leaf itself must be
+ * Non-S members retain the owner-recorded leaf rule: the leaf itself must be
  * `seen()` and the existing ancestor-aware `topFieldAvailable()` gate must
- * also pass. The latter preserves the current global absent-key semantics;
- * composing the two here makes a missing leaf unknown and lets a stale parent
- * veto an otherwise-fresh leaf without changing `field-status.ts`.
+ * also pass. S-meter is the deliberate qualified exception: it additionally
+ * requires matching provider identity, valid evidence and value, and a
+ * `current` observation. Global absent-key semantics remain unchanged.
  */
 function deriveReceiverIndicators(
   state: ServerState | null,

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -35,6 +35,7 @@ import type {
   ScopeDisplayViewModel, ScopeSourceKind, ScopeHealthState,
   ReceiverIndicatorViewModel, TxTargetViewModel,
   RadioWideIndicatorsViewModel, DualActionBlockViewModel,
+  DisplayObservation,
 } from '../../../semantic/radio-view-model';
 import type { TxAuthoritySnapshot } from '../../../semantic/rx-tx-surface';
 import { qualifyDisplayObservation, qualifyRadioDisplayObservation } from './display-observation';
@@ -272,11 +273,13 @@ function meterRfState(tx: MetersTxAuthority): MeterRfState {
   return tx.radioTx === 'off' && tx.txRisk === 'none' ? 'receiving' : 'unknown';
 }
 
-function meterField(structural: boolean, fieldFresh: boolean, raw: unknown, relevant: boolean): MeterField {
-  const operational = structural && fieldFresh;
-  const value = numOrUndef(raw);
+function meterField(
+  structural: boolean, observation: DisplayObservation<number>, relevant: boolean,
+  receiverOperational = true,
+): MeterField {
+  const operational = structural && receiverOperational && observation.state === 'current';
   return {
-    reading: operational && value !== undefined ? { status: 'known', value } : { status: 'unknown' },
+    reading: operational ? { status: 'known', value: observation.value } : { status: 'unknown' },
     availability: { structural, operational },
     relevant,
   };
@@ -302,39 +305,65 @@ function meterField(structural: boolean, fieldFresh: boolean, raw: unknown, rele
  */
 function deriveMeters(
   state: ServerState | null, caps: Capabilities | null, tx: MetersTxAuthority | null | undefined,
+  activeId: ReceiverId | null,
+  structuralReceivers: readonly ReceiverId[],
+  operationalReceivers: readonly ReceiverId[],
 ): MetersViewModel | undefined {
   if (!tx || !state) return undefined;
   const rfState = meterRfState(tx);
   const onTx = rfState !== 'receiving';
   const hasTx = caps?.tx ?? false;
-  // Mirrors the shipped dock's own active-receiver read (`RadioLayout.svelte`):
-  // the S-meter follows the receiver the operator is listening to.
-  const onSub = state.active === 'SUB';
-  const rx = onSub ? state.sub : state.main;
-  const sPath = onSub ? 'sub.sMeter' : 'main.sMeter';
   const { powerMeter, swrMeter, alcMeter, compMeter, vdMeter, idMeter } = state;
-  const raws = [rx?.sMeter, powerMeter, swrMeter, alcMeter, compMeter, vdMeter, idMeter];
+  const signalRaws = structuralReceivers.map((receiver) => state[RECEIVER_KEY[receiver]]?.sMeter);
+  const raws = [...signalRaws, powerMeter, swrMeter, alcMeter, compMeter, vdMeter, idMeter];
   if (!raws.some((v) => v !== undefined)) return undefined;
-  const txMeter = (raw: unknown, path: string): MeterField =>
-    meterField(hasTx && raw !== undefined, topFieldAvailable(state, path), raw, onTx);
-  const displayTxMeter = (raw: unknown, path: string) => ({
-    ...txMeter(raw, path),
-    display: qualifyRadioDisplayObservation({
-      state, caps, path, structural: hasTx && raw !== undefined, value: numOrUndef(raw),
-    }),
+  const displayTxMeter = (raw: unknown, path: string) => {
+    const structural = hasTx && raw !== undefined;
+    const display = qualifyRadioDisplayObservation({
+      state, caps, path, structural, value: numOrUndef(raw),
+    });
+    return { ...meterField(structural, display, onTx), display };
+  };
+  const signalStructural = activeId === null
+    ? signalRaws.some((raw) => raw !== undefined)
+    : structuralReceivers.includes(activeId) && state[RECEIVER_KEY[activeId]]?.sMeter !== undefined;
+  const signalRaw = activeId === null ? undefined : state[RECEIVER_KEY[activeId]]?.sMeter;
+  const signalObservation: DisplayObservation<number> = activeId === null
+    ? { state: 'unknown', reason: 'identity-unresolved' }
+    : qualifyDisplayObservation({
+      state, caps, receiver: activeId, path: `${RECEIVER_KEY[activeId]}.sMeter`,
+      structural: signalStructural, value: numOrUndef(signalRaw),
+    });
+  const compressionStructural = hasTx && compMeter !== undefined;
+  const compressionObservation = qualifyRadioDisplayObservation({
+    state, caps, path: 'compMeter', structural: compressionStructural,
+    value: numOrUndef(compMeter),
+  });
+  const drainVoltageStructural = vdMeter !== undefined;
+  const drainVoltageObservation = qualifyRadioDisplayObservation({
+    state, caps, path: 'vdMeter', structural: drainVoltageStructural,
+    value: numOrUndef(vdMeter),
+  });
+  const drainCurrentStructural = hasTx && idMeter !== undefined;
+  const drainCurrentObservation = qualifyRadioDisplayObservation({
+    state, caps, path: 'idMeter', structural: drainCurrentStructural,
+    value: numOrUndef(idMeter),
   });
   return {
     rfState,
-    signal: meterField(rx?.sMeter !== undefined, topFieldAvailable(state, sPath), rx?.sMeter, !onTx),
+    signal: meterField(
+      signalStructural, signalObservation, !onTx,
+      activeId !== null && operationalReceivers.includes(activeId),
+    ),
     power: displayTxMeter(powerMeter, 'powerMeter'),
     swr: displayTxMeter(swrMeter, 'swrMeter'),
     alc: displayTxMeter(alcMeter, 'alcMeter'),
-    compression: txMeter(compMeter, 'compMeter'),
+    compression: meterField(compressionStructural, compressionObservation, onTx),
     // Vd is the station's supply rail, not a TX reading: it is worth showing
     // in every RF state (the dock keeps it on instantaneous display for the
     // same reason), so it is structurally gated but never relevance-gated.
-    drainVoltage: meterField(vdMeter !== undefined, topFieldAvailable(state, 'vdMeter'), vdMeter, true),
-    drainCurrent: txMeter(idMeter, 'idMeter'),
+    drainVoltage: meterField(drainVoltageStructural, drainVoltageObservation, true),
+    drainCurrent: meterField(drainCurrentStructural, drainCurrentObservation, onTx),
   };
 }
 
@@ -837,6 +866,10 @@ function deriveReceiverIndicators(
     const agcMode = agcOrdinal === undefined
       ? undefined
       : (caps.agcLabels?.[String(agcOrdinal)] ?? agcOrdinal);
+    const sMeterObservation = qualifyDisplayObservation({
+      state, caps, receiver, path: path('sMeter'), structural: true,
+      value: numOrUndef(rx?.sMeter),
+    });
 
     return {
       receiver,
@@ -844,7 +877,10 @@ function deriveReceiverIndicators(
       // Every structural receiver owns one S-meter shell. The reading stays
       // unknown until its own leaf passes the strict gate; numeric zero is a
       // valid calibrated S9 reading and is preserved by numOrUndef.
-      sMeter: strictField(true, 'sMeter', numOrUndef(rx?.sMeter)),
+      sMeter: txAuxField(
+        true, receiverOperational && sMeterObservation.state === 'current',
+        sMeterObservation.state === 'current' ? sMeterObservation.value : undefined,
+      ),
       bandwidthHz: strictField(hasFilters, 'filterWidth', numOrUndef(rx?.filterWidth)),
       agcMode: strictField(hasAgc, 'agc', agcMode),
       nbActive: strictField(hasNb, 'nb', boolOrUndef(rx?.nb)),
@@ -1696,7 +1732,9 @@ export function toRadioViewModel(
   // from "has the group" to any consumer that inventories keys — same
   // reasoning as the validator's own omission below `validateRadioViewModel`.
   const txAux = deriveTxAux(state, caps);
-  const meters = deriveMeters(state, caps, tx);
+  const meters = deriveMeters(
+    state, caps, tx, activeId, topology.structuralReceivers, topology.operationalReceivers,
+  );
   const rxAudio = deriveRxAudio(state, caps, facts, modInputSource, rxAudioSnapshot);
   const modeFilter = deriveModeFilter(state, caps, activeId);
   const filterPassband = deriveFilterPassband(state, caps, activeId);

--- a/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
@@ -129,7 +129,10 @@ vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
 
 const { default: PeerSplitLayout } = await import('../PeerSplitLayout.svelte');
 
-const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const fresh = {
+  storePath: 'x', observed: true, freshness: 'fresh', availability: 'available',
+  lastObservedMonotonic: 0,
+};
 
 /** 2/ab_shared — one of `peer-split`'s two declared compatible topologies
  *  (`presentation/layouts/segmentline-declarations.ts`), also the FTX-1's
@@ -137,13 +140,14 @@ const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability
 function abSharedState(): ServerState {
   const paths = ['active', 'split', 'dualWatch', 'txTarget',
     'main.freqHz', 'main.mode', 'main.filter', 'sub.freqHz', 'sub.mode', 'sub.filter',
-    'powerMeter', 'swrMeter', 'main.sMeter', 'sub.sMeter'];
+    'powerMeter', 'swrMeter', 'vdMeter', 'main.sMeter', 'sub.sMeter'];
   return {
+    stateContractVersion: 1, providerGeneration: 1,
     active: 'MAIN', split: false, dualWatch: false, ptt: false,
     txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14250000 },
     main: { freqHz: 14250000, mode: 'USB', filter: 1, sMeter: -12 },
     sub: { freqHz: 146520000, mode: 'FM', filter: 1, sMeter: -30 },
-    powerMeter: 0, swrMeter: 10,
+    powerMeter: 0, swrMeter: 10, vdMeter: 200,
     fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
   } as unknown as ServerState;
 }
@@ -228,6 +232,8 @@ describe('the peer-split chassis mounts', () => {
     expect(glass!.querySelector('[data-testid="peer-split-display"]')).not.toBeNull();
     expect(glass!.querySelectorAll('[data-testid="lcd-peer-column"]')).toHaveLength(2);
     expect(glass!.querySelector('[data-testid="peer-split-clock"]')).toBeNull();
+    expect(glass!.querySelectorAll('.receiver-column > .s-meter[data-state="known"]')).toHaveLength(2);
+    expect(glass!.querySelector('.telemetry [aria-label="VD: 200"][data-state="known"]')).not.toBeNull();
   });
 
   it.each([


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-2395/qualify-all-canonical-meter-readings-and-receiver-s-meters-through

## Summary
- qualify all seven canonical meter readings against contract identity and leaf observation evidence
- select active S-meter data through canonical structural and operational receiver identities
- qualify receiver-indicator S-meters without changing other indicator availability semantics
- strengthen adapter and composed UI fixtures for stale, mismatched, invalid, zero, and ambiguous evidence

## Compatibility
No public API, CLI, config, or wire-protocol changes. Existing shells, raw units, relevance, TX authority, and stale P/SWR/ALC display provenance are preserved.

## Verification
- focused six-file Vitest matrix: 391 passed
- changed-file ESLint: passed
- frontend npm run check: passed
- git diff --check: passed

## Scope rationale and review correction
Seven files form one meter-qualification change: the existing adapter and six adapter/composed-consumer test files. The PR is 339 additions plus deletions, within the hard limits; separating those fixtures would leave the positive composed evidence inconsistent with the stricter admission rule.

The required receiver-indicator comment correction was applied in 066614a16e40e4a5ab75a6ee3714755ad8d76dbc and independently verified by the fresh exact-head review. No executable code changed in that correction.
