### PR TITLE
fix: preserve normalized AF/RF wire intent

### DIFF
--- a/docs/api/command-catalog.md
+++ b/docs/api/command-catalog.md
@@ -28,6 +28,33 @@ protocol examples.
 
 **Response shape:** on success the `result` object echoes accepted parameter values. Non-trivial response fields are listed in the Notes column.
 
+## Explicit normalized levels
+
+Browser controls that operate in the normalized `0.0`–`1.0` domain send
+`level_unit: "normalized"` with `set_af_level` and `set_rf_power`. The server
+validates that marker, consumes it before command binding, and converts the
+level to the radio's native integer scale. Untagged integer levels keep their
+native meaning. An untagged JSON decimal token such as `1.0` keeps the existing
+normalized-float meaning.
+
+The matching server must be installed before enabling a client that emits the
+marker. An older server can ignore the additional field and therefore can
+still misinterpret normalized endpoint `1` as native integer `1`.
+
+These are the canonical WebSocket wire examples used for the normalized AF/RF
+boundary:
+
+<!-- normalized-level-wire-vectors:start -->
+```jsonl
+{"type":"cmd","name":"set_af_level","id":"af-normalized-0","params":{"level":0,"receiver":0,"level_unit":"normalized"}}
+{"type":"cmd","name":"set_af_level","id":"af-normalized-half","params":{"level":0.5,"receiver":0,"level_unit":"normalized"}}
+{"type":"cmd","name":"set_af_level","id":"af-normalized-1","params":{"level":1,"receiver":0,"level_unit":"normalized"}}
+{"type":"cmd","name":"set_rf_power","id":"rf-normalized-0","params":{"level":0,"level_unit":"normalized"}}
+{"type":"cmd","name":"set_rf_power","id":"rf-normalized-half","params":{"level":0.5,"level_unit":"normalized"}}
+{"type":"cmd","name":"set_rf_power","id":"rf-normalized-1","params":{"level":1,"level_unit":"normalized"}}
+```
+<!-- normalized-level-wire-vectors:end -->
+
 ## Rate limiting
 
 `set_*` commands over WebSocket are physically enqueued at most once per 50 ms per client, per command name. Commands arriving before the interval expires are coalesced with last-value-wins semantics (MOR-1427) rather than dropped: the newest frame in the window always survives to the next paced enqueue. Any frame it replaces before that flush receives an immediate ACK with `{"superseded": true}` and is never enqueued; the surviving frame gets the normal enqueue ACK at the pacing boundary. HTTP endpoints are not throttled at this layer.
@@ -87,8 +114,8 @@ Use `set_freq` directly for bands that have no `bsrCode` in capabilities.
 | `ptt` | `state: bool` | — | Yes | `true`=TX on, `false`=TX off. Rejected in read-only mode. |
 | `ptt_on` | — | — | Yes | Equivalent to `ptt` with `state: true`. Rejected in read-only mode. |
 | `ptt_off` | — | — | Yes | Equivalent to `ptt` with `state: false`. Rejected in read-only mode. |
-| `set_rf_power` | `level: int` | `power_control` | Yes | Canonical. Level scale: 0–255 raw (Icom CI-V); watts (Yaesu CAT). Requires `PowerControlCapable`. |
-| `set_power` | `level: int` | `power_control` | Yes | Alias for `set_rf_power`. |
+| `set_rf_power` | `level: int \| float`, `level_unit?: "normalized"` | `power_control` | Yes | Canonical. Untagged integers are native: 0–255 raw (Icom CI-V) or watts (Yaesu CAT). Tagged levels are normalized 0.0–1.0. Requires `PowerControlCapable`. |
+| `set_power` | `level: int \| float`, `level_unit?: "normalized"` | `power_control` | Yes | Alias for `set_rf_power`. |
 | `set_powerstat` | `on?: bool=true` | `power_control` | Yes | Power the radio on or off via CI-V. |
 | `set_drive_gain` | `level: int` | `drive_gain` | Yes | Drive gain; radio-specific range. |
 
@@ -126,7 +153,7 @@ Use `set_freq` directly for bands that have no `bsrCode` in capabilities.
 
 | Command | Params | Capability | Batch | Notes |
 |---------|--------|------------|-------|-------|
-| `set_af_level` | `level: int`, `receiver?: int=0` | `af_level` | Yes | AF volume; 0–255 raw scale. |
+| `set_af_level` | `level: int \| float`, `level_unit?: "normalized"`, `receiver?: int=0` | `af_level` | Yes | Untagged integers use the native 0–255 scale. Tagged levels are normalized 0.0–1.0. |
 | `set_rf_gain` | `level: int`, `receiver?: int=0` | `rf_gain` | Yes | |
 | `set_sql` | `level: int`, `receiver?: int=0` | `squelch` | Yes | Canonical. |
 | `set_squelch` | `level: int`, `receiver?: int=0` | `squelch` | Yes | Alias for `set_sql`. |

