### PR TITLE
MOR-1687: preserve current control status

### DIFF
--- a/frontend/src/__tests__/control-feedback-presentation.test.ts
+++ b/frontend/src/__tests__/control-feedback-presentation.test.ts
@@ -18,6 +18,12 @@ const PHASES: readonly PresentationPhase[] = [
 const BUSY = new Set<PresentationPhase>([
   'submitted', 'queued', 'dispatched', 'awaiting-confirmation',
 ]);
+const PHASE_TEXT: Readonly<Record<PresentationPhase, string>> = {
+  unavailable: 'Control unavailable', idle: 'Control idle', submitted: 'Submitting',
+  queued: 'Queued', dispatched: 'Dispatched',
+  'awaiting-confirmation': 'Awaiting confirmation', confirmed: 'Confirmed',
+  failed: 'Failed', 'timed-out': 'Timed out', cancelled: 'Cancelled', superseded: 'Superseded',
+};
 const EMPTY: ControlFeedbackPresentationState = { announcedTransitionIds: [] };
 const feedback = <T>(phase: PresentationPhase, overrides: Partial<ControlFeedbackPresentationInput<T>> = {}) => ({
   confirmed: null, target: null, requestedTarget: null, phase,
@@ -41,6 +47,9 @@ describe('pure ControlFeedback presentation contract (MOR-1711)', () => {
       'data-command-phase': phase, 'aria-busy': BUSY.has(phase) ? 'true' : 'false',
     });
     expect(result.targetDescription).toBe('2400');
+    expect(result.currentStatus).toBe(
+      phase === 'idle' ? null : `${PHASE_TEXT[phase]}: 2400`,
+    );
     expect(result.politeAnnouncement === null).toBe(phase === 'idle' || phase === 'unavailable');
   });
 
@@ -67,6 +76,7 @@ describe('pure ControlFeedback presentation contract (MOR-1711)', () => {
       feedback<number>('submitted', { target: 3000, requestedTarget: 3000 }), first.state, String,
     );
     expect(repeated.politeAnnouncement).toBeNull();
+    expect(repeated.currentStatus).toBe('Submitting: 3000');
     const next = projectControlFeedbackPresentation(
       feedback<number>('awaiting-confirmation', {
         target: 3000, requestedTarget: 3000, transitionId: 'transition-new',
@@ -77,6 +87,28 @@ describe('pure ControlFeedback presentation contract (MOR-1711)', () => {
       feedback<number>('submitted', { transitionId: 'transition-submitted' }), next.state, String,
     );
     expect(delayedOld.politeAnnouncement).toBeNull();
+  });
+
+  it('replaces current status from current facts without retaining old terminal text', () => {
+    const failed = projectControlFeedbackPresentation(
+      feedback<number>('failed', {
+        requestedTarget: 1800,
+        outcome: { phase: 'failed', error: 'radio rejected' },
+      }), EMPTY, (value) => `${value} Hz`,
+    );
+    expect(failed.currentStatus).toBe('Failed: 1800 Hz');
+
+    const unavailable = projectControlFeedbackPresentation(
+      feedback<number>('unavailable'), failed.state, (value) => `${value} Hz`,
+    );
+    expect(unavailable.currentStatus).toBe('Control unavailable');
+    expect(unavailable.politeAnnouncement).toBeNull();
+
+    const idle = projectControlFeedbackPresentation(
+      feedback<number>('idle'), unavailable.state, (value) => `${value} Hz`,
+    );
+    expect(idle.currentStatus).toBeNull();
+    expect(idle.politeAnnouncement).toBeNull();
   });
 
   it('derives toggle and choice ARIA only from confirmed truth', () => {

--- a/frontend/src/components-v2/controls/value-control/DiscreteRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/DiscreteRenderer.svelte
@@ -66,7 +66,9 @@
     legacy,
   }: Props = $props();
 
-  const feedbackDescriptionId = $props.id();
+  const feedbackId = $props.id();
+  const feedbackDescriptionId = `${feedbackId}-description`;
+  const feedbackCurrentStatusId = `${feedbackId}-current-status`;
 
   let containerEl: HTMLDivElement | null = $state(null);
   let activePointer: { id: number; token: number; target: HTMLElement } | null = null;
@@ -116,6 +118,17 @@
     : displayFn ? displayFn(renderedValue)
       : `${renderedValue}${unit ? '\u00a0' + unit : ''}`);
   let renderPresentation = $derived(projectScalarRenderPresentation(view, legacy));
+  let currentStatusDescription = $derived(
+    renderPresentation.currentStatus === null
+      ? renderPresentation.error
+      : renderPresentation.error === null
+        ? renderPresentation.currentStatus
+        : `${renderPresentation.currentStatus}: ${renderPresentation.error}`,
+  );
+  let feedbackDescriptionIds = $derived([
+    renderPresentation.description === null ? null : feedbackDescriptionId,
+    currentStatusDescription === null ? null : feedbackCurrentStatusId,
+  ].filter((id): id is string => id !== null).join(' ') || undefined);
   let effectiveDimmed = $derived(dimmed ?? !view.editable);
 
   let tickItems = $derived.by(() => {
@@ -254,7 +267,7 @@
     aria-valuenow={view.domainValid ? view.canonical ?? undefined : undefined}
     aria-disabled={!view.editable}
     aria-busy={renderPresentation.attributes['aria-busy']}
-    aria-describedby={renderPresentation.description !== null ? feedbackDescriptionId : undefined}
+    aria-describedby={feedbackDescriptionIds}
     data-command-phase={renderPresentation.attributes['data-command-phase'] ?? undefined}
     onpointerdown={handlePointerDown}
     onpointermove={handlePointerMove}
@@ -387,6 +400,13 @@
 
   {#if renderPresentation.description !== null}
     <span id={feedbackDescriptionId} class="sr-only">{renderPresentation.description}</span>
+  {/if}
+  {#if currentStatusDescription !== null}
+    <span
+      id={feedbackCurrentStatusId}
+      class="sr-only"
+      data-control-feedback-current-status
+    >{currentStatusDescription}</span>
   {/if}
   {#if renderPresentation.status !== null}
     <span

--- a/frontend/src/components-v2/controls/value-control/__tests__/DualParamRenderer.controlled.svelte.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/DualParamRenderer.controlled.svelte.test.ts
@@ -189,6 +189,7 @@ describe('binding-only DualParamRenderer', () => {
           'aria-busy': supplied.busy ? 'true' : 'false',
         },
         targetDescription: null,
+        currentStatus: supplied.phase === 'idle' ? null : announcement,
         politeAnnouncement: supplied.transitionId === null ? null : {
           politeness: 'polite', transitionId: supplied.transitionId,
           phase: supplied.phase, targetDescription: null, message: announcement,

--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
@@ -1165,26 +1165,47 @@ describe('ValueControl controlled Discrete rendering', () => {
     binding.destroy();
   });
 
-  it('preserves full command feedback and one-shot announcement identity in Discrete', () => {
-    const binding = commandBinding(vi.fn(), {
+  it.each([
+    ['built-in', undefined],
+    ['selected custom Discrete', { name: 'persistent-status-discrete', discrete: DiscreteRenderer }],
+  ] as const)('preserves current feedback without replaying old live status in %s', (_route, skin) => {
+    const request = vi.fn();
+    const owner = commandBinding(request, {
       phase: 'failed',
       busy: false,
       outcome: { phase: 'failed', error: 'radio rejected' },
       transitionId: 'failed-discrete',
     });
-    const { state, target } = mountReactive({ binding, label: 'Feedback', renderer: 'hbar' });
+    let viewReads = 0;
+    const binding = countViewReads(owner, () => { viewReads += 1; });
+    const { state, target } = mountReactive({
+      binding, label: 'Feedback', renderer: 'hbar', skin,
+    });
+    expect(viewReads).toBe(1);
+    const retainedHBar = slider(target);
     expect(target.querySelector('[data-control-feedback-status]')?.textContent)
       .toBe('Failed: 30 Hz: radio rejected');
 
     state.renderer = 'discrete';
     flushSync();
     const replacement = slider(target);
+    expect(viewReads).toBe(3);
     expect(replacement.getAttribute('data-command-phase')).toBe('failed');
     expect(replacement.getAttribute('aria-busy')).toBe('false');
-    const descriptionId = replacement.getAttribute('aria-describedby');
-    expect(target.querySelector(`#${descriptionId}`)?.textContent).toBe('30 Hz');
+    const describedIds = replacement.getAttribute('aria-describedby')?.split(' ') ?? [];
+    expect(describedIds).toHaveLength(2);
+    expect(describedIds.map((id) => target.querySelector(`#${id}`)?.textContent))
+      .toEqual(['30 Hz', 'Failed: 30 Hz: radio rejected']);
+    const currentStatus = target.querySelector('[data-control-feedback-current-status]');
+    expect(currentStatus?.getAttribute('role')).toBeNull();
+    expect(currentStatus?.getAttribute('aria-live')).toBeNull();
     expect(target.querySelector('[data-control-feedback-status]')).toBeNull();
-    binding.destroy();
+
+    retainedHBar.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(request).not.toHaveBeenCalled();
+    replacement.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(request).toHaveBeenCalledExactlyOnceWith(30);
+    owner.destroy();
   });
 
   it.each([

--- a/frontend/src/components-v2/controls/value-control/__tests__/scalar-render-presentation.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/scalar-render-presentation.test.ts
@@ -30,6 +30,7 @@ const commandView = (): ContinuousScalarView => ({
       'aria-busy': 'true',
     },
     targetDescription: '30 Hz',
+    currentStatus: 'Awaiting confirmation: 30 Hz',
     politeAnnouncement: null,
     state: { announcedTransitionIds: [] },
   },
@@ -75,10 +76,22 @@ describe('projectScalarRenderPresentation', () => {
       source: 'command-owner',
       attributes: view.presentation?.attributes,
       description: '30 Hz',
+      currentStatus: 'Awaiting confirmation: 30 Hz',
       status: 'Awaiting confirmation: 30 Hz',
       error: 'radio rejected',
     });
     expect(projectScalarRenderPresentation(view, legacy)).toEqual(projection);
+  });
+
+  it('keeps current command status and error after the one-shot status is consumed', () => {
+    const view = { ...commandView(), announcement: null } satisfies ContinuousScalarView;
+
+    expect(projectScalarRenderPresentation(view)).toMatchObject({
+      source: 'command-owner',
+      currentStatus: 'Awaiting confirmation: 30 Hz',
+      status: null,
+      error: 'radio rejected',
+    });
   });
 
   it('preserves arbitrary legacy reading decoration verbatim', () => {
@@ -96,6 +109,7 @@ describe('projectScalarRenderPresentation', () => {
         'aria-busy': false,
       },
       description: '',
+      currentStatus: null,
       status: 'literal legacy status',
       error: null,
     });
@@ -114,6 +128,7 @@ describe('projectScalarRenderPresentation', () => {
         'aria-busy': undefined,
       },
       description: null,
+      currentStatus: null,
       status: null,
       error: null,
     });

--- a/frontend/src/components-v2/controls/value-control/scalar-render-presentation.ts
+++ b/frontend/src/components-v2/controls/value-control/scalar-render-presentation.ts
@@ -16,6 +16,7 @@ export interface ScalarRenderPresentation {
     'aria-busy': 'true' | 'false' | boolean | undefined;
   }>;
   readonly description: string | null;
+  readonly currentStatus: string | null;
   readonly status: string | null;
   readonly error: string | null;
 }
@@ -27,6 +28,7 @@ const NONE: Readonly<ScalarRenderPresentation> = Object.freeze({
     'aria-busy': undefined,
   }),
   description: null,
+  currentStatus: null,
   status: null,
   error: null,
 });
@@ -40,6 +42,7 @@ export function projectScalarRenderPresentation(
       source: 'command-owner',
       attributes: view.presentation.attributes,
       description: view.presentation.targetDescription,
+      currentStatus: view.presentation.currentStatus,
       status: view.announcement,
       error: view.error,
     });
@@ -57,6 +60,7 @@ export function projectScalarRenderPresentation(
       'aria-busy': legacy.busy,
     }),
     description: legacy.description,
+    currentStatus: null,
     status: legacy.status,
     error: null,
   });

--- a/frontend/src/primitives/control-feedback/control-feedback-presentation.ts
+++ b/frontend/src/primitives/control-feedback/control-feedback-presentation.ts
@@ -34,6 +34,7 @@ export interface ControlFeedbackPresentation {
     'aria-busy': 'true' | 'false';
   }>;
   readonly targetDescription: string | null;
+  readonly currentStatus: string | null;
   readonly politeAnnouncement: Readonly<PoliteControlAnnouncement> | null;
   readonly state: Readonly<ControlFeedbackPresentationState>;
 }
@@ -56,6 +57,10 @@ export function projectControlFeedbackPresentation<T>(
 ): Readonly<ControlFeedbackPresentation> {
   const target = feedback.target ?? feedback.requestedTarget;
   const targetDescription = target === null ? null : describeTarget(target);
+  const statusMessage = targetDescription === null
+    ? PHASE_TEXT[feedback.phase]
+    : `${PHASE_TEXT[feedback.phase]}: ${targetDescription}`;
+  const currentStatus = feedback.phase === 'idle' ? null : statusMessage;
   const shouldAnnounce = feedback.transitionId !== null
     && !previous.announcedTransitionIds.includes(feedback.transitionId);
   const state = shouldAnnounce
@@ -67,9 +72,7 @@ export function projectControlFeedbackPresentation<T>(
     ? Object.freeze({
       politeness: 'polite' as const,
       transitionId: feedback.transitionId!, phase: feedback.phase, targetDescription,
-      message: targetDescription === null
-        ? PHASE_TEXT[feedback.phase]
-        : `${PHASE_TEXT[feedback.phase]}: ${targetDescription}`,
+      message: statusMessage,
     })
     : null;
   return Object.freeze({
@@ -77,7 +80,7 @@ export function projectControlFeedbackPresentation<T>(
       'data-command-phase': feedback.phase,
       'aria-busy': BUSY_PHASES.has(feedback.phase) ? 'true' : 'false',
     }),
-    targetDescription, politeAnnouncement, state,
+    targetDescription, currentStatus, politeAnnouncement, state,
   });
 }
 

--- a/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
+++ b/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
@@ -155,7 +155,7 @@ describe('continuous scalar contract', () => {
       editable: false,
       phase: 'failed',
       error: 'radio rejected',
-      presentation: { targetDescription: '2700' },
+      presentation: { targetDescription: '2700', currentStatus: 'Failed: 2700' },
     });
   });
 
@@ -206,10 +206,16 @@ describe('continuous scalar contract', () => {
       requested: 2_800,
       phase: 'awaiting-confirmation',
       busy: true,
-      presentation: { attributes: { 'aria-busy': 'true' } },
+      presentation: {
+        attributes: { 'aria-busy': 'true' },
+        currentStatus: 'Awaiting confirmation: 2800',
+      },
       announcement: 'Awaiting confirmation: 2800',
     });
-    expect(scalar.view.announcement).toBeNull();
+    expect(scalar.view).toMatchObject({
+      presentation: { currentStatus: 'Awaiting confirmation: 2800' },
+      announcement: null,
+    });
 
     const malformed = feedback('submitted', {
       confirmed: Number.POSITIVE_INFINITY,
@@ -1291,17 +1297,84 @@ describe('continuous scalar deferred work', () => {
       feedback: terminal,
     });
     const stale = scalar.attachRenderer();
-    expect(stale.view.announcement).toBe('Failed: 2500');
+    expect(stale.view).toMatchObject({
+      presentation: { currentStatus: 'Failed: 2500' },
+      announcement: 'Failed: 2500',
+    });
+    expect(stale.view).toMatchObject({
+      presentation: { currentStatus: 'Failed: 2500' },
+      announcement: null,
+    });
     const staleToken = stale.beginPointer()!;
     stale.pointer(staleToken, 2_700);
     expect(scalar.view.draft).toBe(2_700);
 
     update({ feedback: feedback('idle', { providerGeneration: 4 }) });
-    expect(scalar.view).toMatchObject({ draft: null, announcement: null });
+    expect(scalar.view).toMatchObject({
+      draft: null,
+      presentation: { currentStatus: null },
+      announcement: null,
+    });
     stale.pointer(staleToken, 2_800);
     expect(scalar.view.draft).toBeNull();
     stale.nativeInput(2_900);
     expect(scalar.view.draft).toBe(2_900);
+  });
+
+  it.each([
+    ['provider', { feedback: feedback('idle', { providerGeneration: 4 }) }, null, null, null],
+    ['session', { feedback: feedback('idle', { sessionEpoch: 8 }) }, null, null, null],
+    ['scope', {
+      feedback: feedback('failed', {
+        scope: { control: 'filter-width', receiver: 1, slot: 'main' },
+        requestedTarget: 2_600,
+        transitionId: 'new-scope-failed',
+        outcome: { phase: 'failed', error: 'new receiver rejected' },
+      }),
+    }, 'Failed: 2600', 'new receiver rejected', 'Failed: 2600'],
+    ['domain', { domain: { ...DOMAIN, max: 4_000 }, feedback: feedback('idle') }, null, null, null],
+    ['availability', {
+      feedback: feedback('unavailable', { confirmed: null, availability: 'unavailable' }),
+    }, 'Control unavailable', null, null],
+  ] as const)(
+    'projects only current facts after %s replacement',
+    (_label, replacement, expectedStatus, expectedError, expectedAnnouncement) => {
+      const { scalar, update } = commandSetup(nativeRangeContinuousScalarPolicy, {
+        feedback: feedback('failed', {
+          requestedTarget: 2_500,
+          transitionId: 'old-failed',
+          outcome: { phase: 'failed', error: 'old failure' },
+        }),
+      });
+      expect(scalar.view.presentation?.currentStatus).toBe('Failed: 2500');
+
+      update(replacement);
+
+      const replaced = scalar.view;
+      expect(replaced.presentation?.currentStatus).toBe(expectedStatus);
+      expect(replaced.presentation?.currentStatus).not.toBe('Failed: 2500');
+      expect(replaced.error).toBe(expectedError);
+      expect(replaced.announcement).toBe(expectedAnnouncement);
+    },
+  );
+
+  it('removes current command status when authority changes to an unknown reading', () => {
+    const request = vi.fn<(value: number) => void>();
+    let current: ContinuousScalarInput = commandInput(request, {
+      feedback: feedback('failed', {
+        requestedTarget: 2_500,
+        transitionId: 'command-failed',
+        outcome: { phase: 'failed', error: 'radio rejected' },
+      }),
+    });
+    const scalar = createContinuousScalar(() => current, nativeRangeContinuousScalarPolicy);
+    expect(scalar.view.presentation?.currentStatus).toBe('Failed: 2500');
+
+    current = readingInput(request, { reading: { status: 'unknown' } });
+
+    expect(scalar.view).toMatchObject({
+      evidence: 'reading', canonical: null, presentation: null, announcement: null, error: null,
+    });
   });
 
   it.each([


### PR DESCRIPTION
## Summary
- add an immutable current-status projection beside the existing one-shot polite announcement
- expose Discrete current phase, target, and error through a non-live described region without replaying consumed transitions
- preserve command authority, renderer leases, legacy reading decoration, and every existing scalar-render status consumer

## Scope
Linear owner: MOR-1687.

Exactly eight leased files, 186 additions and 17 deletions. The file-count rationale is one additive shared presentation field, its Discrete consumer, focused projection/scalar/replacement proofs, and the sole manually constructed pair fixture needed by the typed expansion. No scalar production owner, HBar, ValueControl, skin, panel, store, backend, protocol, or baseline changes.

Compatibility impact: additive frontend presentation API only. Existing ScalarRenderPresentation.status remains the nullable one-shot event; legacy reading behavior is unchanged.

## Verification
- RED: 27 focused failures before implementation across missing current projection, scalar forwarding, and Discrete persistent-region behavior; unrelated cases remained green
- GREEN: 209 tests across the five changed suites plus committed-scalar and continuous-pair regressions
- GREEN: npm run check with 0 errors and 0 warnings
- GREEN: changed-file ESLint
- GREEN: git diff --check
- built-in and selected Discrete routes prove consumed-event remount, non-live described status/error, exact owner-view reads, active replacement I/O, and revoked old callbacks
- provider, session, scope, domain, availability, idle, and unknown-evidence replacements prove current DTO projection without stale text; a fresh replacement terminal remains announceable

## Boundaries
Public/open-core boundary checked. No release, migration, hardware, service, or deployment claim. Broader current-status adoption in other appearances and the MOR-2423 four-control modal correction remain open.

## Agent Review
Independent exact-head review remains required before merge. Natural frontend and path-selected visual CI should run on this Ready PR.