### PR TITLE
MOR-2410: bind legacy RF/SQL controls to command feedback

### DIFF
--- a/frontend/src/components-v2/controls/value-control/DualParamRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/DualParamRenderer.svelte
@@ -1,23 +1,16 @@
 <script lang="ts">
-  import { untrack } from 'svelte';
+  import { onDestroy, untrack } from 'svelte';
+  import type {
+    ContinuousPairBinding,
+    ContinuousPairLaneView,
+    ContinuousPairRendererLease,
+    ContinuousPairView,
+  } from '../../../primitives/scalar/continuous-pair.svelte';
+  import { clamp } from '../../../primitives/scalar/value-control-core';
   import './value-control.css';
-  import {
-    clamp,
-    snapToStep,
-    debounce,
-    dualParamValuesFromNormX,
-    dualParamThumbPercent,
-    dualParamDeviationFromValues,
-    dualParamStepAlongAxis,
-  } from '../../../primitives/scalar/value-control-core';
 
   interface Props {
-    rfValue: number;
-    sqlValue: number;
-    min?: number;
-    max?: number;
-    step?: number;
-    fineStepDivisor?: number;
+    binding: ContinuousPairBinding;
     rfLabel?: string;
     sqlLabel?: string;
     rfAccentColor?: string;
@@ -25,21 +18,12 @@
     trackColor?: string;
     showValues?: boolean;
     variant?: 'modern' | 'hardware' | 'hardware-illuminated';
-    onRfChange: (v: number) => void;
-    onSqlChange: (v: number) => void;
-    debounceMs?: number;
-    disabled?: boolean;
     shortcutHint?: string | null;
     title?: string | null;
   }
 
   let {
-    rfValue,
-    sqlValue,
-    min = 0,
-    max = 255,
-    step = 1,
-    fineStepDivisor = 10,
+    binding,
     rfLabel = 'RF',
     sqlLabel = 'SQL',
     rfAccentColor = '#22C55E',
@@ -47,175 +31,124 @@
     trackColor = 'var(--v2-bg-gradient-start)',
     showValues = true,
     variant = 'hardware-illuminated',
-    onRfChange,
-    onSqlChange,
-    debounceMs = 0,
-    disabled = false,
     shortcutHint = null,
     title = null,
   }: Props = $props();
 
   let containerEl: HTMLDivElement | null = $state(null);
-  let isDragging = $state(false);
-  let wheelLocked = $state(false);
-  let wheelUnlockTimer: ReturnType<typeof setTimeout> | null = null;
-  let localRf = $state(untrack(() => rfValue));
-  let localSql = $state(untrack(() => sqlValue));
+  let activePointer: { id: number; token: number; target: HTMLElement } | null = null;
+  const initialBinding = untrack(() => binding);
+  let attachedBinding = initialBinding;
+  let lease: ContinuousPairRendererLease = initialBinding.attachRenderer();
+  let view = $state<ContinuousPairView | null>(null);
 
