### PR TITLE
MOR-2422: Adopt semantic TX/VOX command feedback

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -27,6 +27,7 @@
   import {
     bindSemanticSurfaceHandlers, getBreakInDelayControlFeedback, getFilterWidthControlFeedback,
     getCwPitchControlFeedback, getKeySpeedControlFeedback, getRfSqlControlFeedback,
+    getTxAuxControlFeedback, type TxAuxControlFeedbackField,
     getPendingFrequencyHz,
     getPendingFilterSelection, getPendingNbOn, getPendingNrOn, getPendingPreampLevel,
     getSystemHandlers, getDataModeArmed,
@@ -54,6 +55,7 @@
   import RxTxSurface from '../../semantic/RxTxSurface.svelte';
   import ScopeDisplaySurface from '../../semantic/ScopeDisplaySurface.svelte';
   import TxAuxSurface, {
+    TX_AUX_FEEDBACK_LEVELS, type TxAuxFeedbackLevelField, type TxAuxLevelFeedback,
     type TxAuxLevelField, type TxAuxToggleField,
   } from '../../semantic/TxAuxSurface.svelte';
   import { keyBlockedReasons } from '../../semantic/rx-tx-surface';
@@ -216,6 +218,13 @@
     driveGain: txAuxIntents.onDriveGainChange, voxGain: txAuxIntents.onVoxGainChange,
     antiVoxGain: txAuxIntents.onAntiVoxGainChange, voxDelay: txAuxIntents.onVoxDelayChange,
     compressorLevel: txAuxIntents.onCompLevelChange, monitorLevel: txAuxIntents.onMonLevelChange,
+  };
+  const TX_AUX_FEEDBACK_FIELD: Readonly<Record<
+    TxAuxFeedbackLevelField, TxAuxControlFeedbackField
+  >> = {
+    micGain: 'micGain', driveGain: 'driveGain', voxGain: 'voxGain',
+    antiVoxGain: 'antiVoxGain', voxDelay: 'voxDelay',
+    compressorLevel: 'compressorLevel', monitorLevel: 'monitorGain',
   };
   /**
    * MOR-1279. The RX-audio intent vocabulary, composed from the SHIPPED
@@ -726,6 +735,11 @@
   let filterWidthFeedback = $derived(getFilterWidthControlFeedback());
   let cwPitchFeedback = $derived(getCwPitchControlFeedback(controlSession));
   let keySpeedFeedback = $derived(getKeySpeedControlFeedback(controlSession));
+  let txAuxLevelFeedback = $derived.by<TxAuxLevelFeedback>(() => Object.fromEntries(
+    TX_AUX_FEEDBACK_LEVELS.map(field => [
+      field, getTxAuxControlFeedback(TX_AUX_FEEDBACK_FIELD[field], controlSession),
+    ]),
+  ) as unknown as TxAuxLevelFeedback);
   let dataModeArmed = $derived(getDataModeArmed());
   let pendingDataMode = $derived(dataModeArmed.armed ? dataModeArmed.value : null);
   let pendingPreamp = $derived(
@@ -1080,7 +1094,7 @@
   {#snippet txAuxSurface()}
     {#if view?.txAux}
       <TxAuxSurface
-        {view} tx={txState}
+        {view} tx={txState} levelFeedback={txAuxLevelFeedback}
         onToggle={(field) => TX_AUX_TOGGLE_INTENT[field]()}
         onLevelChange={(field, value) => TX_AUX_LEVEL_INTENT[field](value)}
         onAtuTune={requestAtuTune}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -17,6 +17,7 @@ import { flushSync, mount, unmount } from 'svelte';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
+import type { ControlSessionSnapshot } from '$lib/runtime/frontend-runtime';
 
 const h = vi.hoisted(() => ({
   state: null as unknown,
@@ -36,6 +37,9 @@ const h = vi.hoisted(() => ({
   compLevel: vi.fn(),
   monLevel: vi.fn(),
   noop: vi.fn(),
+  session: { state: 'connected', epoch: 7 } as ControlSessionSnapshot,
+  sessionSubscriber: null as ((next: ControlSessionSnapshot) => void) | null,
+  radioListeners: new Set<(state: ServerState | null) => void>(),
 }));
 
 vi.mock('$lib/runtime', () => ({
@@ -43,6 +47,11 @@ vi.mock('$lib/runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    get controlSession() { return h.session; },
+    subscribeControlSession(handler: (next: ControlSessionSnapshot) => void) {
+      h.sessionSubscriber = handler;
+      return () => { if (h.sessionSubscriber === handler) h.sessionSubscriber = null; };
+    },
     // MOR-1279 slice 3B: the wiring now also hands the adapter an
     // App-owned RX-audio snapshot (the FOURTH argument). Muted with no
     // browser stream keeps every fixture below on its pre-1279 path.
@@ -62,10 +71,26 @@ vi.mock('$lib/runtime', () => ({
     get scope() { return { hardwareScopeConnected: false }; },
   },
 }));
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    get state() { return h.state; },
+    get caps() { return h.caps; },
+    get controlSession() { return h.session; },
+  },
+}));
 vi.mock('$lib/runtime/tx-controller/managed-app-host', () => ({
   getManagedAppTxController: () => {
     if (!h.txController) throw new Error('managed TX harness is not installed');
     return h.txController;
+  },
+}));
+vi.mock('$lib/stores/radio.svelte', () => ({
+  radio: { get current() { return h.state; } },
+  getRadioState: () => h.state,
+  subscribeRadioState(listener: (state: ServerState | null) => void) {
+    h.radioListeners.add(listener);
+    listener(h.state as ServerState | null);
+    return () => h.radioListeners.delete(listener);
   },
 }));
 vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
@@ -162,6 +187,10 @@ import {
 import {
   ManagedAppTxHarness, type ManagedAppTxServerSnapshot,
 } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
+import {
+  TX_AUX_COMMAND_DESCRIPTORS, acknowledgeCommand, beginCommand, getCommandLifecycles,
+  resetCommandLifecycle,
+} from '$lib/stores/commands.svelte';
 
 const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 0 };
 const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
@@ -238,14 +267,29 @@ function push(next: ManagedAppTxServerSnapshot): void {
   flushSync();
 }
 
+function pushSession(next: ControlSessionSnapshot): void {
+  h.session = next;
+  h.sessionSubscriber?.(next);
+  flushSync();
+}
+
+function pushRadioState(next: ServerState): void {
+  h.state = next;
+  for (const listener of h.radioListeners) listener(next);
+  flushSync();
+}
+
 const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
 let txHarness: ManagedAppTxHarness;
 
 beforeEach(() => {
+  resetCommandLifecycle();
   txHarness = new ManagedAppTxHarness();
   h.txController = txHarness.controller;
   h.state = liveState(true);
   h.caps = liveCaps(true);
+  h.session = { state: 'connected', epoch: 7 };
+  h.sessionSubscriber = null;
   for (const value of Object.values(h)) {
     if (typeof value === 'function' && 'mockReset' in value) (value as ReturnType<typeof vi.fn>).mockReset();
   }
@@ -254,6 +298,8 @@ beforeEach(() => {
 afterEach(() => {
   if (component) unmount(component);
   component = null;
+  resetCommandLifecycle();
+  expect(h.sessionSubscriber).toBeNull();
   document.body.innerHTML = '';
 });
 
@@ -523,6 +569,120 @@ describe('every txAux intent reaches its own command-bus handler', () => {
     const others = [h.rfPower, h.micGain, h.driveGain, h.voxGain, h.antiVoxGain,
       h.voxDelay, h.compLevel, h.monLevel].filter((s) => s !== spy());
     for (const other of others) expect(other).not.toHaveBeenCalled();
+  });
+});
+
+const FEEDBACK_LANES = [
+  ['micGain', 'micGain', 'mic-gain', 128, 200],
+  ['driveGain', 'driveGain', 'drive-gain', 128, 201],
+  ['voxGain', 'voxGain', 'vox-gain', 50, 202],
+  ['antiVoxGain', 'antiVoxGain', 'anti-vox-gain', 30, 203],
+  ['voxDelay', 'voxDelay', 'vox-delay', 10, 7],
+  ['compressorLevel', 'compressorLevel', 'compressor-level', 40, 204],
+  ['monitorLevel', 'monitorGain', 'monitor-level', 60, 205],
+] as const;
+
+describe('the composed TX/VOX controls consume the real feedback lifecycle', () => {
+  it.each(FEEDBACK_LANES)(
+    'maps semantic %s to accessor %s and command scope %s', (
+      semanticField, accessorField, control, canonical, requested,
+    ) => {
+      const descriptor = TX_AUX_COMMAND_DESCRIPTORS[accessorField];
+      beginCommand({
+        id: `feedback-${accessorField}`, name: descriptor.intentName,
+        params: { level: requested }, originalEpoch: 7,
+      });
+      render();
+      const row = q<HTMLElement>(`[data-testid="tx-aux-${semanticField}"]`)!;
+      const input = row.querySelector<HTMLInputElement>('input')!;
+      expect(input.dataset.commandPhase).toBe('submitted');
+      expect(input.valueAsNumber).toBe(requested);
+      expect(row.querySelector('[data-canonical-value]')?.textContent).toContain(
+        semanticField === 'voxDelay' ? `${(canonical * 0.1).toFixed(1)}s` : `${Math.round(canonical / 255 * 100)}%`,
+      );
+      expect(row.dataset.feedbackControl).toBe(control);
+      for (const [otherSemantic] of FEEDBACK_LANES) {
+        if (otherSemantic !== semanticField) {
+          expect(q<HTMLInputElement>(`[data-testid="tx-aux-${otherSemantic}"] input`)!
+            .dataset.commandPhase).toBe('idle');
+        }
+      }
+    },
+  );
+
+  it('keeps ACK pending through unrelated, mismatched and stale readback, then confirms fresh exact truth', () => {
+    const descriptor = TX_AUX_COMMAND_DESCRIPTORS.micGain;
+    const command = beginCommand({
+      id: 'mic-feedback', name: descriptor.intentName, params: { level: 200 }, originalEpoch: 7,
+    });
+    render();
+    const input = () => q<HTMLInputElement>('[data-testid="tx-aux-micGain"] input')!;
+    expect(input().dataset.commandPhase).toBe('submitted');
+    acknowledgeCommand(command.id, 7, 7);
+    flushSync();
+    expect(input().dataset.commandPhase).toBe('awaiting-confirmation');
+
+    const observed = (revision: number, micGain: number, freshness: 'fresh' | 'stale') => ({
+      ...liveState(true), active: 'SUB', micGain,
+      revision, stateRevision: revision, freshnessRevision: revision, observationSeq: revision,
+      fieldStatus: {
+        ...liveState(true).fieldStatus,
+        driveGain: { ...fresh, lastObservedMonotonic: revision + 10 },
+        micGain: { ...fresh, freshness, lastObservedMonotonic: revision },
+      },
+    } as unknown as ServerState);
+    pushRadioState(observed(1, 199, 'fresh'));
+    pushSession({ state: 'connected', epoch: 7 });
+    expect(input().dataset.commandPhase).toBe('awaiting-confirmation');
+    pushRadioState(observed(2, 200, 'stale'));
+    pushSession({ state: 'connected', epoch: 7 });
+    expect(input().dataset.commandPhase).toBe('unavailable');
+    expect(input().disabled).toBe(true);
+    expect(getCommandLifecycles()[0]?.status).toBe('acknowledged');
+    pushRadioState(observed(3, 200, 'fresh'));
+    expect(getCommandLifecycles()[0]?.status).toBe('confirmed');
+    pushSession({ state: 'connected', epoch: 7 });
+    expect(input().dataset.commandPhase).toBe('confirmed');
+    expect(input().valueAsNumber).toBe(200);
+    expect(input().closest('[data-testid]')?.querySelector('[data-command-status]')?.textContent)
+      .toContain('confirmed');
+    expect(TX_AUX_COMMAND_DESCRIPTORS.micGain.scope(command)?.receiver).toBe(0);
+  });
+
+  it('fails closed and recovers in place across provider and session replacement', () => {
+    render();
+    const input = () => q<HTMLInputElement>('[data-testid="tx-aux-monitorLevel"] input')!;
+    expect(input().dataset.commandPhase).toBe('idle');
+    const original = input();
+
+    h.state = { ...liveState(true), providerGeneration: 2 } as ServerState;
+    h.caps = { ...liveCaps(true), providerGeneration: 2 } as Capabilities;
+    pushSession({ state: 'disconnected', epoch: 8 });
+    expect(input()).toBe(original);
+    expect(input().disabled).toBe(true);
+    expect(input().dataset.commandPhase).toBe('unavailable');
+
+    pushSession({ state: 'connected', epoch: 8 });
+    expect(input()).toBe(original);
+    expect(input().disabled).toBe(false);
+    expect(input().dataset.commandPhase).toBe('idle');
+    expect(input().valueAsNumber).toBe(60);
+  });
+
+  it('emits only the selected lane handler and no PTT, TUNE, toggle or lifecycle side effect', () => {
+    render();
+    for (const [semanticField, _accessor, _control, _canonical, requested] of FEEDBACK_LANES) {
+      const input = q<HTMLInputElement>(`[data-testid="tx-aux-${semanticField}"] input`)!;
+      input.value = String(requested);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    flushSync();
+    expect([h.micGain, h.driveGain, h.voxGain, h.antiVoxGain, h.voxDelay, h.compLevel, h.monLevel]
+      .map(mock => mock.mock.calls.length)).toEqual([1, 1, 1, 1, 1, 1, 1]);
+    expect([h.atuTune, h.atuToggle, h.voxToggle, h.compToggle, h.monToggle]
+      .map(mock => mock.mock.calls.length)).toEqual([0, 0, 0, 0, 0]);
+    expect(txHarness.trace()).toEqual([]);
+    expect(getCommandLifecycles()).toEqual([]);
   });
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -13,6 +13,7 @@ const h = vi.hoisted(() => ({
   main: vi.fn(), sub: vi.fn(), equalize: vi.fn(), swap: vi.fn(), split: vi.fn(),
   dualWatch: vi.fn(), speak: vi.fn(),
   filterWidthFeedback: vi.fn(), cwPitchFeedback: vi.fn(), keySpeedFeedback: vi.fn(),
+  txAuxFeedback: vi.fn(),
   session: { state: 'connected', epoch: 1 } as ControlSessionSnapshot,
   sessionSubscriber: null as ((next: ControlSessionSnapshot) => void) | null,
 }));
@@ -57,6 +58,7 @@ vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   getFilterWidthControlFeedback: h.filterWidthFeedback,
   getCwPitchControlFeedback: h.cwPitchFeedback,
   getKeySpeedControlFeedback: h.keySpeedFeedback,
+  getTxAuxControlFeedback: h.txAuxFeedback,
   getPendingFrequencyHz: () => null,
   getPendingFilterSelection: () => null, getPendingNbOn: () => null,
   getPendingNrOn: () => null, getPendingPreampLevel: () => null,
@@ -150,6 +152,14 @@ beforeEach(() => {
     phase: 'unavailable', busy: false, availability: 'unavailable',
     outcome: null, lifecycleId: null, transitionId: null, sessionEpoch: 1,
     scope: Object.freeze({ control: 'keyer-speed', receiver: 0 }),
+    repeatPolicy: 'latest-target-wins',
+  }));
+  h.txAuxFeedback.mockImplementation((field: string) => Object.freeze({
+    confirmed: null, target: null, requestedTarget: null,
+    phase: 'unavailable', busy: false, availability: 'unavailable',
+    outcome: null, lifecycleId: null, transitionId: null,
+    providerGeneration: null, sessionEpoch: h.session.epoch,
+    scope: Object.freeze({ control: field, receiver: 0 as const }),
     repeatPolicy: 'latest-target-wins',
   }));
   for (const mock of [

--- a/frontend/src/semantic/TxAuxSurface.svelte
+++ b/frontend/src/semantic/TxAuxSurface.svelte
@@ -215,6 +215,7 @@
   };
   const levelRow = (field: TxAuxFeedbackLevelField) =>
     TX_AUX_LEVELS.find(([candidate]) => candidate === field)!;
+  const feedbackIntegratedRange = { 'feedback-policy': 'feedback-integrated' } as const;
   function feedbackLevelInput(field: TxAuxFeedbackLevelField): Readonly<ContinuousScalarInput> {
     const current = txAux?.[field];
     const [, , min, max, step] = levelRow(field);
@@ -391,6 +392,7 @@
             <span class="tx-aux-name">{label}</span>
             <input
               type="range" {min} {max} {step} value={display ?? min}
+              {...feedbackIntegratedRange}
               title={feedbackReason(field)}
               aria-describedby={feedbackReason(field) === undefined
                 ? undefined : `${reasonIdPrefix}-${field}`}
@@ -408,7 +410,11 @@
               <span id={`${reasonIdPrefix}-${field}`} class="sr-only">{feedbackReason(field)}</span>
             {/if}
             <output data-canonical-value>{formattedLevel(field, levelView.canonical)}</output>
-            {#if status !== ''}<span data-command-status class:command-pending={levelView.busy}>{status}</span>{/if}
+            {#if status !== ''}<span
+              data-command-status
+              class:command-pending={levelView.busy}
+              class:sr-only={levelView.phase === 'unavailable'}
+            >{status}</span>{/if}
             {#if announcement !== null}
               {#key announcement.eventKey}
                 <span

--- a/frontend/src/semantic/TxAuxSurface.svelte
+++ b/frontend/src/semantic/TxAuxSurface.svelte
@@ -3,8 +3,9 @@
 
   Presentation only. It renders the MOR-1244 `txAux` fact group — ATU, VOX
   (+gain/anti-VOX/delay), COMP (+level), MON (+level), RF power, mic gain,
-  drive gain — and emits control intents as callbacks. It holds no state and
-  consults no controller (v3 ADR invariant 11).
+  drive gain — and emits control intents as callbacks. It owns only the
+  shared scalar primitive's presentation state and consults no controller
+  (v3 ADR invariant 11).
 
   SAFETY. Two rules govern this file and nothing may relax them:
 
@@ -31,6 +32,7 @@
   import { pressedOf } from './pressed-of';
   import { rawToPercentDisplay } from '../primitives/scalar/value-control-core';
   import { disabledReasonText } from './disabled-reason';
+  import type { CommandScalarFeedback } from '../primitives/scalar/continuous-scalar.svelte';
 
   /** On/off controls, `[field, label]`. ATU's reading is a three-state enum,
    *  the rest are booleans; `pressedOf` normalises both to one aria state. */
