### PR TITLE
MOR-2421: Migrate mobile TX levels to v3 feedback

### DIFF
--- a/frontend/fixtures/stubs/panel-adapters.ts
+++ b/frontend/fixtures/stubs/panel-adapters.ts
@@ -60,6 +60,27 @@ export function getFilterWidthControlFeedback() {
   });
 }
 
+const txAuxControls = Object.freeze({
+  micGain: 'mic-gain',
+  driveGain: 'drive-gain',
+  voxGain: 'vox-gain',
+  antiVoxGain: 'anti-vox-gain',
+  voxDelay: 'vox-delay',
+  compressorLevel: 'compressor-level',
+  monitorGain: 'monitor-level',
+} as const);
+
+/** Offline fixtures never fabricate radio-global TX/VOX feedback authority. */
+export function getTxAuxControlFeedback(field: keyof typeof txAuxControls) {
+  return Object.freeze({
+    confirmed: null, target: null, requestedTarget: null,
+    phase: 'unavailable' as const, busy: false, availability: 'unavailable' as const,
+    outcome: null, lifecycleId: null, transitionId: null, sessionEpoch: 1,
+    scope: Object.freeze({ control: txAuxControls[field], receiver: 0 as const }),
+    repeatPolicy: 'latest-target-wins' as const,
+  });
+}
+
 /** The offline fixture has no qualified RF/SQL command-feedback authority. */
 export function getRfSqlControlFeedback(_controlSession: unknown): null {
   return null;

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ScopeController } from '$lib/runtime/scope-controller.svelte';
 import { PresentationResourceHost } from '$lib/runtime/resource-host';
 import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
+import type { ControlSessionSnapshot } from '$lib/runtime/frontend-runtime';
 
 const txHarness = new ManagedAppTxHarness({ stale: true });
 import { mount, unmount, flushSync } from 'svelte';
