### PR TITLE
MOR-2397 Separate absolute choice eligibility from selection

### DIFF
--- a/frontend/src/primitives/control-instruments/__tests__/control-instrument-behavior.test.ts
+++ b/frontend/src/primitives/control-instruments/__tests__/control-instrument-behavior.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
-  bindActionInstrument, bindChoiceInstrument, bindToggleInstrument,
+  bindAbsoluteChoiceInstrument, bindActionInstrument, bindChoiceInstrument, bindToggleInstrument,
   type InstrumentField,
 } from '../control-instrument-behavior';
 
@@ -77,5 +77,76 @@ describe('control-instrument behavior bindings', () => {
     expect(behavior.selected).toBe(2);
     behavior.invoke(3);
     expect(invoke).toHaveBeenCalledExactlyOnceWith(3);
+  });
+
+  it('keeps known-field selection independent from availability and permits offered targets', () => {
+    let field = unavailable(9);
+    const invoke = vi.fn();
+    const behavior = bindChoiceInstrument(() => ({ field, choices: [1, 2], invoke }));
+
+    expect(behavior.selected).toBeUndefined();
+    expect(behavior.available).toBe(false);
+    field = usable(9);
+    behavior.invoke(1);
+    expect(invoke).toHaveBeenCalledExactlyOnceWith(1);
+  });
+
+  it('separates absolute invocation eligibility from an unknown canonical selection', () => {
+    const invoke = vi.fn();
+    const behavior = bindAbsoluteChoiceInstrument(() => ({
+      choices: ['local', 'live'] as const, selected: undefined, available: true, invoke,
+    }));
+
+    expect(behavior.available).toBe(true);
+    expect(behavior.selected).toBeUndefined();
+    expect(behavior.isSelected('live')).toBe(false);
+    behavior.invoke('live');
+    expect(invoke).toHaveBeenCalledExactlyOnceWith('live');
+    expect(behavior.selected).toBeUndefined();
+  });
+
+  it('rechecks absolute blockers and offered membership at invocation time', () => {
+    let choices = [1, 2] as readonly number[];
+    let blocked = false;
+    const invoke = vi.fn();
+    const behavior = bindAbsoluteChoiceInstrument(() => ({
+      choices, selected: 2, available: true, blocked, invoke,
+    }));
+
+    choices = [2, 3];
+    behavior.invoke(1);
+    blocked = true;
+    expect(behavior.available).toBe(false);
+    expect(behavior.selected).toBe(2);
+    behavior.invoke(3);
+    blocked = false;
+    behavior.invoke(3);
+    expect(invoke).toHaveBeenCalledExactlyOnceWith(3);
+  });
+
+  it('uses exact membership and never substitutes an invoked target for selection', () => {
+    const invoke = vi.fn();
+    const behavior = bindAbsoluteChoiceInstrument<number | boolean>(() => ({
+      choices: [1, true], selected: 1, available: true, invoke,
+    }));
+
+    expect(behavior.isSelected(1)).toBe(true);
+    expect(behavior.isSelected(true)).toBe(false);
+    behavior.invoke(true);
+    expect(invoke).toHaveBeenCalledExactlyOnceWith(true);
+    expect(behavior.selected).toBe(1);
+  });
+
+  it('forwards arbitrary absolute-choice feedback by identity without manufacturing it', () => {
+    const feedback = { phase: 'submitted', target: 'live' } as const;
+    const present = bindAbsoluteChoiceInstrument(() => ({
+      choices: ['live'], selected: undefined, available: true, feedback, invoke: vi.fn(),
+    }));
+    const absent = bindAbsoluteChoiceInstrument(() => ({
+      choices: ['live'], selected: undefined, available: true, invoke: vi.fn(),
+    }));
+
+    expect(present.feedback).toBe(feedback);
+    expect(absent.feedback).toBeUndefined();
   });
 });

--- a/frontend/src/primitives/control-instruments/control-instrument-behavior.ts
+++ b/frontend/src/primitives/control-instruments/control-instrument-behavior.ts
@@ -34,6 +34,15 @@ interface ChoiceInput<T, Feedback> extends BindingInput<T, Feedback> {
   readonly invoke: (value: T) => void;
 }
 
