### PR TITLE
[MOR-2412] Adopt truthful legacy filter width

### DIFF
--- a/frontend/src/components-v2/controls/value-control/HBarRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/HBarRenderer.svelte
@@ -1,38 +1,21 @@
 <script lang="ts">
   import { onDestroy, untrack } from 'svelte';
   import type {
-    ContinuousScalarBinding,
     ContinuousScalarRendererLease,
     ContinuousScalarView,
   } from '../../../primitives/scalar/continuous-scalar.svelte';
   import './value-control.css';
   import {
+    clamp,
     getFillPercent,
     calculateClickValue,
   } from '../../../primitives/scalar/value-control-core';
   import {
     projectScalarRenderPresentation,
-    type LegacyReadingPresentation,
   } from './scalar-render-presentation';
+  import type { HBarSkinRendererProps } from './skin';
 
-  interface Props {
-    binding: ContinuousScalarBinding;
-    label: string;
-    displayFn?: (v: number) => string;
-    unknownDisplay?: string;
-    fillColor?: string;
-    fillGradient?: string[];
-    trackColor?: string;
-    accentColor?: string;
-    showValue?: boolean;
-    showLabel?: boolean;
-    compact?: boolean;
-    variant?: 'modern' | 'hardware' | 'hardware-illuminated';
-    unit?: string;
-    shortcutHint?: string | null;
-    title?: string | null;
-    legacy?: LegacyReadingPresentation;
-  }
+  type Props = HBarSkinRendererProps;
 
   let {
     binding,
@@ -51,32 +34,50 @@
     shortcutHint = null,
     title = null,
     legacy,
+    valueProjection,
+    issuedStatusPresentation,
   }: Props = $props();
 
   const feedbackDescriptionId = $props.id();
 
   let containerEl: HTMLDivElement | null = $state(null);
-  let activePointer: { id: number; token: number; target: HTMLElement } | null = null;
+  let activePointer: {
+    id: number;
+    token: number;
+    target: HTMLElement;
+    contextKey: string | null;
+  } | null = null;
   const initialBinding = untrack(() => binding);
   let attachedBinding = initialBinding;
   let lease: ContinuousScalarRendererLease = $state(initialBinding.attachRenderer());
 
-  $effect(() => {
-    if (binding === attachedBinding) return;
+  function releaseActivePointer(): void {
     if (activePointer?.target.hasPointerCapture?.(activePointer.id)) {
       activePointer.target.releasePointerCapture(activePointer.id);
     }
     activePointer = null;
+  }
+
+  $effect(() => {
+    if (binding === attachedBinding) return;
+    releaseActivePointer();
     lease.dispose();
     attachedBinding = binding;
     lease = binding.attachRenderer();
   });
   onDestroy(() => {
-    if (activePointer?.target.hasPointerCapture?.(activePointer.id)) {
-      activePointer.target.releasePointerCapture(activePointer.id);
-    }
-    activePointer = null;
+    releaseActivePointer();
     lease.dispose();
+  });
+
+  const initialProjectionContext = untrack(() => valueProjection?.contextKey ?? null);
+  let attachedProjectionContext = initialProjectionContext;
+  $effect(() => {
+    const nextContext = valueProjection?.contextKey ?? null;
+    if (nextContext === attachedProjectionContext) return;
+    attachedBinding.cancel('authority');
+    releaseActivePointer();
+    attachedProjectionContext = nextContext;
   });
 
   // Reading a lease reconciles its owner. Keep that mutable reconciliation in
@@ -92,9 +93,14 @@
     }
   });
   let renderedValue = $derived(view.displayed);
+  let projectedPosition = $derived(renderedValue === null || valueProjection === undefined
+    ? null : valueProjection.positionOf(renderedValue));
   let fillPercent = $derived(!view.domainValid || renderedValue === null
     ? 0
-    : getFillPercent(renderedValue, view.domain.min, view.domain.max));
+    : valueProjection === undefined
+      ? getFillPercent(renderedValue, view.domain.min, view.domain.max)
+      : projectedPosition !== null && Number.isFinite(projectedPosition)
+        && projectedPosition >= 0 && projectedPosition <= 1 ? projectedPosition * 100 : 0);
   let effectiveFill = $derived(fillGradient
     ? `linear-gradient(90deg, ${fillGradient.join(', ')})`
     : (fillColor ?? accentColor));
@@ -102,6 +108,47 @@
     ? unknownDisplay ?? (displayFn ? displayFn(Number.NaN) : '—')
     : displayFn ? displayFn(renderedValue) : `${renderedValue}${unit ? '\u00a0' + unit : ''}`);
   let renderPresentation = $derived(projectScalarRenderPresentation(view, legacy));