@@ -47,6 +48,7 @@ vi.mock('../../../lib/runtime/frontend-runtime', () => ({
     onTxAudioDied: () => () => {},
     caps: { scope: true },
     connectionStatus: 'disconnected',
+    controlSession: Object.freeze({ state: 'disconnected', epoch: -1 }) satisfies ControlSessionSnapshot,
     radioPowerOn: null,
     connection: { status: 'disconnected', radioPowerOn: null },
     audio: { rxEnabled: false, txEnabled: false, volume: 50, muted: false },

--- a/frontend/src/components-v2/panels/TxPanel.svelte
+++ b/frontend/src/components-v2/panels/TxPanel.svelte
@@ -1,10 +1,23 @@
 <script lang="ts">
-  import { onDestroy } from 'svelte';
+  import { onDestroy, untrack } from 'svelte';
   import { HardwareButton } from '$lib/Button';
   import { ValueControl } from '../controls/value-control';
   import { normalizedPercentDisplay, rawToPercentDisplay } from '../../primitives/scalar/value-control-core';
   import { txStatusColor } from './tx-utils';
-  import { deriveTxProps, getTxHandlers } from '$lib/runtime/adapters/panel-adapters';
+  import {
+    deriveTxProps,
+    getTxAuxControlFeedback,
+    getTxHandlers,
+  } from '$lib/runtime/adapters/panel-adapters';
+  import {
+    createContinuousScalar,
+    createHBarContinuousScalarPolicy,
+    type ContinuousScalarBinding,
+  } from '../../primitives/scalar/continuous-scalar.svelte';
+  import type {
+    HBarIssuedStatusPresentation,
+    HBarIssuedStatusSnapshot,
+  } from '../controls/value-control/skin';
   import { getManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
   import { createManagedTxGesture } from '../wiring/managed-tx-gesture';
   import {
@@ -23,7 +36,6 @@
   let autoLan = $derived(deriveAutoLanModInputProps());
 
   let rfPower = $derived(p.rfPower);
-  let micGain = $derived(p.micGain);
   let atuActive = $derived(p.atuActive);
   let atuTuning = $derived(p.atuTuning);
   let voxActive = $derived(p.voxActive);
@@ -31,7 +43,6 @@
   let compLevel = $derived(p.compLevel);
   let monActive = $derived(p.monActive);
   let monLevel = $derived(p.monLevel);
-  let driveGain = $derived(p.driveGain);
   const onRfPowerChange = handlers.onRfPowerChange;
   const onMicGainChange = handlers.onMicGainChange;
   const onAtuToggle = handlers.onAtuToggle;
@@ -54,6 +65,83 @@
   let compLevelAvailable = $derived(p.compLevelAvailable ?? true);
   let monLevelAvailable = $derived(p.monLevelAvailable ?? true);
   let driveGainAvailable = $derived(p.driveGainAvailable ?? true);
+
+  let micGainFeedback = $derived(getTxAuxControlFeedback('micGain'));
+  let driveGainFeedback = $derived(getTxAuxControlFeedback('driveGain'));
+  let compLevelFeedback = $derived(getTxAuxControlFeedback('compressorLevel'));
+  let monLevelFeedback = $derived(getTxAuxControlFeedback('monitorGain'));
+  const rawTxLevelDisplay = (value: number): string =>
+    Number.isFinite(value) ? rawToPercentDisplay(value) : '—';
+  const txLevelPolicy = () => createHBarContinuousScalarPolicy({
+    preview: 'optimistic', debounceMs: 50, describeTarget: rawToPercentDisplay,
+  });
+  const micGainBinding = createContinuousScalar(
+    () => ({
+      evidence: 'command-feedback', feedback: micGainFeedback, command: 'set_mic_gain',
+      domain: { min: 0, max: 255, step: 1, defaultValue: null, fineStepDivisor: 10 },
+      enabled: micGainAvailable, request: onMicGainChange,
+    }),
+    txLevelPolicy(),
+  );
+  const driveGainBinding = createContinuousScalar(
+    () => ({
+      evidence: 'command-feedback', feedback: driveGainFeedback, command: 'set_drive_gain',
+      domain: { min: 0, max: 255, step: 1, defaultValue: null, fineStepDivisor: 10 },
+      enabled: driveGainAvailable, request: onDriveGainChange,
+    }),
+    txLevelPolicy(),
+  );
+  const compLevelBinding = createContinuousScalar(
+    () => ({
+      evidence: 'command-feedback', feedback: compLevelFeedback, command: 'set_compressor_level',
+      domain: { min: 0, max: 255, step: 1, defaultValue: null, fineStepDivisor: 10 },
+      enabled: compLevelAvailable, request: onCompLevelChange,
+    }),
+    txLevelPolicy(),
+  );
+  const monLevelBinding = createContinuousScalar(
+    () => ({
+      evidence: 'command-feedback', feedback: monLevelFeedback, command: 'set_monitor_gain',
+      domain: { min: 0, max: 255, step: 1, defaultValue: null, fineStepDivisor: 10 },
+      enabled: monLevelAvailable, request: onMonLevelChange,
+    }),
+    txLevelPolicy(),
+  );
+
+  type TxLevelLane = 'micGain' | 'driveGain' | 'compressorLevel' | 'monitorGain';
+  let issuedStatusText = $state<Record<TxLevelLane, string | null>>({
+    micGain: null, driveGain: null, compressorLevel: null, monitorGain: null,
+  });
+  function formatIssuedStatus({ view, announcement }: Readonly<HBarIssuedStatusSnapshot>): string {
+    return view.error === null
+      ? announcement.message
+      : `${announcement.message.replace(/[.!?]$/, '')}: ${view.error}`;
+  }
+  function issuedStatusPresentation(lane: TxLevelLane): Readonly<HBarIssuedStatusPresentation> {
+    return {
+      get text() { return issuedStatusText[lane]; },
+      format: formatIssuedStatus,
+      accept(text) { issuedStatusText[lane] = text; },
+    };
+  }
+  const micGainStatus = issuedStatusPresentation('micGain');
+  const driveGainStatus = issuedStatusPresentation('driveGain');
+  const compLevelStatus = issuedStatusPresentation('compressorLevel');
+  const monLevelStatus = issuedStatusPresentation('monitorGain');
+  function consumeHiddenStatus(
+    binding: ContinuousScalarBinding,
+    presentation: Readonly<HBarIssuedStatusPresentation>,
+  ): void {
+    const view = binding.view;
+    if (view.evidence !== 'command-feedback') return;
+    const announcement = view.presentation.politeAnnouncement;
+    if (announcement !== null) {
+      presentation.accept(untrack(() => presentation.format({ view, announcement })));
+    } else if (view.feedback.transitionId === null) {
+      presentation.accept(null);
+    }
+  }
+  const feedbackIntegratedControl = { 'feedback-policy': 'feedback-integrated' } as const;
 
   // Gesture timing is local; all displayed TX truth comes from the server snapshot.
   const tx = getManagedAppTxController();
@@ -80,7 +168,14 @@
     event.preventDefault(); ptt.up();
   };
 
-  onDestroy(() => { stopWatchingTx(); ptt.destroy(); });
+  onDestroy(() => {
+    stopWatchingTx();
+    ptt.destroy();
+    micGainBinding.destroy();
+    driveGainBinding.destroy();
+    compLevelBinding.destroy();
+    monLevelBinding.destroy();
+  });
 
   let owned = $derived(txState.intent === 'momentary');
   let starting = $derived(txState.phase === 'key-confirm-pending');
@@ -101,6 +196,18 @@
   let settingsOpen = $state(false);
   let modalStyle = $state('');
   let modalAnchor: HTMLElement | undefined = $state();
+
+  $effect(() => {
+    if (!settingsOpen) {
+      consumeHiddenStatus(micGainBinding, micGainStatus);
+      consumeHiddenStatus(driveGainBinding, driveGainStatus);
+      consumeHiddenStatus(compLevelBinding, compLevelStatus);
+      consumeHiddenStatus(monLevelBinding, monLevelStatus);
+      return;
+    }
+    if (!compActive) consumeHiddenStatus(compLevelBinding, compLevelStatus);
+    if (!(showMon && monActive)) consumeHiddenStatus(monLevelBinding, monLevelStatus);
+  });
 
   function openSettings(): void {
     if (modalAnchor) {
@@ -225,22 +332,22 @@
       <ValueControl label="RF Power" value={rfPower} min={0} max={1} step={0.01}
         renderer="hbar" displayFn={normalizedPercentDisplay} accentColor="var(--v2-accent-red)"
         onChange={onRfPowerChange} variant="hardware-illuminated" disabled={!rfPowerAvailable} />
-      <ValueControl label="Mic Gain" value={micGain} min={0} max={255} step={1}
-        renderer="hbar" displayFn={rawToPercentDisplay} accentColor="var(--v2-accent-orange)"
-        onChange={onMicGainChange} variant="hardware-illuminated" disabled={!micGainAvailable} />
+      <ValueControl {...feedbackIntegratedControl} label="Mic Gain" binding={micGainBinding}
+        renderer="hbar" displayFn={rawTxLevelDisplay} accentColor="var(--v2-accent-orange)"
+        issuedStatusPresentation={micGainStatus} variant="hardware-illuminated" />
       {#if compActive}
-        <ValueControl label="Comp Level" value={compLevel} min={0} max={255} step={1}
-          renderer="hbar" displayFn={rawToPercentDisplay} accentColor="var(--v2-accent-orange)"
-          onChange={onCompLevelChange} variant="hardware-illuminated" disabled={!compLevelAvailable} />
+        <ValueControl {...feedbackIntegratedControl} label="Comp Level" binding={compLevelBinding}
+          renderer="hbar" displayFn={rawTxLevelDisplay} accentColor="var(--v2-accent-orange)"
+          issuedStatusPresentation={compLevelStatus} variant="hardware-illuminated" />
       {/if}
       {#if showMon && monActive}
-        <ValueControl label="Mon Level" value={monLevel} min={0} max={255} step={1}
-          renderer="hbar" displayFn={rawToPercentDisplay} accentColor="var(--v2-accent-orange)"
-          onChange={onMonLevelChange} variant="hardware-illuminated" disabled={!monLevelAvailable} />
+        <ValueControl {...feedbackIntegratedControl} label="Mon Level" binding={monLevelBinding}
+          renderer="hbar" displayFn={rawTxLevelDisplay} accentColor="var(--v2-accent-orange)"
+          issuedStatusPresentation={monLevelStatus} variant="hardware-illuminated" />
       {/if}
-      <ValueControl label="Drive Gain" value={driveGain} min={0} max={255} step={1}
-        renderer="hbar" displayFn={rawToPercentDisplay} accentColor="var(--v2-accent-orange)"
-        onChange={onDriveGainChange} variant="hardware-illuminated" disabled={!driveGainAvailable} />
+      <ValueControl {...feedbackIntegratedControl} label="Drive Gain" binding={driveGainBinding}
+        renderer="hbar" displayFn={rawTxLevelDisplay} accentColor="var(--v2-accent-orange)"
+        issuedStatusPresentation={driveGainStatus} variant="hardware-illuminated" />
       {#if autoLan.available}
         <!-- MOR-618: opt-in auto LAN MOD-input for web TX (default OFF) -->
         <div class="auto-lan-section">

--- a/frontend/src/components-v2/panels/__tests__/TxPanel.feedback-wiring.svelte.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/TxPanel.feedback-wiring.svelte.test.ts
@@ -1,0 +1,357 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import type { CommandLifecycle } from '$lib/stores/commands.svelte';
+
+const VALUES = {
+  micGain: 40,
+  driveGain: 80,
+  compressorLevel: 120,
+  monitorGain: 160,
+} as const;
+const COMMANDS = {
+  micGain: 'set_mic_gain',
+  driveGain: 'set_drive_gain',
+  compressorLevel: 'set_compressor_level',
+  monitorGain: 'set_monitor_gain',
+} as const;
+const LABELS = {
+  micGain: 'Mic Gain',
+  driveGain: 'Drive Gain',
+  compressorLevel: 'Comp Level',
+  monitorGain: 'Mon Level',
+} as const;
+const FIELDS = Object.keys(VALUES) as (keyof typeof VALUES)[];
+
+const fresh = (marker = 1) => ({
+  storePath: 'fixture', observed: true, freshness: 'fresh' as const,
+  availability: 'available' as const, lastObservedMonotonic: marker,
+});
+function connectedState(providerGeneration = 3): ServerState {
+  return {
+    stateContractVersion: 1, providerGeneration, active: 'MAIN', main: {}, sub: {},
+    ...VALUES,
+    fieldStatus: Object.fromEntries(FIELDS.map((field) => [field, fresh()])),
+  } as unknown as ServerState;
+}
+function connectedCaps(providerGeneration = 3): Capabilities {
+  return {
+    stateContractVersion: 1, providerGeneration,
+    capabilities: ['tx', 'drive_gain', 'compressor', 'monitor'],
+  } as unknown as Capabilities;
+}
+
+const canonical = $state({
+  state: connectedState() as ServerState | null,
+  caps: connectedCaps() as Capabilities | null,
+  session: { state: 'connected' as 'connected' | 'disconnected', epoch: 1 },
+});
+const radioListeners = new Set<(state: ServerState | null) => void>();
+const props = $state({
+  txActive: false, txActiveAvailable: true, rfPower: 0.5, micGain: VALUES.micGain,
+  atuActive: false, atuTuning: false, voxActive: false, compActive: true,
+  compLevel: VALUES.compressorLevel, monActive: true, monLevel: VALUES.monitorGain,
+  driveGain: VALUES.driveGain, hasTx: true, hasTuner: true, hasMonitor: true,
+});
+const handlers = {
+  onRfPowerChange: vi.fn(), onMicGainChange: vi.fn(), onAtuToggle: vi.fn(),
+  onAtuTune: vi.fn(), onVoxToggle: vi.fn(), onCompToggle: vi.fn(),
+  onCompLevelChange: vi.fn(), onMonToggle: vi.fn(), onMonLevelChange: vi.fn(),
+  onDriveGainChange: vi.fn(),
+};
+const LEVEL_HANDLERS = {
+  micGain: handlers.onMicGainChange,
+  driveGain: handlers.onDriveGainChange,
+  compressorLevel: handlers.onCompLevelChange,
+  monitorGain: handlers.onMonLevelChange,
+} as const;
+const managedSnapshot = {
+  intent: 'rx', phase: 'idle', fault: null, radioTx: 'off', txRisk: 'none', fresh: true,
+};
+const managedController = {
+  snapshot: () => managedSnapshot,
+  subscribe: (listener: (snapshot: typeof managedSnapshot) => void) => {
+    listener(managedSnapshot);
+    return () => {};
+  },
+  pttOn: vi.fn(), pttOff: vi.fn(), transmitOn: vi.fn(), forceOff: vi.fn(),
+};
+
+let TxPanel: typeof import('../TxPanel.svelte').default;
+let commands: typeof import('$lib/stores/commands.svelte');
+let component: ReturnType<typeof mount> | null = null;
+let target: HTMLDivElement;
+
+beforeAll(async () => {
+  vi.doMock('$lib/runtime/frontend-runtime', () => ({ runtime: {
+    get state() { return canonical.state; },
+    get caps() { return canonical.caps; },
+    get controlSession() { return canonical.session; },
+  } }));
+  vi.doMock('$lib/stores/radio.svelte', () => ({
+    getRadioState: () => canonical.state,
+    subscribeRadioState: (listener: (state: ServerState | null) => void) => {
+      radioListeners.add(listener);
+      listener(canonical.state);
+      return () => radioListeners.delete(listener);
+    },
+  }));
+  vi.doMock('$lib/runtime/adapters/panel-adapters', async (importOriginal) => ({
+    ...await importOriginal<typeof import('$lib/runtime/adapters/panel-adapters')>(),
+    deriveTxProps: () => props,
+    getTxHandlers: () => handlers,
+  }));
+  vi.doMock('$lib/runtime/tx-controller/managed-app-host', () => ({
+    getManagedAppTxController: () => managedController,
+  }));
+  vi.doMock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+    deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: null }),
+    getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+  }));
+  vi.doMock('$lib/runtime/adapters/mod-input-auto.svelte', () => ({
+    deriveAutoLanModInputProps: () => ({ available: false, enabled: false }),
+    setAutoLanModInputEnabled: vi.fn(),
+  }));
+  commands = await import('$lib/stores/commands.svelte');
+  TxPanel = (await import('../TxPanel.svelte')).default;
+});
+
+afterAll(() => {
+  vi.doUnmock('$lib/runtime/frontend-runtime');
+  vi.doUnmock('$lib/stores/radio.svelte');
+  vi.doUnmock('$lib/runtime/adapters/panel-adapters');
+  vi.doUnmock('$lib/runtime/tx-controller/managed-app-host');
+  vi.doUnmock('$lib/runtime/adapters/mod-input-tx-guard.svelte');
+  vi.doUnmock('$lib/runtime/adapters/mod-input-auto.svelte');
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  target?.remove();
+  commands.resetCommandLifecycle();
+  canonical.state = connectedState();
+  canonical.caps = connectedCaps();
+  canonical.session = { state: 'connected', epoch: 1 };
+  Object.assign(props, { compActive: true, monActive: true, hasMonitor: true });
+  for (const handler of Object.values(handlers)) handler.mockClear();
+});
+
+function render(): void {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(TxPanel, { target });
+  flushSync();
+}
+function openSettings(): void {
+  const button = [...target.querySelectorAll<HTMLButtonElement>('.v2-control-button')]
+    .find((entry) => entry.textContent?.includes('LEVELS'))!;
+  button.click();
+  flushSync();
+}
+function closeSettings(): void {
+  target.querySelector<HTMLButtonElement>('[aria-label="Close TX settings"]')!.click();
+  flushSync();
+}
+function slider(field: keyof typeof VALUES): HTMLElement {
+  return target.querySelector<HTMLElement>(`[aria-label="${LABELS[field]}"]`)!;
+}
+function value(field: keyof typeof VALUES): string {
+  const header = [...target.querySelectorAll('.vc-header')]
+    .find((entry) => entry.querySelector('.vc-label')?.textContent === LABELS[field]);
+  return header?.querySelector('.vc-value')?.textContent ?? '';
+}
+function begin(field: keyof typeof VALUES, requested: number, id: string = field): CommandLifecycle {
+  return commands.beginCommand({
+    id, name: COMMANDS[field], params: { level: requested }, originalEpoch: 1,
+    timeoutMs: 5_000,
+  });
+}
+
+describe('TxPanel v3 command-feedback wiring', () => {
+  it('projects four independent optimistic targets over canonical raw truth', () => {
+    render();
+    openSettings();
+    for (const [index, field] of FIELDS.entries()) begin(field, VALUES[field] + index + 1);
+    flushSync();
+
+    for (const [index, field] of FIELDS.entries()) {
+      expect(slider(field).dataset.commandPhase).toBe('submitted');
+      expect(slider(field).getAttribute('aria-busy')).toBe('true');
+      expect(slider(field).getAttribute('aria-valuenow')).toBe(String(VALUES[field]));
+      expect(value(field)).toBe(`${Math.round(VALUES[field] / 2.55)}%`);
+      const descriptionId = slider(field).getAttribute('aria-describedby')!;
+      expect(target.querySelector(`#${descriptionId}`)?.textContent)
+        .toContain(`${Math.round(((VALUES[field] + index + 1) / 255) * 100)}%`);
+    }
+    expect(target.querySelectorAll('[data-control-feedback-status]')).toHaveLength(4);
+  });
+
+  it('keeps ACK awaiting, exposes terminal error, and confirms only exact fresh readback', () => {
+    render();
+    openSettings();
+    const mic = begin('micGain', 99, 'mic');
+    const drive = begin('driveGain', 109, 'drive');
+    commands.acknowledgeCommand(mic.id, 1, 1);
+    commands.failCommand(drive.id, 1, 1, 'radio refused');
+    flushSync();
+    expect(slider('micGain').dataset.commandPhase).toBe('awaiting-confirmation');
+    expect(slider('driveGain').dataset.commandPhase).toBe('failed');
+    expect(target.textContent).toContain('radio refused');
+
+    const next = {
+      ...connectedState(), micGain: 99,
+      fieldStatus: { ...connectedState().fieldStatus, micGain: fresh(2) },
+    } as ServerState;
+    canonical.state = next;
+    for (const listener of radioListeners) listener(next);
+    flushSync();
+    expect(slider('micGain').dataset.commandPhase).toBe('confirmed');
+    expect(slider('micGain').getAttribute('aria-valuenow')).toBe('99');
+  });
+
+  it('consumes a hidden terminal transition and retains evidence without replay on reopen', () => {
+    render();
+    const command = begin('micGain', 99, 'hidden-mic');
+    commands.failCommand(command.id, 1, 1, 'closed failure');
+    flushSync();
+    expect(target.querySelector('[aria-label="Mic Gain"]')).toBeNull();
+
+    openSettings();
+    const first = target.querySelector('[data-control-feedback-status]')?.textContent;
+    expect(slider('micGain').dataset.commandPhase).toBe('failed');
+    expect(first).toContain('closed failure');
+    closeSettings();
+    openSettings();
+    expect(target.querySelectorAll('[data-control-feedback-status]')).toHaveLength(1);
+    expect(target.querySelector('[data-control-feedback-status]')?.textContent).toBe(first);
+  });
+
+  it('fails closed across authority loss and recovers without remount', () => {
+    vi.useFakeTimers();
+    render();
+    openSettings();
+    slider('micGain').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    canonical.state = null;
+    canonical.caps = null;
+    canonical.session = { state: 'disconnected', epoch: 1 };
+    flushSync();
+    vi.advanceTimersByTime(50);
+    expect(slider('micGain').getAttribute('aria-disabled')).toBe('true');
+    expect(handlers.onMicGainChange).not.toHaveBeenCalled();
+
+    canonical.state = connectedState(4);
+    canonical.caps = connectedCaps(4);
+    canonical.session = { state: 'connected', epoch: 2 };
+    flushSync();
+    slider('micGain').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    vi.advanceTimersByTime(50);
+    expect(slider('micGain').getAttribute('aria-disabled')).toBe('false');
+    expect(handlers.onMicGainChange).toHaveBeenCalledExactlyOnceWith(41);
+    vi.useRealTimers();
+  });
+
+  it('keeps scalar gestures away from PTT, TUNE, and toggle routes', () => {
+    vi.useFakeTimers();
+    render();
+    openSettings();
+    slider('monitorGain').dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'ArrowRight', bubbles: true,
+    }));
+    vi.advanceTimersByTime(50);
+    expect(handlers.onMonLevelChange).toHaveBeenCalledExactlyOnceWith(161);
+    expect(managedController.pttOn).not.toHaveBeenCalled();
+    expect(managedController.transmitOn).not.toHaveBeenCalled();
+    expect(handlers.onAtuTune).not.toHaveBeenCalled();
+    expect(handlers.onMonToggle).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('routes all four lanes independently through their existing raw handlers', () => {
+    vi.useFakeTimers();
+    render();
+    openSettings();
+    for (const field of FIELDS) {
+      slider(field).dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'ArrowRight', bubbles: true,
+      }));
+    }
+    vi.advanceTimersByTime(50);
+    for (const field of FIELDS) {
+      expect(LEVEL_HANDLERS[field]).toHaveBeenCalledExactlyOnceWith(VALUES[field] + 1);
+    }
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ['failed', 'micGain', (command: CommandLifecycle) =>
+      commands.failCommand(command.id, 1, 1, 'radio rejected')],
+    ['timed-out', 'driveGain', () => vi.advanceTimersByTime(26)],
+    ['cancelled', 'compressorLevel', () => commands.cancelPendingCommands(1, 'session lost')],
+  ] as const)('projects the actual %s lifecycle outcome', (phase, field, complete) => {
+    vi.useFakeTimers();
+    render();
+    openSettings();
+    const command = commands.beginCommand({
+      id: `terminal-${phase}`, name: COMMANDS[field], params: { level: VALUES[field] + 1 },
+      originalEpoch: 1, timeoutMs: 25,
+    });
+    complete(command);
+    flushSync();
+    expect(slider(field).dataset.commandPhase).toBe(phase);
+    expect(slider(field).getAttribute('aria-busy')).toBe('false');
+    expect(target.querySelector('[data-control-feedback-status]')?.textContent).toBeTruthy();
+    vi.useRealTimers();
+  });
+
+  it('keeps inactive COMP/MON renderer-free and reveals consumed terminal evidence', () => {
+    Object.assign(props, { compActive: false, monActive: false });
+    render();
+    openSettings();
+    const comp = begin('compressorLevel', 121, 'hidden-comp');
+    const mon = begin('monitorGain', 161, 'hidden-mon');
+    commands.failCommand(comp.id, 1, 1, 'comp rejected');
+    commands.failCommand(mon.id, 1, 1, 'mon rejected');
+    flushSync();
+    expect(target.querySelector('[aria-label="Comp Level"]')).toBeNull();
+    expect(target.querySelector('[aria-label="Mon Level"]')).toBeNull();
+
+    Object.assign(props, { compActive: true, monActive: true });
+    flushSync();
+    expect(slider('compressorLevel').dataset.commandPhase).toBe('failed');
+    expect(slider('monitorGain').dataset.commandPhase).toBe('failed');
+    expect([...target.querySelectorAll('[data-control-feedback-status]')].map((node) => node.textContent))
+      .toEqual(expect.arrayContaining([
+        expect.stringContaining('comp rejected'), expect.stringContaining('mon rejected'),
+      ]));
+  });
+
+  it('fails each malformed or stale authority lane closed, then follows fresh truth', () => {
+    render();
+    openSettings();
+    canonical.state = {
+      ...connectedState(),
+      micGain: Number.NaN,
+      fieldStatus: {
+        ...connectedState().fieldStatus,
+        driveGain: { ...fresh(), freshness: 'stale' },
+        compressorLevel: { ...fresh(), observed: false },
+        monitorGain: { ...fresh(), lastObservedMonotonic: undefined },
+      },
+    } as unknown as ServerState;
+    flushSync();
+    for (const field of FIELDS) {
+      expect(slider(field).getAttribute('aria-disabled')).toBe('true');
+      expect(value(field)).toBe('—');
+    }
+
+    canonical.state = {
+      ...connectedState(), micGain: 41, driveGain: 81, compressorLevel: 121, monitorGain: 161,
+    } as ServerState;
+    flushSync();
+    for (const field of FIELDS) expect(slider(field).getAttribute('aria-disabled')).toBe('false');
+    expect(FIELDS.map((field) => slider(field).getAttribute('aria-valuenow')))
+      .toEqual(['41', '81', '121', '161']);
+  });
+});

