### PR TITLE
MOR-2423: adopt four DSP scalar controls on v3 feedback

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts
@@ -21,6 +21,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import type { Capabilities } from '$lib/types/capabilities';
+import type { ControlSessionSnapshot } from '$lib/runtime/frontend-runtime';
 import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
 
 let txHarness: ManagedAppTxHarness;
@@ -87,6 +88,7 @@ const h = vi.hoisted(() => {
           get caps() { subscribe(); return h.caps; },
           get scope() { return h.scope; },
           connectionStatus: 'disconnected',
+          controlSession: Object.freeze({ state: 'disconnected', epoch: -1 }) satisfies ControlSessionSnapshot,
           radioPowerOn: null,
           connection: { status: 'disconnected', radioPowerOn: null },
           audio: { rxEnabled: false, txEnabled: false, volume: 50, muted: false },

--- a/frontend/src/components-v2/panels/DspPanel.svelte
+++ b/frontend/src/components-v2/panels/DspPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy, untrack } from 'svelte';
   import { ValueControl } from '../controls/value-control';
   import { rawToPercentDisplay } from '../../primitives/scalar/value-control-core';
   import { HardwareButton } from '$lib/Button';
@@ -15,7 +16,18 @@
 
   import {
     deriveDspProps, getDspHandlers, getAutoNotchArmed, getManualNotchArmed,
+    getDspControlFeedback,
   } from '$lib/runtime/adapters/panel-adapters';
+  import {
+    createContinuousScalar,
+    createDiscreteContinuousScalarPolicy,
+    createHBarContinuousScalarPolicy,
+    type ContinuousScalarBinding,
+  } from '../../primitives/scalar/continuous-scalar.svelte';
+  import type {
+    HBarIssuedStatusPresentation,
+    HBarIssuedStatusSnapshot,
+  } from '../controls/value-control/skin';
   import { t } from '$lib/i18n';
 
   const handlers = getDspHandlers();
@@ -102,6 +114,82 @@
   let showNotch = $derived(p.hasNotch ?? true);
   let showAutoNotch = $derived(p.hasAutoNotch ?? true);
   let showAgcTime = $derived(p.hasAgcTime ?? true);
+
+  let nbLevelFeedback = $derived(getDspControlFeedback('nbLevel'));
+  let nbWidthFeedback = $derived(getDspControlFeedback('nbWidth'));
+  let notchPositionFeedback = $derived(getDspControlFeedback('notchFilter'));
+  let agcTimeFeedback = $derived(getDspControlFeedback('agcTimeConstant'));
+  const hbarPolicy = (describeTarget: (value: number) => string) =>
+    createHBarContinuousScalarPolicy({ preview: 'optimistic', debounceMs: 50, describeTarget });
+  const nbLevelBinding = createContinuousScalar(
+    () => ({
+      evidence: 'command-feedback', feedback: nbLevelFeedback, command: 'set_nb_level',
+      domain: { min: 0, max: nbLevelMax, step: 1, defaultValue: null, fineStepDivisor: 10 },
+      enabled: showNb && nbLevelFeedback.availability === 'available', request: onNbLevelChange,
+    }),
+    hbarPolicy((value) => nbLevelDisplayFn(value)),
+  );
+  const nbWidthBinding = createContinuousScalar(
+    () => ({
+      evidence: 'command-feedback', feedback: nbWidthFeedback, command: 'set_nb_width',
+      domain: { min: 0, max: 255, step: 1, defaultValue: null, fineStepDivisor: 10 },
+      enabled: showNb && hasNbWidth && nbWidthFeedback.availability === 'available',
+      request: onNbWidthChange,
+    }),
+    hbarPolicy(rawToPercentDisplay),
+  );
+  const notchPositionBinding = createContinuousScalar(
+    () => ({
+      evidence: 'command-feedback', feedback: notchPositionFeedback, command: 'set_notch_filter',
+      domain: { min: 0, max: 255, step: 1, defaultValue: null, fineStepDivisor: 10 },
+      enabled: showNotch && notchMode === 'manual'
+        && notchPositionFeedback.availability === 'available',
+      request: onNotchFreqChange,
+    }),
+    hbarPolicy(String),
+  );
+  const agcTimeBinding = createContinuousScalar(
+    () => ({
+      evidence: 'command-feedback', feedback: agcTimeFeedback, command: 'set_agc_time_constant',
+      domain: { min: 0, max: 9, step: 1, defaultValue: null, fineStepDivisor: 10 },
+      enabled: showAgcTime && agcTimeFeedback.availability === 'available', request: onAgcTimeChange,
+    }),
+    createDiscreteContinuousScalarPolicy({ debounceMs: 50, describeTarget: formatAgcTime }),
+  );
+
+  type HBarDspLane = 'nbLevel' | 'nbWidth' | 'notchPosition';
+  let issuedStatusText = $state<Record<HBarDspLane, string | null>>({
+    nbLevel: null, nbWidth: null, notchPosition: null,
+  });
+  function formatIssuedStatus({ view, announcement }: Readonly<HBarIssuedStatusSnapshot>): string {
+    return view.error === null
+      ? announcement.message
+      : `${announcement.message.replace(/[.!?]$/, '')}: ${view.error}`;
+  }
+  function issuedStatusPresentation(lane: HBarDspLane): Readonly<HBarIssuedStatusPresentation> {
+    return {
+      get text() { return issuedStatusText[lane]; },
+      format: formatIssuedStatus,
+      accept(text) { issuedStatusText[lane] = text; },
+    };
+  }
+  const nbLevelStatus = issuedStatusPresentation('nbLevel');
+  const nbWidthStatus = issuedStatusPresentation('nbWidth');
+  const notchPositionStatus = issuedStatusPresentation('notchPosition');
+  function consumeHiddenStatus(
+    binding: ContinuousScalarBinding,
+    presentation?: Readonly<HBarIssuedStatusPresentation>,
+  ): void {
+    const view = binding.view;
+    if (presentation === undefined || view.evidence !== 'command-feedback') return;
+    const announcement = view.presentation.politeAnnouncement;
+    if (announcement !== null) {
+      presentation.accept(untrack(() => presentation.format({ view, announcement })));
+    } else if (view.feedback.transitionId === null) {
+      presentation.accept(null);
+    }
+  }
+  const feedbackIntegratedControl = { 'feedback-policy': 'feedback-integrated' } as const;
 
   let nrOptions = $derived(buildNrOptions());
   let notchOptions = $derived(buildNotchOptions());
@@ -212,6 +300,26 @@
     } else if (openModal === 'agc') {
       agcModalStyle = computeModalStyle(agcAnchorEl);
     }
