### PR TITLE
MOR-2411: Adopt native CW scalar feedback

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -26,7 +26,7 @@
   import { getManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
   import {
     bindSemanticSurfaceHandlers, getBreakInDelayControlFeedback, getFilterWidthControlFeedback,
-    getRfSqlControlFeedback,
+    getCwPitchControlFeedback, getKeySpeedControlFeedback, getRfSqlControlFeedback,
     getPendingFrequencyHz,
     getPendingFilterSelection, getPendingNbOn, getPendingNrOn, getPendingPreampLevel,
     getSystemHandlers, getDataModeArmed,
@@ -724,6 +724,8 @@
     activeReceiverIndex === null ? null : getPendingFilterSelection(activeReceiverIndex),
   );
   let filterWidthFeedback = $derived(getFilterWidthControlFeedback());
+  let cwPitchFeedback = $derived(getCwPitchControlFeedback(controlSession));
+  let keySpeedFeedback = $derived(getKeySpeedControlFeedback(controlSession));
   let dataModeArmed = $derived(getDataModeArmed());
   let pendingDataMode = $derived(dataModeArmed.armed ? dataModeArmed.value : null);
   let pendingPreamp = $derived(
@@ -1391,6 +1393,8 @@
       <CwKeyerSurface
         {view}
         {breakInDelayFeedback}
+        {cwPitchFeedback}
+        {keySpeedFeedback}
         {autoTuneAvailable}
         onBreakInMode={(mode) => cwIntents.onBreakInModeChange(mode)}
         onLevelChange={(field, value) => CW_LEVEL_INTENT[field](value)}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
@@ -47,6 +47,7 @@ const h = vi.hoisted(() => ({
   rxEnabled: true,
   txController: null as ManagedAppTxController | null,
   session: { state: 'connected' as ControlSessionTransition['state'], epoch: 1 },
+  sessionSubscriber: undefined as ((event: ControlSessionTransition) => void) | undefined,
   delivery: undefined as ((event: CommandDeliveryEvent) => void) | undefined,
   transition: undefined as ((event: ControlSessionTransition) => void) | undefined,
 }));
@@ -74,6 +75,11 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    get controlSession() { return h.session; },
+    subscribeControlSession(handler: (event: ControlSessionTransition) => void) {
+      h.sessionSubscriber = handler;
+      return () => { if (h.sessionSubscriber === handler) h.sessionSubscriber = undefined; };
+    },
     get audio() { return h.audio; },
     get connectionAudio() { return h.audioConnected; },
     get rxEnabled() { return h.rxEnabled; },
@@ -240,6 +246,23 @@ function advanceDelay(value: number, marker: number): void {
   flushSync();
 }
 
+function advanceCw(cwPitch: number, keySpeed: number, marker: number): void {
+  const state = liveState({
+    cwPitch, keySpeed, revision: marker, stateRevision: marker,
+    freshnessRevision: marker, observationSeq: marker,
+  });
+  state.fieldStatus = {
+    ...state.fieldStatus,
+    cwPitch: { ...fresh, freshness: 'fresh' as const, availability: 'available' as const,
+      lastObservedMonotonic: marker },
+    keySpeed: { ...fresh, freshness: 'fresh' as const, availability: 'available' as const,
+      lastObservedMonotonic: marker },
+  };
+  h.state = state;
+  setRadioState(state);
+  flushSync();
+}
+
 function delayInput(): HTMLInputElement {
   return el('breakInDelay')!.querySelector('input') as HTMLInputElement;
 }
@@ -249,6 +272,18 @@ function submitDelay(value: number): string {
   input.value = String(value);
   input.dispatchEvent(new Event('input', { bubbles: true }));
   input.dispatchEvent(new Event('change', { bubbles: true }));
+  flushSync();
+  return vi.mocked(sendCommand).mock.calls.at(-1)![2] as string;
+}
+
+function cwInput(field: 'pitchHz' | 'keyerSpeed'): HTMLInputElement {
+  return el(field)!.querySelector('input') as HTMLInputElement;
+}
+
+function submitCw(field: 'pitchHz' | 'keyerSpeed', value: number): string {
+  const input = cwInput(field);
+  input.value = String(value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
   flushSync();
   return vi.mocked(sendCommand).mock.calls.at(-1)![2] as string;
 }
@@ -266,6 +301,7 @@ beforeEach(() => {
   useState(liveState());
   h.caps = liveCaps(CW_TAGS);
   h.session = { state: 'connected', epoch: 1 };
+  h.sessionSubscriber = undefined;
   vi.mocked(sendCommand).mockClear();
   resetCommandLifecycle();
 });
@@ -276,6 +312,7 @@ afterEach(() => {
   document.body.innerHTML = '';
   resetCommandLifecycle();
   vi.useRealTimers();
+  expect(h.sessionSubscriber).toBeUndefined();
 });
 
 /* ── (a) THE NO-KEY-PATH PIN ───────────────────────────────────── */
@@ -287,6 +324,60 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
     expect(el('surface')).not.toBeNull();
     expect(el('break-in-full')!.hasAttribute('disabled')).toBe(false);
     expect(sendCommand).not.toHaveBeenCalled();
+    expect(txHarness.trace()).toEqual([]);
+  });
+
+  it('projects independent native CW feedback from intent through confirmation and failure', () => {
+    render();
+    expect(cwInput('pitchHz').dataset.commandPhase).toBe('idle');
+    expect(cwInput('keyerSpeed').dataset.commandPhase).toBe('idle');
+
+    const pitchId = submitCw('pitchHz', 725);
+    expect(sendCommand).toHaveBeenLastCalledWith(
+      'set_cw_pitch', { value: 725 }, pitchId,
+    );
+    const speedId = submitCw('keyerSpeed', 31);
+    expect(sendCommand).toHaveBeenLastCalledWith(
+      'set_key_speed', { speed: 31 }, speedId,
+    );
+    expect(cwInput('pitchHz').dataset.commandPhase).toBe('submitted');
+    expect(cwInput('keyerSpeed').dataset.commandPhase).toBe('submitted');
+
+    deliver(pitchId, 'ack');
+    deliver(speedId, 'ack');
+    expect(cwInput('pitchHz').dataset.commandPhase).toBe('awaiting-confirmation');
+    expect(cwInput('keyerSpeed').dataset.commandPhase).toBe('awaiting-confirmation');
+
+    advanceCw(725, 24, 11);
+    expect(cwInput('pitchHz').dataset.commandPhase).toBe('confirmed');
+    expect(cwInput('pitchHz').value).toBe('725');
+    expect(cwInput('keyerSpeed').dataset.commandPhase).toBe('awaiting-confirmation');
+    deliver(speedId, 'response-error', 'speed rejected');
+    expect(cwInput('keyerSpeed').dataset.commandPhase).toBe('failed');
+    expect(cwInput('keyerSpeed').value).toBe('24');
+    expect(el('keyerSpeed')!.textContent).toContain('speed rejected');
+    expect(txHarness.trace()).toEqual([]);
+  });
+
+  it('keeps the newest CW target and invalidates both lanes on session replacement', () => {
+    render();
+    const oldId = submitCw('pitchHz', 650);
+    const latestId = submitCw('pitchHz', 700);
+    submitCw('keyerSpeed', 31);
+    deliver(oldId, 'response-error', 'late superseded failure');
+    expect(cwInput('pitchHz').dataset.commandPhase).toBe('submitted');
+    expect(cwInput('pitchHz').value).toBe('700');
+    expect(getCommandLifecycle(latestId, 1)?.status).toBe('pending');
+
+    h.session = { state: 'disconnected', epoch: 2 };
+    h.transition!({ state: 'disconnected', epoch: 2 });
+    h.sessionSubscriber!({ state: 'disconnected', epoch: 2 });
+    flushSync();
+    for (const field of ['pitchHz', 'keyerSpeed'] as const) {
+      expect(cwInput(field).disabled).toBe(true);
+      expect(cwInput(field).dataset.commandPhase).toBe('unavailable');
+      expect(el(field)!.dataset.observed).toBe('false');
+    }
     expect(txHarness.trace()).toEqual([]);
   });
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
@@ -342,6 +342,13 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
     );
     expect(cwInput('pitchHz').dataset.commandPhase).toBe('submitted');
     expect(cwInput('keyerSpeed').dataset.commandPhase).toBe('submitted');
