### PR TITLE
MOR-2400 Fence S-meter continuity by source

### DIFF
--- a/frontend/fixtures/stubs/runtime.ts
+++ b/frontend/fixtures/stubs/runtime.ts
@@ -27,6 +27,7 @@ const DEFAULT_SCOPE_STATUS = {
   source: null, available: false, resourceSelected: false, demand: 0,
   lifecycle: 'inactive' as const, transport: 'disconnected' as const, frameSeen: false,
 };
+const FIXTURE_CONTROL_SESSION = Object.freeze({ state: 'connected' as const, epoch: 1 });
 
 type FixturePresentationResource = 'hardware-scope' | 'audio-fft';
 type FixturePresentationLease = Readonly<{
@@ -99,6 +100,13 @@ const fixtureScope = {
 export const runtime = {
   get state() { return harness.state; },
   get caps() { return harness.caps; },
+  // The fixture mounts one already-current state/caps snapshot for its whole
+  // page lifetime. This is its fixed authority boundary, not a socket or a
+  // transition producer; scope-frame transport remains separately absent.
+  get controlSession() { return FIXTURE_CONTROL_SESSION; },
+  subscribeControlSession(_handler: (next: typeof FIXTURE_CONTROL_SESSION) => void) {
+    return () => {};
+  },
   get audio() {
     const { rxEnabled, volume, muted } = harness.audioRuntime;
     return { rxEnabled, volume, muted };

--- a/frontend/src/components-v2/meters/LinearSMeter.svelte
+++ b/frontend/src/components-v2/meters/LinearSMeter.svelte
@@ -47,6 +47,8 @@
   import {
     createFrameStepPeakStrategy,
     createMeterBallistics,
+    type MeterContinuitySession,
+    type MeterSourceIdentity,
   } from '../../primitives/meters/meter-ballistics.svelte';
   import type { MeterDisplay } from '../../presentation/languages/contract';
   import { DEFAULT_METER_DISPLAY } from './meter-display';
@@ -90,11 +92,13 @@
      * sibling `data-main-relevant` / `data-lower-relevant` groups below.
      */
     relevant?: boolean;
+    source?: MeterSourceIdentity | null;
+    session?: MeterContinuitySession | null;
   }
 
   let {
     value, compact = false, label, variant, display = DEFAULT_METER_DISPLAY, lowerScale,
-    relevant = true, mainPresent = true,
+    relevant = true, mainPresent = true, source, session,
   }: Props = $props();
 
   const isVfoVariant = $derived(variant === 'vfo' || variant === 'vfo-wide');
@@ -350,7 +354,12 @@
     const current = value === null || !mainPresent
       ? null
       : (calibratedToSegments(value) / RAW_SEGMENT_DOMAIN) * SEG_COUNT;
-    untrack(() => ballistics.sync({ sample: current, smoothTarget: current, peakEnabled: true }));
+    const currentSource = source;
+    const currentSession = session;
+    untrack(() => ballistics.sync({
+      sample: current, smoothTarget: current, peakEnabled: true,
+      source: currentSource, session: currentSession,
+    }));
   });
 
   onMount(() => {
@@ -515,12 +524,14 @@
     <!-- Active -->
     {#if i < fullSegs}
       <rect
+        data-meter-fill={i}
         {x} y={TRACK_Y + 1}
         width={SEG_W} height={TRACK_H - 2}
         fill={activeColor(i)}
       />
     {:else if i === fullSegs && fracSeg > 0.01}
       <rect
+        data-meter-fill={i}
         {x} y={TRACK_Y + 1}
         width={Math.max(1, SEG_W * fracSeg)} height={TRACK_H - 2}
         fill={activeColor(i)}
@@ -639,6 +650,7 @@
   <!-- Peak hold indicator -->
   {#if showPeak}
     <line
+      data-meter-peak
       x1={peakX} y1={TRACK_Y}
       x2={peakX} y2={TRACK_Y + TRACK_H}
       stroke={peakColor}

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -43,6 +43,7 @@
   } from '../../semantic/DspSurface.svelte';
   import FilterSurface from '../../semantic/FilterSurface.svelte';
   import MetersSurface from '../../semantic/MetersSurface.svelte';
+  import type { MeterContinuitySession } from '../../primitives/meters/meter-ballistics.svelte';
   import type { RadioViewModel } from '../../semantic/radio-view-model';
   import RfFrontEndSurface, {
     type RfFrontEndLevelField, type RfFrontEndToggleField,
@@ -604,6 +605,11 @@
   const readControlSession = 'controlSession' in runtime ? () => runtime.controlSession : undefined;
   const subscribeControlSession = 'subscribeControlSession' in runtime ? runtime.subscribeControlSession : undefined;
   let controlSession = $state(readControlSession?.() ?? { state: 'disconnected' as const, epoch: -1 });
+  let meterContinuitySession: MeterContinuitySession | null = $derived(
+    controlSession.state === 'connected'
+      && Number.isSafeInteger(controlSession.epoch) && controlSession.epoch >= 0
+      ? { controlSessionEpoch: controlSession.epoch } : null,
+  );
   const pbtFloorKey = (generation: number, receiver: 'MAIN' | 'SUB', field: PbtField) =>
     `${generation}:${receiver}:${field}`;
   const unsubscribePbtSession = subscribeControlSession?.((next) => {
@@ -1098,7 +1104,7 @@
   -->
   {#snippet metersSurface()}
     {#if view?.meters}
-      <MetersSurface {view} />
+      <MetersSurface {view} continuitySession={meterContinuitySession} />
     {/if}
   {/snippet}
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -253,6 +253,7 @@ afterEach(() => {
   expect(txHarness.trace()).toEqual([]);
   expect(h.sessionSubscriber).toBeNull();
   document.body.innerHTML = '';
+  vi.unstubAllGlobals();
 });
 
 // ── 1. The structural gate: absent group ⇒ no surface, no element drift ────
@@ -329,6 +330,11 @@ describe('the meters surface mounts only when the view model carries the group',
   });
 
   it('re-seeds the mounted S-meter immediately at source, session, provider, and disconnect boundaries', () => {
+    vi.stubGlobal('matchMedia', (query: string): MediaQueryList => ({
+      matches: query === '(prefers-reduced-motion: reduce)', media: query, onchange: null,
+      addEventListener: vi.fn(), removeEventListener: vi.fn(),
+      addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(() => false),
+    }));
     const signalState = (
       active: 'MAIN' | 'SUB', sMeter: number, providerGeneration = 1,
     ): ServerState => {
@@ -339,34 +345,50 @@ describe('the meters surface mounts only when the view model carries the group',
         [key]: { ...state[key], sMeter },
       } as ServerState;
     };
+    const setSignal = (
+      active: 'MAIN' | 'SUB', sMeter: number, providerGeneration = 1,
+    ): void => {
+      h.state = signalState(active, sMeter, providerGeneration);
+      h.caps = { ...liveCaps(true), providerGeneration };
+      push({});
+    };
+    const signalObserved = (): string | undefined =>
+      q('[data-testid="meter-signal"]')!.dataset.observed;
+    const armPeak = (active: 'MAIN' | 'SUB', providerGeneration = 1): number => {
+      setSignal(active, 240, providerGeneration);
+      setSignal(active, 60, providerGeneration);
+      expect(signalObserved()).toBe('true');
+      expect(signalHasPeak()).toBe(true);
+      return signalFillCount();
+    };
 
     h.state = signalState('MAIN', 240);
     render();
-    const mainFill = signalFillCount();
-    expect(mainFill).toBeGreaterThan(0);
-
-    h.state = signalState('SUB', 180);
-    push({});
-    const subFill = signalFillCount();
-    expect(subFill).toBeLessThan(mainFill);
+    const receiverFill = armPeak('MAIN');
+    setSignal('SUB', 60);
+    expect(signalObserved()).toBe('true');
+    expect(signalFillCount()).toBe(receiverFill);
     expect(signalHasPeak()).toBe(false);
 
-    h.state = signalState('SUB', 120);
-    push({});
-    expect(signalFillCount()).toBe(subFill);
+    const sessionFill = armPeak('SUB');
     pushSession({ state: 'connected', epoch: 2 });
-    const nextSessionFill = signalFillCount();
-    expect(nextSessionFill).toBeLessThan(subFill);
+    expect(signalObserved()).toBe('true');
+    expect(signalFillCount()).toBe(sessionFill);
     expect(signalHasPeak()).toBe(false);
 
-    h.state = signalState('SUB', 60, 2);
-    h.caps = { ...liveCaps(true), providerGeneration: 2 };
-    push({});
-    expect(signalFillCount()).toBeLessThan(nextSessionFill);
+    const providerFill = armPeak('SUB');
+    setSignal('SUB', 60, 2);
+    expect(signalObserved()).toBe('true');
+    expect(signalFillCount()).toBe(providerFill);
     expect(signalHasPeak()).toBe(false);
 
+    const reconnectFill = armPeak('SUB', 2);
     pushSession({ state: 'disconnected', epoch: 3 });
     expect(signalFillCount()).toBe(0);
+    expect(signalHasPeak()).toBe(false);
+    pushSession({ state: 'connected', epoch: 4 });
+    expect(signalObserved()).toBe('true');
+    expect(signalFillCount()).toBe(reconnectFill);
     expect(signalHasPeak()).toBe(false);
   });
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -21,12 +21,15 @@ import { flushSync, mount, unmount } from 'svelte';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
+import type { ControlSessionSnapshot } from '$lib/runtime/frontend-runtime';
 
 
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
   txController: null as ManagedAppTxController | null,
+  session: { state: 'connected', epoch: 1 } as ControlSessionSnapshot,
+  sessionSubscriber: null as ((next: ControlSessionSnapshot) => void) | null,
   noop: vi.fn(),
 }));
 
@@ -35,6 +38,11 @@ vi.mock('$lib/runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    get controlSession() { return h.session; },
+    subscribeControlSession(handler: (next: ControlSessionSnapshot) => void) {
+      h.sessionSubscriber = handler;
+      return () => { if (h.sessionSubscriber === handler) h.sessionSubscriber = null; };
+    },
     // MOR-1279 slice 3B: the wiring now also hands the adapter an
     // App-owned RX-audio snapshot (the FOURTH argument). Muted with no
     // browser stream keeps every fixture below on its pre-1279 path.
@@ -208,9 +216,19 @@ function push(next: ManagedAppTxServerSnapshot): void {
   flushSync();
 }
 
+function pushSession(next: ControlSessionSnapshot): void {
+  h.session = next;
+  h.sessionSubscriber?.(next);
+  flushSync();
+}
+
 const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
 /** SVG elements have `.dataset` too, but don't satisfy `q`'s `HTMLElement` bound. */
 const qSvg = (sel: string) => target.querySelector(sel) as SVGSVGElement | null;
+const signalFillCount = (): number => qSvg('[data-testid="meter-signal"] svg')!
+  .querySelectorAll('[data-meter-fill]').length;
+const signalHasPeak = (): boolean => qSvg('[data-testid="meter-signal"] svg')!
+  .querySelector('[data-meter-peak]') !== null;
 const rfState = (): string | undefined => q('[data-testid="meters-surface"]')!.dataset.rfState;
 /** `data-meter -> data-relevant` for every rendered tile. */
 const relevance = (): Record<string, string> => Object.fromEntries(
@@ -223,6 +241,8 @@ beforeEach(() => {
   h.txController = txHarness.controller;
   h.state = liveState(true);
   h.caps = liveCaps(true);
+  h.session = { state: 'connected', epoch: 1 };
+  h.sessionSubscriber = null;
   h.noop.mockReset();
 });
 
@@ -231,6 +251,7 @@ afterEach(() => {
   component = null;
   expect(txHarness.listenerCount()).toBe(0);
   expect(txHarness.trace()).toEqual([]);
+  expect(h.sessionSubscriber).toBeNull();
   document.body.innerHTML = '';
 });
 
@@ -305,6 +326,48 @@ describe('the meters surface mounts only when the view model carries the group',
     expect(q('[data-testid="meters-surface"]')).not.toBeNull();
     expect(q('[data-testid="meter-signal"]')!.dataset.observed).toBe('false');
     expect(q('[data-testid="meter-drainVoltage"]')!.dataset.observed).toBe('false');
+  });
+
+  it('re-seeds the mounted S-meter immediately at source, session, provider, and disconnect boundaries', () => {
+    const signalState = (
+      active: 'MAIN' | 'SUB', sMeter: number, providerGeneration = 1,
+    ): ServerState => {
+      const state = liveState(true);
+      const key = active === 'MAIN' ? 'main' : 'sub';
+      return {
+        ...state, active, providerGeneration,
+        [key]: { ...state[key], sMeter },
+      } as ServerState;
+    };
+
+    h.state = signalState('MAIN', 240);
+    render();
+    const mainFill = signalFillCount();
+    expect(mainFill).toBeGreaterThan(0);
+
+    h.state = signalState('SUB', 180);
+    push({});
+    const subFill = signalFillCount();
+    expect(subFill).toBeLessThan(mainFill);
+    expect(signalHasPeak()).toBe(false);
+
+    h.state = signalState('SUB', 120);
+    push({});
+    expect(signalFillCount()).toBe(subFill);
+    pushSession({ state: 'connected', epoch: 2 });
+    const nextSessionFill = signalFillCount();
+    expect(nextSessionFill).toBeLessThan(subFill);
+    expect(signalHasPeak()).toBe(false);
+
+    h.state = signalState('SUB', 60, 2);
+    h.caps = { ...liveCaps(true), providerGeneration: 2 };
+    push({});
+    expect(signalFillCount()).toBeLessThan(nextSessionFill);
+    expect(signalHasPeak()).toBe(false);
+
+    pushSession({ state: 'disconnected', epoch: 3 });
+    expect(signalFillCount()).toBe(0);
+    expect(signalHasPeak()).toBe(false);
   });
 
   // MUTATION KILLED: giving the meters surface a `data-zone-id` of its own.

--- a/frontend/src/lib/runtime/adapters/__tests__/meters-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/meters-adapter.test.ts
@@ -124,6 +124,46 @@ describe('meters TX truth comes from the App TX authority (R9 / MOR-1235)', () =
   });
 });
 
+describe('canonical meter source identity (MOR-2400)', () => {
+  it('emits the already-qualified generation, scope, receiver, and closed path for all seven meters', () => {
+    const meters = model(meterState(), caps(), TX).meters!;
+    expect(Object.fromEntries(
+      (['signal', 'power', 'swr', 'alc', 'compression', 'drainVoltage', 'drainCurrent'] as const)
+        .map((field) => [field, meters[field].source]),
+    )).toEqual({
+      signal: { providerGeneration: 1, scope: 'receiver', receiver: 'MAIN', path: 'main.sMeter' },
+      power: { providerGeneration: 1, scope: 'radio', receiver: null, path: 'powerMeter' },
+      swr: { providerGeneration: 1, scope: 'radio', receiver: null, path: 'swrMeter' },
+      alc: { providerGeneration: 1, scope: 'radio', receiver: null, path: 'alcMeter' },
+      compression: { providerGeneration: 1, scope: 'radio', receiver: null, path: 'compMeter' },
+      drainVoltage: { providerGeneration: 1, scope: 'radio', receiver: null, path: 'vdMeter' },
+      drainCurrent: { providerGeneration: 1, scope: 'radio', receiver: null, path: 'idMeter' },
+    });
+  });
+
+  it('follows the active signal receiver and emits null for every noncurrent field', () => {
+    const dualCaps = caps({
+      receivers: 2, vfoScheme: 'main_sub',
+      capabilities: ['scope', 'audio', 'tx', 'dual_rx'],
+    });
+    const onSub = meterState({
+      active: 'SUB',
+      sub: { freqHz: 7100000, mode: 'LSB', filter: 1, sMeter: 60 } as ServerState['main'],
+    });
+    expect(model(onSub, dualCaps, RX).meters!.signal.source).toEqual({
+      providerGeneration: 1, scope: 'receiver', receiver: 'SUB', path: 'sub.sMeter',
+    });
+
+    const state = meterState();
+    const fieldStatus = Object.fromEntries(METER_PATHS.map((path) => [path, stale]));
+    const meters = model({ ...state, fieldStatus }, caps(), TX).meters!;
+    for (const field of [
+      meters.signal, meters.power, meters.swr, meters.alc, meters.compression,
+      meters.drainVoltage, meters.drainCurrent,
+    ]) expect(field.source).toBeNull();
+  });
+});
+
 describe('target meter display provenance (MOR-2359)', () => {
   const targets = [['power', 'powerMeter'], ['swr', 'swrMeter'], ['alc', 'alcMeter']] as const;
   const observed = { ...fresh, lastObservedMonotonic: 310658.42975425 };
@@ -185,6 +225,9 @@ describe('target meter display provenance (MOR-2359)', () => {
           expect(strict).toEqual({
             reading: operational ? { status: 'known', value: state[path] } : { status: 'unknown' },
             availability: { structural: true, operational }, relevant,
+            source: operational
+              ? { providerGeneration: 1, scope: 'radio', receiver: null, path }
+              : null,
           });
         }
         for (const meter of ['signal', 'compression', 'drainVoltage', 'drainCurrent'] as const) {
@@ -244,7 +287,7 @@ describe('meters evidence gate and per-meter derivation (MOR-1262 slice 2A)', ()
     const meters = model(meterState({ alcMeter: undefined }), caps(), TX).meters!;
     expect(meters.alc).toEqual({
       reading: { status: 'unknown' }, availability: { structural: false, operational: false }, relevant: true,
-      display: { state: 'unsupported' },
+      display: { state: 'unsupported' }, source: null,
     });
   });
 
@@ -254,7 +297,7 @@ describe('meters evidence gate and per-meter derivation (MOR-1262 slice 2A)', ()
     }), caps(), TX).meters!;
     expect(meters.swr).toEqual({
       reading: { status: 'unknown' }, availability: { structural: true, operational: false }, relevant: true,
-      display: { state: 'stale', value: 20 },
+      display: { state: 'stale', value: 20 }, source: null,
     });
   });
 
@@ -363,6 +406,7 @@ describe('meters evidence gate and per-meter derivation (MOR-1262 slice 2A)', ()
       reading: { status: 'unknown' },
       availability: { structural: true, operational: false },
       relevant: true,
+      source: null,
     });
   });
 