+  });
+
+  $effect(() => {
+    if (openModal !== 'nb') {
+      consumeHiddenStatus(nbLevelBinding, nbLevelStatus);
+      consumeHiddenStatus(nbWidthBinding, nbWidthStatus);
+    } else if (!hasNbWidth) {
+      consumeHiddenStatus(nbWidthBinding, nbWidthStatus);
+    }
+    if (!(openModal === 'notch' && notchMode === 'manual')) {
+      consumeHiddenStatus(notchPositionBinding, notchPositionStatus);
+    }
+    if (openModal !== 'agc') consumeHiddenStatus(agcTimeBinding);
+  });
+
+  onDestroy(() => {
+    nbLevelBinding.destroy();
+    nbWidthBinding.destroy();
+    notchPositionBinding.destroy();
+    agcTimeBinding.destroy();
   });
 
   /* LONG_PRESS_MS imported from dsp-panel-logic */
@@ -410,15 +518,13 @@
       </HardwareButton>
     </div>
     <ValueControl
+      {...feedbackIntegratedControl}
       label="NB Level"
-      value={nbLevel}
-      min={0}
-      max={nbLevelMax}
-      step={1}
+      binding={nbLevelBinding}
       renderer="hbar"
       displayFn={nbLevelDisplayFn}
       accentColor="var(--v2-accent-yellow)"