+    unmount(component!); component = null; target.remove();
+    render();
+    expect(cwInput('pitchHz').value).toBe('725');
+    expect(cwInput('keyerSpeed').value).toBe('31');
+    expect(cwInput('pitchHz').dataset.commandPhase).toBe('submitted');
+    expect(cwInput('keyerSpeed').dataset.commandPhase).toBe('submitted');
+    expect(sendCommand).toHaveBeenCalledTimes(2);
 
     deliver(pitchId, 'ack');
     deliver(speedId, 'ack');
@@ -368,6 +375,9 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
     expect(cwInput('pitchHz').dataset.commandPhase).toBe('submitted');
     expect(cwInput('pitchHz').value).toBe('700');
     expect(getCommandLifecycle(latestId, 1)?.status).toBe('pending');
+    const oldPitchStatus = el('pitchHz')!.querySelector<HTMLElement>('[data-cw-feedback-status]')!;
+    const oldPitchText = oldPitchStatus.textContent;
+    expect(target.querySelectorAll('[data-cw-feedback-status]')).toHaveLength(2);
 
     h.session = { state: 'disconnected', epoch: 2 };
     h.transition!({ state: 'disconnected', epoch: 2 });
@@ -378,6 +388,19 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
       expect(cwInput(field).dataset.commandPhase).toBe('unavailable');
       expect(el(field)!.dataset.observed).toBe('false');
     }
+    expect(target.querySelectorAll('[data-cw-feedback-status]')).toHaveLength(0);
+    expect(sendCommand).toHaveBeenCalledTimes(3);
+
+    h.session = { state: 'connected', epoch: 3 };
+    h.transition!({ state: 'connected', epoch: 3 });
+    h.sessionSubscriber!({ state: 'connected', epoch: 3 });
+    flushSync();
+    submitCw('pitchHz', 700);
+    const newPitchStatus = el('pitchHz')!.querySelector<HTMLElement>('[data-cw-feedback-status]')!;
+    expect(newPitchStatus.textContent).toBe(oldPitchText);
+    expect(newPitchStatus).not.toBe(oldPitchStatus);
+    expect(el('pitchHz')!.querySelectorAll('[data-cw-feedback-status]')).toHaveLength(1);
+    expect(sendCommand).toHaveBeenCalledTimes(4);
     expect(txHarness.trace()).toEqual([]);
   });
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -12,7 +12,7 @@ const h = vi.hoisted(() => ({
   txController: null as ManagedAppTxController | null,
   main: vi.fn(), sub: vi.fn(), equalize: vi.fn(), swap: vi.fn(), split: vi.fn(),
   dualWatch: vi.fn(), speak: vi.fn(),
-  filterWidthFeedback: vi.fn(),
+  filterWidthFeedback: vi.fn(), cwPitchFeedback: vi.fn(), keySpeedFeedback: vi.fn(),
   session: { state: 'connected', epoch: 1 } as ControlSessionSnapshot,
   sessionSubscriber: null as ((next: ControlSessionSnapshot) => void) | null,
 }));
@@ -55,6 +55,8 @@ vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   getDataModeArmed: () => ({ armed: false, value: null }),
   getBreakInDelayControlFeedback: () => null,
   getFilterWidthControlFeedback: h.filterWidthFeedback,
+  getCwPitchControlFeedback: h.cwPitchFeedback,
+  getKeySpeedControlFeedback: h.keySpeedFeedback,
   getPendingFrequencyHz: () => null,
   getPendingFilterSelection: () => null, getPendingNbOn: () => null,
   getPendingNrOn: () => null, getPendingPreampLevel: () => null,