-  function markWheelActive() {
-    wheelLocked = true;
-    if (wheelUnlockTimer) clearTimeout(wheelUnlockTimer);
-    wheelUnlockTimer = setTimeout(() => {
-      wheelLocked = false;
-      wheelUnlockTimer = null;
-    }, 300);
+  function releaseActivePointer(): void {
+    if (activePointer?.target.hasPointerCapture?.(activePointer.id)) {
+      activePointer.target.releasePointerCapture(activePointer.id);
+    }
+    activePointer = null;
   }
 
-  let prevRf = untrack(() => rfValue);
-  let prevSql = untrack(() => sqlValue);
-  $effect(() => {
-    const r = rfValue;
-    const s = sqlValue;
-    if (isDragging || wheelLocked) {
-      if (r !== prevRf) prevRf = r;
-      if (s !== prevSql) prevSql = s;
-      return;
-    }
-    if (r !== prevRf) {
-      prevRf = r;
-      localRf = r;
-    }
-    if (s !== prevSql) {
-      prevSql = s;
-      localSql = s;
-    }
+  onDestroy(() => {
+    releaseActivePointer();
+    lease.dispose();
   });
 
-  let thumbPct = $derived(dualParamThumbPercent(localRf, localSql, min, max));
-  let absDeviation = $derived(dualParamDeviationFromValues(localRf, localSql, min, max));
+  $effect.pre(() => {
+    if (binding !== attachedBinding) {
+      releaseActivePointer();
+      lease.dispose();
+      attachedBinding = binding;
+      lease = binding.attachRenderer();
+    }
+    view = lease.view;
+  });
 
-  /** Display values as 0–100% instead of raw 0–255. */
-  let displayRf = $derived(max > min ? Math.round((localRf - min) / (max - min) * 100) : 0);
-  let displaySql = $derived(max > min ? Math.round((localSql - min) / (max - min) * 100) : 0);
+  function laneValue(lane: ContinuousPairLaneView): number | null {
+    if (lane.evidence === 'command-feedback' && lane.feedback.target !== null) {
+      return lane.feedback.target;
+    }
+    return lane.localRequested ?? lane.canonical;
+  }
+
+  function percent(value: number | null, snapshot: ContinuousPairView | null): number | null {
+    if (value === null || snapshot === null || !snapshot.domainValid) return null;
+    const span = snapshot.domain.max - snapshot.domain.min;
+    return span > 0 ? Math.round((value - snapshot.domain.min) / span * 100) : null;
+  }
+
+  let thumbPct = $derived(view?.displayedPosition === null || view?.displayedPosition === undefined
+    ? 50 : clamp(view.displayedPosition, 0, 1) * 100);
+  let displayRf = $derived(view === null ? null : percent(laneValue(view.lanes.rf), view));
+  let displaySql = $derived(view === null ? null : percent(laneValue(view.lanes.sql), view));
+  let absDeviation = $derived(Math.abs(thumbPct - 50) / 50);
   let fillRatio = $derived(absDeviation);
   let rfFillWidth = $derived(Math.max(0, 50 - thumbPct));
   let sqlFillWidth = $derived(Math.max(0, thumbPct - 50));
   let slitAccent = $derived(thumbPct <= 50 ? rfAccentColor : sqlAccentColor);
+  let ariaNow = $derived(view?.position === null || view?.position === undefined
+    ? undefined : Math.round(view.position * 100));
+  let rfLane = $derived(view?.lanes.rf ?? null);
+  let sqlLane = $derived(view?.lanes.sql ?? null);
 
-  let adaptiveWheelMultiplier = $derived(Math.max(1, Math.ceil((max - min) / 255)));
-
-  let debouncedRf = $derived.by<(...args: unknown[]) => void>(() => {
-    if (debounceMs > 0) {
-      return debounce((v: number) => onRfChange(v), debounceMs) as (...args: unknown[]) => void;
-    }
-    return ((v: number) => onRfChange(v)) as (...args: unknown[]) => void;
-  });
-
-  let debouncedSql = $derived.by<(...args: unknown[]) => void>(() => {
-    if (debounceMs > 0) {
-      return debounce((v: number) => onSqlChange(v), debounceMs) as (...args: unknown[]) => void;
-    }
-    return ((v: number) => onSqlChange(v)) as (...args: unknown[]) => void;
-  });
-
-  function emitPair(nextRf: number, nextSql: number, immediate: boolean) {
-    if (nextRf !== localRf) localRf = nextRf;
-    if (nextSql !== localSql) localSql = nextSql;
-    if (nextRf !== rfValue) {
-      if (immediate) onRfChange(nextRf);
-      else debouncedRf(nextRf);
-    }
-    if (nextSql !== sqlValue) {
-      if (immediate) onSqlChange(nextSql);
-      else debouncedSql(nextSql);
-    }
-  }
-
-  function normX(clientX: number): number {
-    if (!containerEl) return 0;
+  function normX(clientX: number): number | null {
+    if (!containerEl) return null;
     const rect = containerEl.getBoundingClientRect();
+    if (!Number.isFinite(rect.width) || rect.width <= 0) return null;
     return clamp((clientX - rect.left) / rect.width, 0, 1);
   }
 
-  function applyNormX(nx: number, immediate: boolean) {
-    const { rf, sql } = dualParamValuesFromNormX(nx, min, max, step);
-    emitPair(rf, sql, immediate);
-  }
-
   function handlePointerDown(e: PointerEvent) {
-    if (disabled || !containerEl) return;
+    if (!containerEl || view === null) return;
+    const token = lease.beginPointer();
+    if (token === null) return;
     e.preventDefault();
     const target = e.currentTarget as HTMLElement;
     target.setPointerCapture(e.pointerId);
-    isDragging = true;
-    applyNormX(normX(e.clientX), true);
+    activePointer = { id: e.pointerId, token, target };
+    const candidate = normX(e.clientX);
+    if (candidate !== null) lease.pointer(token, candidate);
   }
 
   function handlePointerMove(e: PointerEvent) {
-    if (!isDragging || disabled || !containerEl) return;
-    applyNormX(normX(e.clientX), true);
+    if (!activePointer || activePointer.id !== e.pointerId) return;
+    const candidate = normX(e.clientX);
+    if (candidate !== null) lease.pointer(activePointer.token, candidate);
   }
 
   function handlePointerUp(e: PointerEvent) {
-    if (!isDragging) return;
-    const target = e.currentTarget as HTMLElement;
-    target.releasePointerCapture(e.pointerId);
-    isDragging = false;
+    if (!activePointer || activePointer.id !== e.pointerId) return;
+    const token = activePointer.token;
+    releaseActivePointer();
+    lease.endPointer(token);
+  }
+
+  function handlePointerCancel(e: PointerEvent) {
+    if (!activePointer || activePointer.id !== e.pointerId) return;
+    const token = activePointer.token;
+    releaseActivePointer();
+    lease.cancelPointer(token);
   }
 
   function handleWheel(e: WheelEvent) {
-    if (disabled || !containerEl) return;
+    if (view === null || !view.editable) return;
     e.preventDefault();
-    const wheelMultiplier = e.shiftKey ? 1 : 4 * adaptiveWheelMultiplier;
-    const wheelStep = e.shiftKey ? step / fineStepDivisor : step * wheelMultiplier;
-    const direction = (e.deltaY > 0 ? -1 : 1) as 1 | -1;
-    const { rf, sql } = dualParamStepAlongAxis(
-      localRf,
-      localSql,
-      direction,
-      wheelStep,
-      fineStepDivisor,
-      min,
-      max,
-      false,
-    );
-    localRf = rf;
-    localSql = sql;
-    markWheelActive();
-    if (rf !== rfValue) onRfChange(rf);
-    if (sql !== sqlValue) onSqlChange(sql);
+    lease.wheel({ direction: e.deltaY > 0 ? -1 : 1, fine: e.shiftKey });
   }
 
   function handleKeyDown(e: KeyboardEvent) {
-    if (disabled) return;
-    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
-    const direction = (e.key === 'ArrowRight' ? 1 : -1) as 1 | -1;
-    const { rf, sql } = dualParamStepAlongAxis(
-      localRf,
-      localSql,
-      direction,
-      step,
-      fineStepDivisor,
-      min,
-      max,
-      e.shiftKey,
-    );
-    if (rf === localRf && sql === localSql) return;
-    e.preventDefault();
-    emitPair(rf, sql, false);
+    if (lease.key({ key: e.key, fine: e.shiftKey })) e.preventDefault();
   }
 
   function handleDoubleClick() {
-    if (disabled) return;
-    emitPair(max, min, true);
+    lease.reset();
   }
-
-  let ariaNow = $derived(Math.round(thumbPct));
 </script>
 
+{#if view !== null}
 <div
   class="vc-dual"
-  class:disabled
+  class:disabled={!view.editable}
   class:hw-illum={variant === 'hardware-illuminated'}
   class:hardware={variant === 'hardware'}
   bind:this={containerEl}
@@ -233,26 +166,37 @@
 >
   {#if showValues}
     <div class="vc-header">
-      <span class="vc-label-rf">{rfLabel}<span class="vc-num">{displayRf}%</span></span>
-      <span class="vc-label-sql"><span class="vc-num">{displaySql}%</span>{sqlLabel}</span>
+      <span class="vc-label-rf">{rfLabel}<span class="vc-num">{displayRf === null ? '—' : `${displayRf}%`}</span></span>
+      <span class="vc-label-sql"><span class="vc-num">{displaySql === null ? '—' : `${displaySql}%`}</span>{sqlLabel}</span>
     </div>
   {/if}
 
   <div
     class="vc-track-container"
     role="slider"
-    tabindex={disabled ? -1 : 0}
+    tabindex={view.editable ? 0 : -1}
     data-control="rf-sql-dual"
     aria-label="RF gain and squelch (single control). Center is default; left reduces RF; right adds squelch."
     aria-valuemin={0}
     aria-valuemax={100}
     aria-valuenow={ariaNow}
-    aria-valuetext="RF {displayRf}%, squelch {displaySql}%"
-    aria-disabled={disabled}
+    aria-valuetext="RF {displayRf === null ? '—' : `${displayRf}%`}, squelch {displaySql === null ? '—' : `${displaySql}%`}"
+    aria-disabled={!view.editable}
+    aria-busy={view.busy}
+    data-rf-command-phase={rfLane?.phase ?? undefined}
+    data-sql-command-phase={sqlLane?.phase ?? undefined}
+    data-rf-confirmed={rfLane?.canonical ?? undefined}
+    data-rf-target={rfLane?.evidence === 'command-feedback' ? rfLane.feedback.target ?? '' : undefined}
+    data-rf-requested={rfLane?.evidence === 'command-feedback' ? rfLane.feedback.requestedTarget ?? '' : undefined}
+    data-rf-error={rfLane?.error ?? undefined}
+    data-sql-confirmed={sqlLane?.canonical ?? undefined}
+    data-sql-target={sqlLane?.evidence === 'command-feedback' ? sqlLane.feedback.target ?? '' : undefined}
+    data-sql-requested={sqlLane?.evidence === 'command-feedback' ? sqlLane.feedback.requestedTarget ?? '' : undefined}
+    data-sql-error={sqlLane?.error ?? undefined}
     onpointerdown={handlePointerDown}
     onpointermove={handlePointerMove}
     onpointerup={handlePointerUp}
-    onpointercancel={handlePointerUp}
+    onpointercancel={handlePointerCancel}
     onwheel={handleWheel}
     onkeydown={handleKeyDown}
     ondblclick={handleDoubleClick}
@@ -295,7 +239,14 @@
     <span class="axis-gap"></span>
     <span class="axis-sql">{sqlLabel}</span>
   </div>
+  {#if rfLane?.announcement}
+    <span class="sr-only" role="status" aria-live="polite" aria-atomic="true" data-control-feedback-status>{rfLane.announcement}</span>
+  {/if}
+  {#if sqlLane?.announcement}
+    <span class="sr-only" role="status" aria-live="polite" aria-atomic="true" data-control-feedback-status>{sqlLane.announcement}</span>
+  {/if}
 </div>
+{/if}
 
 <style>
   .vc-dual {

--- a/frontend/src/components-v2/controls/value-control/__tests__/DualParamRenderer.controlled.svelte.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/DualParamRenderer.controlled.svelte.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import DualParamRenderer from '../DualParamRenderer.svelte';
+import {
+  type ContinuousPairBinding,
+  type ContinuousPairInput,
+  type ContinuousPairLaneView,
+  type ContinuousPairRendererLease,
+  type ContinuousPairView,
+} from '../../../../primitives/scalar/continuous-pair.svelte';
+import type { CommandScalarFeedback } from '../../../../primitives/scalar/continuous-scalar.svelte';
+
+let mounted: ReturnType<typeof mount>[] = [];
+
+afterEach(async () => {
+  await Promise.all(mounted.map(component => unmount(component)));
+  mounted = [];
+  document.body.innerHTML = '';
+});
+
+function readingView(): ContinuousPairView {
+  const lane = (value: number) => ({
+    evidence: 'reading' as const,
+    reading: { status: 'known' as const, value },
+    availability: 'available' as const,
+    canonical: value,
+    localRequested: null,
+    feedback: null,
+    phase: null,
+    error: null,
+    presentation: null,
+    announcement: null,
+  });
+  return {
+    evidence: 'reading',
+    domain: { min: 0, max: 1, step: 0.01, defaultValue: null, fineStepDivisor: 10 },
+    domainValid: true,
+    canonical: { rf: 1, sql: 0 },
+    position: 0.5,
+    axisDraft: null,
+    draft: null,
+    displayedPosition: 0.5,
+    editable: true,
+    busy: false,
+    interaction: 'idle',
+    lanes: { rf: lane(1), sql: lane(0) },
+  };
+}
+
+function fakeBinding(token: number, readView: () => ContinuousPairView = readingView) {
+  const lease: ContinuousPairRendererLease = {
+    get view() { return readView(); },
+    beginPointer: vi.fn(() => token),
+    pointer: vi.fn(),
+    endPointer: vi.fn(),
+    cancelPointer: vi.fn(),
+    nativeInput: vi.fn(),
+    wheel: vi.fn(),
+    key: vi.fn(() => true),
+    reset: vi.fn(),
+    dispose: vi.fn(),
+  };
+  const binding: ContinuousPairBinding = {
+    get view() { return readView(); },
+    attachRenderer: vi.fn(() => lease),
+    cancel: vi.fn(),
+    destroy: vi.fn(),
+  };
+  return { binding, lease };
+}
+
+function mountReactive(binding: ContinuousPairBinding) {
+  const state = $state({ binding });
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(DualParamRenderer, { target, props: state });
+  mounted.push(component);
+  flushSync();
+  return { state, target, component };
+}
+
+function slider(target: HTMLElement): HTMLElement {
+  return target.querySelector('[role="slider"]') as HTMLElement;
+}
+
+describe('binding-only DualParamRenderer', () => {
+  it('owns one lease, forwards every gesture, and disposes leases without destroying owners', async () => {
+    const first = fakeBinding(11);
+    const second = fakeBinding(22);
+    const { state, target, component } = mountReactive(first.binding);
+    const control = slider(target) as HTMLElement & {
+      setPointerCapture(id: number): void;
+      hasPointerCapture(id: number): boolean;
+      releasePointerCapture(id: number): void;
+    };
+    control.setPointerCapture = vi.fn();
+    control.hasPointerCapture = vi.fn(() => true);
+    control.releasePointerCapture = vi.fn();
+    vi.spyOn(target.querySelector('.vc-dual') as HTMLElement, 'getBoundingClientRect')
+      .mockReturnValue({ left: 0, width: 100 } as DOMRect);
+
+    control.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true, cancelable: true, pointerId: 1, clientX: 0,
+    }));
+    control.dispatchEvent(new PointerEvent('pointermove', {
+      bubbles: true, pointerId: 1, clientX: 100,
+    }));
+    control.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }));
+    expect(first.lease.pointer).toHaveBeenNthCalledWith(1, 11, 0);
+    expect(first.lease.pointer).toHaveBeenNthCalledWith(2, 11, 1);
+    expect(first.lease.endPointer).toHaveBeenCalledExactlyOnceWith(11);
+
+    control.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true, cancelable: true, pointerId: 2, clientX: 50,
+    }));
+    control.dispatchEvent(new PointerEvent('pointercancel', { bubbles: true, pointerId: 2 }));
+    expect(first.lease.cancelPointer).toHaveBeenCalledExactlyOnceWith(11);
+    control.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: -1 }));
+    control.dispatchEvent(new WheelEvent('wheel', {
+      bubbles: true, cancelable: true, deltaY: 1, shiftKey: true,
+    }));
+    expect(first.lease.wheel).toHaveBeenNthCalledWith(1, { direction: 1, fine: false });
+    expect(first.lease.wheel).toHaveBeenNthCalledWith(2, { direction: -1, fine: true });
+    control.dispatchEvent(new KeyboardEvent('keydown', {
+      bubbles: true, cancelable: true, key: 'ArrowRight', shiftKey: true,
+    }));
+    control.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+    expect(first.lease.key).toHaveBeenCalledExactlyOnceWith({ key: 'ArrowRight', fine: true });
+    expect(first.lease.reset).toHaveBeenCalledOnce();
+
+    control.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true, cancelable: true, pointerId: 3, clientX: 25,
+    }));
+    state.binding = second.binding;
+    flushSync();
+    expect(first.lease.dispose).toHaveBeenCalledOnce();
+    expect(control.releasePointerCapture).toHaveBeenCalledWith(3);
+    control.dispatchEvent(new PointerEvent('pointermove', {
+      bubbles: true, pointerId: 3, clientX: 75,
+    }));
+    expect(second.lease.pointer).not.toHaveBeenCalled();
+    control.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowLeft' }));
+    expect(second.lease.key).toHaveBeenCalledExactlyOnceWith({ key: 'ArrowLeft', fine: false });
+
+    mounted = mounted.filter(item => item !== component);
+    await unmount(component);
+    expect(second.lease.dispose).toHaveBeenCalledOnce();
+    expect(first.binding.destroy).not.toHaveBeenCalled();
+    expect(second.binding.destroy).not.toHaveBeenCalled();
+  });
+
+  it('renders distinct lane truth and one status for each supplied lane announcement', () => {
+    const feedback = (
+      control: string,
+      confirmed: number,
+      over: Partial<CommandScalarFeedback>,
+    ): CommandScalarFeedback => ({
+      confirmed, target: null, requestedTarget: null, phase: 'idle', busy: false,
+      availability: 'available', outcome: null, lifecycleId: null, transitionId: null,
+      providerGeneration: 3, sessionEpoch: 7, scope: { control, receiver: 0 },
+      repeatPolicy: 'latest-target-wins', ...over,
+    });
+    const input: ContinuousPairInput = {
+      evidence: 'command-feedback', enabled: true,
+      domain: { min: 0, max: 1, step: 0.01, defaultValue: null, fineStepDivisor: 10 },
+      requestRf: vi.fn(), requestSql: vi.fn(),
+      rf: { command: 'set_rf_gain', feedback: feedback('rf-gain', 0.5, {
+        target: 0.55, requestedTarget: 0.6, phase: 'submitted', busy: true,
+        lifecycleId: 'rf-1', transitionId: 'rf-submitted',
+      }) },
+      sql: { command: 'set_squelch', feedback: feedback('squelch', 0.2, {
+        requestedTarget: 0.3, phase: 'failed',
+        outcome: { phase: 'failed', error: 'radio rejected' },
+        lifecycleId: 'sql-1', transitionId: 'sql-failed',
+      }) },
+    };
+    const lane = (
+      command: string,
+      supplied: CommandScalarFeedback,
+      announcement: string,
+    ): ContinuousPairLaneView => ({
+      evidence: 'command-feedback', command, feedback: supplied,
+      availability: supplied.availability, canonical: supplied.confirmed,
+      localRequested: null, phase: supplied.phase,
+      error: supplied.outcome?.error ?? null,
+      presentation: {
+        attributes: {
+          'data-command-phase': supplied.phase,
+          'aria-busy': supplied.busy ? 'true' : 'false',
+        },
+        targetDescription: null,
+        politeAnnouncement: supplied.transitionId === null ? null : {
+          politeness: 'polite', transitionId: supplied.transitionId,
+          phase: supplied.phase, targetDescription: null, message: announcement,
+        },
+        state: { announcedTransitionIds: supplied.transitionId === null ? [] : [supplied.transitionId] },
+      },
+      announcement,
+    });
+    const rf = lane('set_rf_gain', input.rf.feedback, 'Submitting RF gain');
+    const sql = lane('set_squelch', input.sql.feedback, 'Failed squelch');
+    const view: ContinuousPairView = {
+      evidence: 'command-feedback', domain: input.domain, domainValid: true,
+      canonical: { rf: 0.5, sql: 0.2 }, position: 0.65,
+      axisDraft: null, draft: null, displayedPosition: 0.65,
+      editable: true, busy: true, interaction: 'idle', lanes: { rf, sql },
+    };
+    const binding = fakeBinding(31, () => view).binding;
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    mounted.push(mount(DualParamRenderer, { target, props: { binding } }));
+    flushSync();
+    const control = slider(target);
+
+    expect(control.dataset).toMatchObject({
+      rfCommandPhase: 'submitted', sqlCommandPhase: 'failed',
+      rfConfirmed: '0.5', rfTarget: '0.55', rfRequested: '0.6',
+      sqlConfirmed: '0.2', sqlTarget: '', sqlRequested: '0.3',
+      sqlError: 'radio rejected',
+    });
+    expect(control.getAttribute('aria-busy')).toBe('true');
+    expect(target.querySelectorAll('[data-control-feedback-status]')).toHaveLength(2);
+  });
+});

