### PR TITLE
MOR-2402: Adopt source continuity in BarGauge meters

### DIFF
--- a/frontend/src/components-v2/meters/BarGauge.svelte
+++ b/frontend/src/components-v2/meters/BarGauge.svelte
@@ -8,6 +8,8 @@
   import {
     createElapsedEnvelopePeakStrategy,
     createMeterBallistics,
+    type MeterContinuitySession,
+    type MeterSourceIdentity,
   } from '../../primitives/meters/meter-ballistics.svelte';
   import { DEFAULT_ZONES, valueToSegments, getSegmentZone, dimColor, valueFontSize } from './bar-gauge-utils';
   import type { Zone } from './bar-gauge-utils';
@@ -30,11 +32,13 @@
     compact?: boolean;
     showPeak?: boolean;    // MOR-1282: optional peak-hold marker
     fault?: boolean;       // MOR-1345: SWR/ALC over-threshold fault highlight
+    source?: MeterSourceIdentity | null;
+    session?: MeterContinuitySession | null;
   }
 
   let {
     value, label, displayValue, zones = DEFAULT_ZONES, compact = false, showPeak = false,
-    fault = false, accessibleDescription,
+    fault = false, accessibleDescription, source, session,
   }: Props = $props();
 
   // ── Segment geometry ────────────────────────────────────────────────────────