+export interface AbsoluteChoiceInput<T, Feedback> {
+  readonly choices: readonly T[];
+  readonly selected: T | undefined;
+  readonly available: boolean;
+  readonly blocked?: boolean;
+  readonly invoke: (value: T) => void;
+  readonly feedback?: Feedback;
+}
+
 const canInvoke = <T>(input: BindingInput<T, unknown>): input is BindingInput<T, unknown> & {
   readonly field: InstrumentField<T> & { readonly reading: Readonly<{ status: 'known'; value: T }> };
 } => input.blocked !== true
@@ -90,22 +99,59 @@ export interface ChoiceInstrumentBehavior<T, Feedback> {
   invoke(value: T): void;
 }
 
-export function bindChoiceInstrument<T, Feedback = never>(
-  current: () => ChoiceInput<T, Feedback>,
+interface ChoiceBehaviorInput<T, Feedback> {
+  readonly choices: readonly T[];
+  readonly selected: T | undefined;
+  readonly available: boolean;
+  readonly blocked?: boolean;
+  readonly invoke: (value: T) => void;
+  readonly feedback?: Feedback;
+}
+
+const offered = <T>(choices: readonly T[], value: T): boolean =>
+  choices.some(choice => Object.is(choice, value));
+
+function bindChoiceBehavior<T, Feedback>(
+  current: () => ChoiceBehaviorInput<T, Feedback>,
 ): ChoiceInstrumentBehavior<T, Feedback> {
-  const offered = (choices: readonly T[], value: T): boolean => choices.some(choice => Object.is(choice, value));
   return {
-    get available() { return canInvoke(current()); },
+    get available() {
+      const input = current();
+      return input.available && input.blocked !== true;
+    },
     get selected() {
       const input = current();
-      return input.field?.reading.status === 'known' && offered(input.choices, input.field.reading.value)
-        ? input.field.reading.value : undefined;
+      return input.selected !== undefined && offered(input.choices, input.selected)
+        ? input.selected : undefined;
     },
     get feedback() { return current().feedback; },
     isSelected(value) { return this.selected !== undefined && Object.is(this.selected, value); },
     invoke(value) {
       const input = current();
-      if (canInvoke(input) && offered(input.choices, value)) input.invoke(value);
+      if (input.available && input.blocked !== true && offered(input.choices, value)) {
+        input.invoke(value);
+      }
     },
   };
+}
+
+export function bindChoiceInstrument<T, Feedback = never>(
+  current: () => ChoiceInput<T, Feedback>,
+): ChoiceInstrumentBehavior<T, Feedback> {
+  return bindChoiceBehavior(() => {
+    const input = current();
+    return {
+      choices: input.choices,
+      selected: input.field?.reading.status === 'known' ? input.field.reading.value : undefined,
+      available: canInvoke(input),
+      invoke: input.invoke,
+      feedback: input.feedback,
+    };
+  });
+}
+
+export function bindAbsoluteChoiceInstrument<T, Feedback = never>(
+  current: () => AbsoluteChoiceInput<T, Feedback>,
+): ChoiceInstrumentBehavior<T, Feedback> {
+  return bindChoiceBehavior(current);
 }

--- a/frontend/src/semantic/AntennaSurface.svelte
+++ b/frontend/src/semantic/AntennaSurface.svelte
@@ -123,6 +123,10 @@
 </script>
 
 <script lang="ts">
+  import {
+    bindAbsoluteChoiceInstrument, bindToggleInstrument,
+  } from '../primitives/control-instruments/control-instrument-behavior';
+
   interface Props {
     view: RadioViewModel;
     tx: TxAuthoritySnapshot;
@@ -136,22 +140,20 @@
    *  a single-port radio gets no empty panel and no zone had to learn about it. */
   let ant = $derived(view.antenna);
   let blocked = $derived(antennaSwitchBlocks(view, tx));
-  /** Rule (4). */
-  let currentPort = $derived(ant ? valueOf(ant.txAntenna) : undefined);
-
-  /** The handler half of rule (1). The port choice is ABSOLUTE, so it does not
-   *  need the current reading and is deliberately NOT gated on it — a radio
-   *  that never reported its port must still be able to select one; that is a
-   *  readability gap, not a hazard. The hazard gate is `blocked`. */
-  function selectPort(port: number): void {
-    if (ant && blocked.length === 0) onSelectPort?.(port);
-  }
-  /** RX-ANT is a RELATIVE toggle computed from the current value, so it needs
-   *  an observed reading as well — and `rxAnt`'s own `operational` flag
-   *  already carries "the TX port it belongs to was observed" (MOR-1295). */
-  function toggleRxAnt(): void {
-    if (ant && blocked.length === 0 && usable(ant.rxAnt)) onToggleRxAnt?.();
-  }
+  const portBehavior = bindAbsoluteChoiceInstrument<number>(() => ({
+    choices: ANTENNA_PORTS,
+    selected: ant ? valueOf(ant.txAntenna) : undefined,
+    available: ant !== undefined,
+    blocked: blocked.length > 0,
+    invoke: (port) => onSelectPort?.(port),
+  }));
+  /** RX-ANT remains relative: its own known boolean is required before the
+   *  existing zero-argument callback may invert it downstream. */
+  const rxAntBehavior = bindToggleInstrument(() => ({
+    field: ant?.rxAnt,
+    blocked: blocked.length > 0,
+    invoke: () => onToggleRxAnt?.(),
+  }));
 </script>
 
 {#if ant}
@@ -167,9 +169,9 @@
         <button
           type="button" role="radio" class="antenna-choice"
           data-testid={`antenna-port-${port}`} data-port={port}
-          aria-checked={currentPort === port} aria-describedby={blockedId}
-          disabled={blocked.length > 0}
-          onclick={() => selectPort(port)}
+          aria-checked={portBehavior.isSelected(port)} aria-describedby={blockedId}
+          disabled={!portBehavior.available}
+          onclick={() => portBehavior.invoke(port)}
         >ANT {port}</button>
       {/each}
       <output data-testid="antenna-port-value">{textOf(ant.txAntenna)}</output>
@@ -180,8 +182,8 @@
         <button
           type="button" class="antenna-choice" data-testid="antenna-rx-toggle"
           aria-pressed={pressedOf(ant.rxAnt)} aria-describedby={blockedId}
-          disabled={blocked.length > 0 || !usable(ant.rxAnt)}
-          onclick={toggleRxAnt}
+          disabled={!rxAntBehavior.available}
+          onclick={() => rxAntBehavior.invoke()}
         >RX-ANT: {textOf(ant.rxAnt)}</button>
       </div>
     {/if}

--- a/frontend/src/semantic/BandSurface.svelte
+++ b/frontend/src/semantic/BandSurface.svelte
@@ -55,6 +55,7 @@
   import type {
     BandChoice, BandField, DisabledReasonCode, RadioViewModel,
   } from './radio-view-model';
+  import { bindAbsoluteChoiceInstrument } from '../primitives/control-instruments/control-instrument-behavior';
 
   /** The ONE rendering of "not measured". Never a band name, never a number. */
   export const UNKNOWN_TEXT = '—';
@@ -262,10 +263,15 @@
     entryReady && interpretedHz !== null ? `→ ${mhz(interpretedHz)}` : '',
   );
 
-  function selectBand(choice: BandChoice): void {
-    if (!receiverKnown) return;
-    onSelectBand?.(choice.name, choice.defaultHz, choice.bsrCode);
-  }
+  const bandChoiceBehavior = bindAbsoluteChoiceInstrument<string>(() => ({
+    choices: band?.bandChoices.map((choice) => choice.name) ?? [],
+    selected: band?.currentBand.reading.status === 'known' ? band.currentBand.reading.value : undefined,
+    available: receiverKnown && band !== undefined,
+    invoke: (name) => {
+      const choice = band?.bandChoices.find((candidate) => candidate.name === name);
+      if (choice) onSelectBand?.(choice.name, choice.defaultHz, choice.bsrCode);
+    },
+  }));
   function commitFrequency(): void {
     if (!entryReady || interpretedHz === null) return;
     onEnterFrequency?.(interpretedHz);
@@ -353,9 +359,9 @@
           <button
             type="button" class="band-choice" data-testid={`band-choice-${choice.name}`}
             data-default-permit={choice.defaultHzTxPermit.status}
-            aria-pressed={isCurrent(band.currentBand, choice.name)}
-            disabled={!receiverKnown}
-            onclick={() => selectBand(choice)}
+            aria-pressed={bandChoiceBehavior.isSelected(choice.name)}
+            disabled={!bandChoiceBehavior.available}
+            onclick={() => bandChoiceBehavior.invoke(choice.name)}
           >{choice.name}
             <small data-testid={`band-choice-permit-${choice.name}`}
             >{defaultPermitLabel(choice)}</small></button>

--- a/frontend/src/semantic/RxAudioSurface.svelte
+++ b/frontend/src/semantic/RxAudioSurface.svelte
@@ -78,13 +78,14 @@
   /** Honest text: an unread fact reads as unknown, never as a default. */
   export const textOf = (f: RxAudioField<unknown>): string =>
     f.reading.status === 'known' ? String(f.reading.value) : UNKNOWN_TEXT;
-  const isValue = (f: RxAudioField<unknown>, value: unknown): boolean =>
-    f.reading.status === 'known' && f.reading.value === value;
 </script>
 
 <script lang="ts">
   import { t } from '$lib/i18n';
   import type { RadioViewModel } from './radio-view-model';
+  import {
+    bindAbsoluteChoiceInstrument, bindChoiceInstrument,
+  } from '../primitives/control-instruments/control-instrument-behavior';
 
   interface Props {
     view: RadioViewModel;
@@ -104,21 +105,48 @@
    *  a radio with no audio chain gets no empty panel and no zone had to learn
    *  about it. */
   let rx = $derived(view.rxAudio);
-  let modInputValue = $derived(
+  /** Rule (3): the FACT, not a capability re-derivation. */
+  let liveOffered = $derived(rx?.liveAudio.structural === true);
+  const monitorBehavior = bindAbsoluteChoiceInstrument<MonitorMode>(() => ({
+    choices: MONITOR_MODES.filter((mode) => mode !== 'live' || liveOffered),
+    selected: rx?.monitorMode,
+    available: rx !== undefined,
+    invoke: (mode) => onMonitorMode?.(mode),
+  }));
+  const focusBehavior = bindAbsoluteChoiceInstrument<AudioFocus>(() => ({
+    choices: FOCUS_CHOICES,
+    selected: rx?.routingFocus.reading.status === 'known'
+      ? rx.routingFocus.reading.value : undefined,
+    available: rx?.routingFocus.availability.structural === true,
+    invoke: (focus) => onRoutingFocus?.(focus),
+  }));
+  const splitBehavior = bindAbsoluteChoiceInstrument<boolean>(() => ({
+    choices: SPLIT_CHOICES.map(([value]) => value),
+    selected: rx?.routingSplit.reading.status === 'known'
+      ? rx.routingSplit.reading.value : undefined,
+    available: rx?.routingSplit.availability.structural === true,
+    invoke: (split) => onRoutingSplit?.(split),
+  }));
+  let modInputRecognized = $derived(
     rx?.modInputSource.reading.status === 'known'
-      && modInputSourceLabel(rx.modInputSource.reading.value) !== null
-      ? String(rx.modInputSource.reading.value) : '',
+      && modInputSourceLabel(rx.modInputSource.reading.value) !== null,
   );
-  let modInputUsable = $derived(!!rx && usable(rx.modInputSource) && modInputValue !== '');
+  const modInputBehavior = bindChoiceInstrument<number>(() => ({
+    field: rx?.modInputSource,
+    choices: MOD_INPUT_SOURCES.map((option) => option.value),
+    blocked: !modInputRecognized,
+    invoke: (source) => onModInputChange?.(source),
+  }));
+  let modInputValue = $derived(
+    modInputBehavior.selected === undefined ? '' : String(modInputBehavior.selected),
+  );
 
   function changeModInput(select: HTMLSelectElement): void {
     const value = select.value;
     const source = MOD_INPUT_SOURCES.find((option) => String(option.value) === value);
     select.value = modInputValue;
-    if (modInputUsable && source) onModInputChange?.(source.value);
+    if (source) modInputBehavior.invoke(source.value);
   }
-  /** Rule (3): the FACT, not a capability re-derivation. */
-  let liveOffered = $derived(rx?.liveAudio.structural === true);
   /** MOR-1384 — the v2 `RxAudioPanel` link-lost readout, restored from the SAME
    *  underlying fact (`liveAudio.operational` is `runtime.connectionAudio`, the
    *  identical audio-WS health the retired panel read as `isAudioConnected`).
@@ -153,8 +181,9 @@
             type="button" role="radio" class="rx-audio-choice"
             data-testid={`rx-audio-monitor-${mode}`} data-mode={mode}
             data-live-link={mode === 'live' ? rx.liveAudio.operational : undefined}
-            aria-checked={rx.monitorMode === mode}
-            onclick={() => onMonitorMode?.(mode)}
+            aria-checked={monitorBehavior.isSelected(mode)}
+            disabled={!monitorBehavior.available}
+            onclick={() => monitorBehavior.invoke(mode)}
           >{mode}</button>
         {/if}
       {/each}
@@ -194,8 +223,9 @@
           <button
             type="button" role="radio" class="rx-audio-choice"
             data-testid={`rx-audio-focus-${focus}`}
-            aria-checked={isValue(rx.routingFocus, focus)}
-            onclick={() => onRoutingFocus?.(focus)}
+            aria-checked={focusBehavior.isSelected(focus)}
+            disabled={!focusBehavior.available}
+            onclick={() => focusBehavior.invoke(focus)}
           >{focus}</button>
         {/each}
         <output data-testid="rx-audio-focus-value">{textOf(rx.routingFocus)}</output>
@@ -211,8 +241,9 @@
           <button
             type="button" role="radio" class="rx-audio-choice"
             data-testid={`rx-audio-split-${label}`}
-            aria-checked={isValue(rx.routingSplit, value)}
-            onclick={() => onRoutingSplit?.(value)}
+            aria-checked={splitBehavior.isSelected(value)}
+            disabled={!splitBehavior.available}
+            onclick={() => splitBehavior.invoke(value)}
           >split {label}</button>
         {/each}
         <output data-testid="rx-audio-split-value">{textOf(rx.routingSplit)}</output>
@@ -231,7 +262,7 @@
             data-testid="rx-audio-mod-select"
             aria-label={t('core.modePanel.modInputAria')}
             value={modInputValue}
-            disabled={!modInputUsable}
+            disabled={!modInputBehavior.available}
             onchange={(event) => changeModInput(event.currentTarget)}
           >
             {#if modInputValue === ''}

--- a/frontend/src/semantic/__tests__/AntennaSurface.test.ts
+++ b/frontend/src/semantic/__tests__/AntennaSurface.test.ts
@@ -124,11 +124,16 @@ describe('the antenna surface owns no state and no TX authority (R9)', () => {
   // specifiers only, so that premise is pinned one level down by
   // `pressed-of.test.ts`'s `'has no runtime import'` case (verify-MOR-1358
   // F1) — the two together are the closure.
-  it('imports nothing but the fact contract and the shared RX/TX vocabulary', () => {
+  it('imports only facts, shared TX vocabulary and control behavior', () => {
     const specifiers = [...CODE.matchAll(/from\s+'([^']+)'/g)].map((m) => m[1]);
     expect(specifiers.length).toBeGreaterThan(0);
     expect([...new Set(specifiers)].sort())
-      .toEqual(['./pressed-of', './radio-view-model', './rx-tx-surface']);
+      .toEqual([
+        '../primitives/control-instruments/control-instrument-behavior',
+        './pressed-of', './radio-view-model', './rx-tx-surface',
+      ]);
+    expect(CODE).toContain('bindAbsoluteChoiceInstrument');
+    expect(CODE).toContain('bindToggleInstrument');
   });
 
   // Kills: a lifecycle hook, an effect, or a dynamic import that could reach a
@@ -228,6 +233,21 @@ describe('an unread TX port renders as unknown, never as ANT 1 (CF3)', () => {
     expect(r.btn('port-2')!.getAttribute('aria-checked')).toBe('true');
     expect(r.btn('port-1')!.getAttribute('aria-checked')).toBe('false');
     expect(r.text('port-value')).toBe('2');
+    r.dispose();
+  });
+
+  it('permits an absolute port choice while the current port is unread', () => {
+    const onSelectPort = vi.fn();
+    const r = render(
+      withAnt({ txAntenna: unread<number>(DEGRADED) }), RECEIVING, { onSelectPort },
+    );
+    expect(r.btn('port-2')!.disabled).toBe(false);
+    r.btn('port-2')!.click();
+    flushSync();
+    expect(onSelectPort).toHaveBeenCalledExactlyOnceWith(2);
+    for (const port of ANTENNA_PORTS) {
+      expect(r.btn(`port-${port}`)!.getAttribute('aria-checked')).toBe('false');
+    }
     r.dispose();
   });
 

--- a/frontend/src/semantic/__tests__/BandSurface.test.ts
+++ b/frontend/src/semantic/__tests__/BandSurface.test.ts
@@ -31,6 +31,7 @@
 import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
 import BandSurface, {
   activeReceiverUnconfirmedReason, reasonLabel, UNKNOWN_TEXT, unresolvedReason,
   defaultPermitLabel, mhz,
@@ -110,13 +111,17 @@ describe('the band surface derives nothing (7B carry-forward 1)', () => {
   // import beyond `./radio-view-model` — pure operator-wording lookup
   // (`t()`), never a second fact derivation. See the two tests below for
   // the narrowed guard this replaces.
-  it('imports nothing but the fact contract, plus the i18n wording lookup', () => {
+  it('imports only facts, i18n wording and control behavior', () => {
     // MOR-1448 review F6: quote-agnostic — a double-quoted import must be
     // caught exactly like a single-quoted one, not slip past a single-quote
     // -only pattern.
     const specifiers = [...CODE.matchAll(/from\s+['"]([^'"]+)['"]/g)].map((m) => m[1]);
     expect(specifiers.length).toBeGreaterThan(0);
-    expect([...new Set(specifiers)]).toEqual(['$lib/i18n', './radio-view-model']);
+    expect([...new Set(specifiers)]).toEqual([
+      '$lib/i18n', './radio-view-model',
+      '../primitives/control-instruments/control-instrument-behavior',
+    ]);
+    expect(CODE).toContain('bindAbsoluteChoiceInstrument');
   });
 
   it('never mentions the permit derivation, the band plan or a capability read', () => {
@@ -592,11 +597,34 @@ describe('defaultHzTxPermit is never presented as band-wide permission (carry-fo
   });
 
   it('presses nothing while the current band is unread', () => {
-    const r = render(withB({ currentBand: unreadBand() }));
+    const onSelectBand = vi.fn();
+    const r = render(withB({ currentBand: unreadBand() }), { onSelectBand });
     for (const name of ['40m', '20m', 'MW']) {
       expect(r.el(`choice-${name}`)!.getAttribute('aria-pressed')).toBe('false');
     }
+    r.btn('choice-20m')!.click();
+    flushSync();
+    expect(onSelectBand).toHaveBeenCalledExactlyOnceWith('20m', 14195000, 5);
     r.dispose();
+  });
+
+  it('re-resolves the current offered payload when an existing band button invokes', () => {
+    const facts = new SvelteMap([['view', base()]]);
+    const onSelectBand = vi.fn();
+    const component = mount(BandSurface, {
+      target, props: { get view() { return facts.get('view')!; }, onSelectBand },
+    });
+    flushSync();
+    const button = target.querySelector<HTMLButtonElement>('[data-testid="band-choice-20m"]')!;
+    const nextChoices = facts.get('view')!.band!.bandChoices.map((choice) => choice.name === '20m'
+      ? { ...choice, defaultHz: 14225000, bsrCode: 7 }
+      : choice);
+    facts.set('view', withB({ bandChoices: nextChoices }));
+    flushSync();
+    button.click();
+    flushSync();
+    expect(onSelectBand).toHaveBeenCalledExactlyOnceWith('20m', 14225000, 7);
+    unmount(component);
   });
 });
 

--- a/frontend/src/semantic/__tests__/RxAudioSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RxAudioSurface.test.ts
@@ -90,10 +90,15 @@ describe('the RX-audio surface owns no audio lifetime (MOR-972 P0 / MOR-1058)', 
   /** The whole static import closure of the file, allow-listed. Kills: adding
    *  ANY import that could reach transport or the audio manager — including
    *  through a relative specifier, which a `$lib/...` regex would miss. */
-  it('imports only the fact contract, MOD-input vocabulary and localization', () => {
+  it('imports only facts, MOD-input vocabulary, localization and control behavior', () => {
     const specifiers = [...CODE.matchAll(/from\s+'([^']+)'/g)].map((m) => m[1]);
     expect(specifiers.length).toBeGreaterThan(0);
-    expect([...new Set(specifiers)].sort()).toEqual(['$lib/i18n', '$lib/radio/mod-input', './radio-view-model']);
+    expect([...new Set(specifiers)].sort()).toEqual([
+      '$lib/i18n', '$lib/radio/mod-input',
+      '../primitives/control-instruments/control-instrument-behavior', './radio-view-model',
+    ]);
+    expect(CODE).toContain('bindAbsoluteChoiceInstrument');
+    expect(CODE).toContain('bindChoiceInstrument');
   });
 
   // Kills: `onMount(() => audioManager.startRx())` and every relative of it.
@@ -400,6 +405,20 @@ describe('routing focus and split are rendered from the facts and emitted absolu
     r.dispose();
   });
 
+  it('allows an absolute focus choice while the saved preference is unread', () => {
+    const onRoutingFocus = vi.fn();
+    const r = render(
+      withRx({ routingFocus: unread<AudioFocus>(DEGRADED) }), { onRoutingFocus },
+    );
+    r.el('focus-main')!.click();
+    flushSync();
+    expect(onRoutingFocus).toHaveBeenCalledExactlyOnceWith('main');
+    for (const focus of FOCUS_CHOICES) {
+      expect(r.el(`focus-${focus}`)!.getAttribute('aria-checked')).toBe('false');
+    }
+    r.dispose();
+  });
+
   it.each(SPLIT_CHOICES)('checks exactly the observed split %s', (value, label) => {
     const r = render(withRx({ routingSplit: known(value) }));
     expect(r.el(`split-${label}`)!.getAttribute('aria-checked')).toBe('true');
@@ -492,6 +511,24 @@ describe('MOD-input selection uses observed facts and absolute intents (MOR-2366
       expect(select!.disabled).toBe(disabled);
     }
     expect(onModInputChange).not.toHaveBeenCalled();
+    unmount(component);
+  });
+
+  it('refuses a stale DOM selection and restores the latest observed source', () => {
+    const facts = new SvelteMap([['view', base()]]);
+    const onModInputChange = vi.fn();
+    const component = mount(RxAudioSurface, {
+      target, props: { get view() { return facts.get('view')!; }, onModInputChange },
+    });
+    flushSync();
+    const select = target.querySelector<HTMLSelectElement>('[data-testid="rx-audio-mod-select"]')!;
+    facts.set('view', withRx({ modInputSource: known(1, DEGRADED) }));
+    flushSync();
+    select.value = '4';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    flushSync();
+    expect(onModInputChange).not.toHaveBeenCalled();
+    expect(select.value).toBe('1');
     unmount(component);
   });
 });


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-2397/separate-finite-choice-selection-from-absolute-invocation-eligibility

## Summary
- add a narrow absolute-choice binding beside the unchanged known-field choice API, sharing one stateless membership/selection/invocation implementation
- adopt absolute choices for antenna ports, Band, monitor mode, and audio routing while preserving their existing family gates
- adopt the existing known-field choice binding for MOD input with its recognized-current blocker and DOM restoration
- preserve RX-ANT as a relative known-field toggle with its zero-argument callback ABI

## Compatibility
No wire, command, feedback-descriptor, state-owner, or public callback changes. Canonical selection remains separate from requested targets. Antenna RF/ATU safety, Band receiver routing and informational TX permits, live-link reachability, local routing preferences, and DATA-group MOD routing are unchanged.

## Verification
- focused baseline: 4 files, 193 tests passed
- intentional RED: 7 failures for the missing entrypoint and surface adoption
- focused GREEN: 4 leased files, 202 tests passed
- unchanged production wiring matrix: combined 7 files, 278 tests passed
- changed-file ESLint: passed
- frontend npm run check: passed with 0 errors and 0 warnings
- git diff --check: passed
- exact lease: 8 files, 359 additions/deletions; no baselines

Scope rationale: the eight files form one shared choice contract plus its test and three production surface/test pairs. Independent review PASS at f97d45113a8a740ba397871760a9b76bdb755041 found no code or prose blockers; natural quick 34020412047 and visual 34020412106 passed.
