### PR TITLE
MOR-2425: add portable component kit API package

### DIFF
--- a/frontend/component-kit-api/build.mjs
+++ b/frontend/component-kit-api/build.mjs
@@ -1,0 +1,113 @@
+import { spawnSync } from 'node:child_process';
+import { mkdir, readFile, readdir, rm, unlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { build } from 'vite';
+
+const packageRoot = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.dirname(packageRoot);
+const apiDist = path.join(packageRoot, 'dist');
+const fixtureRoot = path.join(packageRoot, 'fixtures', 'external-kit');
+const fixtureDist = path.join(fixtureRoot, 'dist');
+const tsc = path.join(frontendRoot, 'node_modules', 'typescript', 'bin', 'tsc');
+
+function runTypeScript(config) {
+  const result = spawnSync(process.execPath, [tsc, '-p', config], {
+    cwd: frontendRoot,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(`TypeScript declaration build failed.\n${result.stdout}${result.stderr}`);
+  }
+}
+
+async function bundle(entry, outDir, external) {
+  await build({
+    configFile: false,
+    logLevel: 'warn',
+    publicDir: false,
+    build: {
+      emptyOutDir: false,
+      lib: { entry, formats: ['es'], fileName: () => 'index.js' },
+      minify: false,
+      outDir,
+      rollupOptions: { external },
+      sourcemap: false,
+    },
+  });
+}
+
+async function declarationFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const nested = await Promise.all(entries.map(async (entry) => {
+    const candidate = path.join(directory, entry.name);
+    return entry.isDirectory() ? declarationFiles(candidate) : candidate.endsWith('.d.ts') ? [candidate] : [];
+  }));
+  return nested.flat();
+}
+
+async function rewriteLibAliases() {
+  const typesRoot = path.join(apiDist, 'types');
+  const libRoot = path.join(typesRoot, 'src', 'lib');
+  for (const file of await declarationFiles(typesRoot)) {
+    const source = await readFile(file, 'utf8');
+    const rewritten = source.replace(/(['"])\$lib(?:\/([^'"]+))?\1/g, (_match, quote, suffix = '') => {
+      const target = path.join(libRoot, suffix);
+      let relative = path.relative(path.dirname(file), target).replaceAll(path.sep, '/');
+      if (!relative.startsWith('.')) relative = `./${relative}`;
+      return `${quote}${relative}${quote}`;
+    });
+    if (rewritten !== source) await writeFile(file, rewritten);
+  }
+}
+
+async function buildApi() {
+  await rm(apiDist, { recursive: true, force: true });
+  await mkdir(apiDist, { recursive: true });
+  await bundle(path.join(packageRoot, 'src', 'index.ts'), apiDist, ['svelte']);
+  runTypeScript(path.join(packageRoot, 'tsconfig.json'));
+  await rewriteLibAliases();
+}
+
+async function buildFixture() {
+  await rm(fixtureDist, { recursive: true, force: true });
+  await mkdir(fixtureDist, { recursive: true });
+  await bundle(
+    path.join(fixtureRoot, 'src', 'index.ts'),
+    fixtureDist,
+    ['@rigplane/component-kit-api', 'svelte'],
+  );
+  const temporaryConfig = path.join(fixtureDist, 'tsconfig.build.json');
+  await writeFile(temporaryConfig, JSON.stringify({
+    extends: '../../../../tsconfig.app.json',
+    compilerOptions: {
+      allowJs: false,
+      baseUrl: '../../../..',
+      checkJs: false,
+      composite: false,
+      declaration: true,
+      declarationMap: false,
+      emitDeclarationOnly: true,
+      noEmit: false,
+      outDir: '.',
+      paths: {
+        '@rigplane/component-kit-api': [
+          'component-kit-api/dist/types/component-kit-api/src/index.d.ts',
+        ],
+      },
+      rootDir: '../src',
+      stripInternal: true,
+      tsBuildInfoFile: '../../../../node_modules/.tmp/component-kit-fixture.tsbuildinfo',
+    },
+    include: ['../src/index.ts'],
+  }, null, 2));
+  try {
+    runTypeScript(temporaryConfig);
+  } finally {
+    await unlink(temporaryConfig).catch(() => {});
+  }
+}
+
+await buildApi();
+await buildFixture();

--- a/frontend/component-kit-api/fixtures/external-kit/package.json
+++ b/frontend/component-kit-api/fixtures/external-kit/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@rigplane/external-component-kit-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "sideEffects": false,
+  "peerDependencies": {
+    "@rigplane/component-kit-api": "0.1.0",
+    "svelte": ">=5.45.2 <6"
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  }
+}

--- a/frontend/component-kit-api/fixtures/external-kit/src/index.ts
+++ b/frontend/component-kit-api/fixtures/external-kit/src/index.ts
@@ -1,0 +1,73 @@
+import {
+  COMPONENT_KIT_API_VERSION,
+  defineComponentKit,
+  type ComponentKitDeclaration,
+  type DesignLanguageManifest,
+  type FrequencyRenderer,
+  type InstrumentGroup,
+  type LayoutManifest,
+  type PresentationComponent,
+  type PresentationDeclaration,
+  type ScalarAppearance,
+} from '@rigplane/component-kit-api';
+
+const component = (() => ({})) as unknown as PresentationComponent;
+const scalarRenderer = (() => ({})) as unknown as NonNullable<ScalarAppearance['hbar']>;
+const frequencyRenderer = (() => ({})) as unknown as FrequencyRenderer;
+
+const language: DesignLanguageManifest = {
+  id: 'fixture-line',
+  displayName: 'Fixture Line',
+  tokens: {
+    typography: { fontFamily: 'sans-serif', weight: 600, fontVariantNumeric: 'tabular-nums' },
+    geometry: { radius: '0', borderWidth: '1px' },
+    meters: { trackWidth: '1px', segmentGap: '1px' },
+    frequency: { digitWeight: 600, rankedGroups: true },
+    motion: { durationMs: 0, reducedMotionSafe: true },
+    focusRing: '#00ffff',
+    rx: { idle: '#777777', active: '#00ffff', tuning: '#ffffff' },
+    tx: { idle: '#777777', active: '#ff0000', tuning: '#ffffff' },
+  },
+  density: { kind: 'clamped', supported: ['comfortable', 'compact'] },
+  layoutCompatibility: [{ layoutId: 'fixture-layout', compatible: true }],
+  renderers: {},
+};
+
+const layout: LayoutManifest = {
+  schemaVersion: 1,
+  id: 'fixture-layout',
+  displayName: 'Fixture Layout',
+  zones: [{ id: 'primary', surfaces: ['vfo', 'rxTx'] }],
+  compatibleTopologies: ['1/single'],
+  requiredSemanticSurfaces: ['vfo', 'rxTx'],
+  stageSizing: { mode: 'fluid', responsiveBreakpoints: [640] },
+  fallbackLayoutId: null,
+};
+
+const group: InstrumentGroup = {
+  schemaVersion: 1,
+  id: 'fixture-group',
+  canvas: { w: 800, h: 480 },
+  scaling: { mode: 'fixed-native', minScale: 0.5 },
+};
+
+const presentation: PresentationDeclaration = {
+  id: 'fixture-presentation',
+  loader: async () => component,
+  resources: ['hardware-scope'],
+};
+
+export const fixtureKit: ComponentKitDeclaration = defineComponentKit({
+  apiVersion: COMPONENT_KIT_API_VERSION,
+  id: 'external-fixture',
+  scalarAppearances: {
+    fixture: { name: 'fixture', hbar: scalarRenderer },
+  },
+  frequencyReadouts: { fixture: frequencyRenderer },
+  designLanguages: [language],
+  layouts: [layout],
+  instrumentGroups: [group],
+  presentations: [presentation],
+});
+
+export default fixtureKit;

--- a/frontend/component-kit-api/package.json
+++ b/frontend/component-kit-api/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@rigplane/component-kit-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "sideEffects": false,
+  "peerDependencies": {
+    "svelte": ">=5.45.2 <6"
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/types/component-kit-api/src/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  }
+}