@@ -376,6 +420,7 @@ describe('meters evidence gate and per-meter derivation (MOR-1262 slice 2A)', ()
       reading: { status: 'unknown' },
       availability: { structural: true, operational: false },
       relevant: true,
+      source: null,
     });
   });
 

--- a/frontend/src/lib/runtime/adapters/__tests__/meters-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/meters-adapter.test.ts
@@ -1,10 +1,10 @@
 /**
  * MOR-1262 decomposition slice 2A — `meters` fact-group adapter derivation.
  *
- * Companion to `radio-view-model-adapter.test.ts` (MOR-1065) and
- * `tx-aux-adapter.test.ts` (MOR-1244), neither of which this file modifies.
- * Those files never pass a TX authority snapshot, so `deriveMeters` declines
- * to emit for them and their exact-key-list assertions stand unchanged.
+ * Companion to `radio-view-model-adapter.test.ts` (MOR-1065), whose RF-gain
+ * cases pass a TX authority and therefore receive meters. That suite owns a
+ * source-normalized legacy digest; this focused suite owns exact meter-source
+ * projection. `tx-aux-adapter.test.ts` remains outside this group's fanout.
  *
  * The first describe block is the SAFETY block (invariant R9, MOR-1235): the
  * discriminating pair proves the group's TX truth comes from the App TX

--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -1065,7 +1065,11 @@ describe('RF gain additive display observation', () => {
   }
   it.each([false, true])('preserves legacy strict model members for stale=%s', (stale) => {
     const view = toRadioViewModel(displayState(stale), displayCaps, RECEIVING)!;
-    const strictJson = JSON.stringify(view, (key, value) => ['display', 'activeFilterConfiguration', 'dataModeChoices'].includes(key) ? undefined : value);
+    const legacyView = structuredClone(view);
+    for (const field of [
+      'signal', 'power', 'swr', 'alc', 'compression', 'drainVoltage', 'drainCurrent',
+    ] as const) delete legacyView.meters?.[field].source;
+    const strictJson = JSON.stringify(legacyView, (key, value) => ['display', 'activeFilterConfiguration', 'dataModeChoices'].includes(key) ? undefined : value);
     const digest = createHash('sha256').update(strictJson).digest('hex');
     expect(digest).toBe(stale ? 'b4b5cff2b85557e39baa48e4d73c756e12ff026488ffa05a1ef558ca0b3f0507' : '379a5f00e3bebae780e4215af4e014351df2a07fc067d412f97df6aeadca840f');
   });

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -27,7 +27,7 @@ import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import type {
   RadioViewModel, TxAuxField, TxAuxViewModel, AtuStatus,
-  MeterField, MeterRfState, MetersViewModel,
+  MeterField, MeterRfState, MeterSourceIdentity, MeterSourcePath, MetersViewModel,
   AudioFocus, MonitorMode, RxAudioViewModel, ModeFilterViewModel,
   ActiveFilterConfiguration, FilterPassbandViewModel, DspViewModel, RfFrontEndViewModel,
   BandChoice, BandViewModel, RitXitViewModel, AntennaViewModel, ScanViewModel,
@@ -275,13 +275,20 @@ function meterRfState(tx: MetersTxAuthority): MeterRfState {
 
 function meterField(
   structural: boolean, observation: DisplayObservation<number>, relevant: boolean,
+  state: ServerState,
+  source: Omit<MeterSourceIdentity, 'providerGeneration'> | null,
   receiverOperational = true,
 ): MeterField {
   const operational = structural && receiverOperational && observation.state === 'current';
+  const providerGeneration = state.providerGeneration;
   return {
     reading: operational ? { status: 'known', value: observation.value } : { status: 'unknown' },
     availability: { structural, operational },
     relevant,
+    source: operational && source !== null
+      && typeof providerGeneration === 'number'
+      && Number.isSafeInteger(providerGeneration) && providerGeneration >= 0
+      ? { providerGeneration, ...source } : null,
   };
 }
 
@@ -317,12 +324,18 @@ function deriveMeters(
   const signalRaws = structuralReceivers.map((receiver) => state[RECEIVER_KEY[receiver]]?.sMeter);
   const raws = [...signalRaws, powerMeter, swrMeter, alcMeter, compMeter, vdMeter, idMeter];
   if (!raws.some((v) => v !== undefined)) return undefined;
-  const displayTxMeter = (raw: unknown, path: string) => {
+  const displayTxMeter = (
+    raw: unknown,
+    path: Exclude<MeterSourcePath, 'main.sMeter' | 'sub.sMeter' | 'compMeter' | 'vdMeter' | 'idMeter'>,
+  ) => {
     const structural = hasTx && raw !== undefined;
     const display = qualifyRadioDisplayObservation({
       state, caps, path, structural, value: numOrUndef(raw),
     });
-    return { ...meterField(structural, display, onTx), display };
+    return {
+      ...meterField(structural, display, onTx, state, { scope: 'radio', receiver: null, path }),
+      display,
+    };
   };
   const signalStructural = activeId === null
     ? signalRaws.some((raw) => raw !== undefined)
@@ -352,18 +365,31 @@ function deriveMeters(
   return {
     rfState,
     signal: meterField(
-      signalStructural, signalObservation, !onTx,
+      signalStructural, signalObservation, !onTx, state,
+      activeId === null ? null : {
+        scope: 'receiver', receiver: activeId,
+        path: activeId === 'MAIN' ? 'main.sMeter' : 'sub.sMeter',
+      },
       activeId !== null && operationalReceivers.includes(activeId),
     ),
     power: displayTxMeter(powerMeter, 'powerMeter'),
     swr: displayTxMeter(swrMeter, 'swrMeter'),
     alc: displayTxMeter(alcMeter, 'alcMeter'),
-    compression: meterField(compressionStructural, compressionObservation, onTx),
+    compression: meterField(
+      compressionStructural, compressionObservation, onTx, state,
+      { scope: 'radio', receiver: null, path: 'compMeter' },
+    ),
     // Vd is the station's supply rail, not a TX reading: it is worth showing
     // in every RF state (the dock keeps it on instantaneous display for the
     // same reason), so it is structurally gated but never relevance-gated.
-    drainVoltage: meterField(drainVoltageStructural, drainVoltageObservation, true),
-    drainCurrent: meterField(drainCurrentStructural, drainCurrentObservation, onTx),
+    drainVoltage: meterField(
+      drainVoltageStructural, drainVoltageObservation, true, state,
+      { scope: 'radio', receiver: null, path: 'vdMeter' },
+    ),
+    drainCurrent: meterField(
+      drainCurrentStructural, drainCurrentObservation, onTx, state,
+      { scope: 'radio', receiver: null, path: 'idMeter' },
+    ),
   };
 }
 

--- a/frontend/src/primitives/meters/__tests__/meter-ballistics.test.ts
+++ b/frontend/src/primitives/meters/__tests__/meter-ballistics.test.ts
@@ -5,7 +5,9 @@ import {
   createFrameStepPeakStrategy,
   createMeterBallistics,
   createMeterBallisticsGroup,
+  type MeterContinuitySession,
   type MeterMotionHost,
+  type MeterSourceIdentity,
   type MeterSmoother,
 } from '../meter-ballistics.svelte';
 
@@ -135,6 +137,15 @@ function elapsedSetup(reduced = false) {
   return { host, smoother, meter, update, display };
 }
 
+const MAIN_SOURCE = {
+  providerGeneration: 1, scope: 'receiver', receiver: 'MAIN', path: 'main.sMeter',
+} as const satisfies MeterSourceIdentity;
+const SUB_SOURCE = {
+  providerGeneration: 1, scope: 'receiver', receiver: 'SUB', path: 'sub.sMeter',
+} as const satisfies MeterSourceIdentity;
+const SESSION_1 = { controlSessionEpoch: 1 } as const satisfies MeterContinuitySession;
+const SESSION_2 = { controlSessionEpoch: 2 } as const satisfies MeterContinuitySession;
+
 const GROUP_KEYS = ['po', 'swr', 'alc', 'id'] as const;
 
 function groupSetup(reduced = false) {
@@ -246,6 +257,101 @@ describe('createMeterBallistics frame-step strategy', () => {
     expect(host.activeFrames).toBe(0);
     meter.stop();
     expect(host.listenerCount).toBe(0);
+  });
+});
+
+describe('createMeterBallistics continuity boundaries (MOR-2400)', () => {
+  it('keeps the omitted-source legacy path byte-for-behavior compatible', () => {
+    const { meter, smoother } = frameSetup();
+    meter.sync({ sample: 10, smoothTarget: 10, peakEnabled: true });
+    meter.sync({ sample: 2, smoothTarget: 2, peakEnabled: true });
+    expect(smoother.reset).not.toHaveBeenCalled();
+    expect(smoother.update).toHaveBeenCalledTimes(2);
+    expect(meter.view).toEqual({ smoothedValue: 2, peakValue: 10 });
+  });
+
+  it('always observes repeated samples from the same qualified source', () => {
+    const { meter, smoother } = frameSetup();
+    meter.sync({
+      sample: 10, smoothTarget: 10, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    vi.mocked(smoother.update).mockClear();
+    vi.mocked(smoother.reset).mockClear();
+    meter.sync({
+      sample: 2, smoothTarget: 2, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    meter.sync({
+      sample: 2, smoothTarget: 2, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    expect(smoother.update).toHaveBeenCalledTimes(2);
+    expect(smoother.reset).not.toHaveBeenCalled();
+    expect(meter.view).toEqual({ smoothedValue: 2, peakValue: 10 });
+  });
+
+  it('re-seeds smoothing and peak state when source identity changes', () => {
+    const { meter, smoother } = frameSetup();
+    meter.sync({
+      sample: 10, smoothTarget: 10, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    meter.sync({
+      sample: 2, smoothTarget: 2, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    expect(meter.view.peakValue).toBe(10);
+    vi.mocked(smoother.reset).mockClear();
+    meter.sync({
+      sample: 3, smoothTarget: 3, peakEnabled: true, source: SUB_SOURCE, session: SESSION_1,
+    });
+    expect(smoother.reset).toHaveBeenCalledExactlyOnceWith(3);
+    expect(meter.view).toEqual({ smoothedValue: 3, peakValue: 3 });
+  });
+
+  it('re-seeds on a control-session epoch change even when source identity is unchanged', () => {
+    const { meter, smoother } = frameSetup();
+    meter.sync({
+      sample: 10, smoothTarget: 10, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    meter.sync({
+      sample: 2, smoothTarget: 2, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    vi.mocked(smoother.reset).mockClear();
+    meter.sync({
+      sample: 4, smoothTarget: 4, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_2,
+    });
+    expect(smoother.reset).toHaveBeenCalledExactlyOnceWith(4);
+    expect(meter.view).toEqual({ smoothedValue: 4, peakValue: 4 });
+  });
+
+  it('gives explicit null precedence over transitional undefined and clears immediately', () => {
+    const { meter, smoother } = frameSetup();
+    meter.sync({
+      sample: 10, smoothTarget: 10, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    meter.sync({ sample: 8, smoothTarget: 8, peakEnabled: true, source: null });
+    expect(smoother.reset).toHaveBeenLastCalledWith(0);
+    expect(meter.view).toEqual({ smoothedValue: 0, peakValue: null });
+
+    meter.sync({
+      sample: 10, smoothTarget: 10, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    meter.sync({ sample: 8, smoothTarget: 8, peakEnabled: true, session: null });
+    expect(smoother.reset).toHaveBeenLastCalledWith(0);
+    expect(meter.view).toEqual({ smoothedValue: 0, peakValue: null });
+  });
+
+  it('clears prior history when entering or leaving qualified mode', () => {
+    const { meter, smoother } = frameSetup();
+    meter.sync({ sample: 10, smoothTarget: 10, peakEnabled: true });
+    meter.sync({
+      sample: 2, smoothTarget: 2, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    expect(meter.view).toEqual({ smoothedValue: 2, peakValue: 2 });
+    meter.sync({
+      sample: 9, smoothTarget: 9, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    vi.mocked(smoother.reset).mockClear();
+    meter.sync({ sample: 3, smoothTarget: 3, peakEnabled: true });
+    expect(smoother.reset).toHaveBeenCalledExactlyOnceWith(3);
+    expect(meter.view).toEqual({ smoothedValue: 3, peakValue: 3 });
   });
 });
 

--- a/frontend/src/primitives/meters/__tests__/meter-ballistics.test.ts
+++ b/frontend/src/primitives/meters/__tests__/meter-ballistics.test.ts
@@ -226,12 +226,16 @@ describe('createMeterBallistics frame-step strategy', () => {
 
   it('keeps a static reduced-motion peak and re-seats it on the next expired sync', () => {
     const { host, meter } = frameSetup({ reduced: true });
-    meter.sync({ sample: 10, smoothTarget: 10, peakEnabled: true });
+    meter.sync({
+      sample: 10, smoothTarget: 10, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
     meter.start();
     expect(host.activeFrames).toBe(0);
     host.advance(1001);
     expect(meter.view.peakValue).toBe(10);
-    meter.sync({ sample: 2, smoothTarget: 2, peakEnabled: true });
+    meter.sync({
+      sample: 2, smoothTarget: 2, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
     expect(meter.view.peakValue).toBe(2);
   });
 
@@ -281,14 +285,23 @@ describe('createMeterBallistics continuity boundaries (MOR-2400)', () => {
       sample: 2, smoothTarget: 2, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
     });
     meter.sync({
-      sample: 2, smoothTarget: 2, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+      sample: 2, smoothTarget: 3, peakEnabled: true,
+      source: { ...MAIN_SOURCE }, session: { ...SESSION_1 },
     });
     expect(smoother.update).toHaveBeenCalledTimes(2);
+    expect(smoother.update).toHaveBeenLastCalledWith(3);
     expect(smoother.reset).not.toHaveBeenCalled();
-    expect(meter.view).toEqual({ smoothedValue: 2, peakValue: 10 });
+    expect(meter.view).toEqual({ smoothedValue: 3, peakValue: 10 });
   });
 
-  it('re-seeds smoothing and peak state when source identity changes', () => {
+  it.each([
+    ['provider generation', { ...MAIN_SOURCE, providerGeneration: 2 }, SESSION_1],
+    ['scope', { ...MAIN_SOURCE, scope: 'radio' }, SESSION_1],
+    ['receiver', { ...MAIN_SOURCE, receiver: 'SUB' }, SESSION_1],
+    ['path', { ...MAIN_SOURCE, path: 'sub.sMeter' }, SESSION_1],
+    ['control-session epoch', MAIN_SOURCE, SESSION_2],
+  ] as readonly [string, MeterSourceIdentity, MeterContinuitySession][])(
+    're-seeds same-value history when only %s changes', (_label, nextSource, nextSession) => {
     const { meter, smoother } = frameSetup();
     meter.sync({
       sample: 10, smoothTarget: 10, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
@@ -298,27 +311,50 @@ describe('createMeterBallistics continuity boundaries (MOR-2400)', () => {
     });
     expect(meter.view.peakValue).toBe(10);
     vi.mocked(smoother.reset).mockClear();
+    vi.mocked(smoother.update).mockClear();
     meter.sync({
-      sample: 3, smoothTarget: 3, peakEnabled: true, source: SUB_SOURCE, session: SESSION_1,
+      sample: 2, smoothTarget: 2, peakEnabled: true, source: nextSource, session: nextSession,
     });
-    expect(smoother.reset).toHaveBeenCalledExactlyOnceWith(3);
-    expect(meter.view).toEqual({ smoothedValue: 3, peakValue: 3 });
+    expect(smoother.reset).toHaveBeenCalledExactlyOnceWith(2);
+    expect(smoother.update).not.toHaveBeenCalled();
+    expect(meter.view).toEqual({ smoothedValue: 2, peakValue: 2 });
   });
 
-  it('re-seeds on a control-session epoch change even when source identity is unchanged', () => {
-    const { meter, smoother } = frameSetup();
+  it.each([
+    ['frame-step', frameSetup],
+    ['elapsed-envelope', elapsedSetup],
+  ] as const)('re-seeds same-value source replacement through the %s strategy', (_label, setup) => {
+    const { meter, smoother } = setup();
     meter.sync({
       sample: 10, smoothTarget: 10, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
     });
     meter.sync({
       sample: 2, smoothTarget: 2, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
     });
+    expect(meter.view.peakValue).toBe(10);
     vi.mocked(smoother.reset).mockClear();
     meter.sync({
-      sample: 4, smoothTarget: 4, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_2,
+      sample: 2, smoothTarget: 2, peakEnabled: true, source: SUB_SOURCE, session: SESSION_1,
     });
-    expect(smoother.reset).toHaveBeenCalledExactlyOnceWith(4);
-    expect(meter.view).toEqual({ smoothedValue: 4, peakValue: 4 });
+    expect(smoother.reset).toHaveBeenCalledExactlyOnceWith(2);
+    expect(meter.view).toEqual({ smoothedValue: 2, peakValue: 2 });
+  });
+
+  it.each([
+    ['frame-step', frameSetup],
+    ['elapsed-envelope', elapsedSetup],
+  ] as const)('keeps qualified manual reset owned by the %s strategy', (_label, setup) => {
+    const { meter } = setup();
+    meter.sync({
+      sample: 10, smoothTarget: 10, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    meter.resetPeak();
+    expect(meter.view.peakValue).toBeNull();
+    meter.sync({
+      sample: 2, smoothTarget: 2, peakEnabled: true,
+      source: { ...MAIN_SOURCE }, session: { ...SESSION_1 },
+    });
+    expect(meter.view.peakValue).toBe(2);
   });
 
   it('gives explicit null precedence over transitional undefined and clears immediately', () => {
@@ -381,26 +417,38 @@ describe('createMeterBallistics elapsed-envelope strategy', () => {
 
   it('hides without clearing state and reset remains clear until a new sync', () => {
     const { meter } = elapsedSetup();
-    meter.sync({ sample: 1, smoothTarget: 10, peakEnabled: true });
-    meter.sync({ sample: 0.2, smoothTarget: 2, peakEnabled: false });
+    meter.sync({
+      sample: 1, smoothTarget: 10, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    meter.sync({
+      sample: 0.2, smoothTarget: 2, peakEnabled: false, source: MAIN_SOURCE, session: SESSION_1,
+    });
     expect(meter.view.peakValue).toBeNull();
-    meter.sync({ sample: 0.2, smoothTarget: 2, peakEnabled: true });
+    meter.sync({
+      sample: 0.2, smoothTarget: 2, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
     expect(meter.view.peakValue).toBe(1);
     meter.resetPeak();
     expect(meter.view.peakValue).toBeNull();
     expect(meter.view.peakValue).toBeNull();
-    meter.sync({ sample: 0.2, smoothTarget: 2, peakEnabled: true });
+    meter.sync({
+      sample: 0.2, smoothTarget: 2, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
     expect(meter.view.peakValue).toBe(0.2);
   });
 
   it('uses static reduced-motion projection and re-seats only on genuine sync', () => {
     const { host, meter } = elapsedSetup(true);
-    meter.sync({ sample: 1, smoothTarget: 10, peakEnabled: true });
+    meter.sync({
+      sample: 1, smoothTarget: 10, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
     meter.start();
     expect(host.activeIntervals).toBe(0);
     host.advance(2000);
     expect(meter.view.peakValue).toBe(1);
-    meter.sync({ sample: 0.2, smoothTarget: 2, peakEnabled: true });
+    meter.sync({
+      sample: 0.2, smoothTarget: 2, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
     expect(meter.view.peakValue).toBe(0.2);
   });
 
@@ -514,7 +562,9 @@ describe('createMeterBallistics scheduling lifecycle', () => {
     ['interval', elapsedSetup, 'activeIntervals'],
   ] as const)('keeps one %s schedule across preference flips and tears down once', (_name, setup, count) => {
     const { host, meter, smoother } = setup();
-    meter.sync({ sample: 1, smoothTarget: 1, peakEnabled: true });
+    meter.sync({
+      sample: 1, smoothTarget: 1, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
     meter.start();
     expect(smoother.start).toHaveBeenCalledTimes(1);
     expect(host[count]).toBe(1);

--- a/frontend/src/primitives/meters/meter-ballistics.svelte.ts
+++ b/frontend/src/primitives/meters/meter-ballistics.svelte.ts
@@ -1,7 +1,20 @@
+export type MeterSourceIdentity = Readonly<{
+  providerGeneration: number;
+  scope: 'radio' | 'receiver';
+  receiver: 'MAIN' | 'SUB' | null;
+  path: string;
+}>;
+
+export type MeterContinuitySession = Readonly<{
+  controlSessionEpoch: number;
+}>;
+
 export type MeterBehaviorInput = Readonly<{
   sample: number | null;
   smoothTarget: number | null;
   peakEnabled: boolean;
+  source?: MeterSourceIdentity | null;
+  session?: MeterContinuitySession | null;
 }>;
 
 export interface MeterBallisticsView {
@@ -240,6 +253,17 @@ export function createMeterBallistics<State>(
   let peakEnabled = $state(false);
   let projectionNow = $state(host.now());
   let started = false;
+  let continuityMode: 'legacy' | 'qualified' | null = null;
+  let continuitySource: MeterSourceIdentity | undefined;
+  let continuitySession: MeterContinuitySession | undefined;
+
+  const sameSource = (left: MeterSourceIdentity, right: MeterSourceIdentity): boolean =>
+    left.providerGeneration === right.providerGeneration
+    && left.scope === right.scope
+    && left.receiver === right.receiver
+    && left.path === right.path;
+  const sameSession = (left: MeterContinuitySession, right: MeterContinuitySession): boolean =>
+    left.controlSessionEpoch === right.controlSessionEpoch;
 
   function peakCurrent(): number {
     return policy.peakSource === 'sample' ? sample : smoother.value;
@@ -268,6 +292,27 @@ export function createMeterBallistics<State>(
     sync(input) {
       peakEnabled = input.peakEnabled;
       projectionNow = host.now();
+      if (input.source === null || input.session === null) {
+        sample = 0;
+        smoother.reset(0);
+        channel.reset();
+        continuityMode = null;
+        continuitySource = undefined;
+        continuitySession = undefined;
+        lifecycle.reconcile();
+        return;
+      }
+
+      const qualified = input.source !== undefined && input.session !== undefined;
+      const boundary = qualified
+        ? continuityMode !== 'qualified'
+          || continuitySource === undefined || !sameSource(continuitySource, input.source)
+          || continuitySession === undefined || !sameSession(continuitySession, input.session)
+        : continuityMode === 'qualified';
+      continuityMode = qualified ? 'qualified' : 'legacy';
+      continuitySource = qualified ? input.source : undefined;
+      continuitySession = qualified ? input.session : undefined;
+
       if (input.sample === null || input.smoothTarget === null) {
         sample = 0;
         smoother.reset(0);
@@ -276,7 +321,12 @@ export function createMeterBallistics<State>(
         return;
       }
       sample = input.sample;
-      smoother.update(input.smoothTarget);
+      if (boundary) {
+        smoother.reset(input.smoothTarget);
+        channel.reset();
+      } else {
+        smoother.update(input.smoothTarget);
+      }
       if (peakEnabled) {
         channel.observe(peakCurrent(), projectionNow, lifecycle.reducedMotion);
       }

--- a/frontend/src/semantic/MetersSurface.svelte
+++ b/frontend/src/semantic/MetersSurface.svelte
@@ -118,10 +118,14 @@
   import BarGauge from '../components-v2/meters/BarGauge.svelte';
   import LinearSMeter from '../components-v2/meters/LinearSMeter.svelte';
   import type { RadioViewModel } from './radio-view-model';
+  import type { MeterContinuitySession } from '../primitives/meters/meter-ballistics.svelte';
   import { RF_LABEL, RF_MARK } from './rx-tx-surface';
 
-  interface Props { view: RadioViewModel }
-  let { view }: Props = $props();
+  interface Props {
+    view: RadioViewModel;
+    continuitySession?: MeterContinuitySession | null;
+  }
+  let { view, continuitySession }: Props = $props();
 
   /** Absent group ⇒ this surface renders nothing (S0 optional-group doctrine,
    *  risk R3): a radio that reports no meters gets no empty dock, and no zone
@@ -174,6 +178,8 @@
           display={display?.display ?? undefined}
           lowerScale={present(meters.swr) ? swrLowerScale(meters.swr, meters.rfState) : undefined}
           relevant={meters.signal.relevant}
+          source={meters.signal.source}
+          session={continuitySession}
         />
       </div>
     {/if}

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -395,8 +395,11 @@ describe('TX truth reaches this surface only through the fact layer (R9)', () =>
     expect(SOURCE).not.toMatch(/\bptt\b/i);
     expect(SOURCE).not.toMatch(/TxAuthoritySnapshot/);
     expect(SOURCE).not.toMatch(/radioState/);
-    // `view` is the ONE prop. A second one would be a second TX input.
-    expect(SOURCE).toMatch(/interface Props\s*\{\s*view:\s*RadioViewModel;?\s*\}/);
+    // Exactly one fact input plus the generic continuity boundary. Neither is
+    // a second TX authority or a raw runtime/state input.
+    expect(SOURCE).toMatch(
+      /interface Props\s*\{\s*view:\s*RadioViewModel;\s*continuitySession\?:\s*MeterContinuitySession\s*\|\s*null;\s*\}/,
+    );
   });
 
   // MUTATION KILLED: computing an RF state locally (e.g. from txPermit, or

--- a/frontend/src/semantic/__tests__/meters.test.ts
+++ b/frontend/src/semantic/__tests__/meters.test.ts
@@ -20,7 +20,8 @@
  */
 import { describe, expect, it } from 'vitest';
 import {
-  validateRadioViewModel, type MeterField, type MeterRfState, type MetersViewModel,
+  validateRadioViewModel, type MeterField, type MeterRfState, type MeterSourceIdentity,
+  type MetersViewModel,
 } from '../radio-view-model';
 import { topologyFixtures, withMeters } from '../fixtures/topologies';
 import { rfState, type RfState, type TxAuthoritySnapshot } from '../rx-tx-surface';
