### PR TITLE
Adopt qualified receiver S-meter continuity

### DIFF
--- a/frontend/src/components-v2/vfo/VfoPanel.svelte
+++ b/frontend/src/components-v2/vfo/VfoPanel.svelte
@@ -9,6 +9,9 @@
   import { splitFrequencyToDigits, groupDigitsForDisplay } from '../../primitives/frequency/frequency-tuning';
   import { formatRitOffset } from './vfo-utils';
   import type { VfoLayoutProfile } from '../layout/vfo-layout-tokens';
+  import type {
+    MeterContinuitySession, MeterSourceIdentity,
+  } from '../../primitives/meters/meter-ballistics.svelte';
 
   export interface VfoPanelBadge {
     label: string;
@@ -46,6 +49,8 @@
     sValue: number | null;
     meterPresent?: boolean;
     meterOperational?: boolean;
+    meterSource?: MeterSourceIdentity | null;
+    continuitySession?: MeterContinuitySession | null;
     isActive: boolean;
     badgeItems: readonly VfoPanelBadge[];
     bandText?: string | null;
@@ -60,7 +65,7 @@
   let {
     receiver, receiverLabel, slotTag, freq, displayHz, pendingDisplayHz = null,
     frequencyState = 'current', staleReason, contextKey, frequencyDisabled = false,
-    mode, filter, sValue, meterPresent = true, meterOperational,
+    mode, filter, sValue, meterPresent = true, meterOperational, meterSource, continuitySession,
     isActive,
     badgeItems, bandText, rit, slotChoices = [],
     layoutProfile = 'baseline',
@@ -109,7 +114,7 @@
       <div data-testid="receiver-s-meter" data-receiver={receiver}
         data-operational={meterOperational === undefined ? undefined : String(meterOperational)}
         aria-label={sValue === null ? `${receiverLabel} S meter unknown` : undefined}>
-        <LinearSMeter value={Number.isFinite(sValue) ? sValue : null} compact label={slotTag} variant={meterVariant} />
+        <LinearSMeter value={Number.isFinite(sValue) ? sValue : null} compact label={slotTag} variant={meterVariant} source={meterSource} session={continuitySession} />
       </div>
     {/if}
   </div>

--- a/frontend/src/components-v2/vfo/__tests__/VfoPanel.isolated.test.ts
+++ b/frontend/src/components-v2/vfo/__tests__/VfoPanel.isolated.test.ts
@@ -466,4 +466,14 @@ describe('explicit presentation contract', () => {
     const source = readFileSync('src/components-v2/vfo/VfoPanel.svelte', 'utf8');
     expect(source).not.toMatch(/stores\/|runtime\/|capabilities/);
   });
+
+  it('forwards optional meter context while the legacy adapter omits it', () => {
+    const panel = readFileSync('src/components-v2/vfo/VfoPanel.svelte', 'utf8');
+    const meter = panel.match(/<LinearSMeter([\s\S]*?)\/>/)?.[1] ?? '';
+    expect(meter).toMatch(/source=\{meterSource\}/);
+    expect(meter).toMatch(/session=\{continuitySession\}/);
+    const legacy = readFileSync('src/components-v2/vfo/LegacyVfoPanelAdapter.svelte', 'utf8');
+    const call = legacy.match(/<VfoPanel([\s\S]*?)\/>/)?.[1] ?? '';
+    expect(call).not.toMatch(/meterSource|continuitySession/);
+  });
 });

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -880,6 +880,7 @@
               onTuneFrequency={tuneFrequency}
               disabled={!isOperationalStrip(view, receiverId)}
               indicatorReceiver={receiverId}
+              continuitySession={meterContinuitySession}
               {pendingFrequencyHz}
             />
           </div>
@@ -948,6 +949,7 @@
         onSelectMainReceiver={vfo.onMainVfoClick}
         onSelectSubReceiver={vfo.onSubVfoClick}
         onSpeak={systemIntents.onSpeak}
