### PR TITLE
MOR-2413: Invalidate Filter Width announcements by authority

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/semantic-discrete-pending-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-discrete-pending-wiring.component.test.ts
@@ -62,13 +62,18 @@ vi.mock('$lib/transport/ws-client', async (importOriginal) => {
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 import { setCapabilities, clearCapabilities } from '$lib/stores/capabilities.svelte';
 import { setRadioState, resetRadioState } from '$lib/stores/radio.svelte';
-import { acknowledgeCommand, getCommandLifecycles, resetCommandLifecycle } from '$lib/stores/commands.svelte';
+import {
+  acknowledgeCommand, failCommand, getCommandLifecycles, resetCommandLifecycle,
+} from '$lib/stores/commands.svelte';
 import { dispatchRadioIntent } from '$lib/runtime/commands/radio-intents';
 import { sendCommand } from '$lib/transport/ws-client';
 import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
 
 const PROVIDER_GENERATION = 0;
-const fresh = { storePath: 'x', observed: true, freshness: 'fresh' as const, availability: 'available' as const };
+const fresh = {
+  storePath: 'x', observed: true, freshness: 'fresh' as const,
+  availability: 'available' as const, lastObservedMonotonic: 1,
+};
 
 /**
  * Single-receiver (IC-7300/FTX-1-shaped) fixture — the live-bench topology
@@ -299,6 +304,45 @@ describe('discrete pending markers reach the mounted DOM over the real wiring pa
     // accessor (e.g. reading `pendingPreamp` here) would mark every choice,
     // or none, rather than the one actually in flight.
     expect(q('[data-testid="filter-select-1"]')!.dataset.pending).toBe('false');
+  });
+
+  it('clears the native Filter Width announcement when its real-store evidence becomes unavailable', () => {
+    vi.useFakeTimers();
+    try {
+      render();
+      const input = q<HTMLInputElement>('[data-testid="filter-width"] input')!;
+      expect(input.disabled).toBe(false);
+      input.value = '3000';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      vi.advanceTimersByTime(201);
+      flushSync();
+
+      const command = getCommandLifecycles().find(candidate => candidate.name === 'set_filter_width');
+      expect(command).toBeDefined();
+      failCommand(command!.id, command!.originalEpoch, command!.originalEpoch, 'radio refused width');
+      flushSync();
+
+      const first = q<HTMLElement>('[data-testid="filter-width"] [data-control-feedback-status]');
+      expect(first).not.toBeNull();
+      expect(sendCommand).toHaveBeenCalledExactlyOnceWith(
+        'set_filter_width', { width: 3000, receiver: 0 }, expect.any(String),
+      );
+
+      const unavailable = liveState();
+      expect(setRadioState({
+        ...unavailable, revision: 2, stateRevision: 2, freshnessRevision: 2, observationSeq: 2,
+        fieldStatus: {
+          ...unavailable.fieldStatus,
+          'main.filterWidth': { ...fresh, observed: false, lastObservedMonotonic: 2 },
+        },
+      })).toBe(true);
+      flushSync();
+
+      expect(q('[data-testid="filter-width"] [data-control-feedback-status]')).toBeNull();
+      expect(sendCommand).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('marks the clicked preamp choice pending while set_preamp is in flight (RfFrontEndSurface)', () => {

--- a/frontend/src/semantic/FilterSurface.svelte
+++ b/frontend/src/semantic/FilterSurface.svelte
@@ -161,10 +161,44 @@
   let filterWidthLease: ContinuousScalarRendererLease | null = $state(null);
   const initialFilterWidthView = untrack(() => filterWidthScalar.view);
   let filterWidthView: Readonly<ContinuousScalarView> = $state(initialFilterWidthView);
-  const statusOf = (current: Readonly<ContinuousScalarView>): string | null =>
-    current.announcement === null ? null
-      : current.error === null ? current.announcement : `${current.announcement}: ${current.error}`;
-  let filterWidthAnnouncement: string | null = $state(statusOf(initialFilterWidthView));
+  type IssuedFilterWidthAnnouncement = Readonly<{
+    authorityKey: string;
+    eventKey: string;
+    text: string;
+  }>;
+  function filterWidthAuthorityKey(current: Readonly<ContinuousScalarView>): string {
+    const domain = current.domain;
+    const shared = [
+      current.evidence, current.editable, domain.min, domain.max, domain.step,
+      domain.defaultValue, domain.fineStepDivisor, domain.keyboardStep,
+    ];
+    if (current.evidence === 'reading') {
+      return JSON.stringify([...shared, current.reading.status]);
+    }
+    const feedback = current.feedback;
+    return JSON.stringify([
+      ...shared, feedback.providerGeneration ?? null, feedback.sessionEpoch,
+      feedback.availability, feedback.scope.control, feedback.scope.receiver, feedback.scope.slot,
+    ]);
+  }
+  function nextFilterWidthAnnouncement(
+    current: Readonly<ContinuousScalarView>,
+    previous: IssuedFilterWidthAnnouncement | null,
+  ): IssuedFilterWidthAnnouncement | null {
+    const authorityKey = filterWidthAuthorityKey(current);
+    const issued = current.presentation?.politeAnnouncement;
+    if (issued === null || issued === undefined || current.announcement === null) {
+      return previous?.authorityKey === authorityKey ? previous : null;
+    }
+    return Object.freeze({
+      authorityKey,
+      eventKey: JSON.stringify([authorityKey, issued.transitionId]),
+      text: current.error === null ? current.announcement : `${current.announcement}: ${current.error}`,
+    });
+  }
+  let filterWidthAnnouncement: IssuedFilterWidthAnnouncement | null = $state(
+    nextFilterWidthAnnouncement(initialFilterWidthView, null),
+  );
   $effect(() => {
     const lease = filterWidthScalar.attachRenderer();
     filterWidthLease = lease;
@@ -174,8 +208,9 @@
     const next = filterWidthLease === null
       ? filterWidthScalar.view : filterWidthLease.view;
     filterWidthView = next;
-    const status = statusOf(next);
-    if (status !== null) filterWidthAnnouncement = status;
+    filterWidthAnnouncement = nextFilterWidthAnnouncement(
+      next, untrack(() => filterWidthAnnouncement),
+    );
   });
   onDestroy(() => filterWidthScalar.destroy());
   function modeInstrument() {
@@ -273,8 +308,10 @@
           />
           <output>{textOf(modeFilter.filterWidth)}</output>
           {#if filterWidthAnnouncement !== null}
-            <span class="sr-only" role="status" aria-live="polite" aria-atomic="true"
-              data-control-feedback-status>{filterWidthAnnouncement}</span>
+            {#key filterWidthAnnouncement.eventKey}
+              <span class="sr-only" role="status" aria-live="polite" aria-atomic="true"
+                data-control-feedback-status>{filterWidthAnnouncement.text}</span>
+            {/key}
           {/if}
         </label>
       {/if}

--- a/frontend/src/semantic/__tests__/FilterSurface.test.ts
+++ b/frontend/src/semantic/__tests__/FilterSurface.test.ts
@@ -718,6 +718,85 @@ describe('full Filter Width scalar feedback', () => {
     }) });
   });
 
+  it('retains an issued status only while its presentation authority is unchanged', () => {
+    const state = new SvelteMap<string, Readonly<CommandScalarFeedback>>();
+    state.set('feedback', widthFeedback('failed', {
+      requestedTarget: 3000, outcome: { phase: 'failed', error: 'radio refused width' },
+      lifecycleId: '7:width', transitionId: '7:width:failed',
+    }));
+    const surface = render(base(), {}, {
+      get filterWidthFeedback() { return state.get('feedback')!; },
+    });
+    try {
+      const status = surface.group('filter-width')!.querySelector('[data-control-feedback-status]')!;
+      const frozen = status.textContent;
+
+      flushSync(() => state.set('feedback', widthFeedback('idle', { confirmed: 2500 })));
+
+      const retained = surface.group('filter-width')!.querySelector('[data-control-feedback-status]');
+      expect(retained).toBe(status);
+      expect(retained?.textContent).toBe(frozen);
+
+      flushSync(() => state.set('feedback', widthFeedback('unavailable', {
+        confirmed: null, availability: 'unavailable',
+      })));
+
+      expect(surface.group('filter-width')!.querySelector('[data-control-feedback-status]')).toBeNull();
+    } finally { void surface.dispose(); }
+  });
+
+  it.each([
+    ['provider', { providerGeneration: 2 }],
+    ['session', { sessionEpoch: 8 }],
+    ['scope', { scope: { control: 'filter-width', receiver: 1 as const } }],
+  ])('clears an issued status when %s authority is replaced without a fresh event', (_name, authority) => {
+    const state = new SvelteMap<string, Readonly<CommandScalarFeedback>>();
+    state.set('feedback', widthFeedback('failed', {
+      providerGeneration: 1, requestedTarget: 3000,
+      outcome: { phase: 'failed', error: 'radio refused width' },
+      lifecycleId: '7:width', transitionId: '7:width:failed',
+    }));
+    const surface = render(base(), {}, {
+      get filterWidthFeedback() { return state.get('feedback')!; },
+    });
+    try {
+      expect(surface.group('filter-width')!.querySelector('[data-control-feedback-status]')).not.toBeNull();
+
+      flushSync(() => state.set('feedback', widthFeedback('idle', {
+        providerGeneration: 1, ...authority,
+      })));
+
+      expect(surface.group('filter-width')!.querySelector('[data-control-feedback-status]')).toBeNull();
+    } finally { void surface.dispose(); }
+  });
+
+  it('replaces the live node for a fresh same-text event under replacement authority', () => {
+    const state = new SvelteMap<string, Readonly<CommandScalarFeedback>>();
+    const failure = {
+      requestedTarget: 3000, outcome: { phase: 'failed' as const, error: 'radio refused width' },
+      lifecycleId: 'width', transitionId: 'width:failed',
+    };
+    state.set('feedback', widthFeedback('failed', {
+      ...failure, providerGeneration: 1, sessionEpoch: 7,
+    }));
+    const surface = render(base(), {}, {
+      get filterWidthFeedback() { return state.get('feedback')!; },
+    });
+    try {
+      const first = surface.group('filter-width')!.querySelector('[data-control-feedback-status]')!;
+
+      flushSync(() => state.set('feedback', widthFeedback('failed', {
+        ...failure, providerGeneration: 2, sessionEpoch: 8,
+      })));
+
+      const statuses = surface.group('filter-width')!.querySelectorAll('[data-control-feedback-status]');
+      expect(statuses).toHaveLength(1);
+      expect(statuses[0]).not.toBe(first);
+      expect(statuses[0].textContent).toBe('Failed: 3000: radio refused width');
+      expect(statuses[0].textContent?.match(/radio refused width/g)).toHaveLength(1);
+    } finally { void surface.dispose(); }
+  });
+
   it('makes forced input inert when feedback is unavailable', () => {
     const request = vi.fn();
     withSurface(base(), (surface) => {


### PR DESCRIPTION
## Summary

- retain native Filter Width announcement text only while the captured scalar presentation authority is unchanged
- clear stale live-region output on availability, provider, session, or scope replacement
- key fresh owner events by authority and transition so identical text still produces a new DOM mutation
- preserve native thumb preview and the canonical sibling readout

Linear: https://linear.app/morozsm/issue/MOR-2413/correct-native-filter-width-announcement-invalidation-using-the

## Verification

- RED: 5 isolated assertions failed before the production change (four authority-clearing cases and same-text DOM replacement)
- RED wiring witness: after correcting the test harness for the real 200ms command debounce, the final unavailable-authority assertion failed with the retained terminal status still mounted
- GREEN: 105 tests across the two changed test files
- focused regression matrix: 450 tests across 15 Filter Width, adapter, scalar-owner, ownership, and debt-guard files
- `npm run check`
- `npm run lint`
- `npm run lint:boundaries`
- `npm run i18n:check`
- `git diff --check`
- Focused development checks: https://github.com/rigplane/rigplane-core/actions/runs/34033918142

## Independent review

PASS at the exact PR head: https://github.com/rigplane/rigplane-core/pull/3266#issuecomment-5559328349. Required quick and Agent Review Gate, plus selected visual, passed before merge. The review wording was clarified to acknowledge the test harness's existing unrelated managed-TX mocks; the investigated Filter command/store/projector path remains real.
