### PR TITLE
MOR-2418: add DSP command feedback foundation

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/dsp-command-feedback.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/dsp-command-feedback.isolated.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import type { CommandLifecycle } from '$lib/stores/commands.svelte';
+
+const h = vi.hoisted(() => ({
+  state: null as ServerState | null,
+  caps: null as Capabilities | null,
+  commands: [] as CommandLifecycle[],
+  session: { state: 'connected' as 'connected' | 'disconnected', epoch: 7 },
+  active: 'MAIN' as 'MAIN' | 'SUB' | null,
+  operational: true,
+  stateReads: 0, capsReads: 0, commandReads: 0, sessionReads: 0,
+}));
+
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    get state() { h.stateReads += 1; return h.state; },
+    get caps() { h.capsReads += 1; return h.caps; },
+    get controlSession() { h.sessionReads += 1; return h.session; },
+  },
+}));
+vi.mock('$lib/stores/commands.svelte', async (importOriginal) => ({
+  ...await importOriginal<typeof import('$lib/stores/commands.svelte')>(),
+  getCommandLifecycles: () => { h.commandReads += 1; return h.commands; },
+  isCommandLifecycleSuperseded: (command: CommandLifecycle) => command.id.endsWith('-old'),
+}));
+vi.mock('$lib/runtime/adapters/radio-view-model-adapter', () => ({
+  toRadioViewModel: () => h.active === null
+    ? { activeReceiver: { status: 'unknown' }, receiverIndicators: [] }
+    : {
+      activeReceiver: { status: 'known', receiver: h.active },
+      receiverIndicators: [{
+        receiver: h.active,
+        availability: { structural: true, operational: h.operational },
+      }],
+    },
+}));
+
+import { DSP_COMMAND_DESCRIPTORS, type DspCommandFeedbackField } from '$lib/stores/commands.svelte';
+import { getDspControlFeedback } from '../panel-adapters';
+
+const FIELDS = [
+  'nbLevel', 'nbWidth', 'notchFilter', 'manualNotchWidth', 'agcTimeConstant',
+] as const satisfies readonly DspCommandFeedbackField[];
+const VALUES: Readonly<Record<DspCommandFeedbackField, number>> = {
+  nbLevel: 60, nbWidth: 70, notchFilter: -80, manualNotchWidth: 3, agcTimeConstant: 900,
+};
+const fresh = (marker = 5) => ({
+  storePath: 'fixture', observed: true, freshness: 'fresh' as const,
+  availability: 'available' as const, lastObservedMonotonic: marker,
+});
+const state = (over: Record<string, unknown> = {}): ServerState => ({
+  stateContractVersion: 1, providerGeneration: 3, active: 'MAIN', nbWidth: VALUES.nbWidth,
+  main: {
+    nbLevel: VALUES.nbLevel, notchFilter: VALUES.notchFilter,
+    manualNotchWidth: VALUES.manualNotchWidth, agcTimeConstant: VALUES.agcTimeConstant,
+  },
+  sub: { nbLevel: 61, notchFilter: -81, manualNotchWidth: 4, agcTimeConstant: 901 },
+  fieldStatus: {
+    nbWidth: fresh(), 'main.nbLevel': fresh(), 'main.notchFilter': fresh(),
+    'main.manualNotchWidth': fresh(), 'main.agcTimeConstant': fresh(),
+    'sub.nbLevel': fresh(), 'sub.notchFilter': fresh(),
+    'sub.manualNotchWidth': fresh(), 'sub.agcTimeConstant': fresh(),
+  },
+  ...over,
+} as unknown as ServerState);
+const caps = (over: Record<string, unknown> = {}): Capabilities => ({
+  stateContractVersion: 1, providerGeneration: 3, receivers: 1, vfoScheme: 'single',
+  capabilities: ['nb', 'notch', 'agc'], controls: { nb_depth: { min: 0, max: 255, step: 1 } },
+  ...over,
+} as unknown as Capabilities);
+const connected = { state: 'connected' as const, epoch: 7 };
+const command = (
+  field: DspCommandFeedbackField, target: number, over: Partial<CommandLifecycle> = {},
+): CommandLifecycle => {
+  const descriptor = DSP_COMMAND_DESCRIPTORS[field];
+  const receiver = h.active === 'SUB' ? 1 : 0;
+  const key = field === 'nbLevel' || field === 'nbWidth' ? 'level' : 'value';
+  return {
+    id: field, name: descriptor.intentName,
+    params: field === 'nbWidth' ? { [key]: target } : { [key]: target, receiver },
+    originalEpoch: 7, createdAt: 1, updatedAt: 1, timeoutMs: 5_000,
+    status: 'pending', providerGeneration: 3, ...over,
+  };
+};
+
+describe('qualified raw DSP command feedback', () => {
+  afterEach(() => {
+    h.state = null; h.caps = null; h.commands = [];
+    h.session = { state: 'connected', epoch: 7 }; h.active = 'MAIN'; h.operational = true;
+    h.stateReads = 0; h.capsReads = 0; h.commandReads = 0; h.sessionReads = 0;
+  });
+
+  it('reads every reactive authority before unavailable guards and recovers on replacement', () => {
+    h.session = { state: 'disconnected', epoch: -1 };
+    expect(getDspControlFeedback('nbLevel')).toMatchObject({
+      confirmed: null, target: null, requestedTarget: null,
+      phase: 'unavailable', availability: 'unavailable', sessionEpoch: -1,
+      scope: { control: 'nb-level', receiver: 0 },
+    });
+    expect([h.stateReads, h.capsReads, h.commandReads, h.sessionReads]).toEqual([1, 1, 1, 1]);
+
+    h.state = state(); h.caps = caps(); h.session = connected;
+    expect(getDspControlFeedback('nbLevel')).toMatchObject({
+      confirmed: 60, phase: 'idle', availability: 'available', sessionEpoch: 7,
+    });
+    expect([h.stateReads, h.capsReads, h.commandReads, h.sessionReads]).toEqual([2, 2, 2, 2]);
+  });
+
+  it.each(FIELDS)('projects exact raw submitted feedback for %s', field => {
+    h.state = state(); h.caps = caps();
+    const target = VALUES[field] + 10;
+    h.commands = [command(field, target)];
+    const feedback = getDspControlFeedback(field, connected);
+    expect(feedback).toMatchObject({
+      confirmed: VALUES[field], target, requestedTarget: target,
+      phase: 'submitted', availability: 'available', busy: true,
+      providerGeneration: 3, sessionEpoch: 7,
+      scope: DSP_COMMAND_DESCRIPTORS[field].scope({ params: h.commands[0].params }),
+    });
+    expect(h.sessionReads).toBe(0);
+  });
+
+  it('uses canonical SUB receiver fields while NB Width keeps global receiver-zero identity', () => {
+    h.active = 'SUB';
+    h.state = state({ active: 'SUB' });
+    h.caps = caps({ receivers: 2, vfoScheme: 'main_sub', capabilities: ['dual_rx', 'nb', 'notch', 'agc'] });
+    expect(getDspControlFeedback('notchFilter', connected)).toMatchObject({
+      confirmed: -81, scope: { control: 'notch-position', receiver: 1 },
+    });
+    expect(getDspControlFeedback('nbWidth', connected)).toMatchObject({
+      confirmed: 70, scope: { control: 'nb-width', receiver: 0 },
+    });
+  });
+
+  it('keeps fields independent and selects only the latest non-superseded lifecycle', () => {
+    h.state = state(); h.caps = caps();
+    h.commands = [
+      command('nbLevel', 90, { id: 'level-old', createdAt: 1 }),
+      command('notchFilter', -100, { id: 'notch' }),
+      command('nbLevel', 100, { id: 'level-new', createdAt: 2 }),
+    ];
+    expect(getDspControlFeedback('nbLevel', connected)).toMatchObject({ target: 100, requestedTarget: 100 });
+    expect(getDspControlFeedback('notchFilter', connected)).toMatchObject({ target: -100, confirmed: -80 });
+
+    h.state = state({
+      fieldStatus: { ...state().fieldStatus, 'main.nbLevel': { ...fresh(), freshness: 'stale' } },
+    });
+    expect(getDspControlFeedback('nbLevel', connected)).toMatchObject({
+      phase: 'unavailable', confirmed: null, target: null, outcome: null,
+    });
+    expect(getDspControlFeedback('notchFilter', connected)).toMatchObject({
+      phase: 'submitted', confirmed: -80, target: -100,
+    });
+  });
+
+  it.each([
+    ['failed', 'nbLevel', { status: 'failed', error: 'radio refused' }],
+    ['timed-out', 'nbWidth', { status: 'timed-out' }],
+    ['cancelled', 'agcTimeConstant', { status: 'cancelled' }],
+  ] as const)('projects a real %s terminal outcome', (phase, field, outcome) => {
+    h.state = state(); h.caps = caps();
+    h.commands = [command(field, VALUES[field] + 1, outcome)];
+    expect(getDspControlFeedback(field, connected)).toMatchObject({
+      target: null, requestedTarget: VALUES[field] + 1,
+      phase, outcome: { phase }, busy: false,
+    });
+  });
+
+  it.each([
+    ['disconnected', { state: 'disconnected' as const, epoch: 7 }, state(), caps()],
+    ['invalid epoch', { state: 'connected' as const, epoch: -1 }, state(), caps()],
+    ['state contract', connected, state({ stateContractVersion: 2 }), caps()],
+    ['caps contract', connected, state(), caps({ stateContractVersion: 2 })],
+    ['provider mismatch', connected, state(), caps({ providerGeneration: 4 })],
+  ])('fails closed for %s authority', (_name, session, currentState, currentCaps) => {
+    h.state = currentState; h.caps = currentCaps;
+    expect(getDspControlFeedback('manualNotchWidth', session)).toMatchObject({
+      availability: 'unavailable', confirmed: null, target: null, outcome: null,
+    });
+  });
+
+  it('requires active-receiver admission and each field structural contract', () => {
+    h.state = state(); h.caps = caps();
+    h.active = null;
+    expect(getDspControlFeedback('nbWidth', connected).availability).toBe('unavailable');
+    h.active = 'MAIN'; h.operational = false;
+    expect(getDspControlFeedback('nbLevel', connected).availability).toBe('unavailable');
+    h.operational = true;
+    h.caps = caps({ capabilities: ['notch', 'agc'], controls: {} });
+    expect(getDspControlFeedback('nbLevel', connected).availability).toBe('unavailable');
+    expect(getDspControlFeedback('nbWidth', connected).availability).toBe('unavailable');
+    expect(getDspControlFeedback('notchFilter', connected).availability).toBe('available');
+  });
+
+  it('drops old provider and session lifecycles after authority replacement', () => {
+    h.state = state({ providerGeneration: 4 });
+    h.caps = caps({ providerGeneration: 4 });
+    h.commands = [command('nbWidth', 100, {
+      originalEpoch: 6, providerGeneration: 3, status: 'failed', error: 'old provider',
+    })];
+    expect(getDspControlFeedback('nbWidth', connected)).toMatchObject({
+      providerGeneration: 4, sessionEpoch: 7, confirmed: 70,
+      phase: 'idle', target: null, requestedTarget: null, outcome: null,
+    });
+  });
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -61,7 +61,7 @@ import {
 } from '../panel-adapters';
 import {
   BREAK_IN_DELAY_COMMAND_DESCRIPTOR, CW_PITCH_COMMAND_DESCRIPTOR, FILTER_WIDTH_COMMAND_DESCRIPTOR,
-  KEY_SPEED_COMMAND_DESCRIPTOR,
+  DSP_COMMAND_DESCRIPTORS, KEY_SPEED_COMMAND_DESCRIPTOR,
   RF_GAIN_COMMAND_DESCRIPTOR, SQUELCH_COMMAND_DESCRIPTOR,
   STATE_BACKED_COMMAND_DESCRIPTORS,
   TX_AUX_COMMAND_DESCRIPTORS,
@@ -109,7 +109,8 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
       'set_filter_width', 'set_break_in_delay', 'set_rf_gain', 'set_squelch',
       'set_cw_pitch', 'set_key_speed', 'set_mic_gain', 'set_drive_gain',
       'set_vox_gain', 'set_anti_vox_gain', 'set_vox_delay',
-      'set_compressor_level', 'set_monitor_gain',
+      'set_compressor_level', 'set_monitor_gain', 'set_nb_level', 'set_nb_width',
+      'set_notch_filter', 'set_manual_notch_width', 'set_agc_time_constant',
     ]);
     expect(RADIO_INTENT_NAMES).toContain(FILTER_WIDTH_COMMAND_DESCRIPTOR.intentName);
     const main = FILTER_WIDTH_COMMAND_DESCRIPTOR.scope(command({ params: { width: 3000, receiver: 0 } }))!;
@@ -509,6 +510,11 @@ describe('Break-in Delay ControlFeedback projection (MOR-1744)', () => {
       ['set_vox_delay', TX_AUX_COMMAND_DESCRIPTORS.voxDelay],
       ['set_compressor_level', TX_AUX_COMMAND_DESCRIPTORS.compressorLevel],
       ['set_monitor_gain', TX_AUX_COMMAND_DESCRIPTORS.monitorGain],
+      ['set_nb_level', DSP_COMMAND_DESCRIPTORS.nbLevel],
+      ['set_nb_width', DSP_COMMAND_DESCRIPTORS.nbWidth],
+      ['set_notch_filter', DSP_COMMAND_DESCRIPTORS.notchFilter],
+      ['set_manual_notch_width', DSP_COMMAND_DESCRIPTORS.manualNotchWidth],
+      ['set_agc_time_constant', DSP_COMMAND_DESCRIPTORS.agcTimeConstant],
     ]);
     const scope = BREAK_IN_DELAY_COMMAND_DESCRIPTOR.scope(delayCommand());
     expect(scope).toEqual({ control: 'break-in-delay', receiver: 0 });

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -36,6 +36,7 @@ import { recordQsy } from './qsy-history-adapter';
 import {
   BREAK_IN_DELAY_COMMAND_DESCRIPTOR,
   CW_PITCH_COMMAND_DESCRIPTOR,
+  DSP_COMMAND_DESCRIPTORS,
   FILTER_WIDTH_COMMAND_DESCRIPTOR,
   KEY_SPEED_COMMAND_DESCRIPTOR,
   RF_GAIN_COMMAND_DESCRIPTOR,
@@ -45,6 +46,7 @@ import {
   isCommandLifecycleSuperseded,
   type CommandLifecycle,
   type ControlFeedbackScope,
+  type DspCommandFeedbackField,
   type StateBackedCommandDescriptor,
   type StateBackedRepeatPolicy,
   type TxAuxCommandFeedbackField,
@@ -477,6 +479,72 @@ export function getTxAuxControlFeedback(
     });
     return session.state === 'connected' && epoch >= 0
       && observation.state === 'current' && Number.isSafeInteger(observation.value)
+      ? feedback : unavailableControlFeedback(feedback);
+  } catch {
+    return unavailableControlFeedback(feedback);
+  }
+}
+
+export type DspControlFeedbackField = DspCommandFeedbackField;
+const DSP_FEEDBACK_CAPABILITIES: Readonly<Record<
+  Exclude<DspControlFeedbackField, 'nbWidth'>, string
+>> = Object.freeze({
+  nbLevel: 'nb', notchFilter: 'notch', manualNotchWidth: 'notch', agcTimeConstant: 'agc',
+});
+
+/** Qualified raw DSP feedback; NB Width alone has stable radio-global identity. */
+export function getDspControlFeedback(
+  field: DspControlFeedbackField,
+  currentControlSession?: ControlSessionSnapshot,
+): Readonly<ControlFeedback<number>> {
+  const state = runtime.state;
+  const caps = runtime.caps;
+  const commands = getCommandLifecycles();
+  const session = currentControlSession ?? runtime.controlSession;
+  const epoch = Number.isSafeInteger(session.epoch) && session.epoch >= 0 ? session.epoch : -1;
+  const descriptor = DSP_COMMAND_DESCRIPTORS[field];
+  const receiver: 0 | 1 = state?.active === 'SUB' ? 1 : 0;
+  const scope = Object.freeze({
+    control: field === 'nbLevel' ? 'nb-level'
+      : field === 'nbWidth' ? 'nb-width'
+        : field === 'notchFilter' ? 'notch-position'
+          : field === 'manualNotchWidth' ? 'manual-notch-width' : 'agc-time',
+    receiver: field === 'nbWidth' ? 0 as const : receiver,
+  });
+  const feedback = projectControlFeedback(
+    descriptor, state, commands, scope, epoch, isCommandLifecycleSuperseded,
+  );
+  try {
+    const view = toRadioViewModel(state, caps);
+    if (session.state !== 'connected' || epoch < 0
+      || view === null || view.activeReceiver.status !== 'known') {
+      return unavailableControlFeedback(feedback);
+    }
+    const activeReceiver = view.activeReceiver.receiver;
+    const receiverEntries = view.receiverIndicators?.filter(
+      entry => entry.receiver === activeReceiver,
+    ) ?? [];
+    if (receiverEntries.length !== 1 || !receiverEntries[0].availability.operational) {
+      return unavailableControlFeedback(feedback);
+    }
+    if (field === 'nbWidth') {
+      const observation = qualifyRadioDisplayObservation({
+        state, caps, path: field, structural: caps?.controls?.nb_depth != null,
+        value: state?.nbWidth,
+      });
+      return observation.state === 'current' && Number.isSafeInteger(observation.value)
+        ? feedback : unavailableControlFeedback(feedback);
+    }
+    const receiverId = activeReceiver;
+    const receiverState = receiverId === 'SUB' ? state?.sub : state?.main;
+    const base = receiverId === 'SUB' ? 'sub' : 'main';
+    const tags = Array.isArray(caps?.capabilities) ? caps.capabilities : [];
+    const observation = qualifyDisplayObservation({
+      state, caps, receiver: receiverId, path: `${base}.${field}`,
+      structural: tags.includes(DSP_FEEDBACK_CAPABILITIES[field]),
+      value: receiverState?.[field],
+    });
+    return observation.state === 'current' && Number.isSafeInteger(observation.value)
       ? feedback : unavailableControlFeedback(feedback);
   } catch {
     return unavailableControlFeedback(feedback);

--- a/frontend/src/lib/stores/__tests__/commands.test.ts
+++ b/frontend/src/lib/stores/__tests__/commands.test.ts
@@ -253,7 +253,8 @@ describe('command lifecycle store', () => {
         'set_filter_width', 'set_break_in_delay', 'set_rf_gain', 'set_squelch',
         'set_cw_pitch', 'set_key_speed', 'set_mic_gain', 'set_drive_gain',
         'set_vox_gain', 'set_anti_vox_gain', 'set_vox_delay',
-        'set_compressor_level', 'set_monitor_gain',
+        'set_compressor_level', 'set_monitor_gain', 'set_nb_level', 'set_nb_width',
+        'set_notch_filter', 'set_manual_notch_width', 'set_agc_time_constant',
       ]);
       expect(rfMain).toEqual({ control: 'rf-gain', receiver: 0 });
       expect(rfSub).toEqual({ control: 'rf-gain', receiver: 1 });
@@ -367,7 +368,8 @@ describe('command lifecycle store', () => {
         'set_filter_width', 'set_break_in_delay', 'set_rf_gain', 'set_squelch',
         'set_cw_pitch', 'set_key_speed', 'set_mic_gain', 'set_drive_gain',
         'set_vox_gain', 'set_anti_vox_gain', 'set_vox_delay',
-        'set_compressor_level', 'set_monitor_gain',
+        'set_compressor_level', 'set_monitor_gain', 'set_nb_level', 'set_nb_width',
+        'set_notch_filter', 'set_manual_notch_width', 'set_agc_time_constant',
       ]);
       const pitchScope = store.CW_PITCH_COMMAND_DESCRIPTOR.scope({ params: { value: 640 } })!;
       const speedScope = store.KEY_SPEED_COMMAND_DESCRIPTOR.scope({ params: { speed: 27 } })!;
@@ -518,6 +520,147 @@ describe('command lifecycle store', () => {
       expect(status()).toBe('acknowledged');
       emitState(observed(target, 7));
       expect(status()).toBe('confirmed');
+    });
+  });
+
+  describe('raw DSP state-backed descriptors', () => {
+    const receiverRegistrations = [
+      ['nbLevel', 'set_nb_level', 'nb-level', 'level'],
+      ['notchFilter', 'set_notch_filter', 'notch-position', 'value'],
+      ['manualNotchWidth', 'set_manual_notch_width', 'manual-notch-width', 'value'],
+      ['agcTimeConstant', 'set_agc_time_constant', 'agc-time', 'value'],
+    ] as const;
+
+    it.each(receiverRegistrations)('registers %s with exact MAIN and SUB raw scopes', (
+      field, intentName, control, param,
+    ) => {
+      const descriptor = store.DSP_COMMAND_DESCRIPTORS[field];
+      const main = descriptor.scope({ params: { [param]: -12, receiver: 0 } })!;
+      const sub = descriptor.scope({ params: { [param]: 2048, receiver: 1 } })!;
+      expect(descriptor.intentName).toBe(intentName);
+      expect(store.getStateBackedCommandDescriptor(intentName)).toBe(descriptor);
+      expect(main).toEqual({ control, receiver: 0 });
+      expect(sub).toEqual({ control, receiver: 1 });
+      expect(descriptor.fieldPath(main)).toBe(`main.${field}`);
+      expect(descriptor.fieldPath(sub)).toBe(`sub.${field}`);
+      expect(descriptor.target({ params: { [param]: -12, receiver: 0 } })).toBe(-12);
+      expect(descriptor.confirmed({ main: { [field]: -12 } } as never, main)).toBe(-12);
+      expect(descriptor.matches(2048, 2048)).toBe(true);
+      expect(descriptor.matches(2047, 2048)).toBe(false);
+    });
+
+    it('registers NB Width as one raw global lane with stable receiver-zero identity', () => {
+      const descriptor = store.DSP_COMMAND_DESCRIPTORS.nbWidth;
+      const scope = descriptor.scope({ params: { level: 255 } })!;
+      expect(descriptor.intentName).toBe('set_nb_width');
+      expect(store.getStateBackedCommandDescriptor('set_nb_width')).toBe(descriptor);
+      expect(scope).toEqual({ control: 'nb-width', receiver: 0 });
+      expect(descriptor.fieldPath(scope)).toBe('nbWidth');
+      expect(descriptor.target({ params: { level: -1 } })).toBe(-1);
+      expect(descriptor.confirmed({ active: 'SUB', nbWidth: 255 } as ServerState, scope)).toBe(255);
+    });
+
+    it('rejects malformed DSP envelopes without coercion or throwing', () => {
+      const inherited = Object.create({ level: 10, receiver: 0 }) as Record<string, unknown>;
+      const throwing = Object.defineProperty({ receiver: 0 }, 'level', {
+        enumerable: true, get: () => { throw new Error('read'); },
+      });
+      const ownKeysTrap = new Proxy({}, { ownKeys: () => { throw new Error('keys'); } });
+      for (const params of [
+        {}, inherited, { level: true, receiver: 0 }, { level: '10', receiver: 0 },
+        { level: 10.5, receiver: 0 }, { level: 10, receiver: false },
+        { level: 10, receiver: 2 }, { level: 10, receiver: 0, extra: true },
+        { level: 10, receiver: 0, [Symbol('extra')]: true }, throwing, ownKeysTrap,
+      ]) {
+        expect(store.DSP_COMMAND_DESCRIPTORS.nbLevel.scope({ params })).toBeNull();
+        expect(store.DSP_COMMAND_DESCRIPTORS.nbLevel.target({ params })).toBeNull();
+      }
+      for (const params of [
+        {}, { level: true }, { level: '10' }, { level: 10.5 },
+        { level: 10, receiver: 0 }, { level: 10, extra: true }, ownKeysTrap,
+      ]) {
+        expect(store.DSP_COMMAND_DESCRIPTORS.nbWidth.scope({ params })).toBeNull();
+        expect(store.DSP_COMMAND_DESCRIPTORS.nbWidth.target({ params })).toBeNull();
+      }
+    });
+
+    it.each([
+      ['set_nb_level', 'main.nbLevel', 'level', 50, 49, 0],
+      ['set_notch_filter', 'sub.notchFilter', 'value', -20, -19, 1],
+      ['set_manual_notch_width', 'main.manualNotchWidth', 'value', 3, 2, 0],
+      ['set_agc_time_constant', 'sub.agcTimeConstant', 'value', 900, 899, 1],
+      ['set_nb_width', 'nbWidth', 'level', 64, 63, null],
+    ] as const)('confirms %s only from a newer fresh exact field observation', (
+      name, path, param, target, mismatch, receiver,
+    ) => {
+      const observed = (value: number, marker: number, freshness: 'fresh' | 'stale' = 'fresh') => ({
+        stateContractVersion: 1, providerGeneration: 3, active: receiver === 1 ? 'SUB' : 'MAIN',
+        main: receiver === 0 ? { [path.split('.')[1]]: value } : {},
+        sub: receiver === 1 ? { [path.split('.')[1]]: value } : {},
+        ...(receiver === null ? { nbWidth: value } : {}),
+        fieldStatus: { [path]: {
+          observed: true, freshness, availability: 'available', lastObservedMonotonic: marker,
+        } },
+      } as unknown as ServerState);
+      emitState(observed(mismatch, 4));
+      const params = receiver === null ? { [param]: target } : { [param]: target, receiver };
+      const command = store.beginCommand({ id: name, name, params, originalEpoch: 7 });
+      store.acknowledgeCommand(command.id, 7, 7);
+      const status = () => store.getCommandLifecycle(command.id, 7)?.status;
+      expect(status()).toBe('acknowledged');
+      emitState(observed(target, 4));
+      emitState(observed(mismatch, 5));
+      emitState(observed(target, 6, 'stale'));
+      expect(status()).toBe('acknowledged');
+      emitState(observed(target, 7));
+      expect(status()).toBe('confirmed');
+    });
+
+    it('keeps global NB Width identity fixed while receiver controls and fields stay independent', () => {
+      const widthA = store.beginCommand({
+        id: 'width-a', name: 'set_nb_width', params: { level: 20 }, originalEpoch: 7,
+      });
+      const levelMain = store.beginCommand({
+        id: 'level-main', name: 'set_nb_level', params: { level: 30, receiver: 0 }, originalEpoch: 7,
+      });
+      const levelSub = store.beginCommand({
+        id: 'level-sub', name: 'set_nb_level', params: { level: 40, receiver: 1 }, originalEpoch: 7,
+      });
+      store.beginCommand({ id: 'width-b', name: 'set_nb_width', params: { level: 50 }, originalEpoch: 7 });
+      expect(store.isCommandLifecycleSuperseded(widthA)).toBe(true);
+      expect(store.isCommandLifecycleSuperseded(levelMain)).toBe(false);
+      expect(store.isCommandLifecycleSuperseded(levelSub)).toBe(false);
+      expect(store.DSP_COMMAND_DESCRIPTORS.nbWidth.scope({ params: { level: 50 } }))
+        .toEqual({ control: 'nb-width', receiver: 0 });
+    });
+
+    it('does not confirm receiver or global DSP commands from the wrong field path', () => {
+      emitState({
+        providerGeneration: 3, active: 'SUB', nbWidth: 20,
+        main: { nbLevel: 40 }, sub: { nbLevel: 30 },
+        fieldStatus: {
+          nbWidth: { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
+          'main.nbLevel': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
+          'sub.nbLevel': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
+        },
+      } as unknown as ServerState);
+      store.beginCommand({
+        id: 'sub-level', name: 'set_nb_level', params: { level: 40, receiver: 1 }, originalEpoch: 7,
+      });
+      store.beginCommand({ id: 'global-width', name: 'set_nb_width', params: { level: 40 }, originalEpoch: 7 });
+      store.acknowledgeCommand('sub-level', 7, 7);
+      store.acknowledgeCommand('global-width', 7, 7);
+      emitState({
+        providerGeneration: 3, active: 'MAIN', nbWidth: 20,
+        main: { nbLevel: 40 }, sub: { nbLevel: 30 },
+        fieldStatus: {
+          nbWidth: { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 },
+          'main.nbLevel': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 },
+          'sub.nbLevel': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
+        },
+      } as unknown as ServerState);
+      expect(store.getCommandLifecycle('sub-level', 7)?.status).toBe('acknowledged');
+      expect(store.getCommandLifecycle('global-width', 7)?.status).toBe('acknowledged');
     });
   });
 });

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -78,6 +78,26 @@ function exactSafeIntegerTarget(
   }
 }
 