@@ -63,6 +64,57 @@ describe('target meter display observation contract (MOR-2359)', () => {
       expect(() => validateRadioViewModel(withDisplay(meter, display)))
         .toThrow(new RegExp(`\\$\\.meters\\.${meter}\\.display`));
     }
+  });
+});
+
+describe('meter source identity contract (MOR-2400)', () => {
+  const SOURCES = {
+    signal: { providerGeneration: 7, scope: 'receiver', receiver: 'MAIN', path: 'main.sMeter' },
+    power: { providerGeneration: 7, scope: 'radio', receiver: null, path: 'powerMeter' },
+    swr: { providerGeneration: 7, scope: 'radio', receiver: null, path: 'swrMeter' },
+    alc: { providerGeneration: 7, scope: 'radio', receiver: null, path: 'alcMeter' },
+    compression: { providerGeneration: 7, scope: 'radio', receiver: null, path: 'compMeter' },
+    drainVoltage: { providerGeneration: 7, scope: 'radio', receiver: null, path: 'vdMeter' },
+    drainCurrent: { providerGeneration: 7, scope: 'radio', receiver: null, path: 'idMeter' },
+  } as const satisfies Record<keyof Omit<MetersViewModel, 'rfState'>, MeterSourceIdentity>;
+
+  function withSource(meter: keyof typeof SOURCES, source: unknown) {
+    const view = withMeters(base);
+    return {
+      ...view,
+      meters: { ...view.meters, [meter]: { ...view.meters![meter], source } },
+    };
+  }
+
+  it('preserves omission and explicit null as different states', () => {
+    const omitted = withMeters(base);
+    expect(validateRadioViewModel(omitted).meters!.signal).not.toHaveProperty('source');
+    expect(validateRadioViewModel(withSource('signal', null)).meters!.signal.source).toBeNull();
+  });
+
+  it.each(Object.entries(SOURCES) as [keyof typeof SOURCES, MeterSourceIdentity][])(
+    'round-trips the canonical source for %s', (meter, source) => {
+      expect(validateRadioViewModel(withSource(meter, source)).meters![meter].source).toEqual(source);
+    },
+  );
+
+  it('accepts the canonical SUB receiver source only on signal', () => {
+    const source = { providerGeneration: 8, scope: 'receiver', receiver: 'SUB', path: 'sub.sMeter' };
+    expect(validateRadioViewModel(withSource('signal', source)).meters!.signal.source).toEqual(source);
+  });
+
+  it.each([
+    ['unsafe generation', 'power', { ...SOURCES.power, providerGeneration: Number.MAX_SAFE_INTEGER + 1 }],
+    ['negative generation', 'power', { ...SOURCES.power, providerGeneration: -1 }],
+    ['extra key', 'power', { ...SOURCES.power, provider: 'rigctld' }],
+    ['wrong radio path', 'power', SOURCES.swr],
+    ['receiver source on radio field', 'power', SOURCES.signal],
+    ['radio source on receiver field', 'signal', SOURCES.power],
+    ['crossed receiver and path', 'signal', { ...SOURCES.signal, receiver: 'SUB' }],
+    ['open path', 'signal', { ...SOURCES.signal, path: 'main.noiseMeter' }],
+  ] as const)('rejects %s', (_label, meter, source) => {
+    expect(() => validateRadioViewModel(withSource(meter, source)))
+      .toThrow(new RegExp(`\\$\\.meters\\.${meter}\\.source`));
   });
 });
 

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -18,6 +18,7 @@
 import type { VfoScheme } from '$lib/types/capabilities';
 import type { NrLevelProjection } from '$lib/radio/filter-controls';
 import type { FrequencyPermit, TxPermit } from '$lib/utils/tx-permit';