@@ -134,6 +136,20 @@ beforeEach(() => {
     phase: 'unavailable', busy: false, availability: 'unavailable',
     outcome: null, lifecycleId: null, transitionId: null, sessionEpoch: 1,
     scope: Object.freeze({ control: 'filter-width', receiver: 0 }),
+    repeatPolicy: 'latest-target-wins',
+  }));
+  h.cwPitchFeedback.mockReturnValue(Object.freeze({
+    confirmed: null, target: null, requestedTarget: null,
+    phase: 'unavailable', busy: false, availability: 'unavailable',
+    outcome: null, lifecycleId: null, transitionId: null, sessionEpoch: 1,
+    scope: Object.freeze({ control: 'cw-pitch', receiver: 0 }),
+    repeatPolicy: 'latest-target-wins',
+  }));
+  h.keySpeedFeedback.mockReturnValue(Object.freeze({
+    confirmed: null, target: null, requestedTarget: null,
+    phase: 'unavailable', busy: false, availability: 'unavailable',
+    outcome: null, lifecycleId: null, transitionId: null, sessionEpoch: 1,
+    scope: Object.freeze({ control: 'keyer-speed', receiver: 0 }),
     repeatPolicy: 'latest-target-wins',
   }));
   for (const mock of [
@@ -232,6 +248,25 @@ describe('production receiver-indicator partitioning', () => {
     expect(h.filterWidthFeedback()).toMatchObject({
       phase: 'unavailable', availability: 'unavailable',
       scope: { control: 'filter-width', receiver: 0 },
+    });
+  });
+
+  it('keeps the complete panel-adapter facade while wiring both CW lanes to the live session', () => {
+    const source = readFileSync('src/components-v2/wiring/SemanticRadioSurfaces.svelte', 'utf8');
+    expect(source).toMatch(
+      /cwPitchFeedback\s*=\s*\$derived\(getCwPitchControlFeedback\(controlSession\)\)/,
+    );
+    expect(source).toMatch(
+      /keySpeedFeedback\s*=\s*\$derived\(getKeySpeedControlFeedback\(controlSession\)\)/,
+    );
+    expect(source).toMatch(
+      /<CwKeyerSurface[\s\S]*?\{cwPitchFeedback\}[\s\S]*?\{keySpeedFeedback\}[\s\S]*?\/>/,
+    );
+    expect(h.cwPitchFeedback()).toMatchObject({
+      phase: 'unavailable', scope: { control: 'cw-pitch', receiver: 0 },
+    });
+    expect(h.keySpeedFeedback()).toMatchObject({
+      phase: 'unavailable', scope: { control: 'keyer-speed', receiver: 0 },
     });
   });
 

--- a/frontend/src/semantic/CwKeyerSurface.svelte
+++ b/frontend/src/semantic/CwKeyerSurface.svelte
@@ -123,11 +123,17 @@
 </script>
 
 <script lang="ts">
+  import { onDestroy, untrack } from 'svelte';
   import {
     type ControlFeedbackPresentationInput,
     type PresentationPhase,
   } from '../primitives/control-feedback/control-feedback-presentation';
   import { createCommittedScalar } from '../primitives/scalar/committed-scalar.svelte';
+  import {
+    createContinuousScalar, nativeRangeContinuousScalarPolicy,
+    type CommandScalarFeedback, type ContinuousScalarInput,
+    type ContinuousScalarRendererLease, type ContinuousScalarView,
+  } from '../primitives/scalar/continuous-scalar.svelte';
   import { clamp, snapToStep } from '../primitives/scalar/value-control-core';
   import {
     bindChoiceInstrument,
@@ -148,12 +154,14 @@
     onTwinPeakToggle?: () => void;
     onReversePaddleToggle?: () => void;
     breakInDelayFeedback?: Readonly<BreakInDelayFeedback>;
+    cwPitchFeedback?: Readonly<CommandScalarFeedback>;
+    keySpeedFeedback?: Readonly<CommandScalarFeedback>;
     autoTuneAvailable?: boolean;
     onAutoTune?: () => void;
   }
   let {
     view, onBreakInMode, onLevelChange, onApfOn, onTwinPeakToggle, onReversePaddleToggle,
-    breakInDelayFeedback,
+    breakInDelayFeedback, cwPitchFeedback, keySpeedFeedback,
     autoTuneAvailable = false, onAutoTune,
   }: Props = $props();
 
@@ -204,6 +212,82 @@
   }
   function setLevel(field: CwLevelField, value: number): void {
     if (cw && usable(cw[field])) onLevelChange?.(field, value);
+  }
+  type FeedbackLevelField = 'keyerSpeed' | 'pitchHz';
+  const feedbackLevelDomain = {
+    keyerSpeed: { min: 6, max: 48, step: 1, defaultValue: null, fineStepDivisor: 1 },
+    pitchHz: { min: 300, max: 900, step: 5, defaultValue: null, fineStepDivisor: 1 },
+  } as const;
+  function feedbackLevelInput(field: FeedbackLevelField): Readonly<ContinuousScalarInput> {
+    const current = cw?.[field];
+    const feedback = field === 'keyerSpeed' ? keySpeedFeedback : cwPitchFeedback;
+    const common = {
+      domain: feedbackLevelDomain[field],
+      enabled: current !== undefined && usable(current),
+      request: (value: number) => setLevel(field, value),
+    } as const;
+    if (feedback !== undefined) {
+      return {
+        ...common, evidence: 'command-feedback', feedback,
+        command: field === 'keyerSpeed' ? 'set_key_speed' : 'set_cw_pitch',
+      };
+    }
+    return {
+      ...common, evidence: 'reading', ownerKey: `cw-keyer-${field}-reading`,
+      reading: current?.reading.status === 'known'
+        ? { status: 'known', value: current.reading.value } : { status: 'unknown' },
+    };
+  }
+  const keySpeedScalar = createContinuousScalar(
+    () => feedbackLevelInput('keyerSpeed'), nativeRangeContinuousScalarPolicy,
+  );
+  const cwPitchScalar = createContinuousScalar(
+    () => feedbackLevelInput('pitchHz'), nativeRangeContinuousScalarPolicy,
+  );
+  let keySpeedLease: ContinuousScalarRendererLease | null = $state(null);
+  let cwPitchLease: ContinuousScalarRendererLease | null = $state(null);
+  const initialKeySpeedView = untrack(() => keySpeedScalar.view);
+  const initialCwPitchView = untrack(() => cwPitchScalar.view);
+  let keySpeedView: Readonly<ContinuousScalarView> = $state(initialKeySpeedView);
+  let cwPitchView: Readonly<ContinuousScalarView> = $state(initialCwPitchView);
+  const feedbackStatus = (current: Readonly<ContinuousScalarView>): string | null =>
+    current.announcement === null ? null
+      : current.error === null ? current.announcement : `${current.announcement}: ${current.error}`;
+  let keySpeedAnnouncement: string | null = $state(feedbackStatus(initialKeySpeedView));
+  let cwPitchAnnouncement: string | null = $state(feedbackStatus(initialCwPitchView));
+  $effect(() => {
+    const lease = keySpeedScalar.attachRenderer();
+    keySpeedLease = lease;
+    return () => lease.dispose();
+  });
+  $effect(() => {
+    const lease = cwPitchScalar.attachRenderer();
+    cwPitchLease = lease;
+    return () => lease.dispose();
+  });
+  $effect(() => {
+    const next = keySpeedLease === null ? keySpeedScalar.view : keySpeedLease.view;
+    keySpeedView = next;
+    const status = feedbackStatus(next);
+    if (status !== null) keySpeedAnnouncement = status;
+  });
+  $effect(() => {
+    const next = cwPitchLease === null ? cwPitchScalar.view : cwPitchLease.view;
+    cwPitchView = next;
+    const status = feedbackStatus(next);
+    if (status !== null) cwPitchAnnouncement = status;
+  });
+  onDestroy(() => {
+    keySpeedScalar.destroy();
+    cwPitchScalar.destroy();
+  });
+  function feedbackLevelValueText(
+    label: string, current: Readonly<ContinuousScalarView>, unit: string,
+  ): string {
+    if (current.displayed === null) return `${label} unavailable`;
+    const phase = current.phase?.replaceAll('-', ' ');
+    const error = current.error === null ? '' : `; ${current.error}`;
+    return `${label} ${current.displayed}${unit === '' ? '' : ` ${unit}`}${phase ? `; ${phase}` : ''}${error}`;
   }
   const BUSY_BREAK_IN_DELAY_PHASES: ReadonlySet<PresentationPhase> = new Set([
     'submitted', 'queued', 'dispatched', 'awaiting-confirmation',
@@ -263,7 +347,6 @@
     breakInDelayFeedback?.scope?.slot ?? null,
   ]));
   const INTEGRATED_RANGE_POLICY = { 'feedback-policy': 'feedback-integrated' } as const;
