### PR TITLE
MOR-2425: select external scalar appearances

### DIFF
--- a/frontend/src/components-v2/controls/value-control/ValueControl.svelte
+++ b/frontend/src/components-v2/controls/value-control/ValueControl.svelte
@@ -4,6 +4,7 @@
   import BipolarRenderer from './BipolarRenderer.svelte';
   import KnobRenderer from './KnobRenderer.svelte';
   import DiscreteRenderer from './DiscreteRenderer.svelte';
+  import { getSelectedScalarAppearance } from '../../../component-kits/activation';
   import type { LegacyReadingPresentation } from './scalar-render-presentation';
   import type {
     HBarIssuedStatusPresentation,
@@ -127,6 +128,8 @@
   }: Props = $props();
 
   let effectiveOnChange = $derived(onChange ?? onchange ?? (() => {}));
+  const configuredAppearance = getSelectedScalarAppearance();
+  let effectiveAppearance = $derived(skin ?? configuredAppearance);
   const mountId = $props.id();
   let hbarPolicy = $derived(createHBarContinuousScalarPolicy({
     preview: optimistic ? 'optimistic' : 'confirmed',
@@ -246,11 +249,11 @@
     dimmed: externalBinding === undefined ? disabled : undefined,
   });
   let skinComponent = $derived(
-    skin
-      ? renderer === 'knob' ? skin.knob
-      : renderer === 'hbar' ? skin.hbar
-        : renderer === 'bipolar' ? skin.bipolar
-          : skin.discrete
+    effectiveAppearance
+      ? renderer === 'knob' ? effectiveAppearance.knob
+      : renderer === 'hbar' ? effectiveAppearance.hbar
+        : renderer === 'bipolar' ? effectiveAppearance.bipolar
+          : effectiveAppearance.discrete
       : undefined,
   );
 </script>

--- a/frontend/src/components-v2/controls/value-control/__tests__/ExternalScalarRendererFixture.svelte
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ExternalScalarRendererFixture.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import { onDestroy, untrack } from 'svelte';
+  import type { ContinuousScalarRendererLease } from '../../../../primitives/scalar/continuous-scalar.svelte';
+  import type {
+    DiscreteSkinRendererProps,
+    HBarSkinRendererProps,
+    KnobSkinRendererProps,
+  } from '../skin';
+
+  type FixtureProps = HBarSkinRendererProps & KnobSkinRendererProps & DiscreteSkinRendererProps;
+
+  let {
+    binding,
+    label,
+    displayFn,
+    unknownDisplay,
+    accentColor,
+    fillColor,
+    fillGradient,
+    trackColor,
+    showValue,
+    showLabel,
+    compact,
+    variant,
+    unit,
+    shortcutHint,
+    title,
+    legacy,
+    valueProjection,
+    issuedStatusPresentation,
+    arcAngle,
+    tickCount,
+    tickLabels,
+    showAllTicks,
+    tickStyle,
+    dimmed,
+  }: FixtureProps = $props();
+
+  let attachedBinding = untrack(() => binding);
+  let lease: ContinuousScalarRendererLease = $state(attachedBinding.attachRenderer());
+  let view = $derived(lease.view);
+  let renderer = $derived(valueProjection !== undefined
+    ? 'hbar'
+    : arcAngle !== undefined || tickCount !== undefined
+      ? 'knob'
+      : tickStyle !== undefined || showAllTicks !== undefined || dimmed !== undefined
+        ? 'discrete'
+        : 'bipolar');
+
+  $effect(() => {
+    if (binding === attachedBinding) return;
+    lease.dispose();
+    attachedBinding = binding;
+    lease = binding.attachRenderer();
+  });
+
+  onDestroy(() => lease.dispose());
+
+  function exposeLease(node: HTMLElement) {
+    Object.defineProperty(node, 'rendererLease', {
+      configurable: true,
+      get: () => lease,
+    });
+  }
+</script>
+
+<button
+  type="button"
+  role="slider"
+  use:exposeLease
+  data-external-scalar-renderer={renderer}
+  data-evidence={view.evidence}
+  data-confirmed={view.confirmed ?? ''}
+  data-requested={view.requested ?? ''}
+  data-phase={view.phase}
+  data-error={view.error ?? ''}
+  data-label={label}
+  data-display={displayFn?.(view.displayed ?? Number.NaN) ?? ''}
+  data-unknown-display={unknownDisplay ?? ''}
+  data-accent-color={accentColor ?? ''}
+  data-fill-color={fillColor ?? ''}
+  data-fill-gradient={fillGradient?.join('|') ?? ''}
+  data-track-color={trackColor ?? ''}
+  data-show-value={String(showValue)}
+  data-show-label={String(showLabel)}
+  data-compact={String(compact)}
+  data-variant={variant ?? ''}
+  data-unit={unit ?? ''}
+  data-shortcut-hint={shortcutHint ?? ''}
+  data-title={title ?? ''}
+  data-legacy-phase={legacy?.phase ?? ''}
+  data-legacy-busy={String(legacy?.busy)}
+  data-legacy-description={legacy?.description ?? ''}
+  data-legacy-status={legacy?.status ?? ''}
+  data-projection-context={valueProjection?.contextKey ?? ''}
+  data-issued-status={issuedStatusPresentation?.text ?? ''}
+  data-arc-angle={arcAngle ?? ''}
+  data-tick-count={tickCount ?? ''}
+  data-tick-labels={tickLabels?.join('|') ?? ''}
+  data-show-all-ticks={String(showAllTicks)}
+  data-tick-style={tickStyle ?? ''}
+  data-dimmed={String(dimmed)}
+  aria-label={label}
+  aria-valuenow={view.confirmed ?? undefined}
+  aria-disabled={!view.editable}
+  onclick={() => lease.key({ key: 'ArrowRight', fine: false })}
+>
+  {view.displayed ?? unknownDisplay ?? 'unknown'}
+</button>

--- a/frontend/src/components-v2/controls/value-control/__tests__/ExternalScalarRendererFixture.svelte
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ExternalScalarRendererFixture.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { onDestroy, untrack } from 'svelte';
-  import type { ContinuousScalarRendererLease } from '../../../../primitives/scalar/continuous-scalar.svelte';
+  import type {
+    ContinuousScalarRendererLease,
+    ContinuousScalarView,
+  } from '../../../../primitives/scalar/continuous-scalar.svelte';
   import type {
     DiscreteSkinRendererProps,
     HBarSkinRendererProps,
@@ -37,8 +40,8 @@
   }: FixtureProps = $props();
 
   let attachedBinding = untrack(() => binding);
-  let lease: ContinuousScalarRendererLease = $state(attachedBinding.attachRenderer());
-  let view = $derived(lease.view);
+  let lease: ContinuousScalarRendererLease = attachedBinding.attachRenderer();
+  let view = $state<ContinuousScalarView>(untrack(() => lease.view));
   let renderer = $derived(valueProjection !== undefined
     ? 'hbar'
     : arcAngle !== undefined || tickCount !== undefined
@@ -47,11 +50,13 @@
         ? 'discrete'
         : 'bipolar');
 
-  $effect(() => {
-    if (binding === attachedBinding) return;
-    lease.dispose();
-    attachedBinding = binding;
-    lease = binding.attachRenderer();
+  $effect.pre(() => {
+    if (binding !== attachedBinding) {
+      lease.dispose();
+      attachedBinding = binding;
+      lease = binding.attachRenderer();
+    }
+    view = lease.view;
   });
 
   onDestroy(() => lease.dispose());

--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
@@ -4,7 +4,9 @@ import { SvelteMap } from 'svelte/reactivity';
 import ValueControl from '../ValueControl.svelte';
 import HBarRenderer from '../HBarRenderer.svelte';
 import DiscreteRenderer from '../DiscreteRenderer.svelte';
+import ExternalScalarRendererFixture from './ExternalScalarRendererFixture.svelte';
 import { professionalSkin } from '../skins';
+import type { Skin } from '../skin';
 import {
   createBipolarContinuousScalarPolicy,
   createContinuousScalar,
@@ -16,6 +18,12 @@ import {
   type ContinuousScalarInput,
   type ContinuousScalarRendererLease,
 } from '../../../../primitives/scalar/continuous-scalar.svelte';
+
+const activationState = vi.hoisted(() => ({ selectedScalarAppearance: undefined as unknown }));
+
+vi.mock('../../../../component-kits/activation', () => ({
+  getSelectedScalarAppearance: () => activationState.selectedScalarAppearance,
+}));
 
 let components: ReturnType<typeof mount>[] = [];
 let roots: HTMLElement[] = [];
@@ -55,6 +63,7 @@ function pointer(target: HTMLElement, x: number) {
 beforeEach(() => {
   components = [];
   roots = [];
+  activationState.selectedScalarAppearance = undefined;
 });
 
 afterEach(() => {
@@ -1422,6 +1431,171 @@ describe('ValueControl controlled Knob skins', () => {
     expect(target.querySelector('.vc-knob-value')?.textContent).toBe(expected);
     expect(slider(target).getAttribute('aria-valuenow')).toBeNull();
     expect(slider(target).getAttribute('aria-disabled')).toBe('true');
+  });
+});
+
+describe('ValueControl external scalar appearances', () => {
+  const fixtureComponent = ExternalScalarRendererFixture as unknown as NonNullable<Skin['hbar']>;
+  const externalAppearance = {
+    name: 'External fixture',
+    knob: fixtureComponent as unknown as NonNullable<Skin['knob']>,
+    hbar: fixtureComponent,
+    bipolar: fixtureComponent as unknown as NonNullable<Skin['bipolar']>,
+    discrete: fixtureComponent as unknown as NonNullable<Skin['discrete']>,
+  } satisfies Skin;
+
+  it.each([
+    ['hbar', {
+      valueProjection: {
+        contextKey: 'USB:[1800,2100,3000]',
+        positionOf: () => 0.5,
+        valueAt: () => 20,
+      },
+      issuedStatusPresentation: { text: 'issued', format: () => 'issued', accept: vi.fn() },
+    }],
+    ['bipolar', {}],
+    ['knob', { arcAngle: 180, tickCount: 5, tickLabels: ['A', 'B'] }],
+    ['discrete', {
+      tickLabels: ['Low', 'High'], showAllTicks: false, tickStyle: 'led', disabled: true,
+    }],
+  ] as const)('renders the selected external %s member with the complete host prop set', (
+    renderer, extra,
+  ) => {
+    activationState.selectedScalarAppearance = externalAppearance;
+    const { target } = mountReactive({
+      ...baseProps,
+      ...extra,
+      renderer,
+      displayFn: (candidate: number) => `display:${candidate}`,
+      accentColor: '#123456',
+      fillColor: '#234567',
+      fillGradient: ['#345678', '#456789'],
+      trackColor: '#56789a',
+      showValue: false,
+      showLabel: false,
+      compact: true,
+      variant: 'hardware-illuminated',
+      unit: 'dB',
+      shortcutHint: 'Alt+S',
+      title: 'Scalar title',
+      feedbackPhase: 'failed',
+      feedbackBusy: false,
+      feedbackDescription: 'Legacy description',
+      feedbackStatus: 'Legacy status',
+      onChange: vi.fn(),
+    });
+    const control = slider(target);
+
+    expect(control.getAttribute('data-external-scalar-renderer')).toBe(renderer);
+    expect(control.getAttribute('data-label')).toBe('Controlled');
+    expect(control.getAttribute('data-display')).toBe('display:20');
+    expect(control.getAttribute('data-accent-color')).toBe('#123456');
+    expect(control.getAttribute('data-fill-color')).toBe('#234567');
+    expect(control.getAttribute('data-fill-gradient')).toBe('#345678|#456789');
+    expect(control.getAttribute('data-track-color')).toBe('#56789a');
+    expect(control.getAttribute('data-show-value')).toBe('false');
+    expect(control.getAttribute('data-show-label')).toBe('false');
+    expect(control.getAttribute('data-compact')).toBe('true');
+    expect(control.getAttribute('data-variant')).toBe('hardware-illuminated');
+    expect(control.getAttribute('data-unit')).toBe('dB');
+    expect(control.getAttribute('data-shortcut-hint')).toBe('Alt+S');
+    expect(control.getAttribute('data-title')).toBe('Scalar title');
+    expect(control.getAttribute('data-legacy-phase')).toBe('failed');
+    expect(control.getAttribute('data-legacy-busy')).toBe('false');
+    expect(control.getAttribute('data-legacy-description')).toBe('Legacy description');
+    expect(control.getAttribute('data-legacy-status')).toBe('Legacy status');
+    if (renderer === 'hbar') {
+      expect(control.getAttribute('data-projection-context')).toBe('USB:[1800,2100,3000]');
+      expect(control.getAttribute('data-issued-status')).toBe('issued');
+    } else if (renderer === 'knob') {
+      expect(control.getAttribute('data-arc-angle')).toBe('180');
+      expect(control.getAttribute('data-tick-count')).toBe('5');
+      expect(control.getAttribute('data-tick-labels')).toBe('A|B');
+    } else if (renderer === 'discrete') {
+      expect(control.getAttribute('data-tick-labels')).toBe('Low|High');
+      expect(control.getAttribute('data-show-all-ticks')).toBe('false');
+      expect(control.getAttribute('data-tick-style')).toBe('led');
+      expect(control.getAttribute('data-dimmed')).toBe('true');
+    }
+  });
+
+  it('keeps explicit appearance authoritative and falls back within that appearance only', () => {
+    activationState.selectedScalarAppearance = externalAppearance;
+    const explicit = mountReactive({
+      ...baseProps,
+      renderer: 'knob',
+      skin: professionalSkin,
+      onChange: vi.fn(),
+    });
+    expect(explicit.target.querySelector('.pro-knob')).not.toBeNull();
+    expect(explicit.target.querySelector('[data-external-scalar-renderer]')).toBeNull();
+
+    const partialExplicit = mountReactive({
+      ...baseProps,
+      skin: { name: 'Explicit partial' },
+      onChange: vi.fn(),
+    });
+    expect(partialExplicit.target.querySelector('.vc-hbar')).not.toBeNull();
+    expect(partialExplicit.target.querySelector('[data-external-scalar-renderer]')).toBeNull();
+  });
+
+  it('uses the built-in member when the selected appearance omits the requested renderer', () => {
+    activationState.selectedScalarAppearance = {
+      name: 'Partial external',
+      hbar: fixtureComponent,
+    } satisfies Skin;
+    const { target } = mountReactive({
+      ...baseProps,
+      renderer: 'knob',
+      onChange: vi.fn(),
+    });
+
+    expect(target.querySelector('.vc-knob')).not.toBeNull();
+    expect(target.querySelector('[data-external-scalar-renderer]')).toBeNull();
+  });
+
+  it('preserves the default built-in UI when no external appearance is selected', () => {
+    const { target } = mountReactive({ ...baseProps, onChange: vi.fn() });
+
+    expect(target.querySelector('.vc-hbar')).not.toBeNull();
+    expect(target.querySelector('[data-external-scalar-renderer]')).toBeNull();
+  });
+
+  it('replaces the external renderer without replacing its binding, policy, or feedback', () => {
+    activationState.selectedScalarAppearance = externalAppearance;
+    const request = vi.fn();
+    const binding = commandBinding(request, {
+      phase: 'failed',
+      busy: false,
+      outcome: { phase: 'failed', error: 'radio rejected' },
+      transitionId: 'external-failed',
+    });
+    const { state, target } = mountReactive({ binding, label: 'External command', renderer: 'hbar' });
+    const external = slider(target) as HTMLElement & {
+      readonly rendererLease: ContinuousScalarRendererLease;
+    };
+    const staleLease = external.rendererLease;
+
+    expect(staleLease.view).toEqual(binding.view);
+    expect(external.getAttribute('data-confirmed')).toBe('20');
+    expect(external.getAttribute('data-requested')).toBe('30');
+    expect(external.getAttribute('data-phase')).toBe('failed');
+    expect(external.getAttribute('data-error')).toBe('radio rejected');
+
+    state.skin = { name: 'Explicit built-in fallback' };
+    flushSync();
+    const replacement = slider(target);
+    expect(target.querySelector('.vc-hbar')).not.toBeNull();
+    expect(replacement.getAttribute('aria-valuenow')).toBe('20');
+    expect(replacement.getAttribute('data-command-phase')).toBe('failed');
+    expect(target.querySelector('[data-control-feedback-status]')?.textContent)
+      .toBe('Failed: 30 Hz: radio rejected');
+
+    expect(staleLease.key({ key: 'ArrowRight', fine: false })).toBe(false);
+    expect(request).not.toHaveBeenCalled();
+    replacement.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(request).toHaveBeenCalledExactlyOnceWith(30);
+    binding.destroy();
   });
 });
 

--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
@@ -1588,8 +1588,10 @@ describe('ValueControl external scalar appearances', () => {
     expect(target.querySelector('.vc-hbar')).not.toBeNull();
     expect(replacement.getAttribute('aria-valuenow')).toBe('20');
     expect(replacement.getAttribute('data-command-phase')).toBe('failed');
-    expect(target.querySelector('[data-control-feedback-status]')?.textContent)
-      .toBe('Failed: 30 Hz: radio rejected');
+    expect(binding.view).toMatchObject({
+      confirmed: 20, requested: 30, phase: 'failed', error: 'radio rejected',
+    });
+    expect(target.querySelector('[data-control-feedback-status]')).toBeNull();
 
     expect(staleLease.key({ key: 'ArrowRight', fine: false })).toBe(false);
     expect(request).not.toHaveBeenCalled();


### PR DESCRIPTION
`ValueControl` ignored the scalar appearance selected during component-kit activation, so installed kits could register scalar renderers but never occupy the production renderer seat. This change resolves the selected appearance once at mount and uses its member at the existing rendering branch, while an explicit `skin` prop remains authoritative and missing members fall back to the existing built-in renderer.

The renderer continues to receive the host-created `ContinuousScalarBinding` and the existing renderer-specific prop objects. A real Svelte fixture proves all four members, complete prop forwarding, unchanged default rendering, explicit and partial fallback, preserved confirmed/requested/error evidence, stale renderer-lease revocation, and live replacement input through the same policy and request path.

Linear: https://linear.app/morozsm/issue/MOR-2425/expose-a-supported-v3-host-boundary-for-independently-installed

Depends on accepted activation PR #3285 (`35e2b95a41991d1bb6bb9c3ca7bc672e7c50c71d`).

Scope: 3 code + 0 regenerated baselines = 3 files; 303 A+D.

Validation:

- `npx vitest run src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts` — 76 passed
- `npm run check` — 0 errors, 0 warnings
- targeted ESLint on the three changed files — passed
- `git diff --check origin/main...HEAD` — passed
