### PR TITLE
feat: adopt RF SQL command feedback (MOR-2403)

### DIFF
--- a/frontend/fixtures/stubs/panel-adapters.ts
+++ b/frontend/fixtures/stubs/panel-adapters.ts
@@ -42,6 +42,11 @@ export function getFilterWidthControlFeedback() {
   });
 }
 
+/** The offline fixture has no qualified RF/SQL command-feedback authority. */
+export function getRfSqlControlFeedback(_controlSession: unknown): null {
+  return null;
+}
+
 /**
  * MOR-1441 — `SemanticRadioSurfaces.svelte` now also imports
  * `getPendingFrequencyHz` from the real `panel-adapters` module. Per this

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -26,6 +26,7 @@
   import { getManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
   import {
     bindSemanticSurfaceHandlers, getBreakInDelayControlFeedback, getFilterWidthControlFeedback,
+    getRfSqlControlFeedback,
     getPendingFrequencyHz,
     getPendingFilterSelection, getPendingNbOn, getPendingNrOn, getPendingPreampLevel,
     getSystemHandlers, getDataModeArmed,
@@ -728,6 +729,7 @@
   let pendingPreamp = $derived(
     activeReceiverIndex === null ? null : getPendingPreampLevel(activeReceiverIndex),
   );
+  let rfSqlFeedback = $derived(getRfSqlControlFeedback(controlSession));
   let pendingNb = $derived(activeReceiverIndex === null ? null : getPendingNbOn(activeReceiverIndex));
   let pendingNr = $derived(activeReceiverIndex === null ? null : getPendingNrOn(activeReceiverIndex));
 
@@ -1292,6 +1294,7 @@
       <RfFrontEndSurface
         {view}
         controlModel={rfSqlControlModel}
+        {rfSqlFeedback}
         {pendingPreamp}
         onPreampChange={(level) => rfFrontEndIntents.onPreChange(level)}
         onAttenuatorChange={(db) => rfFrontEndIntents.onAttChange(db)}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -38,6 +38,9 @@ import { flushSync, mount, unmount } from 'svelte';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
+import {
+  acknowledgeCommand, beginCommand, confirmCommand, failCommand, resetCommandLifecycle,
+} from '$lib/stores/commands.svelte';
 
 
 const h = vi.hoisted(() => ({
@@ -51,6 +54,8 @@ const h = vi.hoisted(() => ({
   squelch: vi.fn(),
   digiSel: vi.fn(),
   ipPlus: vi.fn(),
+  session: { state: 'connected' as 'connected' | 'disconnected' | 'reconnecting', epoch: 7 },
+  sessionListeners: new Set<(next: { state: 'connected' | 'disconnected' | 'reconnecting'; epoch: number }) => void>(),
 }));
 
 vi.mock('$lib/runtime', () => ({
@@ -60,6 +65,10 @@ vi.mock('$lib/runtime', () => ({
     get caps() { return h.caps; },
     get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
     get connectionAudio() { return false; },
+    get controlSession() { return h.session; },
+    subscribeControlSession(handler: (next: typeof h.session) => void) {
+      h.sessionListeners.add(handler); return () => h.sessionListeners.delete(handler);
+    },
     // MOR-1312 slice 12B (rebase fix): the wiring now also hands the adapter
     // a scope-display snapshot (the FIFTH argument). This file tests
     // rfFrontEnd, so this stays on its pre-1312 path regardless of these
@@ -71,6 +80,12 @@ vi.mock('$lib/runtime', () => ({
       };
     },
     get scope() { return { hardwareScopeConnected: false }; },
+  },
+}));
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    get state() { return h.state; },
+    get caps() { return h.caps; },
   },
 }));
 vi.mock('$lib/runtime/tx-controller/managed-app-host', () => ({
@@ -173,7 +188,10 @@ import { desktopV2Layout } from '../../../presentation/layouts/declarations';
 import { readWorkspace } from '../../../presentation/workspace/contract';
 import { resolveSurfacePlan, SURFACE_PLAN_CONTEXT_KEY, type SurfacePlan } from '../../../presentation/workspace/resolution';
 
-const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const fresh = {
+  storePath: 'x', observed: true, freshness: 'fresh', availability: 'available',
+  lastObservedMonotonic: 5,
+};
 const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
 
 /** Every rfFrontEnd raw field the MOR-1292/1293 adapter reads, all observed fresh. */