-  const RADIO_BACKED_RANGE_POLICY = { 'feedback-policy': 'radio-backed' } as const;
   let breakInDelayEditable = $derived(
     cw !== undefined && usable(cw.breakInDelay)
       && effectiveBreakInDelayFeedback.phase !== 'unavailable',
@@ -370,7 +453,13 @@
     {#each CW_LEVELS as [field, label, min, max, step, unit] (field)}
       {@const f = cw[field]}
       {#if f.availability.structural}
-        <label class="cw-keyer-level" data-testid={`cw-keyer-${field}`} data-observed={usable(f)}>
+        <label
+          class="cw-keyer-level" data-testid={`cw-keyer-${field}`}
+          data-observed={field === 'breakInDelay' ? usable(f)
+            : field === 'keyerSpeed'
+              ? keySpeedView.canonical !== null && keySpeedView.editable
+              : cwPitchView.canonical !== null && cwPitchView.editable}
+        >
           <span class="cw-keyer-name">{label}</span>
           {#if field === 'breakInDelay'}
             <input
@@ -406,13 +495,36 @@
               <output data-testid="cw-keyer-breakInDelay-value">{textOf(f)} {unit}</output>
             {/if}
           {:else}
+            {@const levelView = field === 'keyerSpeed' ? keySpeedView : cwPitchView}
+            {@const levelLease = field === 'keyerSpeed' ? keySpeedLease : cwPitchLease}
+            {@const hasFeedback = field === 'keyerSpeed'
+              ? keySpeedFeedback !== undefined : cwPitchFeedback !== undefined}
+            {@const announcement = field === 'keyerSpeed'
+              ? keySpeedAnnouncement : cwPitchAnnouncement}
             <input
-              {...RADIO_BACKED_RANGE_POLICY} type="range" {min} {max} {step}
-              value={f.reading.status === 'known' ? f.reading.value : min}
-              disabled={!usable(f)}
-              oninput={(event) => setLevel(field, event.currentTarget.valueAsNumber)}
+              {...INTEGRATED_RANGE_POLICY} type="range" {min} {max} {step}
+              value={levelView.displayed ?? min}
+              disabled={!levelView.editable}
+              data-command-phase={levelView.phase ?? undefined}
+              aria-busy={hasFeedback ? levelView.busy : undefined}
+              aria-valuenow={hasFeedback && levelView.displayed !== null
+                ? levelView.displayed : undefined}
+              aria-valuetext={hasFeedback ? feedbackLevelValueText(label, levelView, unit) : undefined}
+              oninput={(event) => levelLease?.nativeInput(event.currentTarget.valueAsNumber)}
             />
-            <output data-testid={`cw-keyer-${field}-value`}>{textOf(f)} {unit}</output>
+            <output data-testid={`cw-keyer-${field}-value`} data-command-phase={levelView.phase ?? undefined}
+            >{levelView.displayed === null ? UNKNOWN_TEXT : levelView.displayed} {unit}
+              {#if hasFeedback && levelView.phase !== null}
+                <span class:command-pending={levelView.busy}>{levelView.phase.replaceAll('-', ' ')}</span>
+                {#if levelView.error !== null}<span>{levelView.error}</span>{/if}
+              {/if}
+            </output>
+            {#if hasFeedback && announcement !== null}
+              <span
+                class="sr-only" role="status" aria-live="polite" aria-atomic="true"
+                data-control-feedback-status data-cw-feedback-status data-feedback-lane={field}
+              >{announcement}</span>
+            {/if}
           {/if}
         </label>
       {/if}

--- a/frontend/src/semantic/CwKeyerSurface.svelte
+++ b/frontend/src/semantic/CwKeyerSurface.svelte
@@ -3,8 +3,9 @@
 
   Presentation only. It renders the MOR-1296 `cwKeyer` fact group — break-in
   posture (+delay), keyer speed, CW pitch, reverse paddle, APF and the twin-peak
-  filter — and emits control intents as callbacks. It holds no state, consults
-  no controller and owns no TX authority (v3 ADR invariant 11).
+  filter — and emits control intents as callbacks. It owns only local renderer
+  interaction and issued presentation events; it consults no controller and
+  owns no TX authority (v3 ADR invariant 11).
 
   SAFETY. Five rules govern this file and nothing may relax them:
 
@@ -250,11 +251,47 @@
   const initialCwPitchView = untrack(() => cwPitchScalar.view);
   let keySpeedView: Readonly<ContinuousScalarView> = $state(initialKeySpeedView);
   let cwPitchView: Readonly<ContinuousScalarView> = $state(initialCwPitchView);
-  const feedbackStatus = (current: Readonly<ContinuousScalarView>): string | null =>
-    current.announcement === null ? null
-      : current.error === null ? current.announcement : `${current.announcement}: ${current.error}`;
-  let keySpeedAnnouncement: string | null = $state(feedbackStatus(initialKeySpeedView));
-  let cwPitchAnnouncement: string | null = $state(feedbackStatus(initialCwPitchView));
+  type IssuedLevelAnnouncement = Readonly<{
+    authorityKey: string;
+    eventKey: string;
+    text: string;
+  }>;
+  function feedbackAuthorityKey(current: Readonly<ContinuousScalarView>): string {
+    const domain = current.domain;
+    const shared = [
+      current.evidence, current.editable, domain.min, domain.max, domain.step,
+      domain.defaultValue, domain.fineStepDivisor, domain.keyboardStep,
+    ];
+    if (current.evidence === 'reading') {
+      return JSON.stringify([...shared, current.reading.status]);
+    }
+    const feedback = current.feedback;
+    return JSON.stringify([
+      ...shared, feedback.providerGeneration ?? null, feedback.sessionEpoch,
+      feedback.availability, feedback.scope.control, feedback.scope.receiver, feedback.scope.slot,
+    ]);
+  }
+  function nextLevelAnnouncement(
+    current: Readonly<ContinuousScalarView>,
+    previous: IssuedLevelAnnouncement | null,
+  ): IssuedLevelAnnouncement | null {
+    const authorityKey = feedbackAuthorityKey(current);
+    const issued = current.presentation?.politeAnnouncement;
+    if (issued === null || issued === undefined || current.announcement === null) {
+      return previous?.authorityKey === authorityKey ? previous : null;
+    }
+    return Object.freeze({
+      authorityKey,
+      eventKey: JSON.stringify([authorityKey, issued.transitionId]),
+      text: current.error === null ? current.announcement : `${current.announcement}: ${current.error}`,
+    });
+  }
+  let keySpeedAnnouncement: IssuedLevelAnnouncement | null = $state(
+    nextLevelAnnouncement(initialKeySpeedView, null),
+  );
+  let cwPitchAnnouncement: IssuedLevelAnnouncement | null = $state(
+    nextLevelAnnouncement(initialCwPitchView, null),
+  );
   $effect(() => {
     const lease = keySpeedScalar.attachRenderer();
     keySpeedLease = lease;
@@ -268,27 +305,32 @@
   $effect(() => {
     const next = keySpeedLease === null ? keySpeedScalar.view : keySpeedLease.view;
     keySpeedView = next;
-    const status = feedbackStatus(next);
-    if (status !== null) keySpeedAnnouncement = status;
+    keySpeedAnnouncement = nextLevelAnnouncement(
+      next, untrack(() => keySpeedAnnouncement),
+    );
   });
   $effect(() => {
     const next = cwPitchLease === null ? cwPitchScalar.view : cwPitchLease.view;
     cwPitchView = next;
-    const status = feedbackStatus(next);
-    if (status !== null) cwPitchAnnouncement = status;
+    cwPitchAnnouncement = nextLevelAnnouncement(
+      next, untrack(() => cwPitchAnnouncement),
+    );
   });
   onDestroy(() => {
     keySpeedScalar.destroy();
     cwPitchScalar.destroy();
   });
   function feedbackLevelValueText(
-    label: string, current: Readonly<ContinuousScalarView>, unit: string,
+    label: string, current: Readonly<ContinuousScalarView>, displayed: number | null, unit: string,
   ): string {
-    if (current.displayed === null) return `${label} unavailable`;
+    if (displayed === null) return `${label} unavailable`;
     const phase = current.phase?.replaceAll('-', ' ');
     const error = current.error === null ? '' : `; ${current.error}`;
-    return `${label} ${current.displayed}${unit === '' ? '' : ` ${unit}`}${phase ? `; ${phase}` : ''}${error}`;
+    return `${label} ${displayed}${unit === '' ? '' : ` ${unit}`}${phase ? `; ${phase}` : ''}${error}`;
   }
+  const feedbackLevelDisplay = (current: Readonly<ContinuousScalarView>): number | null =>
+    current.draft ?? (current.evidence === 'command-feedback' && current.busy
+      ? current.target : null) ?? current.canonical;
   const BUSY_BREAK_IN_DELAY_PHASES: ReadonlySet<PresentationPhase> = new Set([
     'submitted', 'queued', 'dispatched', 'awaiting-confirmation',
   ]);
@@ -501,29 +543,32 @@
               ? keySpeedFeedback !== undefined : cwPitchFeedback !== undefined}
             {@const announcement = field === 'keyerSpeed'
               ? keySpeedAnnouncement : cwPitchAnnouncement}
+            {@const levelDisplay = feedbackLevelDisplay(levelView)}
             <input
               {...INTEGRATED_RANGE_POLICY} type="range" {min} {max} {step}
-              value={levelView.displayed ?? min}
+              value={levelDisplay ?? min}
               disabled={!levelView.editable}
               data-command-phase={levelView.phase ?? undefined}
               aria-busy={hasFeedback ? levelView.busy : undefined}
-              aria-valuenow={hasFeedback && levelView.displayed !== null
-                ? levelView.displayed : undefined}
-              aria-valuetext={hasFeedback ? feedbackLevelValueText(label, levelView, unit) : undefined}
+              aria-valuenow={hasFeedback && levelDisplay !== null ? levelDisplay : undefined}
+              aria-valuetext={hasFeedback
+                ? feedbackLevelValueText(label, levelView, levelDisplay, unit) : undefined}
               oninput={(event) => levelLease?.nativeInput(event.currentTarget.valueAsNumber)}
             />
             <output data-testid={`cw-keyer-${field}-value`} data-command-phase={levelView.phase ?? undefined}
-            >{levelView.displayed === null ? UNKNOWN_TEXT : levelView.displayed} {unit}
+            >{levelDisplay === null ? UNKNOWN_TEXT : levelDisplay} {unit}
               {#if hasFeedback && levelView.phase !== null}
                 <span class:command-pending={levelView.busy}>{levelView.phase.replaceAll('-', ' ')}</span>
                 {#if levelView.error !== null}<span>{levelView.error}</span>{/if}
               {/if}
             </output>
             {#if hasFeedback && announcement !== null}
-              <span
-                class="sr-only" role="status" aria-live="polite" aria-atomic="true"
-                data-control-feedback-status data-cw-feedback-status data-feedback-lane={field}
-              >{announcement}</span>
+              {#key announcement.eventKey}
+                <span
+                  class="sr-only" role="status" aria-live="polite" aria-atomic="true"
+                  data-control-feedback-status data-cw-feedback-status data-feedback-lane={field}
+                >{announcement.text}</span>
+              {/key}
             {/if}
           {/if}
         </label>

--- a/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
@@ -42,11 +42,13 @@ import { t } from '$lib/i18n';
 import type {
   ControlFeedbackPresentationInput, PresentationPhase,
 } from '../../primitives/control-feedback/control-feedback-presentation';
+import type { CommandScalarFeedback } from '../../primitives/scalar/continuous-scalar.svelte';
 
 type BreakInDelayFeedback = ControlFeedbackPresentationInput<number> & {
   readonly sessionEpoch?: number;
   readonly scope?: Readonly<{ control: string; receiver: number; slot?: string }>;
 };
+type CwLevelFeedback = Readonly<CommandScalarFeedback>;
 
 const SOURCE = readFileSync('src/semantic/CwKeyerSurface.svelte', 'utf8');
 /** Comments stripped, so the file's own doctrine prose can never be what a
@@ -84,6 +86,8 @@ type Handlers = {
   onTwinPeakToggle?: () => void;
   onReversePaddleToggle?: () => void;
   breakInDelayFeedback?: Readonly<BreakInDelayFeedback>;
+  cwPitchFeedback?: CwLevelFeedback;
+  keySpeedFeedback?: CwLevelFeedback;
   onAutoTune?: () => void;
 };
 
@@ -131,6 +135,37 @@ const feedback = (
   confirmed: 64, target: null, requestedTarget: null, phase,
   transitionId: null, outcome: null, ...over,
 });
+const cwFeedback = (
+  control: 'cw-pitch' | 'keyer-speed',
+  phase: PresentationPhase = 'idle',
+  over: Partial<CommandScalarFeedback> = {},
+): CwLevelFeedback => Object.freeze({
+  confirmed: 600, target: null, requestedTarget: null, phase,
+  busy: ['submitted', 'queued', 'dispatched', 'awaiting-confirmation'].includes(phase),
+  availability: 'available', outcome: null, lifecycleId: null, transitionId: null,
+  providerGeneration: 1, sessionEpoch: 1,
+  scope: Object.freeze({ control, receiver: 0 as const }),
+  repeatPolicy: 'latest-target-wins', ...over,
+});
+
+function renderReactiveCwLevels(
+  pitch: CwLevelFeedback = cwFeedback('cw-pitch'),
+  speed: CwLevelFeedback = cwFeedback('keyer-speed', 'idle', { confirmed: 24 }),
+) {
+  const onLevelChange = vi.fn();
+  const props = proxy({
+    view: base(), onLevelChange, cwPitchFeedback: pitch, keySpeedFeedback: speed,
+  });
+  const component = mount(CwKeyerSurface, { target, props });
+  flushSync();
+  const input = (field: 'pitchHz' | 'keyerSpeed') => target.querySelector<HTMLInputElement>(
+    `[data-testid="cw-keyer-${field}"] input`,
+  )!;
+  const row = (field: 'pitchHz' | 'keyerSpeed') => target.querySelector<HTMLElement>(
+    `[data-testid="cw-keyer-${field}"]`,
+  )!;
+  return { dispose: () => unmount(component), input, row, onLevelChange, props };
+}
 
 /* ── (a) the surface is not a key path ────────────────────────── */
 
@@ -156,8 +191,10 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
     // widen this file's reach any more than `./pressed-of` does.
     expect([...new Set(specifiers)]).toEqual([
       '$lib/i18n', './radio-view-model', './pressed-of',
+      'svelte',
       '../primitives/control-feedback/control-feedback-presentation',
       '../primitives/scalar/committed-scalar.svelte',
+      '../primitives/scalar/continuous-scalar.svelte',
       '../primitives/scalar/value-control-core',
       '../primitives/control-instruments/control-instrument-behavior',
     ]);
@@ -174,10 +211,12 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
 
   // Kills: `onMount(() => …)` and every relative of it, plus a dynamic import
   // used to smuggle in the controller.
-  it('declares no lifecycle hook and no effect', () => {
-    for (const forbidden of ['onMount', 'onDestroy', '$effect', 'import(']) {
+  it('allows cleanup-only lifecycle ownership without a mount-time dispatch path', () => {
+    expect(CODE).toContain('onDestroy');
+    for (const forbidden of ['onMount', 'import(', 'sendCommand']) {
       expect(CODE).not.toContain(forbidden);
     }
+    expect(CODE).not.toMatch(/onDestroy\s*\([^)]*=>[\s\S]*?(?:onLevelChange|nativeInput)\s*\(/);
   });
 
   // Kills: (a) a key path, (c) a second permit derivation. Neither the key
@@ -198,7 +237,8 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
     const props = CODE.slice(CODE.indexOf('interface Props'), CODE.indexOf('}: Props'));
     expect([...props.matchAll(/^\s{4}(\w+)[?]?:/gm)].map((m) => m[1])).toEqual([
       'view', 'onBreakInMode', 'onLevelChange', 'onApfOn', 'onTwinPeakToggle',
-      'onReversePaddleToggle', 'breakInDelayFeedback', 'autoTuneAvailable', 'onAutoTune',
+      'onReversePaddleToggle', 'breakInDelayFeedback', 'cwPitchFeedback',
+      'keySpeedFeedback', 'autoTuneAvailable', 'onAutoTune',
     ]);
   });
 
@@ -278,6 +318,130 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
       'level:keyerSpeed:48', 'level:pitchHz:900', 'level:breakInDelay:255',
       'reversePaddle', 'apf:false', 'apf:true', 'twinPeak',
     ]);
+    r.dispose();
+  });
+});
+
+/* ── MOR-2411 — native CW scalar feedback ownership ──────────── */
+
+describe('CW pitch and keyer speed own independent command feedback', () => {
+  it('treats explicit unavailable feedback as authoritative over retained raw readings', () => {
+    const unavailable = (control: 'cw-pitch' | 'keyer-speed'): CwLevelFeedback => cwFeedback(
+      control, 'unavailable', {
+        confirmed: null, availability: 'unavailable', sessionEpoch: 2,
+      },
+    );
+    const r = renderReactiveCwLevels(unavailable('cw-pitch'), unavailable('keyer-speed'));
+    for (const field of ['pitchHz', 'keyerSpeed'] as const) {
+      expect(r.input(field).disabled).toBe(true);
+      expect(r.input(field).dataset.commandPhase).toBe('unavailable');
+      expect(r.row(field).dataset.observed).toBe('false');
+      expect(r.row(field).textContent).toContain(UNKNOWN_TEXT);
+      slide(r.input(field), Number(r.input(field).max));
+    }
+    expect(r.onLevelChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('maps each native input immediately and exactly once to its own setting intent', () => {
+    const r = renderReactiveCwLevels();
+    slide(r.input('pitchHz'), 725);
+    slide(r.input('keyerSpeed'), 31);
+    expect(r.onLevelChange.mock.calls).toEqual([
+      ['pitchHz', 725], ['keyerSpeed', 31],
+    ]);
+    expect(r.input('pitchHz').value).toBe('725');
+    expect(r.input('keyerSpeed').value).toBe('31');
+    r.dispose();
+  });
+
+  it.each([
+    ['idle', false, 600, null],
+    ['submitted', true, 600, null],
+    ['queued', true, 600, null],
+    ['dispatched', true, 600, null],
+    ['awaiting-confirmation', true, 600, null],
+    ['confirmed', false, 725, 'confirmed'],
+    ['failed', false, 600, 'failed'],
+    ['timed-out', false, 600, 'timed-out'],
+    ['cancelled', false, 600, 'cancelled'],
+    ['superseded', false, 600, 'superseded'],
+  ] as const)('projects pitch phase %s through its scalar owner', (phase, busy, shown, outcome) => {
+    const active = busy;
+    const terminal = outcome === null ? null : {
+      phase: outcome, ...(outcome === 'failed' ? { error: 'pitch rejected' } : {}),
+    };
+    const pitch = cwFeedback('cw-pitch', phase, {
+      confirmed: phase === 'confirmed' ? 725 : 600,
+      target: active ? 725 : null,
+      requestedTarget: phase === 'idle' ? null : 725,
+      lifecycleId: phase === 'idle' ? null : 'pitch-command',
+      transitionId: phase === 'idle' ? null : `pitch-${phase}`,
+      outcome: terminal,
+    });
+    const r = renderReactiveCwLevels(pitch);
+    expect(r.input('pitchHz').value).toBe(String(shown));
+    expect(r.input('pitchHz').dataset.commandPhase).toBe(phase);
+    expect(r.input('pitchHz').getAttribute('aria-busy')).toBe(String(busy));
+    if (phase === 'failed') expect(r.row('pitchHz').textContent).toContain('pitch rejected');
+    r.dispose();
+  });
+
+  it('keeps mixed phases, errors and polite announcements lane-local and nonduplicated', () => {
+    const pitch = cwFeedback('cw-pitch', 'failed', {
+      requestedTarget: 725, lifecycleId: 'pitch-command', transitionId: 'pitch-failed',
+      outcome: { phase: 'failed', error: 'pitch rejected' },
+    });
+    const speed = cwFeedback('keyer-speed', 'timed-out', {
+      confirmed: 24, requestedTarget: 31, lifecycleId: 'speed-command',
+      transitionId: 'speed-timeout', outcome: { phase: 'timed-out' },
+    });
+    const r = renderReactiveCwLevels(pitch, speed);
+    expect(r.input('pitchHz').dataset.commandPhase).toBe('failed');
+    expect(r.input('keyerSpeed').dataset.commandPhase).toBe('timed-out');
+    expect(r.row('pitchHz').textContent).toContain('pitch rejected');
+    const announcements = [...target.querySelectorAll<HTMLElement>(
+      '[data-cw-feedback-status]',
+    )];
+    expect(announcements).toHaveLength(2);
+    expect(announcements.map((node) => node.dataset.feedbackLane).sort())
+      .toEqual(['keyerSpeed', 'pitchHz']);
+    expect(announcements.every((node) => node.getAttribute('aria-live') === 'polite')).toBe(true);
+    r.dispose();
+  });
+
+  it('clears a rapid optimistic target when either lane receives replacement authority', () => {
+    const r = renderReactiveCwLevels();
+    slide(r.input('pitchHz'), 650);
+    slide(r.input('pitchHz'), 700);
+    slide(r.input('keyerSpeed'), 31);
+    expect(r.input('pitchHz').value).toBe('700');
+    expect(r.input('keyerSpeed').value).toBe('31');
+
+    r.props.cwPitchFeedback = cwFeedback('cw-pitch', 'unavailable', {
+      confirmed: null, availability: 'unavailable', providerGeneration: 2, sessionEpoch: 2,
+    });
+    r.props.keySpeedFeedback = cwFeedback('keyer-speed', 'idle', {
+      confirmed: 22, providerGeneration: 2, sessionEpoch: 2,
+    });
+    flushSync();
+    expect(r.input('pitchHz').disabled).toBe(true);
+    expect(r.input('pitchHz').value).toBe('300');
+    expect(r.input('keyerSpeed').value).toBe('22');
+    expect(r.onLevelChange.mock.calls).toEqual([
+      ['pitchHz', 650], ['pitchHz', 700], ['keyerSpeed', 31],
+    ]);
+    r.dispose();
+  });
+
+  it('retains reading compatibility when both optional feedback props are omitted', () => {
+    const onLevelChange = vi.fn();
+    const r = render(base(), { onLevelChange });
+    expect(r.input('pitchHz')?.dataset.commandPhase).toBeUndefined();
+    expect(r.input('keyerSpeed')?.dataset.commandPhase).toBeUndefined();
+    slide(r.input('pitchHz')!, 725);
+    slide(r.input('keyerSpeed')!, 31);
+    expect(onLevelChange.mock.calls).toEqual([['pitchHz', 725], ['keyerSpeed', 31]]);
     r.dispose();
   });
 });

--- a/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
@@ -357,10 +357,10 @@ describe('CW pitch and keyer speed own independent command feedback', () => {
 
   it.each([
     ['idle', false, 600, null],
-    ['submitted', true, 600, null],
-    ['queued', true, 600, null],
-    ['dispatched', true, 600, null],
-    ['awaiting-confirmation', true, 600, null],
+    ['submitted', true, 725, null],
+    ['queued', true, 725, null],
+    ['dispatched', true, 725, null],
+    ['awaiting-confirmation', true, 725, null],
     ['confirmed', false, 725, 'confirmed'],
     ['failed', false, 600, 'failed'],
     ['timed-out', false, 600, 'timed-out'],
@@ -384,6 +384,93 @@ describe('CW pitch and keyer speed own independent command feedback', () => {
     expect(r.input('pitchHz').dataset.commandPhase).toBe(phase);
     expect(r.input('pitchHz').getAttribute('aria-busy')).toBe(String(busy));
     if (phase === 'failed') expect(r.row('pitchHz').textContent).toContain('pitch rejected');
+    r.dispose();
+  });
+
+  it.each([
+    ['pitchHz', 'cw-pitch', 600, 725],
+    ['keyerSpeed', 'keyer-speed', 24, 31],
+  ] as const)('mounts and remounts %s at its pre-existing active target', (
+    field, control, confirmed, targetValue,
+  ) => {
+    const pending = cwFeedback(control, 'awaiting-confirmation', {
+      confirmed, target: targetValue, requestedTarget: targetValue,
+      lifecycleId: `${control}-command`, transitionId: `${control}-awaiting`,
+    });
+    const renderPending = () => field === 'pitchHz'
+      ? renderReactiveCwLevels(pending) : renderReactiveCwLevels(undefined, pending);
+    let r = renderPending();
+    expect(r.input(field).value).toBe(String(targetValue));
+    expect(r.onLevelChange).not.toHaveBeenCalled();
+    r.dispose(); target.innerHTML = '';
+    r = renderPending();
+    expect(r.input(field).value).toBe(String(targetValue));
+    expect(r.onLevelChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it.each([
+    ['pitchHz', 'cw-pitch', 600, 725],
+    ['keyerSpeed', 'keyer-speed', 24, 31],
+  ] as const)('keeps terminal %s requested target distinct from canonical display', (
+    field, control, confirmed, requestedTarget,
+  ) => {
+    const terminal = cwFeedback(control, 'failed', {
+      confirmed, requestedTarget, lifecycleId: `${control}-command`,
+      transitionId: `${control}-failed`, outcome: { phase: 'failed', error: 'rejected' },
+    });
+    const r = field === 'pitchHz'
+      ? renderReactiveCwLevels(terminal) : renderReactiveCwLevels(undefined, terminal);
+    expect(r.input(field).value).toBe(String(confirmed));
+    expect(r.input(field).getAttribute('aria-valuenow')).toBe(String(confirmed));
+    expect(r.row(field).querySelector('output')?.textContent).toContain(String(confirmed));
+    expect(r.row(field).querySelector('output')?.textContent).not.toContain(String(requestedTarget));
+    r.dispose();
+  });
+
+  it.each([
+    ['pitchHz', 'cw-pitch', 600, 605, 725],
+    ['keyerSpeed', 'keyer-speed', 24, 25, 31],
+  ] as const)('invalidates and reissues the %s live event across authority replacement', (
+    field, control, confirmed, rerendered, requestedTarget,
+  ) => {
+    const failed = (canonical: number, providerGeneration = 1, sessionEpoch = 1) => cwFeedback(
+      control, 'failed', {
+        confirmed: canonical, requestedTarget, providerGeneration, sessionEpoch,
+        lifecycleId: `${control}-command`, transitionId: `${control}-failed`,
+        outcome: { phase: 'failed', error: 'rejected' },
+      },
+    );
+    const r = field === 'pitchHz'
+      ? renderReactiveCwLevels(failed(confirmed))
+      : renderReactiveCwLevels(undefined, failed(confirmed));
+    const status = () => r.row(field).querySelector<HTMLElement>('[data-cw-feedback-status]');
+    const initial = status()!;
+    const initialText = initial.textContent;
+    const update = (next: CwLevelFeedback) => {
+      if (field === 'pitchHz') r.props.cwPitchFeedback = next;
+      else r.props.keySpeedFeedback = next;
+      flushSync();
+    };
+    update(failed(rerendered));
+    expect(status()).toBe(initial);
+    expect(status()?.textContent).toBe(initialText);
+
+    update(failed(rerendered, 2, 2));
+    const replaced = status()!;
+    expect(replaced).not.toBe(initial);
+    expect(replaced.textContent).toBe(initialText);
+    expect(r.row(field).querySelectorAll('[data-cw-feedback-status]')).toHaveLength(1);
+
+    update(cwFeedback(control, 'unavailable', {
+      confirmed: null, availability: 'unavailable', providerGeneration: 3, sessionEpoch: 3,
+    }));
+    expect(status()).toBeNull();
+    update(failed(rerendered, 3, 3));
+    expect(status()).not.toBeNull();
+    expect(status()).not.toBe(replaced);
+    expect(status()?.textContent).toBe(initialText);
+    expect(r.row(field).querySelectorAll('[data-cw-feedback-status]')).toHaveLength(1);
     r.dispose();
   });
 


### PR DESCRIPTION
## Scope

- Linked task: [MOR-2411](https://linear.app/morozsm/issue/MOR-2411/adopt-existing-cw-pitch-and-keyer-speed-feedback-in-the-native)
- Wire the existing CW Pitch and Keyer Speed feedback accessors through `SemanticRadioSurfaces` using its subscribed control session.
- Give each native range its own continuous-scalar owner, renderer lease, active-target display projection, authority-scoped issued announcement, phase/error projection, and polite emitter while preserving immediate input and the existing Break-in Delay committed scalar.
- Compatibility impact: none; omitted feedback props retain isolated reading compatibility, while explicit unavailable feedback remains authoritative.

## Verification

- [x] Focused matrix: 12 test files, 294 tests passed (`npm test -- --run ...`).
- [x] Frontend type and Svelte checks passed (`npm run check`).
- [x] Changed-file ESLint passed (`npx eslint` on the five leased files).
- [x] Boundary lint passed (`npm run lint:boundaries`).
- [x] Production frontend build passed (`npm run build`; existing dynamic/static import chunk warning only).
- [x] Public/open-core boundary checked.
- [x] Release or migration impact: none.

## Agent Review

- [x] Independent exact-head review completed.
- Reviewer: independent task 01a0764b-13f0-7e52-a6f7-122f4f2371bd.
- Result: PASS aa68b239cd785a73c8aa5b2ea55c65b3a4ca93c6 ([review](https://github.com/rigplane/rigplane-core/pull/3264#issuecomment-5559105218)); required quick and Agent Review Gate, plus selected visual, passed at this head.

## Notes

- Exactly the five MOR-2411 leased files changed: 576 insertions, 15 deletions (591 A+D).
- First ordinary correction is commit `aa68b239cd785a73c8aa5b2ea55c65b3a4ca93c6`; it addresses authority-scoped announcement invalidation, pre-existing active-target display, and the stale ownership comment.
- No descriptor, adapter, store, fixture, baseline, provider, TX/PTT, or Break-in Delay implementation changes.
- Out of scope: FilterSurface follow-up, provider polling guarantees, and MOR-1682 range/profile expansion.