@@ -71,6 +73,14 @@
   ] as const;
   export type TxAuxToggleField = (typeof TX_AUX_TOGGLES)[number][0];
   export type TxAuxLevelField = (typeof TX_AUX_LEVELS)[number][0];
+  export const TX_AUX_FEEDBACK_LEVELS = [
+    'micGain', 'driveGain', 'voxGain', 'antiVoxGain', 'voxDelay',
+    'compressorLevel', 'monitorLevel',
+  ] as const;
+  export type TxAuxFeedbackLevelField = (typeof TX_AUX_FEEDBACK_LEVELS)[number];
+  export type TxAuxLevelFeedback = Readonly<Record<
+    TxAuxFeedbackLevelField, Readonly<CommandScalarFeedback>
+  >>;
 
   /** Usable ⇔ the radio HAS it, it is readable NOW, and it has been observed. */
   const usable = (f: TxAuxField<unknown>): boolean =>
@@ -125,7 +135,13 @@
 </script>
 
 <script lang="ts">
+  import { onDestroy, untrack } from 'svelte';
   import '../components-v2/controls/control-button.css';
+  import {
+    createContinuousScalar, nativeRangeContinuousScalarPolicy,
+    type ContinuousScalarInput, type ContinuousScalarRendererLease,
+    type ContinuousScalarView,
+  } from '../primitives/scalar/continuous-scalar.svelte';
   import type { RadioViewModel } from './radio-view-model';
   import { blockedLabel, keyBlockedReasons, type TxAuthoritySnapshot } from './rx-tx-surface';
 
