### PR TITLE
MOR-2398: Fence command feedback by provider generation

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.component.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.component.test.ts
@@ -6,7 +6,7 @@ import { getFilterWidthControlFeedback } from '../panel-adapters';
 
 type Command = {
   id: string; name: string; params: { width: number; receiver: 0 | 1 };
-  createdAt: number; originalEpoch: number;
+  providerGeneration: number; createdAt: number; originalEpoch: number;
   status: 'pending' | 'acknowledged' | 'confirmed';
 };
 const h = vi.hoisted(() => ({
@@ -32,6 +32,7 @@ vi.mock('$lib/runtime/adapters/radio-view-model-adapter', () => ({ toRadioViewMo
 function observed(width: number, active: 'MAIN' | 'SUB' = 'MAIN', otherWidth = 2400) {
   const path = active === 'MAIN' ? 'main.filterWidth' : 'sub.filterWidth';
   return {
+    providerGeneration: 3,
     active,
     main: { filterWidth: active === 'MAIN' ? width : otherWidth },
     sub: { filterWidth: active === 'SUB' ? width : otherWidth },
@@ -67,7 +68,7 @@ describe('mounted Filter Width lifecycle projection (MOR-1667)', () => {
     const refresh = (mounted[0] as { refresh: () => void }).refresh;
     expect(probe.dataset).toMatchObject({ phase: 'idle', confirmed: '2400', target: '' });
 
-    h.commands = [{ id: 'main', name: 'set_filter_width', params: { width: 3000, receiver: 0 }, createdAt: 1, originalEpoch: currentControlSessionEpoch(), status: 'acknowledged' }];
+    h.commands = [{ id: 'main', name: 'set_filter_width', params: { width: 3000, receiver: 0 }, providerGeneration: 3, createdAt: 1, originalEpoch: currentControlSessionEpoch(), status: 'acknowledged' }];
     refresh(); flushSync();
     expect(probe.dataset).toMatchObject({ phase: 'acknowledged', confirmed: '2400', target: '3000' });
 
@@ -84,7 +85,7 @@ describe('mounted Filter Width lifecycle projection (MOR-1667)', () => {
   it('exposes the complete descriptor evidence without collapsing requested into confirmed truth', () => {
     h.state = observed(2400);
     h.commands = [{ id: 'main', name: 'set_filter_width', params: { width: 3000, receiver: 0 },
-      createdAt: 1, originalEpoch: currentControlSessionEpoch(), status: 'acknowledged' }];
+      providerGeneration: 3, createdAt: 1, originalEpoch: currentControlSessionEpoch(), status: 'acknowledged' }];
     expect(getFilterWidthControlFeedback()).toMatchObject({
       confirmed: 2400, target: 3000, requestedTarget: 3000,
       phase: 'awaiting-confirmation', busy: true, availability: 'available',
@@ -95,7 +96,7 @@ describe('mounted Filter Width lifecycle projection (MOR-1667)', () => {
 
   it('keeps SUB command evidence isolated from MAIN projection', () => {
     h.state = observed(2800, 'MAIN', 2400);
-    h.commands = [{ id: 'sub', name: 'set_filter_width', params: { width: 2800, receiver: 1 }, createdAt: 1, originalEpoch: currentControlSessionEpoch(), status: 'acknowledged' }];
+    h.commands = [{ id: 'sub', name: 'set_filter_width', params: { width: 2800, receiver: 1 }, providerGeneration: 3, createdAt: 1, originalEpoch: currentControlSessionEpoch(), status: 'acknowledged' }];
     expect(render().dataset).toMatchObject({ phase: 'idle', confirmed: '2800', target: '' });
   });
 });

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 type FakeCommand = { id: string; name: string; params: Record<string, unknown>;
   originalEpoch: number; eventEpoch?: number; createdAt: number;
   status: 'pending' | 'acknowledged' | 'confirmed' | 'failed' | 'cancelled' | 'timed-out';
+  providerGeneration?: number | null;
   error?: string;
   ackObservationSeq?: number;
   ackFieldObservationTimes?: Record<string, number>;
@@ -73,10 +74,10 @@ function emitAcceptedState(value: FakeState | null): void {
 const command = (over: Partial<FakeCommand> = {}): FakeCommand => ({
   id: 'width-1', name: 'set_filter_width', params: { width: 3000 },
   originalEpoch: controlSession.epoch, eventEpoch: controlSession.epoch,
-  createdAt: 1, status: 'pending', ...over,
+  providerGeneration: 3, createdAt: 1, status: 'pending', ...over,
 });
 const state = (over: Partial<FakeState> = {}): FakeState => ({
-  active: 'MAIN', main: { filterWidth: 2400 }, sub: {}, observationSeq: 4,
+  active: 'MAIN', providerGeneration: 3, main: { filterWidth: 2400 }, sub: {}, observationSeq: 4,
   fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 } }, ...over,
 });
 describe('Filter Width command lifecycle projection (MOR-1664)', () => {
@@ -125,6 +126,25 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     lifecycle.commands = [command()];
     expect(getFilterWidthCommandLifecycle()).toMatchObject({
       confirmed: 2400, target: 3000, phase: 'pending', busy: true, outcome: null,
+    });
+  });
+  it('excludes unresolved, invalid, and prior-provider records including terminals', () => {
+    runtimeState.state = state({ providerGeneration: 4 });
+    for (const providerGeneration of [undefined, null, -1, 3]) {
+      lifecycle.commands = [command({ providerGeneration })];
+      expect(getFilterWidthCommandLifecycle()).toMatchObject({
+        confirmed: 2400, target: null, phase: 'idle', presentation: null,
+      });
+    }
+    lifecycle.commands = [command({
+      providerGeneration: 3, status: 'failed', error: 'old provider rejected',
+    })];
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({
+      confirmed: 2400, target: null, phase: 'idle', outcome: null, presentation: null,
+    });
+    lifecycle.commands = [command({ providerGeneration: 4 })];
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({
+      confirmed: 2400, target: 3000, phase: 'pending',
     });
   });
   it('keeps a fresh matching observation acknowledged when a caller only reads the pure accessor', () => {
@@ -238,7 +258,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
       index === 142 ? 'sub.filterWidth' : `other.${index}`,
       { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: index === 142 ? 73 : Number.NaN },
     ]));
-    commandRadio.current = { observationSeq: 41, fieldStatus: fields };
+    commandRadio.current = { providerGeneration: 3, observationSeq: 41, fieldStatus: fields };
     const store = await import('$lib/stores/commands.svelte');
     store.beginCommand({ id: 'real-ack', name: 'set_filter_width', params: { width: 3000, receiver: 1 }, originalEpoch: 9 });
     store.acknowledgeCommand('real-ack', 9, 10);
@@ -258,7 +278,6 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     runtimeState.state = state({ active: 'SUB', sub: { filterWidth: 3000 }, fieldStatus: { 'sub.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 74 } } });
     emitAcceptedState(runtimeState.state);
     expect(store.getCommandLifecycle('real-ack', 9)?.status).toBe('confirmed');
-    const retained = getLiveView().presentation;
     expect(getLiveView()).toMatchObject({ confirmed: 3000, phase: 'confirmed', busy: false, outcome: { phase: 'confirmed' }, presentation: {
       receiver: 1, sessionEpoch: 9, target: 3000, status: 'confirmed',
     } });
@@ -269,17 +288,17 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     store.beginCommand({ id: 'cold-ack', name: 'set_filter_width', params: { width: 2800, receiver: 0 }, originalEpoch: 9 });
     store.acknowledgeCommand('cold-ack', 9, 10);
     expect(store.getCommandLifecycle('cold-ack', 9)).toMatchObject({
-      status: 'acknowledged', ackObservationSeq: undefined, ackFieldObservationTimes: {},
+      status: 'acknowledged', providerGeneration: null, ackObservationSeq: undefined, ackFieldObservationTimes: {},
     });
     runtimeState.state = state({ main: { filterWidth: 2400 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
     emitAcceptedState(runtimeState.state);
-    expect(getLiveView()).toMatchObject({ confirmed: 2400, target: 2800, phase: 'acknowledged', busy: true });
-    expect(store.getCommandLifecycle('cold-ack', 9)?.ackFieldObservationTimes).toEqual({ 'main.filterWidth': 5 });
+    expect(getLiveView()).toMatchObject({ confirmed: 2400, target: null, phase: 'idle', busy: false });
+    expect(store.getCommandLifecycle('cold-ack', 9)?.ackFieldObservationTimes).toEqual({});
     runtimeState.state = state({ main: { filterWidth: 2800 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 6 } } });
     emitAcceptedState(runtimeState.state);
-    expect(getLiveView()).toMatchObject({ confirmed: 2800, target: null, phase: 'confirmed', busy: false, outcome: { phase: 'confirmed' } });
-    expect(store.getCommandLifecycle('cold-ack', 9)?.status).toBe('confirmed');
-    expect(getLiveView().presentation?.lifecycleId).not.toBe(retained?.lifecycleId);
+    expect(getLiveView()).toMatchObject({ confirmed: 2800, target: null, phase: 'idle', busy: false, outcome: null });
+    expect(store.getCommandLifecycle('cold-ack', 9)?.status).toBe('acknowledged');
+    expect(getLiveView().presentation).toBeNull();
     store.resetCommandLifecycle();
     expect(getLiveView().presentation).toBeNull();
   });
@@ -288,6 +307,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     vi.doUnmock('$lib/stores/commands.svelte');
     vi.resetModules();
     runtimeState.state = state({ main: { filterWidth: 2400 }, sub: { filterWidth: 1800 } });
+    commandRadio.current = runtimeState.state as unknown as Record<string, unknown>;
     const store = await import('$lib/stores/commands.svelte');
     const { getFilterWidthCommandLifecycle: getLiveView } = await import('../panel-adapters');
 
@@ -449,7 +469,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
 const delayCommand = (over: Partial<FakeCommand> = {}): FakeCommand => ({
   id: 'delay-1', name: 'set_break_in_delay', params: Object.freeze({ level: 64 }),
   originalEpoch: controlSession.epoch, eventEpoch: controlSession.epoch,
-  createdAt: 1, status: 'pending', ...over,
+  providerGeneration: 3, createdAt: 1, status: 'pending', ...over,
 });
 const delayState = (over: Partial<FakeState> = {}): FakeState => ({
   active: 'MAIN', providerGeneration: 3, breakInDelay: 32, main: {}, sub: {},
@@ -512,6 +532,24 @@ describe('Break-in Delay ControlFeedback projection (MOR-1744)', () => {
     });
     expect(JSON.stringify([pending])).toBe(before);
     expect(dispatch).not.toHaveBeenCalled();
+  });
+  it('publishes current provider identity and rejects old-provider Break-in Delay outcomes', () => {
+    runtimeState.state = delayState({ providerGeneration: 4 });
+    lifecycle.commands = [delayCommand({
+      providerGeneration: 3, status: 'failed', error: 'old provider rejected',
+    })];
+    expect(getBreakInDelayControlFeedback()).toMatchObject({
+      providerGeneration: 4, confirmed: 32, target: null,
+      phase: 'idle', outcome: null, lifecycleId: null,
+    });
+    lifecycle.commands = [delayCommand({ providerGeneration: 4 })];
+    expect(getBreakInDelayControlFeedback()).toMatchObject({
+      providerGeneration: 4, phase: 'submitted', target: 64,
+    });
+    runtimeState.state = null;
+    expect(getBreakInDelayControlFeedback()).toMatchObject({
+      providerGeneration: null, phase: 'unavailable',
+    });
   });
 
   it.each([

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -287,6 +287,7 @@ export interface ControlFeedback<T> {
   readonly outcome: Readonly<{ phase: ControlFeedbackOutcome; error?: string }> | null;
   readonly lifecycleId: string | null;
   readonly transitionId: string | null;
+  readonly providerGeneration?: number | null;
   readonly sessionEpoch: number;
   readonly scope: Readonly<ControlFeedbackScope>;
   readonly repeatPolicy: StateBackedRepeatPolicy;
@@ -305,10 +306,15 @@ export function projectControlFeedback<T>(
   commands: readonly CommandLifecycle[], scope: ControlFeedbackScope, currentSessionEpoch: number,
   superseded: (command: CommandLifecycle) => boolean,
 ): Readonly<ControlFeedback<T>> {
+  const candidateProviderGeneration = state?.providerGeneration;
+  const currentProviderGeneration = typeof candidateProviderGeneration === 'number'
+    && Number.isSafeInteger(candidateProviderGeneration) && candidateProviderGeneration >= 0
+    ? candidateProviderGeneration : null;
   const empty = (availability: 'available' | 'unavailable', confirmed: T | null): Readonly<ControlFeedback<T>> => Object.freeze({
     confirmed, target: null, requestedTarget: null,
     phase: availability === 'available' ? 'idle' : 'unavailable', busy: false, availability,
-    outcome: null, lifecycleId: null, transitionId: null, sessionEpoch: currentSessionEpoch,
+    outcome: null, lifecycleId: null, transitionId: null,
+    providerGeneration: currentProviderGeneration, sessionEpoch: currentSessionEpoch,
     scope: Object.freeze({ ...scope }), repeatPolicy: descriptor.repeatPolicy,
   });
   if (state === null) return empty('unavailable', null);
@@ -320,7 +326,12 @@ export function projectControlFeedback<T>(
 
   let latest: CommandLifecycle | null = null;
   for (const command of commands) {
-    if (command.originalEpoch !== currentSessionEpoch || command.name !== descriptor.intentName
+    const commandProviderGeneration = command.providerGeneration;
+    if (currentProviderGeneration === null
+      || typeof commandProviderGeneration !== 'number'
+      || !Number.isSafeInteger(commandProviderGeneration) || commandProviderGeneration < 0
+      || commandProviderGeneration !== currentProviderGeneration
+      || command.originalEpoch !== currentSessionEpoch || command.name !== descriptor.intentName
       || !sameFeedbackScope(descriptor.scope(command), scope) || descriptor.target(command) === null
       || superseded(command)) continue;
     if (latest === null || command.createdAt >= latest.createdAt) latest = command;
@@ -339,7 +350,8 @@ export function projectControlFeedback<T>(
       ...(error === undefined ? {} : { error }) }) : null,
     lifecycleId: JSON.stringify([latest.originalEpoch, latest.id]),
     transitionId: JSON.stringify([latest.originalEpoch, latest.id, latest.status]),
-    sessionEpoch: currentSessionEpoch, scope: Object.freeze({ ...scope }), repeatPolicy: descriptor.repeatPolicy,
+    providerGeneration: currentProviderGeneration, sessionEpoch: currentSessionEpoch,
+    scope: Object.freeze({ ...scope }), repeatPolicy: descriptor.repeatPolicy,
   });
 }
 

--- a/frontend/src/lib/stores/__tests__/commands.test.ts
+++ b/frontend/src/lib/stores/__tests__/commands.test.ts
@@ -37,6 +37,19 @@ describe('command lifecycle store', () => {
     expect(() => store.beginCommand({ ...command })).toThrow(/duplicate command id/i);
   });
 
+  it('captures unresolved provider identity once and never backfills it on acknowledgement', () => {
+    const command = store.beginCommand({
+      id: 'unresolved-provider',
+      name: 'set_filter_width',
+      params: { width: 2_400, receiver: 0 },
+      originalEpoch: 7,
+    });
+
+    expect(command.providerGeneration).toBeNull();
+    store.acknowledgeCommand(command.id, 7, 7);
+    expect(store.getCommandLifecycle(command.id, 7)?.providerGeneration).toBeNull();
+  });
+
   it('fences acknowledgement and failure by command id and originating epoch', () => {
     store.beginCommand({ id: 'same', name: 'set_mode', params: { mode: 'USB' }, originalEpoch: 3 });
     store.acknowledgeCommand('same', 2, 3);

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -7,6 +7,8 @@ export interface CommandLifecycle {
   id: string; name: string; params: Readonly<Record<string, unknown>>;
   originalEpoch: number; eventEpoch?: number; createdAt: number; updatedAt: number;
   timeoutMs: number; status: CommandLifecycleStatus; error?: string;
+  /** Actual provider at submission; absent/null legacy records fail closed. */
+  providerGeneration?: number | null;
   /**
    * The radio-observed `observationSeq` (MOR-1488 review R2) at the instant
    * this command transitioned to 'acknowledged', or `undefined` if no radio
@@ -60,6 +62,8 @@ const finiteNumber = (value: unknown): number | null =>
   typeof value === 'number' && Number.isFinite(value) ? value : null;
 const safeInteger = (value: unknown): number | null =>
   typeof value === 'number' && Number.isSafeInteger(value) ? value : null;
+const providerGeneration = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : null;
 
 export const FILTER_WIDTH_COMMAND_DESCRIPTOR: StateBackedCommandDescriptor<number> = Object.freeze({
   intentName: 'set_filter_width', repeatPolicy: 'latest-target-wins',
@@ -206,8 +210,11 @@ function transition(
 /** Accepted StateStore observations, never presentation reads, reconcile commands. */
 function reconcileStateBackedCommands(state: ServerState | null): void {
   if (!state) return;
+  const currentProviderGeneration = providerGeneration(state.providerGeneration);
   for (const command of commands) {
     if (command.status !== 'acknowledged' || isCommandLifecycleSuperseded(command)) continue;
+    const commandProviderGeneration = providerGeneration(command.providerGeneration);
+    if (currentProviderGeneration === null || commandProviderGeneration !== currentProviderGeneration) continue;
     const descriptor = getStateBackedCommandDescriptor(command.name);
     const scope = descriptor?.scope(command);
     const target = descriptor?.target(command);
@@ -243,7 +250,14 @@ export function beginCommand(input: BeginCommandInput): CommandLifecycle {
   reserveRecordSlot();
   const now = Date.now();
   const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const command: CommandLifecycle = { ...input, timeoutMs, createdAt: now, updatedAt: now, status: 'pending' };
+  const command: CommandLifecycle = {
+    ...input,
+    providerGeneration: providerGeneration(getRadioState()?.providerGeneration),
+    timeoutMs,
+    createdAt: now,
+    updatedAt: now,
+    status: 'pending',
+  };
   for (const existing of commands) if (existing.originalEpoch === command.originalEpoch
     && existing.name === command.name && commandScopeKey(existing) === commandScopeKey(command)) {
     supersededRecordKeys.add(key(existing.id, existing.originalEpoch));

--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -13,6 +13,7 @@ type ServerStateWithObservation = ServerState & {
 // ─── Mock store before importing ws-client ──────────────────────────────────
 const radioStoreMock = vi.hoisted(() => ({
   current: null as ServerStateWithObservation | null,
+  listeners: new Set<(state: ServerStateWithObservation | null) => void>(),
 }));
 
 vi.mock('../../stores/connection.svelte', () => ({
@@ -32,7 +33,13 @@ vi.mock('../../stores/radio.svelte', () => ({
   getRadioState: vi.fn(() => radioStoreMock.current),
   resetRadioState: vi.fn(() => {
     radioStoreMock.current = null;
+    for (const handler of radioStoreMock.listeners) handler(null);
   }),
+  subscribeRadioState: (handler: (state: ServerStateWithObservation | null) => void) => {
+    radioStoreMock.listeners.add(handler);
+    handler(radioStoreMock.current);
+    return () => radioStoreMock.listeners.delete(handler);
+  },
   isValidServerState: vi.fn(() => true),
   matchesCurrentCapabilityTopology: vi.fn(() => true),
   setRadioState: vi.fn((state: ServerStateWithObservation) => {
@@ -57,6 +64,7 @@ vi.mock('../../stores/radio.svelte', () => ({
     );
     if (current === null || semanticAdvanced || metadataAdvanced) {
       radioStoreMock.current = state;
+      for (const handler of radioStoreMock.listeners) handler(state);
     }
   }),
 }));
@@ -81,6 +89,7 @@ import { resetRadioState, setRadioState } from '../../stores/radio.svelte';
 
 beforeEach(() => {
   radioStoreMock.current = null;
+  radioStoreMock.listeners.clear();
   vi.mocked(isLiveRadioAvailable).mockReturnValue(true);
   vi.mocked(resetRadioState).mockClear();
   vi.mocked(setRadioState).mockClear();
@@ -1271,6 +1280,56 @@ describe('control channel singleton', () => {
       { commandId: 'provider-pending', kind: 'transport-sent', originalEpoch: 1, eventEpoch: 1 },
       { commandId: 'provider-pending', kind: 'error', cancelled: true, error: 'provider session replaced' },
     ]);
+  });
+
+  it('fences an acknowledged successful command from matching replacement-provider evidence on the same socket', async () => {
+    const { connect, disconnect, getControlSession, onCommandDelivery } = await import('../ws-client');
+    const { dispatchRadioIntent } = await import('../../runtime/commands/radio-intents');
+    const lifecycle = await import('../../stores/commands.svelte');
+    const deliveries: CommandDeliveryEvent[] = [];
+    onCommandDelivery((event) => deliveries.push(event));
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    sendStateUpdate(instances[0], fullEnvelope(makeState({
+      providerGeneration: 0, revision: 4, observationSeq: 4,
+      main: makeReceiver({ filterWidth: 3000 }),
+      fieldStatus: { 'main.filterWidth': {
+        storePath: 'main.filterWidth', observed: true, freshness: 'fresh', availability: 'available',
+        lastObservedMonotonic: 4,
+      } },
+    })));
+
+    dispatchRadioIntent({
+      id: 'provider-acknowledged', name: 'set_filter_width',
+      params: { width: 3000, receiver: 0 },
+    });
+    instances[0].simulateMessage(JSON.stringify({ type: 'ack', id: 'provider-acknowledged' }));
+    instances[0].simulateMessage(JSON.stringify({
+      type: 'response', id: 'provider-acknowledged', ok: true,
+    }));
+    expect(lifecycle.getCommandLifecycle('provider-acknowledged', 1)).toMatchObject({
+      status: 'acknowledged', providerGeneration: 0,
+      ackFieldObservationTimes: { 'main.filterWidth': 4 },
+    });
+
+    sendStateUpdate(instances[0], fullEnvelope(makeState({
+      providerGeneration: 1, revision: 5, observationSeq: 5,
+      main: makeReceiver({ filterWidth: 3000 }),
+      fieldStatus: { 'main.filterWidth': {
+        storePath: 'main.filterWidth', observed: true, freshness: 'fresh', availability: 'available',
+        lastObservedMonotonic: 5,
+      } },
+    })));
+
+    expect(getControlSession().epoch).toBe(1);
+    expect(deliveries).not.toContainEqual(expect.objectContaining({
+      commandId: 'provider-acknowledged', cancelled: true,
+    }));
+    expect(lifecycle.getCommandLifecycle('provider-acknowledged', 1)).toMatchObject({
+      status: 'acknowledged', providerGeneration: 0,
+    });
+    lifecycle.resetCommandLifecycle();
+    disconnect();
   });
 
   it('keeps all 100 live correlations and rejects the 101st facade send', async () => {

--- a/frontend/src/primitives/scalar/__tests__/committed-scalar.test.ts
+++ b/frontend/src/primitives/scalar/__tests__/committed-scalar.test.ts
@@ -7,12 +7,16 @@ import {
   type CommittedScalarPolicy,
 } from '../committed-scalar.svelte';
 
+type ProviderFeedback = ControlFeedbackPresentationInput<number> & {
+  readonly providerGeneration?: number | null;
+};
+
 const feedback = (
   phase: ControlFeedbackPresentationInput<number>['phase'] = 'idle',
-  over: Partial<ControlFeedbackPresentationInput<number>> = {},
-): Readonly<ControlFeedbackPresentationInput<number>> => ({
+  over: Partial<ProviderFeedback> = {},
+): Readonly<ProviderFeedback> => ({
   confirmed: 64, target: null, requestedTarget: null, phase,
-  transitionId: null, outcome: null, ...over,
+  transitionId: null, outcome: null, providerGeneration: 3, ...over,
 });
 
 const rejectPolicy: Readonly<CommittedScalarPolicy> = {
@@ -130,6 +134,22 @@ describe('createCommittedScalar', () => {
     expect(scalar.view.draft).toBe(111);
     scalar.commit(111);
     expect(request).toHaveBeenCalledExactlyOnceWith(111);
+  });
+
+  it('clears draft and announcement memory when provider changes without an intermediate null read', () => {
+    const terminal = feedback('failed', {
+      requestedTarget: 111, transitionId: 'old-provider-failed',
+      outcome: { phase: 'failed' },
+    });
+    const { scalar, request, update } = setup(rejectPolicy, terminal);
+    expect(scalar.view.announcement).toBe('Failed: 111');
+    scalar.input(90);
+    expect(scalar.view.draft).toBe(90);
+
+    update({ feedback: feedback('idle', { providerGeneration: 4 }) });
+    expect(scalar.view).toMatchObject({ draft: null, announcement: null });
+    expect(scalar.commit(90)).toBe(64);
+    expect(request).not.toHaveBeenCalled();
   });
 
   it('supports no-input changes and repeated accepted requests while busy', () => {

--- a/frontend/src/primitives/scalar/__tests__/continuous-pair.test.ts
+++ b/frontend/src/primitives/scalar/__tests__/continuous-pair.test.ts
@@ -18,6 +18,7 @@ const feedback = (
 ): Readonly<CommandScalarFeedback> => ({
   confirmed, target: null, requestedTarget: null, phase: 'idle', busy: false,
   availability: 'available', outcome: null, lifecycleId: null, transitionId: null,
+  providerGeneration: 3,
   sessionEpoch: 7, scope: { control, receiver: 0 }, repeatPolicy: 'latest-target-wins',
   ...over,
 });
@@ -268,6 +269,31 @@ describe('continuous pair delegates one scalar lifetime', () => {
     vi.advanceTimersByTime(50);
     expect(requestSql).not.toHaveBeenCalled();
     vi.useRealTimers();
+  });
+
+  it('invalidates pair draft, lease, and lane announcements on provider replacement without a null read', () => {
+    const { pair, read, update } = commandSetup();
+    update({ rf: { ...read().rf, feedback: feedback('rf-gain', 0.8, {
+      requestedTarget: 0.8, phase: 'failed', outcome: { phase: 'failed' },
+      lifecycleId: 'old-rf', transitionId: 'old-rf-failed',
+    }) } });
+    const stale = pair.attachRenderer();
+    expect(stale.view.lanes.rf.announcement).toBe('Failed: 0.8');
+    const staleToken = stale.beginPointer()!;
+    stale.pointer(staleToken, 0.5);
+    expect(pair.view.draft).not.toBeNull();
+
+    update({
+      rf: { ...read().rf, feedback: feedback('rf-gain', 0.8, { providerGeneration: 4 }) },
+      sql: { ...read().sql, feedback: feedback('squelch', 0.2, { providerGeneration: 4 }) },
+    });
+    expect(pair.view).toMatchObject({
+      draft: null, lanes: { rf: { announcement: null }, sql: { announcement: null } },
+    });
+    stale.pointer(staleToken, 0);
+    expect(pair.view.draft).toBeNull();
+    stale.nativeInput(0);
+    expect(pair.view.draft).not.toBeNull();
   });
 
   it('keeps lane announcement identity when appearance leases are replaced', () => {

--- a/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
+++ b/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
@@ -36,6 +36,7 @@ const feedback = (
   outcome: null,
   lifecycleId: null,
   transitionId: null,
+  providerGeneration: 3,
   sessionEpoch: 7,
   scope: { control: 'filter-width', receiver: 0, slot: 'main' },
   repeatPolicy: 'latest-target-wins',
@@ -666,6 +667,7 @@ describe('continuous scalar deferred work', () => {
   });
 
   it.each([
+    ['provider', { feedback: feedback('idle', { providerGeneration: 4 }) }],
     ['epoch', { feedback: feedback('idle', { sessionEpoch: 8 }) }],
     ['receiver', { feedback: feedback('idle', { scope: { control: 'filter-width', receiver: 1, slot: 'main' } }) }],
     ['control', { feedback: feedback('idle', { scope: { control: 'other', receiver: 0, slot: 'main' } }) }],
@@ -683,6 +685,28 @@ describe('continuous scalar deferred work', () => {
     expect(request).not.toHaveBeenCalled();
     expect(scalar.view.draft).toBeNull();
     vi.useRealTimers();
+  });
+
+  it('invalidates draft, lease, and announcement memory on provider replacement without a null read', () => {
+    const terminal = feedback('failed', {
+      requestedTarget: 2_500, lifecycleId: 'old-provider',
+      transitionId: 'old-provider-failed', outcome: { phase: 'failed' },
+    });
+    const { scalar, update } = commandSetup(nativeRangeContinuousScalarPolicy, {
+      feedback: terminal,
+    });
+    const stale = scalar.attachRenderer();
+    expect(stale.view.announcement).toBe('Failed: 2500');
+    const staleToken = stale.beginPointer()!;
+    stale.pointer(staleToken, 2_700);
+    expect(scalar.view.draft).toBe(2_700);
+
+    update({ feedback: feedback('idle', { providerGeneration: 4 }) });
+    expect(scalar.view).toMatchObject({ draft: null, announcement: null });
+    stale.pointer(staleToken, 2_800);
+    expect(scalar.view.draft).toBeNull();
+    stale.nativeInput(2_900);
+    expect(scalar.view.draft).toBe(2_900);
   });
 
   it.each([

--- a/frontend/src/primitives/scalar/committed-scalar.svelte.ts
+++ b/frontend/src/primitives/scalar/committed-scalar.svelte.ts
@@ -5,7 +5,9 @@ import {
   type ControlFeedbackPresentationState,
   type PresentationOutcome,
 } from '../control-feedback/control-feedback-presentation';
-export type ScalarFeedback = Readonly<ControlFeedbackPresentationInput<number>>;
+export type ScalarFeedback = Readonly<ControlFeedbackPresentationInput<number> & {
+  readonly providerGeneration?: number | null;
+}>;
 export interface CommittedScalarInput {
   readonly feedback: ScalarFeedback;
   readonly editable: boolean;
@@ -44,7 +46,13 @@ type DraftIdentity = {
   transitionId: string | null;
   outcomePhase: PresentationOutcome | null;
   outcomeError: string | undefined;
+  providerGeneration: number | null;
 };
+function providerGenerationOf(feedback: ScalarFeedback): number | null {
+  const providerGeneration = feedback.providerGeneration;
+  return typeof providerGeneration === 'number' && Number.isSafeInteger(providerGeneration)
+    && providerGeneration >= 0 ? providerGeneration : null;
+}
 function identityOf(input: Readonly<CommittedScalarInput>): DraftIdentity {
   return Object.freeze({
     contextKey: input.contextKey,
@@ -56,6 +64,7 @@ function identityOf(input: Readonly<CommittedScalarInput>): DraftIdentity {
     transitionId: input.feedback.transitionId,
     outcomePhase: input.feedback.outcome?.phase ?? null,
     outcomeError: input.feedback.outcome?.error,
+    providerGeneration: providerGenerationOf(input.feedback),
   });
 }
 
@@ -68,7 +77,8 @@ function sameIdentity(left: DraftIdentity, right: DraftIdentity): boolean {
     && left.phase === right.phase
     && left.transitionId === right.transitionId
     && left.outcomePhase === right.outcomePhase
-    && left.outcomeError === right.outcomeError;
+    && left.outcomeError === right.outcomeError
+    && left.providerGeneration === right.providerGeneration;
 }
 
 export function createCommittedScalar(
@@ -81,6 +91,8 @@ export function createCommittedScalar(
   let suppressCommit = false;
   let presentationState: Readonly<ControlFeedbackPresentationState> = { announcedTransitionIds: [] };
   let announcement: string | null = null;
+  let providerAuthorityInitialized = false;
+  let lastProviderGeneration: number | null = null;
 
   function isEditable(input: Readonly<CommittedScalarInput>): boolean {
     return input.editable && input.feedback.phase !== 'unavailable';
@@ -98,6 +110,16 @@ export function createCommittedScalar(
   }
 
   function reconcile(input: Readonly<CommittedScalarInput>): void {
+    const providerGeneration = providerGenerationOf(input.feedback);
+    if (providerAuthorityInitialized && providerGeneration !== lastProviderGeneration) {
+      draft = null;
+      draftIdentity = null;
+      suppressCommit = true;
+      presentationState = { announcedTransitionIds: [] };
+      announcement = null;
+    }
+    providerAuthorityInitialized = true;
+    lastProviderGeneration = providerGeneration;
     if (draft === null || draftIdentity === null) return;
     if (sameIdentity(draftIdentity, identityOf(input))) return;
     draftIdentity = null;

--- a/frontend/src/primitives/scalar/continuous-pair.svelte.ts
+++ b/frontend/src/primitives/scalar/continuous-pair.svelte.ts
@@ -244,11 +244,19 @@ function authorityOf(input: Readonly<ContinuousPairInput>): Identity {
       input.sql.availability, input.sql.reading.status,
     ]);
   }
+  const rfProviderGeneration = input.rf.feedback.providerGeneration;
+  const sqlProviderGeneration = input.sql.feedback.providerGeneration;
   return Object.freeze([
     ...shared,
-    input.rf.command, input.rf.feedback.sessionEpoch, input.rf.feedback.availability,
+    input.rf.command,
+    typeof rfProviderGeneration === 'number' && Number.isSafeInteger(rfProviderGeneration)
+      && rfProviderGeneration >= 0 ? rfProviderGeneration : null,
+    input.rf.feedback.sessionEpoch, input.rf.feedback.availability,
     input.rf.feedback.scope.control, input.rf.feedback.scope.receiver, input.rf.feedback.scope.slot,
-    input.sql.command, input.sql.feedback.sessionEpoch, input.sql.feedback.availability,
+    input.sql.command,
+    typeof sqlProviderGeneration === 'number' && Number.isSafeInteger(sqlProviderGeneration)
+      && sqlProviderGeneration >= 0 ? sqlProviderGeneration : null,
+    input.sql.feedback.sessionEpoch, input.sql.feedback.availability,
     input.sql.feedback.scope.control, input.sql.feedback.scope.receiver, input.sql.feedback.scope.slot,
   ]);
 }

--- a/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
+++ b/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
@@ -22,6 +22,7 @@ export interface CommandScalarFeedback extends ControlFeedbackPresentationInput<
   readonly busy: boolean;
   readonly availability: 'available' | 'unavailable';
   readonly lifecycleId: string | null;
+  readonly providerGeneration?: number | null;
   readonly sessionEpoch: number;
   readonly scope: Readonly<{ control: string; receiver: 0 | 1; slot?: string }>;
   readonly repeatPolicy: 'latest-target-wins';
@@ -374,8 +375,12 @@ function authorityOf(input: Readonly<ContinuousScalarInput>): AuthorityIdentity 
     domain.defaultValue, domain.fineStepDivisor, domain.keyboardStep,
   ] as const;
   if (input.evidence === 'command-feedback') {
+    const providerGeneration = input.feedback.providerGeneration;
     return Object.freeze([
-      ...shared, input.command, input.feedback.sessionEpoch, input.feedback.availability,
+      ...shared, input.command,
+      typeof providerGeneration === 'number' && Number.isSafeInteger(providerGeneration)
+        && providerGeneration >= 0 ? providerGeneration : null,
+      input.feedback.sessionEpoch, input.feedback.availability,
       input.feedback.scope.control, input.feedback.scope.receiver, input.feedback.scope.slot,
     ]);
   }


### PR DESCRIPTION
12 code + 0 regenerated baselines = 12 files

## Summary

- capture the accepted provider generation once when a command begins
- fail closed during reconciliation and feedback projection when provider identity is missing, invalid, or different
- invalidate scalar drafts, gestures, presentation state, and announcement memory when the provider changes without an intermediate null state
- cover the unchanged WebSocket and radio-intent call graph, including ACK and successful response tracker removal on a same-socket provider replacement
- migrate the mounted Filter Width component fixture to the explicit provider-generation contract

## Validation

- `npx vitest run` over the 7 leased tests and 4 existing CW/Filter adopter tests: 11 files, 452 tests passed
- mounted Filter Width lifecycle component test: reproduced 2 failures / 2 passes before fixture correction, then 4 tests passed after correction
- `npm run check`: 0 errors and 0 warnings
- `npx eslint` over all 12 changed files
- `git diff --check`

## Tracking

- [MOR-2398](https://linear.app/morozsm/issue/MOR-2398/fence-command-feedback-across-provider-replacement-on-an-unchanged)

## Compatibility and independent review

This adds actual provider identity to the existing source-level lifecycle/feedback interfaces while preserving optional legacy-shaped inputs. An unresolved command origin is never backfilled or confirmed by a later provider. Wire commands, CLI, config, TX/PTT and existing timing policies are unchanged. Stronger per-control admission and RF/SQL consumer adoption remain separate follow-ups.

- Independent [PASS 3653732890a8b525299a1d735fa34d9ab7a08e38](https://github.com/rigplane/rigplane-core/pull/3253#issuecomment-5558240467); the omitted mounted fixture is corrected and no findings remain.
- Coordinator verified natural quick 34023553645, visual 34023553646 and actual required Agent Review Gate are successful at this head.
- Exact aggregate scope is 12 files, 269 additions plus 27 deletions (296 A+D). The file-count exception covers the existing store/projector/three primitive owners and their real affected tests; no new owner is introduced.
- The earlier accidental misconfigured repository-root command is excluded from verification evidence.