--- a/frontend/src/components-v2/panels/__tests__/TxPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/TxPanel.isolated.test.ts
@@ -76,9 +76,27 @@ const mockHandlers = {
   onDriveGainChange: vi.fn(),
 };
 
+const feedbackAccess = vi.hoisted(() => vi.fn());
+const feedbackControls = {
+  micGain: 'mic-gain',
+  driveGain: 'drive-gain',
+  compressorLevel: 'compressor-level',
+  monitorGain: 'monitor-level',
+} as const;
+
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveTxProps: () => mockProps,
   getTxHandlers: () => mockHandlers,
+  getTxAuxControlFeedback: (field: keyof typeof feedbackControls) => {
+    feedbackAccess(field);
+    const confirmed = field === 'compressorLevel' || field === 'monitorGain' ? 64 : 128;
+    return {
+      confirmed, target: null, requestedTarget: null, phase: 'idle', busy: false,
+      availability: 'available', outcome: null, lifecycleId: null, transitionId: null,
+      sessionEpoch: 1, scope: { control: feedbackControls[field], receiver: 0 },
+      repeatPolicy: 'latest-target-wins',
+    };
+  },
 }));
 
 const txHost = vi.hoisted(() => ({ current: undefined as unknown as ManagedAppTxController }));
@@ -150,6 +168,7 @@ beforeEach(() => {
   mockAutoLanProps.available = false;
   mockAutoLanProps.enabled = false;
   mockSetAutoLan.mockReset();
+  feedbackAccess.mockClear();
 });
 
 afterEach(() => {
@@ -159,6 +178,19 @@ afterEach(() => {
 });
 
 describe('panel structure', () => {
+  it('owns feedback bindings for exactly the four live raw TX controls', () => {
+    mountPanel({ compActive: true, monActive: true });
+    expect(new Set(feedbackAccess.mock.calls.map(([field]) => field))).toEqual(new Set([
+      'micGain', 'driveGain', 'compressorLevel', 'monitorGain',
+    ]));
+    expect(txPanelSource.match(/binding=\{(?:mic|drive|comp|mon)\w*Binding\}/g)).toHaveLength(4);
+    expect(txPanelSource).not.toMatch(/label="RF Power"[^>]*binding=/s);
+    expect(txPanelSource).not.toMatch(/stores\/(commands|radio)|sendCommand|dispatchRadioIntent/);
+    for (const seam of ['ptt.down()', 'ptt.up()', 'onAtuTune', 'onCompToggle', 'onMonToggle']) {
+      expect(txPanelSource).toContain(seam);
+    }
+  });
+
   it('mounts the managed TOT fallback only when explicitly requested', () => {
     let t = mountPanel();
     expect(t.querySelector('[data-testid="managed-tot-control"]')).toBeNull();
@@ -187,6 +219,20 @@ describe('panel structure', () => {
     openTxSettings(t);
     const labels = Array.from(t.querySelectorAll('.vc-label'));
     expect(labels.some((el) => el.textContent === 'Mic Gain')).toBe(true);
+  });
+
+  it('preserves the level order and illuminated orange presentation', () => {
+    const t = mountPanel({ compActive: true, monActive: true });
+    openTxSettings(t);
+    expect([...t.querySelectorAll('.vc-label')].map((node) => node.textContent)).toEqual([
+      'RF Power', 'Mic Gain', 'Comp Level', 'Mon Level', 'Drive Gain',
+    ]);
+    const txLevels = [...t.querySelectorAll<HTMLElement>('.vc-hbar')].slice(1);
+    expect(txLevels).toHaveLength(4);
+    for (const level of txLevels) {
+      expect(level.classList.contains('hw-illum')).toBe(true);
+      expect(level.getAttribute('style')).toContain('--vc-accent: var(--v2-accent-orange)');
+    }
   });
 
   it('renders ATU toggle', () => {
@@ -454,6 +500,24 @@ describe('PTT via the App TX controller (MOR-1011)', () => {
       flushSync();
       expect(label(a)).toBe('TX');
       expect(label(b)).toBe('TX');
+    });
+
+    it('keeps one independent level binding and renderer lease per panel', () => {
+      vi.useFakeTimers();
+      const a = mountPanel();
+      const b = mountPanel();
+      openTxSettings(a);
+      openTxSettings(b);
+      for (const panel of [a, b]) {
+        panel.querySelector<HTMLElement>('[aria-label="Mic Gain"]')?.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+        );
+      }
+      vi.advanceTimersByTime(50);
+      expect(mockHandlers.onMicGainChange).toHaveBeenCalledTimes(2);
+      expect(mockHandlers.onMicGainChange).toHaveBeenNthCalledWith(1, 129);
+      expect(mockHandlers.onMicGainChange).toHaveBeenNthCalledWith(2, 129);
+      vi.useRealTimers();
     });
   });
 

--- a/frontend/src/components-v2/wiring/__tests__/fixture-adapter-command-seam.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/fixture-adapter-command-seam.isolated.test.ts
@@ -12,4 +12,21 @@ describe('fixture semantic command seam (MOR-1409 A04a)', () => {
       expect(stub).toContain(`${family}:`);
     }
   });
+
+  it('exports unavailable feedback with every TX auxiliary control scope', () => {
+    expect(stub).toContain('getTxAuxControlFeedback');
+    for (const [field, control] of [
+      ['micGain', 'mic-gain'],
+      ['driveGain', 'drive-gain'],
+      ['voxGain', 'vox-gain'],
+      ['antiVoxGain', 'anti-vox-gain'],
+      ['voxDelay', 'vox-delay'],
+      ['compressorLevel', 'compressor-level'],
+      ['monitorGain', 'monitor-level'],
+    ]) {
+      expect(stub).toContain(`${field}: '${control}'`);
+    }
+    expect(stub).toContain("phase: 'unavailable' as const");
+    expect(stub).toContain('confirmed: null');
+  });
 });


### PR DESCRIPTION
## Scope

- Linked issue / task: [MOR-2421](https://linear.app/morozsm/issue/MOR-2421/migrate-four-live-mobile-tx-controls-to-the-existing-v3-feedback)
- Migrate the existing Mic Gain, Drive Gain, Comp Level, and Mon Level HBars in the mobile TX settings sheet to the accepted command-feedback scalar binding.
- Consume hidden announcements while the modal or conditional renderer is absent, retain current terminal evidence, and keep the existing command handlers and managed TX behavior unchanged.
- Add the fixture-safe seven-field accessor with explicit unavailable global scopes.
- Supply the adjacent RadioLayout fixture with a typed, truthful disconnected control session so its real TxPanel/accessor mount fails closed.
- Compatibility impact: none (no API, CLI, config, wire, docs, or raw-value behavior change).

## Verification

- [x] RED captured on accepted base: 5 expected failures, 37 existing tests passed.
- [x] Focused panel and fixture tests: 52 passed.
- [x] Accepted scalar, HBar, presentation, and CW regressions: 178 passed.
- [x] `npm run check`: 0 errors and 0 warnings.
- [x] `npm run lint` and `npm run lint:boundaries`.
- [x] `npm run i18n:check`: OK; existing fallback notes only.
- [x] `npm run build`.
- [x] `git diff --check`.
- [x] Correction RED: focused RadioLayout fixture reproduced 22 failures / 33 passes from the missing session.
- [x] Correction GREEN: focused RadioLayout fixture passed 55/55; changed-file ESLint and `npm run check` passed.
- [x] Public/open-core boundary checked.
- [x] No release or migration impact.

## Agent Review

- [ ] Independent exact-head agent review comment posted before merge.
- Reviewer:
- Result: pending

## Notes

- Coordinator-approved six-file correction lease: 585 additions, 17 deletions (602 A+D). The two lines above the original 600-line soft threshold are the typed disconnected-session fixture required by independent review; the hard 1000 A+D limit is unchanged.
- No hardware, browser actuation, service/deploy action, or visual baseline mutation was performed.
- The accepted foundation currently emits submitted/awaiting-confirmation and confirmed/failed/timed-out/cancelled from its concrete lifecycle. Its broader DTO also names queued/dispatched/superseded, but those phases are not emitted by the current `CommandLifecycleStatus` projection; this PR does not widen into the adapter/store lease. The shared scalar/presentation regressions remain green for the broader DTO behavior.