--- a/frontend/src/components-v2/panels/RfFrontEnd.svelte
+++ b/frontend/src/components-v2/panels/RfFrontEnd.svelte
@@ -1,6 +1,17 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import { ValueControl } from '../controls/value-control';
   import { normalizedPercentDisplay } from '../../primitives/scalar/value-control-core';
+  import {
+    createContinuousPair,
+    createLegacyContinuousPairPolicy,
+    type ContinuousPairInput,
+  } from '../../primitives/scalar/continuous-pair.svelte';
+  import {
+    createContinuousScalar,
+    createHBarContinuousScalarPolicy,
+    type ContinuousScalarInput,
+  } from '../../primitives/scalar/continuous-scalar.svelte';
   import DualParamRenderer from '../controls/value-control/DualParamRenderer.svelte';
   import AttenuatorControl from '../controls/AttenuatorControl.svelte';
   import { HardwareButton } from '$lib/Button';
@@ -10,6 +21,7 @@
 
   import {
     deriveRfFrontEndProps, getRfFrontEndHandlers, getPreampArmed, getAttenuatorArmed,
+    getRfSqlControlFeedback,
   } from '$lib/runtime/adapters/panel-adapters';
 
   const handlers = getRfFrontEndHandlers();
@@ -25,8 +37,6 @@
   let attArmed = $derived(getAttenuatorArmed());
   const armedIdBase = $props.id();
 