+        continuitySession={meterContinuitySession}
         {pendingFrequencyHz}
       />
     {/if}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -1,10 +1,11 @@
 /** MOR-2299 slice 1: the production dual composition partitions indicators. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { flushSync, mount, unmount } from 'svelte';
+import { flushSync, mount, unmount, type ComponentProps } from 'svelte';
 import { readFileSync } from 'node:fs';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
+import type { ControlSessionSnapshot } from '$lib/runtime/frontend-runtime';
 
 const h = vi.hoisted(() => ({
   state: null as ServerState | null, caps: null as Capabilities | null, noop: vi.fn(),
@@ -12,6 +13,8 @@ const h = vi.hoisted(() => ({
   main: vi.fn(), sub: vi.fn(), equalize: vi.fn(), swap: vi.fn(), split: vi.fn(),
   dualWatch: vi.fn(), speak: vi.fn(),
   filterWidthFeedback: vi.fn(),
+  session: { state: 'connected', epoch: 1 } as ControlSessionSnapshot,
+  sessionSubscriber: null as ((next: ControlSessionSnapshot) => void) | null,
 }));
 const group = new Proxy({}, { get: () => h.noop });
 
@@ -19,6 +22,11 @@ vi.mock('$lib/runtime', () => ({
   runtime: {
     onTxAudioDied: () => () => {},
     get state() { return h.state; }, get caps() { return h.caps; },
+    get controlSession() { return h.session; },
+    subscribeControlSession(handler: (next: ControlSessionSnapshot) => void) {
+      h.sessionSubscriber = handler;
+      return () => { if (h.sessionSubscriber === handler) h.sessionSubscriber = null; };
+    },
     get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
     get connectionAudio() { return false; },
     get defaultScopeStatus() {
@@ -96,10 +104,22 @@ function render(
   capabilities: Capabilities,
   stateValue: ServerState = state(),
   txSnapshot: ManagedAppTxServerSnapshot = {},
+  props: ComponentProps<typeof SemanticRadioSurfaces> = { strips: 'dual' },
 ): void {
   h.state = stateValue; h.caps = capabilities; txHarness.emitServerSnapshot(txSnapshot);
   target = document.createElement('div'); document.body.appendChild(target);
-  component = mount(SemanticRadioSurfaces, { target, props: { strips: 'dual' } }); flushSync();
+  component = mount(SemanticRadioSurfaces, { target, props }); flushSync();
+}
+function pushSession(next: ControlSessionSnapshot): void {
+  h.session = next; h.sessionSubscriber?.(next); flushSync();
+}
+function pushMeter(value: number, providerGeneration = 1): void {
+  const next = state({ providerGeneration });
+  next.main!.sMeter = value;
+  h.state = next;
+  h.caps = { ...caps('main_sub', 2), providerGeneration };
+  txHarness.emitServerSnapshot({});
+  flushSync();
 }
 const rowReceivers = (root: ParentNode) => [...root.querySelectorAll<HTMLElement>('[data-testid="vfo-indicator-row"]')]
   .map((row) => row.dataset.indicatorReceiver);
@@ -107,6 +127,8 @@ const rowReceivers = (root: ParentNode) => [...root.querySelectorAll<HTMLElement
 beforeEach(() => {
   txHarness = new ManagedAppTxHarness();
   h.txController = txHarness.controller;
+  h.session = { state: 'connected', epoch: 1 };
+  h.sessionSubscriber = null;
   h.filterWidthFeedback.mockReturnValue(Object.freeze({
     confirmed: null, target: null, requestedTarget: null,
     phase: 'unavailable', busy: false, availability: 'unavailable',
@@ -123,10 +145,67 @@ afterEach(() => {
   component = null;
   expect(txHarness.listenerCount()).toBe(0);
   expect(txHarness.trace()).toEqual([]);
+  expect(h.sessionSubscriber).toBeNull();
   document.body.innerHTML = '';
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe('production receiver-indicator partitioning', () => {
+  it.each([
+    ['dual semantic receiver strip', { strips: 'dual' }],
+    ['live Standard composition', { strips: 'single', vfoAppearance: 'standard' }],
+  ] as const)('re-seeds %s at equal-value session and provider boundaries', (_name, props) => {
+    vi.stubGlobal('matchMedia', (query: string): MediaQueryList => ({
+      matches: query === '(prefers-reduced-motion: reduce)', media: query, onchange: null,
+      addEventListener: vi.fn(), removeEventListener: vi.fn(),
+      addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(() => false),
+    }));
+    render(caps('main_sub', 2), state(), {}, props);
+    const meter = () => target.querySelector('[data-indicator-receiver="MAIN"] [data-testid="receiver-s-meter"] svg')!;
+    const fillCount = () => meter().querySelectorAll('[data-meter-fill]').length;
+    const hasPeak = () => meter().querySelector('[data-meter-peak]') !== null;
+    const arm = (generation = 1) => {
+      pushMeter(240, generation); pushMeter(60, generation);
+      expect(hasPeak()).toBe(true);
+      return fillCount();
+    };
+
+    const epochFill = arm();
+    pushSession({ state: 'connected', epoch: 2 });
+    expect(fillCount()).toBe(epochFill);
+    expect(hasPeak()).toBe(false);
+
+    const generationFill = arm();
+    pushMeter(60, 2);
+    expect(fillCount()).toBe(generationFill);
+    expect(hasPeak()).toBe(false);
+
+    const reconnectFill = arm(2);
+    pushSession({ state: 'disconnected', epoch: 3 });
+    expect(fillCount()).toBe(0);
+    expect(hasPeak()).toBe(false);
+    pushSession({ state: 'connected', epoch: 4 });
+    expect(fillCount()).toBe(reconnectFill);
+    expect(hasPeak()).toBe(false);
+  });
+
+  it('stops mounted meter schedulers and the control-session join on unmount', () => {
+    vi.stubGlobal('matchMedia', (query: string): MediaQueryList => ({
+      matches: false, media: query, onchange: null,
+      addEventListener: vi.fn(), removeEventListener: vi.fn(),
+      addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(() => false),
+    }));
+    const requestFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1);
+    const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+    render(caps('main_sub', 2));
+    expect(requestFrame).toHaveBeenCalled();
+    unmount(component!);
+    component = null;
+    expect(cancelFrame).toHaveBeenCalled();
+    expect(h.sessionSubscriber).toBeNull();
+  });
+
   it('passes the complete Filter Width feedback projection through production wiring', () => {
     const source = readFileSync('src/components-v2/wiring/SemanticRadioSurfaces.svelte', 'utf8');
     expect(source).toMatch(

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -190,20 +190,37 @@ describe('production receiver-indicator partitioning', () => {
     expect(hasPeak()).toBe(false);
   });
 
-  it('stops mounted meter schedulers and the control-session join on unmount', () => {
+  it.each([
+    ['dual semantic receiver strip', { strips: 'dual' }],
+    ['live Standard composition', { strips: 'single', vfoAppearance: 'standard' }],
+  ] as const)('stops every %s meter scheduler and the control-session join on unmount', (_name, props) => {
     vi.stubGlobal('matchMedia', (query: string): MediaQueryList => ({
       matches: false, media: query, onchange: null,
       addEventListener: vi.fn(), removeEventListener: vi.fn(),
       addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(() => false),
     }));
-    const requestFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1);
-    const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
-    render(caps('main_sub', 2));
-    expect(requestFrame).toHaveBeenCalled();
+    let nextFrameId = 0;
+    const requestedFrameIds = new Set<number>();
+    const outstandingFrameIds = new Set<number>();
+    const cancelledFrameIds = new Set<number>();
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => {
+      const frameId = ++nextFrameId;
+      requestedFrameIds.add(frameId);
+      outstandingFrameIds.add(frameId);
+      return frameId;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((frameId) => {
+      cancelledFrameIds.add(frameId);
+      outstandingFrameIds.delete(frameId);
+    });
+    render(caps('main_sub', 2), state(), {}, props);
+    expect(requestedFrameIds.size).toBeGreaterThan(0);
+    expect(outstandingFrameIds).toEqual(requestedFrameIds);
     unmount(component!);
     component = null;
-    expect(cancelFrame).toHaveBeenCalled();
     expect(h.sessionSubscriber).toBeNull();
+    expect(outstandingFrameIds).toEqual(new Set());
+    expect(cancelledFrameIds).toEqual(requestedFrameIds);
   });
 
   it('passes the complete Filter Width feedback projection through production wiring', () => {

--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -329,6 +329,7 @@ describe('receiver indicators are structural-receiver addressed (MOR-2299 slice 
     const sub = view.receiverIndicators?.find((indicator) => indicator.receiver === 'SUB');
     expect(sub?.availability).toEqual({ structural: true, operational: false });
     expect(sub?.sMeter.reading).toEqual({ status: 'unknown' });
+    expect(sub?.sMeter.source).toBeNull();
     expect(sub?.nbActive.reading).toEqual({ status: 'unknown' });
   });
 
@@ -338,6 +339,7 @@ describe('receiver indicators are structural-receiver addressed (MOR-2299 slice 
     const signature = (view: RadioViewModel) => view.receiverIndicators?.map((indicator) => ({
       receiver: indicator.receiver,
       s: indicator.sMeter.reading,
+      source: indicator.sMeter.source,
       bw: indicator.bandwidthHz.reading,
       agc: indicator.agcMode.reading,
       nb: indicator.nbActive.reading,
@@ -351,6 +353,7 @@ describe('receiver indicators are structural-receiver addressed (MOR-2299 slice 
     expect(signature(before)).toEqual([
       {
         receiver: 'MAIN', s: { status: 'known', value: 0 },
+        source: { providerGeneration: 1, scope: 'receiver', receiver: 'MAIN', path: 'main.sMeter' },
         bw: { status: 'known', value: 2400 }, agc: { status: 'known', value: 0 },
         nb: { status: 'known', value: false }, att: { status: 'known', value: 0 },
         pre: { status: 'known', value: 0 }, rfg: { status: 'known', value: 0 },
@@ -358,6 +361,7 @@ describe('receiver indicators are structural-receiver addressed (MOR-2299 slice 
       },
       {
         receiver: 'SUB', s: { status: 'known', value: -37 },
+        source: { providerGeneration: 1, scope: 'receiver', receiver: 'SUB', path: 'sub.sMeter' },
         bw: { status: 'known', value: 500 }, agc: { status: 'known', value: 'SLOW' },
         nb: { status: 'known', value: true }, att: { status: 'known', value: 12 },
         pre: { status: 'known', value: 2 }, rfg: { status: 'known', value: 0.75 },
@@ -385,6 +389,7 @@ describe('receiver indicators are structural-receiver addressed (MOR-2299 slice 
       .receiverIndicators?.find((indicator) => indicator.receiver === 'MAIN');
     expect(main?.sMeter.reading).toEqual({ status: 'unknown' });
     expect(main?.sMeter.availability.operational).toBe(false);
+    expect(main?.sMeter.source).toBeNull();
   });
 
   it.each([
@@ -399,6 +404,7 @@ describe('receiver indicators are structural-receiver addressed (MOR-2299 slice 
       .receiverIndicators?.find((indicator) => indicator.receiver === 'MAIN')!;
     expect(main.sMeter.reading).toEqual({ status: 'unknown' });
     expect(main.sMeter.availability.operational).toBe(false);
+    expect(main.sMeter.source).toBeNull();
     expect(main.nbActive.reading).toEqual({ status: 'known', value: false });
   });
 
@@ -1069,6 +1075,7 @@ describe('RF gain additive display observation', () => {
     for (const field of [
       'signal', 'power', 'swr', 'alc', 'compression', 'drainVoltage', 'drainCurrent',
     ] as const) delete legacyView.meters?.[field].source;
+    for (const indicator of legacyView.receiverIndicators ?? []) delete indicator.sMeter.source;
     const strictJson = JSON.stringify(legacyView, (key, value) => ['display', 'activeFilterConfiguration', 'dataModeChoices'].includes(key) ? undefined : value);
     const digest = createHash('sha256').update(strictJson).digest('hex');
     expect(digest).toBe(stale ? 'b4b5cff2b85557e39baa48e4d73c756e12ff026488ffa05a1ef558ca0b3f0507' : '379a5f00e3bebae780e4215af4e014351df2a07fc067d412f97df6aeadca840f');

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -896,6 +896,8 @@ function deriveReceiverIndicators(
       state, caps, receiver, path: path('sMeter'), structural: true,
       value: numOrUndef(rx?.sMeter),
     });
+    const sMeterOperational = receiverOperational && sMeterObservation.state === 'current';
+    const providerGeneration = state?.providerGeneration;
 
     return {
       receiver,
@@ -903,10 +905,20 @@ function deriveReceiverIndicators(
       // Every structural receiver owns one S-meter shell. The reading stays
       // unknown until its own leaf passes the strict gate; numeric zero is a
       // valid calibrated S9 reading and is preserved by numOrUndef.
-      sMeter: txAuxField(
-        true, receiverOperational && sMeterObservation.state === 'current',
-        sMeterObservation.state === 'current' ? sMeterObservation.value : undefined,
-      ),
+      sMeter: {
+        ...txAuxField(
+          true, sMeterOperational,
+          sMeterObservation.state === 'current' ? sMeterObservation.value : undefined,
+        ),
+        source: sMeterOperational
+          && typeof providerGeneration === 'number'
+          && Number.isSafeInteger(providerGeneration) && providerGeneration >= 0
+          ? {
+              providerGeneration, scope: 'receiver', receiver,
+              path: receiver === 'MAIN' ? 'main.sMeter' : 'sub.sMeter',
+            }
+          : null,
+      },
       bandwidthHz: strictField(hasFilters, 'filterWidth', numOrUndef(rx?.filterWidth)),
       agcMode: strictField(hasAgc, 'agc', agcMode),
       nbActive: strictField(hasNb, 'nb', boolOrUndef(rx?.nb)),

--- a/frontend/src/semantic/VfoIndicatorRow.svelte
+++ b/frontend/src/semantic/VfoIndicatorRow.svelte
@@ -6,6 +6,7 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import LinearSMeter from '../components-v2/meters/LinearSMeter.svelte';
+  import type { MeterContinuitySession } from '../primitives/meters/meter-ballistics.svelte';
   import type {
     DisplayObservedField, RadioWideIndicatorsViewModel, ReceiverIndicatorField,
     ReceiverIndicatorViewModel, TxAuxField,
@@ -17,9 +18,12 @@
     children?: Snippet;
     slotLabel?: string;
     radioWide?: RadioWideIndicatorsViewModel;
+    continuitySession?: MeterContinuitySession | null;
   }
 
-  let { indicator, radioWide, appearance = 'semantic', children, slotLabel }: Props = $props();
+  let {
+    indicator, radioWide, appearance = 'semantic', children, slotLabel, continuitySession,
+  }: Props = $props();
 
   const rfLabel = (state: RadioWideIndicatorsViewModel['rfState']): string =>
     state === 'transmitting' ? 'TX'
@@ -92,7 +96,7 @@
 
   <div class="s-meter" data-testid="receiver-s-meter" data-receiver={indicator.receiver}>
     {#if indicator.sMeter.reading.status === 'known' && Number.isFinite(indicator.sMeter.reading.value)}
-      <LinearSMeter value={indicator.sMeter.reading.value} compact label={appearance === 'standard' ? slotLabel : undefined} variant={appearance === 'sdr' ? 'sdr-screen' : 'vfo-wide'} />
+      <LinearSMeter value={indicator.sMeter.reading.value} compact label={appearance === 'standard' ? slotLabel : undefined} variant={appearance === 'sdr' ? 'sdr-screen' : 'vfo-wide'} source={indicator.sMeter.source} session={continuitySession} />
     {:else}
       <div
         class="s-meter-unknown"

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -43,6 +43,7 @@
   import VfoIndicatorRow from './VfoIndicatorRow.svelte';
   import { splitFrequencyToDigits, groupDigitsForDisplay } from '../primitives/frequency/frequency-tuning';
   import { renderSlot } from './design-language-renderers';
+  import type { MeterContinuitySession } from '../primitives/meters/meter-ballistics.svelte';
   import type { BooleanFact, DisplayObservation, RadioViewModel, ReceiverIndicatorViewModel, VfoViewModel } from './radio-view-model';
 
   interface Props {
@@ -140,6 +141,7 @@
      * once; the radio-wide `showVfoList={false}` mount renders no rows.
      */
     indicatorReceiver?: ReceiverId;