@@ -82,8 +86,13 @@
   });
 
   $effect(() => {
+    const continuitySource = source;
+    const continuitySession = session;
     const smoothTarget = value === null ? null : valueToSegments(value, SEG_COUNT);
-    untrack(() => ballistics.sync({ sample: value, smoothTarget, peakEnabled: showPeak }));
+    untrack(() => ballistics.sync({
+      sample: value, smoothTarget, peakEnabled: showPeak,
+      source: continuitySource, session: continuitySession,
+    }));
   });
 
   onMount(() => {

--- a/frontend/src/components-v2/meters/__tests__/BarGauge.peakhold.svelte.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/BarGauge.peakhold.svelte.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
 import BarGauge from '../BarGauge.svelte';
+import type {
+  MeterContinuitySession,
+  MeterSourceIdentity,
+} from '../../../primitives/meters/meter-ballistics.svelte';
 
 // MOR-1282: BarGauge's optional peak-hold marker channel. Reuses
 // meter-utils::updatePeakHold/peakHoldDisplay — the single MOR-1252 semantics
@@ -53,6 +57,15 @@ function markerX(t: HTMLElement): number | null {
   const x = el?.getAttribute('x');
   return x === null || x === undefined ? null : parseFloat(x);
 }
+
+function fillCount(t: HTMLElement): number {
+  return t.querySelectorAll('[data-gauge-fill]').length;
+}
+
+const MAIN_SOURCE = {
+  providerGeneration: 1, scope: 'receiver', receiver: 'MAIN', path: 'main.sMeter',
+} as const satisfies MeterSourceIdentity;
+const SESSION_1 = { controlSessionEpoch: 1 } as const satisfies MeterContinuitySession;
 
 describe('BarGauge peak-hold marker (MOR-1282)', () => {
   it('renders no marker when showPeak is not set', () => {
@@ -134,4 +147,96 @@ it('null empties immediately and clears old fill/peak before a smaller sample', 
   vi.advanceTimersByTime(100);
   flushSync();
   expect(t.querySelectorAll('rect').length).toBeLessThanOrEqual(14);
+});
+
+describe('BarGauge source continuity (MOR-2402)', () => {
+  const highThenLow = (source: MeterSourceIdentity = MAIN_SOURCE) => {
+    const mounted = mountReactive({
+      value: 1, label: 'Po', displayValue: '100W', showPeak: true,
+      source, session: SESSION_1,
+    });
+    vi.advanceTimersByTime(600);
+    flushSync();
+    const retainedFill = fillCount(mounted.t);
+    expect(retainedFill).toBeGreaterThan(5);
+    mounted.state.value = 0.1;
+    mounted.state.displayValue = '10W';
+    flushSync();
+    expect(fillCount(mounted.t)).toBe(retainedFill);
+    const retainedPeak = markerX(mounted.t)!;
+    expect(retainedPeak).toBeGreaterThan(64);
+    return { ...mounted, retainedFill, retainedPeak };
+  };
+
+  it('keeps omitted context legacy-compatible, then clears at legacy/qualified boundaries', () => {
+    const { t, state } = mountReactive({
+      value: 1, label: 'Po', displayValue: '100W', showPeak: true,
+    });
+    vi.advanceTimersByTime(600);
+    flushSync();
+    const retainedFill = fillCount(t);
+    expect(retainedFill).toBeGreaterThan(5);
+    state.value = 0.1;
+    state.displayValue = '10W';
+    flushSync();
+    expect(fillCount(t)).toBe(retainedFill);
+    const retainedPeak = markerX(t)!;
+    expect(retainedPeak).toBeGreaterThan(64);
+
+    state.source = MAIN_SOURCE;
+    state.session = SESSION_1;
+    flushSync();
+    expect(fillCount(t)).toBe(1);
+    expect(markerX(t)).toBe(64);
+
+    state.value = 1;
+    flushSync();
+    state.value = 0.1;
+    flushSync();
+    expect(markerX(t)).toBeGreaterThan(64);
+    state.source = undefined;
+    state.session = undefined;
+    flushSync();
+    expect(fillCount(t)).toBe(1);
+    expect(markerX(t)).toBe(64);
+  });
+
+  it('treats reconstructed equal tuples as the same source and observes the equal sample', () => {
+    const { t, state, retainedFill, retainedPeak } = highThenLow();
+    state.source = { ...MAIN_SOURCE };
+    state.session = { ...SESSION_1 };
+    flushSync();
+    expect(fillCount(t)).toBe(retainedFill);
+    expect(markerX(t)).toBe(retainedPeak);
+  });
+
+  it.each([
+    ['provider generation', { ...MAIN_SOURCE, providerGeneration: 2 }, SESSION_1],
+    ['scope', { ...MAIN_SOURCE, scope: 'radio' }, SESSION_1],
+    ['receiver', { ...MAIN_SOURCE, receiver: 'SUB' }, SESSION_1],
+    ['path', { ...MAIN_SOURCE, path: 'sub.sMeter' }, SESSION_1],
+    ['control-session epoch', MAIN_SOURCE, { controlSessionEpoch: 2 }],
+  ] as readonly [string, MeterSourceIdentity, MeterContinuitySession][])(
+    're-seeds segment fill and raw-sample peak when only %s changes',
+    (_label, nextSource, nextSession) => {
+      const { t, state } = highThenLow();
+      state.source = nextSource;
+      state.session = nextSession;
+      flushSync();
+      expect(fillCount(t)).toBe(1);
+      expect(markerX(t)).toBe(64);
+    },
+  );
+
+  it.each([
+    ['source', null, undefined],
+    ['session', undefined, null],
+  ] as const)('gives explicit null %s precedence over an omitted peer', (_label, source, session) => {
+    const { t, state } = highThenLow();
+    state.source = source;
+    state.session = session;
+    flushSync();
+    expect(fillCount(t)).toBe(0);
+    expect(markerCount(t)).toBe(0);
+  });
 });

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -229,6 +229,14 @@ const signalFillCount = (): number => qSvg('[data-testid="meter-signal"] svg')!
   .querySelectorAll('[data-meter-fill]').length;
 const signalHasPeak = (): boolean => qSvg('[data-testid="meter-signal"] svg')!
   .querySelector('[data-meter-peak]') !== null;
+const barSvg = (field: string): SVGSVGElement =>
+  qSvg(`[data-testid="meter-${field}"] svg`)!;
+const barFillCount = (field: string): number =>
+  barSvg(field).querySelectorAll('[data-gauge-fill]').length;
+const barPeakX = (field: string): number | null => {
+  const x = barSvg(field).querySelector('[data-testid="bar-gauge-peak-marker"]')?.getAttribute('x');
+  return x === null || x === undefined ? null : Number(x);
+};
 const rfState = (): string | undefined => q('[data-testid="meters-surface"]')!.dataset.rfState;
 /** `data-meter -> data-relevant` for every rendered tile. */
 const relevance = (): Record<string, string> => Object.fromEntries(
@@ -254,6 +262,7 @@ afterEach(() => {
   expect(h.sessionSubscriber).toBeNull();
   document.body.innerHTML = '';
   vi.unstubAllGlobals();
+  vi.useRealTimers();
 });
 
 // ── 1. The structural gate: absent group ⇒ no surface, no element drift ────
@@ -390,6 +399,71 @@ describe('the meters surface mounts only when the view model carries the group',
     expect(signalObserved()).toBe('true');
     expect(signalFillCount()).toBe(reconnectFill);
     expect(signalHasPeak()).toBe(false);
+  });
+
+  it('re-seeds and clears a mounted radio-wide BarGauge across real context boundaries', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    vi.stubGlobal('matchMedia', (query: string): MediaQueryList => ({
+      matches: false, media: query, onchange: null,
+      addEventListener: vi.fn(), removeEventListener: vi.fn(),
+      addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(() => false),
+    }));
+    h.session = { state: 'disconnected', epoch: 0 };
+    h.state = liveState(true, { powerMeter: 255 });
+    render();
+    push({ intent: 'transmit', observedPtt: 'on' });
+
+    const setPower = (value: number, providerGeneration: number): void => {
+      h.state = { ...(h.state as ServerState), powerMeter: value, providerGeneration };
+      h.caps = { ...(h.caps as Capabilities), providerGeneration };
+      push({ intent: 'transmit', observedPtt: 'on' });
+    };
+    const armRetainedPeak = (epoch: number, providerGeneration: number): void => {
+      setPower(255, providerGeneration);
+      pushSession({ state: 'connected', epoch });
+      vi.advanceTimersByTime(600);
+      flushSync();
+      const retainedFill = barFillCount('power');
+      expect(retainedFill).toBeGreaterThan(5);
+      setPower(25.5, providerGeneration);
+      expect(barFillCount('power')).toBe(retainedFill);
+      expect(barPeakX('power')).toBeGreaterThan(64);
+    };
+
+    armRetainedPeak(1, 1);
+    pushSession({ state: 'connected', epoch: 2 });
+    expect(barFillCount('power')).toBe(1);
+    expect(barPeakX('power')).toBe(64);
+
+    armRetainedPeak(3, 1);
+    setPower(25.5, 2);
+    expect(barFillCount('power')).toBe(1);
+    expect(barPeakX('power')).toBe(64);
+
+    armRetainedPeak(4, 2);
+    pushSession({ state: 'disconnected', epoch: 5 });
+    expect(barFillCount('power')).toBe(0);
+    expect(barPeakX('power')).toBeNull();
+    pushSession({ state: 'connected', epoch: 6 });
+    expect(barFillCount('power')).toBe(1);
+    expect(barPeakX('power')).toBe(64);
+
+    armRetainedPeak(7, 2);
+    const mountedPower = barSvg('power');
+    const state = h.state as ServerState;
+    h.state = {
+      ...state,
+      fieldStatus: {
+        ...state.fieldStatus,
+        powerMeter: { ...fresh, freshness: 'stale' },
+      },
+    };
+    push({ intent: 'transmit', observedPtt: 'on' });
+    expect(barSvg('power')).toBe(mountedPower);
+    expect(q('[data-testid="meter-power"]')!.dataset.observed).toBe('false');
+    expect(barFillCount('power')).toBe(0);
+    expect(barPeakX('power')).toBeNull();
   });
 
   // MUTATION KILLED: giving the meters surface a `data-zone-id` of its own.

--- a/frontend/src/semantic/MetersSurface.svelte
+++ b/frontend/src/semantic/MetersSurface.svelte
@@ -208,6 +208,7 @@
               accessibleDescription={tx ? `${label}: ${tx.description}${isObserved ? `. ${format(raw)}` : ''}` : undefined}
               compact showPeak={showPeak && isObserved} {fault}
               zones={display?.display?.zones}
+              source={meters[field].source} session={continuitySession}
             />
           {:else}
             <span class="meter-unknown">{label} ?</span>

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -544,6 +544,16 @@ describe('the meter table matches the shipped dock', () => {
 // ── 9. Peak-hold channel (MOR-1282) — the surface passes it through ────────
 
 describe('BarGauge peak channel (MOR-1282)', () => {
+  it('forwards each keyed bar field source and the existing surface session', () => {
+    const calls = [...SOURCE.matchAll(/<BarGauge([\s\S]*?)\/>/g)];
+    expect(calls).toHaveLength(1);
+    expect(calls[0][1]).toMatch(/source=\{meters\[field\]\.source\}/);
+    expect(calls[0][1]).toMatch(/session=\{continuitySession\}/);
+    expect(METER_BARS.map(([field]) => field)).toEqual([
+      'power', 'alc', 'drainCurrent', 'drainVoltage', 'compression',
+    ]);
+  });
+
   // MUTATION KILLED: enabling (or dropping) the peak flag on the wrong
   // meters. Matches the dock's own peak-held set RESTRICTED to what
   // `METER_BARS` still carries post-MOR-2250 (PR 2 of 2) — SWR left this


### PR DESCRIPTION
## Summary

- add optional accepted source/session continuity inputs to the existing BarGauge ballistics owner
- forward every canonical Po/ALC/Id/Vd/COMP source and the existing MetersSurface control-session context
- cover generic identity boundaries and the real mounted provider/session/unavailable/disconnect/reconnect path

Linear: https://linear.app/morozsm/issue/MOR-2402/adopt-accepted-source-continuity-in-all-five-production-bargauge

## Compatibility

Omitted context remains the accepted legacy mode when neither input is null. Explicit null in either input clears even when its peer is omitted, and qualified-to-legacy transitions retain MOR-2400's accepted boundary clearing. The BarGauge source API gains two optional props. CLI, configuration, wire protocol, TX/PTT authority, geometry, visual strategy, and baselines are unchanged.

This completes the sole production BarGauge importer and its five keyed radio-wide bars. Receiver/Standard, segmentline, dual-SDR, Amber, mobile, SWR lower-scale, and dormant legacy dock-group work remain outside this PR.

## Verification

- RED before production wiring: 159 tests passed and 10 new continuity/forwarding tests failed; the new equal-tuple case already passed
- GREEN: 169 tests passed in the three changed suites
- GREEN: 191 tests passed in the eight focused unchanged primitive, geometry, fault, reduced-motion, contract, Linear renderer, and design-language suites
- `npm run check`: 0 errors and 0 warnings
- changed-path ESLint: passed
- `git diff --check`: passed

Diff: 5 files, 201 additions, 2 deletions (203 A+D). No baselines regenerated.

Coordinator evidence correction: clarified the additive optional-prop source API and RED denominator before merge; values checked against the exact diff and builder result.
