### PR TITLE
MOR-2417: Register raw TX/VOX command feedback

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -64,6 +64,7 @@ import {
   KEY_SPEED_COMMAND_DESCRIPTOR,
   RF_GAIN_COMMAND_DESCRIPTOR, SQUELCH_COMMAND_DESCRIPTOR,
   STATE_BACKED_COMMAND_DESCRIPTORS,
+  TX_AUX_COMMAND_DESCRIPTORS,
   beginCommand, getStateBackedCommandDescriptor,
 } from '$lib/stores/commands.svelte';
 import {
@@ -106,7 +107,9 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     expect(getStateBackedCommandDescriptor('set_filter_width')).toBe(FILTER_WIDTH_COMMAND_DESCRIPTOR);
     expect([...STATE_BACKED_COMMAND_DESCRIPTORS.keys()]).toEqual([
       'set_filter_width', 'set_break_in_delay', 'set_rf_gain', 'set_squelch',
-      'set_cw_pitch', 'set_key_speed',
+      'set_cw_pitch', 'set_key_speed', 'set_mic_gain', 'set_drive_gain',
+      'set_vox_gain', 'set_anti_vox_gain', 'set_vox_delay',
+      'set_compressor_level', 'set_monitor_gain',
     ]);
     expect(RADIO_INTENT_NAMES).toContain(FILTER_WIDTH_COMMAND_DESCRIPTOR.intentName);
     const main = FILTER_WIDTH_COMMAND_DESCRIPTOR.scope(command({ params: { width: 3000, receiver: 0 } }))!;
@@ -499,6 +502,13 @@ describe('Break-in Delay ControlFeedback projection (MOR-1744)', () => {
       ['set_squelch', SQUELCH_COMMAND_DESCRIPTOR],
       ['set_cw_pitch', CW_PITCH_COMMAND_DESCRIPTOR],
       ['set_key_speed', KEY_SPEED_COMMAND_DESCRIPTOR],
+      ['set_mic_gain', TX_AUX_COMMAND_DESCRIPTORS.micGain],
+      ['set_drive_gain', TX_AUX_COMMAND_DESCRIPTORS.driveGain],
+      ['set_vox_gain', TX_AUX_COMMAND_DESCRIPTORS.voxGain],
+      ['set_anti_vox_gain', TX_AUX_COMMAND_DESCRIPTORS.antiVoxGain],
+      ['set_vox_delay', TX_AUX_COMMAND_DESCRIPTORS.voxDelay],
+      ['set_compressor_level', TX_AUX_COMMAND_DESCRIPTORS.compressorLevel],
+      ['set_monitor_gain', TX_AUX_COMMAND_DESCRIPTORS.monitorGain],
     ]);
     const scope = BREAK_IN_DELAY_COMMAND_DESCRIPTOR.scope(delayCommand());
     expect(scope).toEqual({ control: 'break-in-delay', receiver: 0 });

--- a/frontend/src/lib/runtime/adapters/__tests__/support/TxAuxFeedbackDerivedProbe.svelte
+++ b/frontend/src/lib/runtime/adapters/__tests__/support/TxAuxFeedbackDerivedProbe.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { getTxAuxControlFeedback } from '../../panel-adapters';
+
+  const feedback = $derived(getTxAuxControlFeedback('micGain'));
+</script>
+
+<output
+  data-phase={feedback.phase}
+  data-availability={feedback.availability}
+  data-confirmed={feedback.confirmed ?? ''}
+  data-target={feedback.target ?? ''}
+  data-outcome={feedback.outcome?.phase ?? ''}
+  data-provider={feedback.providerGeneration ?? ''}
+  data-session={feedback.sessionEpoch}
+></output>

--- a/frontend/src/lib/runtime/adapters/__tests__/tx-aux-command-feedback.component.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/tx-aux-command-feedback.component.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+const h = vi.hoisted(() => ({
+  session: { state: 'disconnected' as 'connected' | 'disconnected', epoch: -1 },
+}));
+
+// The runtime facade is the only outer mock. Its state and capability getters
+// read the real reactive stores; controlSession deliberately remains plain,
+// matching the production getter rather than creating a test-only dependency.
+vi.mock('$lib/runtime/frontend-runtime', async () => {
+  const radio = await import('$lib/stores/radio.svelte');
+  const capabilities = await import('$lib/stores/capabilities.svelte');
+  return { runtime: {
+    get state() { return radio.getRadioState(); },
+    get caps() { return capabilities.getCapabilities(); },
+    get controlSession() { return h.session; },
+  } };
+});
+vi.mock('$lib/runtime/commands/radio-intents', async (importOriginal) => ({
+  ...await importOriginal<typeof import('$lib/runtime/commands/radio-intents')>(),
+  currentControlSessionEpoch: () => h.session.epoch,
+}));
+
+import TxAuxFeedbackDerivedProbe from './support/TxAuxFeedbackDerivedProbe.svelte';
+import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
+import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
+import {
+  acknowledgeCommand, beginCommand, resetCommandLifecycle,
+} from '$lib/stores/commands.svelte';
+
+const receiver = {
+  freqHz: 14_200_000, mode: 'USB', filter: 1, dataMode: 0, sMeter: 0,
+  att: 0, preamp: 0, nb: false, nr: false, afLevel: 0.5, rfGain: 0.5, squelch: 0,
+};
+const fresh = (marker: number) => ({
+  storePath: 'fixture', observed: true, freshness: 'fresh' as const,
+  availability: 'available' as const, lastObservedMonotonic: marker,
+});
+function capabilities(providerGeneration: number): Capabilities {
+  return {
+    stateContractVersion: 1, providerGeneration, receivers: 1,
+    capabilities: ['tx'],
+  } as unknown as Capabilities;
+}
+function radioState(
+  providerGeneration: number, revision: number, micGain: number, marker: number,
+): ServerState {
+  return {
+    stateContractVersion: 1, providerGeneration,
+    revision, stateRevision: revision, freshnessRevision: revision, observationSeq: revision,
+    updatedAt: `2026-09-06T14:00:0${revision}Z`, active: 'MAIN',
+    ptt: false, split: false, dualWatch: false, tunerStatus: 0,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: receiver.freqHz },
+    main: { ...receiver },
+    connection: { rigConnected: true, radioReady: true, controlConnected: true },
+    micGain,
+    fieldStatus: { micGain: fresh(marker) },
+  } as unknown as ServerState;
+}
+
+let component: ReturnType<typeof mount> | null = null;
+let target: HTMLDivElement | null = null;
+function render(): HTMLOutputElement {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(TxAuxFeedbackDerivedProbe, { target });
+  flushSync();
+  const output = target.querySelector('output');
+  if (!(output instanceof HTMLOutputElement)) throw new Error('TX/VOX probe did not mount');
+  return output;
+}
+
+afterEach(() => {
+  if (component !== null) void unmount(component);
+  component = null; target?.remove(); target = null;
+  resetCommandLifecycle(); resetRadioState(); clearCapabilities();
+  h.session = { state: 'disconnected', epoch: -1 };
+});
+
+describe('mounted raw TX/VOX feedback recovery', () => {
+  it('reactively recovers one persistent derived consumer across lifecycle and authority replacement', () => {
+    resetCommandLifecycle(); resetRadioState(); clearCapabilities();
+    h.session = { state: 'disconnected', epoch: -1 };
+    const probe = render();
+    expect(probe.dataset).toMatchObject({
+      phase: 'unavailable', availability: 'unavailable', confirmed: '',
+      target: '', outcome: '', provider: '', session: '-1',
+    });
+
+    h.session = { state: 'connected', epoch: 7 };
+    flushSync();
+    expect(probe.dataset.phase).toBe('unavailable');
+    expect(setCapabilities(capabilities(3))).toBe(true);
+    expect(setRadioState(radioState(3, 1, 120, 1))).toBe(true);
+    flushSync();
+    expect(probe.dataset).toMatchObject({
+      phase: 'idle', availability: 'available', confirmed: '120',
+      target: '', provider: '3', session: '7',
+    });
+
+    const command = beginCommand({
+      id: 'mic-7', name: 'set_mic_gain', params: { level: 128 }, originalEpoch: 7,
+    });
+    flushSync();
+    expect(probe.dataset).toMatchObject({ phase: 'submitted', confirmed: '120', target: '128' });
+
+    acknowledgeCommand(command.id, 7, 7);
+    flushSync();
+    expect(probe.dataset).toMatchObject({
+      phase: 'awaiting-confirmation', confirmed: '120', target: '128', outcome: '',
+    });
+
+    expect(setRadioState(radioState(3, 2, 127, 2))).toBe(true);
+    flushSync();
+    expect(probe.dataset.phase).toBe('awaiting-confirmation');
+    expect(setRadioState(radioState(3, 3, 128, 3))).toBe(true);
+    flushSync();
+    expect(probe.dataset).toMatchObject({
+      phase: 'confirmed', confirmed: '128', target: '', outcome: 'confirmed',
+    });
+
+    h.session = { state: 'disconnected', epoch: 8 };
+    flushSync();
+    expect(probe.dataset.phase).toBe('confirmed');
+    resetRadioState(); clearCapabilities();
+    flushSync();
+    expect(probe.dataset).toMatchObject({
+      phase: 'unavailable', availability: 'unavailable', confirmed: '',
+      provider: '', session: '8',
+    });
+
+    h.session = { state: 'connected', epoch: 8 };
+    expect(setCapabilities(capabilities(4))).toBe(true);
+    expect(setRadioState(radioState(4, 1, 130, 1))).toBe(true);
+    flushSync();
+    expect(probe.dataset).toMatchObject({
+      phase: 'idle', availability: 'available', confirmed: '130',
+      target: '', outcome: '', provider: '4', session: '8',
+    });
+
+    beginCommand({
+      id: 'mic-8', name: 'set_mic_gain', params: { level: 140 }, originalEpoch: 8,
+    });
+    flushSync();
+    expect(probe.dataset).toMatchObject({
+      phase: 'submitted', confirmed: '130', target: '140',
+      provider: '4', session: '8',
+    });
+    expect(target!.querySelector('output')).toBe(probe);
+  });
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/tx-aux-command-feedback.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/tx-aux-command-feedback.isolated.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+const h = vi.hoisted(() => ({
+  state: null as ServerState | null,
+  caps: null as Capabilities | null,
+  session: { state: 'disconnected' as 'connected' | 'disconnected', epoch: -1 },
+  stateReads: 0, capsReads: 0, sessionReads: 0,
+  listeners: new Set<(state: ServerState | null) => void>(),
+}));
+
+// Only the runtime-owned state/capability/session inputs and radio-store
+// subscription are replaceable test boundaries. Descriptor parsing,
+// lifecycle storage, reconciliation, projection, and qualification stay real.
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    get state() { h.stateReads += 1; return h.state; },
+    get caps() { h.capsReads += 1; return h.caps; },
+    get controlSession() { h.sessionReads += 1; return h.session; },
+  },
+}));
+vi.mock('$lib/stores/radio.svelte', () => ({
+  getRadioState: () => h.state,
+  subscribeRadioState: (listener: (state: ServerState | null) => void) => {
+    h.listeners.add(listener);
+    listener(h.state);
+    return () => h.listeners.delete(listener);
+  },
+}));
+
+import {
+  TX_AUX_COMMAND_DESCRIPTORS, acknowledgeCommand, beginCommand,
+  cancelPendingCommands, failCommand, getCommandLifecycle, resetCommandLifecycle,
+} from '$lib/stores/commands.svelte';
+import {
+  getTxAuxControlFeedback, type TxAuxControlFeedbackField,
+} from '../panel-adapters';
+
+const FIELDS = [
+  'micGain', 'driveGain', 'voxGain', 'antiVoxGain', 'voxDelay',
+  'compressorLevel', 'monitorGain',
+] as const satisfies readonly TxAuxControlFeedbackField[];
+const ALL_CAPABILITIES = ['tx', 'drive_gain', 'vox', 'compressor', 'monitor'];
+const VALUES: Readonly<Record<TxAuxControlFeedbackField, number>> = {
+  micGain: 120, driveGain: 121, voxGain: 122, antiVoxGain: 123,
+  voxDelay: 10, compressorLevel: 124, monitorGain: 125,
+};
+const REQUIRED: Readonly<Record<TxAuxControlFeedbackField, readonly string[]>> = {
+  micGain: ['tx'], driveGain: ['tx', 'drive_gain'],
+  voxGain: ['tx', 'vox'], antiVoxGain: ['tx', 'vox'], voxDelay: ['tx', 'vox'],
+  compressorLevel: ['tx', 'compressor'], monitorGain: ['tx', 'monitor'],
+};
+const connected = { state: 'connected' as const, epoch: 7 };
+
+const fresh = (marker = 1) => ({
+  storePath: 'fixture', observed: true, freshness: 'fresh' as const,
+  availability: 'available' as const, lastObservedMonotonic: marker,
+});
+function state(over: Record<string, unknown> = {}): ServerState {
+  return {
+    stateContractVersion: 1, providerGeneration: 3, active: 'MAIN', main: {}, sub: {},
+    ...VALUES,
+    fieldStatus: Object.fromEntries(FIELDS.map(field => [field, fresh()])),
+    ...over,
+  } as unknown as ServerState;
+}
+function caps(over: Record<string, unknown> = {}): Capabilities {
+  return {
+    stateContractVersion: 1, providerGeneration: 3,
+    capabilities: [...ALL_CAPABILITIES], ...over,
+  } as unknown as Capabilities;
+}
+function emitState(next: ServerState): void {
+  h.state = next;
+  for (const listener of h.listeners) listener(next);
+}
+function begin(
+  field: TxAuxControlFeedbackField, target: number, id: string = field, timeoutMs = 5_000,
+) {
+  const descriptor = TX_AUX_COMMAND_DESCRIPTORS[field];
+  return beginCommand({
+    id, name: descriptor.intentName, params: { level: target },
+    originalEpoch: h.session.epoch, timeoutMs,
+  });
+}
+
+describe('qualified raw TX/VOX command feedback', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetCommandLifecycle();
+    h.state = state(); h.caps = caps(); h.session = connected;
+    h.stateReads = 0; h.capsReads = 0; h.sessionReads = 0;
+  });
+
+  afterEach(() => {
+    resetCommandLifecycle();
+    vi.useRealTimers();
+  });
+
+  it('reads all reactive authority inputs before failing closed', () => {
+    h.state = null; h.caps = null;
+    h.session = { state: 'disconnected', epoch: -1 };
+    const feedback = getTxAuxControlFeedback('micGain');
+    expect([h.stateReads, h.capsReads, h.sessionReads]).toEqual([1, 1, 1]);
+    expect(feedback).toMatchObject({
+      confirmed: null, target: null, requestedTarget: null,
+      phase: 'unavailable', availability: 'unavailable', busy: false,
+      sessionEpoch: -1, scope: { control: 'mic-gain', receiver: 0 },
+    });
+  });
+
+  it.each(FIELDS)('projects exact raw submitted feedback for %s', field => {
+    const target = field === 'voxDelay' ? 20 : VALUES[field] + 10;
+    begin(field, target);
+    const feedback = getTxAuxControlFeedback(field, connected);
+    expect(feedback).toMatchObject({
+      confirmed: VALUES[field], target, requestedTarget: target,
+      phase: 'submitted', availability: 'available', busy: true,
+      providerGeneration: 3, sessionEpoch: 7,
+      scope: { control: TX_AUX_COMMAND_DESCRIPTORS[field].scope({ params: { level: 0 } })!.control,
+        receiver: 0 },
+    });
+    expect(h.sessionReads).toBe(0);
+  });
+
+  it('keeps ACK awaiting across active-receiver, other-field, stale, and mismatch observations', () => {
+    h.state = state({ micGain: 100 });
+    const command = begin('micGain', 128, 'mic');
+    expect(getTxAuxControlFeedback('micGain', connected).phase).toBe('submitted');
+    acknowledgeCommand(command.id, 7, 7);
+    expect(getTxAuxControlFeedback('micGain', connected)).toMatchObject({
+      phase: 'awaiting-confirmation', target: 128, scope: { control: 'mic-gain', receiver: 0 },
+    });
+
+    emitState(state({
+      active: 'SUB', micGain: 100,
+      fieldStatus: { ...state().fieldStatus, micGain: fresh(1), driveGain: fresh(2) },
+    }));
+    expect(getCommandLifecycle(command.id, 7)?.status).toBe('acknowledged');
+    expect(getTxAuxControlFeedback('micGain', connected).scope.receiver).toBe(0);
+
+    emitState(state({ micGain: 127, fieldStatus: { ...state().fieldStatus, micGain: fresh(2) } }));
+    emitState(state({
+      micGain: 128,
+      fieldStatus: { ...state().fieldStatus, micGain: { ...fresh(3), freshness: 'stale' } },
+    }));
+    expect(getCommandLifecycle(command.id, 7)?.status).toBe('acknowledged');
+
+    emitState(state({ micGain: 128, fieldStatus: { ...state().fieldStatus, micGain: fresh(4) } }));
+    expect(getCommandLifecycle(command.id, 7)?.status).toBe('confirmed');
+    expect(getTxAuxControlFeedback('micGain', connected)).toMatchObject({
+      confirmed: 128, target: null, requestedTarget: 128,
+      phase: 'confirmed', outcome: { phase: 'confirmed' }, busy: false,
+    });
+  });
+
+  it('selects the latest target per control while independent controls coexist', () => {
+    const micA = begin('micGain', 100, 'mic-a');
+    begin('driveGain', 200, 'drive');
+    begin('micGain', 150, 'mic-b');
+    expect(getTxAuxControlFeedback('micGain', connected)).toMatchObject({
+      target: 150, requestedTarget: 150,
+    });
+    expect(getTxAuxControlFeedback('driveGain', connected)).toMatchObject({
+      target: 200, requestedTarget: 200,
+    });
+    expect(getTxAuxControlFeedback('micGain', connected).lifecycleId)
+      .not.toContain(micA.id);
+  });
+
+  it.each([
+    ['failed', 'micGain', (id: string) => failCommand(id, 7, 7, 'radio refused')],
+    ['timed-out', 'driveGain', () => vi.advanceTimersByTime(26)],
+    ['cancelled', 'voxGain', () => cancelPendingCommands(7, 'session-disconnected')],
+  ] as const)('projects the real %s terminal outcome', (phase, field, complete) => {
+    const command = begin(field, VALUES[field] + 1, phase, 25);
+    complete(command.id);
+    expect(getTxAuxControlFeedback(field, connected)).toMatchObject({
+      target: null, requestedTarget: VALUES[field] + 1,
+      phase, outcome: { phase }, busy: false,
+    });
+  });
+
+  it.each(FIELDS)('requires the declared capability set for %s', field => {
+    for (const missing of REQUIRED[field]) {
+      h.caps = caps({ capabilities: ALL_CAPABILITIES.filter(tag => tag !== missing) });
+      expect(getTxAuxControlFeedback(field, connected)).toMatchObject({
+        availability: 'unavailable', confirmed: null, target: null,
+      });
+    }
+  });
+
+  it.each([
+    ['not observed', { ...fresh(), observed: false }, VALUES.micGain],
+    ['stale', { ...fresh(), freshness: 'stale' as const }, VALUES.micGain],
+    ['unavailable', { ...fresh(), availability: 'unavailable' as const }, VALUES.micGain],
+    ['missing marker', { ...fresh(), lastObservedMonotonic: undefined }, VALUES.micGain],
+    ['fractional truth', fresh(), 120.5],
+    ['boolean truth', fresh(), true],
+  ])('rejects %s field evidence without retaining canonical truth', (_name, evidence, value) => {
+    h.state = state({
+      micGain: value,
+      fieldStatus: { ...state().fieldStatus, micGain: evidence },
+    });
+    expect(getTxAuxControlFeedback('micGain', connected)).toMatchObject({
+      availability: 'unavailable', confirmed: null, target: null,
+      requestedTarget: null, phase: 'unavailable', outcome: null,
+    });
+  });
+
+  it.each([
+    ['disconnected', { state: 'disconnected' as const, epoch: 7 }, state(), caps()],
+    ['invalid epoch', { state: 'connected' as const, epoch: -1 }, state(), caps()],
+    ['missing state', connected, null, caps()],
+    ['missing caps', connected, state(), null],
+    ['state contract', connected, state({ stateContractVersion: 2 }), caps()],
+    ['caps contract', connected, state(), caps({ stateContractVersion: 2 })],
+    ['provider mismatch', connected, state(), caps({ providerGeneration: 4 })],
+  ])('returns explicit unavailable feedback for %s authority', (
+    _name, session, currentState, currentCaps,
+  ) => {
+    h.state = currentState; h.caps = currentCaps;
+    expect(getTxAuxControlFeedback('monitorGain', session)).toMatchObject({
+      confirmed: null, target: null, requestedTarget: null,
+      phase: 'unavailable', availability: 'unavailable', busy: false,
+    });
+  });
+
+  it('fences old provider and session records and recovers from current authority inputs', () => {
+    begin('compressorLevel', 200, 'old');
+    expect(getTxAuxControlFeedback('compressorLevel', connected).phase).toBe('submitted');
+
+    h.state = state({ providerGeneration: 4 });
+    h.caps = caps({ providerGeneration: 4 });
+    expect(getTxAuxControlFeedback('compressorLevel', connected)).toMatchObject({
+      providerGeneration: 4, confirmed: VALUES.compressorLevel,
+      phase: 'idle', target: null, outcome: null,
+    });
+
+    const epoch8 = { state: 'connected' as const, epoch: 8 };
+    h.session = epoch8;
+    expect(getTxAuxControlFeedback('compressorLevel')).toMatchObject({
+      sessionEpoch: 8, phase: 'idle', target: null,
+    });
+    h.session = { state: 'disconnected', epoch: 8 };
+    expect(getTxAuxControlFeedback('compressorLevel').availability).toBe('unavailable');
+
+    h.session = epoch8;
+    begin('compressorLevel', 210, 'current');
+    expect(getTxAuxControlFeedback('compressorLevel')).toMatchObject({
+      providerGeneration: 4, sessionEpoch: 8, target: 210, phase: 'submitted',
+    });
+  });
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/tx-aux-command-feedback.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/tx-aux-command-feedback.isolated.test.ts
@@ -85,7 +85,7 @@ function begin(
   });
 }
 