--- a/frontend/component-kit-api/src/index.ts
+++ b/frontend/component-kit-api/src/index.ts
@@ -1,0 +1,53 @@
+import type { Component } from 'svelte';
+import type { Skin as HostScalarAppearance } from '../../src/components-v2/controls/value-control/skin';
+import type { FrequencyInteraction as HostFrequencyInteraction } from '../../src/primitives/frequency/frequency-interaction.svelte';
+import type { FrequencyReadoutModel as HostFrequencyReadoutModel } from '../../src/primitives/frequency/frequency-readout';
+import type { InstrumentGroup as HostInstrumentGroup } from '../../src/presentation/groups/contract';
+import type { DesignLanguageManifest as HostDesignLanguageManifest } from '../../src/presentation/languages/contract';
+import type { LayoutManifest as HostLayoutManifest } from '../../src/presentation/layouts/contract';
+import type { loadSkin, presentationResourcePlan } from '../../src/skins/registry';
+
+export const COMPONENT_KIT_API_VERSION = 1 as const;
+
+export type ComponentKitApiVersion = typeof COMPONENT_KIT_API_VERSION;
+export type ScalarAppearance = HostScalarAppearance;
+export type FrequencyInteraction = HostFrequencyInteraction;
+export type FrequencyReadoutModel = HostFrequencyReadoutModel;
+export type DesignLanguageManifest = HostDesignLanguageManifest;
+export type LayoutManifest = Omit<HostLayoutManifest, 'loader'>;
+export type InstrumentGroup = HostInstrumentGroup;
+export type PresentationComponent = Awaited<ReturnType<typeof loadSkin>>;
+export type PresentationResources = ReturnType<typeof presentationResourcePlan>;
+
+export interface FrequencyRendererProps {
+  readonly model: Readonly<FrequencyReadoutModel>;
+  readonly interaction: FrequencyInteraction;
+  readonly presentation: 'interactive' | 'passive';
+  readonly compact: boolean;
+  readonly active: boolean;
+  readonly receiver: 'main' | 'sub';
+  readonly vfoFreqHook: boolean;
+}
+
+export type FrequencyRenderer = Component<FrequencyRendererProps>;
+
+export interface PresentationDeclaration {
+  readonly id: string;
+  readonly loader: () => ReturnType<typeof loadSkin>;
+  readonly resources: PresentationResources;
+}
+
+export interface ComponentKitDeclaration {
+  readonly apiVersion: ComponentKitApiVersion;
+  readonly id: string;
+  readonly scalarAppearances?: Readonly<Record<string, ScalarAppearance>>;
+  readonly frequencyReadouts?: Readonly<Record<string, FrequencyRenderer>>;
+  readonly designLanguages?: readonly DesignLanguageManifest[];
+  readonly layouts?: readonly LayoutManifest[];
+  readonly instrumentGroups?: readonly InstrumentGroup[];
+  readonly presentations?: readonly PresentationDeclaration[];
+}
+
+export function defineComponentKit<const T extends ComponentKitDeclaration>(kit: T): T {
+  return kit;
+}