-  let rfGain = $derived(p.rfGain);
-  let squelch = $derived(p.squelch);
   let att = $derived(p.att);
   let pre = $derived(p.pre);
   let preDisabled = $derived(p.preDisabled);
@@ -49,45 +59,95 @@
   let showRfSqlDual = $derived(showRfGain && showSquelch);
   let visible = $derived(shouldShowPanel(showRfGain, showAtt, showPre, showSquelch));
 
+  const rfSqlDomain = Object.freeze({
+    min: 0, max: 1, step: 0.01, defaultValue: 0, fineStepDivisor: 10,
+  });
+  let rfSqlFeedback = $derived(getRfSqlControlFeedback());
+  function rfSqlPairInput(): Readonly<ContinuousPairInput> {
+    const common = {
+      domain: rfSqlDomain,
+      enabled: showRfSqlDual,
+      requestRf: onRfGainChange,
+      requestSql: onSquelchChange,
+    };
+    if (rfSqlFeedback === null) return {
+      ...common,
+      evidence: 'reading',
+      ownerKey: 'legacy-rf-sql:authority-unresolved',
+      enabled: false,
+      rf: { reading: { status: 'unknown' }, availability: 'unavailable' },
+      sql: { reading: { status: 'unknown' }, availability: 'unavailable' },
+    };
+    return {
+      ...common,
+      evidence: 'command-feedback',
+      rf: rfSqlFeedback.rf,
+      sql: rfSqlFeedback.sql,
+    };
+  }
+  function rfGainInput(): Readonly<ContinuousScalarInput> {
+    const common = { domain: rfSqlDomain, request: onRfGainChange };
+    if (rfSqlFeedback === null) return {
+      ...common,
+      evidence: 'reading',
+      ownerKey: 'legacy-rf-gain:authority-unresolved',
+      enabled: false,
+      reading: { status: 'unknown' },
+    };
+    return {
+      ...common,
+      evidence: 'command-feedback',
+      enabled: showRfGain && !showRfSqlDual,
+      command: rfSqlFeedback.rf.command,
+      feedback: rfSqlFeedback.rf.feedback,
+    };
+  }
+  const rfSqlBinding = createContinuousPair(
+    rfSqlPairInput,
+    createLegacyContinuousPairPolicy({ keyboardDebounceMs: 0 }),
+  );
+  const rfGainBinding = createContinuousScalar(
+    rfGainInput,
+    createHBarContinuousScalarPolicy({ preview: 'optimistic', debounceMs: 50 }),
+  );
+  onDestroy(() => {
+    rfSqlBinding.destroy();
+    rfGainBinding.destroy();
+  });
+
   let attValues = $derived(p.attValues);
   let attLabels = $derived(p.attLabels);
   let preOptions = $derived(p.preOptions);
   const rfGainShortcut = getShortcutHint('adjust_rf_gain');
   const attShortcut = getShortcutHint('cycle_att');
   const preShortcut = getShortcutHint('cycle_preamp');
