### PR TITLE
MOR-2425: activate configured component kits before App mount

### DIFF
--- a/.github/scripts/quick-path-filters.test.py
+++ b/.github/scripts/quick-path-filters.test.py
@@ -20,6 +20,7 @@ QUICK_YML = ROOT / ".github" / "workflows" / "quick.yml"
 DOCS_QUICK_YML = ROOT / ".github" / "workflows" / "docs-only-quick.yml"
 DOCS_PATHS_JS = ROOT / ".github" / "scripts" / "docs-only-paths.js"
 VISUAL_YML = ROOT / ".github" / "workflows" / "visual.yml"
+QUICK_WORKER = ROOT / ".github" / "scripts" / "quick-v2-worker-v1.sh"
 DOC_CITATION_YML = ROOT / ".github" / "workflows" / "doc-citation-gate.yml"
 REBRAND_YML = ROOT / ".github" / "workflows" / "rebrand-gate.yml"
 BASE_GATES_TEST = ROOT / ".github" / "scripts" / "base-controlled-gates-v1.test.js"
@@ -188,6 +189,27 @@ new AsyncFunction('github', 'context', 'core', script)(github, context, core)
         self.assertIn('      - "!frontend/**/*.md"', visual)
         self.assertIn('      - "!frontend/**/*.rst"', visual)
         self.assertNotIn('      - ".github/workflows/visual.yml"', visual)
+
+    def test_component_kit_api_proof_is_frontend_selected_and_mirrored(self) -> None:
+        quick = QUICK_YML.read_text(encoding="utf-8")
+        worker = QUICK_WORKER.read_text(encoding="utf-8")
+        command = "npm run verify:component-kit-api"
+
+        for path in (
+            "frontend/component-kit-api/src/index.ts",
+            "frontend/src/components-v2/controls/value-control/skin.ts",
+            "frontend/src/primitives/frequency/frequency-readout.ts",
+        ):
+            with self.subTest(path=path):
+                self.assertEqual(
+                    CLASSIFIER.classify([path]),
+                    {"core": False, "frontend": True, "ci": False, "docs": False},
+                )
+
+        self.assertEqual(quick.count(command), 1)
+        self.assertEqual(worker.count(command), 1)
+        self.assertLess(quick.index("npm ci"), quick.index(command))
+        self.assertLess(worker.index("npm ci"), worker.index(command))
 
     def test_docs_only_routes_match_predicate_and_are_base_controlled(self) -> None:
         quick = QUICK_YML.read_text(encoding="utf-8")

--- a/.github/scripts/quick-v2-worker-v1.sh
+++ b/.github/scripts/quick-v2-worker-v1.sh
@@ -56,6 +56,7 @@ if [[ "$frontend" == true ]]; then
   (
     cd frontend
     npm ci
+    npm run verify:component-kit-api
     npm run i18n:check
     npm run check
     npx vitest run

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -208,6 +208,7 @@ jobs:
         run: |
           cd frontend
           npm ci
+          npm run verify:component-kit-api
           npm run lint
           npm run i18n:check
           npm run check

--- a/frontend/component-kits.config.ts
+++ b/frontend/component-kits.config.ts
@@ -1,0 +1,5 @@
+import type { ComponentKitHostConfig } from './src/component-kits/activation';
+
+export default {
+  kits: [],
+} satisfies ComponentKitHostConfig;

--- a/frontend/src/__tests__/component-kit-bootstrap.isolated.test.ts
+++ b/frontend/src/__tests__/component-kit-bootstrap.isolated.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const events: string[] = [];
+const mount = vi.fn((_component: unknown, _options: { target: HTMLElement }) => ({ mounted: true }));
+
+function installMocks(options: { activationError?: Error } = {}): void {
+  vi.doMock('../lib/migrate-legacy-storage', () => {
+    events.push('migration');
+    return {};
+  });
+  vi.doMock('../../component-kits.config', () => {
+    events.push('config');
+    return {
+      default: {
+        kits: [async () => {
+          events.push('kit');
+          return { default: { apiVersion: 1, id: 'boot-kit' } };
+        }],
+      },
+    };
+  });
+  vi.doMock('../component-kits/activation', () => ({
+    activateComponentKits: async (config: { kits: readonly (() => Promise<unknown>)[] }) => {
+      await Promise.all(config.kits.map((load) => load()));
+      events.push('activation');
+      if (options.activationError) throw options.activationError;
+    },
+  }));
+  vi.doMock('../App.svelte', () => {
+    events.push('app');
+    return { default: function App() {} };
+  });
+  vi.doMock('../app.css', () => {
+    events.push('css');
+    return {};
+  });
+  vi.doMock('svelte', () => ({
+    mount: (component: unknown, options: { target: HTMLElement }) => {
+      events.push('mount');
+      return mount(component, options);
+    },
+  }));
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  events.length = 0;
+  document.body.innerHTML = '<main id="app"></main>';
+});
+
+describe('component-kit application bootstrap', () => {
+  it('migrates, loads configuration, activates kits, then evaluates and mounts App once', async () => {
+    installMocks();
+
+    const { default: started } = await import('../main');
+    await started;
+
+    expect(events[0]).toBe('migration');
+    expect(events.indexOf('config')).toBeGreaterThan(events.indexOf('migration'));
+    expect(events.indexOf('kit')).toBeGreaterThan(events.indexOf('config'));
+    expect(events.indexOf('app')).toBeGreaterThan(events.indexOf('activation'));
+    expect(events.indexOf('css')).toBeGreaterThan(events.indexOf('activation'));
+    expect(events.at(-1)).toBe('mount');
+    expect(mount).toHaveBeenCalledOnce();
+    expect(mount.mock.calls[0][1]).toEqual({ target: document.getElementById('app') });
+  });
+
+  it('renders one host-owned failure surface and never evaluates or mounts App after activation fails', async () => {
+    installMocks({ activationError: new Error('bad component kit') });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { default: started } = await import('../main');
+    await expect(started).rejects.toThrow('bad component kit');
+
+    expect(events).not.toContain('app');
+    expect(events).not.toContain('css');
+    expect(events).not.toContain('mount');
+    expect(mount).not.toHaveBeenCalled();
+    expect(document.querySelectorAll('[data-component-kit-startup-error]')).toHaveLength(1);
+    expect(document.querySelector('[role="alert"]')?.textContent).toContain('RigPlane could not start');
+    expect(consoleError).toHaveBeenCalledWith('[rigplane] startup failed:', expect.any(Error));
+  });
+});