@@ -135,8 +151,9 @@
     onToggle?: (field: TxAuxToggleField) => void;
     onLevelChange?: (field: TxAuxLevelField, value: number) => void;
     onAtuTune?: () => void;
+    levelFeedback?: TxAuxLevelFeedback;
   }
-  let { view, tx, onToggle, onLevelChange, onAtuTune }: Props = $props();
+  let { view, tx, onToggle, onLevelChange, onAtuTune, levelFeedback }: Props = $props();
 
   const blockedId = `tx-aux-blocked-${++sequence}`;
   /** MOR-1422: prefix for the per-field hidden reason text `aria-describedby`
@@ -191,6 +208,105 @@
   function level(field: TxAuxLevelField, value: number): void {
     if (txAux && usable(txAux[field])) onLevelChange?.(field, value);
   }
+  const LEVEL_COMMAND: Readonly<Record<TxAuxFeedbackLevelField, string>> = {
+    micGain: 'set_mic_gain', driveGain: 'set_drive_gain', voxGain: 'set_vox_gain',
+    antiVoxGain: 'set_anti_vox_gain', voxDelay: 'set_vox_delay',
+    compressorLevel: 'set_compressor_level', monitorLevel: 'set_monitor_gain',
+  };
+  const levelRow = (field: TxAuxFeedbackLevelField) =>
+    TX_AUX_LEVELS.find(([candidate]) => candidate === field)!;
+  function feedbackLevelInput(field: TxAuxFeedbackLevelField): Readonly<ContinuousScalarInput> {
+    const current = txAux?.[field];
+    const [, , min, max, step] = levelRow(field);
+    const common = {
+      domain: { min, max, step, defaultValue: null, fineStepDivisor: 1 },
+      enabled: current !== undefined && usable(current),
+      request: (value: number) => level(field, value),
+    } as const;
+    if (levelFeedback !== undefined) return {
+      ...common, evidence: 'command-feedback', feedback: levelFeedback[field],
+      command: LEVEL_COMMAND[field],
+    };
+    return {
+      ...common, evidence: 'reading', ownerKey: `tx-aux-${field}-reading`,
+      reading: current?.reading.status === 'known'
+        ? { status: 'known', value: current.reading.value } : { status: 'unknown' },
+    };
+  }
+  const levelScalars = Object.fromEntries(TX_AUX_FEEDBACK_LEVELS.map(field => [
+    field, createContinuousScalar(
+      () => feedbackLevelInput(field), nativeRangeContinuousScalarPolicy,
+    ),
+  ])) as Record<TxAuxFeedbackLevelField, ReturnType<typeof createContinuousScalar>>;
+  const levelLeases = Object.fromEntries(TX_AUX_FEEDBACK_LEVELS.map(field => [
+    field, levelScalars[field].attachRenderer(),
+  ])) as Record<TxAuxFeedbackLevelField, ContinuousScalarRendererLease>;
+  const readLevelViews = () => Object.fromEntries(TX_AUX_FEEDBACK_LEVELS.map(field => [
+    field, levelLeases[field].view,
+  ])) as Record<TxAuxFeedbackLevelField, Readonly<ContinuousScalarView>>;
+  type IssuedAnnouncement = Readonly<{ authorityKey: string; eventKey: string; text: string }>;
+  const authorityKey = (current: Readonly<ContinuousScalarView>): string => current.evidence === 'reading'
+    ? JSON.stringify(['reading', current.editable, current.reading.status])
+    : JSON.stringify([
+      current.evidence, current.editable, current.feedback.providerGeneration ?? null,
+      current.feedback.sessionEpoch, current.feedback.availability,
+      current.feedback.scope.control, current.feedback.scope.receiver,
+      current.feedback.scope.slot ?? null,
+    ]);
+  function nextAnnouncement(
+    current: Readonly<ContinuousScalarView>, previous: IssuedAnnouncement | null,
+  ): IssuedAnnouncement | null {
+    const authority = authorityKey(current);
+    const issued = current.presentation?.politeAnnouncement;
+    if (issued === null || issued === undefined || current.announcement === null) {
+      return previous?.authorityKey === authority ? previous : null;
+    }
+    return {
+      authorityKey: authority, eventKey: JSON.stringify([authority, issued.transitionId]),
+      text: current.error === null ? current.announcement : `${current.announcement}: ${current.error}`,
+    };
+  }
+  const initialLevelViews = untrack(readLevelViews);
+  let levelViews = $state(initialLevelViews);
+  let levelAnnouncements = $state(Object.fromEntries(TX_AUX_FEEDBACK_LEVELS.map(field => [
+    field, nextAnnouncement(initialLevelViews[field], null),
+  ])) as Record<TxAuxFeedbackLevelField, IssuedAnnouncement | null>);
+  $effect(() => {
+    const nextViews = readLevelViews();
+    const nextAnnouncements = Object.fromEntries(TX_AUX_FEEDBACK_LEVELS.map(field => [
+      field, nextAnnouncement(nextViews[field], untrack(() => levelAnnouncements[field])),
+    ])) as Record<TxAuxFeedbackLevelField, IssuedAnnouncement | null>;
+    levelViews = nextViews;
+    levelAnnouncements = nextAnnouncements;
+  });
+  onDestroy(() => {
+    for (const field of TX_AUX_FEEDBACK_LEVELS) {
+      levelLeases[field].dispose();
+      levelScalars[field].destroy();
+    }
+  });
+  const displayedLevel = (current: Readonly<ContinuousScalarView>): number | null =>
+    current.draft ?? (current.evidence === 'command-feedback' && current.busy
+      ? current.target : null) ?? current.canonical;
+  const formattedLevel = (field: TxAuxFeedbackLevelField, value: number | null): string => {
+    if (value === null) return '?';
+    const [, , min, max, , format] = levelRow(field);
+    return (format ?? ((raw: number) => rawToPercentDisplay(raw, min, max)))(value);
+  };
+  const statusText = (field: TxAuxFeedbackLevelField): string => {
+    const current = levelViews[field];
+    if (current.evidence !== 'command-feedback' || current.phase === 'idle') return '';
+    const [, label] = levelRow(field);
+    const target = current.feedback.target ?? current.feedback.requestedTarget;
+    const requested = target === null ? '' : `; requested ${formattedLevel(field, target)}`;
+    const confirmed = `; confirmed ${formattedLevel(field, current.canonical)}`;
+    const error = current.error === null ? '' : `; ${current.error}`;
+    return `${label}: ${current.phase.replaceAll('-', ' ')}${requested}${confirmed}${error}`;
+  };
+  const feedbackReason = (
+    field: TxAuxFeedbackLevelField,
+  ): string | undefined => levelViews[field].editable
+    ? undefined : reasonTextOf(txAux?.[field] ?? view.txAux![field]) ?? 'Not yet observed';
   /** The handler half of the TUNE gate. `disabled` alone is not enough: a
    *  design language may restyle this control, and a programmatic click must
    *  not start a carrier the key intent would have been refused. */