+  const displayRfGain = (value: number): string => Number.isFinite(value)
+    ? normalizedPercentDisplay(value) : '—';
+  const feedbackIntegratedControl = { 'feedback-policy': 'feedback-integrated' } as const;
 </script>
 
 {#if visible}
   <div class="controls">
     {#if showRfSqlDual}
       <DualParamRenderer
-        rfValue={rfGain}
-        sqlValue={squelch}
-        min={0}
-        max={1}
-        step={0.01}
+        binding={rfSqlBinding}
         rfAccentColor="#22C55E"
         sqlAccentColor="#F59E0B"
         shortcutHint={rfGainShortcut}
         title={rfGainShortcut}
-        onRfChange={onRfGainChange}
-        onSqlChange={onSquelchChange}
         variant="hardware-illuminated"
       />
     {:else if showRfGain}
       <div data-control="rf-gain">
         <ValueControl
-          value={rfGain}
-          min={0}
-          max={1}
-          step={0.01}
+          {...feedbackIntegratedControl}
+          binding={rfGainBinding}
           label="RF Gain"
           renderer="hbar"
-          displayFn={normalizedPercentDisplay}
+          displayFn={displayRfGain}
           accentColor="#22C55E"
           shortcutHint={rfGainShortcut}
           title={rfGainShortcut}
-          onChange={onRfGainChange}
           variant="hardware-illuminated"
         />
       </div>

--- a/frontend/src/components-v2/panels/__tests__/RfFrontEnd.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/RfFrontEnd.component.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
 
 const baseProps = {
   rfGain: 255,
@@ -32,7 +33,25 @@ const baseProps = {
   showIpPlus: true,
 };
 
-const mockProps = { ...baseProps };
+const propsState = new SvelteMap([['value', { ...baseProps }]]);
+
+const feedback = (
+  control: 'rf-gain' | 'squelch',
+  confirmed: number | null,
+  over: Record<string, unknown> = {},
+) => ({
+  confirmed, target: null, requestedTarget: null, phase: 'idle' as const, busy: false,
+  availability: 'available' as const, outcome: null, lifecycleId: null, transitionId: null,
+  providerGeneration: 3, sessionEpoch: 7, scope: { control, receiver: 0 as const },
+  repeatPolicy: 'latest-target-wins' as const, ...over,
+});
+const availableFeedback = () => ({
+  rf: { command: 'set_rf_gain', feedback: feedback('rf-gain', 0.5) },
+  sql: { command: 'set_squelch', feedback: feedback('squelch', 0.2) },
+});
+const feedbackState = new SvelteMap<string, ReturnType<typeof availableFeedback> | null>([
+  ['value', availableFeedback()],
+]);
 
 const mockHandlers = {
   onRfGainChange: vi.fn(),
@@ -49,8 +68,9 @@ const mockHandlers = {
 const unarmed = { armed: false, value: null };
 
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
-  deriveRfFrontEndProps: () => mockProps,
+  deriveRfFrontEndProps: () => propsState.get('value')!,
   getRfFrontEndHandlers: () => mockHandlers,
+  getRfSqlControlFeedback: () => feedbackState.get('value')!,
   getPreampArmed: () => unarmed,
   getAttenuatorArmed: () => unarmed,
 }));
@@ -60,7 +80,7 @@ import RfFrontEnd from '../RfFrontEnd.svelte';
 let components: ReturnType<typeof mount>[] = [];
 
 function mountPanel(overrides?: Partial<typeof baseProps>) {
-  if (overrides) Object.assign(mockProps, overrides);
+  propsState.set('value', { ...baseProps, ...overrides });
   const t = document.createElement('div');
   document.body.appendChild(t);
   const component = mount(RfFrontEnd, { target: t });
@@ -78,7 +98,8 @@ function findPreButton(t: HTMLElement, label: string): HTMLButtonElement {
 
 beforeEach(() => {
   components = [];
-  Object.assign(mockProps, baseProps);
+  propsState.set('value', { ...baseProps });
+  feedbackState.set('value', availableFeedback());
   mockHandlers.onRfGainChange = vi.fn();
   mockHandlers.onSquelchChange = vi.fn();
   mockHandlers.onAttChange = vi.fn();
@@ -115,5 +136,139 @@ describe('RfFrontEnd preamp/digisel mutex (component)', () => {
     flushSync();
 
     expect(mockHandlers.onPreChange).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('RfFrontEnd RF/SQL feedback bindings', () => {
+  function slider(target: HTMLElement): HTMLElement {
+    return target.querySelector('[role="slider"]') as HTMLElement;
+  }
+
+  it('mounts the combined pair owner and preserves RF-before-SQL gesture order', () => {
+    feedbackState.set('value', {
+      rf: { command: 'set_rf_gain', feedback: feedback('rf-gain', 1) },
+      sql: { command: 'set_squelch', feedback: feedback('squelch', 0) },
+    });
+    const target = mountPanel({ showRfGain: true, showSquelch: true });
+    const control = slider(target) as HTMLElement & {
+      setPointerCapture(id: number): void;
+      hasPointerCapture(id: number): boolean;
+      releasePointerCapture(id: number): void;
+    };
+    control.setPointerCapture = vi.fn();
+    control.hasPointerCapture = vi.fn(() => true);
+    control.releasePointerCapture = vi.fn();
+    vi.spyOn(target.querySelector('.vc-dual') as HTMLElement, 'getBoundingClientRect')
+      .mockReturnValue({ left: 0, width: 100 } as DOMRect);
+    const order: string[] = [];
+    mockHandlers.onRfGainChange.mockImplementation(value => order.push(`rf:${value}`));
+    mockHandlers.onSquelchChange.mockImplementation(value => order.push(`sql:${value}`));
+
+    control.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true, cancelable: true, pointerId: 1, clientX: 0,
+    }));
+    control.dispatchEvent(new PointerEvent('pointermove', {
+      bubbles: true, pointerId: 1, clientX: 100,
+    }));
+    control.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }));
+    flushSync();
+
+    expect(order).toEqual(['rf:0', 'rf:1', 'sql:1']);
+    expect(control.getAttribute('aria-valuetext')).toContain('RF 100%, squelch 100%');
+  });
+
+  it('keeps an optimistic RF-only HBar through pending, exact confirmation, and later truth', () => {
+    const target = mountPanel({ showRfGain: true, showSquelch: false });
+    const control = slider(target) as HTMLElement & {
+      setPointerCapture(id: number): void;
+      hasPointerCapture(id: number): boolean;
+      releasePointerCapture(id: number): void;
+    };
+    control.setPointerCapture = vi.fn();
+    control.hasPointerCapture = vi.fn(() => true);
+    control.releasePointerCapture = vi.fn();
+    vi.spyOn(target.querySelector('.vc-hbar') as HTMLElement, 'getBoundingClientRect')
+      .mockReturnValue({ left: 0, width: 100 } as DOMRect);
+
+    control.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true, cancelable: true, pointerId: 2, clientX: 70,
+    }));
+    control.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 2 }));
+    flushSync();
+    expect(Math.round(mockHandlers.onRfGainChange.mock.calls[0][0] * 255)).toBe(179);
+    expect(target.querySelector('.vc-value')?.textContent).toBe('70%');
+
+    feedbackState.set('value', {
+      ...availableFeedback(),
+      rf: { command: 'set_rf_gain', feedback: feedback('rf-gain', 0.5, {
+        target: 179 / 255, requestedTarget: 179 / 255,
+        phase: 'awaiting-confirmation', busy: true,
+        lifecycleId: 'rf-179', transitionId: 'rf-awaiting-179',
+      }) },
+    });
+    flushSync();
+    expect(target.querySelector('.vc-value')?.textContent).toBe('70%');
+    expect(control.dataset.commandPhase).toBe('awaiting-confirmation');
+    expect(control.getAttribute('aria-valuenow')).toBe('0.5');
+
+    feedbackState.set('value', {
+      ...availableFeedback(),
+      rf: { command: 'set_rf_gain', feedback: feedback('rf-gain', 179 / 255, {
+        requestedTarget: 179 / 255, phase: 'confirmed',
+        outcome: { phase: 'confirmed' }, lifecycleId: 'rf-179',
+        transitionId: 'rf-confirmed-179',
+      }) },
+    });
+    flushSync();
+    expect(control.getAttribute('aria-valuenow')).toBe(String(179 / 255));
+
+    feedbackState.set('value', {
+      ...availableFeedback(),
+      rf: { command: 'set_rf_gain', feedback: feedback('rf-gain', 0.8) },
+    });
+    flushSync();
+    expect(target.querySelector('.vc-value')?.textContent).toBe('80%');
+  });
+
+  it('switches branches, keeps qualified RF when SQL disappears, and recovers from null authority', () => {
+    vi.useFakeTimers();
+    const target = mountPanel({ showRfGain: true, showSquelch: true });
+    expect(target.querySelector('.vc-dual')).not.toBeNull();
+
+    const unavailableSql = feedback('squelch', null, {
+      availability: 'unavailable', phase: 'unavailable',
+    });
+    feedbackState.set('value', {
+      rf: { command: 'set_rf_gain', feedback: feedback('rf-gain', 0.5) },
+      sql: { command: 'set_squelch', feedback: unavailableSql },
+    });
+    propsState.set('value', { ...baseProps, showRfGain: true, showSquelch: false });
+    flushSync();
+    const rfOnly = slider(target);
+    expect(target.querySelector('.vc-hbar')).not.toBeNull();
+    expect(rfOnly.getAttribute('aria-valuenow')).toBe('0.5');
+
+    feedbackState.set('value', null);
+    flushSync();
+    expect(slider(target)).toBe(rfOnly);
+    expect(rfOnly.getAttribute('aria-disabled')).toBe('true');
+    expect(target.querySelector('.vc-value')?.textContent).toBe('—');
+
+    feedbackState.set('value', {
+      rf: { command: 'set_rf_gain', feedback: feedback('rf-gain', 0.8, {
+        providerGeneration: 4, sessionEpoch: 8,
+      }) },
+      sql: { command: 'set_squelch', feedback: feedback('squelch', 0.1, {
+        providerGeneration: 4, sessionEpoch: 8,
+      }) },
+    });
+    flushSync();
+    expect(slider(target)).toBe(rfOnly);
+    expect(rfOnly.getAttribute('aria-disabled')).toBe('false');
+    expect(rfOnly.getAttribute('aria-valuenow')).toBe('0.8');
+    vi.advanceTimersByTime(1_000);
+    expect(mockHandlers.onRfGainChange).not.toHaveBeenCalled();
+    expect(mockHandlers.onSquelchChange).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 });