--- a/frontend/src/component-kits/__tests__/activation.test.ts
+++ b/frontend/src/component-kits/__tests__/activation.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  ComponentKitDeclaration,
+  FrequencyRenderer,
+  ScalarAppearance,
+} from '../../../component-kit-api/src/index';
+
+const renderer = (() => ({})) as unknown as FrequencyRenderer;
+const scalarRenderer = (() => ({})) as unknown as NonNullable<ScalarAppearance['knob']>;
+
+function appearance(name: string): ScalarAppearance {
+  return { name, knob: scalarRenderer };
+}
+
+function kit(
+  id: string,
+  overrides: Partial<ComponentKitDeclaration> = {},
+): ComponentKitDeclaration {
+  return {
+    apiVersion: 1,
+    id,
+    scalarAppearances: { [`${id}-scalar`]: appearance(`${id} scalar`) },
+    frequencyReadouts: { [`${id}-frequency`]: renderer },
+    ...overrides,
+  };
+}
+
+function config(kits: readonly unknown[], selection: Record<string, unknown> = {}) {
+  return {
+    kits: kits.map((declaration) => async () => ({ default: declaration })),
+    selection,
+  };
+}
+
+async function subject() {
+  return import('../activation');
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe('component-kit activation transaction', () => {
+  it('keeps the empty configuration inert', async () => {
+    const activation = await subject();
+    await activation.activateComponentKits(config([]));
+
+    expect(activation.getSelectedScalarAppearance()).toBeUndefined();
+    expect(activation.getSelectedFrequencyReadout()).toBeUndefined();
+  });
+
+  it('loads every kit, then commits selected scalar and frequency renderers', async () => {
+    const activation = await subject();
+    const declaration = kit('field-kit');
+
+    await activation.activateComponentKits(config([declaration], {
+      scalarAppearance: 'field-kit-scalar',
+      frequencyReadout: 'field-kit-frequency',
+    }));
+
+    expect(activation.getSelectedScalarAppearance()).toEqual(appearance('field-kit scalar'));
+    expect(activation.getSelectedFrequencyReadout()).toBe(renderer);
+  });
+
+  it('copies declarations and selection before the single commit', async () => {
+    const activation = await subject();
+    const scalars: Record<string, ScalarAppearance> = { original: appearance('Original') };
+    const frequencies: Record<string, FrequencyRenderer> = { original: renderer };
+    const selection = { scalarAppearance: 'original', frequencyReadout: 'original' };
+    const declaration = kit('copy-kit', {
+      scalarAppearances: scalars,
+      frequencyReadouts: frequencies,
+    });
+    const configured = config([declaration], selection);
+
+    await activation.activateComponentKits(configured);
+    scalars.original.name = 'Mutated';
+    scalars.late = appearance('Late');
+    delete frequencies.original;
+    selection.scalarAppearance = 'late';
+    configured.kits.push?.(async () => ({ default: kit('late-kit') }));
+
+    const selected = activation.getSelectedScalarAppearance();
+    expect(selected?.name).toBe('Original');
+    expect(Object.isFrozen(selected)).toBe(true);
+    expect(activation.getSelectedFrequencyReadout()).toBe(renderer);
+  });
+
+  it.each([
+    ['wrong API version', { ...kit('bad-version'), apiVersion: 2 }],
+    ['missing kit id', { ...kit('missing-id'), id: '' }],
+    ['unknown kit property', { ...kit('unknown-key'), extra: true }],
+    ['non-record scalar declarations', { ...kit('bad-scalars'), scalarAppearances: [] }],
+    ['scalar without a name', { ...kit('bad-scalar'), scalarAppearances: { bad: { knob: scalarRenderer } } }],
+    ['scalar with a non-component member', { ...kit('bad-scalar-component'), scalarAppearances: { bad: { name: 'Bad', knob: 'nope' } } }],
+    ['non-record frequency declarations', { ...kit('bad-frequencies'), frequencyReadouts: [] }],
+    ['non-component frequency declaration', { ...kit('bad-frequency'), frequencyReadouts: { bad: 'nope' } }],
+  ])('rejects %s without committing', async (_name, declaration) => {
+    const activation = await subject();
+
+    await expect(activation.activateComponentKits(config([declaration]))).rejects.toThrow();
+    expect(activation.getSelectedScalarAppearance()).toBeUndefined();
+    expect(activation.getSelectedFrequencyReadout()).toBeUndefined();
+  });
+
+  it.each([
+    ['non-object configuration', null],
+    ['unknown configuration property', { kits: [], extra: true }],
+    ['non-array kit loaders', { kits: {} }],
+    ['non-function kit loader', { kits: [false] }],
+    ['non-object selection', { kits: [], selection: [] }],
+    ['unknown selection property', { kits: [], selection: { extra: true } }],
+    ['non-string selection', { kits: [], selection: { scalarAppearance: 4 } }],
+    ['module without a default export', { kits: [async () => ({ kit: kit('named-only') })] }],
+  ])('rejects %s', async (_name, configured) => {
+    const activation = await subject();
+
+    await expect(activation.activateComponentKits(configured)).rejects.toThrow();
+    expect(activation.getSelectedScalarAppearance()).toBeUndefined();
+  });
+
+  it.each(['designLanguages', 'layouts', 'instrumentGroups', 'presentations'] as const)(
+    'explicitly rejects the unsupported %s property, including an empty array',
+    async (property) => {
+      const activation = await subject();
+      const declaration = { ...kit(`unsupported-${property}`), [property]: [] };
+
+      await expect(activation.activateComponentKits(config([declaration])))
+        .rejects.toThrow(property);
+    },
+  );
+
+  it.each([
+    ['duplicate kit id', [kit('duplicate-kit'), kit('duplicate-kit')]],
+    ['duplicate scalar id', [kit('scalar-a', { scalarAppearances: { shared: appearance('A') } }), kit('scalar-b', { scalarAppearances: { shared: appearance('B') } })]],
+    ['duplicate frequency id', [kit('frequency-a', { frequencyReadouts: { shared: renderer } }), kit('frequency-b', { frequencyReadouts: { shared: renderer } })]],
+  ])('rejects %s across the complete loaded set', async (_name, declarations) => {
+    const activation = await subject();
+
+    await expect(activation.activateComponentKits(config(declarations))).rejects.toThrow(/duplicate/i);
+    expect(activation.getSelectedScalarAppearance()).toBeUndefined();
+  });
+
+  it('rejects a collision with the existing professional scalar owner', async () => {
+    const activation = await subject();
+    const declaration = kit('collision-kit', {
+      scalarAppearances: { professional: appearance('Replacement') },
+    });
+
+    await expect(activation.activateComponentKits(config([declaration])))
+      .rejects.toThrow(/professional.*built-in/i);
+  });
+
+  it.each([
+    ['scalarAppearance', 'missing-scalar'],
+    ['frequencyReadout', 'missing-frequency'],
+  ])('rejects an unresolved %s selection', async (property, value) => {
+    const activation = await subject();
+
+    await expect(activation.activateComponentKits(config([kit('selection-kit')], {
+      [property]: value,
+    }))).rejects.toThrow(value);
+  });
+
+  it('leaves the default snapshot intact when a later loaded kit is invalid', async () => {
+    const activation = await subject();
+    const configured = config([
+      kit('valid-kit'),
+      { ...kit('invalid-second-kit'), apiVersion: 2 },
+    ]);
+
+    await expect(activation.activateComponentKits(configured)).rejects.toThrow('invalid-second-kit');
+    expect(activation.getSelectedScalarAppearance()).toBeUndefined();
+  });
+
+  it('rejects a second successful activation for the page lifetime', async () => {
+    const activation = await subject();
+    await activation.activateComponentKits(config([]));
+
+    await expect(activation.activateComponentKits(config([])))
+      .rejects.toThrow(/already activated/i);
+  });
+});

--- a/frontend/src/component-kits/__tests__/activation.test.ts
+++ b/frontend/src/component-kits/__tests__/activation.test.ts
@@ -32,6 +32,14 @@ function config(kits: readonly unknown[], selection: Record<string, unknown> = {
   };
 }
 
+function addUnknownOwnProperty(target: object, kind: 'symbol' | 'non-enumerable'): void {
+  if (kind === 'symbol') {
+    Reflect.defineProperty(target, Symbol('extra'), { value: true, enumerable: true });
+  } else {
+    Reflect.defineProperty(target, 'extra', { value: true, enumerable: false });
+  }
+}
+
 async function subject() {
   return import('../activation');
 }
@@ -117,6 +125,111 @@ describe('component-kit activation transaction', () => {
 
     await expect(activation.activateComponentKits(configured)).rejects.toThrow();
     expect(activation.getSelectedScalarAppearance()).toBeUndefined();
+  });
+
+  it.each([
+    ['configuration', () => {
+      const configured = config([]);
+      return { configured, target: configured };
+    }],
+    ['selection', () => {
+      const selection = {};
+      return { configured: config([], selection), target: selection };
+    }],
+    ['kit declaration', () => {
+      const declaration = kit('exact-kit');
+      return { configured: config([declaration]), target: declaration };
+    }],
+    ['scalar appearance', () => {
+      const selectedAppearance = appearance('Exact');
+      return {
+        configured: config([kit('exact-scalar-kit', { scalarAppearances: { exact: selectedAppearance } })]),
+        target: selectedAppearance,
+      };
+    }],
+  ] as const)('rejects symbol and non-enumerable unknown properties on %s', async (_name, makeCase) => {
+    const activation = await subject();
+    for (const kind of ['symbol', 'non-enumerable'] as const) {
+      const { configured, target } = makeCase();
+      addUnknownOwnProperty(target, kind);
+
+      await expect(activation.activateComponentKits(configured)).rejects.toThrow(/unknown property/i);
+      expect(activation.getSelectedScalarAppearance()).toBeUndefined();
+    }
+  });
+
+  it('rejects an empty-string unknown property', async () => {
+    const activation = await subject();
+    const configured = config([]);
+    Reflect.defineProperty(configured, '', { value: true, enumerable: true });
+
+    await expect(activation.activateComponentKits(configured)).rejects.toThrow(/unknown property/i);
+  });
+
+  it.each([
+    ['configuration', () => {
+      const configured = config([]);
+      Reflect.defineProperty(configured, 'kits', { value: configured.kits, enumerable: false });
+      return configured;
+    }],
+    ['selection', () => {
+      const selection = { scalarAppearance: 'professional' };
+      Reflect.defineProperty(selection, 'scalarAppearance', { value: 'professional', enumerable: false });
+      return config([], selection);
+    }],
+    ['kit declaration', () => {
+      const declaration = kit('descriptor-kit');
+      Reflect.defineProperty(declaration, 'id', { value: 'descriptor-kit', enumerable: false });
+      return config([declaration]);
+    }],
+    ['scalar appearance', () => {
+      const selectedAppearance = appearance('Descriptor');
+      Reflect.defineProperty(selectedAppearance, 'name', { value: 'Descriptor', enumerable: false });
+      return config([kit('descriptor-scalar-kit', { scalarAppearances: { descriptor: selectedAppearance } })]);
+    }],
+  ] as const)('rejects a non-enumerable allowed property on %s', async (_name, makeConfig) => {
+    const activation = await subject();
+
+    await expect(activation.activateComponentKits(makeConfig()))
+      .rejects.toThrow(/enumerable data property/i);
+  });
+
+  it('rejects an accessor without invoking it', async () => {
+    const activation = await subject();
+    const configured: Record<string, unknown> = {};
+    const getter = vi.fn(() => []);
+    Reflect.defineProperty(configured, 'kits', { get: getter, enumerable: true });
+
+    await expect(activation.activateComponentKits(configured))
+      .rejects.toThrow(/enumerable data property/i);
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  it('allows additional exports on the loader module namespace', async () => {
+    const activation = await subject();
+
+    await activation.activateComponentKits({
+      kits: [async () => ({ default: kit('module-kit'), namedExport: true })],
+    });
+  });
+
+  it.each([
+    ['scalarAppearances', 'symbol'],
+    ['scalarAppearances', 'non-enumerable'],
+    ['frequencyReadouts', 'symbol'],
+    ['frequencyReadouts', 'non-enumerable'],
+  ] as const)('rejects a %s map with a %s entry', async (mapName, kind) => {
+    const activation = await subject();
+    const declarations: Record<PropertyKey, unknown> = {};
+    const key = kind === 'symbol' ? Symbol('hidden') : 'hidden';
+    Reflect.defineProperty(declarations, key, {
+      value: mapName === 'scalarAppearances' ? appearance('Hidden') : renderer,
+      enumerable: kind === 'symbol',
+    });
+
+    await expect(activation.activateComponentKits(config([
+      kit(`hidden-${mapName}-${kind}`, { [mapName]: declarations }),
+    ]))).rejects.toThrow(/property/i);
   });
 
   it.each(['designLanguages', 'layouts', 'instrumentGroups', 'presentations'] as const)(

--- a/frontend/src/component-kits/activation.ts
+++ b/frontend/src/component-kits/activation.ts
@@ -50,13 +50,25 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return prototype === Object.prototype || prototype === null;
 }
 
-function rejectUnknownKeys(
+function ownDataEntries(
   value: Record<string, unknown>,
-  allowed: readonly string[],
   owner: string,
-): void {
-  const unknown = Object.keys(value).find((key) => !allowed.includes(key));
-  if (unknown) throw new ComponentKitActivationError(`${owner} has unknown property "${unknown}".`);
+  allowed?: readonly string[],
+): [string, unknown][] {
+  const entries: [string, unknown][] = [];
+  for (const key of Reflect.ownKeys(value)) {
+    if (typeof key !== 'string' || (allowed !== undefined && !allowed.includes(key))) {
+      throw new ComponentKitActivationError(`${owner} has unknown property "${String(key)}".`);
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (descriptor === undefined || !descriptor.enumerable || !('value' in descriptor)) {
+      throw new ComponentKitActivationError(
+        `${owner} property "${key}" must be an enumerable data property.`,
+      );
+    }
+    entries.push([key, descriptor.value]);
+  }
+  return entries;
 }
 
 function requireId(value: unknown, owner: string): string {
@@ -70,7 +82,7 @@ function copyAppearance(value: unknown, id: string): ScalarAppearance {
   if (!isPlainRecord(value)) {
     throw new ComponentKitActivationError(`Scalar appearance "${id}" must be an object.`);
   }
-  rejectUnknownKeys(value, APPEARANCE_KEYS, `Scalar appearance "${id}"`);
+  ownDataEntries(value, `Scalar appearance "${id}"`, APPEARANCE_KEYS);
   if (typeof value.name !== 'string' || value.name.trim() === '') {
     throw new ComponentKitActivationError(`Scalar appearance "${id}" must have a non-empty name.`);
   }
@@ -87,7 +99,7 @@ function readSelection(value: unknown): ComponentKitSelection {
   if (!isPlainRecord(value)) {
     throw new ComponentKitActivationError('Component-kit selection must be an object.');
   }
-  rejectUnknownKeys(value, SELECTION_KEYS, 'Component-kit selection');
+  ownDataEntries(value, 'Component-kit selection', SELECTION_KEYS);
   for (const key of SELECTION_KEYS) {
     if (value[key] !== undefined && (typeof value[key] !== 'string' || value[key].trim() === '')) {
       throw new ComponentKitActivationError(`Component-kit selection "${key}" must be a non-empty string.`);
@@ -99,7 +111,7 @@ function readSelection(value: unknown): ComponentKitSelection {
 function prepareSnapshot(declarations: readonly unknown[], selectionValue: unknown): ActiveSnapshot {
   const scalarAppearances = new Map<string, ScalarAppearance>();
   const scalarOwners = new Map<string, string>();
-  for (const [id, appearance] of Object.entries(builtInScalarAppearances)) {
+  for (const [id, appearance] of ownDataEntries(builtInScalarAppearances, 'Built-in scalar appearances')) {
     scalarAppearances.set(id, copyAppearance(appearance, id));
     scalarOwners.set(id, 'built-in scalar appearances');
   }
@@ -111,7 +123,7 @@ function prepareSnapshot(declarations: readonly unknown[], selectionValue: unkno
     if (!isPlainRecord(value)) {
       throw new ComponentKitActivationError('A component-kit module did not export an object.');
     }
-    rejectUnknownKeys(value, KIT_KEYS, 'Component kit');
+    ownDataEntries(value, 'Component kit', KIT_KEYS);
     const id = requireId(value.id, 'Component kit');
     if (value.apiVersion !== COMPONENT_KIT_API_VERSION) {
       throw new ComponentKitActivationError(`Component kit "${id}" requires unsupported API version ${String(value.apiVersion)}.`);
@@ -129,7 +141,10 @@ function prepareSnapshot(declarations: readonly unknown[], selectionValue: unkno
       if (!isPlainRecord(value.scalarAppearances)) {
         throw new ComponentKitActivationError(`Component kit "${id}" scalarAppearances must be a record.`);
       }
-      for (const [appearanceId, appearance] of Object.entries(value.scalarAppearances)) {
+      for (const [appearanceId, appearance] of ownDataEntries(
+        value.scalarAppearances,
+        `Component kit "${id}" scalarAppearances`,
+      )) {
         requireId(appearanceId, `Component kit "${id}" scalar appearance`);
         const owner = scalarOwners.get(appearanceId);
         if (owner) {
@@ -144,7 +159,10 @@ function prepareSnapshot(declarations: readonly unknown[], selectionValue: unkno
       if (!isPlainRecord(value.frequencyReadouts)) {
         throw new ComponentKitActivationError(`Component kit "${id}" frequencyReadouts must be a record.`);
       }
-      for (const [readoutId, readout] of Object.entries(value.frequencyReadouts)) {
+      for (const [readoutId, readout] of ownDataEntries(
+        value.frequencyReadouts,
+        `Component kit "${id}" frequencyReadouts`,
+      )) {
         requireId(readoutId, `Component kit "${id}" frequency readout`);
         if (frequencyOwners.has(readoutId)) {
           throw new ComponentKitActivationError(`Duplicate frequency readout "${readoutId}" conflicts with ${frequencyOwners.get(readoutId)}.`);
@@ -180,7 +198,7 @@ export async function activateComponentKits(configValue: unknown): Promise<void>
     if (!isPlainRecord(configValue)) {
       throw new ComponentKitActivationError('Component-kit configuration must be an object.');
     }
-    rejectUnknownKeys(configValue, CONFIG_KEYS, 'Component-kit configuration');
+    ownDataEntries(configValue, 'Component-kit configuration', CONFIG_KEYS);
     if (!Array.isArray(configValue.kits) || configValue.kits.some((load) => typeof load !== 'function')) {
       throw new ComponentKitActivationError('Component-kit configuration kits must be an array of loaders.');
     }

--- a/frontend/src/component-kits/activation.ts
+++ b/frontend/src/component-kits/activation.ts
@@ -1,0 +1,213 @@
+import {
+  COMPONENT_KIT_API_VERSION,
+  type FrequencyRenderer,
+  type ScalarAppearance,
+} from '../../component-kit-api/src/index';
+import { skins as builtInScalarAppearances } from '../components-v2/controls/value-control/skins';
+
+export interface ComponentKitSelection {
+  readonly scalarAppearance?: string;
+  readonly frequencyReadout?: string;
+}
+
+export interface ComponentKitHostConfig {
+  readonly kits: readonly (() => Promise<{ default: unknown }>)[];
+  readonly selection?: ComponentKitSelection;
+}
+
+interface ActiveSnapshot {
+  readonly scalarAppearances: ReadonlyMap<string, ScalarAppearance>;
+  readonly frequencyReadouts: ReadonlyMap<string, FrequencyRenderer>;
+  readonly selectedScalarAppearance?: string;
+  readonly selectedFrequencyReadout?: string;
+}
+
+const EMPTY_SNAPSHOT: ActiveSnapshot = Object.freeze({
+  scalarAppearances: new Map(),
+  frequencyReadouts: new Map(),
+});
+const CONFIG_KEYS = ['kits', 'selection'] as const;
+const SELECTION_KEYS = ['scalarAppearance', 'frequencyReadout'] as const;
+const KIT_KEYS = [
+  'apiVersion', 'id', 'scalarAppearances', 'frequencyReadouts',
+  'designLanguages', 'layouts', 'instrumentGroups', 'presentations',
+] as const;
+const APPEARANCE_KEYS = ['name', 'knob', 'hbar', 'bipolar', 'discrete'] as const;
+const UNSUPPORTED_SECTIONS = [
+  'designLanguages', 'layouts', 'instrumentGroups', 'presentations',
+] as const;
+const hasOwn = (value: object, key: PropertyKey): boolean =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+let snapshot = EMPTY_SNAPSHOT;
+let phase: 'idle' | 'activating' | 'active' = 'idle';
+
+export class ComponentKitActivationError extends Error {}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function rejectUnknownKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  owner: string,
+): void {
+  const unknown = Object.keys(value).find((key) => !allowed.includes(key));
+  if (unknown) throw new ComponentKitActivationError(`${owner} has unknown property "${unknown}".`);
+}
+
+function requireId(value: unknown, owner: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new ComponentKitActivationError(`${owner} must have a non-empty id.`);
+  }
+  return value;
+}
+
+function copyAppearance(value: unknown, id: string): ScalarAppearance {
+  if (!isPlainRecord(value)) {
+    throw new ComponentKitActivationError(`Scalar appearance "${id}" must be an object.`);
+  }
+  rejectUnknownKeys(value, APPEARANCE_KEYS, `Scalar appearance "${id}"`);
+  if (typeof value.name !== 'string' || value.name.trim() === '') {
+    throw new ComponentKitActivationError(`Scalar appearance "${id}" must have a non-empty name.`);
+  }
+  for (const slot of APPEARANCE_KEYS.slice(1)) {
+    if (value[slot] !== undefined && typeof value[slot] !== 'function') {
+      throw new ComponentKitActivationError(`Scalar appearance "${id}" member "${slot}" must be a component.`);
+    }
+  }
+  return Object.freeze({ ...value }) as unknown as ScalarAppearance;
+}
+
+function readSelection(value: unknown): ComponentKitSelection {
+  if (value === undefined) return {};
+  if (!isPlainRecord(value)) {
+    throw new ComponentKitActivationError('Component-kit selection must be an object.');
+  }
+  rejectUnknownKeys(value, SELECTION_KEYS, 'Component-kit selection');
+  for (const key of SELECTION_KEYS) {
+    if (value[key] !== undefined && (typeof value[key] !== 'string' || value[key].trim() === '')) {
+      throw new ComponentKitActivationError(`Component-kit selection "${key}" must be a non-empty string.`);
+    }
+  }
+  return { ...value } as ComponentKitSelection;
+}
+
+function prepareSnapshot(declarations: readonly unknown[], selectionValue: unknown): ActiveSnapshot {
+  const scalarAppearances = new Map<string, ScalarAppearance>();
+  const scalarOwners = new Map<string, string>();
+  for (const [id, appearance] of Object.entries(builtInScalarAppearances)) {
+    scalarAppearances.set(id, copyAppearance(appearance, id));
+    scalarOwners.set(id, 'built-in scalar appearances');
+  }
+  const frequencyReadouts = new Map<string, FrequencyRenderer>();
+  const frequencyOwners = new Map<string, string>();
+  const kitIds = new Set<string>();
+
+  for (const value of declarations) {
+    if (!isPlainRecord(value)) {
+      throw new ComponentKitActivationError('A component-kit module did not export an object.');
+    }
+    rejectUnknownKeys(value, KIT_KEYS, 'Component kit');
+    const id = requireId(value.id, 'Component kit');
+    if (value.apiVersion !== COMPONENT_KIT_API_VERSION) {
+      throw new ComponentKitActivationError(`Component kit "${id}" requires unsupported API version ${String(value.apiVersion)}.`);
+    }
+    if (kitIds.has(id)) throw new ComponentKitActivationError(`Duplicate component-kit id "${id}".`);
+    kitIds.add(id);
+
+    for (const section of UNSUPPORTED_SECTIONS) {
+      if (hasOwn(value, section)) {
+        throw new ComponentKitActivationError(`Component kit "${id}" declares unsupported property "${section}".`);
+      }
+    }
+
+    if (value.scalarAppearances !== undefined) {
+      if (!isPlainRecord(value.scalarAppearances)) {
+        throw new ComponentKitActivationError(`Component kit "${id}" scalarAppearances must be a record.`);
+      }
+      for (const [appearanceId, appearance] of Object.entries(value.scalarAppearances)) {
+        requireId(appearanceId, `Component kit "${id}" scalar appearance`);
+        const owner = scalarOwners.get(appearanceId);
+        if (owner) {
+          throw new ComponentKitActivationError(`Duplicate scalar appearance "${appearanceId}" conflicts with ${owner}.`);
+        }
+        scalarAppearances.set(appearanceId, copyAppearance(appearance, appearanceId));
+        scalarOwners.set(appearanceId, `component kit "${id}"`);
+      }
+    }
+
+    if (value.frequencyReadouts !== undefined) {
+      if (!isPlainRecord(value.frequencyReadouts)) {
+        throw new ComponentKitActivationError(`Component kit "${id}" frequencyReadouts must be a record.`);
+      }
+      for (const [readoutId, readout] of Object.entries(value.frequencyReadouts)) {
+        requireId(readoutId, `Component kit "${id}" frequency readout`);
+        if (frequencyOwners.has(readoutId)) {
+          throw new ComponentKitActivationError(`Duplicate frequency readout "${readoutId}" conflicts with ${frequencyOwners.get(readoutId)}.`);
+        }
+        if (typeof readout !== 'function') {
+          throw new ComponentKitActivationError(`Frequency readout "${readoutId}" must be a component.`);
+        }
+        frequencyReadouts.set(readoutId, readout as FrequencyRenderer);
+        frequencyOwners.set(readoutId, `component kit "${id}"`);
+      }
+    }
+  }
+
+  const selection = readSelection(selectionValue);
+  if (selection.scalarAppearance !== undefined && !scalarAppearances.has(selection.scalarAppearance)) {
+    throw new ComponentKitActivationError(`Selected scalar appearance "${selection.scalarAppearance}" is not registered.`);
+  }
+  if (selection.frequencyReadout !== undefined && !frequencyReadouts.has(selection.frequencyReadout)) {
+    throw new ComponentKitActivationError(`Selected frequency readout "${selection.frequencyReadout}" is not registered.`);
+  }
+  return Object.freeze({
+    scalarAppearances,
+    frequencyReadouts,
+    selectedScalarAppearance: selection.scalarAppearance,
+    selectedFrequencyReadout: selection.frequencyReadout,
+  });
+}
+
+export async function activateComponentKits(configValue: unknown): Promise<void> {
+  if (phase !== 'idle') throw new ComponentKitActivationError('Component kits are already activated.');
+  phase = 'activating';
+  try {
+    if (!isPlainRecord(configValue)) {
+      throw new ComponentKitActivationError('Component-kit configuration must be an object.');
+    }
+    rejectUnknownKeys(configValue, CONFIG_KEYS, 'Component-kit configuration');
+    if (!Array.isArray(configValue.kits) || configValue.kits.some((load) => typeof load !== 'function')) {
+      throw new ComponentKitActivationError('Component-kit configuration kits must be an array of loaders.');
+    }
+    const modules = await Promise.all(configValue.kits.map((load) => load()));
+    const declarations = modules.map((module, index) => {
+      if (!isPlainRecord(module) || !hasOwn(module, 'default')) {
+        throw new ComponentKitActivationError(`Component-kit loader ${index} must return a module with a default export.`);
+      }
+      return module.default;
+    });
+    const prepared = prepareSnapshot(declarations, configValue.selection);
+    snapshot = prepared;
+    phase = 'active';
+  } catch (error) {
+    phase = 'idle';
+    throw error;
+  }
+}
+
+export function getSelectedScalarAppearance(): ScalarAppearance | undefined {
+  return snapshot.selectedScalarAppearance === undefined
+    ? undefined
+    : snapshot.scalarAppearances.get(snapshot.selectedScalarAppearance);
+}
+
+export function getSelectedFrequencyReadout(): FrequencyRenderer | undefined {
+  return snapshot.selectedFrequencyReadout === undefined
+    ? undefined
+    : snapshot.frequencyReadouts.get(snapshot.selectedFrequencyReadout);
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -10,12 +10,36 @@
 // is evaluated.
 import './lib/migrate-legacy-storage'
 
-import { mount } from 'svelte'
-import './app.css'
-import App from './App.svelte'
+async function startApp() {
+  try {
+    const [{ default: config }, { activateComponentKits }] = await Promise.all([
+      import('../component-kits.config'),
+      import('./component-kits/activation'),
+    ])
+    await activateComponentKits(config)
 
-const app = mount(App, {
-  target: document.getElementById('app')!,
-})
+    const [{ mount }, , { default: App }] = await Promise.all([
+      import('svelte'),
+      import('./app.css'),
+      import('./App.svelte'),
+    ])
+    const target = document.getElementById('app')
+    if (!target) throw new Error('Application root #app was not found.')
+    return mount(App, { target })
+  } catch (error) {
+    console.error('[rigplane] startup failed:', error)
+    const target = document.getElementById('app')
+    if (target) {
+      const alert = document.createElement('p')
+      alert.dataset.componentKitStartupError = ''
+      alert.setAttribute('role', 'alert')
+      alert.textContent = 'RigPlane could not start. Check the console for component kit configuration details.'
+      target.replaceChildren(alert)
+    }
+    throw error
+  }
+}
+
+const app = startApp()
 
 export default app


### PR DESCRIPTION
8 code + 0 regenerated baselines = 8 files

## Linear owner

[MOR-2425](https://linear.app/morozsm/issue/MOR-2425/expose-a-supported-v3-host-boundary-for-independently-installed)

## Summary

- Add a build-time component-kit configuration and one host-private, immutable activation snapshot.
- Validate and load all configured kits before one assignment-only commit, then evaluate and mount App.
- Support exactly `scalarAppearances` and `frequencyReadouts` in this slice; explicitly reject every other API1 declaration property, including empty arrays.
- Run the existing portable package verifier in both frontend-selected quick execution paths.

## Boundary

`defineComponentKit` remains inert. Activation is once per page lifetime and exposes only selected scalar/frequency lookup functions; there is no public map, reset, store, persistence, unregister lifecycle, renderer wiring, presentation loader, resource owner, or runtime hot-install path.

The first static migration import remains first. The promise-based bootstrap dynamically loads configuration and activation, completes activation, then dynamically imports App/CSS/Svelte and mounts once. It uses no top-level await. Activation failure logs the error, renders one host-owned alert, and never evaluates or mounts App.

## Atomicity

Configuration, selection, kit, appearance, and declaration-map records must contain only enumerable own string data properties. Symbol, non-enumerable, accessor, unknown, and empty-string keys are rejected without invoking getters. The loader module namespace remains outside this DTO restriction and may carry additional exports.

Configuration, kit modules, versions, actual built-in collisions, cross-kit duplicates, selected IDs, and unsupported sections are checked before commit. Invalid kit N and loader failures leave the default snapshot unchanged. Appearance declarations and selections are copied before commit so later input mutation cannot alter active resolution.

## Verification

- Initial RED: 25 activation/bootstrap tests failed before the activation module/bootstrap existed; CI contract test failed before the verifier hook existed.
- Review correction RED: 14 descriptor/exact-shape tests failed and 31 existing tests passed before the validator correction.
- GREEN: focused Vitest: 2 files, 48 tests passed.
- `npm run check`: 0 errors, 0 warnings.
- Targeted ESLint: passed.
- `npm run build`: passed (4,263 modules transformed).
- `npm run verify:component-kit-api`: passed; isolated package consumer used one physical Svelte install.
- `.github/scripts/quick-path-filters.test.py`: 9 tests passed; nested Node contract suite 11 tests passed.
- `bash -n .github/scripts/quick-v2-worker-v1.sh`: passed.
- `git diff --check`: passed.

## Size rationale

This exceeds the six-file soft threshold because the activation contract, its transaction tests, the sole browser bootstrap, and the existing quick/worker pair must land together: separating them would leave either an unused boundary or owner-derived SDK types without continuous package verification. It remains 676 A+D, below the 1,000-line hard ceiling.

## Compatibility

Default configuration is empty, so the existing host selects no external renderer and preserves current rendering. This slice does not change App, layouts, ValueControl, frequency renderers, hardware, services, protocol, CLI, or resources. P2b live renderer adoption remains separately leased.