+  $effect(() => {
+    const snapshot = view;
+    if (issuedStatusPresentation === undefined || snapshot.evidence !== 'command-feedback') return;
+    const announcement = snapshot.presentation.politeAnnouncement;
+    if (announcement !== null) {
+      const formatted = untrack(() => issuedStatusPresentation.format({ view: snapshot, announcement }));
+      untrack(() => issuedStatusPresentation.accept(formatted));
+    } else if (snapshot.feedback.transitionId === null) {
+      untrack(() => issuedStatusPresentation.accept(null));
+    }
+  });
+  let statusText = $derived(issuedStatusPresentation === undefined
+    ? renderPresentation.status === null ? null
+      : `${renderPresentation.status}${renderPresentation.error === null ? '' : `: ${renderPresentation.error}`}`
+    : issuedStatusPresentation.text);
+  let ariaValueNow = $derived(!view.domainValid || view.canonical === null
+    ? undefined
+    : valueProjection === undefined
+      ? view.canonical
+      : (() => {
+        const position = valueProjection.positionOf(view.canonical!);
+        return position !== null && Number.isFinite(position) && position >= 0 && position <= 1
+          ? view.canonical! : undefined;
+      })());
+
+  function pointerValue(clientX: number, rect: DOMRect, domain: ContinuousScalarView['domain']): number | null {
+    if (valueProjection === undefined) {
+      return calculateClickValue(clientX, rect.left, rect.width, domain.min, domain.max, domain.step);
+    }
+    if (!Number.isFinite(rect.width) || rect.width <= 0) return null;
+    const value = valueProjection.valueAt(clamp((clientX - rect.left) / rect.width, 0, 1));
+    return value !== null && Number.isFinite(value) ? value : null;
+  }
+
+  function pointerContextCurrent(): boolean {
+    if (activePointer === null
+      || activePointer.contextKey === (valueProjection?.contextKey ?? null)) return true;
+    attachedBinding.cancel('authority');
+    releaseActivePointer();
+    return false;
+  }
 
   function handlePointerDown(e: PointerEvent) {
     if (!containerEl) return;
@@ -111,29 +158,31 @@
     e.preventDefault();
     const target = e.currentTarget as HTMLElement;
     target.setPointerCapture(e.pointerId);
-    activePointer = { id: e.pointerId, token, target };
+    activePointer = {
+      id: e.pointerId,
+      token,
+      target,
+      contextKey: valueProjection?.contextKey ?? null,
+    };
 
     const rect = containerEl.getBoundingClientRect();
     const domain = view.domain;
-    const newValue = calculateClickValue(
-      e.clientX, rect.left, rect.width, domain.min, domain.max, domain.step,
-    );
-    lease.pointer(token, newValue);
+    const newValue = pointerValue(e.clientX, rect, domain);
+    if (newValue !== null) lease.pointer(token, newValue);
   }
 
   function handlePointerMove(e: PointerEvent) {
-    if (!activePointer || activePointer.id !== e.pointerId || !containerEl) return;
+    if (!activePointer || activePointer.id !== e.pointerId || !containerEl
+      || !pointerContextCurrent()) return;
 
     const rect = containerEl.getBoundingClientRect();
     const domain = view.domain;
-    const newValue = calculateClickValue(
-      e.clientX, rect.left, rect.width, domain.min, domain.max, domain.step,
-    );
-    lease.pointer(activePointer.token, newValue);
+    const newValue = pointerValue(e.clientX, rect, domain);
+    if (newValue !== null) lease.pointer(activePointer.token, newValue);
   }
 
   function handlePointerUp(e: PointerEvent) {
-    if (!activePointer || activePointer.id !== e.pointerId) return;
+    if (!activePointer || activePointer.id !== e.pointerId || !pointerContextCurrent()) return;
     if (activePointer.target.hasPointerCapture?.(e.pointerId)) {
       activePointer.target.releasePointerCapture(e.pointerId);
     }
@@ -142,7 +191,7 @@
   }
 
   function handlePointerCancel(e: PointerEvent) {
-    if (!activePointer || activePointer.id !== e.pointerId) return;
+    if (!activePointer || activePointer.id !== e.pointerId || !pointerContextCurrent()) return;
     if (activePointer.target.hasPointerCapture?.(e.pointerId)) {
       activePointer.target.releasePointerCapture(e.pointerId);
     }
@@ -194,7 +243,8 @@
     aria-label={label}
     aria-valuemin={view.domainValid ? view.domain.min : undefined}
     aria-valuemax={view.domainValid ? view.domain.max : undefined}
-    aria-valuenow={view.domainValid ? view.canonical ?? undefined : undefined}
+    aria-valuenow={ariaValueNow}
+    aria-valuetext={valueProjection === undefined ? undefined : displayValue}
     aria-disabled={!view.editable}
     aria-busy={renderPresentation.attributes['aria-busy']}
     aria-describedby={renderPresentation.description !== null ? feedbackDescriptionId : undefined}
@@ -234,14 +284,14 @@
   {#if renderPresentation.description !== null}
     <span id={feedbackDescriptionId} class="sr-only">{renderPresentation.description}</span>
   {/if}
-  {#if renderPresentation.status !== null}
+  {#if statusText !== null}
     <span
       class="sr-only"
       role="status"
       aria-live="polite"
       aria-atomic="true"
       data-control-feedback-status
-    >{renderPresentation.status}{renderPresentation.error === null ? '' : `: ${renderPresentation.error}`}</span>
+    >{statusText}</span>
   {/if}
 </div>
 

--- a/frontend/src/components-v2/controls/value-control/HBarRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/HBarRenderer.svelte
@@ -49,7 +49,7 @@
   } | null = null;
   const initialBinding = untrack(() => binding);
   let attachedBinding = initialBinding;
-  let lease: ContinuousScalarRendererLease = $state(initialBinding.attachRenderer());
+  let lease: ContinuousScalarRendererLease = initialBinding.attachRenderer();
 
   function releaseActivePointer(): void {
     if (activePointer?.target.hasPointerCapture?.(activePointer.id)) {
@@ -58,13 +58,6 @@
     activePointer = null;
   }
 
-  $effect(() => {
-    if (binding === attachedBinding) return;
-    releaseActivePointer();
-    lease.dispose();
-    attachedBinding = binding;
-    lease = binding.attachRenderer();
-  });
   onDestroy(() => {
     releaseActivePointer();
     lease.dispose();
@@ -80,22 +73,20 @@
     attachedProjectionContext = nextContext;
   });
 
-  // Reading a lease reconciles its owner. Keep that mutable reconciliation in
-  // an effect, then render the resulting snapshot as ordinary Svelte state.
-  let view = $state<ContinuousScalarView>(untrack(() => lease.view));
-  let skipViewAssignment = true;
-  $effect(() => {
-    const next = lease.view;
-    if (skipViewAssignment) {
-      skipViewAssignment = false;
-    } else {
-      view = next;
+  let view = $state<ContinuousScalarView | null>();
+  $effect.pre(() => {
+    if (binding !== attachedBinding) {
+      releaseActivePointer();
+      lease.dispose();
+      attachedBinding = binding;
+      lease = binding.attachRenderer();
     }
+    view = lease.view;
   });
-  let renderedValue = $derived(view.displayed);
+  let renderedValue = $derived(view?.displayed ?? null);
   let projectedPosition = $derived(renderedValue === null || valueProjection === undefined
     ? null : valueProjection.positionOf(renderedValue));
-  let fillPercent = $derived(!view.domainValid || renderedValue === null
+  let fillPercent = $derived(view == null || !view.domainValid || renderedValue === null
     ? 0
     : valueProjection === undefined
       ? getFillPercent(renderedValue, view.domain.min, view.domain.max)
@@ -107,10 +98,11 @@
   let displayValue = $derived(renderedValue === null
     ? unknownDisplay ?? (displayFn ? displayFn(Number.NaN) : '—')
     : displayFn ? displayFn(renderedValue) : `${renderedValue}${unit ? '\u00a0' + unit : ''}`);
-  let renderPresentation = $derived(projectScalarRenderPresentation(view, legacy));
+  let renderPresentation = $derived(view == null ? null : projectScalarRenderPresentation(view, legacy));
   $effect(() => {
     const snapshot = view;
-    if (issuedStatusPresentation === undefined || snapshot.evidence !== 'command-feedback') return;
+    if (issuedStatusPresentation === undefined || snapshot == null
+      || snapshot.evidence !== 'command-feedback') return;
     const announcement = snapshot.presentation.politeAnnouncement;
     if (announcement !== null) {
       const formatted = untrack(() => issuedStatusPresentation.format({ view: snapshot, announcement }));
@@ -120,10 +112,10 @@
     }
   });
   let statusText = $derived(issuedStatusPresentation === undefined
-    ? renderPresentation.status === null ? null
+    ? renderPresentation?.status === null || renderPresentation === null ? null
       : `${renderPresentation.status}${renderPresentation.error === null ? '' : `: ${renderPresentation.error}`}`
     : issuedStatusPresentation.text);
-  let ariaValueNow = $derived(!view.domainValid || view.canonical === null
+  let ariaValueNow = $derived(view == null || !view.domainValid || view.canonical === null
     ? undefined
     : valueProjection === undefined
       ? view.canonical
@@ -151,7 +143,7 @@
   }
 
   function handlePointerDown(e: PointerEvent) {
-    if (!containerEl) return;
+    if (!containerEl || view == null) return;
     const token = lease.beginPointer();
     if (token === null) return;
 
@@ -172,7 +164,7 @@
   }
 
   function handlePointerMove(e: PointerEvent) {
-    if (!activePointer || activePointer.id !== e.pointerId || !containerEl
+    if (!activePointer || activePointer.id !== e.pointerId || !containerEl || view == null
       || !pointerContextCurrent()) return;
 
     const rect = containerEl.getBoundingClientRect();
@@ -200,7 +192,7 @@
   }
 
   function handleWheel(e: WheelEvent) {
-    if (!view.editable) return;
+    if (view == null || !view.editable) return;
     e.preventDefault();
     lease.wheel({ direction: e.deltaY > 0 ? -1 : 1, fine: e.shiftKey });
   }
@@ -214,6 +206,7 @@
   }
 </script>
 
+{#if view != null && renderPresentation !== null}
 <div
   class="vc-hbar"
   class:compact
@@ -294,6 +287,7 @@
     >{statusText}</span>
   {/if}
 </div>
+{/if}
 
 <style>
   .vc-hbar {

--- a/frontend/src/components-v2/controls/value-control/ValueControl.svelte
+++ b/frontend/src/components-v2/controls/value-control/ValueControl.svelte
@@ -5,7 +5,11 @@
   import KnobRenderer from './KnobRenderer.svelte';
   import DiscreteRenderer from './DiscreteRenderer.svelte';
   import type { LegacyReadingPresentation } from './scalar-render-presentation';
-  import type { Skin } from './skin';
+  import type {
+    HBarIssuedStatusPresentation,
+    HBarValueProjection,
+    Skin,
+  } from './skin';
   import {
     createBipolarContinuousScalarPolicy,
     createContinuousScalar,
@@ -40,6 +44,8 @@
     shortcutHint?: string | null;
     title?: string | null;
     skin?: Skin;
+    valueProjection?: Readonly<HBarValueProjection>;
+    issuedStatusPresentation?: Readonly<HBarIssuedStatusPresentation>;
   }
 
   interface RawProps {
@@ -116,6 +122,8 @@
     title = null,
     onchange,
     skin,
+    valueProjection,
+    issuedStatusPresentation,
   }: Props = $props();
 
   let effectiveOnChange = $derived(onChange ?? onchange ?? (() => {}));
@@ -229,6 +237,7 @@
     legacy,
   });
   let knobProps = $derived({ ...rendererProps, arcAngle, tickCount, tickLabels });
+  let hbarProps = $derived({ ...rendererProps, valueProjection, issuedStatusPresentation });
   let discreteProps = $derived({
     ...rendererProps,
     tickLabels,
@@ -239,7 +248,7 @@
   let skinComponent = $derived(
     skin
       ? renderer === 'knob' ? skin.knob
-        : renderer === 'hbar' ? skin.hbar
+      : renderer === 'hbar' ? skin.hbar
         : renderer === 'bipolar' ? skin.bipolar
           : skin.discrete
       : undefined,
@@ -250,6 +259,8 @@
   {@const SkinRenderer = skinComponent}
   {#if renderer === 'knob'}
     <SkinRenderer {...knobProps} />
+  {:else if renderer === 'hbar'}
+    <SkinRenderer {...hbarProps} />
   {:else if renderer === 'discrete'}
     <SkinRenderer {...discreteProps} />
   {:else}
@@ -260,7 +271,7 @@
     binding={scalarBinding} {label} {displayFn} {unknownDisplay}
     {fillColor} {fillGradient} {trackColor}
     {accentColor} {showValue} {showLabel} {compact} {variant} {unit} {shortcutHint} {title}
-    {legacy}
+    {legacy} {valueProjection} {issuedStatusPresentation}
   />
 {:else if renderer === 'bipolar'}
   <BipolarRenderer

--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
 import ValueControl from '../ValueControl.svelte';
+import HBarRenderer from '../HBarRenderer.svelte';
 import DiscreteRenderer from '../DiscreteRenderer.svelte';
 import { professionalSkin } from '../skins';
 import {
@@ -172,6 +174,157 @@ function knobCommandBinding(
 }
 
 describe('ValueControl controlled HBar rendering', () => {
+  it.each([
+    ['built-in', undefined],
+    ['selected custom HBar', { name: 'test-hbar', hbar: HBarRenderer }],
+  ] as const)('forwards semantic value projection through the %s route', (_route, skin) => {
+    const request = vi.fn();
+    const binding = createContinuousScalar(
+      () => ({
+        evidence: 'reading' as const,
+        reading: { status: 'known' as const, value: 2100 },
+        ownerKey: 'nonuniform-width',
+        domain: { min: 1800, max: 3000, step: 1, defaultValue: 1800, fineStepDivisor: 1 },
+        enabled: true,
+        request,
+      }),
+      createHBarContinuousScalarPolicy({ preview: 'confirmed', debounceMs: 0 }),
+    );
+    const valueProjection = {
+      contextKey: 'USB:[1800,2100,3000]',
+      positionOf: (value: number) => value === 2100 ? 0.5 : null,
+      valueAt: (position: number) => position < 0.75 ? 2100 : 3000,
+    };
+    const { target } = mountReactive({
+      binding, label: 'Projected width', renderer: 'hbar', skin,
+      valueProjection, displayFn: (value: number) => `${value} Hz`,
+    });
+
+    expect(fill(target)).toContain('--vc-fill-percent: 50%');
+    expect(slider(target).getAttribute('aria-valuenow')).toBe('2100');
+    expect(slider(target).getAttribute('aria-valuetext')).toBe('2100 Hz');
+    binding.destroy();
+  });
+
+  it.each([
+    ['built-in', undefined],
+    ['selected custom HBar', { name: 'status-hbar', hbar: HBarRenderer }],
+  ] as const)('delivers one whole owner-issued status through the %s route', (_route, skin) => {
+    const feedback = new SvelteMap([['value', commandFeedback({
+      confirmed: 2100, target: null, requestedTarget: 2501, phase: 'failed', busy: false,
+      outcome: { phase: 'failed', error: 'radio rejected' }, transitionId: 'width-failed',
+    })]]);
+    const binding = createContinuousScalar(
+      () => ({
+        evidence: 'command-feedback' as const,
+        command: 'set_filter_width',
+        domain: { min: 1800, max: 3000, step: 1, defaultValue: 1800, fineStepDivisor: 1 },
+        enabled: true,
+        request: vi.fn(),
+        feedback: feedback.get('value')!,
+      }),
+      createHBarContinuousScalarPolicy({ preview: 'confirmed', debounceMs: 0 }),
+    );
+    const retained = $state({ text: null as string | null });
+    let locale = 'en';
+    const format = vi.fn(({ view }) =>
+      `${locale}:${view.feedback.requestedTarget}/${view.feedback.confirmed}:radio rejected`);
+    const accept = vi.fn((text: string | null) => { retained.text = text; });
+    const issuedStatusPresentation = {
+      get text() { return retained.text; }, format, accept,
+    };
+    const { state, target } = mountReactive({
+      binding, label: 'Projected width', renderer: 'hbar', skin,
+      valueProjection: {
+        contextKey: 'USB:[1800,2100,3000]',
+        positionOf: () => 0.5,
+        valueAt: () => 2100,
+      },
+      issuedStatusPresentation,
+    });
+
+    expect(format).toHaveBeenCalledOnce();
+    expect(accept).toHaveBeenCalledExactlyOnceWith('en:2501/2100:radio rejected');
+    expect(target.querySelectorAll('[data-control-feedback-status]')).toHaveLength(1);
+    expect(target.querySelector('[data-control-feedback-status]')?.textContent)
+      .toBe('en:2501/2100:radio rejected');
+
+    locale = 'ru';
+    state.valueProjection = {
+      contextKey: 'AM:[1800,2200,3000]',
+      positionOf: () => 0.5,
+      valueAt: () => 2200,
+    };
+    feedback.set('value', commandFeedback({
+      confirmed: 2200, target: null, requestedTarget: 2501, phase: 'failed', busy: false,
+      outcome: { phase: 'failed', error: 'radio rejected' }, transitionId: 'width-failed',
+    }));
+    flushSync();
+
+    expect(format).toHaveBeenCalledOnce();
+    expect(target.querySelector('[data-control-feedback-status]')?.textContent)
+      .toBe('en:2501/2100:radio rejected');
+    binding.destroy();
+  });
+
+  it('cancels deferred work and releases capture when projection context changes', () => {
+    vi.useFakeTimers();
+    const request = vi.fn();
+    const binding = createContinuousScalar(
+      () => ({
+        evidence: 'reading' as const,
+        reading: { status: 'known' as const, value: 20 },
+        ownerKey: 'stable-owner',
+        domain: { min: 0, max: 100, step: 10, defaultValue: 0, fineStepDivisor: 10 },
+        enabled: true,
+        request,
+      }),
+      createHBarContinuousScalarPolicy({ preview: 'confirmed', debounceMs: 50 }),
+    );
+    const projection = (contextKey: string) => ({
+      contextKey,
+      positionOf: (value: number) => value / 100,
+      valueAt: (position: number) => position * 100,
+    });
+    const { state, target } = mountReactive({
+      binding, label: 'Contextual', renderer: 'hbar', valueProjection: projection('USB:a'),
+    });
+    const control = slider(target) as HTMLElement & {
+      setPointerCapture: (id: number) => void;
+      hasPointerCapture: (id: number) => boolean;
+      releasePointerCapture: (id: number) => void;
+    };
+    control.setPointerCapture = vi.fn();
+    control.hasPointerCapture = vi.fn(() => true);
+    control.releasePointerCapture = vi.fn();
+    vi.spyOn(target.querySelector('.vc-hbar') as HTMLElement, 'getBoundingClientRect')
+      .mockReturnValue({ left: 0, width: 100 } as DOMRect);
+
+    control.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true, clientX: 40, pointerId: 7,
+    }));
+    expect(request).toHaveBeenCalledExactlyOnceWith(40);
+    request.mockClear();
+    state.valueProjection = projection('USB:b');
+    flushSync();
+    expect(control.releasePointerCapture).toHaveBeenCalledExactlyOnceWith(7);
+    control.dispatchEvent(new PointerEvent('pointermove', {
+      bubbles: true, clientX: 90, pointerId: 7,
+    }));
+    expect(request).not.toHaveBeenCalled();
+
+    control.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    state.valueProjection = projection('AM:b');
+    flushSync();
+    vi.advanceTimersByTime(60);
+    expect(request).not.toHaveBeenCalled();
+    control.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    vi.advanceTimersByTime(60);
+    expect(request).toHaveBeenCalledExactlyOnceWith(30);
+    binding.destroy();
+    vi.useRealTimers();
+  });
+
   it('renders external command-owner feedback and domain without legacy decoration', () => {
     const pendingBinding = commandBinding(vi.fn());
     const failedBinding = commandBinding(vi.fn(), {

--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
@@ -14,6 +14,7 @@ import {
   type CommandScalarFeedback,
   type ContinuousScalarBinding,
   type ContinuousScalarInput,
+  type ContinuousScalarRendererLease,
 } from '../../../../primitives/scalar/continuous-scalar.svelte';
 
 let components: ReturnType<typeof mount>[] = [];
@@ -108,6 +109,30 @@ function commandBinding(
       preview: 'confirmed', debounceMs: 0, describeTarget: (value) => `${value} Hz`,
     }),
   );
+}
+
+function countViewReads(
+  binding: ContinuousScalarBinding,
+  onRead: () => void,
+): ContinuousScalarBinding {
+  const countedLease = (lease: ContinuousScalarRendererLease): ContinuousScalarRendererLease => ({
+    get view() { onRead(); return lease.view; },
+    beginPointer: () => lease.beginPointer(),
+    pointer: (token, candidate) => lease.pointer(token, candidate),
+    endPointer: (token) => lease.endPointer(token),
+    cancelPointer: (token) => lease.cancelPointer(token),
+    nativeInput: (candidate) => lease.nativeInput(candidate),
+    wheel: (event) => lease.wheel(event),
+    key: (event) => lease.key(event),
+    reset: () => lease.reset(),
+    dispose: () => lease.dispose(),
+  });
+  return {
+    get view() { onRead(); return binding.view; },
+    attachRenderer: () => countedLease(binding.attachRenderer()),
+    cancel: (reason) => binding.cancel(reason),
+    destroy: () => binding.destroy(),
+  };
 }
 
 function readingBinding(value: number, request: (value: number) => void): ContinuousScalarBinding {
@@ -214,7 +239,7 @@ describe('ValueControl controlled HBar rendering', () => {
       confirmed: 2100, target: null, requestedTarget: 2501, phase: 'failed', busy: false,
       outcome: { phase: 'failed', error: 'radio rejected' }, transitionId: 'width-failed',
     })]]);
-    const binding = createContinuousScalar(
+    const owner = createContinuousScalar(
       () => ({
         evidence: 'command-feedback' as const,
         command: 'set_filter_width',
@@ -225,6 +250,8 @@ describe('ValueControl controlled HBar rendering', () => {
       }),
       createHBarContinuousScalarPolicy({ preview: 'confirmed', debounceMs: 0 }),
     );
+    let viewReads = 0;
+    const binding = countViewReads(owner, () => { viewReads += 1; });
     const retained = $state({ text: null as string | null });
     let locale = 'en';
     const format = vi.fn(({ view }) =>
@@ -243,6 +270,7 @@ describe('ValueControl controlled HBar rendering', () => {
       issuedStatusPresentation,
     });
 
+    expect(viewReads).toBe(1);
     expect(format).toHaveBeenCalledOnce();
     expect(accept).toHaveBeenCalledExactlyOnceWith('en:2501/2100:radio rejected');
     expect(target.querySelectorAll('[data-control-feedback-status]')).toHaveLength(1);
@@ -261,6 +289,7 @@ describe('ValueControl controlled HBar rendering', () => {
     }));
     flushSync();
 
+    expect(viewReads).toBe(2);
     expect(format).toHaveBeenCalledOnce();
     expect(target.querySelector('[data-control-feedback-status]')?.textContent)
       .toBe('en:2501/2100:radio rejected');

--- a/frontend/src/components-v2/controls/value-control/skin.ts
+++ b/frontend/src/components-v2/controls/value-control/skin.ts
@@ -6,7 +6,11 @@
  * skin's component instead of the built-in renderer.
  */
 import type { Component } from 'svelte';
-import type { ContinuousScalarBinding } from '../../../primitives/scalar/continuous-scalar.svelte';
+import type {
+  ContinuousScalarBinding,
+  ContinuousScalarView,
+} from '../../../primitives/scalar/continuous-scalar.svelte';
+import type { PoliteControlAnnouncement } from '../../../primitives/control-feedback/control-feedback-presentation';
 import type { LegacyReadingPresentation } from './scalar-render-presentation';
 
 /** Binding and presentation inputs shared by every appearance renderer. */
@@ -29,6 +33,28 @@ export interface SkinRendererProps {
   legacy?: LegacyReadingPresentation;
 }
 
+export interface HBarValueProjection {
+  readonly contextKey: string;
+  positionOf(value: number): number | null;
+  valueAt(position: number): number | null;
+}
+
+export interface HBarIssuedStatusSnapshot {
+  readonly view: Readonly<Extract<ContinuousScalarView, { evidence: 'command-feedback' }>>;
+  readonly announcement: Readonly<PoliteControlAnnouncement>;
+}
+
+export interface HBarIssuedStatusPresentation {
+  readonly text: string | null;
+  format(snapshot: Readonly<HBarIssuedStatusSnapshot>): string;
+  accept(text: string | null): void;
+}
+
+export interface HBarSkinRendererProps extends SkinRendererProps {
+  valueProjection?: Readonly<HBarValueProjection>;
+  issuedStatusPresentation?: Readonly<HBarIssuedStatusPresentation>;
+}
+
 /** Extra props for knob skin renderers. */
 export interface KnobSkinRendererProps extends SkinRendererProps {
   arcAngle?: number;
@@ -48,7 +74,7 @@ export interface DiscreteSkinRendererProps extends SkinRendererProps {
 export interface Skin {
   name: string;
   knob?: Component<KnobSkinRendererProps>;
-  hbar?: Component<SkinRendererProps>;
+  hbar?: Component<HBarSkinRendererProps>;
   bipolar?: Component<SkinRendererProps>;
   discrete?: Component<DiscreteSkinRendererProps>;
 }

--- a/frontend/src/components-v2/panels/FilterPanel.svelte
+++ b/frontend/src/components-v2/panels/FilterPanel.svelte
@@ -1,16 +1,27 @@
 <script lang="ts">
+  import { onDestroy, untrack } from 'svelte';
   import type { FilterModeConfig } from '$lib/types/capabilities';
   import { HardwareButton } from '$lib/Button';
   import { ValueControl } from '../controls/value-control';
   import { formatFilterWidth } from './filter-utils';
   import { getShortcutHint, joinShortcutHints } from '../layout/shortcut-hints';
   import { t } from '$lib/i18n';
+  import {
+    createContinuousScalar,
+    type ContinuousScalarPolicy,
+    type ContinuousScalarView,
+  } from '../../primitives/scalar/continuous-scalar.svelte';
+  import type {
+    HBarIssuedStatusPresentation,
+    HBarIssuedStatusSnapshot,
+    HBarValueProjection,
+  } from '../controls/value-control/skin';
 
   import {
     deriveFilterProps,
     getFilterHandlers,
     getFilterArmed,
-    getFilterWidthCommandLifecycle,
+    getFilterWidthControlFeedback,
   } from '$lib/runtime/adapters/panel-adapters';
 
   const handlers = getFilterHandlers();
@@ -21,11 +32,7 @@
   // pending command is racing toward, never a substitute for the confirmed
   // reading.
   let filterArmed = $derived(getFilterArmed());
-  // The lifecycle is presentation-only. `filterWidth` remains the sole
-  // canonical/confirmed source for all displayed and selected widths.
-  let filterWidthLifecycle = $derived(getFilterWidthCommandLifecycle());
-  let lastFilterWidthTransitionId = $state<string | null>(null);
-  let filterWidthLiveStatus = $state('');
+  let filterWidthFeedback = $derived(getFilterWidthControlFeedback());
   const filterArmedIdBase = $props.id();
 
   let currentMode = $derived(p.currentMode);
@@ -95,16 +102,6 @@
     isTableMode ? 1 : (filterConfig?.stepHz ?? filterConfig?.segments?.[0]?.stepHz ?? 50)
   );
 
-  function snapToTable(hz: number, table: number[]): number {
-    let closest = table[0];
-    let minDist = Math.abs(hz - table[0]);
-    for (let i = 1; i < table.length; i++) {
-      const dist = Math.abs(hz - table[i]);
-      if (dist < minDist) { minDist = dist; closest = table[i]; }
-    }
-    return closest;
-  }
-
   function tableIndexToHz(idx: number): number {
     const table = filterConfig?.table ?? [];
     return table[Math.max(0, Math.min(table.length - 1, Math.round(idx)))] ?? idx;
@@ -128,7 +125,7 @@
   const filterSettingsShortcut = getShortcutHint('open_filter_settings');
 
   $effect(() => {
-    if (!modalOpen || (!filterWidthLifecycle.busy && filterWidthLifecycle.outcome !== null)) {
+    if (!modalOpen || (!filterWidthFeedback.busy && filterWidthFeedback.outcome !== null)) {
       draftWidths = [...visibleWidths];
     }
   });
@@ -146,42 +143,153 @@
     return formatted.includes('k') ? `${formatted}Hz` : `${formatted} Hz`;
   }
 
-  let lifecycleTarget = $derived(
-    filterWidthLifecycle.busy ? (filterWidthLifecycle.presentation?.target ?? filterWidthLifecycle.target) : null
-  );
-
-  $effect(() => {
-    const lifecycle = filterWidthLifecycle.presentation;
-    if (lifecycle === null) {
-      lastFilterWidthTransitionId = null;
-      filterWidthLiveStatus = '';
-    } else if (lifecycle.transitionId !== lastFilterWidthTransitionId) {
-      // Capture both radio-confirmed state and the exact DTO target once per
-      // immutable transition identity. Retained reads and later canonical
-      // polls cannot rewrite/reannounce this historical transition.
-      const target = formatWidthDisplay(lifecycle.target);
-      const confirmed = formatWidthDisplay(filterWidth);
-      lastFilterWidthTransitionId = lifecycle.transitionId;
-      switch (lifecycle.status) {
-        case 'pending':
-        case 'acknowledged':
-          filterWidthLiveStatus = t('core.filter.width.pendingAnnouncement', { target });
-          break;
-        case 'confirmed':
-          filterWidthLiveStatus = t('core.filter.width.confirmedAnnouncement', { confirmed });
-          break;
-        case 'failed':
-          filterWidthLiveStatus = t('core.filter.width.failedAnnouncement', { target, confirmed });
-          break;
-        case 'timed-out':
-          filterWidthLiveStatus = t('core.filter.width.timedOutAnnouncement', { target, confirmed });
-          break;
-        case 'cancelled':
-          filterWidthLiveStatus = t('core.filter.width.cancelledAnnouncement', { target, confirmed });
-          break;
-      }
+  function formatExactWidthDisplay(hz: number): string {
+    if (!Number.isFinite(hz)) return '--- Hz';
+    if (Number.isInteger(hz) && hz >= 1000 && hz % 100 === 0) {
+      const kilohertz = hz / 1000;
+      return `${Number.isInteger(kilohertz) ? kilohertz : kilohertz.toFixed(1)}kHz`;
     }
+    return `${hz} Hz`;
+  }
+
+  let currentWidthTable = $derived(filterConfig?.table ?? []);
+  const validWidthCatalog = (): boolean => currentWidthTable.length > 0
+    && currentWidthTable.every((value, index) => Number.isFinite(value)
+      && (index === 0 || value > currentWidthTable[index - 1]));
+  function nearestWidthChoice(value: number): number | null {
+    if (!validWidthCatalog() || !Number.isFinite(value)) return null;
+    return currentWidthTable.reduce((nearest, choice) =>
+      Math.abs(choice - value) < Math.abs(nearest - value) ? choice : nearest);
+  }
+  function adjacentWidthChoice(value: number, direction: -1 | 1): number | null {
+    if (!validWidthCatalog() || !Number.isFinite(value)) return null;
+    if (direction > 0) return currentWidthTable.find((choice) => choice > value)
+      ?? currentWidthTable[currentWidthTable.length - 1];
+    for (let index = currentWidthTable.length - 1; index >= 0; index -= 1) {
+      if (currentWidthTable[index] < value) return currentWidthTable[index];
+    }
+    return currentWidthTable[0];
+  }
+  function widthPosition(value: number): number | null {
+    if (!validWidthCatalog() || !Number.isFinite(value)) return null;
+    const first = currentWidthTable[0];
+    const last = currentWidthTable[currentWidthTable.length - 1];
+    if (value < first || value > last) return null;
+    if (currentWidthTable.length === 1) return 0;
+    const upper = currentWidthTable.findIndex((choice) => choice >= value);
+    if (upper <= 0) return 0;
+    const lower = upper - 1;
+    const fraction = (value - currentWidthTable[lower])
+      / (currentWidthTable[upper] - currentWidthTable[lower]);
+    return (lower + fraction) / (currentWidthTable.length - 1);
+  }
+  function widthChoiceAt(position: number): number | null {
+    if (!validWidthCatalog() || !Number.isFinite(position)) return null;
+    const index = Math.round(Math.max(0, Math.min(1, position)) * (currentWidthTable.length - 1));
+    return currentWidthTable[index];
+  }
+
+  const filterWidthProjection: Readonly<HBarValueProjection> = {
+    get contextKey() { return JSON.stringify([currentMode, currentWidthTable]); },
+    positionOf: widthPosition,
+    valueAt: widthChoiceAt,
+  };
+  const filterWidthPolicy: Readonly<ContinuousScalarPolicy> = {
+    name: 'filter-width-catalog',
+    preview: 'confirmed',
+    normalize: (value) => nearestWidthChoice(value),
+    wheel: (current, event) => adjacentWidthChoice(current, event.direction),
+    key: (current, event) => {
+      if (event.key === 'Home') return validWidthCatalog() ? currentWidthTable[0] : null;
+      if (event.key === 'End') return validWidthCatalog()
+        ? currentWidthTable[currentWidthTable.length - 1] : null;
+      if (event.key === 'ArrowRight' || event.key === 'ArrowUp') return adjacentWidthChoice(current, 1);
+      if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') return adjacentWidthChoice(current, -1);
+      return null;
+    },
+    reset: () => validWidthCatalog() ? currentWidthTable[0] : null,
+    dispatch: (source) => source === 'keyboard' || source === 'reset'
+      ? { debounceMs: 50 } : 'immediate',
+    dispatchesCanonical: (source) => source === 'wheel',
+    wheelIdleMs: 300,
+    describeTarget: formatExactWidthDisplay,
+  };
+  function filterWidthInput() {
+    const catalogValid = validWidthCatalog();
+    const min = catalogValid ? currentWidthTable[0] : filterWidthMin;
+    const max = catalogValid ? currentWidthTable[currentWidthTable.length - 1] : filterWidthMax;
+    const confirmed = filterWidthFeedback.confirmed;
+    const tableReadingInRange = !isTableMode || (catalogValid && confirmed !== null
+      && Number.isFinite(confirmed) && confirmed >= min && confirmed <= max);
+    return {
+      evidence: 'command-feedback' as const,
+      feedback: filterWidthFeedback,
+      command: 'set_filter_width',
+      domain: { min, max, step: 1, defaultValue: min, fineStepDivisor: 1 },
+      enabled: filterWidthFeedback.availability === 'available' && tableReadingInRange,
+      request: onFilterWidthChange,
+    };
+  }
+  const filterWidthBinding = createContinuousScalar(filterWidthInput, filterWidthPolicy);
+  const feedbackIntegratedRange = { 'feedback-policy': 'feedback-integrated' } as const;
+  onDestroy(() => filterWidthBinding.destroy());
+
+  function formatIssuedWidthStatus(snapshot: Readonly<HBarIssuedStatusSnapshot>): string {
+    const feedback = snapshot.view.feedback;
+    const requested = formatExactWidthDisplay(feedback.requestedTarget ?? Number.NaN);
+    const confirmed = formatExactWidthDisplay(feedback.confirmed ?? Number.NaN);
+    let message: string;
+    switch (snapshot.announcement.phase) {
+      case 'submitted':
+      case 'queued':
+      case 'dispatched':
+      case 'awaiting-confirmation':
+        message = t('core.filter.width.pendingAnnouncement', { target: requested });
+        break;
+      case 'confirmed':
+        message = t('core.filter.width.confirmedAnnouncement', { confirmed });
+        break;
+      case 'failed':
+        message = t('core.filter.width.failedAnnouncement', { target: requested, confirmed });
+        break;
+      case 'timed-out':
+        message = t('core.filter.width.timedOutAnnouncement', { target: requested, confirmed });
+        break;
+      case 'cancelled':
+        message = t('core.filter.width.cancelledAnnouncement', { target: requested, confirmed });
+        break;
+      case 'superseded':
+        message = t('core.filter.width.supersededAnnouncement', { target: requested, confirmed });
+        break;
+      default:
+        message = '';
+    }
+    return snapshot.view.error === null ? message
+      : `${message.replace(/[.!?]$/, '')}: ${snapshot.view.error}`;
+  }
+  let filterWidthStatusText = $state<string | null>(null);
+  const filterWidthStatusPresentation: Readonly<HBarIssuedStatusPresentation> = {
+    get text() { return filterWidthStatusText; },
+    format: formatIssuedWidthStatus,
+    accept(text) { filterWidthStatusText = text; },
+  };
+  function consumeReadOnlyWidthStatus(view: Readonly<ContinuousScalarView>): void {
+    if (view.evidence !== 'command-feedback') return;
+    const announcement = view.presentation.politeAnnouncement;
+    if (announcement !== null) {
+      filterWidthStatusPresentation.accept(untrack(() =>
+        filterWidthStatusPresentation.format({ view, announcement })));
+    } else if (view.feedback.transitionId === null) {
+      filterWidthStatusPresentation.accept(null);
+    }
+  }
+  $effect(() => {
+    if (isTableMode) return;
+    const view = filterWidthBinding.view;
+    consumeReadOnlyWidthStatus(view);
   });
+
+  let lifecycleTarget = $derived(filterWidthFeedback.busy ? filterWidthFeedback.target : null);
 
   function openSettings(): void {
     draftWidths = [...visibleWidths];
@@ -216,29 +324,26 @@
       data-filter-width-lifecycle
       role="group"
       aria-label="Filter width"
-      aria-busy={filterWidthLifecycle.busy}
+      aria-busy={filterWidthFeedback.busy}
     >
       <ValueControl
+        {...feedbackIntegratedRange}
+        binding={filterWidthBinding}
         label="WIDTH"
-        value={hzToTableIndex(filterWidth)}
-        min={0}
-        max={(filterConfig?.table?.length ?? 1) - 1}
-        step={1}
         unit="Hz"
         renderer="hbar"
-        optimistic={false}
         accentColor="var(--v2-accent-cyan)"
-        displayFn={(idx) => formatWidthDisplay(tableIndexToHz(idx))}
-        onChange={(idx) => onFilterWidthChange(tableIndexToHz(idx))}
+        displayFn={formatExactWidthDisplay}
+        valueProjection={filterWidthProjection}
+        issuedStatusPresentation={filterWidthStatusPresentation}
         variant="hardware-illuminated"
       />
-      {#if filterWidthLifecycle.busy && lifecycleTarget !== null}
+      {#if filterWidthFeedback.busy && lifecycleTarget !== null}
         <span class="bw-pending-target" data-pending-width-target>
-          PENDING {formatWidthDisplay(lifecycleTarget)}
+          PENDING {formatExactWidthDisplay(lifecycleTarget)}
         </span>
       {/if}
     </div>
-    <span class="sr-only" aria-live="polite" aria-atomic="true" data-filter-width-live>{filterWidthLiveStatus}</span>
 
     {#if hasIfShift}
       <ValueControl
@@ -311,17 +416,19 @@
       data-filter-width-lifecycle
       role="group"
       aria-label="Filter width"
-      aria-busy={filterWidthLifecycle.busy}
+      aria-busy={filterWidthFeedback.busy}
     >
       <span class="bw-label">BW</span>
-      <span class="bw-value" data-confirmed-width>{formatWidthDisplay(filterWidth)}</span>
-      {#if filterWidthLifecycle.busy && lifecycleTarget !== null}
+      <span class="bw-value" data-confirmed-width>{formatExactWidthDisplay(filterWidthFeedback.confirmed ?? Number.NaN)}</span>
+      {#if filterWidthFeedback.busy && lifecycleTarget !== null}
         <span class="bw-pending-target" data-pending-width-target>
-          PENDING {formatWidthDisplay(lifecycleTarget)}
+          PENDING {formatExactWidthDisplay(lifecycleTarget)}
         </span>
       {/if}
     </div>
-    <span class="sr-only" aria-live="polite" aria-atomic="true" data-filter-width-live>{filterWidthLiveStatus}</span>
+    {#if filterWidthStatusText !== null}
+      <span class="sr-only" role="status" aria-live="polite" aria-atomic="true" data-filter-width-live>{filterWidthStatusText}</span>
+    {/if}
 
     {#if hasIfShift}
       <ValueControl

--- a/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
@@ -3,6 +3,8 @@ import { mount, unmount, flushSync } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import { formatFilterWidth } from '../filter-utils';
 import { deriveIfShift } from '../filter-controls';
+import { setLocale } from '$lib/i18n';
+import type { CommandScalarFeedback } from '../../../primitives/scalar/continuous-scalar.svelte';
 
 const mockProps = {
   currentMode: 'USB',
@@ -11,6 +13,8 @@ const mockProps = {
   hasFilterShape: true,
   filterLabels: ['FIL1', 'FIL2', 'FIL3'],
   filterWidth: 2400,
+  filterWidthMin: 50,
+  filterWidthMax: 9999,
   filterConfig: {
     defaults: [3000, 2400, 1800],
     fixed: false,
@@ -46,17 +50,19 @@ const widthLifecycle = {
   target: null as number | null,
   phase: 'idle',
   busy: false,
-  outcome: null as { phase: 'confirmed' | 'failed' | 'timed-out' | 'cancelled'; error?: string } | null,
+  outcome: null as { phase: 'confirmed' | 'failed' | 'timed-out' | 'cancelled' | 'superseded'; error?: string } | null,
   presentation: null as {
     lifecycleId: string; transitionId: string; receiver: 0 | 1; sessionEpoch: number;
-    target: number; status: 'pending' | 'acknowledged' | 'confirmed' | 'failed' | 'timed-out' | 'cancelled';
+    target: number; status: 'pending' | 'acknowledged' | 'confirmed' | 'failed' | 'timed-out' | 'cancelled' | 'superseded';
   } | null,
 };
 const propsVersion = new SvelteMap([['value', 0]]);
 const lifecycleState = new SvelteMap([['value', widthLifecycle]]);
+const feedbackOverride = new SvelteMap<string, Readonly<CommandScalarFeedback> | null>([['value', null]]);
 
 function setMockProps(overrides: Partial<typeof mockProps>): void {
   Object.assign(mockProps, overrides);
+  if ('filterWidth' in overrides) setWidthLifecycle({ confirmed: overrides.filterWidth });
   propsVersion.set('value', (propsVersion.get('value') ?? 0) + 1);
 }
 
@@ -74,6 +80,33 @@ function presentation(
   return { lifecycleId, transitionId: `${sessionEpoch}:${lifecycleId}:${status}`, receiver, sessionEpoch, target, status };
 }
 
+function feedbackFromLifecycle(): Readonly<CommandScalarFeedback> {
+  const lifecycle = lifecycleState.get('value') ?? widthLifecycle;
+  const status = lifecycle.presentation?.status;
+  const phase = status === 'pending' ? 'submitted'
+    : status === 'acknowledged' ? 'awaiting-confirmation'
+      : status ?? (lifecycle.phase === 'unavailable' ? 'unavailable' : 'idle');
+  return {
+    confirmed: lifecycle.confirmed,
+    target: lifecycle.busy ? lifecycle.target : null,
+    requestedTarget: lifecycle.presentation?.target ?? lifecycle.target,
+    phase,
+    busy: lifecycle.busy,
+    availability: lifecycle.phase === 'unavailable' ? 'unavailable' : 'available',
+    outcome: lifecycle.outcome,
+    lifecycleId: lifecycle.presentation?.lifecycleId ?? null,
+    transitionId: lifecycle.presentation?.transitionId ?? null,
+    providerGeneration: 1,
+    sessionEpoch: lifecycle.presentation?.sessionEpoch ?? 7,
+    scope: { control: 'filter-width', receiver: lifecycle.presentation?.receiver ?? 0 },
+    repeatPolicy: 'latest-target-wins',
+  } as Readonly<CommandScalarFeedback>;
+}
+
+function setWidthFeedback(overrides: Partial<CommandScalarFeedback>): void {
+  feedbackOverride.set('value', { ...feedbackFromLifecycle(), ...overrides });
+}
+
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveFilterProps: () => {
     propsVersion.get('value');
@@ -81,7 +114,7 @@ vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   },
   getFilterHandlers: () => mockHandlers,
   getFilterArmed: () => unarmed,
-  getFilterWidthCommandLifecycle: () => lifecycleState.get('value')!,
+  getFilterWidthControlFeedback: () => feedbackOverride.get('value') ?? feedbackFromLifecycle(),
 }));
 
 import FilterPanel from '../FilterPanel.svelte';
@@ -151,6 +184,7 @@ function mountPanel(overrides?: Partial<typeof mockProps>) {
 
 beforeEach(() => {
   components = [];
+  setLocale('en-US');
   setMockProps({
     currentMode: 'USB',
     currentFilter: 2,
@@ -158,6 +192,8 @@ beforeEach(() => {
     hasFilterShape: true,
     filterLabels: ['FIL1', 'FIL2', 'FIL3'],
     filterWidth: 2400,
+    filterWidthMin: 50,
+    filterWidthMax: 9999,
     filterConfig: {
       defaults: [3000, 2400, 1800],
       fixed: false,
@@ -188,6 +224,7 @@ beforeEach(() => {
     outcome: null,
     presentation: null,
   });
+  feedbackOverride.set('value', null);
 });
 
 afterEach(() => {
@@ -240,6 +277,237 @@ describe('Filter Width lifecycle presentation (MOR-1665)', () => {
     table: [1800, 2400, 3000],
   } as typeof mockProps.filterConfig;
 
+  it('keeps an off-table 2501 Hz reading exact on nonuniform catalog geometry', () => {
+    const t = mountPanel({
+      filterWidth: 2501,
+      filterConfig: {
+        defaults: [2100, 2100, 2100], fixed: false,
+        minHz: 1800, maxHz: 3000, stepHz: 1,
+        table: [1800, 2100, 3000],
+      } as typeof mockProps.filterConfig,
+    });
+    const control = t.querySelector<HTMLElement>('[role="slider"]')!;
+
+    expect(t.querySelector('.vc-value')?.textContent).toBe('2501 Hz');
+    expect(t.querySelector('.vc-hbar')?.getAttribute('style'))
+      .toContain('--vc-fill-percent: 72.27777777777777%');
+    expect(control.getAttribute('aria-valuenow')).toBe('2501');
+    expect(control.getAttribute('aria-valuetext')).toBe('2501 Hz');
+  });
+
+  it.each([
+    [2100, '2.1kHz', '50%'],
+    [2500, '2.5kHz', '72.22222222222221%'],
+  ] as const)('keeps %i Hz exact at its piecewise catalog position', (confirmed, text, percent) => {
+    setWidthFeedback({ confirmed });
+    const t = mountPanel({
+      filterConfig: {
+        defaults: [2100, 2100, 2100], fixed: false,
+        minHz: 1800, maxHz: 3000, stepHz: 1, table: [1800, 2100, 3000],
+      } as typeof mockProps.filterConfig,
+    });
+
+    expect(t.querySelector('.vc-value')?.textContent).toBe(text);
+    expect(t.querySelector('.vc-hbar')?.getAttribute('style')).toContain(`--vc-fill-percent: ${percent}`);
+    expect(t.querySelector('[role="slider"]')?.getAttribute('aria-valuenow')).toBe(String(confirmed));
+  });
+
+  it.each([
+    [null, '--- Hz'],
+    [1700, '1.7kHz'],
+    [3100, '3.1kHz'],
+  ] as const)('does not fabricate geometry for confirmed value %s', (confirmed, text) => {
+    setWidthFeedback({ confirmed });
+    const t = mountPanel({ filterConfig: {
+      defaults: [2100, 2100, 2100], fixed: false,
+      minHz: 1800, maxHz: 3000, stepHz: 1, table: [1800, 2100, 3000],
+    } as typeof mockProps.filterConfig });
+    const control = t.querySelector<HTMLElement>('[role="slider"]')!;
+
+    expect(t.querySelector('.vc-value')?.textContent).toBe(text);
+    expect(t.querySelector('.vc-hbar')?.getAttribute('style')).toContain('--vc-fill-percent: 0%');
+    expect(control.getAttribute('aria-valuenow')).toBeNull();
+    expect(control.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('keeps confirmed, active target, and requested target in their distinct roles', () => {
+    setWidthFeedback({
+      confirmed: 2501, target: 3000, requestedTarget: 2100,
+      phase: 'awaiting-confirmation', busy: true,
+      lifecycleId: 'distinct', transitionId: 'distinct:acknowledged',
+    });
+    const t = mountPanel({ filterConfig: {
+      defaults: [2100, 2100, 2100], fixed: false,
+      minHz: 1800, maxHz: 3000, stepHz: 1, table: [1800, 2100, 3000],
+    } as typeof mockProps.filterConfig });
+    const status = t.querySelector('[data-control-feedback-status]')?.textContent ?? '';
+
+    expect(t.querySelector('.vc-value')?.textContent).toBe('2501 Hz');
+    expect(t.querySelector('[data-pending-width-target]')?.textContent).toContain('3kHz');
+    expect(status).toContain('2.1kHz requested');
+    expect(status).not.toContain('3kHz requested');
+    expect(t.querySelectorAll('[role="status"]')).toHaveLength(1);
+  });
+
+  it.each(['submitted', 'queued', 'dispatched', 'awaiting-confirmation'] as const)(
+    'localizes the owner-issued %s phase through one table emitter', (phase) => {
+      setWidthFeedback({
+        confirmed: 2100, target: 3000, requestedTarget: 2501, phase, busy: true,
+        lifecycleId: `busy-${phase}`, transitionId: `busy-${phase}:${phase}`,
+      });
+      const t = mountPanel({ filterConfig: {
+        defaults: [2100, 2100, 2100], fixed: false,
+        minHz: 1800, maxHz: 3000, stepHz: 1, table: [1800, 2100, 3000],
+      } as typeof mockProps.filterConfig });
+
+      expect(t.querySelector('[data-pending-width-target]')?.textContent).toContain('3kHz');
+      expect(t.querySelector('[data-control-feedback-status]')?.textContent)
+        .toContain('2501 Hz requested');
+      expect(t.querySelectorAll('[role="status"]')).toHaveLength(1);
+    },
+  );
+
+  it.each([
+    ['pointer-left', 1800], ['pointer-middle', 2100], ['pointer-right', 3000],
+    ['ArrowRight', 3000], ['Home', 1800], ['End', 3000], ['Shift+ArrowRight', 3000],
+    ['wheel', 3000], ['fine-wheel', 3000], ['reset', 1800],
+  ] as const)('%s requests only the actual nonuniform catalog choice %i', (gesture, expected) => {
+    setWidthFeedback({ confirmed: gesture === 'pointer-middle' ? 1800 : 2100 });
+    const t = mountPanel({ filterConfig: {
+      defaults: [2100, 2100, 2100], fixed: false,
+      minHz: 1800, maxHz: 3000, stepHz: 1, table: [1800, 2100, 3000],
+    } as typeof mockProps.filterConfig });
+    const control = t.querySelector<HTMLElement>('[role="slider"]')!;
+    const hbar = t.querySelector<HTMLElement>('.vc-hbar')!;
+    if (gesture.startsWith('pointer')) {
+      control.setPointerCapture = vi.fn();
+      vi.spyOn(hbar, 'getBoundingClientRect').mockReturnValue({ left: 0, width: 100 } as DOMRect);
+      const x = gesture === 'pointer-left' ? 0 : gesture === 'pointer-middle' ? 50 : 100;
+      control.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: x, pointerId: 1 }));
+    } else if (gesture.includes('wheel')) {
+      control.dispatchEvent(new WheelEvent('wheel', {
+        bubbles: true, cancelable: true, deltaY: -1, shiftKey: gesture === 'fine-wheel',
+      }));
+    } else if (gesture === 'reset') {
+      control.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+    } else {
+      control.dispatchEvent(new KeyboardEvent('keydown', {
+        bubbles: true, key: gesture.replace('Shift+', ''), shiftKey: gesture.startsWith('Shift+'),
+      }));
+    }
+    vi.advanceTimersByTime(60);
+
+    expect(mockHandlers.onFilterWidthChange).toHaveBeenCalledWith(expected);
+    expect([1800, 2100, 3000]).toContain(mockHandlers.onFilterWidthChange.mock.calls.at(-1)?.[0]);
+  });
+
+  it('invalidates a deferred choice when same-endpoint catalog content changes', () => {
+    setWidthFeedback({ confirmed: 2100 });
+    const t = mountPanel({ filterConfig: {
+      defaults: [2100, 2100, 2100], fixed: false,
+      minHz: 1800, maxHz: 3000, stepHz: 1, table: [1800, 2100, 3000],
+    } as typeof mockProps.filterConfig });
+    const control = t.querySelector<HTMLElement>('[role="slider"]')!;
+    control.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowRight' }));
+    setMockProps({ filterConfig: {
+      defaults: [2200, 2200, 2200], fixed: false,
+      minHz: 1800, maxHz: 3000, stepHz: 1, table: [1800, 2200, 3000],
+    } as typeof mockProps.filterConfig });
+    flushSync();
+    vi.advanceTimersByTime(60);
+    expect(mockHandlers.onFilterWidthChange).not.toHaveBeenCalled();
+
+    control.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowRight' }));
+    vi.advanceTimersByTime(60);
+    expect(mockHandlers.onFilterWidthChange).toHaveBeenCalledExactlyOnceWith(2200);
+
+    mockHandlers.onFilterWidthChange.mockClear();
+    control.setPointerCapture = vi.fn();
+    control.hasPointerCapture = vi.fn(() => true);
+    control.releasePointerCapture = vi.fn();
+    vi.spyOn(t.querySelector('.vc-hbar') as HTMLElement, 'getBoundingClientRect')
+      .mockReturnValue({ left: 0, width: 100 } as DOMRect);
+    control.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true, clientX: 100, pointerId: 9,
+    }));
+    expect(mockHandlers.onFilterWidthChange).toHaveBeenCalledExactlyOnceWith(3000);
+    mockHandlers.onFilterWidthChange.mockClear();
+    setMockProps({ currentMode: 'AM' });
+    flushSync();
+    expect(control.releasePointerCapture).toHaveBeenCalledExactlyOnceWith(9);
+    control.dispatchEvent(new PointerEvent('pointermove', {
+      bubbles: true, clientX: 0, pointerId: 9,
+    }));
+    expect(mockHandlers.onFilterWidthChange).not.toHaveBeenCalled();
+  });
+
+  it('keeps the compound table Reset outside scalar reset semantics', () => {
+    const t = mountPanel({ filterConfig: tableConfig });
+    const reset = Array.from(t.querySelectorAll('button'))
+      .find((button) => button.textContent?.trim() === 'Reset')!;
+    (reset as HTMLButtonElement).click();
+
+    expect(mockHandlers.onFilterWidthChange).toHaveBeenCalledExactlyOnceWith(3200);
+    expect(mockHandlers.onIfShiftChange).toHaveBeenCalledExactlyOnceWith(0);
+  });
+
+  it.each([
+    [[1800, 1800, 3000], 2100],
+    [[1800, Number.NaN, 3000], 2100],
+  ] as const)('disables malformed table %j without replacing its exact reading', (table, confirmed) => {
+    setWidthFeedback({ confirmed });
+    const t = mountPanel({ filterConfig: {
+      defaults: [2100, 2100, 2100], fixed: false,
+      minHz: 1800, maxHz: 3000, stepHz: 1, table: [...table],
+    } as typeof mockProps.filterConfig });
+    const control = t.querySelector<HTMLElement>('[role="slider"]')!;
+
+    expect(t.querySelector('.vc-value')?.textContent).toBe('2.1kHz');
+    expect(control.getAttribute('aria-disabled')).toBe('true');
+    expect(control.getAttribute('aria-valuenow')).toBeNull();
+    expect(t.querySelector('.vc-hbar')?.getAttribute('style')).toContain('--vc-fill-percent: 0%');
+  });
+
+  it('keeps a single-entry catalog at zero geometry without inventing another value', () => {
+    setWidthFeedback({ confirmed: 2100 });
+    const t = mountPanel({ filterConfig: {
+      defaults: [2100, 2100, 2100], fixed: false,
+      minHz: 2100, maxHz: 2100, stepHz: 1, table: [2100],
+    } as typeof mockProps.filterConfig });
+    const control = t.querySelector<HTMLElement>('[role="slider"]')!;
+
+    expect(t.querySelector('.vc-value')?.textContent).toBe('2.1kHz');
+    expect(t.querySelector('.vc-hbar')?.getAttribute('style')).toContain('--vc-fill-percent: 0%');
+    expect(control.getAttribute('aria-valuenow')).toBe('2100');
+    expect(control.getAttribute('aria-disabled')).toBe('false');
+    control.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowRight' }));
+    vi.advanceTimersByTime(60);
+    expect(mockHandlers.onFilterWidthChange).not.toHaveBeenCalled();
+  });
+
+  it('retains one localized owner message across locale and table-branch replacement', () => {
+    setWidthFeedback({
+      confirmed: 2100, target: null, requestedTarget: 2501,
+      phase: 'failed', busy: false, outcome: { phase: 'failed', error: 'radio rejected' },
+      lifecycleId: 'frozen', transitionId: 'frozen:failed',
+    });
+    const t = mountPanel({ filterWidthMin: 1800, filterWidthMax: 3000 });
+    const frozen = t.querySelector('[data-filter-width-live]')?.textContent;
+    expect(frozen).toContain('2501 Hz was not applied');
+    expect(frozen?.match(/radio rejected/g)).toHaveLength(1);
+
+    setLocale('ru-RU');
+    setMockProps({ filterConfig: {
+      defaults: [2100, 2100, 2100], fixed: false,
+      minHz: 1800, maxHz: 3000, stepHz: 1, table: [1800, 2100, 3000],
+    } as typeof mockProps.filterConfig });
+    flushSync();
+
+    expect(t.querySelector('[data-filter-width-live]')).toBeNull();
+    expect(t.querySelectorAll('[role="status"]')).toHaveLength(1);
+    expect(t.querySelector('[data-control-feedback-status]')?.textContent).toBe(frozen);
+  });
+
   it('keeps the canonical BW readout distinct from a pending target and marks the group busy', () => {
     setWidthLifecycle({
       target: 3000, phase: 'acknowledged', busy: true,
@@ -259,6 +527,7 @@ describe('Filter Width lifecycle presentation (MOR-1665)', () => {
     ['failed', 'not applied'],
     ['timed-out', 'timed out'],
     ['cancelled', 'cancelled'],
+    ['superseded', 'superseded'],
   ] as const)('announces the terminal %s outcome once without changing canonical BW', (phase, message) => {
     setWidthLifecycle({
       target: null,
@@ -294,7 +563,7 @@ describe('Filter Width lifecycle presentation (MOR-1665)', () => {
       expect(mockHandlers.onFilterWidthChange).toHaveBeenCalledWith(3000);
       expect(t.querySelector('.vc-value')?.textContent).toBe('2.4kHz');
       expect(hbar.getAttribute('style')).toContain('--vc-fill-percent: 50%');
-      expect(slider.getAttribute('aria-valuenow')).toBe('1');
+      expect(slider.getAttribute('aria-valuenow')).toBe('2400');
       expect(t.querySelector('[data-pending-width-target]')).toBeNull();
 
       setWidthLifecycle({
@@ -313,7 +582,7 @@ describe('Filter Width lifecycle presentation (MOR-1665)', () => {
       flushSync();
       expect(t.querySelector('.vc-value')?.textContent).toBe('3kHz');
       expect(hbar.getAttribute('style')).toContain('--vc-fill-percent: 100%');
-      expect(slider.getAttribute('aria-valuenow')).toBe('2');
+      expect(slider.getAttribute('aria-valuenow')).toBe('3000');
       expect(t.querySelector('[data-pending-width-target]')).toBeNull();
     },
   );
@@ -332,7 +601,7 @@ describe('Filter Width lifecycle presentation (MOR-1665)', () => {
       flushSync();
       expect(t.querySelector('.vc-value')?.textContent).toBe('2.4kHz');
       expect(t.querySelector('.vc-hbar')?.getAttribute('style')).toContain('--vc-fill-percent: 50%');
-      expect(slider.getAttribute('aria-valuenow')).toBe('1');
+      expect(slider.getAttribute('aria-valuenow')).toBe('2400');
       expect(t.querySelector('[data-pending-width-target]')).toBeNull();
     },
   );
@@ -396,7 +665,7 @@ describe('Filter Width lifecycle presentation (MOR-1665)', () => {
 
     setWidthLifecycle({ target: null, phase: 'idle', busy: false, outcome: null, presentation: null });
     flushSync();
-    expect(t.querySelector('[data-filter-width-live]')?.textContent).toBe('');
+    expect(t.querySelector('[data-filter-width-live]')).toBeNull();
   });
 
   it('restores an open modal draft to canonical state on one failed transition', () => {
@@ -415,7 +684,7 @@ describe('Filter Width lifecycle presentation (MOR-1665)', () => {
     });
     flushSync();
     expect(activeSlider.getAttribute('aria-valuenow')).toBe('2400');
-    expect(t.querySelector('[data-filter-width-live]')?.textContent).toContain('2.5kHz was not applied');
+    expect(t.querySelector('[data-filter-width-live]')?.textContent).toContain('2450 Hz was not applied');
   });
 });
 

--- a/frontend/src/components-v2/panels/__tests__/mor1536-armed-adoption.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/mor1536-armed-adoption.test.ts
@@ -68,6 +68,12 @@ const mockFilterArmed: { armed: boolean; value: number | null } = { armed: false
 const mockFilterWidthLifecycle = {
   confirmed: 2400, target: null, phase: 'idle' as const, busy: false, outcome: null, presentation: null,
 };
+const mockFilterWidthFeedback = {
+  confirmed: 2400, target: null, requestedTarget: null, phase: 'idle' as const,
+  busy: false, availability: 'available' as const, outcome: null,
+  lifecycleId: null, transitionId: null, providerGeneration: 1, sessionEpoch: 7,
+  scope: { control: 'filter-width', receiver: 0 as const }, repeatPolicy: 'latest-target-wins' as const,
+};
 
 const mockRfProps = {
   rfGain: 1, squelch: 0, att: 0, pre: 0, digiSel: false, ipPlus: false,
@@ -107,6 +113,7 @@ vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   getFilterHandlers: () => mockFilterHandlers,
   getFilterArmed: () => mockFilterArmed,
   getFilterWidthCommandLifecycle: () => mockFilterWidthLifecycle,
+  getFilterWidthControlFeedback: () => mockFilterWidthFeedback,
   deriveRfFrontEndProps: () => mockRfProps,
   getRfFrontEndHandlers: () => mockRfHandlers,
   getPreampArmed: () => mockPreArmed,

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -215,6 +215,7 @@
   "core.filter.width.failedAnnouncement": "Filter width {target} was not applied; confirmed width remains {confirmed}.",
   "core.filter.width.timedOutAnnouncement": "Filter width {target} timed out; confirmed width remains {confirmed}.",
   "core.filter.width.cancelledAnnouncement": "Filter width request for {target} was cancelled; confirmed width remains {confirmed}.",
+  "core.filter.width.supersededAnnouncement": "Filter width request for {target} was superseded; confirmed width remains {confirmed}.",
   "core.rfFrontEnd.preamp.pendingAnnouncement": "Pending, not yet confirmed",
   "core.dsp.pendingAnnouncement": "Pending, not yet confirmed",
   "core.vfo.split.label": "Split",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -195,6 +195,7 @@
   "core.filter.width.failedAnnouncement": "Ширина фильтра {target} не установлена; подтверждённая ширина остаётся {confirmed}.",
   "core.filter.width.timedOutAnnouncement": "Истекло время ожидания ширины фильтра {target}; подтверждённая ширина остаётся {confirmed}.",
   "core.filter.width.cancelledAnnouncement": "Запрос ширины фильтра {target} отменён; подтверждённая ширина остаётся {confirmed}.",
+  "core.filter.width.supersededAnnouncement": "Запрос ширины фильтра {target} заменён; подтверждённая ширина остаётся {confirmed}.",
   "core.rfFrontEnd.preamp.pendingAnnouncement": "В ожидании, ещё не подтверждено",
   "core.dsp.pendingAnnouncement": "В ожидании, ещё не подтверждено",
   "core.vfo.split.label": "Split",


### PR DESCRIPTION
## Linear owner

- [MOR-2412: Adopt truthful legacy Filter Width through the existing scalar and HBar presentation contract](https://linear.app/morozsm/issue/MOR-2412/adopt-truthful-legacy-filter-width-through-the-existing-scalar-and)
- Accepted source/design pin: `e9f6800adb4ffad83b2d1b70fbb0680b707d3fe9`

## Summary

- Keep current Filter Width truth in the original full Hz feedback DTO and one retained continuous-scalar binding.
- Add optional HBar-only geometry and whole-status contracts, forwarded identically through built-in and selected custom HBar routes while omitted props preserve existing behavior.
- Render nonuniform catalogs with equal-spaced choices and piecewise exact off-table geometry; all pointer, key, wheel, and scalar-reset requests remain actual catalog members.
- Localize one owner-issued, frozen Filter Width status with distinct confirmed, active-target, and requested-target roles, plus truthful superseded copy in English and Russian.
- Revoke deferred work and real pointer capture on complete catalog or mode context changes without replacing the binding or its announcement memory.

## Scope and compatibility

This is one cohesive 9-file, 932 A+D package. The two locale rows and the shared armed-panel mock are mechanical parts of the mounted contract; splitting the typed HBar extension from its only adopter would leave an unconsumed API and duplicate CI/review cycles.

No public API, CLI, config, rigctld wire, backend, profile, native FilterSurface, SpectrumPanel, preset, CW/RF, or panel-adapter behavior is broken. Existing omitted-prop HBars and non-HBar renderers retain their current contract. No visual baseline files changed.

## Independent-review correction

The first exact-head review correctly found that HBar's initializer plus first reconciliation effect read `lease.view` twice. The focused RED preserved the visible initial announcement while recording 2 getter reads instead of the required 1 through both built-in and selected custom HBar routes.

Corrected head `f0e55a7b2841a900e5a65b07d4cbad29766f4e6a` combines lease replacement and snapshot acquisition in one pre-render effect. The lease reference is plain renderer ownership, preventing self-invalidation on replacement. The mounted real-owner witness now records exactly 1 initial getter read and exactly 1 additional read for the later update while preserving formatter, accept, frozen status, binding replacement, GC, and live-region behavior.

## Verification

Initial implementation RED: 3 expected failures with 119 passing, proving missing built-in/custom projection and exact legacy Filter Width display.

First-correction RED: 2 expected route failures with 63 passing; both measured 2 initial view reads against expected 1 while the initial message remained visible.

Final focused matrix:

- 21 test files, 649 tests passed: changed tests; ValueControl/default presentation; scalar/pair; Filter Width lifecycle adapters; SpectrumPanel; armed-filter adoption; feedback ownership/debt inventory/baseline/AST; fixture root-cwd; composition/focus.
- `npm --prefix frontend run check` (0 errors, 0 warnings)
- `npm --prefix frontend run lint`
- `npm --prefix frontend run lint:boundaries`
- `npm --prefix frontend run i18n:check` (OK; only existing allowed fallback notes)
- `git diff --check`
- Natural corrected-head quick `34031690408`: passed.
- Natural corrected-head visual `34031690433`: passed with no baseline edits.

Per the accepted contract, no local full suite, hardware run, blind CI rerun, branch refresh, or baseline regeneration was performed.

## Agent Review

Independent PASS f0e55a7b2841a900e5a65b07d4cbad29766f4e6a from task 01a074cc-70ec-7cb1-ae00-140e61fd4183: [exact-head review](https://github.com/rigplane/rigplane-core/pull/3263#issuecomment-5559115422). Required quick and Agent Review Gate, plus selected visual, passed at this head.