@@ -243,23 +359,66 @@
 
     {#each TX_AUX_LEVELS as [field, label, min, max, step, format] (field)}
       {#if txAux[field].availability.structural}
-        <label
-          class="tx-aux-level" data-testid={`tx-aux-${field}`} data-field={field}
-          data-disabled-reason={reasonOf(txAux[field])}
-        >
-          <span class="tx-aux-name">{label}</span>
-          <input
-            type="range" {min} {max} {step}
-            value={numberOf(txAux[field], min)}
-            title={reasonTextOf(txAux[field])} aria-describedby={reasonIdOf(field, txAux[field])}
-            disabled={!usable(txAux[field])}
-            oninput={(event) => level(field, event.currentTarget.valueAsNumber)}
-          />
-          {#if reasonTextOf(txAux[field]) !== undefined}
-            <span id={reasonIdOf(field, txAux[field])} class="sr-only">{reasonTextOf(txAux[field])}</span>
-          {/if}
-          <output>{levelTextOf(txAux[field], min, max, format)}</output>
-        </label>
+        {#if field === 'rfPower'}
+          <label
+            class="tx-aux-level" data-testid={`tx-aux-${field}`} data-field={field}
+            data-disabled-reason={reasonOf(txAux[field])}
+          >
+            <span class="tx-aux-name">{label}</span>
+            <input
+              type="range" {min} {max} {step}
+              value={numberOf(txAux[field], min)}
+              title={reasonTextOf(txAux[field])} aria-describedby={reasonIdOf(field, txAux[field])}
+              disabled={!usable(txAux[field])}
+              oninput={(event) => level(field, event.currentTarget.valueAsNumber)}
+            />
+            {#if reasonTextOf(txAux[field]) !== undefined}
+              <span id={reasonIdOf(field, txAux[field])} class="sr-only">{reasonTextOf(txAux[field])}</span>
+            {/if}
+            <output>{levelTextOf(txAux[field], min, max, format)}</output>
+          </label>
+        {:else}
+          {@const levelView = levelViews[field]}
+          {@const display = displayedLevel(levelView)}
+          {@const announcement = levelAnnouncements[field]}
+          {@const status = statusText(field)}
+          <label
+            class="tx-aux-level" data-testid={`tx-aux-${field}`} data-field={field}
+            data-disabled-reason={levelView.editable ? undefined : 'field-not-observed'}
+            data-feedback-control={levelView.evidence === 'command-feedback'
+              ? levelView.feedback.scope.control : undefined}
+          >
+            <span class="tx-aux-name">{label}</span>
+            <input
+              type="range" {min} {max} {step} value={display ?? min}
+              title={feedbackReason(field)}
+              aria-describedby={feedbackReason(field) === undefined
+                ? undefined : `${reasonIdPrefix}-${field}`}
+              disabled={!levelView.editable}
+              data-command-phase={levelView.phase ?? undefined}
+              aria-busy={levelView.evidence === 'command-feedback' ? levelView.busy : undefined}
+              aria-valuenow={levelView.evidence === 'command-feedback' && display !== null
+                ? display : undefined}
+              aria-valuetext={levelView.evidence === 'command-feedback'
+                ? `${label}: ${formattedLevel(field, display)}${status === '' ? '' : `; ${status}`}`
+                : undefined}
+              oninput={(event) => levelLeases[field].nativeInput(event.currentTarget.valueAsNumber)}
+            />
+            {#if feedbackReason(field) !== undefined}
+              <span id={`${reasonIdPrefix}-${field}`} class="sr-only">{feedbackReason(field)}</span>
+            {/if}
+            <output data-canonical-value>{formattedLevel(field, levelView.canonical)}</output>
+            {#if status !== ''}<span data-command-status class:command-pending={levelView.busy}>{status}</span>{/if}
+            {#if announcement !== null}
+              {#key announcement.eventKey}
+                <span
+                  class="sr-only" role="status" aria-live="polite" aria-atomic="true"
+                  data-tx-aux-feedback-status data-feedback-lane={field}
+                >{announcement.text}</span>
+              {/key}
+            {/if}
+          </label>
+        {/if}
       {/if}
     {/each}
 

--- a/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
+++ b/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
@@ -630,6 +630,12 @@ describe('level intents reach the caller with the field and the raw value', () =
 });
 
 describe('seven TX/VOX levels consume command feedback', () => {
+  it('declares the adopted native range source feedback-integrated without changing debt inventory', () => {
+    const source = readFileSync('src/semantic/TxAuxSurface.svelte', 'utf8');
+    expect(source.match(/'feedback-policy': 'feedback-integrated'/g)).toHaveLength(1);
+    expect(source).toContain('{...feedbackIntegratedRange}');
+  });
+
   it.each(FEEDBACK_LEVELS)('uses canonical %s feedback and preserves its raw native input', (
     field, _control, canonical,
   ) => {
@@ -656,7 +662,16 @@ describe('seven TX/VOX levels consume command feedback', () => {
     expect(r.input(field).disabled).toBe(true);
     expect(r.input(field).dataset.commandPhase).toBe('unavailable');
     expect(r.row(field).querySelector('output')?.textContent).toContain('?');
-    expect(r.row(field).querySelector('[data-command-status]')?.textContent).toContain('unavailable');
+    const status = r.row(field).querySelector<HTMLElement>('[data-command-status]')!;
+    expect(status.textContent).toContain('unavailable');
+    expect(status.classList).toContain('sr-only');
+    expect(r.input(field).title).toBe('Not yet observed');
+    const descriptionId = r.input(field).getAttribute('aria-describedby')!;
+    expect(r.row(field).querySelector(`#${descriptionId}`)?.textContent).toBe('Not yet observed');
+    expect(r.input(field).getAttribute('aria-valuetext')).toContain('unavailable');
+    const visible = r.row(field).cloneNode(true) as HTMLElement;
+    visible.querySelectorAll('.sr-only').forEach((node) => node.remove());
+    expect(visible.textContent).not.toContain('unavailable');
     r.input(field).value = String(field === 'voxDelay' ? 7 : 200);
     r.input(field).dispatchEvent(new Event('input', { bubbles: true }));
     expect(r.onLevelChange).not.toHaveBeenCalled();
@@ -676,6 +691,7 @@ describe('seven TX/VOX levels consume command feedback', () => {
       expect(r.input('micGain').getAttribute('aria-busy')).toBe('true');
       expect(r.row('micGain').querySelector('[data-canonical-value]')?.textContent).toContain('50%');
       expect(r.row('micGain').querySelector('[data-command-status]')?.textContent).toContain('78%');
+      expect(r.row('micGain').querySelector('[data-command-status]')?.classList).not.toContain('sr-only');
       r.dispose();
     },
   );
@@ -694,7 +710,15 @@ describe('seven TX/VOX levels consume command feedback', () => {
     expect(r.row('micGain').querySelector('[data-command-status]')?.textContent).toContain(
       phase.replaceAll('-', ' '),
     );
+    expect(r.row('micGain').querySelector('[data-command-status]')?.classList).not.toContain('sr-only');
     if (error !== null) expect(r.row('micGain').textContent).toContain(error);
+    if (error !== null) {
+      const status = r.row('micGain').querySelector<HTMLElement>('[data-command-status]')!;
+      expect(status.textContent).toContain('requested 78%');
+      expect(status.textContent).toContain('confirmed 50%');
+      expect(status.textContent).toContain(error);
+      expect(getComputedStyle(status).overflow).not.toBe('hidden');
+    }
     expect(r.row('micGain').querySelectorAll('[data-tx-aux-feedback-status]')).toHaveLength(1);
     r.dispose();
   });

--- a/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
+++ b/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
@@ -17,6 +17,8 @@
 import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
 import TxAuxSurface, {
   TX_AUX_LEVELS, TX_AUX_TOGGLES,
   type TxAuxLevelField, type TxAuxToggleField,
@@ -24,6 +26,7 @@ import TxAuxSurface, {
 import { topologyFixtures, withTxAux } from '../fixtures/topologies';
 import type { Availability, RadioViewModel, TxAuxViewModel } from '../radio-view-model';
 import { blockedLabel, keyBlockedReasons, type TxAuthoritySnapshot } from '../rx-tx-surface';
+import type { CommandScalarFeedback } from '../../primitives/scalar/continuous-scalar.svelte';
 
 const IDLE_RX: TxAuthoritySnapshot = {
   phase: 'idle', intent: null, radioTx: 'off', txRisk: 'none', fault: null,
@@ -65,7 +68,33 @@ type Handlers = {
   onToggle?: (field: TxAuxToggleField) => void;
   onLevelChange?: (field: TxAuxLevelField, value: number) => void;
   onAtuTune?: () => void;
+  levelFeedback?: TxAuxFeedbackRecord;
 };
+
+const FEEDBACK_LEVELS = [
+  ['micGain', 'mic-gain', 128], ['driveGain', 'drive-gain', 128],
+  ['voxGain', 'vox-gain', 50], ['antiVoxGain', 'anti-vox-gain', 30],
+  ['voxDelay', 'vox-delay', 20], ['compressorLevel', 'compressor-level', 10],
+  ['monitorLevel', 'monitor-level', 128],
+] as const;
+type FeedbackLevelField = (typeof FEEDBACK_LEVELS)[number][0];
+type TxAuxFeedbackRecord = Readonly<Record<FeedbackLevelField, Readonly<CommandScalarFeedback>>>;
+const feedback = (
+  control: string, confirmed: number, phase: CommandScalarFeedback['phase'] = 'idle',
+  over: Partial<CommandScalarFeedback> = {},
+): Readonly<CommandScalarFeedback> => Object.freeze({
+  confirmed, target: null, requestedTarget: null, phase,
+  busy: ['submitted', 'queued', 'dispatched', 'awaiting-confirmation'].includes(phase),
+  availability: 'available', outcome: null, lifecycleId: null, transitionId: null,
+  providerGeneration: 1, sessionEpoch: 1,
+  scope: Object.freeze({ control, receiver: 0 as const }),
+  repeatPolicy: 'latest-target-wins', ...over,
+});
+const feedbackRecord = (
+  replace: Partial<Record<FeedbackLevelField, Readonly<CommandScalarFeedback>>> = {},
+): TxAuxFeedbackRecord => Object.fromEntries(FEEDBACK_LEVELS.map(([field, control, value]) => [
+  field, replace[field] ?? feedback(control, value),
+])) as unknown as TxAuxFeedbackRecord;
 
 function render(view: RadioViewModel, tx: TxAuthoritySnapshot, handlers: Handlers = {}) {
   const component = mount(TxAuxSurface, { target, props: { view, tx, ...handlers } });
@@ -88,6 +117,18 @@ function withSurface(
 ): void {
   const s = render(view, tx, handlers);
   try { fn(s); } finally { s.dispose(); }
+}
+
+function renderReactiveFeedback(initial: TxAuxFeedbackRecord = feedbackRecord()) {
+  const onLevelChange = vi.fn();
+  const props = proxy({ view: base(), tx: snap(), onLevelChange, levelFeedback: initial });
+  const component = mount(TxAuxSurface, { target, props });
+  flushSync();
+  const row = (field: FeedbackLevelField) => target.querySelector<HTMLElement>(
+    `[data-testid="tx-aux-${field}"]`,
+  )!;
+  const input = (field: FeedbackLevelField) => row(field).querySelector('input')!;
+  return { dispose: () => unmount(component), row, input, onLevelChange, props };
 }
 
 /** `disabled` for a <button>, or for the <input> a level control wraps. */
@@ -585,6 +626,116 @@ describe('level intents reach the caller with the field and the raw value', () =
       expect(s.input('micGain')!.valueAsNumber).toBe(128);
       expect(s.input('voxDelay')!.valueAsNumber).toBe(20);
     });
+  });
+});
+
+describe('seven TX/VOX levels consume command feedback', () => {
+  it.each(FEEDBACK_LEVELS)('uses canonical %s feedback and preserves its raw native input', (
+    field, _control, canonical,
+  ) => {
+    const r = renderReactiveFeedback();
+    const input = r.input(field);
+    expect(input.valueAsNumber).toBe(canonical);
+    expect(input.dataset.commandPhase).toBe('idle');
+    expect(input.getAttribute('aria-busy')).toBe('false');
+    input.value = field === 'voxDelay' ? '7' : '177';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(r.onLevelChange).toHaveBeenCalledExactlyOnceWith(field, input.valueAsNumber);
+    r.dispose();
+  });
+
+  it.each(FEEDBACK_LEVELS)(
+    'keeps supplied unavailable %s evidence unavailable instead of borrowing the view reading', (
+      field, control, canonical,
+    ) => {
+    const unavailable = feedback(control, canonical, 'unavailable', {
+      confirmed: null, availability: 'unavailable', providerGeneration: 2, sessionEpoch: 2,
+    });
+    const r = renderReactiveFeedback(feedbackRecord({ [field]: unavailable }));
+    expect(r.input(field).disabled).toBe(true);
+    expect(r.input(field).dataset.commandPhase).toBe('unavailable');
+    expect(r.row(field).querySelector('output')?.textContent).toContain('?');
+    expect(r.row(field).querySelector('[data-command-status]')?.textContent).toContain('unavailable');
+    r.input(field).value = String(field === 'voxDelay' ? 7 : 200);
+    r.input(field).dispatchEvent(new Event('input', { bubbles: true }));
+    expect(r.onLevelChange).not.toHaveBeenCalled();
+    r.dispose();
+    },
+  );
+
+  it.each(['submitted', 'queued', 'dispatched', 'awaiting-confirmation'] as const)(
+    'shows an optimistic target while %s without replacing canonical truth', (phase) => {
+      const pending = feedback('mic-gain', 128, phase, {
+        target: 200, requestedTarget: 200, lifecycleId: 'mic-command',
+        transitionId: `mic-${phase}`,
+      });
+      const r = renderReactiveFeedback(feedbackRecord({ micGain: pending }));
+      expect(r.input('micGain').valueAsNumber).toBe(200);
+      expect(r.input('micGain').dataset.commandPhase).toBe(phase);
+      expect(r.input('micGain').getAttribute('aria-busy')).toBe('true');
+      expect(r.row('micGain').querySelector('[data-canonical-value]')?.textContent).toContain('50%');
+      expect(r.row('micGain').querySelector('[data-command-status]')?.textContent).toContain('78%');
+      r.dispose();
+    },
+  );
+
+  it.each([
+    ['confirmed', 200, null], ['failed', 128, 'radio refused'],
+    ['timed-out', 128, null], ['cancelled', 128, null], ['superseded', 128, null],
+  ] as const)('settles %s visibly on canonical truth', (phase, canonical, error) => {
+    const terminal = feedback('mic-gain', canonical, phase, {
+      requestedTarget: 200, lifecycleId: 'mic-command', transitionId: `mic-${phase}`,
+      outcome: { phase, ...(error === null ? {} : { error }) },
+    });
+    const r = renderReactiveFeedback(feedbackRecord({ micGain: terminal }));
+    expect(r.input('micGain').valueAsNumber).toBe(canonical);
+    expect(r.input('micGain').getAttribute('aria-busy')).toBe('false');
+    expect(r.row('micGain').querySelector('[data-command-status]')?.textContent).toContain(
+      phase.replaceAll('-', ' '),
+    );
+    if (error !== null) expect(r.row('micGain').textContent).toContain(error);
+    expect(r.row('micGain').querySelectorAll('[data-tx-aux-feedback-status]')).toHaveLength(1);
+    r.dispose();
+  });
+
+  it.each(FEEDBACK_LEVELS)(
+    'announces one %s transition once and resets retained speech on authority replacement', (
+      field, control, canonical,
+    ) => {
+    const requested = field === 'voxDelay' ? 7 : 200;
+    const failed = (generation: number, session: number) => feedback(control, canonical, 'failed', {
+      requestedTarget: requested, lifecycleId: `${field}-command`, transitionId: `${field}-failed`,
+      providerGeneration: generation, sessionEpoch: session,
+      outcome: { phase: 'failed', error: 'radio refused' },
+    });
+    const r = renderReactiveFeedback(feedbackRecord({ [field]: failed(1, 1) }));
+    const status = () => r.row(field).querySelector<HTMLElement>(
+      '[data-tx-aux-feedback-status]',
+    );
+    const first = status()!;
+    r.props.levelFeedback = feedbackRecord({ [field]: failed(1, 1) });
+    flushSync();
+    expect(status()).toBe(first);
+    expect(r.row(field).querySelectorAll('[data-tx-aux-feedback-status]')).toHaveLength(1);
+    r.props.levelFeedback = feedbackRecord({ [field]: failed(2, 2) });
+    flushSync();
+    expect(status()).not.toBe(first);
+    expect(status()?.getAttribute('aria-live')).toBe('polite');
+    expect(r.row(field).querySelectorAll('[data-tx-aux-feedback-status]')).toHaveLength(1);
+    r.dispose();
+    },
+  );
+
+  it('retains the named reading compatibility path when feedback is omitted', () => {
+    const onLevelChange = vi.fn();
+    withSurface(base(), snap(), (s) => {
+      expect(s.input('micGain')?.dataset.commandPhase).toBeUndefined();
+      expect(s.input('micGain')?.valueAsNumber).toBe(128);
+      s.input('micGain')!.value = '177';
+      s.input('micGain')!.dispatchEvent(new Event('input', { bubbles: true }));
+      expect(onLevelChange).toHaveBeenCalledExactlyOnceWith('micGain', 177);
+    }, { onLevelChange });
   });
 });
 


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-2422/connect-seven-semantic-tx-and-vox-controls-to-shared-v3-command

## Summary
- route all seven semantic TX/VOX level controls through the accepted command-feedback accessor and native continuous scalar
- preserve RF Power, toggle, TUNE, raw-value, and reading-only compatibility behavior
- expose canonical and requested values, phase, busy/error status, and deduplicated polite announcements per lane
- declare the adopted native range source feedback-integrated and keep unavailable rows compact while retaining their full accessible explanation

## Dependency
- based on accepted MOR-2421 fixture prerequisite `ed2017dc169fe49246bbf4cebf4824c35f90032a`

## RED provenance
- direct surface RED: 18 genuine missing feedback-consumption failures
- the first composed run was invalidated by 54 suite-wide setup failures because its state fixture was rejected
- after the first harness correction, the composed run exposed 9 relevant missing-feedback failures plus 2 additional harness failures caused by the omitted `radio` mock export
- no clean composed RED run existed after every harness defect was fixed and before the original product edits
- correction-cycle RED: 8 focused failures, one for the missing feedback-policy declaration and seven for visibly expanded unavailable status

## Test plan
- 8 focused Vitest files: 530 tests passed, including debt inventory, composed/native regressions, and the fixture seam
- `npm run check`
- changed-path ESLint and `npm run lint:boundaries`
- `npm run i18n:check`
- `uv run mypy --strict src/rigplane/web`
- `git diff --check`
- local affected visual capture inspected at phone and desktop sizes; no baseline files changed (the macOS comparator remains platform-different from the approved Linux baselines, so natural Linux visual CI is authoritative)

## Scope
- 5 leased files, 545 additions and 21 deletions (566 A+D)
- correction touched only `frontend/src/semantic/TxAuxSurface.svelte` and `frontend/src/semantic/__tests__/TxAuxSurface.test.ts`
- no fixture, baseline, adapter, command, backend, layout, PTT, TUNE, toggle, hardware, or service changes
- queued/dispatched/superseded remain pure supplied-DTO presentation coverage; real accessor source completeness remains MOR-1687