--- a/frontend/component-kit-api/tsconfig.json
+++ b/frontend/component-kit-api/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../tsconfig.app.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "checkJs": false,
+    "composite": false,
+    "declaration": true,
+    "declarationMap": false,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "outDir": "./dist/types",
+    "removeComments": true,
+    "rootDir": "..",
+    "stripInternal": true,
+    "tsBuildInfoFile": "../node_modules/.tmp/component-kit-api.tsbuildinfo"
+  },
+  "include": [
+    "src/index.ts"
+  ]
+}

--- a/frontend/component-kit-api/verify-package.mjs
+++ b/frontend/component-kit-api/verify-package.mjs
@@ -1,0 +1,261 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtemp, mkdir, readFile, readdir, realpath, rm, writeFile,
+} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+
+const packageRoot = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.dirname(packageRoot);
+const fixtureRoot = path.join(packageRoot, 'fixtures', 'external-kit');
+
+function execute(command, args, cwd, allowFailure = false) {
+  const result = spawnSync(command, args, { cwd, encoding: 'utf8' });
+  if (!allowFailure && result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed.\n${result.stdout}${result.stderr}`);
+  }
+  return result;
+}
+
+async function filesUnder(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const nested = await Promise.all(entries.map(async (entry) => {
+    const candidate = path.join(directory, entry.name);
+    return entry.isDirectory() ? filesUnder(candidate) : [candidate];
+  }));
+  return nested.flat();
+}
+
+function packageFiles(pack) {
+  return pack.files.map(({ path: file }) => file).sort();
+}
+
+async function assertPackedShape(pack, directory, requiredTypes) {
+  const files = packageFiles(pack);
+  const builtFiles = (await filesUnder(path.join(directory, 'dist')))
+    .map((file) => path.relative(directory, file).replaceAll(path.sep, '/'))
+    .sort();
+  assert(files.includes('package.json'));
+  assert(files.includes('dist/index.js'));
+  for (const declaration of requiredTypes) assert(files.includes(declaration));
+  assert(files.every((file) => file === 'package.json' || file.startsWith('dist/')));
+  assert.deepEqual(files.filter((file) => file !== 'package.json'), builtFiles);
+  assert.deepEqual(files.filter((file) => file.endsWith('.js')), ['dist/index.js']);
+  assert(!files.some((file) => file.includes('/src/') && !file.startsWith('dist/types/')));
+}
+
+function moduleSpecifiers(source, file) {
+  const parsed = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const specifiers = [];
+  const visit = (node) => {
+    if ((ts.isImportDeclaration(node) || ts.isExportDeclaration(node))
+      && node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)) {
+      specifiers.push(node.moduleSpecifier.text);
+    } else if (ts.isImportTypeNode(node)
+      && ts.isLiteralTypeNode(node.argument) && ts.isStringLiteral(node.argument.literal)) {
+      specifiers.push(node.argument.literal.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(parsed);
+  return specifiers;
+}
+
+async function assertClosedDeclarations(root, allowedBare) {
+  const declarations = (await filesUnder(root)).filter((file) => file.endsWith('.d.ts'));
+  assert(declarations.length > 0);
+  for (const file of declarations) {
+    const source = await readFile(file, 'utf8');
+    assert(!source.includes('$lib'));
+    assert(!source.includes(frontendRoot));
+    for (const specifier of moduleSpecifiers(source, file)) {
+      assert(!path.isAbsolute(specifier));
+      assert(!specifier.startsWith('src/'));
+      if (!specifier.startsWith('.')) {
+        assert(allowedBare.has(specifier), `Unexpected bare declaration import ${specifier} in ${file}`);
+        continue;
+      }
+      const target = path.resolve(path.dirname(file), specifier);
+      assert(target.startsWith(root + path.sep));
+      const candidates = [target, `${target}.d.ts`, path.join(target, 'index.d.ts')];
+      const resolved = await Promise.all(candidates.map(async (candidate) => {
+        try {
+          return (await realpath(candidate)) === candidate;
+        } catch {
+          return false;
+        }
+      }));
+      assert(resolved.some(Boolean), `Unresolved declaration import ${specifier} in ${file}`);
+    }
+  }
+  return declarations;
+}
+
+function pack(directory, destination) {
+  const result = execute('npm', [
+    'pack', '--json', '--ignore-scripts', '--pack-destination', destination,
+  ], directory);
+  const [metadata] = JSON.parse(result.stdout);
+  assert(metadata);
+  return { ...metadata, tarball: path.join(destination, metadata.filename) };
+}
+
+async function installedSveltePackages(nodeModules) {
+  const found = [];
+  async function visit(directory) {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const candidate = path.join(directory, entry.name);
+      if (entry.name === 'svelte') {
+        found.push(await realpath(candidate));
+      } else if (entry.name.startsWith('@') || entry.name === 'node_modules') {
+        await visit(candidate);
+      } else {
+        const nested = path.join(candidate, 'node_modules');
+        try {
+          await visit(nested);
+        } catch {
+          // Most packages do not own a nested node_modules directory.
+        }
+      }
+    }
+  }
+  await visit(nodeModules);
+  return [...new Set(found)];
+}
+
+execute(process.execPath, [path.join(packageRoot, 'build.mjs')], frontendRoot);
+
+const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), 'rigplane-component-kit-'));
+try {
+  const tarballs = path.join(temporaryRoot, 'tarballs');
+  const consumer = path.join(temporaryRoot, 'consumer');
+  await mkdir(tarballs);
+  await mkdir(path.join(consumer, 'src'), { recursive: true });
+
+  const apiPack = pack(packageRoot, tarballs);
+  const fixturePack = pack(fixtureRoot, tarballs);
+  await assertPackedShape(apiPack, packageRoot, ['dist/types/component-kit-api/src/index.d.ts']);
+  await assertPackedShape(fixturePack, fixtureRoot, ['dist/index.d.ts']);
+
+  const apiDeclarations = await assertClosedDeclarations(
+    path.join(packageRoot, 'dist'),
+    new Set(['svelte']),
+  );
+  const fixtureDeclarations = await assertClosedDeclarations(
+    path.join(fixtureRoot, 'dist'),
+    new Set(['@rigplane/component-kit-api', 'svelte']),
+  );
+  const apiRuntime = await readFile(path.join(packageRoot, 'dist', 'index.js'), 'utf8');
+  assert(!apiRuntime.includes('svelte'));
+  assert(!apiRuntime.includes('continuous-scalar'));
+  assert(!apiRuntime.includes('frequency-interaction'));
+
+  await writeFile(path.join(consumer, 'package.json'), JSON.stringify({
+    name: 'component-kit-portable-consumer',
+    private: true,
+    type: 'module',
+    dependencies: {
+      '@rigplane/component-kit-api': `file:${apiPack.tarball}`,
+      '@rigplane/external-component-kit-fixture': `file:${fixturePack.tarball}`,
+      svelte: '5.55.8',
+    },
+    devDependencies: {
+      typescript: '5.9.3',
+      vite: '7.3.3',
+    },
+  }, null, 2));
+  await writeFile(path.join(consumer, 'tsconfig.json'), JSON.stringify({
+    compilerOptions: {
+      lib: ['ES2022', 'DOM'],
+      module: 'ESNext',
+      moduleResolution: 'Bundler',
+      noEmit: true,
+      strict: true,
+      target: 'ES2022',
+      types: ['svelte'],
+    },
+    include: ['src/**/*.ts'],
+  }, null, 2));
+  await writeFile(path.join(consumer, 'vite.config.js'), `export default {
+  publicDir: false,
+  build: {
+    lib: { entry: 'src/index.ts', formats: ['es'], fileName: () => 'consumer.js' },
+  },
+};
+`);
+  await writeFile(path.join(consumer, 'src', 'index.ts'), `import {
+  COMPONENT_KIT_API_VERSION,
+  defineComponentKit,
+  type ComponentKitDeclaration,
+  type FrequencyRendererProps,
+  type LayoutManifest,
+  type PresentationDeclaration,
+  type ScalarAppearance,
+} from '@rigplane/component-kit-api';
+import fixtureKit from '@rigplane/external-component-kit-fixture';
+
+const declaration: ComponentKitDeclaration = fixtureKit;
+const scalar: ScalarAppearance | undefined = declaration.scalarAppearances?.fixture;
+const layout: LayoutManifest | undefined = declaration.layouts?.[0];
+const presentation: PresentationDeclaration | undefined = declaration.presentations?.[0];
+type FrequencyProps = FrequencyRendererProps;
+void (null as FrequencyProps | null);
+void scalar;
+void layout;
+void presentation;
+export const installedKit = defineComponentKit(declaration);
+export const apiVersion = COMPONENT_KIT_API_VERSION;
+`);
+
+  execute('npm', [
+    'install', '--ignore-scripts', '--no-audit', '--no-fund', '--package-lock=false',
+  ], consumer);
+  execute(process.execPath, [
+    path.join(consumer, 'node_modules', 'typescript', 'bin', 'tsc'), '-p', 'tsconfig.json',
+  ], consumer);
+  execute(process.execPath, [
+    path.join(consumer, 'node_modules', 'vite', 'bin', 'vite.js'), 'build', '--config', 'vite.config.js',
+  ], consumer);
+
+  await writeFile(path.join(consumer, 'inspect.mjs'), `import assert from 'node:assert/strict';
+import * as api from '@rigplane/component-kit-api';
+import fixtureKit from '@rigplane/external-component-kit-fixture';
+assert.deepEqual(Object.keys(api).sort(), ['COMPONENT_KIT_API_VERSION', 'defineComponentKit']);
+assert.equal(api.COMPONENT_KIT_API_VERSION, 1);
+assert.equal(api.defineComponentKit(fixtureKit), fixtureKit);
+`);
+  execute(process.execPath, ['inspect.mjs'], consumer);
+  const deepImport = execute(process.execPath, [
+    '--input-type=module', '--eval', "await import('@rigplane/component-kit-api/src/index.ts')",
+  ], consumer, true);
+  assert.notEqual(deepImport.status, 0);
+  assert.match(deepImport.stderr, /ERR_PACKAGE_PATH_NOT_EXPORTED/);
+
+  const sveltePackages = await installedSveltePackages(path.join(consumer, 'node_modules'));
+  assert.equal(sveltePackages.length, 1);
+  const installedApi = JSON.parse(await readFile(
+    path.join(consumer, 'node_modules', '@rigplane', 'component-kit-api', 'package.json'),
+    'utf8',
+  ));
+  const installedSvelte = JSON.parse(await readFile(
+    path.join(consumer, 'node_modules', 'svelte', 'package.json'),
+    'utf8',
+  ));
+  assert.equal(installedApi.version, '0.1.0');
+  assert.equal(installedApi.peerDependencies.svelte, '>=5.45.2 <6');
+
+  console.log('component-kit-api portable package verification: OK');
+  console.log(`runtime exports: COMPONENT_KIT_API_VERSION, defineComponentKit`);
+  console.log(`consumer peer: svelte@${installedSvelte.version} (${sveltePackages.length} physical install)`);
+  console.log(`API declarations: ${apiDeclarations.length}`);
+  console.log(`fixture declarations: ${fixtureDeclarations.length}`);
+  console.log(`API tarball files (${apiPack.files.length}): ${packageFiles(apiPack).join(', ')}`);
+  console.log(`fixture tarball files (${fixturePack.files.length}): ${packageFiles(fixturePack).join(', ')}`);
+} finally {
+  await rm(temporaryRoot, { recursive: true, force: true });
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:component-kit-api": "node component-kit-api/build.mjs",
+    "verify:component-kit-api": "node component-kit-api/verify-package.mjs",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json && tsc -p tsconfig.harness.json",
     "lint": "eslint src/",


### PR DESCRIPTION
Scope rationale: these 8 package-only files are one inseparable pack/build/fixture/verification contract; splitting them would leave no independently installable or verifiable boundary.

## Summary

- add private installable `@rigplane/component-kit-api@0.1.0` with component-kit API version `1`
- expose scalar appearances and frequency readouts through types derived from the existing Core owners
- expose design-language, loader-free layout, instrument-group, and presentation declaration types without exporting registry or runtime authority
- keep the only runtime exports to `COMPONENT_KIT_API_VERSION` and inert identity helper `defineComponentKit`
- require a shared Svelte peer `>=5.45.2 <6`; no Svelte or Core command/state/lifecycle owner is bundled
- add an external fixture package and a portable tarball verifier using the already locked Vite and TypeScript versions

Linear owner: [MOR-2425](https://linear.app/morozsm/issue/MOR-2425)

## Portable boundary

- `scalarAppearances` is `Record<string, Skin>` through the current ValueControl skin owner
- `frequencyReadouts` is `Record<string, Component<FrequencyRendererProps>>` with the frozen v3 model/interaction fields
- `LayoutManifest` is derived as `Omit<HostLayoutManifest, 'loader'>`, so the obsolete loader is not public
- presentation component/resources derive from `loadSkin` and `presentationResourcePlan`
- generated declarations form a package-local relative closure; no `$lib`, absolute workspace path, or unresolved declaration import remains
- package exports only the root; source deep imports are rejected
- package installation does not run scripts or rewrite host sources

## Scope and limits

- 8 files, 561 additions, 0 deletions
- no dependency or lockfile change
- no production registry, activation, selection, App, transport, store, service, hardware, baseline, or public publication change
- the fixture proves the package boundary for scalar and frequency families; it does not claim two real host compositions or complete bolt-on activation
- button, choice, meter, runtime hot-install, and public registry contracts remain out of scope

## Verification

Baseline:
- accepted base `b853315ca257d52ed60793ba4b4470e6db142409`
- natural main quick [34051178788](https://github.com/rigplane/rigplane-core/actions/runs/34051178788): 436 files and 10,634 tests passed

RED:
- `npm run verify:component-kit-api` failed before implementation because the package verifier did not exist

GREEN:
- `npm run verify:component-kit-api`
  - built and packed API plus external fixture
  - installed both tarballs into a fresh consumer with lifecycle scripts disabled
  - typechecked and built using root-only public imports
  - rejected a package source deep import
  - verified exactly one physical `svelte@5.55.8` install satisfying the peer range
  - verified runtime exports contain only the version constant and identity helper
  - verified 24 API declaration files plus one fixture declaration close inside the packed artifacts
- `npm run check`: 0 errors and 0 warnings
- ESLint over both package `.mjs` files: passed
- package TypeScript sources: checked by declaration build and fresh-consumer typecheck
- `git diff --cached --check`: passed

No local full suite, CI rerun, hardware validation, service access, or deployment was performed.

## Independent review and coordinator verification

[Agent Review PASS fd811b145c6b54e385d2b3b9ff53792d6f2c1ce3](https://github.com/rigplane/rigplane-core/pull/3283#issuecomment-5561374289). No blocking or required-before-merge findings. Coordinator read the complete diff, retained-artifact declarations, implementation/review reports, directive and current required check statuses. Natural quick 34052395991 and visual 34052396069 succeeded at this exact head.

The portable package verifier was run by the author and inspected independently; natural quick does not yet invoke it. Continuous package-boundary enforcement is follow-up work under MOR-2425, alongside actual activation and composition integration. This merge does not complete MOR-2425.