-describe('qualified raw TX/VOX command feedback', () => {
+describe('imperative qualified raw TX/VOX command feedback', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     resetCommandLifecycle();
@@ -227,7 +227,7 @@ describe('qualified raw TX/VOX command feedback', () => {
     });
   });
 
-  it('fences old provider and session records and recovers from current authority inputs', () => {
+  it('imperatively projects current authority after provider and session replacement', () => {
     begin('compressorLevel', 200, 'old');
     expect(getTxAuxControlFeedback('compressorLevel', connected).phase).toBe('submitted');
 

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -40,12 +40,14 @@ import {
   KEY_SPEED_COMMAND_DESCRIPTOR,
   RF_GAIN_COMMAND_DESCRIPTOR,
   SQUELCH_COMMAND_DESCRIPTOR,
+  TX_AUX_COMMAND_DESCRIPTORS,
   getCommandLifecycles,
   isCommandLifecycleSuperseded,
   type CommandLifecycle,
   type ControlFeedbackScope,
   type StateBackedCommandDescriptor,
   type StateBackedRepeatPolicy,
+  type TxAuxCommandFeedbackField,
 } from '$lib/stores/commands.svelte';
 import { currentControlSessionEpoch } from '../commands/radio-intents';
 import type { ServerState } from '$lib/types/state';
@@ -437,6 +439,48 @@ export function getKeySpeedControlFeedback(
   return getGlobalCwControlFeedback(
     currentControlSession, KEY_SPEED_COMMAND_DESCRIPTOR, 'keyer-speed', 'keySpeed',
   );
+}
+
+export type TxAuxControlFeedbackField = TxAuxCommandFeedbackField;
+const TX_AUX_FEEDBACK_CAPABILITIES: Readonly<Record<
+  TxAuxControlFeedbackField, readonly string[]
+>> = Object.freeze({
+  micGain: Object.freeze(['tx']),
+  driveGain: Object.freeze(['tx', 'drive_gain']),
+  voxGain: Object.freeze(['tx', 'vox']),
+  antiVoxGain: Object.freeze(['tx', 'vox']),
+  voxDelay: Object.freeze(['tx', 'vox']),
+  compressorLevel: Object.freeze(['tx', 'compressor']),
+  monitorGain: Object.freeze(['tx', 'monitor']),
+});
+
+/** Qualified radio-global TX/VOX feedback; receiver 0 is only stable identity. */
+export function getTxAuxControlFeedback(
+  field: TxAuxControlFeedbackField,
+  currentControlSession?: ControlSessionSnapshot,
+): Readonly<ControlFeedback<number>> {
+  const state = runtime.state;
+  const caps = runtime.caps;
+  const commands = getCommandLifecycles();
+  const session = currentControlSession ?? runtime.controlSession;
+  const epoch = Number.isSafeInteger(session.epoch) && session.epoch >= 0 ? session.epoch : -1;
+  const descriptor = TX_AUX_COMMAND_DESCRIPTORS[field];
+  const scope = descriptor.scope({ params: { level: 0 } })!;
+  const feedback = projectControlFeedback(
+    descriptor, state, commands, scope, epoch, isCommandLifecycleSuperseded,
+  );
+  try {
+    const tags = Array.isArray(caps?.capabilities) ? caps.capabilities : [];
+    const structural = TX_AUX_FEEDBACK_CAPABILITIES[field].every(tag => tags.includes(tag));
+    const observation = qualifyRadioDisplayObservation({
+      state, caps, path: field, structural, value: state?.[field],
+    });
+    return session.state === 'connected' && epoch >= 0
+      && observation.state === 'current' && Number.isSafeInteger(observation.value)
+      ? feedback : unavailableControlFeedback(feedback);
+  } catch {
+    return unavailableControlFeedback(feedback);
+  }
 }
 
 type RfSqlFeedbackLane = Readonly<{

--- a/frontend/src/lib/stores/__tests__/commands.test.ts
+++ b/frontend/src/lib/stores/__tests__/commands.test.ts
@@ -251,7 +251,9 @@ describe('command lifecycle store', () => {
 
       expect([...store.STATE_BACKED_COMMAND_DESCRIPTORS.keys()]).toEqual([
         'set_filter_width', 'set_break_in_delay', 'set_rf_gain', 'set_squelch',
-        'set_cw_pitch', 'set_key_speed',
+        'set_cw_pitch', 'set_key_speed', 'set_mic_gain', 'set_drive_gain',
+        'set_vox_gain', 'set_anti_vox_gain', 'set_vox_delay',
+        'set_compressor_level', 'set_monitor_gain',
       ]);
       expect(rfMain).toEqual({ control: 'rf-gain', receiver: 0 });
       expect(rfSub).toEqual({ control: 'rf-gain', receiver: 1 });
@@ -363,7 +365,9 @@ describe('command lifecycle store', () => {
     it('registers exact global scopes, fields, targets, and canonical values', () => {
       expect([...store.STATE_BACKED_COMMAND_DESCRIPTORS.keys()]).toEqual([
         'set_filter_width', 'set_break_in_delay', 'set_rf_gain', 'set_squelch',
-        'set_cw_pitch', 'set_key_speed',
+        'set_cw_pitch', 'set_key_speed', 'set_mic_gain', 'set_drive_gain',
+        'set_vox_gain', 'set_anti_vox_gain', 'set_vox_delay',
+        'set_compressor_level', 'set_monitor_gain',
       ]);
       const pitchScope = store.CW_PITCH_COMMAND_DESCRIPTOR.scope({ params: { value: 640 } })!;
       const speedScope = store.KEY_SPEED_COMMAND_DESCRIPTOR.scope({ params: { speed: 27 } })!;
@@ -420,6 +424,96 @@ describe('command lifecycle store', () => {
       expect(status()).toBe('acknowledged');
       emitState(observed(target, 4));
       emitState(observed(mismatch, 5));
+      emitState(observed(target, 6, 'stale'));
+      expect(status()).toBe('acknowledged');
+      emitState(observed(target, 7));
+      expect(status()).toBe('confirmed');
+    });
+  });
+
+  describe('raw TX/VOX state-backed descriptors', () => {
+    const registrations = [
+      ['micGain', 'set_mic_gain', 'mic-gain', 128],
+      ['driveGain', 'set_drive_gain', 'drive-gain', 127],
+      ['voxGain', 'set_vox_gain', 'vox-gain', 64],
+      ['antiVoxGain', 'set_anti_vox_gain', 'anti-vox-gain', 192],
+      ['voxDelay', 'set_vox_delay', 'vox-delay', 10],
+      ['compressorLevel', 'set_compressor_level', 'compressor-level', 96],
+      ['monitorGain', 'set_monitor_gain', 'monitor-level', 160],
+    ] as const;
+
+    it.each(registrations)('registers %s as exact raw global command %s', (
+      field, intentName, control, midpoint,
+    ) => {
+      const descriptor = store.TX_AUX_COMMAND_DESCRIPTORS[field];
+      const scope = descriptor.scope({ params: { level: midpoint } })!;
+      expect(descriptor.intentName).toBe(intentName);
+      expect(store.getStateBackedCommandDescriptor(intentName)).toBe(descriptor);
+      expect(scope).toEqual({ control, receiver: 0 });
+      expect(descriptor.fieldPath(scope)).toBe(field);
+      for (const value of [0, midpoint, field === 'voxDelay' ? 20 : 255]) {
+        expect(descriptor.target({ params: { level: value } })).toBe(value);
+        expect(descriptor.confirmed({ [field]: value } as unknown as ServerState, scope)).toBe(value);
+        expect(descriptor.matches(value, value)).toBe(true);
+      }
+      expect(descriptor.matches(midpoint + 1, midpoint)).toBe(false);
+    });
+
+    it('rejects malformed level envelopes for every TX/VOX descriptor', () => {
+      const inherited = Object.create({ level: 10 }) as Record<string, unknown>;
+      const throwing = Object.defineProperty({}, 'level', {
+        enumerable: true, get: () => { throw new Error('read'); },
+      });
+      const ownKeysTrap = new Proxy({}, { ownKeys: () => { throw new Error('keys'); } });
+      const malformed = [
+        {}, inherited, { level: true }, { level: '10' }, { level: 10.5 },
+        { level: Number.POSITIVE_INFINITY }, { level: Number.MAX_VALUE },
+        { level: 10, receiver: 0 }, { level: 10, extra: true },
+        { level: 10, [Symbol('extra')]: true }, throwing, ownKeysTrap,
+      ];
+      for (const descriptor of Object.values(store.TX_AUX_COMMAND_DESCRIPTORS)) {
+        for (const params of malformed) {
+          expect(descriptor.scope({ params })).toBeNull();
+          expect(descriptor.target({ params })).toBeNull();
+        }
+      }
+    });
+
+    it('supersedes only the same TX/VOX control while independent controls remain live', () => {
+      const micA = store.beginCommand({
+        id: 'mic-a', name: 'set_mic_gain', params: { level: 100 }, originalEpoch: 7,
+      });
+      const drive = store.beginCommand({
+        id: 'drive', name: 'set_drive_gain', params: { level: 100 }, originalEpoch: 7,
+      });
+      const micB = store.beginCommand({
+        id: 'mic-b', name: 'set_mic_gain', params: { level: 200 }, originalEpoch: 7,
+      });
+      expect(store.isCommandLifecycleSuperseded(micA)).toBe(true);
+      expect(store.isCommandLifecycleSuperseded(micB)).toBe(false);
+      expect(store.isCommandLifecycleSuperseded(drive)).toBe(false);
+    });
+
+    it.each(registrations)('confirms %s only from a newer fresh exact raw observation', (
+      field, intentName, _control, target,
+    ) => {
+      const observed = (
+        value: number, marker: number, freshness: 'fresh' | 'stale' = 'fresh',
+      ): ServerState => ({
+        stateContractVersion: 1, providerGeneration: 3, [field]: value,
+        fieldStatus: { [field]: {
+          observed: true, freshness, availability: 'available', lastObservedMonotonic: marker,
+        } },
+      } as unknown as ServerState);
+      emitState(observed(target - 1, 4));
+      const command = store.beginCommand({
+        id: intentName, name: intentName, params: { level: target }, originalEpoch: 7,
+      });
+      store.acknowledgeCommand(command.id, 7, 7);
+      const status = () => store.getCommandLifecycle(command.id, 7)?.status;
+      expect(status()).toBe('acknowledged');
+      emitState(observed(target, 4));
+      emitState(observed(target - 1, 5));
       emitState(observed(target, 6, 'stale'));
       expect(status()).toBe('acknowledged');
       emitState(observed(target, 7));

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -184,6 +184,43 @@ export const KEY_SPEED_COMMAND_DESCRIPTOR: StateBackedCommandDescriptor<number> 
   matches: (confirmed: number, target: number) => confirmed === target,
 });
 
+export type TxAuxCommandFeedbackField =
+  | 'micGain' | 'driveGain' | 'voxGain' | 'antiVoxGain' | 'voxDelay'
+  | 'compressorLevel' | 'monitorGain';
+type TxAuxCommandFeedbackIntent =
+  | 'set_mic_gain' | 'set_drive_gain' | 'set_vox_gain' | 'set_anti_vox_gain'
+  | 'set_vox_delay' | 'set_compressor_level' | 'set_monitor_gain';
+
+function rawTxAuxCommandDescriptor(
+  intentName: TxAuxCommandFeedbackIntent,
+  control: string,
+  field: TxAuxCommandFeedbackField,
+): StateBackedCommandDescriptor<number> {
+  const target = (command: Pick<CommandLifecycle, 'params'>): number | null =>
+    exactSafeIntegerTarget(command, 'level');
+  return Object.freeze({
+    intentName, repeatPolicy: 'latest-target-wins' as const,
+    scope: (command: Pick<CommandLifecycle, 'params'>) => target(command) === null
+      ? null : Object.freeze({ control, receiver: 0 as const }),
+    fieldPath: () => field,
+    target,
+    confirmed: (state: ServerState) => safeInteger(state[field]),
+    matches: (confirmed: number, requested: number) => confirmed === requested,
+  });
+}
+
+export const TX_AUX_COMMAND_DESCRIPTORS = Object.freeze({
+  micGain: rawTxAuxCommandDescriptor('set_mic_gain', 'mic-gain', 'micGain'),
+  driveGain: rawTxAuxCommandDescriptor('set_drive_gain', 'drive-gain', 'driveGain'),
+  voxGain: rawTxAuxCommandDescriptor('set_vox_gain', 'vox-gain', 'voxGain'),
+  antiVoxGain: rawTxAuxCommandDescriptor('set_anti_vox_gain', 'anti-vox-gain', 'antiVoxGain'),
+  voxDelay: rawTxAuxCommandDescriptor('set_vox_delay', 'vox-delay', 'voxDelay'),
+  compressorLevel: rawTxAuxCommandDescriptor(
+    'set_compressor_level', 'compressor-level', 'compressorLevel',
+  ),
+  monitorGain: rawTxAuxCommandDescriptor('set_monitor_gain', 'monitor-level', 'monitorGain'),
+}) satisfies Readonly<Record<TxAuxCommandFeedbackField, StateBackedCommandDescriptor<number>>>;
+
 export const STATE_BACKED_COMMAND_DESCRIPTORS: ReadonlyMap<RadioIntentName, StateBackedCommandDescriptor<unknown>> =
   new Map([
     [FILTER_WIDTH_COMMAND_DESCRIPTOR.intentName, FILTER_WIDTH_COMMAND_DESCRIPTOR],
@@ -192,6 +229,9 @@ export const STATE_BACKED_COMMAND_DESCRIPTORS: ReadonlyMap<RadioIntentName, Stat
     [SQUELCH_COMMAND_DESCRIPTOR.intentName, SQUELCH_COMMAND_DESCRIPTOR],
     [CW_PITCH_COMMAND_DESCRIPTOR.intentName, CW_PITCH_COMMAND_DESCRIPTOR],
     [KEY_SPEED_COMMAND_DESCRIPTOR.intentName, KEY_SPEED_COMMAND_DESCRIPTOR],
+    ...Object.values(TX_AUX_COMMAND_DESCRIPTORS).map(
+      descriptor => [descriptor.intentName, descriptor] as const,
+    ),
   ]);
 export const getStateBackedCommandDescriptor = (intentName: string): StateBackedCommandDescriptor<unknown> | undefined =>
   (STATE_BACKED_COMMAND_DESCRIPTORS as ReadonlyMap<string, StateBackedCommandDescriptor<unknown>>).get(intentName);


### PR DESCRIPTION
## Summary

- register seven exact raw-integer TX/VOX descriptors in the existing state-backed command registry
- add one typed, qualified global accessor with the accepted capability and top-level observation table
- preserve stable global identity across active receiver changes and existing latest-target-wins reconciliation
- cover strict `{level}` envelopes, ACK/readback, authority replacement, terminal outcomes, capability/evidence failure, and recovery with the real store/projector/qualifier path
- add a persistent mounted `$derived` witness proving automatic recovery across provider/session authority replacement

Linear: https://linear.app/morozsm/issue/MOR-2417/register-existing-full-feedback-descriptors-and-accessors-for-seven

The live lease was expanded by the coordinator from four to five files after the required Filter lifecycle regression exposed two exact full-registry assertions. The correction review then authorized two exact witness files, bringing the atomic batch to seven files and 618 changed lines. This exceeds the six-file/600-line soft threshold because the seven-entry registry contract, its exact registry assertions, and the mounted reactive witness must land together; no unrelated scope or production refactor is included.

## Review correction

The first exact-head review correctly found that the authority-recovery evidence was imperative: it mutated plain mock inputs and directly called the accessor again. The corrected head keeps all seven-field imperative coverage, labels it accurately, and adds one mounted Svelte consumer whose `$derived` reads the actual accessor.

The witness mounts once while unavailable, uses real reactive radio/capability stores and the real command store/projector/qualifier, then observes ready, submitted, ACK, mismatch, exact confirmation, provider/session reset, unavailable, recovered idle, and a new submitted command without refresh, direct accessor recall, or remount. `controlSession` remains deliberately plain/nonreactive; state and capabilities are cleared and repopulated so the witness would fail if the accessor returned before subscribing to those reactive reads.

## Verification

- RED: 51 failed, 37 passed before descriptor/accessor registration
- changed store/adapter tests: 88 passed
- corrected mounted witness: 1 passed
- selected CW, RF/SQL, Filter, command-store, and TX/VOX matrix: 173 passed across 7 files
- `npm run check`
- `npm run lint`
- `npm run lint:boundaries`
- `npm run i18n:check`
- `git diff --check`
- original focused workflow (superseded head): https://github.com/rigplane/rigplane-core/actions/runs/34037073417

## Test boundaries

The imperative adapter suite replaces runtime-owned state/capability/session inputs and the radio-store subscription while retaining the real descriptor parsing, command lifecycle storage, reconciliation, projection, qualification, and terminal retention implementations.

The mounted witness replaces the outer runtime facade: its state and capability getters read the real reactive stores, while its control-session getter reads a plain object. A partial `radio-intents` mock overrides `currentControlSessionEpoch`; the witness calls `beginCommand` with explicit `originalEpoch` values. The command store, descriptor registry, projector, qualifier, and Svelte `$derived` consumer remain real. These boundaries are visible in `tx-aux-command-feedback.component.test.ts`.