### PR TITLE
MOR-2419: Reconcile native power targets exactly

### DIFF
--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -876,6 +876,8 @@ def _pending_value_for_intent(intent: CommandIntent) -> Any:
 
 def _expected_value_for_path(intent: CommandIntent, path: FieldPath) -> Any:
     value = _pending_value_for_path(intent.params, path)
+    if intent.name in {"set_rf_power", "set_power"} and path.name == "power_level":
+        return value
     if _should_normalize_level_expectation(intent.name, path):
         return _normalize_raw_level_value(value)
     return value
@@ -885,61 +887,34 @@ def _should_normalize_level_expectation(name: str, path: FieldPath) -> bool:
     return _NORMALIZED_LEVEL_EXPECTATION_COMMANDS.get(name) == path.name
 
 
-def _power_level_expectation_from_param(
+def resolve_power_level_target(
     value: Any,
     *,
+    power_native_unit: str | None = None,
     power_max_watts: int | float | None = None,
-) -> int | float:
-    """Coerce ``set_rf_power``/``set_power``'s StateStore expectation param.
+) -> tuple[int, float]:
+    """Resolve the native power integer and its exact normalized readback."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"level {value!r} must be an int or a normalized float")
 
-    MOR-1579 round 3: this used to be a plain ``int(raw_level)``, so a
-    normalized float level (e.g. ``0.4`` from the web power slider —
-    ``control.py``'s ``_level_for_power`` treats ``set_rf_power`` as
-    type-dispatched, same as ``set_af_level``) collapsed to
-    ``int(0.4) == 0``. The StateStore overlay/expectation then sat at 0%
-    for the optimistic-update TTL before jumping to the real readback —
-    the same snap-back class MOR-1579 fixes for ``rf_gain``/``squelch``,
-    reproduced here on every single power-slider move rather than only at
-    a boundary value.
-
-    ``_normalize_raw_level_value`` (below) always divides this value by
-    255 to recover the normalized overlay value, and *both* backends'
-    readbacks normalize to that same fraction ``v`` regardless of unit —
-    Icom CI-V as ``raw / 255``, Yaesu CAT as ``watts / max_watts`` (see
-    ``backends/yaesu_cat/observations.py``'s ``_normalize_power_level``).
-    So for a float input the coherent expectation is ``round(v * 255)``,
-    independent of ``native_power_unit`` — no radio object needed here
-    (unlike ``control.py``'s ``_level_for_power``, which *does* need
-    ``profile.max_watts`` to compute the correct *actuation* value for a
-    watts radio). This is exact for ``raw_255`` radios; for a ``watts``
-    radio it is accurate to within 1/255 of full scale, since
-    ``round(v * max_watts) / max_watts`` (the real readback's
-    quantization) and ``round(v * 255) / 255`` (this expectation's
-    quantization) are different roundings of the same ``v`` and don't
-    always land on the same value — in practice most float positions on
-    a watts radio simply expire by TTL instead of confirming
-    ``reconciled``, rather than snapping to a visibly wrong overlay (the
-    residual error is bounded at <=0.2% of full scale).
-
-    A bare int is the documented raw/watts wire value. When the ingress
-    supplies a positive profile ``power_max_watts`` for a watts-native
-    radio, retain the existing 0-255 expectation representation while
-    scaling that raw watts value to the same normalized fraction as the
-    readback. Callers for raw-255 radios omit the optional profile value.
-    """
-    if isinstance(value, float) and not isinstance(value, bool):
-        if not (0.0 <= value <= 1.0):
-            raise ValueError(f"level {value!r} is out of the normalized 0.0-1.0 domain")
-        return max(0, min(255, round(value * 255)))
-    if (
-        isinstance(value, int)
-        and not isinstance(value, bool)
-        and isinstance(power_max_watts, (int, float))
+    valid_max = (
+        isinstance(power_max_watts, (int, float))
         and not isinstance(power_max_watts, bool)
         and power_max_watts > 0
-    ):
-        return value * 255 / power_max_watts
-    return int(value)
+    )
+    watts_native = power_native_unit == "watts" or (
+        power_native_unit is None and valid_max
+    )
+    scale = float(power_max_watts) if watts_native and valid_max else 255.0
+    upper = int(power_max_watts) if watts_native and valid_max else 255
+
+    if isinstance(value, float):
+        if not (0.0 <= value <= 1.0):
+            raise ValueError(f"level {value!r} is out of the normalized 0.0-1.0 domain")
+        native = max(0, min(upper, round(value * scale)))
+    else:
+        native = value
+    return native, native / scale
 
 
 def _normalize_raw_level_value(value: Any) -> Any:
@@ -1136,6 +1111,7 @@ def command_intent_from_request(
     command_id: str | None = None,
     session_id: str | None = None,
     timeout: float | None = 2.0,
+    power_native_unit: str | None = None,
     power_max_watts: int | float | None = None,
 ) -> CommandIntent:
     """Normalize a production command request into a backend-neutral intent."""
@@ -1208,8 +1184,9 @@ def command_intent_from_request(
         raw_level = (
             normalized["level"] if "level" in normalized else normalized["value"]
         )
-        normalized["power_level"] = _power_level_expectation_from_param(
+        _, normalized["power_level"] = resolve_power_level_target(
             raw_level,
+            power_native_unit=power_native_unit,
             power_max_watts=power_max_watts,
         )
     elif command_name == "set_split":

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -14,6 +14,7 @@ from ...core.command_service import (
     CommandExecutionResult,
     CommandService,
     command_intent_from_request,
+    resolve_power_level_target,
 )
 from ...core.command_dispatch import (
     CommandUnsupportedError,
@@ -275,24 +276,12 @@ def _level_for_power(value: Any, radio: Any) -> int:
     produced (any value ``> 1`` passed through raw) but by accident of
     bucketing on magnitude rather than by declared type.
     """
-    if isinstance(value, bool):
-        raise ValueError(f"level {value!r} must be an int or a normalized float")
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        if not (0.0 <= value <= 1.0):
-            raise ValueError(f"level {value!r} is out of the normalized 0.0-1.0 domain")
-        if getattr(radio, "native_power_unit", "raw_255") == "watts":
-            profile = getattr(radio, "profile", None)
-            max_watts = getattr(profile, "max_watts", None)
-            if (
-                isinstance(max_watts, (int, float))
-                and not isinstance(max_watts, bool)
-                and max_watts > 0
-            ):
-                return max(0, min(int(max_watts), round(value * max_watts)))
-        return max(0, min(255, round(value * 255)))
-    raise ValueError(f"level {value!r} must be an int or a normalized float")
+    native, _ = resolve_power_level_target(
+        value,
+        power_native_unit=getattr(radio, "native_power_unit", "raw_255"),
+        power_max_watts=getattr(getattr(radio, "profile", None), "max_watts", None),
+    )
+    return int(native)
 
 
 class ControlHandler:
@@ -1464,7 +1453,8 @@ class ControlHandler:
             if isinstance(receiver_count, int) and not isinstance(receiver_count, bool):
                 intent_params["receiver_count"] = receiver_count
         power_max_watts = None
-        if getattr(self._radio, "native_power_unit", "raw_255") == "watts":
+        power_native_unit = getattr(self._radio, "native_power_unit", "raw_255")
+        if power_native_unit == "watts":
             power_max_watts = getattr(
                 getattr(self._radio, "profile", None), "max_watts", None
             )
@@ -1495,6 +1485,7 @@ class ControlHandler:
                 source=source,
                 command_id=command_id,
                 session_id=self._session_id if source == "websocket" else None,
+                power_native_unit=power_native_unit,
                 power_max_watts=power_max_watts,
             )
         executor = (

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -19,6 +19,7 @@ from rigplane.core.command_service import (
     PendingOverlay,
     command_intent_from_request,
     command_response_observation,
+    resolve_power_level_target,
 )
 from rigplane.core.exceptions import TimeoutError as RigplaneTimeoutError
 from rigplane.core.state_pipeline_contracts import (
@@ -1412,7 +1413,10 @@ async def test_level_command_readback_expectations_are_normalized_but_params_sta
 
     assert executor.intents == [intent]
     assert executor.intents[0].params["level"] == params["level"]
-    assert executor.intents[0].params[path.name] == params["level"]
+    expected_param = (
+        cast(int, params["level"]) / 255 if name == "set_rf_power" else params["level"]
+    )
+    assert executor.intents[0].params[path.name] == expected_param
     assert service.readback_expectations(
         source="websocket",
         session_id="client-a",
@@ -1631,78 +1635,120 @@ def test_public_api_sync_squelch_actuation_value_is_not_reinterpreted() -> None:
     assert intent.params["squelch"] == 1
 
 
-def test_power_level_float_expectation_matches_readback_scale() -> None:
-    """MOR-1579 round 3 regression (red-first leg): the ``set_rf_power``
-    expectation branch used to do a plain ``int(raw_level)``, so a
-    normalized float level (e.g. ``0.4`` from the web power slider —
-    ``control.py``'s ``_level_for_power`` treats ``set_rf_power`` as
-    type-dispatched, same as ``set_af_level``) collapsed to
-    ``int(0.4) == 0``. The StateStore overlay/expectation then sat at 0%
-    for the optimistic-update TTL on *every single power-slider move*
-    (not just a boundary value like the rf_gain/squelch raw-1 case),
-    before jumping to the real readback — the same snap-back class this
-    PR fixes elsewhere.
-
-    Both backends' readbacks normalize to the same fraction ``v``
-    regardless of unit (Icom CI-V as ``raw / 255``, Yaesu CAT as
-    ``watts / max_watts`` — see
-    ``backends/yaesu_cat/observations.py``'s ``_normalize_power_level``),
-    so the coherent expectation for a float input is ``round(v * 255)``
-    for *both* units, independent of ``native_power_unit`` — no radio
-    object needed here.
-    """
+def test_watts_float_power_expectation_uses_native_quantization() -> None:
     intent = command_intent_from_request(
         "set_rf_power",
-        {"level": 0.4},
+        {"level": 0.5},
         source="websocket",
         command_id="ws-set_rf_power",
         session_id="client-a",
+        power_native_unit="watts",
+        power_max_watts=100,
     )
     path = FieldPath.global_("operator_controls", "power_level")
 
-    # Param is coerced to the raw scale the radio actually receives — not 0.
-    assert intent.params["power_level"] == 102  # round(0.4 * 255)
-
-    # The expectation/overlay value the readback reconciles against is the
-    # normalized form of that same raw value (~0.4), not 0.0.
+    assert intent.params["level"] == 0.5
+    assert intent.params["power_level"] == 0.5
     observation = command_response_observation(
         intent,
         timestamp_monotonic=70.0,
         provider="test",
     )
     assert str(intent.target) == str(path)
-    assert observation.value == pytest.approx(102 / 255)
-    assert observation.value == pytest.approx(0.4, abs=0.01)
+    assert observation.value == 0.5
 
 
 @pytest.mark.parametrize(
-    ("name", "level", "expected"),
+    ("name", "param_name", "level", "expected"),
     [
-        ("set_rf_power", 50, 0.5),
-        ("set_power", 50, 0.5),
-        ("set_rf_power", 0.4, 102 / 255),
-        ("set_power", 0.4, 102 / 255),
+        ("set_rf_power", "level", 0.5, 0.5),
+        ("set_power", "value", 1, 0.01),
     ],
 )
 def test_power_expectations_share_canonical_and_alias_contract(
     name: str,
+    param_name: str,
     level: int | float,
     expected: float,
 ) -> None:
-    """A watts profile input applies only to integer power commands."""
     intent = command_intent_from_request(
         name,
-        {"level": level},
+        {param_name: level},
         source="http",
+        power_native_unit="watts",
         power_max_watts=100,
     )
 
+    assert intent.params[param_name] == level
     observation = command_response_observation(
         intent,
         timestamp_monotonic=70.0,
         provider="test",
     )
-    assert observation.value == pytest.approx(expected)
+    assert observation.value == expected
+
+
+@pytest.mark.parametrize(
+    ("max_watts", "requested", "native", "expected"),
+    [
+        (10, 0.0, 0, 0.0),
+        (10, 0.25, 2, 0.2),
+        (10, 1.0, 10, 1.0),
+        (100, 0.5, 50, 0.5),
+        (200, 0.5, 100, 0.5),
+    ],
+)
+def test_power_target_resolver_uses_native_watts_quantization(
+    max_watts: int,
+    requested: float,
+    native: int,
+    expected: float,
+) -> None:
+    assert resolve_power_level_target(
+        requested,
+        power_native_unit="watts",
+        power_max_watts=max_watts,
+    ) == (native, expected)
+
+
+@pytest.mark.parametrize(
+    ("requested", "expected_native", "expected"),
+    [
+        (0.5, 128, 128 / 255),
+        (255, 255, 1.0),
+    ],
+)
+def test_raw_power_target_ignores_incidental_watts_metadata(
+    requested: int | float,
+    expected_native: int,
+    expected: float,
+) -> None:
+    assert resolve_power_level_target(
+        requested,
+        power_native_unit="raw_255",
+        power_max_watts=100,
+    ) == (expected_native, expected)
+
+
+@pytest.mark.parametrize("power_max_watts", [None, 0, -1, True])
+def test_watts_power_target_invalid_metadata_falls_back_to_raw_scale(
+    power_max_watts: int | None,
+) -> None:
+    assert resolve_power_level_target(
+        0.5,
+        power_native_unit="watts",
+        power_max_watts=power_max_watts,
+    ) == (128, 128 / 255)
+
+
+@pytest.mark.parametrize("requested", [True, -0.01, 1.01, "0.5"])
+def test_power_target_rejects_bool_out_of_domain_and_non_numeric_values(
+    requested: object,
+) -> None:
+    with pytest.raises(ValueError):
+        resolve_power_level_target(
+            requested, power_native_unit="watts", power_max_watts=100
+        )
 
 
 @pytest.mark.parametrize("power_max_watts", [None, 0, -1])
@@ -1747,7 +1793,7 @@ async def test_raw_external_rigctld_level_readback_normalizes_before_reconcile()
 
     await service.execute(intent)
     assert intent.params["level"] == 64
-    assert intent.params["power_level"] == 64
+    assert intent.params["power_level"] == 64 / 255
 
     service.apply_observation(
         Observation(

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import struct
 import time
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -1092,6 +1093,42 @@ async def test_enqueue_set_rf_power_yaesu_tags_watts_unit() -> None:
     await handler2._enqueue_command("set_rf_power", {"level": 0.8})
     assert queue2.items[-1].level == 204
     assert queue2.items[-1].unit == "raw_255"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("name", "max_watts", "requested", "native", "expected"),
+    [
+        ("set_rf_power", 10, 0.25, 2, 0.2),
+        ("set_power", 100, 0.5, 50, 0.5),
+        ("set_rf_power", 100, 1, 1, 0.01),
+        ("set_power", 200, 0.5, 100, 0.5),
+    ],
+)
+async def test_enqueue_watts_power_uses_exact_native_pending_target(
+    name: str,
+    max_watts: int,
+    requested: int | float,
+    native: int,
+    expected: float,
+) -> None:
+    queue = _QueueRecorder()
+    server = SimpleNamespace(command_queue=queue, command_state_store=StateStore())
+    radio = _capable_radio()
+    radio.native_power_unit = "watts"
+    radio.profile = replace(radio.profile, max_watts=max_watts)
+    handler = _control_handler(radio=radio, server=server, session_id="ws-power")
+
+    await handler._enqueue_command(name, {"level": requested})
+
+    assert isinstance(queue.items[-1], SetPower)
+    assert queue.items[-1].level == native
+    assert queue.items[-1].unit == "watts"
+    [pending] = handler._command_service.pending_overlays(  # noqa: SLF001
+        source="websocket",
+        session_id="ws-power",
+    )
+    assert pending.value == expected
 
 
 @pytest.mark.asyncio

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -3400,6 +3400,68 @@ async def test_ftx1_web_receiver_selection_writes_once_and_waits_for_vs_readback
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("requested", "native", "readback", "expected"),
+    [
+        (0.5, 50, "PC2050", 0.5),
+        (1, 1, "PC2001", 0.01),
+    ],
+)
+async def test_ftx1_power_readback_exactly_reconciles_native_target(
+    requested: int | float,
+    native: int,
+    readback: str,
+    expected: float,
+) -> None:
+    radio, handler, poller, store, accept = _real_ftx1_control_path()
+    service = handler._command_service  # noqa: SLF001
+    command_id = f"power-{native}"
+
+    await handler._enqueue_command(  # noqa: SLF001
+        "set_rf_power",
+        {"level": requested},
+        command_id=command_id,
+    )
+    [pending] = service.pending_overlays(
+        source="websocket", session_id="ws-ftx1", command_id=command_id
+    )
+    assert pending.value == expected
+
+    await poller._drain_commands()  # noqa: SLF001
+    radio._transport.write.assert_awaited_once_with(  # noqa: SLF001
+        f"PC2{native:03d};"
+    )
+
+    radio._transport.query = AsyncMock(return_value=readback)  # noqa: SLF001
+    radio.read_mic_gain = AsyncMock(return_value=0)
+    radio._config = replace(  # noqa: SLF001
+        radio._config,
+        capabilities=frozenset({"tx"}),  # noqa: SLF001
+    )
+    radio._profile_cache = None  # noqa: SLF001
+    observations = await YaesuObservationAdapter.from_radio(radio).poll_tx_controls()
+    [power] = [
+        observation
+        for observation in observations
+        if str(observation.path) == "global.operator_controls.power_level"
+    ]
+    assert power.value == expected
+
+    [matched] = poller._annotate_yaesu_readbacks(  # noqa: SLF001
+        poller._stamp_provider_generation((power,), store.provider_generation)  # noqa: SLF001
+    )
+    assert matched.correlation_id == command_id
+    accept((matched,))
+    assert (
+        service.pending_overlays(
+            source="websocket", session_id="ws-ftx1", command_id=command_id
+        )
+        == ()
+    )
+    assert service.lifecycle_events()[-1].state == "reconciled"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("failure", "expected_state"),
     [
         (CatTimeoutError("receiver dispatch timed out"), "timed_out"),


### PR DESCRIPTION
A normalized floating-point power request could actuate 50 W on a 100 W radio while command reconciliation expected 128/255 instead of 0.5. A native integer request for 1 W similarly expected an inexact value after an unnecessary 255-scale round trip.

Use one pure Core resolver for the native integer and its exact canonical target. The web actuation wrapper and command expectation consume the same result. Raw integer inputs, aliases, level/value inputs, raw-255 behavior, metadata fallback, and exact readback guards remain covered by the compatibility tests.

Linear: https://linear.app/morozsm/issue/MOR-2419/match-power-command-expectations-to-the-exact-backend-native-setpoint

Validation: the targeted seven-module pytest command recorded in the author handoff passed 646 tests; Ruff lint/format, strict web mypy, import-linter, and diff checks passed. Natural quick34037795227 passed at the reviewed head. The FTX-1 regression in tests/test_yaesu_cat_poller.py exercises the real command queue, CAT formatting, observation normalization, exact poller correlation, and CommandService reconciliation for 50 W and 1 W. Serial I/O is mocked; no hardware validation is claimed.

Independent exact-head PASS: https://github.com/rigplane/rigplane-core/pull/3270#issuecomment-5559802370 . No required corrections remain. Explicit normalized wire intent is separate MOR-2420 work; this change does not resolve JSON integer/float ambiguity.