-      onChange={onNbLevelChange}
+      issuedStatusPresentation={nbLevelStatus}
       variant="hardware-illuminated"
     />
     {#if hasNbDepth}
@@ -437,15 +543,13 @@
     {/if}
     {#if hasNbWidth}
       <ValueControl
+        {...feedbackIntegratedControl}
         label="NB Width"
-        value={nbWidth}
-        min={0}
-        max={255}
-        step={1}
+        binding={nbWidthBinding}
         renderer="hbar"
         displayFn={rawToPercentDisplay}
         accentColor="var(--v2-accent-orange)"
-        onChange={onNbWidthChange}
+        issuedStatusPresentation={nbWidthStatus}
         variant="hardware-illuminated"
       />
     {/if}
@@ -495,14 +599,12 @@
     {/if}
     {#if notchMode === 'manual'}
       <ValueControl
+        {...feedbackIntegratedControl}
         label="Notch Position"
-        value={notchFreq}
-        min={0}
-        max={255}
-        step={1}
+        binding={notchPositionBinding}
         renderer="hbar"
         accentColor="var(--v2-accent-cyan)"
-        onChange={onNotchFreqChange}
+        issuedStatusPresentation={notchPositionStatus}
         variant="hardware-illuminated"
       />
       <div class="dsp-modal-block dsp-mode-grid">
@@ -518,17 +620,14 @@
   <div class="dsp-modal" role="dialog" aria-label="AGC time settings" style={agcModalStyle}>
     <div class="menu-title">AGC Time Constant</div>
     <ValueControl
+      {...feedbackIntegratedControl}
       label="AGC Time"
-      value={agcTimeConstant}
-      min={0}
-      max={9}
-      step={1}
+      binding={agcTimeBinding}
       renderer="discrete"
       tickStyle="notch"
       displayFn={formatAgcTime}
       unit="s"
       accentColor="var(--v2-accent-cyan)"
-      onChange={onAgcTimeChange}
       variant="hardware-illuminated"
     />
   </div>

--- a/frontend/src/components-v2/panels/DspPanel.svelte
+++ b/frontend/src/components-v2/panels/DspPanel.svelte
@@ -11,7 +11,6 @@
     toggleNrMode,
     toggleNotchMode,
     isNrActive,
-    isNotchActive,
   } from './dsp-panel-logic';
 
   import {
@@ -195,7 +194,6 @@
   let notchOptions = $derived(buildNotchOptions());
 
   let nrActive = $derived(isNrActive(nrMode));
-  let notchToggleActive = $derived(isNotchActive(notchMode));
 
   type ModalId = 'nr' | 'nb' | 'notch' | 'agc';
   let openModal = $state<ModalId | null>(null);

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
 
 const mockProps = {
   nrMode: 0,
@@ -34,12 +36,10 @@ const mockHandlers = {
 };
 
 const runtimeState = vi.hoisted(() => ({
-  state: null as {
-    active: 'MAIN' | 'SUB';
-    main: Record<string, unknown>;
-    sub: Record<string, unknown>;
-    observationSeq?: number;
-  } | null,
+  state: null as ServerState | null,
+  caps: null as Capabilities | null,
+  session: { state: 'connected' as 'connected' | 'disconnected', epoch: 1 },
+  radioListeners: new Set<(state: ServerState | null) => void>(),
   notify: () => {},
 }));
 const mockProjection = vi.hoisted(() => ({ notify: () => {} }));
@@ -48,14 +48,27 @@ vi.mock('$lib/runtime/frontend-runtime', async () => {
   const { createSubscriber } = await import('svelte/reactivity');
   let update = () => {};
   const subscribe = createSubscriber((notify) => { update = notify; return () => {}; });
-  runtimeState.notify = () => update();
+  runtimeState.notify = () => {
+    update();
+    runtimeState.radioListeners.forEach((listener) => listener(runtimeState.state));
+  };
   return {
     runtime: {
       get state() { subscribe(); return runtimeState.state; },
-      get caps() { return null; },
+      get caps() { subscribe(); return runtimeState.caps; },
+      get controlSession() { subscribe(); return runtimeState.session; },
     },
   };
 });
+
+vi.mock('$lib/stores/radio.svelte', () => ({
+  getRadioState: () => runtimeState.state,
+  subscribeRadioState: (listener: (state: ServerState | null) => void) => {
+    runtimeState.radioListeners.add(listener);
+    listener(runtimeState.state);
+    return () => runtimeState.radioListeners.delete(listener);
+  },
+}));
 
 vi.mock('$lib/runtime/adapters/panel-adapters', async (importOriginal) => {
   const actual = await importOriginal<typeof import('$lib/runtime/adapters/panel-adapters')>();
@@ -80,11 +93,55 @@ import {
   failCommand,
   resetCommandLifecycle,
 } from '$lib/stores/commands.svelte';
+import { getDspControlFeedback } from '$lib/runtime/adapters/panel-adapters';
 
 let components: ReturnType<typeof mount>[] = [];
 
+const fresh = (storePath: string, marker = 1) => ({
+  storePath, observed: true, freshness: 'fresh' as const,
+  availability: 'available' as const, lastObservedMonotonic: marker,
+});
+
+function qualifiedState(marker = 1, providerGeneration = 3): ServerState {
+  return {
+    stateContractVersion: 1, providerGeneration, active: 'MAIN',
+    main: {
+      nr: false, nb: mockProps.nbActive, nbLevel: mockProps.nbLevel,
+      autoNotch: false, manualNotch: mockProps.notchMode === 'manual',
+      notchFilter: mockProps.notchFreq, manualNotchWidth: mockProps.manualNotchWidth,
+      agcTimeConstant: mockProps.agcTimeConstant,
+    },
+    sub: {}, nbWidth: mockProps.nbWidth, observationSeq: marker,
+    fieldStatus: {
+      'main.nr': fresh('main.nr', marker),
+      'main.nb': fresh('main.nb', marker),
+      'main.nbLevel': fresh('main.nbLevel', marker),
+      'main.autoNotch': fresh('main.autoNotch', marker),
+      'main.manualNotch': fresh('main.manualNotch', marker),
+      'main.notchFilter': fresh('main.notchFilter', marker),
+      'main.manualNotchWidth': fresh('main.manualNotchWidth', marker),
+      'main.agcTimeConstant': fresh('main.agcTimeConstant', marker),
+      nbWidth: fresh('nbWidth', marker),
+    },
+  } as unknown as ServerState;
+}
+
+function qualifiedCaps(providerGeneration = 3): Capabilities {
+  return {
+    model: 'FTX-1', scope: false, audio: false, tx: false,
+    capabilities: ['nr', 'nb', 'notch', 'agc'], receivers: 1, vfoScheme: 'single',
+    freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48_000, channels: 1, codecs: ['pcm'] },
+    webrtc: { available: false, enabled: false }, txBands: null,
+    stateContractVersion: 1, providerGeneration,
+    controls: { nb_depth: {} },
+  } as unknown as Capabilities;
+}
+
 function mountPanel(overrides?: Partial<typeof mockProps>) {
   if (overrides) Object.assign(mockProps, overrides);
+  runtimeState.state = qualifiedState(runtimeState.state?.observationSeq ?? 1);
+  runtimeState.notify();
   const t = document.createElement('div');
   document.body.appendChild(t);
   const component = mount(DspPanel, { target: t });
@@ -129,18 +186,18 @@ beforeEach(() => {
   mockHandlers.onNbWidthChange = vi.fn();
   mockHandlers.onManualNotchWidthChange = vi.fn();
   mockHandlers.onAgcTimeChange = vi.fn();
-  runtimeState.state = {
-    active: 'MAIN',
-    main: { autoNotch: false, manualNotch: false },
-    sub: {},
-    observationSeq: 1,
-  };
+  runtimeState.caps = qualifiedCaps();
+  runtimeState.session = { state: 'connected', epoch: 1 };
+  runtimeState.state = qualifiedState();
+  runtimeState.notify();
 });
 
 afterEach(() => {
   components.forEach((c) => unmount(c));
   resetCommandLifecycle();
   runtimeState.state = null;
+  runtimeState.caps = null;
+  runtimeState.session = { state: 'disconnected', epoch: -1 };
   vi.useRealTimers();
   document.body.innerHTML = '';
 });
@@ -242,6 +299,122 @@ describe('DspPanel NB modal depth/width gating (MOR-502)', () => {
     expect(modal?.textContent).not.toContain('NB Depth');
     expect(modal?.textContent).not.toContain('NB Width');
     expect(modal?.textContent).toContain('NB Level');
+  });
+});
+
+describe('DspPanel v3 DSP scalar source integration (MOR-2423)', () => {
+  const lanes = [
+    ['nbLevel', 'set_nb_level', { level: 129, receiver: 0 }, 129],
+    ['nbWidth', 'set_nb_width', { level: 64 }, 64],
+    ['notchFilter', 'set_notch_filter', { value: 127, receiver: 0 }, 127],
+    ['agcTimeConstant', 'set_agc_time_constant', { value: 4, receiver: 0 }, 4],
+  ] as const;
+
+  it('routes both NB lanes independently through their existing raw handlers', () => {
+    const t = mountPanel({ nbActive: true, nbLevel: 128, nbWidth: 63 });
+    openLongPressModal(t, 'NB');
+    vi.useFakeTimers();
+    t.querySelector<HTMLElement>('[aria-label="NB Level"]')!
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    t.querySelector<HTMLElement>('[aria-label="NB Width"]')!
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    vi.advanceTimersByTime(50);
+
+    expect(mockHandlers.onNbLevelChange).toHaveBeenCalledExactlyOnceWith(129);
+    expect(mockHandlers.onNbWidthChange).toHaveBeenCalledExactlyOnceWith(64);
+    vi.useRealTimers();
+  });
+
+  it('uses the real descriptors for submitted, ACK, exact fresh confirmation, and authority replacement', () => {
+    const commands = lanes.map(([field, name, params]) => beginCommand({
+      id: `dsp-${field}`, name, params, originalEpoch: 1, timeoutMs: 5_000,
+    }));
+    for (const [field] of lanes) {
+      const feedback = getDspControlFeedback(field);
+      expect(feedback.phase).toBe('submitted');
+      expect(feedback.availability).toBe('available');
+    }
+
+    commands.forEach((command) => acknowledgeCommand(command.id, command.originalEpoch, 1));
+    for (const [field] of lanes) expect(getDspControlFeedback(field).phase).toBe('awaiting-confirmation');
+
+    const next = qualifiedState(2);
+    next.main!.nbLevel = 129;
+    next.nbWidth = 64;
+    next.main!.notchFilter = 127;
+    next.main!.agcTimeConstant = 4;
+    runtimeState.state = next;
+    runtimeState.notify();
+    for (const [field, , , confirmed] of lanes) {
+      const feedback = getDspControlFeedback(field);
+      expect(feedback.phase).toBe('confirmed');
+      expect(feedback.confirmed).toBe(confirmed);
+    }
+
+    runtimeState.state = qualifiedState(3, 4);
+    runtimeState.caps = qualifiedCaps(4);
+    runtimeState.session = { state: 'connected', epoch: 2 };
+    runtimeState.notify();
+    for (const [field] of lanes) {
+      const feedback = getDspControlFeedback(field);
+      expect(feedback.phase).toBe('idle');
+      expect(feedback.lifecycleId).toBeNull();
+      expect(feedback.providerGeneration).toBe(4);
+      expect(feedback.sessionEpoch).toBe(2);
+    }
+  });
+
+  it('requires the exact same-field observation to be newer than ACK', () => {
+    const command = beginCommand({
+      id: 'exact-nb-level', name: 'set_nb_level', params: { level: 129, receiver: 0 },
+      originalEpoch: 1, timeoutMs: 5_000,
+    });
+    acknowledgeCommand(command.id, command.originalEpoch, 1);
+
+    const wrongValue = qualifiedState(2);
+    wrongValue.main!.nbLevel = 130;
+    runtimeState.state = wrongValue;
+    runtimeState.notify();
+    expect(getDspControlFeedback('nbLevel').phase).toBe('awaiting-confirmation');
+
+    const staleExact = qualifiedState(1);
+    staleExact.main!.nbLevel = 129;
+    runtimeState.state = staleExact;
+    runtimeState.notify();
+    expect(getDspControlFeedback('nbLevel').phase).toBe('awaiting-confirmation');
+
+    const freshExact = qualifiedState(2);
+    freshExact.main!.nbLevel = 129;
+    runtimeState.state = freshExact;
+    runtimeState.notify();
+    expect(getDspControlFeedback('nbLevel').phase).toBe('confirmed');
+  });
+
+  it('invalidates a deferred dispatch on authority loss and recovers in place', () => {
+    vi.useFakeTimers();
+    const t = mountPanel({ nbActive: true });
+    openLongPressModal(t, 'NB');
+    vi.useFakeTimers();
+    const slider = t.querySelector<HTMLElement>('[aria-label="NB Level"]')!;
+    slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+
+    runtimeState.session = { state: 'disconnected', epoch: 1 };
+    runtimeState.notify();
+    flushSync();
+    vi.advanceTimersByTime(50);
+    expect(slider.getAttribute('aria-disabled')).toBe('true');
+    expect(mockHandlers.onNbLevelChange).not.toHaveBeenCalled();
+
+    runtimeState.state = qualifiedState(2, 4);
+    runtimeState.caps = qualifiedCaps(4);
+    runtimeState.session = { state: 'connected', epoch: 2 };
+    runtimeState.notify();
+    flushSync();
+    slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    vi.advanceTimersByTime(50);
+    expect(slider.getAttribute('aria-disabled')).toBe('false');
+    expect(mockHandlers.onNbLevelChange).toHaveBeenCalledExactlyOnceWith(129);
+    vi.useRealTimers();
   });
 });
 
@@ -521,7 +694,7 @@ describe('DspPanel mobile notch dialog (MOR-1631)', () => {
       main: { autoNotch: true, manualNotch: false },
       sub: {},
       observationSeq: 2,
-    };
+    } as unknown as ServerState;
     mockProps.notchMode = 'auto';
     runtimeState.notify();
     mockProjection.notify();

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
@@ -309,6 +309,50 @@ describe('DspPanel v3 DSP scalar source integration (MOR-2423)', () => {
     ['notchFilter', 'set_notch_filter', { value: 127, receiver: 0 }, 127],
     ['agcTimeConstant', 'set_agc_time_constant', { value: 4, receiver: 0 }, 4],
   ] as const;
+  const modalLanes = [
+    ['NB', 'NB Level', 'hbar'],
+    ['NB', 'NB Width', 'hbar'],
+    ['NOTCH', 'Notch Position', 'hbar'],
+    ['AGC-T', 'AGC Time', 'discrete'],
+  ] as const;
+
+  function closeModal(t: HTMLElement): void {
+    t.querySelector<HTMLButtonElement>('[aria-label="Close DSP settings"]')!.click();
+    flushSync();
+  }
+
+  function assertModalFeedback(
+    t: HTMLElement,
+    expectedPhase: string,
+    expectedText: string | null,
+  ): void {
+    for (const [button, label, renderer] of modalLanes) {
+      openLongPressModal(t, button);
+      const control = t.querySelector<HTMLElement>(`[aria-label="${label}"]`)!;
+      expect(control.dataset.commandPhase).toBe(expectedPhase);
+      const owner = control.closest(renderer === 'hbar' ? '.vc-hbar' : '.vc-discrete')!;
+      if (renderer === 'discrete') {
+        if (expectedText === null) {
+          const current = owner.querySelector('[data-control-feedback-current-status]');
+          if (expectedPhase === 'unavailable') {
+            expect(current?.textContent).toBe('Control unavailable');
+          } else {
+            expect(current).toBeNull();
+          }
+        } else {
+          expect(owner.querySelector('[data-control-feedback-current-status]')?.textContent)
+            .toContain(expectedText);
+        }
+        expect(owner.querySelector('[data-control-feedback-status]')).toBeNull();
+      } else if (expectedText === null) {
+        expect(owner.querySelector('[data-control-feedback-status]')).toBeNull();
+      } else {
+        expect(owner.querySelectorAll('[data-control-feedback-status]')).toHaveLength(1);
+        expect(owner.querySelector('[data-control-feedback-status]')?.textContent).toContain(expectedText);
+      }
+      closeModal(t);
+    }
+  }
 
   it('routes both NB lanes independently through their existing raw handlers', () => {
     const t = mountPanel({ nbActive: true, nbLevel: 128, nbWidth: 63 });
@@ -364,6 +408,43 @@ describe('DspPanel v3 DSP scalar source integration (MOR-2423)', () => {
     }
   });
 
+  it('keeps all four hidden terminal facts current, clears them, and accepts fresh replacements', () => {
+    for (const [field, name, params] of lanes) {
+      const command = beginCommand({
+        id: `old-${field}`, name, params, originalEpoch: 1, timeoutMs: 5_000,
+      });
+      failCommand(command.id, command.originalEpoch, 1, `old ${field} failure`);
+    }
+    const t = mountPanel({ nbActive: true, notchMode: 'manual', notchFreq: 126 });
+
+    assertModalFeedback(t, 'failed', 'old');
+    assertModalFeedback(t, 'failed', 'old');
+
+    runtimeState.session = { state: 'disconnected', epoch: 1 };
+    runtimeState.notify();
+    flushSync();
+    assertModalFeedback(t, 'unavailable', null);
+    expect(t.textContent).not.toContain('old');
+
+    runtimeState.state = qualifiedState(2, 4);
+    runtimeState.caps = qualifiedCaps(4);
+    runtimeState.session = { state: 'connected', epoch: 2 };
+    mockProps.nbLevelMax = 200;
+    runtimeState.notify();
+    mockProjection.notify();
+    flushSync();
+    assertModalFeedback(t, 'idle', null);
+
+    for (const [field, name, params] of lanes) {
+      const command = beginCommand({
+        id: `new-${field}`, name, params, originalEpoch: 2, timeoutMs: 5_000,
+      });
+      failCommand(command.id, command.originalEpoch, 2, `new ${field} failure`);
+    }
+    flushSync();
+    assertModalFeedback(t, 'failed', 'new');
+  });
+
   it('requires the exact same-field observation to be newer than ACK', () => {
     const command = beginCommand({
       id: 'exact-nb-level', name: 'set_nb_level', params: { level: 129, receiver: 0 },
@@ -390,32 +471,40 @@ describe('DspPanel v3 DSP scalar source integration (MOR-2423)', () => {
     expect(getDspControlFeedback('nbLevel').phase).toBe('confirmed');
   });
 
-  it('invalidates a deferred dispatch on authority loss and recovers in place', () => {
-    vi.useFakeTimers();
-    const t = mountPanel({ nbActive: true });
-    openLongPressModal(t, 'NB');
-    vi.useFakeTimers();
-    const slider = t.querySelector<HTMLElement>('[aria-label="NB Level"]')!;
-    slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+  it.each([
+    ['NB', 'NB Level', 'onNbLevelChange', { nbActive: true, nbLevel: 128 }, 129],
+    ['NB', 'NB Width', 'onNbWidthChange', { nbActive: true, nbWidth: 63 }, 64],
+    ['NOTCH', 'Notch Position', 'onNotchFreqChange', { notchMode: 'manual', notchFreq: 127 }, 128],
+    ['AGC-T', 'AGC Time', 'onAgcTimeChange', { agcTimeConstant: 3 }, 4],
+  ] as const)(
+    'invalidates deferred %s work on authority loss and recovers in place',
+    (button, label, handler, props, expected) => {
+      vi.useFakeTimers();
+      const t = mountPanel(props);
+      openLongPressModal(t, button);
+      vi.useFakeTimers();
+      const slider = t.querySelector<HTMLElement>(`[aria-label="${label}"]`)!;
+      slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
 
-    runtimeState.session = { state: 'disconnected', epoch: 1 };
-    runtimeState.notify();
-    flushSync();
-    vi.advanceTimersByTime(50);
-    expect(slider.getAttribute('aria-disabled')).toBe('true');
-    expect(mockHandlers.onNbLevelChange).not.toHaveBeenCalled();
+      runtimeState.session = { state: 'disconnected', epoch: 1 };
+      runtimeState.notify();
+      flushSync();
+      vi.advanceTimersByTime(50);
+      expect(slider.getAttribute('aria-disabled')).toBe('true');
+      expect(mockHandlers[handler]).not.toHaveBeenCalled();
 
-    runtimeState.state = qualifiedState(2, 4);
-    runtimeState.caps = qualifiedCaps(4);
-    runtimeState.session = { state: 'connected', epoch: 2 };
-    runtimeState.notify();
-    flushSync();
-    slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
-    vi.advanceTimersByTime(50);
-    expect(slider.getAttribute('aria-disabled')).toBe('false');
-    expect(mockHandlers.onNbLevelChange).toHaveBeenCalledExactlyOnceWith(129);
-    vi.useRealTimers();
-  });
+      runtimeState.state = qualifiedState(2, 4);
+      runtimeState.caps = qualifiedCaps(4);
+      runtimeState.session = { state: 'connected', epoch: 2 };
+      runtimeState.notify();
+      flushSync();
+      slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+      vi.advanceTimersByTime(50);
+      expect(slider.getAttribute('aria-disabled')).toBe('false');
+      expect(mockHandlers[handler]).toHaveBeenCalledExactlyOnceWith(expected);
+      vi.useRealTimers();
+    },
+  );
 });
 
 describe('DspPanel manual-notch position (MOR-1633)', () => {

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.isolated.test.ts
@@ -79,6 +79,8 @@ describe('MOR-2423 DSP scalar feedback wiring contract', () => {
     expect(source).toContain("command: 'set_nb_width'");
     expect(source).toContain("command: 'set_notch_filter'");
     expect(source).toContain("command: 'set_agc_time_constant'");
+    expect(source.match(/const view = binding\.view;/g)).toHaveLength(1);
+    expect(source).not.toContain('notchToggleActive');
   });
 });
 
@@ -304,6 +306,60 @@ describe('MOR-2423 supplied feedback phase projection', () => {
       phase === 'idle' || phase === 'unavailable' ? 0 : 1,
     );
   });
+
+  it.each([
+    ['nbLevel', { nbActive: true }, 'NB', 'NB Level', 'hbar'],
+    ['nbWidth', { nbActive: true }, 'NB', 'NB Width', 'hbar'],
+    ['notchFilter', { notchMode: 'manual', notchFreq: 127 }, 'NOTCH', 'Notch Position', 'hbar'],
+    ['agcTimeConstant', { agcTimeConstant: 4 }, 'AGC-T', 'AGC Time', 'discrete'],
+  ] as const)(
+    'retains hidden %s failure facts across repeated modal opens without a second live owner',
+    (field, props, buttonLabel, controlLabel, renderer) => {
+      feedbackOverrides.set(field, {
+        phase: 'failed', busy: false, target: null, requestedTarget: 4,
+        outcome: { phase: 'failed', error: `${field} rejected` },
+        lifecycleId: `${field}-life`, transitionId: `${field}-failed`,
+      });
+      const t = mountPanel(props);
+
+      const open = () => {
+        const button = getFillButtons(t).find((candidate) =>
+          candidate.textContent?.trim().startsWith(buttonLabel));
+        if (buttonLabel === 'AGC-T') {
+          button?.click();
+        } else {
+          vi.useFakeTimers();
+          button?.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+          vi.advanceTimersByTime(600);
+          vi.useRealTimers();
+        }
+        flushSync();
+      };
+      const assertCurrent = () => {
+        const control = t.querySelector<HTMLElement>(`[aria-label="${controlLabel}"]`)!;
+        expect(control.dataset.commandPhase).toBe('failed');
+        if (renderer === 'discrete') {
+          expect(t.querySelector('[data-control-feedback-current-status]')?.textContent)
+            .toContain(`${field} rejected`);
+          expect(t.querySelector('[data-control-feedback-status]')).toBeNull();
+        } else {
+          expect(control.closest('.vc-hbar')?.querySelectorAll('[data-control-feedback-status]'))
+            .toHaveLength(1);
+          expect(control.closest('.vc-hbar')?.querySelector('[data-control-feedback-status]')?.textContent)
+            .toContain(`${field} rejected`);
+        }
+      };
+
+      open();
+      assertCurrent();
+      t.querySelector<HTMLButtonElement>('[aria-label="Close DSP settings"]')!.click();
+      flushSync();
+      expect(t.querySelector(`[aria-label="${controlLabel}"]`)).toBeNull();
+
+      open();
+      assertCurrent();
+    },
+  );
 });
 
 describe('Notch toggle', () => {

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.isolated.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { buildNrOptions, buildNotchOptions } from '../dsp-utils';
 import { rawToPercentDisplay } from '../../../primitives/scalar/value-control-core';
 
@@ -39,15 +41,46 @@ const mockHandlers = {
 // unarmed here, this file's tests are not about that behavior (covered by
 // `mor1536-armed-adoption.test.ts`).
 const unarmed = { armed: false, value: null };
-
+const feedbackOverrides = vi.hoisted(() => new Map<string, Record<string, unknown>>());
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveDspProps: () => mockProps,
   getDspHandlers: () => mockHandlers,
   getAutoNotchArmed: () => unarmed,
   getManualNotchArmed: () => unarmed,
+  getDspControlFeedback: (field: 'nbLevel' | 'nbWidth' | 'notchFilter' | 'agcTimeConstant') => ({
+    confirmed: field === 'notchFilter' ? mockProps.notchFreq : mockProps[field],
+    target: null, requestedTarget: null, phase: 'idle' as const,
+    busy: false, availability: 'available' as const, outcome: null,
+    lifecycleId: null, transitionId: null, providerGeneration: 1, sessionEpoch: 7,
+    scope: {
+      control: field === 'nbLevel' ? 'nb-level'
+        : field === 'nbWidth' ? 'nb-width'
+          : field === 'notchFilter' ? 'notch-position' : 'agc-time',
+      receiver: 0 as const,
+    },
+    repeatPolicy: 'latest-target-wins' as const,
+    ...feedbackOverrides.get(field),
+  }),
 }));
 
 import DspPanel from '../DspPanel.svelte';
+
+describe('MOR-2423 DSP scalar feedback wiring contract', () => {
+  it('adopts only the four leased scalar lanes and leaves manual notch width raw', () => {
+    const source = readFileSync(path.resolve(process.cwd(), 'src/components-v2/panels/DspPanel.svelte'), 'utf8');
+
+    expect(source.match(/getDspControlFeedback\('/g)).toHaveLength(4);
+    expect(source).toContain("getDspControlFeedback('nbLevel')");
+    expect(source).toContain("getDspControlFeedback('nbWidth')");
+    expect(source).toContain("getDspControlFeedback('notchFilter')");
+    expect(source).toContain("getDspControlFeedback('agcTimeConstant')");
+    expect(source).not.toContain("getDspControlFeedback('manualNotchWidth')");
+    expect(source).toContain("command: 'set_nb_level'");
+    expect(source).toContain("command: 'set_nb_width'");
+    expect(source).toContain("command: 'set_notch_filter'");
+    expect(source).toContain("command: 'set_agc_time_constant'");
+  });
+});
 
 // ---------------------------------------------------------------------------
 // buildNrOptions
@@ -111,6 +144,7 @@ function mountPanel(overrides?: Partial<typeof mockProps>) {
 
 beforeEach(() => {
   components = [];
+  feedbackOverrides.clear();
   Object.assign(mockProps, {
     nrMode: 0, nrLevel: 128, nbActive: false, nbLevel: 128,
     notchMode: 'off', notchFreq: 1000, nbDepth: 0, nbWidth: 0,
@@ -241,6 +275,34 @@ describe('NB depth/width capability gating', () => {
     expect(text).not.toContain('NB Width');
     // NB Level remains present regardless of depth/width.
     expect(text).toContain('NB Level');
+  });
+});
+
+describe('MOR-2423 supplied feedback phase projection', () => {
+  it.each([
+    'unavailable', 'idle', 'submitted', 'queued', 'dispatched', 'awaiting-confirmation',
+    'confirmed', 'failed', 'timed-out', 'cancelled', 'superseded',
+  ] as const)('projects the supplied %s DTO without inventing source lifecycle evidence', (phase) => {
+    const busy = ['submitted', 'queued', 'dispatched', 'awaiting-confirmation'].includes(phase);
+    const terminal = ['confirmed', 'failed', 'timed-out', 'cancelled', 'superseded'].includes(phase);
+    feedbackOverrides.set('nbLevel', {
+      phase, busy, availability: phase === 'unavailable' ? 'unavailable' : 'available',
+      confirmed: phase === 'unavailable' ? null : 128,
+      target: busy ? 129 : null, requestedTarget: phase === 'idle' ? null : 129,
+      outcome: terminal ? { phase, ...(phase === 'failed' ? { error: 'radio rejected' } : {}) } : null,
+      lifecycleId: phase === 'idle' || phase === 'unavailable' ? null : `life-${phase}`,
+      transitionId: phase === 'idle' || phase === 'unavailable' ? null : `life-${phase}:${phase}`,
+    });
+    const t = mountPanel({ nbActive: true });
+    openNbModal(t);
+    const control = t.querySelector<HTMLElement>('[aria-label="NB Level"]')!;
+
+    expect(control.dataset.commandPhase).toBe(phase);
+    expect(control.getAttribute('aria-busy')).toBe(String(busy));
+    expect(control.getAttribute('aria-disabled')).toBe(String(phase === 'unavailable'));
+    expect(t.querySelectorAll('[data-control-feedback-status]')).toHaveLength(
+      phase === 'idle' || phase === 'unavailable' ? 0 : 1,
+    );
   });
 });
 

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.nr-level.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.nr-level.component.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 
 import type { Capabilities, ControlDomain } from '$lib/types/capabilities';
+import type { ControlSessionSnapshot } from '$lib/runtime/frontend-runtime';
 
 const handlers = {
   onNrModeChange: vi.fn(),
@@ -21,6 +22,9 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
   runtime: {
     get state() { return runtimeState.state; },
     get caps() { return runtimeState.caps; },
+    get controlSession() {
+      return { state: 'disconnected', epoch: -1 } satisfies ControlSessionSnapshot;
+    },
   },
 }));
 

--- a/frontend/src/components-v2/panels/__tests__/mor1536-armed-adoption.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/mor1536-armed-adoption.test.ts
@@ -123,6 +123,12 @@ vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   getDspHandlers: () => mockDspHandlers,
   getAutoNotchArmed: () => mockAutoNotchArmed,
   getManualNotchArmed: () => mockManualNotchArmed,
+  getDspControlFeedback: (field: string) => ({
+    confirmed: null, target: null, requestedTarget: null, phase: 'unavailable' as const,
+    busy: false, availability: 'unavailable' as const, outcome: null,
+    lifecycleId: null, transitionId: null, providerGeneration: null, sessionEpoch: -1,
+    scope: { control: field, receiver: 0 as const }, repeatPolicy: 'latest-target-wins' as const,
+  }),
 }));
 
 import AgcPanel from '../AgcPanel.svelte';


### PR DESCRIPTION
Scope rationale: MOR-2423 is one coherent six-file / 565-line DSP panel adoption batch (527 additions, 38 deletions), including the exact semantic-LCD fixture reached by the panel dependency graph.

## Summary
- wire NB Level, NB Width, Notch Position, and AGC Time to the existing v3 continuous-scalar command feedback
- consume the accepted persistent current-status foundation from #3279 so hidden AGC failures remain current after reopen without replaying an old live announcement
- preserve the specialized HBar issued-status formatting and one hidden/visible reader for each modal lane
- preserve existing domains, display formatting, handlers, modal visibility, and the raw Manual Notch Width choice controls
- remove the dead `notchToggleActive` local after a source guard proved it had no consumer
- repair the exact semantic-LCD runtime fixture with a truthful disconnected `controlSession`

## Lifecycle coverage
- actual parent + `ValueControl` coverage for hidden failure, repeated reopen, current phase/error, unavailable and idle clearing, authority/domain replacement, fresh terminal replacement, and cancellation of delayed old work with recovery
- all four modal lanes are covered
- queued, dispatched, and superseded are supplied-DTO projection cases only; this PR does not claim new live source phases

## Verification
- RED: semantic-LCD fixture reproduced 32 failures / 1 pass before adding `controlSession`
- RED: 115 passes / 1 deliberate source-guard failure before deleting the dead local
- GREEN: 11 focused files, 416 tests passed
- GREEN: changed component rerun, 40 tests passed
- `npm run check`
- targeted ESLint over all six leased files
- `npm run i18n:check`
- `npm run lint:boundaries`
- `git diff --check`

No hardware validation or deployment is required for this frontend-only change.