+import type { MeterSourceIdentity as PrimitiveMeterSourceIdentity } from '../primitives/meters/meter-ballistics.svelte';
 import { invalid, record, exactKeys, str } from './validator-primitives';
 
 export type ReceiverId = 'MAIN' | 'SUB';
@@ -186,10 +187,17 @@ export interface TxAuxViewModel {
  * authority's conclusion, it never computes one.
  */
 export type MeterReading = { status: 'known'; value: number } | { status: 'unknown' };
+export type MeterSourcePath =
+  | 'main.sMeter' | 'sub.sMeter'
+  | 'powerMeter' | 'swrMeter' | 'alcMeter' | 'compMeter' | 'vdMeter' | 'idMeter';
+export type MeterSourceIdentity = Readonly<
+  Omit<PrimitiveMeterSourceIdentity, 'path'> & { readonly path: MeterSourcePath }
+>;
 export interface MeterField {
   reading: MeterReading;
   availability: Availability;
   relevant: boolean;
+  source?: MeterSourceIdentity | null;
 }
 
 export interface DisplayObservedMeterField extends MeterField {
@@ -1366,10 +1374,43 @@ function validateDisabledReason(value: unknown, path: string): DisabledReason {
 }
 
 const METER_RF_STATES: readonly MeterRfState[] = ['receiving', 'transmitting', 'uncertain', 'unknown'];
+const METER_SOURCE_PATHS: readonly MeterSourcePath[] = [
+  'main.sMeter', 'sub.sMeter', 'powerMeter', 'swrMeter', 'alcMeter', 'compMeter', 'vdMeter', 'idMeter',
+];
+type MeterSourceExpectation = 'signal' | Exclude<MeterSourcePath, 'main.sMeter' | 'sub.sMeter'>;
 
-function validateMeterField(value: unknown, path: string): MeterField {
+function validateMeterSource(
+  value: unknown, path: string, expected: MeterSourceExpectation,
+): MeterSourceIdentity {
   const v = record(value, path);
-  exactKeys(v, ['reading', 'availability', 'relevant'], path);
+  exactKeys(v, ['providerGeneration', 'scope', 'receiver', 'path'], path);
+  if (typeof v.providerGeneration !== 'number'
+    || !Number.isSafeInteger(v.providerGeneration) || v.providerGeneration < 0) {
+    invalid(`${path}.providerGeneration`, 'a non-negative safe integer');
+  }
+  const scope = oneOf(v.scope, ['radio', 'receiver'] as const, `${path}.scope`);
+  const receiver = v.receiver === null
+    ? null : oneOf(v.receiver, ['MAIN', 'SUB'] as const, `${path}.receiver`);
+  const sourcePath = oneOf(v.path, METER_SOURCE_PATHS, `${path}.path`);
+  const source: MeterSourceIdentity = {
+    providerGeneration: v.providerGeneration, scope, receiver, path: sourcePath,
+  };
+  if (expected === 'signal') {
+    const coherent = scope === 'receiver'
+      && ((receiver === 'MAIN' && sourcePath === 'main.sMeter')
+        || (receiver === 'SUB' && sourcePath === 'sub.sMeter'));
+    if (!coherent) invalid(path, 'a canonical MAIN/main.sMeter or SUB/sub.sMeter receiver source');
+  } else if (scope !== 'radio' || receiver !== null || sourcePath !== expected) {
+    invalid(path, `the canonical radio source for ${expected}`);
+  }
+  return source;
+}
+
+function validateMeterField(
+  value: unknown, path: string, expectedSource: MeterSourceExpectation,
+): MeterField {
+  const v = record(value, path);
+  exactKeys(v, ['reading', 'availability', 'relevant', 'source'], path);
   const r = record(v.reading, `${path}.reading`);
   let reading: MeterReading;
   if (r.status === 'known') {
@@ -1385,13 +1426,21 @@ function validateMeterField(value: unknown, path: string): MeterField {
     reading,
     availability: validateAvailability(v.availability, `${path}.availability`),
     relevant: bool(v.relevant, `${path}.relevant`),
+    ...(v.source !== undefined
+      ? { source: v.source === null ? null : validateMeterSource(v.source, `${path}.source`, expectedSource) }
+      : {}),
   };
 }
 
-function validateDisplayObservedMeterField(value: unknown, path: string): DisplayObservedMeterField {
+function validateDisplayObservedMeterField(
+  value: unknown, path: string, expectedSource: MeterSourceExpectation,
+): DisplayObservedMeterField {
   const v = record(value, path);
-  exactKeys(v, ['reading', 'availability', 'relevant', 'display'], path);
-  const strict = validateMeterField({ reading: v.reading, availability: v.availability, relevant: v.relevant }, path);
+  exactKeys(v, ['reading', 'availability', 'relevant', 'display', 'source'], path);
+  const strict = validateMeterField({
+    reading: v.reading, availability: v.availability, relevant: v.relevant,
+    ...(v.source !== undefined ? { source: v.source } : {}),
+  }, path, expectedSource);
   return {
     ...strict,
     ...(v.display !== undefined ? { display: validateDisplayObservation(v.display, `${path}.display`, num) } : {}),
@@ -1408,13 +1457,13 @@ function validateMeters(value: unknown, path: string): MetersViewModel {
   ], path);
   return {
     rfState: oneOf(v.rfState, METER_RF_STATES, `${path}.rfState`),
-    signal: validateMeterField(v.signal, `${path}.signal`),
-    power: validateDisplayObservedMeterField(v.power, `${path}.power`),
-    swr: validateDisplayObservedMeterField(v.swr, `${path}.swr`),
-    alc: validateDisplayObservedMeterField(v.alc, `${path}.alc`),
-    compression: validateMeterField(v.compression, `${path}.compression`),
-    drainVoltage: validateMeterField(v.drainVoltage, `${path}.drainVoltage`),
-    drainCurrent: validateMeterField(v.drainCurrent, `${path}.drainCurrent`),
+    signal: validateMeterField(v.signal, `${path}.signal`, 'signal'),
+    power: validateDisplayObservedMeterField(v.power, `${path}.power`, 'powerMeter'),
+    swr: validateDisplayObservedMeterField(v.swr, `${path}.swr`, 'swrMeter'),
+    alc: validateDisplayObservedMeterField(v.alc, `${path}.alc`, 'alcMeter'),
+    compression: validateMeterField(v.compression, `${path}.compression`, 'compMeter'),
+    drainVoltage: validateMeterField(v.drainVoltage, `${path}.drainVoltage`, 'vdMeter'),
+    drainCurrent: validateMeterField(v.drainCurrent, `${path}.drainCurrent`, 'idMeter'),
   };
 }
 


### PR DESCRIPTION
13 code + 0 regenerated baselines = 13 files

Linear: [MOR-2400](https://linear.app/morozsm/issue/MOR-2400/carry-canonical-meter-source-continuity-into-the-shared-active-s-meter)

## Summary
- add canonical generation/scope/receiver/path identity to the seven meter facts, with strict field-specific validation
- qualify Linear S-meter smoothing and peak history by source identity plus connected control-session epoch
- clear and immediately reseed the mounted meter across receiver, provider, session, and disconnect boundaries while preserving the omitted-provenance legacy path
- complete the static visual fixture with an honest fixed connected epoch while keeping scope-frame transport separately disconnected

## Verification
- six focused owner suites: 444 tests passed
- focused baseline reproduced the three independently reported owner failures before correction
- same-value per-member, reconstructed-identity, both-strategy, qualified lifecycle, and mounted immediate fill/peak witnesses included
- `npm run check`: 0 errors and 0 warnings
- changed-scope ESLint clean for all 12 configured source/test paths; fixture stub is outside ESLint scope and covered by the harness TypeScript check
- `git diff --check` clean
- exact cumulative scope: 13 files, 546 insertions and 44 deletions (590 A+D)

## Compatibility
No API, CLI, config, or wire-format break. The semantic meter source field is optional; omitted callers keep legacy ballistics behavior. Production absent/disconnected session handling remains fail-closed. No visual baseline was regenerated.

## Independent review and acceptance
- Fresh independent [PASS e0376fe2ae10f69bb0eb8f4d589738698389bfde](https://github.com/rigplane/rigplane-core/pull/3252#issuecomment-5558176328); all three prior findings are resolved, with no remaining code or mandatory prose corrections.
- Coordinator verified natural quick 34023070221, visual 34023070167 and the actual required Agent Review Gate are successful at this exact head.
- The recorded file-count exception covers one additive source contract, its existing lifecycle and real mounted consumer, including the two previously omitted owner tests and the static fixture runtime. The 1,000-line ceiling remains unchanged.