+type ExactReceiverSafeIntegerCommand = Readonly<{ receiver: 0 | 1; target: number }>;
+function exactReceiverSafeIntegerCommand(
+  command: Pick<CommandLifecycle, 'params'>, key: string,
+): ExactReceiverSafeIntegerCommand | null {
+  try {
+    const params = command.params;
+    if (typeof params !== 'object' || params === null) return null;
+    const keys = Reflect.ownKeys(params);
+    if (keys.length !== 2
+      || !Object.prototype.hasOwnProperty.call(params, key)
+      || !Object.prototype.hasOwnProperty.call(params, 'receiver')) return null;
+    const target = safeInteger(params[key]);
+    const receiver = params.receiver;
+    return target !== null && (receiver === 0 || receiver === 1)
+      ? Object.freeze({ receiver, target }) : null;
+  } catch {
+    return null;
+  }
+}
+
 type NormalizedLevelCommand = Readonly<{ receiver: 0 | 1; target: number }>;
 function normalizedLevelCommand(
   command: Pick<CommandLifecycle, 'params'>,
@@ -221,6 +241,60 @@ export const TX_AUX_COMMAND_DESCRIPTORS = Object.freeze({
   monitorGain: rawTxAuxCommandDescriptor('set_monitor_gain', 'monitor-level', 'monitorGain'),
 }) satisfies Readonly<Record<TxAuxCommandFeedbackField, StateBackedCommandDescriptor<number>>>;
 
+export type DspCommandFeedbackField =
+  | 'nbLevel' | 'nbWidth' | 'notchFilter' | 'manualNotchWidth' | 'agcTimeConstant';
+type ReceiverDspCommandFeedbackField = Exclude<DspCommandFeedbackField, 'nbWidth'>;
+type ReceiverDspCommandFeedbackIntent =
+  | 'set_nb_level' | 'set_notch_filter' | 'set_manual_notch_width' | 'set_agc_time_constant';
+
+function rawReceiverDspCommandDescriptor(
+  intentName: ReceiverDspCommandFeedbackIntent,
+  control: string,
+  field: ReceiverDspCommandFeedbackField,
+  param: 'level' | 'value',
+): StateBackedCommandDescriptor<number> {
+  const parsed = (command: Pick<CommandLifecycle, 'params'>) =>
+    exactReceiverSafeIntegerCommand(command, param);
+  return Object.freeze({
+    intentName, repeatPolicy: 'latest-target-wins' as const,
+    scope: (command: Pick<CommandLifecycle, 'params'>) => {
+      const value = parsed(command);
+      return value === null ? null : Object.freeze({ control, receiver: value.receiver });
+    },
+    fieldPath: (scope: ControlFeedbackScope) => `${scope.receiver === 1 ? 'sub' : 'main'}.${field}`,
+    target: (command: Pick<CommandLifecycle, 'params'>) => parsed(command)?.target ?? null,
+    confirmed: (state: ServerState, scope: ControlFeedbackScope) =>
+      safeInteger((scope.receiver === 1 ? state.sub : state.main)?.[field]),
+    matches: (confirmed: number, requested: number) => confirmed === requested,
+  });
+}
+
+const nbWidthTarget = (command: Pick<CommandLifecycle, 'params'>): number | null =>
+  exactSafeIntegerTarget(command, 'level');
+const NB_WIDTH_COMMAND_DESCRIPTOR: StateBackedCommandDescriptor<number> = Object.freeze({
+  intentName: 'set_nb_width', repeatPolicy: 'latest-target-wins',
+  scope: (command: Pick<CommandLifecycle, 'params'>) => nbWidthTarget(command) === null
+    ? null : Object.freeze({ control: 'nb-width', receiver: 0 }),
+  fieldPath: () => 'nbWidth',
+  target: nbWidthTarget,
+  confirmed: (state: ServerState) => safeInteger(state.nbWidth),
+  matches: (confirmed: number, requested: number) => confirmed === requested,
+});
+
+export const DSP_COMMAND_DESCRIPTORS = Object.freeze({
+  nbLevel: rawReceiverDspCommandDescriptor('set_nb_level', 'nb-level', 'nbLevel', 'level'),
+  nbWidth: NB_WIDTH_COMMAND_DESCRIPTOR,
+  notchFilter: rawReceiverDspCommandDescriptor(
+    'set_notch_filter', 'notch-position', 'notchFilter', 'value',
+  ),
+  manualNotchWidth: rawReceiverDspCommandDescriptor(
+    'set_manual_notch_width', 'manual-notch-width', 'manualNotchWidth', 'value',
+  ),
+  agcTimeConstant: rawReceiverDspCommandDescriptor(
+    'set_agc_time_constant', 'agc-time', 'agcTimeConstant', 'value',
+  ),
+}) satisfies Readonly<Record<DspCommandFeedbackField, StateBackedCommandDescriptor<number>>>;
+
 export const STATE_BACKED_COMMAND_DESCRIPTORS: ReadonlyMap<RadioIntentName, StateBackedCommandDescriptor<unknown>> =
   new Map([
     [FILTER_WIDTH_COMMAND_DESCRIPTOR.intentName, FILTER_WIDTH_COMMAND_DESCRIPTOR],
@@ -230,6 +304,9 @@ export const STATE_BACKED_COMMAND_DESCRIPTORS: ReadonlyMap<RadioIntentName, Stat
     [CW_PITCH_COMMAND_DESCRIPTOR.intentName, CW_PITCH_COMMAND_DESCRIPTOR],
     [KEY_SPEED_COMMAND_DESCRIPTOR.intentName, KEY_SPEED_COMMAND_DESCRIPTOR],
     ...Object.values(TX_AUX_COMMAND_DESCRIPTORS).map(
+      descriptor => [descriptor.intentName, descriptor] as const,
+    ),
+    ...Object.values(DSP_COMMAND_DESCRIPTORS).map(
       descriptor => [descriptor.intentName, descriptor] as const,
     ),
   ]);


### PR DESCRIPTION
## Summary
- register strict raw state-backed descriptors for NB Level, NB Width, Notch Position, Manual Notch Width, and AGC Time
- expose one qualified DSP control-feedback accessor with receiver-scoped fields and stable global NB Width identity
- cover exact parsing, post-ACK confirmation, lifecycle outcomes, authority replacement, capability/evidence qualification, and reactive recovery

Linear: [MOR-2418](https://linear.app/morozsm/issue/MOR-2418/register-five-existing-raw-dsp-controls-in-shared-command-feedback)

## Verification
- 134 changed-scope Vitest tests
- 539 adjacent CW/RF/Filter/TX/DSP regression tests
- npm run check
- changed-file ESLint
- npm run lint:boundaries
- git diff --check
