### PR TITLE
MOR-2404: route queued Yaesu CW pitch through Hz setter

### DIFF
--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -1252,7 +1252,7 @@ class YaesuCatPoller:
             case SetKeySpeed(speed=speed):
                 await radio.set_keyer_speed(speed)
             case SetCwPitch(value=value):
-                await radio.set_key_pitch(value)
+                await radio.set_cw_pitch(value)
             case SetBreakIn(mode=mode):
                 await radio.set_break_in(bool(mode))
 

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -62,6 +62,7 @@ from rigplane.web.radio_poller import (
     CommandQueue,
     SelectVfo,
     SetBand,
+    SetCwPitch,
     SetFreq,
     SetMode,
     SetSplit,
@@ -3233,6 +3234,52 @@ async def test_fast_poll_reads_tx_meters_when_ptt_active() -> None:
 # ---------------------------------------------------------------------------
 # Command queue: future exception propagation
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("pitch_hz", "expected_frame"),
+    [(300, "KP00;"), (700, "KP40;"), (1050, "KP75;")],
+)
+async def test_ftx1_queued_cw_pitch_uses_hz_semantic_setter(
+    pitch_hz: int,
+    expected_frame: str,
+) -> None:
+    radio = YaesuCatRadio("/dev/null", profile="ftx1", audio_driver=MagicMock())
+    radio._transport._connected = True  # noqa: SLF001
+    radio._transport.write = AsyncMock()  # noqa: SLF001
+    queue = CommandQueue()
+    poller = YaesuCatPoller(radio, command_queue=queue)
+    _set_fresh_ptt_observation(poller, active=False)
+    future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    queue.put_ordered(SetCwPitch(pitch_hz), future=future)
+
+    await poller._drain_commands()  # noqa: SLF001
+
+    assert future.result() is None
+    radio._transport.write.assert_awaited_once_with(expected_frame)  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pitch_hz", [299, 1051])
+async def test_ftx1_queued_cw_pitch_rejects_out_of_range_without_cat_write(
+    pitch_hz: int,
+) -> None:
+    radio = YaesuCatRadio("/dev/null", profile="ftx1", audio_driver=MagicMock())
+    radio._transport._connected = True  # noqa: SLF001
+    radio._transport.write = AsyncMock()  # noqa: SLF001
+    queue = CommandQueue()
+    poller = YaesuCatPoller(radio, command_queue=queue)
+    _set_fresh_ptt_observation(poller, active=False)
+    future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    queue.put_ordered(SetCwPitch(pitch_hz), future=future)
+
+    await poller._drain_commands()  # noqa: SLF001
+
+    error = future.exception()
+    assert isinstance(error, ValueError)
+    assert "300-1050" in str(error)
+    radio._transport.write.assert_not_awaited()  # noqa: SLF001
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- route queued Yaesu `SetCwPitch` values through the existing Hz-semantic `set_cw_pitch` API
- exercise the real FTX-1 profile and real `YaesuCatRadio` conversion through the command queue drain
- pin `300 -> KP00;`, `700 -> KP40;`, and `1050 -> KP75;`
- prove `299` and `1051` propagate `ValueError` through queue futures without a CAT write

Linear: [MOR-2404](https://linear.app/morozsm/issue/MOR-2404/route-queued-yaesu-cw-pitch-through-the-existing-hz-semantic-setter)  
Parent: [MOR-1682](https://linear.app/morozsm/issue/MOR-1682/expose-ftx-1-cw-pitch-3001050-hz-in-exact-10-hz-steps)  
Related: MOR-2215, MOR-2401

## Evidence

Intentional RED before the production change:

```text
5 failed
Actual frames: KP300;, KP700;, KP1050;
Out-of-range futures completed without errors.
```

Focused GREEN:

```text
uv run pytest tests/test_yaesu_cat_poller.py::test_ftx1_queued_cw_pitch_uses_hz_semantic_setter tests/test_yaesu_cat_poller.py::test_ftx1_queued_cw_pitch_rejects_out_of_range_without_cat_write -q --tb=short
5 passed
```

Relevant backend GREEN:

```text
uv run pytest tests/test_yaesu_cat_poller.py tests/test_ftx1_radio.py -q --tb=short
510 passed

uv run ruff check src/rigplane/backends/yaesu_cat/poller.py tests/test_yaesu_cat_poller.py
All checks passed!

uv run ruff format --check src/rigplane/backends/yaesu_cat/poller.py tests/test_yaesu_cat_poller.py
2 files already formatted
```

## CI baseline

The latest accepted-main quick run `34025193473` at base `952895eb2f3cffa523900f3da3e466336ebadb39` selected frontend only and is not backend evidence. The latest main quick with the core `Run tests` step selected and successful is [run 34002301446](https://github.com/rigplane/rigplane-core/actions/runs/34002301446) at `669923b7e9839a7fbd458bd13147cdefb13292e4`. The repository classifier over `669923b...952895e` reports `core: false`, and the core tree is unchanged across that range.

## Limits

This does not change or certify the CW Pitch UI range, 10-Hz lattice, off-lattice policy, profile declarations, readback timing, or hardware behavior. Those remain owned by MOR-1682. No hardware command was issued, and no UI, profile, transport, Yaesu radio, Keyer Speed, TX, or PTT code changed.