--- a/frontend/src/components-v2/wiring/__tests__/tx-aux-command-bus.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/tx-aux-command-bus.isolated.test.ts
@@ -19,7 +19,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
 vi.mock('$lib/runtime/commands/radio-intents', async () => {
   const { sendCommand } = await import('$lib/transport/ws-client');
-  return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
+  return {
+    dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params),
+    isNormalizedLevel: (value: unknown): value is number =>
+      typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1,
+  };
 });
 vi.mock('$lib/stores/radio.svelte', () => ({
   getActiveReceiver: vi.fn(() => null),
@@ -90,7 +94,7 @@ describe('each txAux intent emits the command the radio expects', () => {
     ['onVoxToggle', [], 'set_vox', { on: true }],
     ['onCompToggle', [], 'set_compressor', { on: true }],
     ['onMonToggle', [], 'set_monitor', { on: true }],
-    ['onRfPowerChange', [0.5], 'set_rf_power', { level: 0.5 }],
+    ['onRfPowerChange', [0.5], 'set_rf_power', { level: 0.5, level_unit: 'normalized' }],
     ['onMicGainChange', [200], 'set_mic_gain', { level: 200 }],
     ['onDriveGainChange', [100], 'set_drive_gain', { level: 100 }],
     ['onVoxGainChange', [77], 'set_vox_gain', { level: 77 }],

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1428-ic7300-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1428-ic7300-conformance.isolated.test.ts
@@ -297,7 +297,7 @@ describe('IC-7300 fixture — handler dispatch through real factories (MOR-1418/
   it('AF level: dispatches set_af_level on receiver 0', () => {
     expectFrames(
       () => makeRxAudioHandlers().onAfLevelChange(0.5),
-      [['set_af_level', { level: 0.5, receiver: 0 }]],
+      [['set_af_level', { level: 0.5, receiver: 0, level_unit: 'normalized' }]],
     );
   });
 

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1563-keyboard-fanout-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1563-keyboard-fanout-conformance.isolated.test.ts
@@ -206,6 +206,7 @@ const CASES: readonly KeyboardCase[] = [
     frames: [['set_af_level', {
       level: Math.max(0, Math.min(1, main.afLevel + 5 / (afLevelRange.raw_max - afLevelRange.raw_min))),
       receiver: 0,
+      level_unit: 'normalized',
     }]],
     gate: 'declared af-level-up binding ({delta:5}); main.afLevel observed; delta scaled against '
       + 'caps.controls.af_level raw domain (MOR-1577, fixed)' },
@@ -282,7 +283,11 @@ describe('IC-7300 fixture — keyboard action fan-out conformance (MOR-1563)', (
   it('HANDLER-CAPABILITY PROBE (not profile behavior, MOR-1577): adjust_af_level dispatches set_af_level given {direction}', () => {
     expectFrames(
       () => dispatchKeyboardRadioAction({ action: 'adjust_af_level', params: { direction: 'up' } }),
-      [['set_af_level', { level: Math.max(0, Math.min(1, main.afLevel + 0.05)), receiver: 0 }]],
+      [['set_af_level', {
+        level: Math.max(0, Math.min(1, main.afLevel + 0.05)),
+        receiver: 0,
+        level_unit: 'normalized',
+      }]],
     );
   });
 

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1564-tx-family-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1564-tx-family-conformance.isolated.test.ts
@@ -26,36 +26,10 @@
  * refuse — the same MOR-988 §3.2 fail-closed doctrine the exemplar's
  * `onMicGainChange(100)` case already established for this exact field.
  *
- * FINDING 1 (defense-in-depth / UI-hygiene gap at the frontend handler
- * layer — NOT a live safety issue; verified against the real backend
- * chain): `onRfPowerChange` has no bound check beyond `Number.isFinite` —
- * no reference to `IC7300_CAPABILITIES.controls.rf_power` (the WIRE-side
- * raw 0-255 range; irrelevant here, see below) or to `TxPanel.svelte`'s own
- * slider domain (`min={0} max={1} step={0.01}`, confirmed by reading that
- * component directly). The same shape repeats for `onCompLevelChange`
- * (dispatches `compressor_level` verbatim, no reference to its own
- * declared 0-255 range) — `radio-intents.ts`'s own `dispatchRadioIntent`
- * validation adds no additional bound either (`set_rf_power`'s spec is `{
- * level: 'number' }`, i.e. "any finite number", not the `'normalized'`
- * kind `set_af_level` uses for its own 0-1 domain). BUT the backend closes
- * this: `src/rigplane/web/handlers/control.py:257
- * _normalized_or_raw_level` and `src/rigplane/commands/_codec.py:21
- * _level_bcd_encode` were read directly — the wire-level BCD encoder
- * hard-REJECTS (raises `ValueError`) any value outside 0-255, so no
- * out-of-domain byte can ever reach the radio. The probe below (`level=5`)
- * is also NOT an over-power case: 5 falls outside `[0,1]`, so
- * `_normalized_or_raw_level` takes its RAW branch and interprets 5 as raw
- * units directly — raw 5 of 255 ≈ 2% power, a silent UNDER-power
- * misinterpretation, not an unclamped over-power dispatch. The genuine,
- * already-filed hazard is the normalized-vs-raw semantic switch itself
- * (0-1 is treated as normalized, anything else as raw units, with the
- * value `1` sitting exactly on the boundary between "100% normalized" and
- * "raw unit 1 ≈ 0.4% power") — see MOR-1579
- * ("`_normalized_or_raw_level`: silent normalized→raw semantic switch is a
- * TX-power foot-gun"), which also documents the `(1)→255=full power`
- * boundary trap. This test's finding is limited to the frontend handler
- * layer applying no domain clamp of its own — pinned here per this
- * ticket's instruction to report, not fix.
+ * MOR-2420 makes `onRfPowerChange` an explicit normalized UI boundary:
+ * values in `[0,1]` dispatch with `level_unit: 'normalized'`; values outside
+ * that domain refuse before transport. The production-domain and refusal
+ * cases below pin both halves of that contract.
  *
  * FINDING 2 (latent adapter-layer gate inconsistency, MOR-1576 class —
  * "same intent alive on one path, dead on another"; backend-guarded, no
@@ -80,16 +54,6 @@
  * "set_monitor_gain")` unconditionally) — a profile lacking `monitor`
  * would have its `set_monitor_gain` command rejected server-side either
  * way. Pinned per this ticket's instruction to report, not fix.
- *
- * RED-FIRST EVIDENCE (MOR-1564 build process, not part of this diff): the
- * `set_rf_power` `level=0.5` case below was first authored as
- * `expectFrames(() => makeTxHandlers().onRfPowerChange(0.5), [['set_rf_power',
- * { level: 999 }]])` — a deliberately wrong claimed dispatch value.
- * `vitest run` on that version failed with `expected [ [ 'set_rf_power', {
- * level: 0.5 } ] ] to deeply equal [ [ 'set_rf_power', { level: 999 } ] ]`
- * (RED — the real dispatch carries 0.5, the fixture/production value, not
- * the fabricated 999). Replacing the claim with `{ level: 0.5 }` turned it
- * GREEN.
  *
  * DISCRIMINATION EVIDENCE (MOR-1564 build process, not part of this diff):
  * to prove the `set_mic_gain` refusal below isn't vacuous, its gate was
@@ -129,21 +93,23 @@ describe('IC-7300 fixture — TX-chain family conformance (MOR-1564)', () => {
     resetCommandLifecycle();
   });
 
-  describe('set_rf_power — production-domain walk (TxPanel.svelte slider: min=0 max=1 step=0.01), plus a no-clamp defense-in-depth probe (backend-guarded, see finding 1)', () => {
-    it('powerLevel IS observed on this fixture; rf_power only declares a WIRE raw range (0-255), which onRfPowerChange never reads', () => {
+  describe('set_rf_power — normalized production-domain walk and out-of-domain refusal', () => {
+    it('powerLevel IS observed on this fixture; rf_power declares a native wire range of 0-255', () => {
       expect(IC7300_CAPABILITIES.capabilities).toContain('tx');
       expect(IC7300_STATE.fieldStatus?.powerLevel?.observed).toBe(true);
       expect(IC7300_CAPABILITIES.controls?.rf_power).toEqual({ raw_min: 0, raw_max: 255 });
     });
 
     for (const level of [0, 0.5, 1]) {
-      it(`level=${level} (production domain [0,1]): CLAIMS — dispatches set_rf_power verbatim, no scaling (RED-FIRST evidence in file header)`, () => {
-        expectFrames(() => makeTxHandlers().onRfPowerChange(level), [['set_rf_power', { level }]]);
+      it(`level=${level} (production domain [0,1]): dispatches tagged normalized RF power`, () => {
+        expectFrames(() => makeTxHandlers().onRfPowerChange(level), [
+          ['set_rf_power', { level, level_unit: 'normalized' }],
+        ]);
       });
     }
 
-    it("DEFENSE-IN-DEPTH: level=5 (past TxPanel.svelte's own max=1) still DISPATCHES verbatim — no domain clamp exists at the frontend handler layer, though the backend's BCD encoder hard-rejects true out-of-0-255 values, and 5 itself would be misinterpreted as raw ≈2% power (UNDER-power, not over) under _normalized_or_raw_level's normalized/raw switch — MOR-1579, not a live safety gap here (finding 1, see file header)", () => {
-      expectFrames(() => makeTxHandlers().onRfPowerChange(5), [['set_rf_power', { level: 5 }]]);
+    it('level=5: refuses outside the normalized frontend domain', () => {
+      expectRefusal(() => makeTxHandlers().onRfPowerChange(5));
     });
   });
 
@@ -167,7 +133,7 @@ describe('IC-7300 fixture — TX-chain family conformance (MOR-1564)', () => {
     expectFrames(() => makeTxHandlers().onCompToggle(), [['set_compressor', { on: false }]]);
   });
 
-  describe('set_compressor_level — boundary walk over the declared compressor_level range (TxPanel.svelte slider domain, min=0 max=255); same blind-passthrough shape as set_rf_power', () => {
+  describe('set_compressor_level — boundary walk over the declared compressor_level range (TxPanel.svelte slider domain, min=0 max=255)', () => {
     it('compressor_level declares a wire range on this profile; compressorLevel IS observed', () => {
       expect(IC7300_CAPABILITIES.controls?.compressor_level).toEqual({ raw_min: 0, raw_max: 255 });
       expect(IC7300_STATE.fieldStatus?.compressorLevel?.observed).toBe(true);

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
@@ -431,9 +431,9 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     rxAudio.onAfLevelChange(0.42);
 
     expect(exactCalls()).toEqual([
-      ['set_af_level', { level: 0, receiver: 0 }],
-      ['set_af_level', { level: 50 / 255, receiver: 0 }],
-      ['set_af_level', { level: 0.42, receiver: 0 }],
+      ['set_af_level', { level: 0, receiver: 0, level_unit: 'normalized' }],
+      ['set_af_level', { level: 50 / 255, receiver: 0, level_unit: 'normalized' }],
+      ['set_af_level', { level: 0.42, receiver: 0, level_unit: 'normalized' }],
     ]);
     expectIntentTransport();
     expect(h.setMuted).toHaveBeenNthCalledWith(1, true);
@@ -480,8 +480,8 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     rxAudio.onAfLevelChange(1);
 
     expect(exactCalls()).toEqual([
-      ['set_af_level', { level: 0, receiver: 0 }],
-      ['set_af_level', { level: 1, receiver: 0 }],
+      ['set_af_level', { level: 0, receiver: 0, level_unit: 'normalized' }],
+      ['set_af_level', { level: 1, receiver: 0, level_unit: 'normalized' }],
     ]);
     expectIntentTransport();
 
@@ -590,7 +590,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     tx.onDriveGainChange(100);
 
     expect(exactCalls()).toEqual([
-      ['set_rf_power', { level: 0.42 }],
+      ['set_rf_power', { level: 0.42, level_unit: 'normalized' }],
       ['set_mic_gain', { level: 200 }],
       ['set_tuner_status', { value: 0 }],
       ['set_tuner_status', { value: 2 }],
@@ -604,6 +604,23 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expectIntentTransport();
     expect(exactCalls().map(([name]) => name)).not.toContain('ptt');
     expect(h.patchRadioState).not.toHaveBeenCalled();
+  });
+
+  it('marks only bounded normalized RF-power UI values', () => {
+    const tx = makeTxHandlers();
+    tx.onRfPowerChange(0);
+    tx.onRfPowerChange(0.5);
+    tx.onRfPowerChange(1);
+    for (const invalid of [-0.01, 1.01, Number.NaN, Number.POSITIVE_INFINITY]) {
+      tx.onRfPowerChange(invalid);
+    }
+
+    expect(exactCalls()).toEqual([
+      ['set_rf_power', { level: 0, level_unit: 'normalized' }],
+      ['set_rf_power', { level: 0.5, level_unit: 'normalized' }],
+      ['set_rf_power', { level: 1, level_unit: 'normalized' }],
+    ]);
+    expectIntentTransport();
   });
 
   it('preserves exact antenna and scan command names and params without Store truth', () => {
@@ -729,7 +746,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
       ['set_preamp', { level: 1, receiver: 0 }],
       ['set_agc', { mode: 2, receiver: 0 }],
       ['set_nb', { on: true, receiver: 0 }],
-      ['set_af_level', { level: 0.5, receiver: 0 }],
+      ['set_af_level', { level: 0.5, receiver: 0, level_unit: 'normalized' }],
       ['set_band', { band: 5 }],
       ['set_rit_status', { on: true }],
     ]);
@@ -1355,7 +1372,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
       ['set_rit_status', { on: true }],
       ['set_rit_tx_status', { on: false }],
       ['set_rit_frequency', { freq: 0 }],
-      ['set_af_level', { level: 50 / 255 + 0.05, receiver: 0 }],
+      ['set_af_level', { level: 50 / 255 + 0.05, receiver: 0, level_unit: 'normalized' }],
       ['set_rf_gain', { level: Math.round((128 / 255 - 0.05) * 255), receiver: 0 }],
       ['set_monitor', { on: true }], ['set_split', { on: true }],
       ['vfo_swap', {}], ['vfo_equalize', {}],
@@ -1481,7 +1498,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(dispatchKeyboardRadioAction({ action: 'adjust_af_level', params: { direction: 'up' } })).toBe(true);
     expect(dispatchKeyboardRadioAction({ action: 'adjust_rf_gain', params: { direction: 'down' } })).toBe(true);
     expect(exactCalls()).toEqual([
-      ['set_af_level', { level: 1, receiver: 0 }],
+      ['set_af_level', { level: 1, receiver: 0, level_unit: 'normalized' }],
       ['set_rf_gain', { level: 0, receiver: 0 }],
     ]);
     expectIntentTransport();

--- a/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
@@ -88,7 +88,10 @@ describe('typed non-PTT radio intents', () => {
       for (const accepted of [false, true, false]) {
         harness.sendCommand.mockClear().mockReturnValue(accepted);
         expect(api[method](name, params)).toBe(accepted);
-        expect(harness.sendCommand).toHaveBeenCalledExactlyOnceWith(name, params, expect.any(String));
+        const wireParams = name === 'set_af_level'
+          ? { ...params, level_unit: 'normalized' }
+          : params;
+        expect(harness.sendCommand).toHaveBeenCalledExactlyOnceWith(name, wireParams, expect.any(String));
         expect(lifecycle.getCommandLifecycles().at(-1)).toMatchObject({ name, params, status: 'pending' });
       }
     }
@@ -355,7 +358,7 @@ describe('typed non-PTT radio intents', () => {
     }));
 
     levels.forEach((level, index) => expect(harness.sendCommand).toHaveBeenNthCalledWith(
-      index + 1, 'set_af_level', { level, receiver: 0 }, `af-normalized-${index}`,
+      index + 1, 'set_af_level', { level, receiver: 0, level_unit: 'normalized' }, `af-normalized-${index}`,
     ));
     expect(lifecycle.getCommandLifecycles()).toHaveLength(levels.length);
     expect(lifecycle.getCommandLifecycles()).toEqual(expect.arrayContaining(levels.map((_, index) =>
@@ -365,17 +368,41 @@ describe('typed non-PTT radio intents', () => {
     } as never)).toThrow(TypeError);
   });
 
-  it('accepts the shipped fractional RF-power scale without weakening integer TX fields', () => {
-    intents.dispatchRadioIntent({
-      id: 'rf-fraction', name: 'set_rf_power', params: { level: 0.42 },
-    });
+  it('admits tagged normalized RF while preserving untagged finite RF levels', () => {
+    for (const [id, params] of [
+      ['rf-zero', { level: 0, level_unit: 'normalized' }],
+      ['rf-half', { level: 0.5, level_unit: 'normalized' }],
+      ['rf-one', { level: 1, level_unit: 'normalized' }],
+      ['rf-native', { level: 42 }],
+    ] as const) {
+      intents.dispatchRadioIntent({ id, name: 'set_rf_power', params });
+    }
 
-    expect(harness.sendCommand).toHaveBeenCalledExactlyOnceWith(
-      'set_rf_power', { level: 0.42 }, 'rf-fraction',
-    );
+    expect(harness.sendCommand.mock.calls).toEqual([
+      ['set_rf_power', { level: 0, level_unit: 'normalized' }, 'rf-zero'],
+      ['set_rf_power', { level: 0.5, level_unit: 'normalized' }, 'rf-half'],
+      ['set_rf_power', { level: 1, level_unit: 'normalized' }, 'rf-one'],
+      ['set_rf_power', { level: 42 }, 'rf-native'],
+    ]);
     expect(() => intents.dispatchRadioIntent({
       name: 'set_mic_gain', params: { level: 0.42 },
     } as never)).toThrow(TypeError);
+  });
+
+  it('rejects malformed normalized RF markers and levels before lifecycle or transport', () => {
+    for (const params of [
+      { level: -0.01, level_unit: 'normalized' },
+      { level: 1.01, level_unit: 'normalized' },
+      { level: Number.NaN, level_unit: 'normalized' },
+      { level: true, level_unit: 'normalized' },
+      { level: 0.5, level_unit: 'raw_255' },
+    ]) {
+      expect(() => intents.dispatchRadioIntent({
+        name: 'set_rf_power', params,
+      } as never)).toThrow(/invalid radio intent/i);
+    }
+    expect(harness.sendCommand).not.toHaveBeenCalled();
+    expect(lifecycle.getCommandLifecycles()).toHaveLength(0);
   });
 
   it('accepts representative exact envelopes derived from every descriptor family', () => {

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -661,8 +661,8 @@ export function makeDspHandlers() {
 export function makeTxHandlers() {
   return {
     onRfPowerChange: (level: number) => {
-      if (!hasCapability('tx') || !knownTopLevelField('powerLevel') || !Number.isFinite(level)) return;
-      dispatchRadioIntent({ name: 'set_rf_power', params: { level } });
+      if (!hasCapability('tx') || !knownTopLevelField('powerLevel') || !isNormalizedLevel(level)) return;
+      dispatchRadioIntent({ name: 'set_rf_power', params: { level, level_unit: 'normalized' } });
     },
     onMicGainChange: (level: number) => {
       if (!hasCapability('tx') || !knownTopLevelField('micGain') || !Number.isSafeInteger(level)) return;

--- a/frontend/src/lib/runtime/commands/radio-intents.ts
+++ b/frontend/src/lib/runtime/commands/radio-intents.ts
@@ -3,7 +3,7 @@ import { makeCommandId } from '$lib/types/protocol';
 import * as controlTransport from '$lib/transport/ws-client';
 import { getControlSession, onCommandDelivery, onControlSessionTransition, sendCommand } from '$lib/transport/ws-client';
 
-type FieldKind = 'boolean' | 'integer' | 'normalized' | 'number' | 'receiver' | 'string' | 'vfo';
+type FieldKind = 'boolean' | 'integer' | 'normalized' | 'normalized-unit' | 'number' | 'receiver' | 'string' | 'vfo';
 type FieldSpec = FieldKind | `${FieldKind}?`;
 type IntentSpec = { names: readonly string[]; params: Readonly<Record<string, FieldSpec>> };
 
@@ -21,7 +21,7 @@ const intentSpecs = [
     'set_monitor_gain', 'set_nb_depth', 'set_nb_width', 'set_vox_delay', 'set_vox_gain',
   ], params: { level: 'integer' } },
   { names: ['set_af_level'], params: { level: 'normalized', receiver: 'receiver' } },
-  { names: ['set_rf_power'], params: { level: 'number' } },
+  { names: ['set_rf_power'], params: { level: 'number', level_unit: 'normalized-unit?' } },
   { names: ['set_nb_level', 'set_nr_level', 'set_preamp', 'set_rf_gain', 'set_squelch'], params: { level: 'integer', receiver: 'receiver' } },
   { names: ['set_cw_pitch', 'set_tuner_status'], params: { value: 'integer' } },
   { names: ['set_agc_time_constant', 'set_manual_notch_width', 'set_notch_filter', 'set_pbt_inner', 'set_pbt_outer'], params: { value: 'integer', receiver: 'receiver' } },
@@ -52,7 +52,7 @@ const intentSpecs = [
 ] as const satisfies readonly IntentSpec[];
 
 type Spec = (typeof intentSpecs)[number];
-type KindValue<K extends FieldKind> = K extends 'boolean' ? boolean : K extends 'receiver' ? 0 | 1
+type KindValue<K extends FieldKind> = K extends 'boolean' ? boolean : K extends 'normalized-unit' ? 'normalized' : K extends 'receiver' ? 0 | 1
   : K extends 'string' ? string : K extends 'vfo' ? 'A' | 'B' | 'MAIN' | 'SUB' : number;
 type RequiredKeys<S extends Readonly<Record<string, FieldSpec>>> = {
   [K in keyof S]-?: S[K] extends `${FieldKind}?` ? never : K
@@ -78,6 +78,7 @@ export function isNormalizedLevel(value: unknown): value is number {
 function matchesValue(kind: FieldKind, value: unknown): boolean {
   if (kind === 'integer') return typeof value === 'number' && Number.isSafeInteger(value);
   if (kind === 'normalized') return isNormalizedLevel(value);
+  if (kind === 'normalized-unit') return value === 'normalized';
   if (kind === 'number') return typeof value === 'number' && Number.isFinite(value);
   if (kind === 'boolean') return typeof value === 'boolean';
   if (kind === 'receiver') return value === 0 || value === 1;
@@ -133,14 +134,20 @@ export function dispatchRadioIntentWithResult(intent: RadioIntent): RadioIntentD
   const name = candidate.name;
   if (typeof name !== 'string' || !specsByName.has(name)) throw new TypeError('Only a known non-PTT radio intent may be dispatched');
   const params = candidate.params;
+  const paramsRecord = params as Record<PropertyKey, unknown>;
   if (typeof params !== 'object' || params === null || Array.isArray(params)
-    || !matchesParams(specsByName.get(name)!, params as Record<PropertyKey, unknown>)
+    || !matchesParams(specsByName.get(name)!, paramsRecord)
+    || (name === 'set_rf_power' && paramsRecord.level_unit === 'normalized'
+      && !isNormalizedLevel(paramsRecord.level))
     || (candidate.id !== undefined && (typeof candidate.id !== 'string' || candidate.id.length === 0))) {
     throw new TypeError('Invalid radio intent envelope');
   }
   const id = (candidate.id as string | undefined) ?? makeCommandId();
   const originalEpoch = getControlSession().epoch;
   const lifecycle = beginCommand({ id, name, params: params as Record<string, unknown>, originalEpoch });
-  const transportAccepted = sendCommand(name, params as Record<string, unknown>, id);
+  const wireParams = specsByName.get(name)?.level === 'normalized'
+    ? { ...(params as Record<string, unknown>), level_unit: 'normalized' }
+    : params as Record<string, unknown>;
+  const transportAccepted = sendCommand(name, wireParams, id);
   return { lifecycle, transportAccepted };
 }

--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { WsCommand, WsMessage } from '../../types/protocol';
 import type { ReceiverState, ServerState } from '../../types/state';
@@ -9,6 +11,13 @@ type ServerStateWithObservation = ServerState & {
   publicStateSeq?: number;
   fieldStatus?: Record<string, unknown>;
 };
+
+function normalizedLevelWireVectors(): string[] {
+  const catalog = readFileSync(resolve(process.cwd(), '../docs/api/command-catalog.md'), 'utf8');
+  const match = catalog.match(/<!-- normalized-level-wire-vectors:start -->\n```jsonl\n([\s\S]*?)\n```\n<!-- normalized-level-wire-vectors:end -->/u);
+  if (!match) throw new Error('normalized level wire vectors are missing');
+  return match[1].split('\n').filter(Boolean);
+}
 
 // ─── Mock store before importing ws-client ──────────────────────────────────
 const radioStoreMock = vi.hoisted(() => ({
@@ -1037,6 +1046,42 @@ describe('control channel singleton', () => {
     globalThis.WebSocket = originalWebSocket;
     vi.useRealTimers();
     vi.resetModules();
+  });
+
+  it('serializes the documented normalized AF/RF intents byte-for-byte', async () => {
+    const { connect } = await import('../ws-client');
+    const { dispatchRadioIntent } = await import('../../runtime/commands/radio-intents');
+    const vectors = normalizedLevelWireVectors();
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+
+    for (const raw of vectors) {
+      const command = JSON.parse(raw) as {
+        name: 'set_af_level' | 'set_rf_power';
+        id: string;
+        params: Record<string, unknown>;
+      };
+      const params = { ...command.params };
+      if (command.name === 'set_af_level') delete params.level_unit;
+      dispatchRadioIntent({ name: command.name, id: command.id, params } as never);
+    }
+
+    expect(instances[0].sent).toEqual(vectors);
+  });
+
+  it('preserves normalized marker bytes through the offline reconnect queue', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    const queued = {
+      type: 'cmd', name: 'set_freq', id: 'marker-reconnect',
+      params: { level: 0.5, level_unit: 'normalized' },
+    } as const;
+
+    expect(ch.send(queued)).toBe(false);
+    ch.connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+
+    expect(instances[0].sent).toEqual([JSON.stringify(queued)]);
   });
 
   it('publishes each control session epoch before draining a pinned OFF', async () => {

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -282,6 +283,27 @@ def _level_for_power(value: Any, radio: Any) -> int:
         power_max_watts=getattr(getattr(radio, "profile", None), "max_watts", None),
     )
     return int(native)
+
+
+def _consume_normalized_level_unit(name: str, params: dict[str, Any]) -> dict[str, Any]:
+    if "level_unit" not in params:
+        return dict(params)
+    if name not in {"set_af_level", "set_rf_power", "set_power"}:
+        raise ValueError("level_unit is only valid for AF level and RF power")
+    if params["level_unit"] != "normalized":
+        raise ValueError("level_unit must be 'normalized'")
+    level = params.get("level")
+    if (
+        isinstance(level, bool)
+        or not isinstance(level, (int, float))
+        or not math.isfinite(level)
+        or not 0.0 <= level <= 1.0
+    ):
+        raise ValueError("normalized level must be a finite number from 0.0 to 1.0")
+    normalized = dict(params)
+    normalized.pop("level_unit")
+    normalized["level"] = float(level)
+    return normalized
 
 
 class ControlHandler:
@@ -1443,7 +1465,7 @@ class ControlHandler:
     ) -> dict[str, Any]:
         if name in self._MANAGED_PTT_COMMANDS:
             return await self._enqueue_managed_ptt(name, params, source=source)
-        intent_params = dict(params)
+        intent_params = _consume_normalized_level_unit(name, params)
         if self._server is not None:
             intent_params["_control_server"] = self._server
         if name in ("set_vfo", "select_vfo") and "receiver_count" not in intent_params:

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -1039,6 +1039,17 @@ class ControlHandler:
             )
             return
 
+        if (
+            isinstance(name, str)
+            and name in self._COMMANDS
+            and isinstance(params, dict)
+        ):
+            try:
+                params = _consume_normalized_level_unit(name, params)
+            except Exception as exc:
+                await self._send_command_failure(cmd_id, name, exc)
+                return
+
         # ── Server-side rate limiting (per client, per command) ──
         # Only pace SET commands (continuous slider/knob drag). GET and
         # read-only commands pass through. MOR-1427: a command arriving
@@ -1277,35 +1288,40 @@ class ControlHandler:
                 )
             )
         except Exception as exc:
-            logger.warning("control: command %r failed: %s", name, exc)
-            message = str(exc)
-            if isinstance(exc, RadioNotReadyError):
-                error = "radio_not_ready"
-            elif isinstance(exc, CommandUnsupportedError):
-                error = "unsupported_command"
-            elif isinstance(exc, CommandRejectedError):
-                error = "radio_nak"
-            elif isinstance(exc, (TimeoutError, RigplaneTimeoutError)):
-                error = "command_timeout"
-            elif isinstance(exc, CommandError):
-                error = "command_failed"
-            elif command_descriptor(name) is None and (
-                "does not support" in message or "not supported" in message
-            ):
-                error = "unsupported_command"
-            else:
-                error = "command_failed"
-            await self._ws.send_text(
-                encode_json(
-                    {
-                        "type": "response",
-                        "id": cmd_id,
-                        "ok": False,
-                        "error": error,
-                        "message": message,
-                    }
-                )
+            await self._send_command_failure(cmd_id, name, exc)
+
+    async def _send_command_failure(
+        self, cmd_id: Any, name: str, exc: Exception
+    ) -> None:
+        logger.warning("control: command %r failed: %s", name, exc)
+        message = str(exc)
+        if isinstance(exc, RadioNotReadyError):
+            error = "radio_not_ready"
+        elif isinstance(exc, CommandUnsupportedError):
+            error = "unsupported_command"
+        elif isinstance(exc, CommandRejectedError):
+            error = "radio_nak"
+        elif isinstance(exc, (TimeoutError, RigplaneTimeoutError)):
+            error = "command_timeout"
+        elif isinstance(exc, CommandError):
+            error = "command_failed"
+        elif command_descriptor(name) is None and (
+            "does not support" in message or "not supported" in message
+        ):
+            error = "unsupported_command"
+        else:
+            error = "command_failed"
+        await self._ws.send_text(
+            encode_json(
+                {
+                    "type": "response",
+                    "id": cmd_id,
+                    "ok": False,
+                    "error": error,
+                    "message": message,
+                }
             )
+        )
 
     def _apply_mod_input_restore_cmd(
         self, name: str, params: dict[str, Any]
@@ -1465,7 +1481,7 @@ class ControlHandler:
     ) -> dict[str, Any]:
         if name in self._MANAGED_PTT_COMMANDS:
             return await self._enqueue_managed_ptt(name, params, source=source)
-        intent_params = _consume_normalized_level_unit(name, params)
+        intent_params = dict(params)
         if self._server is not None:
             intent_params["_control_server"] = self._server
         if name in ("set_vfo", "select_vfo") and "receiver_count" not in intent_params:

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -92,6 +92,7 @@ from .handlers import (  # noqa: TID251
     ScopeHandler,
 )
 from .handlers.audio import browser_tx_audio_facts  # noqa: TID251
+from .handlers.control import _consume_normalized_level_unit  # noqa: TID251
 from .managed_tx_view import build_managed_tx_view  # noqa: TID251
 from .transport.webrtc import webrtc_available  # noqa: TID251
 from .radio_poller import (  # noqa: TID251
@@ -4443,9 +4444,10 @@ class WebServer:
             )
             return
         try:
+            params = _consume_normalized_level_unit(raw_name, raw_params)
             result = await self._control_handler_for()._enqueue_command(  # noqa: SLF001
                 raw_name,
-                raw_params,
+                params,
                 command_id=None if payload.get("id") is None else str(payload["id"]),
                 source="http",
             )
@@ -4548,13 +4550,14 @@ class WebServer:
                 f"command {raw_name!r} bypasses the command queue",
             )
 
+        params = _consume_normalized_level_unit(raw_name, raw_params)
         descriptor = command_descriptor(raw_name)
         if descriptor is not None:
             assert self._radio is not None
             intent = prepare_command_intent(
                 self._radio,
                 raw_name,
-                raw_params,
+                params,
                 source="http",
                 command_id=(
                     None if raw_step.get("id") is None else str(raw_step["id"])
@@ -4582,7 +4585,7 @@ class WebServer:
         )()
         result = await self._control_handler_for(server=proxy_server)._enqueue_command(  # noqa: SLF001
             raw_name,
-            raw_params,
+            params,
             source="http",
         )
         if len(collector.commands) != 1:

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -1253,6 +1253,105 @@ async def test_normalized_wire_marker_supports_power_alias_and_af_validation() -
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("name", "valid_params", "invalid_params", "expected"),
+    [
+        (
+            "set_af_level",
+            {"level": 0.5, "receiver": 0, "level_unit": "normalized"},
+            {"level": 1.01, "receiver": 0, "level_unit": "normalized"},
+            128,
+        ),
+        (
+            "set_rf_power",
+            {"level": 0.5, "level_unit": "normalized"},
+            {"level": 1.01, "level_unit": "normalized"},
+            128,
+        ),
+    ],
+)
+async def test_malformed_tagged_level_cannot_displace_valid_pending_command(
+    name: str,
+    valid_params: dict[str, object],
+    invalid_params: dict[str, object],
+    expected: int,
+) -> None:
+    ws = SimpleNamespace(send_text=AsyncMock())
+    queue = _QueueRecorder()
+    radio = _capable_radio()
+    handler = _control_handler(
+        ws=ws,
+        radio=radio,
+        server=SimpleNamespace(command_queue=queue),
+        session_id="normalized-pacing",
+    )
+    handler._CMD_MIN_INTERVAL = 10.0  # noqa: SLF001
+    key = handler._coalesce_key(name, valid_params)  # noqa: SLF001
+    handler._cmd_last[key] = time.monotonic()  # noqa: SLF001
+
+    valid = {"type": "cmd", "name": name, "id": "valid-pending", "params": valid_params}
+    malformed = {
+        "type": "cmd",
+        "name": name,
+        "id": "malformed",
+        "params": invalid_params,
+    }
+
+    try:
+        await handler._handle_text(json.dumps(valid, separators=(",", ":")))  # noqa: SLF001
+        pending_before = dict(handler._cmd_pending)  # noqa: SLF001
+        last_before = dict(handler._cmd_last)  # noqa: SLF001
+        coalesced_before = dict(handler._cmd_coalesced)  # noqa: SLF001
+        flush_task = handler._cmd_flush_tasks[key]  # noqa: SLF001
+        assert queue.items == []
+
+        await handler._handle_text(json.dumps(malformed, separators=(",", ":")))  # noqa: SLF001
+
+        responses = [decode_json(call.args[0]) for call in ws.send_text.await_args_list]
+        assert responses == [
+            {
+                "type": "response",
+                "id": "malformed",
+                "ok": False,
+                "error": "command_failed",
+                "message": "normalized level must be a finite number from 0.0 to 1.0",
+            }
+        ]
+        assert handler._cmd_pending == pending_before  # noqa: SLF001
+        assert handler._cmd_last == last_before  # noqa: SLF001
+        assert handler._cmd_coalesced == coalesced_before  # noqa: SLF001
+        assert handler._cmd_flush_tasks[key] is flush_task  # noqa: SLF001
+        assert queue.items == []
+        radio.set_af_level.assert_not_awaited()
+        radio.set_rf_power.assert_not_awaited()
+
+        flush_task.cancel()
+        await asyncio.gather(flush_task, return_exceptions=True)
+        await handler._flush_coalesced_command(key, 0.0)  # noqa: SLF001
+
+        responses = [decode_json(call.args[0]) for call in ws.send_text.await_args_list]
+        assert [response["id"] for response in responses] == [
+            "malformed",
+            "valid-pending",
+        ]
+        assert all(
+            response.get("result") != {"superseded": True} for response in responses
+        )
+        if name == "set_af_level":
+            _assert_canonical_level_intent(
+                queue.items[-1], name=name, level=expected, receiver=0
+            )
+        else:
+            assert queue.items == [SetPower(expected, unit="raw_255")]
+        radio.set_af_level.assert_not_awaited()
+        radio.set_rf_power.assert_not_awaited()
+    finally:
+        handler._cancel_pending_command_flushes()  # noqa: SLF001
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name", ["set_af_level", "set_rf_power", "set_power"])
+@pytest.mark.parametrize(
     "params",
     [
         '{"level":false,"level_unit":"normalized"}',
@@ -1267,16 +1366,25 @@ async def test_normalized_wire_marker_supports_power_alias_and_af_validation() -
         '{"level_unit":"normalized"}',
     ],
 )
-async def test_normalized_wire_marker_rejects_malformed_requests(params: str) -> None:
+async def test_normalized_wire_marker_rejects_malformed_requests(
+    name: str, params: str
+) -> None:
     ws = SimpleNamespace(send_text=AsyncMock())
     queue = _QueueRecorder()
+    radio = _capable_radio()
     handler = _control_handler(
         ws=ws,
-        radio=_capable_radio(),
+        radio=radio,
         server=SimpleNamespace(command_queue=queue),
         session_id="invalid-normalized-wire",
     )
-    raw = f'{{"type":"cmd","name":"set_rf_power","id":"invalid","params":{params}}}'
+    raw = f'{{"type":"cmd","name":"{name}","id":"invalid","params":{params}}}'
+    pacing_before = (
+        dict(handler._cmd_last),  # noqa: SLF001
+        dict(handler._cmd_pending),  # noqa: SLF001
+        dict(handler._cmd_flush_tasks),  # noqa: SLF001
+        dict(handler._cmd_coalesced),  # noqa: SLF001
+    )
 
     await handler._handle_text(raw)  # noqa: SLF001
 
@@ -1284,6 +1392,14 @@ async def test_normalized_wire_marker_rejects_malformed_requests(params: str) ->
     assert response["ok"] is False
     assert response["error"] == "command_failed"
     assert queue.items == []
+    assert (
+        handler._cmd_last,  # noqa: SLF001
+        handler._cmd_pending,  # noqa: SLF001
+        handler._cmd_flush_tasks,  # noqa: SLF001
+        handler._cmd_coalesced,  # noqa: SLF001
+    ) == pacing_before
+    radio.set_af_level.assert_not_awaited()
+    radio.set_rf_power.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -5,6 +5,7 @@ import json
 import struct
 import time
 from dataclasses import replace
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -99,6 +100,13 @@ from rigplane.web.radio_poller import (
 from rigplane.web.runtime_helpers import runtime_capabilities
 from rigplane.web.server import WebServer
 from rigplane.web.websocket import WS_OP_BINARY, WS_OP_TEXT
+
+
+def _normalized_level_wire_vectors() -> list[str]:
+    catalog = (Path(__file__).parents[1] / "docs/api/command-catalog.md").read_text()
+    block = catalog.split("<!-- normalized-level-wire-vectors:start -->", 1)[1]
+    block = block.split("<!-- normalized-level-wire-vectors:end -->", 1)[0]
+    return [line for line in block.splitlines() if line.startswith("{")]
 
 
 class _RelayRadio:
@@ -1093,6 +1101,189 @@ async def test_enqueue_set_rf_power_yaesu_tags_watts_unit() -> None:
     await handler2._enqueue_command("set_rf_power", {"level": 0.8})
     assert queue2.items[-1].level == 204
     assert queue2.items[-1].unit == "raw_255"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("native_power_unit", "max_watts", "expected_power"),
+    [
+        ("raw_255", 100, [0, 128, 255]),
+        ("watts", 100, [0, 50, 100]),
+    ],
+)
+async def test_documented_normalized_wire_vectors_reach_native_effects(
+    native_power_unit: str,
+    max_watts: int,
+    expected_power: list[int],
+) -> None:
+    vectors = _normalized_level_wire_vectors()
+    af_vectors = [raw for raw in vectors if '"name":"set_af_level"' in raw]
+    power_vectors = [raw for raw in vectors if '"name":"set_rf_power"' in raw]
+
+    for raw, expected in zip(af_vectors, [0, 128, 255], strict=True):
+        ws = SimpleNamespace(send_text=AsyncMock())
+        queue = _QueueRecorder()
+        handler = _control_handler(
+            ws=ws,
+            radio=_capable_radio(),
+            server=SimpleNamespace(command_queue=queue),
+            session_id="normalized-wire",
+        )
+
+        await handler._handle_text(raw)  # noqa: SLF001
+
+        response = decode_json(ws.send_text.await_args.args[0])
+        assert response["ok"] is True
+        _assert_canonical_level_intent(
+            queue.items[-1], name="set_af_level", level=expected, receiver=0
+        )
+        assert "level_unit" not in queue.items[-1].params  # type: ignore[union-attr]
+
+    for raw, expected in zip(power_vectors, expected_power, strict=True):
+        ws = SimpleNamespace(send_text=AsyncMock())
+        queue = _QueueRecorder()
+        radio = _capable_radio()
+        radio.native_power_unit = native_power_unit
+        radio.profile = replace(radio.profile, max_watts=max_watts)
+        handler = _control_handler(
+            ws=ws,
+            radio=radio,
+            server=SimpleNamespace(command_queue=queue),
+            session_id="normalized-wire",
+        )
+
+        await handler._handle_text(raw)  # noqa: SLF001
+
+        response = decode_json(ws.send_text.await_args.args[0])
+        assert response["ok"] is True
+        assert queue.items == [SetPower(expected, unit=native_power_unit)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("name", "native_power_unit", "wire_level", "expected"),
+    [
+        ("set_af_level", "raw_255", "1", 1),
+        ("set_af_level", "raw_255", "1.0", 255),
+        ("set_rf_power", "raw_255", "1", 1),
+        ("set_rf_power", "raw_255", "1.0", 255),
+        ("set_power", "watts", "1", 1),
+        ("set_power", "watts", "1.0", 100),
+    ],
+)
+async def test_untagged_wire_level_type_dispatch_remains_compatible(
+    name: str,
+    native_power_unit: str,
+    wire_level: str,
+    expected: int,
+) -> None:
+    ws = SimpleNamespace(send_text=AsyncMock())
+    queue = _QueueRecorder()
+    radio = _capable_radio()
+    radio.native_power_unit = native_power_unit
+    radio.profile = replace(radio.profile, max_watts=100)
+    handler = _control_handler(
+        ws=ws,
+        radio=radio,
+        server=SimpleNamespace(command_queue=queue),
+        session_id="untagged-wire",
+    )
+    receiver = ',"receiver":0' if name == "set_af_level" else ""
+    raw = (
+        f'{{"type":"cmd","name":"{name}","id":"untagged",'
+        f'"params":{{"level":{wire_level}{receiver}}}}}'
+    )
+
+    await handler._handle_text(raw)  # noqa: SLF001
+
+    response = decode_json(ws.send_text.await_args.args[0])
+    assert response["ok"] is True
+    if name == "set_af_level":
+        _assert_canonical_level_intent(
+            queue.items[-1], name=name, level=expected, receiver=0
+        )
+    else:
+        assert queue.items == [SetPower(expected, unit=native_power_unit)]
+
+
+@pytest.mark.asyncio
+async def test_normalized_wire_marker_supports_power_alias_and_af_validation() -> None:
+    for name, receiver in [("set_power", ""), ("set_af_level", ',"receiver":0')]:
+        ws = SimpleNamespace(send_text=AsyncMock())
+        queue = _QueueRecorder()
+        radio = _capable_radio()
+        radio.native_power_unit = "watts"
+        radio.profile = replace(radio.profile, max_watts=100)
+        handler = _control_handler(
+            ws=ws,
+            radio=radio,
+            server=SimpleNamespace(command_queue=queue),
+            session_id="normalized-alias",
+        )
+        raw = (
+            f'{{"type":"cmd","name":"{name}","id":"normalized-alias",'
+            f'"params":{{"level":1{receiver},"level_unit":"normalized"}}}}'
+        )
+
+        await handler._handle_text(raw)  # noqa: SLF001
+
+        response = decode_json(ws.send_text.await_args.args[0])
+        assert response["ok"] is True
+        if name == "set_power":
+            assert queue.items == [SetPower(100, unit="watts")]
+        else:
+            _assert_canonical_level_intent(
+                queue.items[-1], name=name, level=255, receiver=0
+            )
+
+    ws = SimpleNamespace(send_text=AsyncMock())
+    queue = _QueueRecorder()
+    handler = _control_handler(
+        ws=ws,
+        radio=_capable_radio(),
+        server=SimpleNamespace(command_queue=queue),
+    )
+    await handler._handle_text(  # noqa: SLF001
+        '{"type":"cmd","name":"set_af_level","id":"bad-af-marker",'
+        '"params":{"level":0.5,"receiver":0,"level_unit":"raw_255"}}'
+    )
+    assert decode_json(ws.send_text.await_args.args[0])["ok"] is False
+    assert queue.items == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "params",
+    [
+        '{"level":false,"level_unit":"normalized"}',
+        '{"level":"0.5","level_unit":"normalized"}',
+        '{"level":NaN,"level_unit":"normalized"}',
+        '{"level":Infinity,"level_unit":"normalized"}',
+        '{"level":-Infinity,"level_unit":"normalized"}',
+        '{"level":-0.01,"level_unit":"normalized"}',
+        '{"level":1.01,"level_unit":"normalized"}',
+        '{"level":0.5,"level_unit":"raw_255"}',
+        '{"level":0.5,"level_unit":null}',
+        '{"level_unit":"normalized"}',
+    ],
+)
+async def test_normalized_wire_marker_rejects_malformed_requests(params: str) -> None:
+    ws = SimpleNamespace(send_text=AsyncMock())
+    queue = _QueueRecorder()
+    handler = _control_handler(
+        ws=ws,
+        radio=_capable_radio(),
+        server=SimpleNamespace(command_queue=queue),
+        session_id="invalid-normalized-wire",
+    )
+    raw = f'{{"type":"cmd","name":"set_rf_power","id":"invalid","params":{params}}}'
+
+    await handler._handle_text(raw)  # noqa: SLF001
+
+    response = decode_json(ws.send_text.await_args.args[0])
+    assert response["ok"] is False
+    assert response["error"] == "command_failed"
+    assert queue.items == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_command_batch_http.py
+++ b/tests/test_web_command_batch_http.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from rigplane.core.state_pipeline_contracts import CommandIntent
 from rigplane.profiles import resolve_radio_profile
 from rigplane.web import server as web_server
 from rigplane.web.radio_poller import (
@@ -1567,6 +1568,273 @@ def _watts_radio() -> SimpleNamespace:
         get_rf_power=AsyncMock(return_value=0),
         set_rf_power=AsyncMock(),
     )
+
+
+def _raw_level_radio() -> MagicMock:
+    radio = _radio()
+    radio.native_power_unit = "raw_255"
+    radio.set_af_level = AsyncMock()
+    radio.get_rf_power = AsyncMock(return_value=0)
+    radio.set_rf_power = AsyncMock()
+    radio.get_powerstat = AsyncMock(return_value=True)
+    radio.set_powerstat = AsyncMock()
+    return radio
+
+
+def _level_params(name: str, level: object, *, tagged: bool) -> dict[str, object]:
+    params: dict[str, object] = {"level": level}
+    if name == "set_af_level":
+        params["receiver"] = 0
+    if tagged:
+        params["level_unit"] = "normalized"
+    return params
+
+
+def _assert_native_levels(
+    commands: list[object],
+    *,
+    name: str,
+    expected: list[int],
+    unit: str,
+) -> None:
+    assert len(commands) == len(expected)
+    if name == "set_af_level":
+        assert all(isinstance(command, CommandIntent) for command in commands)
+        assert [
+            command.name for command in commands if isinstance(command, CommandIntent)
+        ] == ["set_af_level"] * len(expected)
+        assert [
+            command.params["af_level"]
+            for command in commands
+            if isinstance(command, CommandIntent)
+        ] == expected
+        assert all(
+            "level_unit" not in command.params
+            for command in commands
+            if isinstance(command, CommandIntent)
+        )
+        return
+    assert commands == [SetPower(level, unit=unit) for level in expected]
+
+
+async def _post_level_series(
+    srv: WebServer,
+    path: str,
+    *,
+    name: str,
+    levels: list[int | float],
+    tagged: bool,
+) -> tuple[list[_FakeWriter], list[object]]:
+    steps = [
+        {"name": name, "params": _level_params(name, level, tagged=tagged)}
+        for level in levels
+    ]
+    if path.endswith("/batch"):
+        captured: list[object] = []
+        consumer = asyncio.create_task(
+            _complete_ordered_commands(srv.command_queue, len(steps), captured)
+        )
+        try:
+            writer = await _post_json(srv, path, {"steps": steps})
+        finally:
+            await asyncio.wait_for(consumer, timeout=1.0)
+        assert [result["status"] for result in writer.response_body["results"]] == [
+            "executed"
+        ] * len(steps)
+        return [writer], captured
+
+    writers: list[_FakeWriter] = []
+    captured = []
+    for step in steps:
+        writer = await _post_json(srv, path, step)
+        writers.append(writer)
+        captured.extend(srv.command_queue.drain())
+    return writers, captured
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/api/v1/commands", "/api/v1/commands/batch"])
+@pytest.mark.parametrize(
+    ("name", "unit", "expected"),
+    [
+        ("set_af_level", "raw_255", [0, 128, 255]),
+        ("set_rf_power", "raw_255", [0, 128, 255]),
+        ("set_power", "raw_255", [0, 128, 255]),
+        ("set_rf_power", "watts", [0, 50, 100]),
+        ("set_power", "watts", [0, 50, 100]),
+    ],
+)
+async def test_http_normalized_level_marker_reaches_native_effects(
+    path: str,
+    name: str,
+    unit: str,
+    expected: list[int],
+) -> None:
+    radio = _watts_radio() if unit == "watts" else _raw_level_radio()
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writers, commands = await _post_level_series(
+        srv,
+        path,
+        name=name,
+        levels=[0, 0.5, 1],
+        tagged=True,
+    )
+
+    assert all(writer.response_status == 200 for writer in writers)
+    assert all(writer.response_body["ok"] is True for writer in writers)
+    _assert_native_levels(commands, name=name, expected=expected, unit=unit)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/api/v1/commands", "/api/v1/commands/batch"])
+@pytest.mark.parametrize(
+    ("name", "unit", "expected"),
+    [
+        ("set_af_level", "raw_255", [1, 255]),
+        ("set_rf_power", "raw_255", [1, 255]),
+        ("set_power", "raw_255", [1, 255]),
+        ("set_rf_power", "watts", [1, 100]),
+        ("set_power", "watts", [1, 100]),
+    ],
+)
+async def test_http_untagged_level_json_type_compatibility(
+    path: str,
+    name: str,
+    unit: str,
+    expected: list[int],
+) -> None:
+    radio = _watts_radio() if unit == "watts" else _raw_level_radio()
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writers, commands = await _post_level_series(
+        srv,
+        path,
+        name=name,
+        levels=[1, 1.0],
+        tagged=False,
+    )
+
+    assert all(writer.response_status == 200 for writer in writers)
+    assert all(writer.response_body["ok"] is True for writer in writers)
+    _assert_native_levels(commands, name=name, expected=expected, unit=unit)
+
+
+_MALFORMED_NORMALIZED_LEVELS = [
+    {"level": False, "level_unit": "normalized"},
+    {"level": "0.5", "level_unit": "normalized"},
+    {"level": float("nan"), "level_unit": "normalized"},
+    {"level": float("inf"), "level_unit": "normalized"},
+    {"level": float("-inf"), "level_unit": "normalized"},
+    {"level": -0.01, "level_unit": "normalized"},
+    {"level": 1.01, "level_unit": "normalized"},
+    {"level": 0.5, "level_unit": "raw_255"},
+    {"level": 0.5, "level_unit": None},
+    {"level_unit": "normalized"},
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/api/v1/commands", "/api/v1/commands/batch"])
+@pytest.mark.parametrize("name", ["set_af_level", "set_rf_power", "set_power"])
+@pytest.mark.parametrize("params", _MALFORMED_NORMALIZED_LEVELS)
+async def test_http_normalized_level_marker_rejects_malformed_without_effect(
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+    name: str,
+    params: dict[str, object],
+) -> None:
+    monkeypatch.setattr(web_server, "_COMMAND_BATCH_STEP_TIMEOUT", 0.001)
+    radio = _raw_level_radio()
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+    attempted: list[object] = []
+    original_put = srv.command_queue.put
+    original_put_ordered = srv.command_queue.put_ordered
+
+    def capture_put(command: object, **metadata: object) -> None:
+        attempted.append(command)
+        original_put(command, **metadata)
+
+    def capture_put_ordered(command: object, **metadata: object) -> object:
+        attempted.append(command)
+        return original_put_ordered(command, **metadata)
+
+    monkeypatch.setattr(srv.command_queue, "put", capture_put)
+    monkeypatch.setattr(srv.command_queue, "put_ordered", capture_put_ordered)
+    command_params = dict(params)
+    if name == "set_af_level":
+        command_params["receiver"] = 0
+    payload = {"name": name, "params": command_params}
+    if path.endswith("/batch"):
+        payload = {"steps": [payload]}
+
+    writer = await _post_json(srv, path, payload)
+
+    if path.endswith("/batch"):
+        assert writer.response_status == 200
+        [result] = writer.response_body["results"]
+        assert result["status"] == "failed_validation"
+        assert result["error"] == "invalid_request"
+    else:
+        assert writer.response_status == 400
+        assert writer.response_body["error"] == "invalid_request"
+    assert attempted == []
+    assert srv.command_queue.drain_entries() == []
+    assert srv.command_service.lifecycle_events() == ()
+    assert srv.command_service.pending_overlays(source="http", session_id=None) == ()
+    radio.set_af_level.assert_not_awaited()
+    radio.set_rf_power.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("continue_on_error", "expected_statuses", "expected_commands"),
+    [
+        (False, ["executed", "failed_validation", "skipped"], [SetFreq(144_030_000)]),
+        (
+            True,
+            ["executed", "failed_validation", "executed"],
+            [SetFreq(144_030_000), SetMode("FM")],
+        ),
+    ],
+)
+async def test_http_batch_malformed_normalized_step_preserves_ordered_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    continue_on_error: bool,
+    expected_statuses: list[str],
+    expected_commands: list[object],
+) -> None:
+    monkeypatch.setattr(web_server, "_COMMAND_BATCH_STEP_TIMEOUT", 0.01)
+    srv = WebServer(_raw_level_radio(), WebConfig(host="127.0.0.1", port=0))
+    captured: list[object] = []
+    consumer = asyncio.create_task(
+        _complete_ordered_commands(srv.command_queue, len(expected_commands), captured)
+    )
+    try:
+        writer = await _post_json(
+            srv,
+            "/api/v1/commands/batch",
+            {
+                "continue_on_error": continue_on_error,
+                "steps": [
+                    {"name": "set_freq", "params": {"freq": 144_030_000}},
+                    {
+                        "name": "set_rf_power",
+                        "params": {"level": 0.5, "level_unit": "raw_255"},
+                    },
+                    {"name": "set_mode", "params": {"mode": "FM"}},
+                ],
+            },
+        )
+    finally:
+        await asyncio.wait_for(consumer, timeout=1.0)
+
+    assert writer.response_status == 200
+    assert writer.response_body["ok"] is False
+    assert [
+        result["status"] for result in writer.response_body["results"]
+    ] == expected_statuses
+    assert captured == expected_commands
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
14 code + 0 regenerated baselines = 14 files; the two HTTP files complete the same public AF/RF marker contract across WebSocket, single-command HTTP, and ordered batch HTTP, while the four conformance files remain required exact-wire witnesses.

## Linear

- [MOR-2420](https://linear.app/rigplane/issue/MOR-2420)
- Accepted base: `9904f62b2622a5b07234e7e07ca4ec7c166201e9`
- Newer accepted `main` head `c67b13ec` is file-disjoint; no rebase was performed solely for movement.

## Summary

- Add the additive `level_unit: "normalized"` wire marker centrally for normalized AF intents and explicitly for normalized RF UI intents.
- Validate and consume tagged WebSocket levels before pacing/coalescing, then carry already-clean params through dispatch without a second validator.
- Reuse that same consumer once at HTTP single ingress and once at HTTP batch ingress, before descriptor binding, expectation creation, collector work, or queue effects.
- Preserve untagged compatibility: JSON integer `1` remains native `1`; JSON decimal `1.0` retains normalized-float meaning on WebSocket and both HTTP endpoints.
- Use one canonical six-line JSONL matrix from the public command catalog to prove exact AF/RF bytes in the real frontend transport and feed those same bytes through real WebSocket ingress.

## Compatibility and rollout

This is additive protocol surface. Existing untagged callers retain their current type-based behavior, the generic WebSocket serializer is unchanged, and existing Q-resolver quantization remains in place. Roll out the matching server first: an older server may ignore the marker and misinterpret normalized endpoint `1` as native integer `1`.

## RED evidence

Initial implementation RED showed missing frontend markers and server marker validation. The first correction recorded 32/32 expected WebSocket pacing-order failures before moving validation ahead of coalescing.

For the HTTP correction, the first real-endpoint matrix collected 82 cases: 22 failed for the representation gap and 60 passed as compatibility/existing late-validation controls. The 10 tagged single/batch endpoint cases failed at integer endpoint `1` for AF, canonical RF, and alias RF on raw-255 and watt profiles; 12 single/batch cases showed unknown/null markers accepted for all three names. Untagged `1`/`1.0` and other malformed controls stayed green. After changing the partial-execution witness to an unknown marker with an otherwise valid level, both `continue_on_error` policies were separately RED because the invalid step executed or timed out instead of failing validation.

## Verification

- Full HTTP command/batch test file: 140 passed.
- Preserved WebSocket marker, pending-order, malformed, and raw-compatibility regressions: 41 passed.
- Related HTTP server/lifecycle regressions: 21 passed.
- Prior unchanged frontend focused evidence carries forward: 7 files, 327 passed.
- Tagged HTTP AF/RF/alias `0`, `0.5`, and `1` reach native `0/128/255` or `0/50/100` effects on both single and batch routes.
- The ten malformed shapes run for AF/RF/alias on both HTTP routes and assert HTTP error classification, no queue attempt, no lifecycle/overlay, and no radio effect.
- Batch witnesses preserve ordered partial execution: prior valid work remains executed; the invalid step has no effect; later work is skipped or executed according to `continue_on_error`.
- Ruff check/format, strict mypy for `src/rigplane/web`, import-linter, and `git diff --check` passed.
- No local full suite was run; the natural required quick on the corrected Ready head owns that evidence.

## Scope and safety

No validated flags, new engines, quantizers, generic harness weakening, marker stripping, assertion deletion, raw API compatibility loss, new schema, PTT/TUNE, audio lifecycle, store, core/backend, global decoder, hardware, service, or deployment changes. Native effects are verified with mocks and queue records only; no radio was keyed or contacted.