+    continuitySession?: MeterContinuitySession | null;
     /**
      * MOR-1321 (v3-rework slice S3a) — the VFO-scoped ACTIONS the legacy
      * `VfoOps` bridge carried and the semantic deck lost at MOR-1313: equalize
@@ -177,6 +179,7 @@
     onTuneFrequency,
     pendingFrequencyHz,
     indicatorReceiver,
+    continuitySession,
     onEqualizeVfos,
     onSwapVfos,
     onQuickSplit,
@@ -704,6 +707,7 @@
       <VfoIndicatorRow
         radioWide={viewModel.radioWideIndicators}
         {appearance}
+        {continuitySession}
       />
     {/if}
     {@const splitReason = viewModel.split.status === 'unknown' ? t('core.vfo.split.unknownReason') : undefined}
@@ -854,7 +858,7 @@
       class:instrument-active={viewModel.vfos.some((vfo) => vfo.receiver === receiver && vfo.isActive)}
       aria-label={`${receiver} instrument`}>
       <VfoIndicatorRow indicator={receiverIndicators.find((item) => item.receiver === receiver)} {appearance}
-        slotLabel={instrumentSlot(receiver)}>
+        slotLabel={instrumentSlot(receiver)} {continuitySession}>
         <div class="freq-stack">
           {#each viewModel.vfos as vfo, i (vfo.receiver + ':' + i)}
             {#if vfo.receiver === receiver}{@render vfoTile(vfo, i)}{/if}
@@ -906,6 +910,8 @@
             && Number.isFinite(indicator.sMeter.reading.value) ? indicator.sMeter.reading.value : null}
           meterPresent={indicator?.sMeter.availability.structural ?? false}
           meterOperational={indicator?.sMeter.availability.operational ?? false}
+          meterSource={indicator?.sMeter.source}
+          {continuitySession}
           isActive={dominant?.isActive ?? false} badgeItems={standardBadges(indicator)}
           bandText={dominant ? standardBand(dominant) : null}
           rit={dominant ? standardRit(dominant) : undefined} slotChoices={choices}
@@ -945,7 +951,7 @@
       {@render identitySelectors()}
       {#if receiverIndicators.length > 0}
         <div class="receiver-indicators" data-testid="vfo-receiver-indicators">
-          {#each receiverIndicators as indicator (indicator.receiver)}<VfoIndicatorRow {indicator} />{/each}
+          {#each receiverIndicators as indicator (indicator.receiver)}<VfoIndicatorRow {indicator} {continuitySession} />{/each}
         </div>
       {/if}
     {/if}

--- a/frontend/src/semantic/__tests__/VfoIndicatorRow.test.ts
+++ b/frontend/src/semantic/__tests__/VfoIndicatorRow.test.ts
@@ -114,6 +114,14 @@ describe('VfoIndicatorRow', () => {
       .replace(/\/\*[\s\S]*?\*\//g, '');
     expect(source).not.toMatch(/radioState|ServerState|fieldStatus|\$lib\/transport|tx-controller|panel-commands/);
   });
+
+  it('forwards only the receiver S-meter source and supplied continuity session', () => {
+    const source = readFileSync('src/semantic/VfoIndicatorRow.svelte', 'utf8');
+    const call = source.match(/<LinearSMeter([\s\S]*?)\/>/)?.[1] ?? '';
+    expect(call).toMatch(/source=\{indicator\.sMeter\.source\}/);
+    expect(call).toMatch(/session=\{continuitySession\}/);
+    expect(source).toMatch(/continuitySession\?: MeterContinuitySession \| null/);
+  });
 });
 
 function shared(): RadioWideIndicatorsViewModel {

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -221,7 +221,13 @@ function receiverIndicator(receiver: ReceiverId): ReceiverIndicatorViewModel {
   return {
     receiver,
     availability: { structural: true, operational: true },
-    sMeter: indicatorField(receiver === 'MAIN' ? 0 : -31),
+    sMeter: {
+      ...indicatorField(receiver === 'MAIN' ? 0 : -31),
+      source: {
+        providerGeneration: 1, scope: 'receiver', receiver,
+        path: receiver === 'MAIN' ? 'main.sMeter' : 'sub.sMeter',
+      },
+    },
     bandwidthHz: indicatorField(receiver === 'MAIN' ? 2400 : 500),
     agcMode: indicatorField(receiver === 'MAIN' ? 0 : 2),
     nbActive: indicatorField(receiver === 'SUB'),
@@ -2283,6 +2289,17 @@ describe('per-digit tuning (MOR-1322) — composition with an ACTIVE design lang
 });
 
 describe('MOR-2342 historical instrument presentations', () => {
+  it('forwards fixed-receiver meter context through every instrument branch', () => {
+    const source = readFileSync('src/semantic/VfoSurface.svelte', 'utf8');
+    expect(source.match(/<VfoIndicatorRow/g)).toHaveLength(3);
+    expect(source).toMatch(/radioWide=\{viewModel\.radioWideIndicators\}[\s\S]*?\{continuitySession\}/);
+    expect(source).toMatch(/slotLabel=\{instrumentSlot\(receiver\)\} \{continuitySession\}/);
+    expect(source).toContain('<VfoIndicatorRow {indicator} {continuitySession} />');
+    const panel = source.match(/<VfoPanel([\s\S]*?)\/>/)?.[1] ?? '';
+    expect(panel).toMatch(/meterSource=\{indicator\?\.sMeter\.source\}/);
+    expect(panel).toMatch(/continuitySession/);
+  });
+
   it.each(['sdr', 'standard'] as const)('pairs addressed facts and one bridge in %s', (appearance) => {
     const root = mountSurface({ viewModel: withReceiverIndicators('2/main_sub'), appearance });
     const panels = root.querySelectorAll('[data-receiver-instrument]');

--- a/frontend/src/semantic/__tests__/radio-view-model.test.ts
+++ b/frontend/src/semantic/__tests__/radio-view-model.test.ts
@@ -60,8 +60,8 @@ describe('validateRadioViewModel', () => {
     expect(validateRadioViewModel(model)).toEqual(model);
   });
 
-  const receiverIndicator = () => ({
-    receiver: 'MAIN' as const,
+  const receiverIndicator = (receiver: 'MAIN' | 'SUB' = 'MAIN') => ({
+    receiver,
     availability: { structural: true, operational: true },
     sMeter: { reading: { status: 'known' as const, value: 0 }, availability: { structural: true, operational: true } },
     bandwidthHz: { reading: { status: 'known' as const, value: 0 }, availability: { structural: true, operational: true } },
@@ -81,6 +81,41 @@ describe('validateRadioViewModel', () => {
     expect(model.receiverIndicators?.[0].sMeter.reading).toEqual({ status: 'known', value: 0 });
     expect(model.receiverIndicators?.[0].nbActive.reading).toEqual({ status: 'known', value: false });
     expect(model.receiverIndicators?.[0].digiSel.reading).toEqual({ status: 'known', value: false });
+  });
+
+  const MAIN_S_SOURCE = {
+    providerGeneration: 7, scope: 'receiver' as const, receiver: 'MAIN' as const, path: 'main.sMeter' as const,
+  };
+  const SUB_S_SOURCE = {
+    providerGeneration: 7, scope: 'receiver' as const, receiver: 'SUB' as const, path: 'sub.sMeter' as const,
+  };
+  const withReceiverSource = (receiver: 'MAIN' | 'SUB', source: unknown) => {
+    const indicator = receiverIndicator(receiver);
+    return { ...valid(), receiverIndicators: [{
+      ...indicator, sMeter: { ...indicator.sMeter, source },
+    }] };
+  };
+
+  it('preserves omitted, null, and exact receiver-owned S-meter sources', () => {
+    expect(validateRadioViewModel({ ...valid(), receiverIndicators: [receiverIndicator()] })
+      .receiverIndicators![0].sMeter).not.toHaveProperty('source');
+    expect(validateRadioViewModel(withReceiverSource('MAIN', null))
+      .receiverIndicators![0].sMeter.source).toBeNull();
+    expect(validateRadioViewModel(withReceiverSource('MAIN', MAIN_S_SOURCE))
+      .receiverIndicators![0].sMeter.source).toEqual(MAIN_S_SOURCE);
+    expect(validateRadioViewModel(withReceiverSource('SUB', SUB_S_SOURCE))
+      .receiverIndicators![0].sMeter.source).toEqual(SUB_S_SOURCE);
+  });
+
+  it.each([
+    ['unsafe generation', { ...MAIN_S_SOURCE, providerGeneration: Number.MAX_SAFE_INTEGER + 1 }],
+    ['extra key', { ...MAIN_S_SOURCE, provider: 'rigctld' }],
+    ['radio scope', { ...MAIN_S_SOURCE, scope: 'radio', receiver: null }],
+    ['null receiver', { ...MAIN_S_SOURCE, receiver: null }],
+    ['wrong path', { ...MAIN_S_SOURCE, path: 'sub.sMeter' }],
+    ['cross-owner source', SUB_S_SOURCE],
+  ])('rejects %s on a MAIN receiver S-meter', (_label, source) => {
+    expect(() => validateRadioViewModel(withReceiverSource('MAIN', source))).toThrow(TypeError);
   });
 
   it('accepts and preserves the exact pre-MOR-2309 receiver RF payload shape', () => {

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -1032,6 +1032,9 @@ export interface ScopeDisplayViewModel {
  * survive without becoming an unknown/default.
  */
 export type ReceiverIndicatorField<T> = TxAuxField<T>;