--- a/frontend/src/components-v2/panels/__tests__/mor1536-armed-adoption.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/mor1536-armed-adoption.test.ts
@@ -116,6 +116,7 @@ vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   getFilterWidthControlFeedback: () => mockFilterWidthFeedback,
   deriveRfFrontEndProps: () => mockRfProps,
   getRfFrontEndHandlers: () => mockRfHandlers,
+  getRfSqlControlFeedback: () => null,
   getPreampArmed: () => mockPreArmed,
   getAttenuatorArmed: () => mockAttArmed,
   deriveDspProps: () => mockDspProps,

--- a/frontend/src/lib/runtime/adapters/__tests__/rf-sql-command-feedback.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/rf-sql-command-feedback.isolated.test.ts
@@ -10,6 +10,8 @@ const h = vi.hoisted(() => ({
   stateReads: 0,
   capsReads: 0,
   commandReads: 0,
+  sessionReads: 0,
+  session: { state: 'connected' as 'connected' | 'disconnected', epoch: 7 },
   active: 'MAIN' as 'MAIN' | 'SUB' | null,
   operational: true,
   project: vi.fn(),
@@ -19,6 +21,7 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
   runtime: {
     get state() { h.stateReads += 1; return h.state; },
     get caps() { h.capsReads += 1; return h.caps; },
+    get controlSession() { h.sessionReads += 1; return h.session; },
   },
 }));
 vi.mock('$lib/stores/commands.svelte', async (importOriginal) => ({
@@ -79,8 +82,23 @@ const connected = { state: 'connected' as const, epoch: 7 };
 describe('qualified RF/SQL command feedback', () => {
   afterEach(() => {
     h.state = null; h.caps = null; h.commands = [];
-    h.stateReads = 0; h.capsReads = 0; h.commandReads = 0;
+    h.stateReads = 0; h.capsReads = 0; h.commandReads = 0; h.sessionReads = 0;
+    h.session = { state: 'connected', epoch: 7 };
     h.active = 'MAIN'; h.operational = true; h.project.mockClear();
+  });
+
+  it('defaults to runtime session after capturing every reactive dependency before guards', () => {
+    h.session = { state: 'disconnected', epoch: -1 };
+    expect(getRfSqlControlFeedback()).toBeNull();
+    expect([h.stateReads, h.capsReads, h.commandReads, h.sessionReads]).toEqual([1, 1, 1, 1]);
+
+    h.state = state(); h.caps = caps();
+    h.session = { state: 'connected', epoch: 7 };
+    expect(getRfSqlControlFeedback()).toMatchObject({
+      rf: { feedback: { confirmed: 0.5, sessionEpoch: 7 } },
+      sql: { feedback: { confirmed: 0.2, sessionEpoch: 7 } },
+    });
+    expect([h.stateReads, h.capsReads, h.commandReads, h.sessionReads]).toEqual([2, 2, 2, 2]);
   });
 
   it('captures one state/caps/list/session authority and freezes normalized lanes', () => {
@@ -105,6 +123,7 @@ describe('qualified RF/SQL command feedback', () => {
     expect(Object.isFrozen(pair)).toBe(true);
     expect(Object.isFrozen(pair.rf)).toBe(true);
     expect(Object.isFrozen(pair.rf.feedback)).toBe(true);
+    expect(Object.isFrozen(pair.sql.feedback)).toBe(true);
   });
 
   it.each([

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -490,13 +490,14 @@ type RfSqlFeedbackLane = Readonly<{
 
 /** One qualified receiver/session snapshot for the two-lane RF/SQL owner. */
 export function getRfSqlControlFeedback(
-  currentControlSession: ControlSessionSnapshot,
+  currentControlSession?: ControlSessionSnapshot,
 ): Readonly<{ rf: RfSqlFeedbackLane; sql: RfSqlFeedbackLane }> | null {
-  const sessionState = currentControlSession.state;
-  const sessionEpoch = currentControlSession.epoch;
   const state = runtime.state;
   const caps = runtime.caps;
   const commands = getCommandLifecycles();
+  const session = currentControlSession ?? runtime.controlSession;
+  const sessionState = session.state;
+  const sessionEpoch = session.epoch;
   const stateGeneration = state?.providerGeneration;
   if (sessionState !== 'connected'
     || !Number.isSafeInteger(sessionEpoch) || sessionEpoch < 0

--- a/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
@@ -632,8 +632,7 @@ describe('the combined RF/SQL knob (controlModel="combined")', () => {
     unmount(component); target.remove();
   });
 
-  // Per-field change guard (verifier follow-up R1, mirrors
-  // `DualParamRenderer.svelte`'s `emitPair`): only a field whose mapped
+  // Per-field change guard (verifier follow-up R1): only a field whose mapped
   // value actually differs from its current confirmed reading emits. `base()`
   // starts at rfGain=known(1)/squelch=known(0) — the knob's own "center, at
   // rest" position — so each case below is chosen to isolate exactly ONE


### PR DESCRIPTION
## Summary

- make the RF/SQL feedback accessor use the runtime control session by default while capturing reactive state, capabilities, commands, and session before authority guards
- convert DualParamRenderer to a binding-only lease consumer and move both legacy combined RF/SQL and RF-only HBar ownership into RfFrontEnd
- preserve legacy gesture policy, normalized handler inputs, independent lane feedback, unknown authority behavior, and RF-only debt shrinkage
- remove the directly affected semantic-test attribution to the renderer-local owner deleted by this change

## Scope and compatibility

This eight-file, 774 A+D change crosses the six-file and 600-line soft thresholds as one semantic unit: the adapter authority source, binding-only renderer, both live branches in their sole panel owner, discriminating tests, and the directly affected ownership prose must move together. The eighth path is the sole ordinary correction authorized after independent review; it changes only a stale test comment and no assertion or production behavior. Splitting the implementation would leave either an unowned renderer or a live raw-feedback branch.

Accepted source API break: DualParamRenderer no longer accepts raw RF/SQL values and callbacks. Its existing barrel export remains, and its sole production caller now supplies a ContinuousPairBinding. No protocol, profile, scalar-owner, hardware, service, or baseline files changed.

Linear: https://linear.app/morozsm/issue/MOR-2410/complete-legacy-rfsql-renderer-separation-and-both-live-panel-branches

## Verification

- prepared RED: 32 passed, 6 expected failures before production edits
- focused matrix on the implementation head: 18 files, 398 tests passed
- correction check: RfFrontEndSurface semantic test, 68 tests passed
- npm run check: 0 errors and 0 warnings
- npm run lint
- npm run lint:boundaries
- git diff --check
- deleted-owner attribution search: no remaining matches

The corrected Ready head receives natural required CI and a fresh independent exact-head review. No hardware validation was performed or required for this mocked frontend-only change.