@@ -194,6 +212,7 @@ function liveState(withRfFrontEnd: boolean): ServerState {
     ...(withRfFrontEnd ? RF_FRONT_END_STATE : {}),
   });
   return {
+    stateContractVersion: 1, providerGeneration: 3,
     active: 'MAIN', split: false, dualWatch: false, ptt: false,
     txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
     main: receiver(14250000), sub: receiver(14300000),
@@ -205,6 +224,7 @@ function liveState(withRfFrontEnd: boolean): ServerState {
 // combined-knob describe block below passes 'combined' explicitly, so every
 // pre-existing test in this file keeps exercising the unchanged two-slider path.
 const liveCaps = (withRfFrontEnd: boolean, rfSqlControlModel?: 'separate' | 'combined'): Capabilities => ({
+  stateContractVersion: 1, providerGeneration: 3,
   model: 'fixture', scope: false, audio: true, tx: true,
   capabilities: withRfFrontEnd
     ? ['audio', 'tx', 'dual_rx', 'preamp', 'attenuator', 'rf_gain', 'squelch', 'digisel', 'ip_plus']
@@ -240,6 +260,9 @@ beforeEach(() => {
   h.txController = txHarness.controller;
   h.state = liveState(true);
   h.caps = liveCaps(true);
+  h.session = { state: 'connected', epoch: 7 };
+  h.sessionListeners.clear();
+  resetCommandLifecycle();
   for (const value of Object.values(h)) {
     if (typeof value === 'function' && 'mockReset' in value) (value as ReturnType<typeof vi.fn>).mockReset();
   }
@@ -250,6 +273,8 @@ afterEach(() => {
   component = null;
   expect(txHarness.listenerCount()).toBe(0);
   expect(txHarness.trace()).toEqual([]);
+  expect(h.sessionListeners.size).toBe(0);
+  resetCommandLifecycle();
   document.body.innerHTML = '';
 });
 
@@ -405,6 +430,37 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
     expect(el('rf-sql')).not.toBeNull();
     expect(el('rfGain')).toBeNull();
     expect(el('squelch')).toBeNull();
+    expect(el('rf-sql')!.dataset.feedbackIntegration).toBe('command-feedback');
+  });
+
+  it('fails closed through explicit null when the actual control session is disconnected', () => {
+    h.caps = liveCaps(true, 'combined');
+    h.session = { state: 'disconnected', epoch: 8 };
+    render();
+    const group = el('rf-sql')!;
+    expect(group.dataset.feedbackIntegration).toBe('authority-unresolved');
+    expect(group.querySelector('input')!.disabled).toBe(true);
+    expect(group.textContent).toContain('?');
+  });
+
+  it('projects real lifecycle phases and independent terminal outcomes into the mounted pair', () => {
+    h.caps = liveCaps(true, 'combined');
+    const rf = beginCommand({
+      id: 'mounted-rf', name: 'set_rf_gain', params: { level: 128, receiver: 0 }, originalEpoch: 7,
+    });
+    const sql = beginCommand({
+      id: 'mounted-sql', name: 'set_squelch', params: { level: 51, receiver: 0 }, originalEpoch: 7,
+    });
+    rf.providerGeneration = 3; sql.providerGeneration = 3;
+    render();
+    expect(el('rf-sql')!.dataset.rfCommandPhase).toBe('submitted');
+    expect(el('rf-sql')!.dataset.sqlCommandPhase).toBe('submitted');
+    acknowledgeCommand(rf.id, 7, 7); acknowledgeCommand(sql.id, 7, 7); flushSync();
+    expect(el('rf-sql')!.dataset.rfCommandPhase).toBe('awaiting-confirmation');
+    confirmCommand(rf.id, 7, 7); failCommand(sql.id, 7, 7, 'denied'); flushSync();
+    expect(el('rf-sql')!.dataset.rfCommandPhase).toBe('confirmed');
+    expect(el('rf-sql')!.dataset.sqlCommandPhase).toBe('failed');
+    expect(el('rf-sql')!.querySelectorAll('[data-control-feedback-status]')).toHaveLength(2);
   });
 
   it('keeps rendering the two separate sliders when the profile omits the declaration', () => {

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -61,6 +61,7 @@ import {
 } from '../panel-adapters';
 import {
   BREAK_IN_DELAY_COMMAND_DESCRIPTOR, FILTER_WIDTH_COMMAND_DESCRIPTOR,
+  RF_GAIN_COMMAND_DESCRIPTOR, SQUELCH_COMMAND_DESCRIPTOR,
   STATE_BACKED_COMMAND_DESCRIPTORS,
   beginCommand, getStateBackedCommandDescriptor,
 } from '$lib/stores/commands.svelte';
@@ -103,7 +104,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     expect(FILTER_WIDTH_FEEDBACK_DESCRIPTOR).toBe(FILTER_WIDTH_COMMAND_DESCRIPTOR);
     expect(getStateBackedCommandDescriptor('set_filter_width')).toBe(FILTER_WIDTH_COMMAND_DESCRIPTOR);
     expect([...STATE_BACKED_COMMAND_DESCRIPTORS.keys()]).toEqual([
-      'set_filter_width', 'set_break_in_delay',
+      'set_filter_width', 'set_break_in_delay', 'set_rf_gain', 'set_squelch',
     ]);
     expect(RADIO_INTENT_NAMES).toContain(FILTER_WIDTH_COMMAND_DESCRIPTOR.intentName);
     const main = FILTER_WIDTH_COMMAND_DESCRIPTOR.scope(command({ params: { width: 3000, receiver: 0 } }))!;
@@ -492,6 +493,8 @@ describe('Break-in Delay ControlFeedback projection (MOR-1744)', () => {
     expect([...STATE_BACKED_COMMAND_DESCRIPTORS.entries()]).toEqual([
       ['set_filter_width', FILTER_WIDTH_COMMAND_DESCRIPTOR],
       ['set_break_in_delay', BREAK_IN_DELAY_COMMAND_DESCRIPTOR],
+      ['set_rf_gain', RF_GAIN_COMMAND_DESCRIPTOR],
+      ['set_squelch', SQUELCH_COMMAND_DESCRIPTOR],
     ]);
     const scope = BREAK_IN_DELAY_COMMAND_DESCRIPTOR.scope(delayCommand());
     expect(scope).toEqual({ control: 'break-in-delay', receiver: 0 });

--- a/frontend/src/lib/runtime/adapters/__tests__/rf-sql-command-feedback.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/rf-sql-command-feedback.isolated.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import type { CommandLifecycle } from '$lib/stores/commands.svelte';
+
+const h = vi.hoisted(() => ({
+  state: null as ServerState | null,
+  caps: null as Capabilities | null,
+  commands: [] as CommandLifecycle[],
+  stateReads: 0,
+  capsReads: 0,
+  commandReads: 0,
+  active: 'MAIN' as 'MAIN' | 'SUB' | null,
+  operational: true,
+  project: vi.fn(),
+}));
+
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    get state() { h.stateReads += 1; return h.state; },
+    get caps() { h.capsReads += 1; return h.caps; },
+  },
+}));
+vi.mock('$lib/stores/commands.svelte', async (importOriginal) => ({
+  ...await importOriginal<typeof import('$lib/stores/commands.svelte')>(),
+  getCommandLifecycles: () => { h.commandReads += 1; return h.commands; },
+  isCommandLifecycleSuperseded: () => false,
+}));
+vi.mock('$lib/runtime/adapters/radio-view-model-adapter', () => ({
+  toRadioViewModel: (state: ServerState | null, caps: Capabilities | null) => {
+    h.project(state, caps);
+    return h.active === null ? { activeReceiver: { status: 'unknown' }, receiverIndicators: [] } : {
+      activeReceiver: { status: 'known', receiver: h.active },
+      receiverIndicators: [{
+        receiver: h.active,
+        availability: { structural: true, operational: h.operational },
+      }],
+    };
+  },
+}));
+vi.mock('$lib/runtime/commands/radio-intents', async (importOriginal) => ({
+  ...await importOriginal<typeof import('$lib/runtime/commands/radio-intents')>(),
+  currentControlSessionEpoch: () => 99,
+}));
+
+import { getRfSqlControlFeedback } from '../panel-adapters';
+
+const fresh = (marker = 5) => ({
+  storePath: 'fixture', observed: true, freshness: 'fresh' as const,
+  availability: 'available' as const, lastObservedMonotonic: marker,
+});
+const state = (over: Record<string, unknown> = {}): ServerState => ({
+  stateContractVersion: 1,
+  providerGeneration: 3,
+  active: 'MAIN',
+  main: { rfGain: 0.5, squelch: 0.2 },
+  sub: { rfGain: 0.75, squelch: 0.4 },
+  fieldStatus: {
+    'main.rfGain': fresh(), 'main.squelch': fresh(),
+    'sub.rfGain': fresh(), 'sub.squelch': fresh(),
+  },
+  ...over,
+} as unknown as ServerState);
+const caps = (over: Record<string, unknown> = {}): Capabilities => ({
+  stateContractVersion: 1,
+  providerGeneration: 3,
+  capabilities: ['rf_gain', 'squelch'],
+  receivers: 1,
+  vfoScheme: 'single',
+  ...over,
+} as unknown as Capabilities);
+const command = (name: 'set_rf_gain' | 'set_squelch', over: Partial<CommandLifecycle> = {}): CommandLifecycle => ({
+  id: name, name, params: { level: 128, receiver: 0 }, originalEpoch: 7,
+  createdAt: 1, updatedAt: 1, timeoutMs: 5_000, status: 'pending', providerGeneration: 3,
+  ...over,
+});
+const connected = { state: 'connected' as const, epoch: 7 };
+
+describe('qualified RF/SQL command feedback', () => {
+  afterEach(() => {
+    h.state = null; h.caps = null; h.commands = [];
+    h.stateReads = 0; h.capsReads = 0; h.commandReads = 0;
+    h.active = 'MAIN'; h.operational = true; h.project.mockClear();
+  });
+
+  it('captures one state/caps/list/session authority and freezes normalized lanes', () => {
+    h.state = state(); h.caps = caps();
+    h.commands = [command('set_rf_gain'), command('set_squelch', {
+      params: { level: 51, receiver: 0 }, createdAt: 2,
+    })];
+
+    const pair = getRfSqlControlFeedback(connected)!;
+
+    expect([h.stateReads, h.capsReads, h.commandReads]).toEqual([1, 1, 1]);
+    expect(h.project).toHaveBeenCalledExactlyOnceWith(h.state, h.caps);
+    expect(pair.rf).toMatchObject({ command: 'set_rf_gain', feedback: {
+      confirmed: 0.5, target: 128 / 255, requestedTarget: 128 / 255,
+      phase: 'submitted', providerGeneration: 3, sessionEpoch: 7,
+      scope: { control: 'rf-gain', receiver: 0 },
+    } });
+    expect(pair.sql).toMatchObject({ command: 'set_squelch', feedback: {
+      confirmed: 0.2, target: 51 / 255, phase: 'submitted',
+      scope: { control: 'squelch', receiver: 0 },
+    } });
+    expect(Object.isFrozen(pair)).toBe(true);
+    expect(Object.isFrozen(pair.rf)).toBe(true);
+    expect(Object.isFrozen(pair.rf.feedback)).toBe(true);
+  });
+
+  it.each([
+    ['disconnected', { state: 'disconnected' as const, epoch: 7 }, state(), caps()],
+    ['invalid epoch', { state: 'connected' as const, epoch: -1 }, state(), caps()],
+    ['missing state', connected, null, caps()],
+    ['missing caps', connected, state(), null],
+    ['state contract', connected, state({ stateContractVersion: 2 }), caps()],
+    ['caps contract', connected, state(), caps({ stateContractVersion: 2 })],
+    ['provider mismatch', connected, state(), caps({ providerGeneration: 4 })],
+  ])('returns null for unresolved %s authority', (_name, session, currentState, currentCaps) => {
+    h.state = currentState; h.caps = currentCaps;
+    expect(getRfSqlControlFeedback(session)).toBeNull();
+  });
+
+  it('uses canonical SUB and rejects unknown or non-operational receiver identity', () => {
+    h.state = state({ active: 'SUB' });
+    h.caps = caps({ receivers: 2, vfoScheme: 'main_sub', capabilities: ['dual_rx', 'rf_gain', 'squelch'] });
+    h.active = 'SUB';
+    expect(getRfSqlControlFeedback(connected)).toMatchObject({
+      rf: { feedback: { confirmed: 0.75, scope: { receiver: 1 } } },
+      sql: { feedback: { confirmed: 0.4, scope: { receiver: 1 } } },
+    });
+    h.active = null;
+    expect(getRfSqlControlFeedback(connected)).toBeNull();
+    h.active = 'SUB'; h.operational = false;
+    expect(getRfSqlControlFeedback(connected)).toBeNull();
+  });
+
+  it('keeps qualified and unavailable lanes independent', () => {
+    h.state = state(); h.caps = caps({ capabilities: ['rf_gain'] });
+    const pair = getRfSqlControlFeedback(connected)!;
+    expect(pair.rf.feedback).toMatchObject({ availability: 'available', confirmed: 0.5, phase: 'idle' });
+    expect(pair.sql.feedback).toMatchObject({
+      availability: 'unavailable', confirmed: null, target: null,
+      requestedTarget: null, phase: 'unavailable', busy: false,
+      providerGeneration: 3, sessionEpoch: 7, scope: { control: 'squelch', receiver: 0 },
+    });
+  });
+
+  it.each([
+    ['negative leaf marker', { 'main.rfGain': fresh(-1), 'main.squelch': fresh() }],
+    ['stale present parent', { main: { ...fresh(), freshness: 'stale' as const }, 'main.rfGain': fresh(), 'main.squelch': fresh() }],
+    ['missing present parent', { main: { ...fresh(), observed: false }, 'main.rfGain': fresh(), 'main.squelch': fresh() }],
+  ])('masks RF when evidence has a %s', (_name, fieldStatus) => {
+    h.state = state({ fieldStatus }); h.caps = caps();
+    const pair = getRfSqlControlFeedback(connected)!;
+    expect(pair.rf.feedback).toMatchObject({ availability: 'unavailable', phase: 'unavailable', confirmed: null });
+    expect(pair.sql.feedback).toMatchObject(_name === 'negative leaf marker'
+      ? { availability: 'available', confirmed: 0.2 }
+      : { availability: 'unavailable', confirmed: null });
+  });
+
+  it('preserves the accepted absent-ancestor skip', () => {
+    h.state = state(); h.caps = caps();
+    expect(getRfSqlControlFeedback(connected)).toMatchObject({
+      rf: { feedback: { availability: 'available', confirmed: 0.5 } },
+      sql: { feedback: { availability: 'available', confirmed: 0.2 } },
+    });
+  });
+
+  it('rejects stale-provider outcomes while retaining current provider identity', () => {
+    h.state = state(); h.caps = caps();
+    h.commands = [command('set_rf_gain', {
+      providerGeneration: 2, status: 'failed', error: 'old provider',
+    })];
+    expect(getRfSqlControlFeedback(connected)?.rf.feedback).toMatchObject({
+      providerGeneration: 3, confirmed: 0.5, target: null, phase: 'idle', outcome: null,
+    });
+  });
+});

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -7,7 +7,7 @@
  * Add new panel adapters here as panels are migrated to self-wiring.
  */
 
-import { runtime } from '../frontend-runtime';
+import { runtime, type ControlSessionSnapshot } from '../frontend-runtime';
 import {
   toAgcProps, toModeProps, toAntennaProps,
   toRfFrontEndProps, toRitXitProps, toScanProps,
@@ -36,6 +36,8 @@ import { recordQsy } from './qsy-history-adapter';
 import {
   BREAK_IN_DELAY_COMMAND_DESCRIPTOR,
   FILTER_WIDTH_COMMAND_DESCRIPTOR,
+  RF_GAIN_COMMAND_DESCRIPTOR,
+  SQUELCH_COMMAND_DESCRIPTOR,
   getCommandLifecycles,
   isCommandLifecycleSuperseded,
   type CommandLifecycle,
@@ -46,6 +48,7 @@ import {
 import { currentControlSessionEpoch } from '../commands/radio-intents';
 import type { ServerState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
+import { qualifyDisplayObservation } from './display-observation';
 
 // Re-export types for panel imports
 export type {
@@ -370,6 +373,72 @@ export function getFilterWidthControlFeedback(): Readonly<ControlFeedback<number
     FILTER_WIDTH_COMMAND_DESCRIPTOR, runtime.state, getCommandLifecycles(),
     { control: 'filter-width', receiver }, currentControlSessionEpoch(), isCommandLifecycleSuperseded,
   );
+}
+
+type RfSqlFeedbackLane = Readonly<{
+  command: string;
+  feedback: Readonly<ControlFeedback<number>>;
+}>;
+
+/** One qualified receiver/session snapshot for the two-lane RF/SQL owner. */
+export function getRfSqlControlFeedback(
+  currentControlSession: ControlSessionSnapshot,
+): Readonly<{ rf: RfSqlFeedbackLane; sql: RfSqlFeedbackLane }> | null {
+  const sessionState = currentControlSession.state;
+  const sessionEpoch = currentControlSession.epoch;
+  const state = runtime.state;
+  const caps = runtime.caps;
+  const commands = getCommandLifecycles();
+  const stateGeneration = state?.providerGeneration;
+  if (sessionState !== 'connected'
+    || !Number.isSafeInteger(sessionEpoch) || sessionEpoch < 0
+    || state === null || caps === null
+    || state.stateContractVersion !== 1 || caps.stateContractVersion !== 1
+    || !Number.isSafeInteger(stateGeneration) || (stateGeneration as number) < 0
+    || caps.providerGeneration !== stateGeneration) return null;
+
+  const view = toRadioViewModel(state, caps);
+  if (view === null || view.activeReceiver.status !== 'known') return null;
+  const receiver = view.activeReceiver.receiver;
+  const receiverEntries = view.receiverIndicators?.filter((entry) => entry.receiver === receiver) ?? [];
+  if (receiverEntries.length !== 1 || !receiverEntries[0].availability.operational) return null;
+  const receiverIndex: 0 | 1 = receiver === 'SUB' ? 1 : 0;
+  const receiverState = receiver === 'SUB' ? state.sub : state.main;
+  const base = receiver === 'SUB' ? 'sub' : 'main';
+  const tags = Array.isArray(caps.capabilities) ? caps.capabilities : [];
+
+  const lane = (
+    command: 'set_rf_gain' | 'set_squelch',
+    descriptor: StateBackedCommandDescriptor<number>,
+    control: 'rf-gain' | 'squelch',
+    leaf: 'rfGain' | 'squelch',
+    structural: boolean,
+  ): RfSqlFeedbackLane => {
+    const scope = { control, receiver: receiverIndex } as const;
+    const feedback = projectControlFeedback(
+      descriptor, state, commands, scope, sessionEpoch, isCommandLifecycleSuperseded,
+    );
+    const observation = qualifyDisplayObservation({
+      state, caps, receiver, path: `${base}.${leaf}`, structural,
+      value: receiverState?.[leaf],
+    });
+    const qualified = observation.state === 'current' ? feedback : Object.freeze({
+      ...feedback,
+      confirmed: null, target: null, requestedTarget: null,
+      phase: 'unavailable' as const, busy: false, availability: 'unavailable' as const,
+      outcome: null, lifecycleId: null, transitionId: null,
+    });
+    return Object.freeze({ command, feedback: qualified });
+  };
+
+  return Object.freeze({
+    rf: lane(
+      'set_rf_gain', RF_GAIN_COMMAND_DESCRIPTOR, 'rf-gain', 'rfGain', tags.includes('rf_gain'),
+    ),
+    sql: lane(
+      'set_squelch', SQUELCH_COMMAND_DESCRIPTOR, 'squelch', 'squelch', tags.includes('squelch'),
+    ),
+  });
 }
 
 function filterWidthPresentation(

--- a/frontend/src/lib/stores/__tests__/commands.test.ts
+++ b/frontend/src/lib/stores/__tests__/commands.test.ts
@@ -1,4 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServerState } from '../../types/state';
+
+let acceptedState: ServerState | null = null;
+const stateListeners = new Set<(state: ServerState | null) => void>();
+const emitState = (state: ServerState): void => {
+  acceptedState = state;
+  for (const listener of stateListeners) listener(state);
+};
 
 describe('command lifecycle store', () => {
   let store: typeof import('../commands.svelte');
@@ -6,11 +14,21 @@ describe('command lifecycle store', () => {
   beforeEach(async () => {
     vi.useFakeTimers();
     vi.resetModules();
+    acceptedState = null;
+    stateListeners.clear();
+    vi.doMock('../radio.svelte', () => ({
+      getRadioState: () => acceptedState,
+      subscribeRadioState: (listener: (state: ServerState | null) => void) => {
+        stateListeners.add(listener); listener(acceptedState);
+        return () => stateListeners.delete(listener);
+      },
+    }));
     store = await import('../commands.svelte');
   });
 
   afterEach(() => {
     store.resetCommandLifecycle();
+    vi.doUnmock('../radio.svelte');
     vi.useRealTimers();
   });
 
@@ -222,5 +240,121 @@ describe('command lifecycle store', () => {
     expect(store.getCommandLifecycles()).toHaveLength(100);
     expect(store.getCommandLifecycle('acknowledged-0', 9)?.status).toBe('acknowledged');
     expect(store.getCommandLifecycle('overflow', 9)).toBeUndefined();
+  });
+
+  describe('RF/SQL state-backed descriptors', () => {
+    it('uses exact receiver scopes and normalized 0..1 targets', () => {
+      const rfMain = store.RF_GAIN_COMMAND_DESCRIPTOR.scope({ params: { level: 128, receiver: 0 } })!;
+      const rfSub = store.RF_GAIN_COMMAND_DESCRIPTOR.scope({ params: { level: 255, receiver: 1 } })!;
+      const sqlMain = store.SQUELCH_COMMAND_DESCRIPTOR.scope({ params: { level: 0, receiver: 0 } })!;
+      const sqlSub = store.SQUELCH_COMMAND_DESCRIPTOR.scope({ params: { level: 64, receiver: 1 } })!;
+
+      expect([...store.STATE_BACKED_COMMAND_DESCRIPTORS.keys()]).toEqual([
+        'set_filter_width', 'set_break_in_delay', 'set_rf_gain', 'set_squelch',
+      ]);
+      expect(rfMain).toEqual({ control: 'rf-gain', receiver: 0 });
+      expect(rfSub).toEqual({ control: 'rf-gain', receiver: 1 });
+      expect(sqlMain).toEqual({ control: 'squelch', receiver: 0 });
+      expect(sqlSub).toEqual({ control: 'squelch', receiver: 1 });
+      expect(store.RF_GAIN_COMMAND_DESCRIPTOR.fieldPath(rfMain)).toBe('main.rfGain');
+      expect(store.RF_GAIN_COMMAND_DESCRIPTOR.fieldPath(rfSub)).toBe('sub.rfGain');
+      expect(store.SQUELCH_COMMAND_DESCRIPTOR.fieldPath(sqlMain)).toBe('main.squelch');
+      expect(store.SQUELCH_COMMAND_DESCRIPTOR.fieldPath(sqlSub)).toBe('sub.squelch');
+      expect(store.RF_GAIN_COMMAND_DESCRIPTOR.target({ params: { level: 128, receiver: 0 } })).toBe(128 / 255);
+      expect(store.SQUELCH_COMMAND_DESCRIPTOR.target({ params: { level: 255, receiver: 1 } })).toBe(1);
+      expect(store.RF_GAIN_COMMAND_DESCRIPTOR.confirmed({
+        main: { rfGain: 0.5 }, sub: { rfGain: 0.75 },
+      } as never, rfMain)).toBe(0.5);
+      expect(store.SQUELCH_COMMAND_DESCRIPTOR.confirmed({
+        main: { squelch: 0.1 }, sub: { squelch: 0.2 },
+      } as never, sqlSub)).toBe(0.2);
+      expect(store.RF_GAIN_COMMAND_DESCRIPTOR.matches(128 / 255, 128 / 255)).toBe(true);
+      expect(store.RF_GAIN_COMMAND_DESCRIPTOR.matches(0.5, 128 / 255)).toBe(false);
+    });
+
+    it.each([
+      ['missing level', { receiver: 0 }],
+      ['missing receiver', { level: 1 }],
+      ['extra key', { level: 1, receiver: 0, slot: 'A' }],
+      ['string level', { level: '1', receiver: 0 }],
+      ['boolean level', { level: true, receiver: 0 }],
+      ['fractional level', { level: 1.5, receiver: 0 }],
+      ['nonfinite level', { level: Number.POSITIVE_INFINITY, receiver: 0 }],
+      ['negative level', { level: -1, receiver: 0 }],
+      ['high level', { level: 256, receiver: 0 }],
+      ['string receiver', { level: 1, receiver: '0' }],
+      ['boolean receiver', { level: 1, receiver: false }],
+      ['unknown receiver', { level: 1, receiver: 2 }],
+    ])('rejects a %s envelope', (_name, params) => {
+      for (const descriptor of [store.RF_GAIN_COMMAND_DESCRIPTOR, store.SQUELCH_COMMAND_DESCRIPTOR]) {
+        expect(descriptor.scope({ params })).toBeNull();
+        expect(descriptor.target({ params })).toBeNull();
+      }
+    });
+
+    it('rejects symbol, inherited, and throwing envelopes without executing a default', () => {
+      const inherited = Object.create({ receiver: 0 }) as Record<string, unknown>;
+      inherited.level = 1;
+      const symbol = { level: 1, receiver: 0, [Symbol('extra')]: true };
+      const throwing = Object.defineProperty({ receiver: 0 }, 'level', {
+        enumerable: true, get: () => { throw new Error('read'); },
+      });
+      const ownKeysTrap = new Proxy({}, { ownKeys: () => { throw new Error('keys'); } });
+
+      for (const params of [inherited, symbol, throwing, ownKeysTrap]) {
+        expect(store.RF_GAIN_COMMAND_DESCRIPTOR.scope({ params })).toBeNull();
+        expect(store.RF_GAIN_COMMAND_DESCRIPTOR.target({ params })).toBeNull();
+      }
+    });
+
+    it('supersedes only the same intent and receiver scope', () => {
+      const rfMain = store.beginCommand({
+        id: 'rf-main', name: 'set_rf_gain', params: { level: 10, receiver: 0 }, originalEpoch: 4,
+      });
+      const rfSub = store.beginCommand({
+        id: 'rf-sub', name: 'set_rf_gain', params: { level: 20, receiver: 1 }, originalEpoch: 4,
+      });
+      const sqlMain = store.beginCommand({
+        id: 'sql-main', name: 'set_squelch', params: { level: 30, receiver: 0 }, originalEpoch: 4,
+      });
+      store.beginCommand({
+        id: 'rf-main-new', name: 'set_rf_gain', params: { level: 40, receiver: 0 }, originalEpoch: 4,
+      });
+
+      expect(store.isCommandLifecycleSuperseded(rfMain)).toBe(true);
+      expect(store.isCommandLifecycleSuperseded(rfSub)).toBe(false);
+      expect(store.isCommandLifecycleSuperseded(sqlMain)).toBe(false);
+    });
+
+    it('confirms only from exact scoped truth after a finite advancing ACK marker', () => {
+      const snapshot = (
+        rfGain: number, marker: number, freshness: 'fresh' | 'stale' = 'fresh',
+      ): ServerState => ({
+        providerGeneration: 3, main: { rfGain }, sub: {},
+        fieldStatus: { 'main.rfGain': {
+          storePath: 'fixture', observed: true, freshness,
+          availability: 'available', lastObservedMonotonic: marker,
+        } },
+      } as unknown as ServerState);
+      emitState(snapshot(128 / 255, 4));
+      const command = store.beginCommand({
+        id: 'rf-confirm', name: 'set_rf_gain', params: { level: 128, receiver: 0 }, originalEpoch: 7,
+      });
+      store.acknowledgeCommand(command.id, 7, 7);
+      const current = () => store.getCommandLifecycle(command.id, 7)!;
+      expect(current()).toMatchObject({
+        status: 'acknowledged', providerGeneration: 3,
+        ackFieldObservationTimes: { 'main.rfGain': 4 },
+      });
+
+      emitState(snapshot(128 / 255, 4));
+      expect(current().status).toBe('acknowledged');
+      emitState(snapshot(0.5, 5));
+      expect(current().status).toBe('acknowledged');
+      emitState(snapshot(128 / 255, 6, 'stale'));
+      expect(current().status).toBe('acknowledged');
+      emitState(snapshot(128 / 255, 7));
+      expect(current().status).toBe('confirmed');
+    });
   });
 });

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -65,6 +65,27 @@ const safeInteger = (value: unknown): number | null =>
 const providerGeneration = (value: unknown): number | null =>
   typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : null;
 
+type NormalizedLevelCommand = Readonly<{ receiver: 0 | 1; target: number }>;
+function normalizedLevelCommand(
+  command: Pick<CommandLifecycle, 'params'>,
+): NormalizedLevelCommand | null {
+  try {
+    const params = command.params;
+    if (typeof params !== 'object' || params === null) return null;
+    const keys = Reflect.ownKeys(params);
+    if (keys.length !== 2
+      || !Object.prototype.hasOwnProperty.call(params, 'level')
+      || !Object.prototype.hasOwnProperty.call(params, 'receiver')) return null;
+    const level = params.level;
+    const receiver = params.receiver;
+    return typeof level === 'number' && Number.isSafeInteger(level) && level >= 0 && level <= 255
+      && (receiver === 0 || receiver === 1)
+      ? Object.freeze({ receiver, target: level / 255 }) : null;
+  } catch {
+    return null;
+  }
+}
+
 export const FILTER_WIDTH_COMMAND_DESCRIPTOR: StateBackedCommandDescriptor<number> = Object.freeze({
   intentName: 'set_filter_width', repeatPolicy: 'latest-target-wins',
   scope: (command: Pick<CommandLifecycle, 'params'>) => {
@@ -96,10 +117,42 @@ export const BREAK_IN_DELAY_COMMAND_DESCRIPTOR: StateBackedCommandDescriptor<num
   matches: (confirmed: number, target: number) => confirmed === target,
 });
 
+export const RF_GAIN_COMMAND_DESCRIPTOR: StateBackedCommandDescriptor<number> = Object.freeze({
+  intentName: 'set_rf_gain', repeatPolicy: 'latest-target-wins',
+  scope: (command: Pick<CommandLifecycle, 'params'>) => {
+    const parsed = normalizedLevelCommand(command);
+    return parsed === null ? null : Object.freeze({ control: 'rf-gain', receiver: parsed.receiver });
+  },
+  fieldPath: (scope: ControlFeedbackScope) => scope.receiver === 1 ? 'sub.rfGain' : 'main.rfGain',
+  target: (command: Pick<CommandLifecycle, 'params'>) => normalizedLevelCommand(command)?.target ?? null,
+  confirmed: (state: ServerState, scope: ControlFeedbackScope) => {
+    const value = finiteNumber((scope.receiver === 1 ? state.sub : state.main)?.rfGain);
+    return value !== null && value >= 0 && value <= 1 ? value : null;
+  },
+  matches: (confirmed: number, target: number) => confirmed === target,
+});
+
+export const SQUELCH_COMMAND_DESCRIPTOR: StateBackedCommandDescriptor<number> = Object.freeze({
+  intentName: 'set_squelch', repeatPolicy: 'latest-target-wins',
+  scope: (command: Pick<CommandLifecycle, 'params'>) => {
+    const parsed = normalizedLevelCommand(command);
+    return parsed === null ? null : Object.freeze({ control: 'squelch', receiver: parsed.receiver });
+  },
+  fieldPath: (scope: ControlFeedbackScope) => scope.receiver === 1 ? 'sub.squelch' : 'main.squelch',
+  target: (command: Pick<CommandLifecycle, 'params'>) => normalizedLevelCommand(command)?.target ?? null,
+  confirmed: (state: ServerState, scope: ControlFeedbackScope) => {
+    const value = finiteNumber((scope.receiver === 1 ? state.sub : state.main)?.squelch);
+    return value !== null && value >= 0 && value <= 1 ? value : null;
+  },
+  matches: (confirmed: number, target: number) => confirmed === target,
+});
+
 export const STATE_BACKED_COMMAND_DESCRIPTORS: ReadonlyMap<RadioIntentName, StateBackedCommandDescriptor<unknown>> =
   new Map([
     [FILTER_WIDTH_COMMAND_DESCRIPTOR.intentName, FILTER_WIDTH_COMMAND_DESCRIPTOR],
     [BREAK_IN_DELAY_COMMAND_DESCRIPTOR.intentName, BREAK_IN_DELAY_COMMAND_DESCRIPTOR],
+    [RF_GAIN_COMMAND_DESCRIPTOR.intentName, RF_GAIN_COMMAND_DESCRIPTOR],
+    [SQUELCH_COMMAND_DESCRIPTOR.intentName, SQUELCH_COMMAND_DESCRIPTOR],
   ]);
 export const getStateBackedCommandDescriptor = (intentName: string): StateBackedCommandDescriptor<unknown> | undefined =>
   (STATE_BACKED_COMMAND_DESCRIPTORS as ReadonlyMap<string, StateBackedCommandDescriptor<unknown>>).get(intentName);

--- a/frontend/src/semantic/RfFrontEndSurface.svelte
+++ b/frontend/src/semantic/RfFrontEndSurface.svelte
@@ -42,9 +42,8 @@
 
   PENDING AFFORDANCE (MOR-1441 leg 2). `pendingPreamp` is a plain, command-
   bus-blind display prop, same "read at the wiring seam" precedent as leg
-  1's `pendingFrequencyHz`. It never touches the MOR-1447 combined pair
-  binding, whose reading evidence comes only from `rf.rfGain`/`rf.squelch` —
-  preamp is a disjoint field. Marks the
+  1's `pendingFrequencyHz`. It never touches the disjoint combined RF/SQL
+  pair binding. Marks the
   targeted preamp CHOICE distinctly; the preamp binding's `aria-checked` keeps reading
   `rf.preamp`'s CONFIRMED reading exclusively, so a click while pending still
   dispatches the CLICKED (explicit) value.
@@ -109,7 +108,8 @@
   import type { RadioViewModel } from './radio-view-model';
   import {
     createContinuousPair, nativeRangeContinuousPairPolicy,
-    type ContinuousPairInput, type ContinuousPairRendererLease, type ContinuousPairView,
+    type CommandFeedbackContinuousPairInput, type ContinuousPairInput,
+    type ContinuousPairRendererLease, type ContinuousPairView,
   } from '../primitives/scalar/continuous-pair.svelte';
   import {
     bindChoiceInstrument,
@@ -121,6 +121,11 @@
     /** Icom-style single-knob RF/SQL (MOR-1447 leg 2). Defaults to
      *  `'separate'` — the two independent sliders leg 1 fixed. */
     controlModel?: RfSqlControlModel;
+    /** Omitted only by compatibility mounts; null means integrated authority
+     *  is unresolved, while an object is the complete pair authority. */
+    rfSqlFeedback?: Readonly<
+      Pick<CommandFeedbackContinuousPairInput, 'rf' | 'sql'>
+    > | null;
     /** MOR-1441 leg 2 — the freshest in-flight `set_preamp` target for the
      *  active receiver, DISPLAY ONLY (see the file header). `null` when
      *  nothing is pending. */
@@ -136,7 +141,7 @@
     onToggle?: (field: RfFrontEndToggleField, next: boolean) => void;
   }
   let {
-    view, controlModel = 'separate', pendingPreamp = null,
+    view, controlModel = 'separate', rfSqlFeedback, pendingPreamp = null,
     onPreampChange, onAttenuatorChange, onLevelChange, onToggle,
   }: Props = $props();
 
@@ -173,6 +178,10 @@
   function changeLevel(field: RfFrontEndLevelField, value: number): void {
     if (rf && usable(rf[field])) onLevelChange?.(field, value);
   }
+  function requestPairLevel(field: RfFrontEndLevelField, value: number): void {
+    if (rfSqlFeedback === undefined) changeLevel(field, value);
+    else if (rfSqlFeedback !== null) onLevelChange?.(field, value);
+  }
   /** MOR-1447 leg 2: both fields structurally present AND the profile
    *  declares the combined knob — the gate for rendering ONE control instead
    *  of two. A profile that declares `'combined'` but only observes one of
@@ -186,18 +195,35 @@
     && !!rf?.squelch.availability.structural,
   );
   function rfSqlInput(): Readonly<ContinuousPairInput> {
-    const availability = (field: RfFrontEndField<number> | undefined) =>
-      field?.availability.structural && field.availability.operational
-        ? 'available' as const : 'unavailable' as const;
-    return {
-      evidence: 'reading', ownerKey: JSON.stringify([
-        view.topologyId, view.activeReceiver.status,
-        view.activeReceiver.status === 'known' ? view.activeReceiver.receiver : null,
-      ]),
+    const common = {
       domain: {
         min: RF_SQL_MIN, max: RF_SQL_MAX, step: RF_SQL_STEP,
         defaultValue: null, fineStepDivisor: 10,
       },
+      requestRf: (value: number) => requestPairLevel('rfGain', value),
+      requestSql: (value: number) => requestPairLevel('squelch', value),
+    };
+    if (rfSqlFeedback === null) return {
+      ...common,
+      evidence: 'reading', ownerKey: 'rf-sql:feedback-integrated:authority-unresolved',
+      enabled: false,
+      rf: { reading: { status: 'unknown' }, availability: 'unavailable' },
+      sql: { reading: { status: 'unknown' }, availability: 'unavailable' },
+    };
+    if (rfSqlFeedback !== undefined) return {
+      ...common,
+      evidence: 'command-feedback', enabled: controlModel === 'combined',
+      rf: rfSqlFeedback.rf, sql: rfSqlFeedback.sql,
+    };
+    const availability = (field: RfFrontEndField<number> | undefined) =>
+      field?.availability.structural && field.availability.operational
+        ? 'available' as const : 'unavailable' as const;
+    return {
+      ...common,
+      evidence: 'reading', ownerKey: JSON.stringify([
+        view.topologyId, view.activeReceiver.status,
+        view.activeReceiver.status === 'known' ? view.activeReceiver.receiver : null,
+      ]),
       enabled: controlModel === 'combined',
       rf: {
         reading: rf?.rfGain.reading ?? { status: 'unknown' },
@@ -207,8 +233,6 @@
         reading: rf?.squelch.reading ?? { status: 'unknown' },
         availability: availability(rf?.squelch),
       },
-      requestRf: (value) => changeLevel('rfGain', value),
-      requestSql: (value) => changeLevel('squelch', value),
     };
   }
   const rfSqlPair = createContinuousPair(rfSqlInput, nativeRangeContinuousPairPolicy);
@@ -223,6 +247,32 @@
     rfSqlView = rfSqlLease === null ? rfSqlPair.view : rfSqlLease.view;
   });
   let combinedNormX = $derived(rfSqlView.displayedPosition ?? RF_SQL_MIN);
+  const FEEDBACK_INTEGRATED_RANGE = { 'feedback-policy': 'feedback-integrated' } as const;
+  let feedbackIntegration = $derived(
+    rfSqlFeedback === undefined ? 'compatibility-reading'
+      : rfSqlFeedback === null ? 'authority-unresolved' : 'command-feedback',
+  );
+  const laneValue = (lane: 'rf' | 'sql'): number | null => {
+    const view = rfSqlView.lanes[lane];
+    return rfSqlView.draft?.[lane]
+      ?? (view.evidence === 'command-feedback' ? view.feedback.target : null)
+      ?? view.canonical;
+  };
+  const laneText = (lane: 'rf' | 'sql'): string => {
+    const value = laneValue(lane);
+    return value === null ? UNKNOWN_TEXT : formatKnownLevel(value, RF_SQL_MIN, RF_SQL_MAX);
+  };
+  const laneStatus = (lane: 'rf' | 'sql'): string => {
+    const view = rfSqlView.lanes[lane];
+    if (view.evidence !== 'command-feedback') return '';
+    const phase = view.phase.charAt(0).toUpperCase() + view.phase.slice(1).replaceAll('-', ' ');
+    const requested = view.feedback.target ?? view.feedback.requestedTarget;
+    const target = requested === null ? ''
+      : ` ${formatKnownLevel(requested, RF_SQL_MIN, RF_SQL_MAX)}`;
+    const confirmed = view.canonical === null ? UNKNOWN_TEXT
+      : formatKnownLevel(view.canonical, RF_SQL_MIN, RF_SQL_MAX);
+    return `${phase}${target}; confirmed ${confirmed}${view.error === null ? '' : `: ${view.error}`}`;
+  };
   onDestroy(() => rfSqlPair.destroy());
 </script>
 
@@ -278,19 +328,40 @@
     {#if combinedUsable}
       <label
         class="rf-front-end-level" data-testid="rf-front-end-rf-sql"
-        data-observed={usable(rf.rfGain) && usable(rf.squelch)}
+        data-feedback-integration={feedbackIntegration}
+        data-observed={rfSqlView.lanes.rf.availability === 'available'
+          && rfSqlView.lanes.sql.availability === 'available'
+          && rfSqlView.canonical.rf !== null && rfSqlView.canonical.sql !== null}
+        data-rf-command-phase={rfSqlView.lanes.rf.phase ?? undefined}
+        data-sql-command-phase={rfSqlView.lanes.sql.phase ?? undefined}
+        aria-busy={rfSqlView.busy}
       >
         <span class="rf-front-end-name">RF/SQL</span>
         <input
           type="range" min={RF_SQL_MIN} max={RF_SQL_MAX} step={RF_SQL_STEP}
+          {...FEEDBACK_INTEGRATED_RANGE}
           value={combinedNormX}
           disabled={!rfSqlView.editable}
           data-pair-evidence={rfSqlView.evidence}
           oninput={(event) => rfSqlLease?.nativeInput(event.currentTarget.valueAsNumber)}
         />
-        <output
-          >{levelTextOf(rf.rfGain, RF_SQL_MIN, RF_SQL_MAX)} / {levelTextOf(rf.squelch, RF_SQL_MIN, RF_SQL_MAX)}</output
-        >
+        <output data-testid="rf-front-end-rf-sql-rf-value">{laneText('rf')}</output>
+        /
+        <output data-testid="rf-front-end-rf-sql-sql-value">{laneText('sql')}</output>
+        {#if rfSqlView.lanes.rf.evidence === 'command-feedback'}
+          <output data-testid="rf-front-end-rf-sql-rf-status">{laneStatus('rf')}</output>
+        {/if}
+        {#if rfSqlView.lanes.sql.evidence === 'command-feedback'}
+          <output data-testid="rf-front-end-rf-sql-sql-status">{laneStatus('sql')}</output>
+        {/if}
+        {#if rfSqlView.lanes.rf.announcement !== null}
+          <span class="sr-only" role="status" aria-live="polite" aria-atomic="true"
+            data-control-feedback-status data-feedback-lane="rf">{rfSqlView.lanes.rf.announcement}</span>
+        {/if}
+        {#if rfSqlView.lanes.sql.announcement !== null}
+          <span class="sr-only" role="status" aria-live="polite" aria-atomic="true"
+            data-control-feedback-status data-feedback-lane="sql">{rfSqlView.lanes.sql.announcement}</span>
+        {/if}
       </label>
     {:else}
       {#each RF_FRONT_END_LEVELS as [field, label, min, max, step] (field)}

--- a/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
@@ -13,6 +13,7 @@
  * Fast-pool-safe by construction (MOR-1272): no `vi.mock`, no global spy.
  */
 import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
 import { flushSync, mount, unmount } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import RfFrontEndSurface, {
@@ -22,6 +23,7 @@ import { topologyFixtures, withRfFrontEnd } from '../fixtures/topologies';
 import type {
   Availability, DisabledReason, RadioViewModel, RfFrontEndField, RfFrontEndViewModel,
 } from '../radio-view-model';
+import type { CommandFeedbackContinuousPairInput } from '../../primitives/scalar/continuous-pair.svelte';
 
 const ON: Availability = { structural: true, operational: true };
 const OFF: Availability = { structural: false, operational: false };
@@ -40,6 +42,24 @@ const unread = <T>(availability: Availability = ON): RfFrontEndField<T> =>
   ({ reading: { status: 'unknown' }, availability });
 const known = <T>(value: T, availability: Availability = ON): RfFrontEndField<T> =>
   ({ reading: { status: 'known', value }, availability });
+type PairFeedback = Readonly<Pick<CommandFeedbackContinuousPairInput, 'rf' | 'sql'>>;
+const pairFeedback = (
+  over: Partial<Record<'rf' | 'sql', Record<string, unknown>>> = {},
+  providerGeneration = 3,
+): PairFeedback => {
+  const lane = (name: 'rf' | 'sql', confirmed: number) => ({
+    command: name === 'rf' ? 'set_rf_gain' : 'set_squelch',
+    feedback: {
+      confirmed, target: null, requestedTarget: null, phase: 'idle' as const,
+      busy: false, availability: 'available' as const, outcome: null,
+      lifecycleId: null, transitionId: null, providerGeneration, sessionEpoch: 7,
+      scope: { control: name === 'rf' ? 'rf-gain' : 'squelch', receiver: 0 as const },
+      repeatPolicy: 'latest-target-wins' as const,
+      ...over[name],
+    },
+  });
+  return { rf: lane('rf', 0.5), sql: lane('sql', 0.2) };
+};
 
 let target: HTMLDivElement;
 
@@ -311,6 +331,14 @@ describe('RF gain and squelch render as 0..1 sliders, no rescale', () => {
 /* ── MOR-1447 leg 2: the combined RF/SQL knob ────────────────────── */
 
 describe('the combined RF/SQL knob (controlModel="combined")', () => {
+  it('keeps its optional feedback prop primitive-shaped and free of runtime imports', () => {
+    const source = readFileSync('src/semantic/RfFrontEndSurface.svelte', 'utf8');
+    const props = source.slice(source.indexOf('interface Props'), source.indexOf('}: Props'));
+    expect(props).toContain("Pick<CommandFeedbackContinuousPairInput, 'rf' | 'sql'>");
+    expect(props).toMatch(/rfSqlFeedback\?:[\s\S]*\| null/);
+    expect(source).not.toMatch(/from ['"]\$lib\/runtime|from ['"][^'"]*runtime\/adapters/);
+  });
+
   it('renders one rf-sql control instead of the two separate sliders', () => {
     const r = render(base(), { controlModel: 'combined' });
     expect(r.el('rf-sql')).not.toBeNull();
@@ -339,7 +367,105 @@ describe('the combined RF/SQL knob (controlModel="combined")', () => {
     const r = render(base(), { controlModel: 'combined' });
     const input = r.el('rf-sql')!.querySelector('input')!;
     expect([input.min, input.max]).toEqual(['0', '1']);
+    expect(input.getAttribute('feedback-policy')).toBe('feedback-integrated');
     r.dispose();
+  });
+
+  it('treats explicit null as unresolved integration with no raw fallback', () => {
+    const onLevelChange = vi.fn();
+    const r = render(base(), { controlModel: 'combined', rfSqlFeedback: null, onLevelChange });
+    const group = r.el('rf-sql')!;
+    const input = group.querySelector('input')!;
+    expect(group.dataset.feedbackIntegration).toBe('authority-unresolved');
+    expect(group.dataset.observed).toBe('false');
+    expect(input.disabled).toBe(true);
+    expect(r.text('rf-sql-rf-value')).toBe(UNKNOWN_TEXT);
+    expect(r.text('rf-sql-sql-value')).toBe(UNKNOWN_TEXT);
+    input.value = '1';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onLevelChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('uses command feedback for position, readout, observation, and request gating', () => {
+    const onLevelChange = vi.fn();
+    const r = render(withRf({ rfGain: unread(DEGRADED), squelch: unread(DEGRADED) }), {
+      controlModel: 'combined', rfSqlFeedback: pairFeedback(), onLevelChange,
+    });
+    const group = r.el('rf-sql')!;
+    const input = group.querySelector('input')!;
+    expect(group.dataset.feedbackIntegration).toBe('command-feedback');
+    expect(group.dataset.observed).toBe('true');
+    expect(input.disabled).toBe(false);
+    expect(input.valueAsNumber).toBeCloseTo(0.632, 3);
+    expect(r.text('rf-sql-rf-value')).toBe('50%');
+    expect(r.text('rf-sql-sql-value')).toBe('20%');
+    input.value = '1';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onLevelChange.mock.calls).toEqual([['rfGain', 1], ['squelch', 1]]);
+    r.dispose();
+  });
+
+  it('renders independent lane phases, errors, busy state, and announcements', () => {
+    const values = new SvelteMap<string, PairFeedback>([['feedback', pairFeedback()]]);
+    target = document.createElement('div'); document.body.appendChild(target);
+    const component = mount(RfFrontEndSurface, { target, props: {
+      view: base(), controlModel: 'combined',
+      get rfSqlFeedback() { return values.get('feedback')!; },
+    } });
+    flushSync();
+    values.set('feedback', pairFeedback({
+      rf: {
+        phase: 'confirmed', requestedTarget: 0.5,
+        outcome: { phase: 'confirmed' }, lifecycleId: 'rf-1', transitionId: 'rf-confirmed',
+      },
+      sql: {
+        phase: 'failed', requestedTarget: 0.4, outcome: { phase: 'failed', error: 'denied' },
+        lifecycleId: 'sql-1', transitionId: 'sql-failed',
+      },
+    }));
+    flushSync();
+    const group = target.querySelector<HTMLElement>('[data-testid="rf-front-end-rf-sql"]')!;
+    expect(group.dataset.rfCommandPhase).toBe('confirmed');
+    expect(group.dataset.sqlCommandPhase).toBe('failed');
+    expect(group.getAttribute('aria-busy')).toBe('false');
+    expect(group.querySelector('[data-testid="rf-front-end-rf-sql-rf-status"]')?.textContent).toContain('Confirmed');
+    expect(group.querySelector('[data-testid="rf-front-end-rf-sql-sql-status"]')?.textContent).toContain('Failed');
+    expect(group.querySelectorAll('[data-control-feedback-status]')).toHaveLength(2);
+    expect(group.textContent).toContain('denied');
+    unmount(component); target.remove();
+  });
+
+  it('keeps requested and last-confirmed lane values distinct while pending', () => {
+    const feedback = pairFeedback({ rf: {
+      target: 0.75, requestedTarget: 0.75, phase: 'awaiting-confirmation', busy: true,
+      lifecycleId: 'rf-pending', transitionId: 'rf-awaiting',
+    } });
+    const r = render(base(), { controlModel: 'combined', rfSqlFeedback: feedback });
+    expect(r.text('rf-sql-rf-value')).toBe('75%');
+    expect(r.text('rf-sql-rf-status')).toContain('Awaiting confirmation 75%; confirmed 50%');
+    expect(r.el('rf-sql')!.getAttribute('aria-busy')).toBe('true');
+    r.dispose();
+  });
+
+  it('invalidates a local draft when provider authority is replaced', () => {
+    const values = new SvelteMap<string, PairFeedback>([['feedback', pairFeedback()]]);
+    target = document.createElement('div'); document.body.appendChild(target);
+    const component = mount(RfFrontEndSurface, { target, props: {
+      view: base(), controlModel: 'combined',
+      get rfSqlFeedback() { return values.get('feedback')!; },
+      onLevelChange: vi.fn(),
+    } });
+    flushSync();
+    const input = target.querySelector<HTMLInputElement>('[data-testid="rf-front-end-rf-sql"] input')!;
+    input.value = '1'; input.dispatchEvent(new Event('input', { bubbles: true })); flushSync();
+    expect(input.valueAsNumber).toBe(1);
+    values.set('feedback', pairFeedback({ rf: { confirmed: 1 }, sql: { confirmed: 0 } }, 4));
+    flushSync();
+    expect(input.valueAsNumber).toBe(0.5);
+    unmount(component); target.remove();
   });
 
   // Per-field change guard (verifier follow-up R1, mirrors


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-2403/adopt-full-command-feedback-in-the-combined-semantic-rfsql-regulator

## Summary

- register strict state-backed `set_rf_gain` and `set_squelch` descriptors with receiver-scoped normalized targets
- project one qualified control-session/provider/receiver snapshot into independent RF and SQL feedback lanes
- adopt that feedback in the combined semantic RF/SQL regulator, including requested vs confirmed values, lifecycle state, terminal errors, busy state, and polite announcements
- fail closed when integrated authority is unresolved while preserving compatibility mounts and the separate-slider path
- preserve the offline fixture harness with an explicit unresolved-authority `null` facade result

## Scope

This is the MOR-2403 open-core semantic combined-control slice. It changes ten files: the eight original leased implementation/test paths, the coordinator-authorized exact registry assertions in `filter-width-command-lifecycle.isolated.test.ts`, and the correction-authorized fixture facade `frontend/fixtures/stubs/panel-adapters.ts`.

The ten files form one complete descriptor-to-production-consumer feedback contract. The registry test preserves exact descriptor identity, and the fixture facade is the full-module replacement required to build the affected semantic wiring in deterministic captures. This is why the batch exceeds the six-file/600-line soft threshold; the hard ceilings remain satisfied.

The change is additive. It does not alter the separate native RF/SQL controls or legacy surfaces, and it does not claim universal hardware echo behavior.

## Correction 1

Natural quick run `34025586679` found one omitted affected fixture export after 10,309 passing tests. The corrected fixture accessor returns explicit `null`, preserving unresolved offline authority without fabricated command feedback or a production fallback. All nine production candidate blobs are byte-identical to the blocked head.

## Verification

- Correction fanout: 16 files, 426 tests passed; this includes the original 14-file/424-test fanout plus the fixture preflight and facade seam
- Standalone root-CWD fixture Vite preflight: 1 test passed; this test is included in the 426 count above and is not additive
- Svelte/TypeScript check: 0 errors, 0 warnings
- Configured frontend lint: passed
- `git diff --check`: passed
- control-feedback debt inventory and digest tests: passed; baseline file unchanged and the live combined RF/SQL debt site is removed
- corrected change size: 716 additions, 18 deletions (734 A+D)

Natural required `quick` and path-selected `visual` workflows should run on the corrected Ready PR head.