+export interface ReceiverSMeterField extends ReceiverIndicatorField<number> {
+  source?: MeterSourceIdentity | null;
+}
 export interface ReceiverIndicatorViewModel {
   receiver: ReceiverId;
   availability: Availability;
@@ -1041,7 +1044,7 @@ export interface ReceiverIndicatorViewModel {
    * radio-wide `radioWideIndicators.rfState` fact.
    */
   rfState?: MeterRfState;
-  sMeter: ReceiverIndicatorField<number>;
+  sMeter: ReceiverSMeterField;
   bandwidthHz: ReceiverIndicatorField<number>;
   /** Capability label when declared for the ordinal; raw ordinal otherwise. */
   agcMode: ReceiverIndicatorField<number | string>;
@@ -1545,6 +1548,23 @@ function validateDisplayObservedField<T>(
   };
 }
 
+function validateReceiverSMeterField(
+  value: unknown, path: string, receiver: ReceiverId,
+): ReceiverSMeterField {
+  const v = record(value, path);
+  exactKeys(v, ['reading', 'availability', 'source'], path);
+  const strict = validateTxAuxField(
+    { reading: v.reading, availability: v.availability }, path, num,
+  );
+  if (v.source === undefined) return strict;
+  if (v.source === null) return { ...strict, source: null };
+  const source = validateMeterSource(v.source, `${path}.source`, 'signal');
+  if (source.receiver !== receiver) {
+    invalid(`${path}.source`, `the canonical ${receiver} receiver source`);
+  }
+  return { ...strict, source };
+}
+
 function validateReceiverIndicator(value: unknown, path: string): ReceiverIndicatorViewModel {
   const v = record(value, path);
   exactKeys(v, [
@@ -1552,13 +1572,14 @@ function validateReceiverIndicator(value: unknown, path: string): ReceiverIndica
     'nbActive', 'nrActive', 'notchMode', 'attenuator', 'preamp', 'rfGain',
     'digiSel', 'ipPlus',
   ], path);
+  const receiver = oneOf(v.receiver, RECEIVER_IDS, `${path}.receiver`);
   return {
-    receiver: oneOf(v.receiver, RECEIVER_IDS, `${path}.receiver`),
+    receiver,
     availability: validateAvailability(v.availability, `${path}.availability`),
     ...(v.rfState !== undefined
       ? { rfState: oneOf(v.rfState, METER_RF_STATES, `${path}.rfState`) }
       : {}),
-    sMeter: validateTxAuxField(v.sMeter, `${path}.sMeter`, num),
+    sMeter: validateReceiverSMeterField(v.sMeter, `${path}.sMeter`, receiver),
     bandwidthHz: validateTxAuxField(v.bandwidthHz, `${path}.bandwidthHz`, num),
     agcMode: validateTxAuxField(v.agcMode, `${path}.agcMode`, strOrNum),
     nbActive: validateTxAuxField(v.nbActive, `${path}.nbActive`, bool),


### PR DESCRIPTION
12 code + 0 regenerated baselines = 12 files

## Summary

- add an optional, strictly validated canonical source identity to receiver S-meter facts only
- carry each fixed receiver's source and the existing real control-session epoch through semantic/SDR receiver rows and the live Standard VFO panel
- keep legacy panel callers unfenced through omitted optional context, while preserving explicit-null and qualified/legacy boundary behavior owned by MOR-2400

## Contract and compatibility

This is one semantic contract with two mounted consumers, so the root-approved file-count exception keeps its source, forwarding owners, strict validators, legacy digest guard, and production wiring proof together. The change is additive: old receiver payloads may omit `source`, explicit `null` remains valid, and all component context props are optional. It does not change the wire protocol, CLI, configuration, TX/PTT authority, meter strategy, calibration, geometry, frequency controls, badges, or actions.

`LegacyVfoPanelAdapter` remains unchanged and omits qualified context. Standard outer-grid/FACE work, needle and segmentline algorithms, Amber/mobile paths, and the dormant dock remain out of scope.

Linear: [MOR-2405](https://linear.app/morozsm/issue/MOR-2405/adopt-qualified-s-meter-continuity-in-receiver-strips-and-live)

## Verification

- pre-correction focused Vitest matrix: 6 files, 499/499 tests passed on production-identical head `903610ebd0162cd1c26f48791b5c90525f2d8bb4`
- corrected exact-head teardown suite: 1 file, 19/19 tests passed
- corrected exact-head `npm run check`: 0 errors, 0 warnings
- configured ESLint for the corrected test path: clean; the other 11 candidate paths are byte-identical to the previously linted head
- `git diff --check`: clean
- exact diff against the PR base: 12 files, 241 additions and 18 deletions (259 A+D)
- mounted production proof covers dual semantic receiver strips and live Standard with equal-value epoch/provider replacement, disconnect/reconnect, and distinct-frame scheduler/session teardown
- no visual baselines regenerated; fresh natural required quick and path-selected visual are left to the corrected Ready head
