### PR TITLE
MOR-2425: add revocable frequency renderer seats

### DIFF
--- a/frontend/src/components-v2/display/FrequencyDisplay.svelte
+++ b/frontend/src/components-v2/display/FrequencyDisplay.svelte
@@ -1,16 +1,39 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import StandardFrequencyReadout from '../../primitives/frequency/StandardFrequencyReadout.svelte';
+  import {
+    createFrequencyInteraction, createFrequencyInteractionLease,
+  } from '../../primitives/frequency/frequency-interaction.svelte';
   import { projectFrequencyReadout } from '../../primitives/frequency/frequency-readout';
 
   interface Props {
     freq: number;       // frequency in Hz (e.g. 14235000)
     compact?: boolean;  // smaller variant (~18px vs ~28px)
     active?: boolean;   // bright (var(--v2-text-bright)) vs dimmed (var(--v2-text-disabled))
+    receiver?: 'main' | 'sub';
   }
 
-  let { freq, compact = false, active = true }: Props = $props();
+  let { freq, compact = false, active = true, receiver = 'main' }: Props = $props();
 
   let model = $derived(projectFrequencyReadout({ confirmedHz: freq }));
+  const owner = createFrequencyInteraction({
+    get confirmedHz() { return freq; },
+    get digits() { return model.digits; },
+    disabled: true,
+    get receiver() { return receiver; },
+    minFreq: 0,
+    maxFreq: 999_000_000,
+  });
+  const lease = createFrequencyInteractionLease(owner, () => true);
+  onDestroy(lease.revoke);
 </script>
 
-<StandardFrequencyReadout {model} presentation="passive" {compact} {active} />
+<StandardFrequencyReadout
+  {model}
+  interaction={lease.interaction}
+  presentation="passive"
+  {compact}
+  {active}
+  {receiver}
+  vfoFreqHook={false}
+/>

--- a/frontend/src/components-v2/display/FrequencyDisplay.svelte
+++ b/frontend/src/components-v2/display/FrequencyDisplay.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
+  import { getSelectedFrequencyReadout } from '../../component-kits/activation';
   import StandardFrequencyReadout from '../../primitives/frequency/StandardFrequencyReadout.svelte';
   import {
     createFrequencyInteraction, createFrequencyInteractionLease,
@@ -24,16 +25,33 @@
     minFreq: 0,
     maxFreq: 999_000_000,
   });
-  const lease = createFrequencyInteractionLease(owner, () => true);
+  const selectedRenderer = getSelectedFrequencyReadout();
+  const lease = createFrequencyInteractionLease(
+    owner,
+    () => getSelectedFrequencyReadout() === selectedRenderer,
+  );
   onDestroy(lease.revoke);
 </script>
 
-<StandardFrequencyReadout
-  {model}
-  interaction={lease.interaction}
-  presentation="passive"
-  {compact}
-  {active}
-  {receiver}
-  vfoFreqHook={false}
-/>
+{#if selectedRenderer}
+  {@const Renderer = selectedRenderer}
+  <Renderer
+    {model}
+    interaction={lease.interaction}
+    presentation="passive"
+    {compact}
+    {active}
+    {receiver}
+    vfoFreqHook={false}
+  />
+{:else}
+  <StandardFrequencyReadout
+    {model}
+    interaction={lease.interaction}
+    presentation="passive"
+    {compact}
+    {active}
+    {receiver}
+    vfoFreqHook={false}
+  />
+{/if}

--- a/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
+++ b/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
@@ -146,7 +146,7 @@ function interactionOwner(options: { disabled?: boolean; onFreqChange?: (hz: num
 }
 
 describe('frequency renderer lifetime', () => {
-  it('revokes the actual external renderer across replacement, context A-B-A, and unmount', () => {
+  it('revokes the actual external renderer across replacement, context A-B-A, and unmount', async () => {
     selectedFrequency.current = AlternateFrequencyReadoutHarness as FrequencyRenderer;
     const context = writable('A');
     const liveContext = fromStore(context);
@@ -173,10 +173,24 @@ describe('frequency renderer lifetime', () => {
     expect(aBaWheel.defaultPrevented).toBe(false);
     expect(first.inert).toBe(true);
     expect(onFreqChange).not.toHaveBeenCalled();
+    flushSync();
+    const recovered = retainedInteractions().at(-1)!;
+    expect(recovered).not.toBe(first);
+    expect(root.querySelector('[data-alternate-frequency-readout]')).not.toBeNull();
+    recovered.handleDigitClick(digit, new MouseEvent('click'));
+    await Promise.resolve();
+    expect(recovered.selectedDigitIndex).toBe(digit.digitIndex);
+    recovered.handleKeyDown(new KeyboardEvent('keydown', { key: 'ArrowUp', cancelable: true }));
+    expect(onFreqChange).toHaveBeenCalledExactlyOnceWith(14_251_000);
+    onFreqChange.mockClear();
+    const staleRecoveredWheel = new WheelEvent('wheel', { deltaY: -1, cancelable: true });
+    first.handleWheel(digit, staleRecoveredWheel);
+    expect(staleRecoveredWheel.defaultPrevented).toBe(false);
+    expect(onFreqChange).not.toHaveBeenCalled();
 
     selectedFrequency.current = undefined;
     const beforeCleanup = new WheelEvent('wheel', { deltaY: -1, cancelable: true });
-    first.handleWheel(digit, beforeCleanup);
+    recovered.handleWheel(digit, beforeCleanup);
     expect(beforeCleanup.defaultPrevented).toBe(false);
     expect(onFreqChange).not.toHaveBeenCalled();
     context.set('B');
@@ -188,6 +202,7 @@ describe('frequency renderer lifetime', () => {
     flushSync();
     const second = retainedInteractions().at(-1)!;
     expect(second).not.toBe(first);
+    expect(second).not.toBe(recovered);
     first.handleDigitClick(digit, new MouseEvent('click'));
     first.handleKeyDown(new KeyboardEvent('keydown', { key: 'ArrowUp', cancelable: true }));
     expect(onFreqChange).not.toHaveBeenCalled();

--- a/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
+++ b/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
@@ -164,6 +164,16 @@ describe('frequency renderer lifetime', () => {
       .toBe('pending');
     first.handleDigitClick(digit, new MouseEvent('click'));
 
+    context.set('B');
+    expect(first.inert).toBe(true);
+    context.set('A');
+    const aBaWheel = new WheelEvent('wheel', { deltaY: -1, cancelable: true });
+    first.handleDigitClick(digit, new MouseEvent('click'));
+    first.handleWheel(digit, aBaWheel);
+    expect(aBaWheel.defaultPrevented).toBe(false);
+    expect(first.inert).toBe(true);
+    expect(onFreqChange).not.toHaveBeenCalled();
+
     selectedFrequency.current = undefined;
     const beforeCleanup = new WheelEvent('wheel', { deltaY: -1, cancelable: true });
     first.handleWheel(digit, beforeCleanup);
@@ -194,7 +204,7 @@ describe('frequency renderer lifetime', () => {
     expect(onFreqChange).toHaveBeenCalledTimes(1);
   });
 
-  it('makes a retained facade synchronously inert and permanently revokes it across A-B-A', () => {
+  it('latches the first authority mismatch across A-B-A until a fresh lease attaches', async () => {
     const onFreqChange = vi.fn();
     const { owner, digit } = interactionOwner({ onFreqChange });
     let authority = 'A';
@@ -203,29 +213,36 @@ describe('frequency renderer lifetime', () => {
     const retainedWheel = first.interaction.handleWheel;
 
     retainedClick(digit, new MouseEvent('click'));
+    first.interaction.handleDigitEnter(digit);
     expect(first.interaction.selectedDigitIndex).toBe(digit.digitIndex);
+    expect(first.interaction.hoveredDigitIndex).toBe(digit.digitIndex);
     authority = 'B';
-    const staleWheel = new WheelEvent('wheel', { deltaY: -1, cancelable: true });
-    retainedWheel(digit, staleWheel);
-    expect(staleWheel.defaultPrevented).toBe(false);
-    expect(onFreqChange).not.toHaveBeenCalled();
-    expect(first.interaction).toMatchObject({
-      inert: true, selectedDigitIndex: null, hoveredDigitIndex: null,
-    });
-
-    const second = createFrequencyInteractionLease(owner, () => authority === 'B');
-    expect(owner.selectedDigitIndex).toBeNull();
-    authority = 'A';
-    retainedClick(digit, new MouseEvent('click'));
-    retainedWheel(digit, new WheelEvent('wheel', { deltaY: -1, cancelable: true }));
     expect(first.interaction.inert).toBe(true);
+    authority = 'A';
+
+    const staleWheel = new WheelEvent('wheel', { deltaY: -1, cancelable: true });
+    const staleKey = new KeyboardEvent('keydown', { key: 'ArrowUp', cancelable: true });
+    retainedClick(digit, new MouseEvent('click'));
+    first.interaction.handleDigitEnter(digit);
+    retainedWheel(digit, staleWheel);
+    first.interaction.handleKeyDown(staleKey);
+    first.interaction.handleDigitLeave();
+    expect(staleWheel.defaultPrevented).toBe(false);
+    expect(staleKey.defaultPrevented).toBe(false);
+    expect(first.interaction.inert).toBe(true);
+    expect(first.interaction.selectedDigitIndex).toBeNull();
+    expect(first.interaction.hoveredDigitIndex).toBeNull();
+    expect(first.interaction.isSelected(digit)).toBe(false);
+    expect(first.interaction.isHovered(digit)).toBe(false);
     expect(onFreqChange).not.toHaveBeenCalled();
+    await Promise.resolve();
+    expect(owner.selectedDigitIndex).toBeNull();
+    expect(owner.hoveredDigitIndex).toBeNull();
 
     const live = createFrequencyInteractionLease(owner, () => authority === 'A');
     live.interaction.handleDigitClick(digit, new MouseEvent('click'));
     live.interaction.handleWheel(digit, new WheelEvent('wheel', { deltaY: -1, cancelable: true }));
     expect(onFreqChange).toHaveBeenCalledExactlyOnceWith(14_251_000);
-    second.revoke();
     live.revoke();
   });
 

--- a/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
+++ b/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
@@ -5,6 +5,12 @@ import type { ComponentProps } from 'svelte';
 import type { ServerState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
 import FrequencyDisplayInteractive from '../../../primitives/frequency/FrequencyDisplayInteractive.svelte';
+import {
+  createFrequencyInteraction,
+  createFrequencyInteractionLease,
+  type FrequencyInteraction,
+} from '../../../primitives/frequency/frequency-interaction.svelte';
+import { projectFrequencyReadout } from '../../../primitives/frequency/frequency-readout';
 // Static import while the stores below are imported dynamically per test:
 // safe ONLY while `panel-props` stays a pure state→props module with no store
 // imports. If a projection ever starts reading a store, move this into the
@@ -102,6 +108,7 @@ function makeMinimalState(overrides: Partial<ServerState> = {}): ServerState {
 }
 
 let components: ReturnType<typeof mount>[] = [];
+let roots: (() => void)[] = [];
 
 function mountDisplay(props: ComponentProps<typeof FrequencyDisplayInteractive>): HTMLElement {
   const t = document.createElement('div');
@@ -110,6 +117,79 @@ function mountDisplay(props: ComponentProps<typeof FrequencyDisplayInteractive>)
   flushSync();
   return t;
 }
+
+function interactionOwner(options: { disabled?: boolean; onFreqChange?: (hz: number) => void } = {}) {
+  const model = projectFrequencyReadout({ confirmedHz: 14_250_000 });
+  let owner!: FrequencyInteraction;
+  roots.push($effect.root(() => {
+    owner = createFrequencyInteraction({
+      confirmedHz: 14_250_000,
+      digits: model.digits,
+      disabled: options.disabled ?? false,
+      minFreq: 0,
+      maxFreq: 999_000_000,
+      onFreqChange: options.onFreqChange,
+    });
+  }));
+  flushSync();
+  return { owner, digit: model.digits.find((candidate) => candidate.multiplier === 1_000)! };
+}
+
+describe('frequency renderer lifetime', () => {
+  it('makes a retained facade synchronously inert and permanently revokes it across A-B-A', () => {
+    const onFreqChange = vi.fn();
+    const { owner, digit } = interactionOwner({ onFreqChange });
+    let authority = 'A';
+    const first = createFrequencyInteractionLease(owner, () => authority === 'A');
+    const retainedClick = first.interaction.handleDigitClick;
+    const retainedWheel = first.interaction.handleWheel;
+
+    retainedClick(digit, new MouseEvent('click'));
+    expect(first.interaction.selectedDigitIndex).toBe(digit.digitIndex);
+    authority = 'B';
+    const staleWheel = new WheelEvent('wheel', { deltaY: -1, cancelable: true });
+    retainedWheel(digit, staleWheel);
+    expect(staleWheel.defaultPrevented).toBe(false);
+    expect(onFreqChange).not.toHaveBeenCalled();
+    expect(first.interaction).toMatchObject({
+      inert: true, selectedDigitIndex: null, hoveredDigitIndex: null,
+    });
+
+    const second = createFrequencyInteractionLease(owner, () => authority === 'B');
+    expect(owner.selectedDigitIndex).toBeNull();
+    authority = 'A';
+    retainedClick(digit, new MouseEvent('click'));
+    retainedWheel(digit, new WheelEvent('wheel', { deltaY: -1, cancelable: true }));
+    expect(first.interaction.inert).toBe(true);
+    expect(onFreqChange).not.toHaveBeenCalled();
+
+    const live = createFrequencyInteractionLease(owner, () => authority === 'A');
+    live.interaction.handleDigitClick(digit, new MouseEvent('click'));
+    live.interaction.handleWheel(digit, new WheelEvent('wheel', { deltaY: -1, cancelable: true }));
+    expect(onFreqChange).toHaveBeenCalledExactlyOnceWith(14_251_000);
+    second.revoke();
+    live.revoke();
+  });
+
+  it('keeps a real disabled no-writer interaction passive before and after revoke', () => {
+    const { owner, digit } = interactionOwner({ disabled: true });
+    const lease = createFrequencyInteractionLease(owner, () => true);
+    const wheel = new WheelEvent('wheel', { deltaY: -1, cancelable: true });
+    lease.interaction.handleDigitClick(digit, new MouseEvent('click'));
+    lease.interaction.handleDigitEnter(digit);
+    lease.interaction.handleWheel(digit, wheel);
+    lease.interaction.handleKeyDown(new KeyboardEvent('keydown', { key: 'ArrowUp', cancelable: true }));
+    lease.interaction.handleDigitLeave();
+    expect(wheel.defaultPrevented).toBe(false);
+    expect(lease.interaction).toMatchObject({
+      inert: true, selectedDigitIndex: null, hoveredDigitIndex: null,
+    });
+    expect(lease.interaction.isSelected(digit)).toBe(false);
+    expect(lease.interaction.isHovered(digit)).toBe(false);
+    lease.revoke();
+    expect(lease.interaction.inert).toBe(true);
+  });
+});
 
 describe('display-only frequency and disabled arithmetic', () => {
   it.each([{ freq: null, disabled: false }, { freq: 14250000, disabled: true }])('rejects every gesture with %j', (authority) => {
@@ -168,6 +248,8 @@ beforeEach(async () => {
 
 afterEach(() => {
   components.forEach((c) => unmount(c));
+  roots.forEach((dispose) => dispose());
+  roots = [];
   document.body.innerHTML = '';
 });
 

--- a/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
+++ b/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
@@ -4,7 +4,17 @@ import { writable, fromStore } from 'svelte/store';
 import type { ComponentProps } from 'svelte';
 import type { ServerState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
+import type { FrequencyRenderer } from '../../../../component-kit-api/src/index';
+
+const selectedFrequency = vi.hoisted(() => ({ current: undefined as unknown }));
+vi.mock('../../../component-kits/activation', () => ({
+  getSelectedFrequencyReadout: () => selectedFrequency.current,
+}));
+
 import FrequencyDisplayInteractive from '../../../primitives/frequency/FrequencyDisplayInteractive.svelte';
+import AlternateFrequencyReadoutHarness, {
+  clearRetainedInteractions, retainedInteractions,
+} from '../../../primitives/frequency/__tests__/AlternateFrequencyReadoutHarness.svelte';
 import {
   createFrequencyInteraction,
   createFrequencyInteractionLease,
@@ -136,6 +146,54 @@ function interactionOwner(options: { disabled?: boolean; onFreqChange?: (hz: num
 }
 
 describe('frequency renderer lifetime', () => {
+  it('revokes the actual external renderer across replacement, context A-B-A, and unmount', () => {
+    selectedFrequency.current = AlternateFrequencyReadoutHarness as FrequencyRenderer;
+    const context = writable('A');
+    const liveContext = fromStore(context);
+    const onFreqChange = vi.fn();
+    const root = mountDisplay({
+      freq: 14_250_000,
+      pendingDisplayHz: 14_260_000,
+      get contextKey() { return liveContext.current; },
+      onFreqChange,
+    });
+    const digit = projectFrequencyReadout({ confirmedHz: 14_250_000 }).digits
+      .find((candidate) => candidate.multiplier === 1_000)!;
+    const first = retainedInteractions()[0];
+    expect(root.querySelector('[data-alternate-frequency-readout]')?.getAttribute('data-source'))
+      .toBe('pending');
+    first.handleDigitClick(digit, new MouseEvent('click'));
+
+    selectedFrequency.current = undefined;
+    const beforeCleanup = new WheelEvent('wheel', { deltaY: -1, cancelable: true });
+    first.handleWheel(digit, beforeCleanup);
+    expect(beforeCleanup.defaultPrevented).toBe(false);
+    expect(onFreqChange).not.toHaveBeenCalled();
+    context.set('B');
+    flushSync();
+    expect(root.querySelector('[data-alternate-frequency-readout]')).toBeNull();
+
+    selectedFrequency.current = AlternateFrequencyReadoutHarness as FrequencyRenderer;
+    context.set('A');
+    flushSync();
+    const second = retainedInteractions().at(-1)!;
+    expect(second).not.toBe(first);
+    first.handleDigitClick(digit, new MouseEvent('click'));
+    first.handleKeyDown(new KeyboardEvent('keydown', { key: 'ArrowUp', cancelable: true }));
+    expect(onFreqChange).not.toHaveBeenCalled();
+    second.handleDigitClick(digit, new MouseEvent('click'));
+    second.handleKeyDown(new KeyboardEvent('keydown', { key: 'ArrowUp', cancelable: true }));
+    expect(onFreqChange).toHaveBeenCalledExactlyOnceWith(14_251_000);
+
+    const component = components.pop()!;
+    unmount(component);
+    const afterUnmount = new WheelEvent('wheel', { deltaY: -1, cancelable: true });
+    second.handleWheel(digit, afterUnmount);
+    expect(afterUnmount.defaultPrevented).toBe(false);
+    expect(second.inert).toBe(true);
+    expect(onFreqChange).toHaveBeenCalledTimes(1);
+  });
+
   it('makes a retained facade synchronously inert and permanently revokes it across A-B-A', () => {
     const onFreqChange = vi.fn();
     const { owner, digit } = interactionOwner({ onFreqChange });
@@ -239,6 +297,8 @@ describe('display-only frequency and disabled arithmetic', () => {
 
 beforeEach(async () => {
   vi.resetModules();
+  selectedFrequency.current = undefined;
+  clearRetainedInteractions();
   // Same module registry: radio.svelte's own capabilities import resolves to
   // this instance, so the epoch we establish here is the one the gate checks.
   capabilities = await import('$lib/stores/capabilities.svelte');
@@ -250,6 +310,8 @@ afterEach(() => {
   components.forEach((c) => unmount(c));
   roots.forEach((dispose) => dispose());
   roots = [];
+  selectedFrequency.current = undefined;
+  clearRetainedInteractions();
   document.body.innerHTML = '';
 });
 

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -612,6 +612,14 @@
   const readControlSession = 'controlSession' in runtime ? () => runtime.controlSession : undefined;
   const subscribeControlSession = 'subscribeControlSession' in runtime ? runtime.subscribeControlSession : undefined;
   let controlSession = $state(readControlSession?.() ?? { state: 'disconnected' as const, epoch: -1 });
+  let frequencyLifetimeKey = $derived.by(() => {
+    void canonicalView;
+    const stateGeneration = runtime.state?.providerGeneration;
+    const capsGeneration = runtime.caps?.providerGeneration;
+    const matchedGeneration = Number.isSafeInteger(stateGeneration)
+      && stateGeneration === capsGeneration ? stateGeneration : 'unmatched';
+    return `${controlSession.state}:${controlSession.epoch}:${matchedGeneration}`;
+  });
   let meterContinuitySession: MeterContinuitySession | null = $derived(
     controlSession.state === 'connected'
       && Number.isSafeInteger(controlSession.epoch) && controlSession.epoch >= 0
@@ -894,6 +902,7 @@
               disabled={!isOperationalStrip(view, receiverId)}
               indicatorReceiver={receiverId}
               continuitySession={meterContinuitySession}
+              {frequencyLifetimeKey}
               {pendingFrequencyHz}
             />
           </div>
@@ -931,6 +940,7 @@
             onSelectMainReceiver={vfo.onMainVfoClick}
             onSelectSubReceiver={vfo.onSubVfoClick}
             onSpeak={systemIntents.onSpeak}
+            {frequencyLifetimeKey}
           />
         </div>
       {/if}
@@ -963,6 +973,7 @@
         onSelectSubReceiver={vfo.onSubVfoClick}
         onSpeak={systemIntents.onSpeak}
         continuitySession={meterContinuitySession}
+        {frequencyLifetimeKey}
         {pendingFrequencyHz}
       />
     {/if}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -179,6 +179,28 @@ afterEach(() => {
 
 describe('production receiver-indicator partitioning', () => {
   it.each([
+    ['dual receiver strip', { strips: 'dual' }, '[data-testid="channel-strip-MAIN"] .digit'],
+    ['single VFO surface', { strips: 'single' }, '.vfo-tile .digit'],
+  ] as const)('rotates the %s frequency authority on session and provider identity', (
+    _name, props, digitSelector,
+  ) => {
+    render(caps('main_sub', 2), state(), {}, props);
+    const digit = () => target.querySelector<HTMLElement>(digitSelector)!;
+
+    digit().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    flushSync();
+    expect(target.querySelector('.freq .selected')).not.toBeNull();
+    pushSession({ state: 'connected', epoch: 2 });
+    expect(target.querySelector('.freq .selected')).toBeNull();
+
+    digit().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    flushSync();
+    expect(target.querySelector('.freq .selected')).not.toBeNull();
+    pushMeter(50, 2);
+    expect(target.querySelector('.freq .selected')).toBeNull();
+  });
+
+  it.each([
     ['dual semantic receiver strip', { strips: 'dual' }],
     ['live Standard composition', { strips: 'single', vfoAppearance: 'standard' }],
   ] as const)('re-seeds %s at equal-value session and provider boundaries', (_name, props) => {

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -6,6 +6,7 @@ import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
 import type { ControlSessionSnapshot } from '$lib/runtime/frontend-runtime';
+import type { FrequencyRenderer } from '../../../../component-kit-api/src/index';
 
 const h = vi.hoisted(() => ({
   state: null as ServerState | null, caps: null as Capabilities | null, noop: vi.fn(),
@@ -17,7 +18,12 @@ const h = vi.hoisted(() => ({
   session: { state: 'connected', epoch: 1 } as ControlSessionSnapshot,
   sessionSubscriber: null as ((next: ControlSessionSnapshot) => void) | null,
 }));
+const selectedFrequency = vi.hoisted(() => ({ current: undefined as unknown }));
 const group = new Proxy({}, { get: () => h.noop });
+
+vi.mock('../../../component-kits/activation', () => ({
+  getSelectedFrequencyReadout: () => selectedFrequency.current,
+}));
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
@@ -65,6 +71,10 @@ vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+import AlternateFrequencyReadoutHarness, {
+  clearRetainedInteractions, retainedInteractions,
+} from '../../../primitives/frequency/__tests__/AlternateFrequencyReadoutHarness.svelte';
+import { projectFrequencyReadout } from '../../../primitives/frequency/frequency-readout';
 import {
   ManagedAppTxHarness, type ManagedAppTxServerSnapshot,
 } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
@@ -133,6 +143,8 @@ beforeEach(() => {
   h.txController = txHarness.controller;
   h.session = { state: 'connected', epoch: 1 };
   h.sessionSubscriber = null;
+  selectedFrequency.current = undefined;
+  clearRetainedInteractions();
   h.filterWidthFeedback.mockReturnValue(Object.freeze({
     confirmed: null, target: null, requestedTarget: null,
     phase: 'unavailable', busy: false, availability: 'unavailable',
@@ -172,6 +184,8 @@ afterEach(() => {
   expect(txHarness.listenerCount()).toBe(0);
   expect(txHarness.trace()).toEqual([]);
   expect(h.sessionSubscriber).toBeNull();
+  selectedFrequency.current = undefined;
+  clearRetainedInteractions();
   document.body.innerHTML = '';
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
@@ -179,25 +193,38 @@ afterEach(() => {
 
 describe('production receiver-indicator partitioning', () => {
   it.each([
-    ['dual receiver strip', { strips: 'dual' }, '[data-testid="channel-strip-MAIN"] .digit'],
-    ['single VFO surface', { strips: 'single' }, '.vfo-tile .digit'],
+    ['dual receiver strip', { strips: 'dual' }],
+    ['single VFO surface', { strips: 'single' }],
   ] as const)('rotates the %s frequency authority on session and provider identity', (
-    _name, props, digitSelector,
+    _name, props,
   ) => {
+    selectedFrequency.current = AlternateFrequencyReadoutHarness as FrequencyRenderer;
     render(caps('main_sub', 2), state(), {}, props);
-    const digit = () => target.querySelector<HTMLElement>(digitSelector)!;
-
-    digit().dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    flushSync();
-    expect(target.querySelector('.freq .selected')).not.toBeNull();
+    const digit = projectFrequencyReadout({ confirmedHz: 14_200_000 }).digits[0];
+    const first = retainedInteractions().find((interaction) => !interaction.inert)!;
+    first.handleDigitClick(digit, new MouseEvent('click'));
+    expect(first.selectedDigitIndex).toBe(digit.digitIndex);
     pushSession({ state: 'connected', epoch: 2 });
-    expect(target.querySelector('.freq .selected')).toBeNull();
+    expect(first.inert).toBe(true);
+    const callsAfterSession = h.noop.mock.calls.length;
+    const staleSessionWheel = new WheelEvent('wheel', { deltaY: -1, cancelable: true });
+    first.handleDigitClick(digit, new MouseEvent('click'));
+    first.handleWheel(digit, staleSessionWheel);
+    expect(staleSessionWheel.defaultPrevented).toBe(false);
+    expect(h.noop).toHaveBeenCalledTimes(callsAfterSession);
 
-    digit().dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    flushSync();
-    expect(target.querySelector('.freq .selected')).not.toBeNull();
+    const second = retainedInteractions().find((interaction) => !interaction.inert)!;
+    expect(second).not.toBe(first);
+    second.handleDigitClick(digit, new MouseEvent('click'));
+    expect(second.selectedDigitIndex).toBe(digit.digitIndex);
     pushMeter(50, 2);
-    expect(target.querySelector('.freq .selected')).toBeNull();
+    expect(second.inert).toBe(true);
+    const callsAfterProvider = h.noop.mock.calls.length;
+    const staleProviderKey = new KeyboardEvent('keydown', { key: 'ArrowUp', cancelable: true });
+    second.handleDigitClick(digit, new MouseEvent('click'));
+    second.handleKeyDown(staleProviderKey);
+    expect(staleProviderKey.defaultPrevented).toBe(false);
+    expect(h.noop).toHaveBeenCalledTimes(callsAfterProvider);
   });
 
   it.each([

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -195,6 +195,7 @@ describe('production receiver-indicator partitioning', () => {
   it.each([
     ['dual receiver strip', { strips: 'dual' }],
     ['single VFO surface', { strips: 'single' }],
+    ['live Standard composition', { strips: 'single', vfoAppearance: 'standard' }],
   ] as const)('rotates the %s frequency authority on session and provider identity', (
     _name, props,
   ) => {

--- a/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
+++ b/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
+  import { onDestroy, untrack } from 'svelte';
   import StandardFrequencyReadout from './StandardFrequencyReadout.svelte';
-  import { createFrequencyInteraction } from './frequency-interaction.svelte';
+  import {
+    createFrequencyInteraction, createFrequencyInteractionLease,
+  } from './frequency-interaction.svelte';
   import { projectFrequencyReadout } from './frequency-readout';
 
   interface Props {
@@ -86,7 +89,7 @@
     pendingDisplayHz,
     pendingAnnouncement,
   }));
-  const interaction = createFrequencyInteraction({
+  const owner = createFrequencyInteraction({
     get confirmedHz() { return freq; },
     get digits() { return model.digits; },
     get disabled() { return disabled; },
@@ -96,12 +99,26 @@
     get maxFreq() { return maxFreq; },
     get onFreqChange() { return onFreqChange; },
   });
+  let attachedContextKey = untrack(() => contextKey);
+  const attachLease = (key: string | undefined) => createFrequencyInteractionLease(
+    owner,
+    () => Object.is(contextKey, key),
+  );
+  let lease = $state.raw(attachLease(attachedContextKey));
+  $effect.pre(() => {
+    const nextContextKey = contextKey;
+    if (Object.is(nextContextKey, attachedContextKey)) return;
+    lease.revoke();
+    attachedContextKey = nextContextKey;
+    lease = attachLease(nextContextKey);
+  });
+  onDestroy(() => lease.revoke());
 </script>
 
 <StandardFrequencyReadout
   {model}
   presentation="interactive"
-  {interaction}
+  interaction={lease.interaction}
   {compact}
   {active}
   {receiver}

--- a/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
+++ b/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
@@ -114,7 +114,8 @@
   $effect.pre(() => {
     const nextContextKey = contextKey;
     const nextRenderer = selectedRenderer;
-    if (Object.is(nextContextKey, attachedContextKey) && nextRenderer === attachedRenderer) return;
+    if (Object.is(nextContextKey, attachedContextKey)
+      && nextRenderer === attachedRenderer && !lease.revoked) return;
     lease.revoke();
     attachedContextKey = nextContextKey;
     attachedRenderer = nextRenderer;

--- a/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
+++ b/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onDestroy, untrack } from 'svelte';
+  import { getSelectedFrequencyReadout } from '../../component-kits/activation';
   import StandardFrequencyReadout from './StandardFrequencyReadout.svelte';
   import {
     createFrequencyInteraction, createFrequencyInteractionLease,
@@ -99,28 +100,48 @@
     get maxFreq() { return maxFreq; },
     get onFreqChange() { return onFreqChange; },
   });
+  let selectedRenderer = $derived.by(() => {
+    void contextKey;
+    return getSelectedFrequencyReadout();
+  });
   let attachedContextKey = untrack(() => contextKey);
-  const attachLease = (key: string | undefined) => createFrequencyInteractionLease(
+  let attachedRenderer = untrack(() => selectedRenderer);
+  const attachLease = (key: string | undefined, renderer: typeof selectedRenderer) => createFrequencyInteractionLease(
     owner,
-    () => Object.is(contextKey, key),
+    () => Object.is(contextKey, key) && getSelectedFrequencyReadout() === renderer,
   );
-  let lease = $state.raw(attachLease(attachedContextKey));
+  let lease = $state.raw(attachLease(attachedContextKey, attachedRenderer));
   $effect.pre(() => {
     const nextContextKey = contextKey;
-    if (Object.is(nextContextKey, attachedContextKey)) return;
+    const nextRenderer = selectedRenderer;
+    if (Object.is(nextContextKey, attachedContextKey) && nextRenderer === attachedRenderer) return;
     lease.revoke();
     attachedContextKey = nextContextKey;
-    lease = attachLease(nextContextKey);
+    attachedRenderer = nextRenderer;
+    lease = attachLease(nextContextKey, nextRenderer);
   });
   onDestroy(() => lease.revoke());
 </script>
 
-<StandardFrequencyReadout
-  {model}
-  presentation="interactive"
-  interaction={lease.interaction}
-  {compact}
-  {active}
-  {receiver}
-  {vfoFreqHook}
-/>
+{#if selectedRenderer}
+  {@const Renderer = selectedRenderer}
+  <Renderer
+    {model}
+    presentation="interactive"
+    interaction={lease.interaction}
+    {compact}
+    {active}
+    {receiver}
+    {vfoFreqHook}
+  />
+{:else}
+  <StandardFrequencyReadout
+    {model}
+    presentation="interactive"
+    interaction={lease.interaction}
+    {compact}
+    {active}
+    {receiver}
+    {vfoFreqHook}
+  />
+{/if}

--- a/frontend/src/primitives/frequency/__tests__/AlternateFrequencyReadoutHarness.svelte
+++ b/frontend/src/primitives/frequency/__tests__/AlternateFrequencyReadoutHarness.svelte
@@ -1,39 +1,21 @@
-<script lang="ts">
-  import { projectFrequencyReadout } from '../frequency-readout';
-  import { createFrequencyInteraction } from '../frequency-interaction.svelte';
+<script module lang="ts">
+  import type { FrequencyInteraction } from '../frequency-interaction.svelte';
 
-  interface Props {
-    confirmedHz: number | null;
-    displayHz?: number | null;
-    pendingDisplayHz?: number | null;
-    disabled?: boolean;
-    contextKey?: string;
-    onFreqChange?: (frequencyHz: number) => void;
+  const retained: FrequencyInteraction[] = [];
+  export const retainedInteractions = () => retained.slice();
+  export const clearRetainedInteractions = () => { retained.length = 0; };
+  function retain(interaction: FrequencyInteraction): void {
+    if (retained.at(-1) !== interaction) retained.push(interaction);
   }
+</script>
+
+<script lang="ts">
+  import type { FrequencyRendererProps } from '../../../../component-kit-api/src/index';
 
   let {
-    confirmedHz,
-    displayHz,
-    pendingDisplayHz = null,
-    disabled = false,
-    contextKey,
-    onFreqChange,
-  }: Props = $props();
-
-  let readout = $derived(projectFrequencyReadout({
-    confirmedHz,
-    displayHz,
-    pendingDisplayHz,
-  }));
-  const interaction = createFrequencyInteraction({
-    get confirmedHz() { return confirmedHz; },
-    get digits() { return readout.digits; },
-    get disabled() { return disabled; },
-    get contextKey() { return contextKey; },
-    minFreq: 0,
-    maxFreq: 999_000_000,
-    get onFreqChange() { return onFreqChange; },
-  });
+    model, interaction, presentation, compact, active, receiver, vfoFreqHook,
+  }: FrequencyRendererProps = $props();
+  $effect(() => retain(interaction));
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
@@ -42,11 +24,16 @@
   role="group"
   tabindex="0"
   data-alternate-frequency-readout
-  data-source={readout.source}
+  data-source={model.source}
+  data-presentation={presentation}
+  data-compact={compact}
+  data-active={active}
+  data-receiver={receiver}
+  data-vfo-freq-hook={vfoFreqHook}
   aria-disabled={interaction.inert}
   onkeydown={interaction.handleKeyDown}
 >
-  {#each readout.digits as digit}
+  {#each model.digits as digit}
     <button
       type="button"
       data-multiplier={digit.multiplier}

--- a/frontend/src/primitives/frequency/__tests__/StandardFrequencyReadout.isolated.test.ts
+++ b/frontend/src/primitives/frequency/__tests__/StandardFrequencyReadout.isolated.test.ts
@@ -1,8 +1,17 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import type { ComponentProps } from 'svelte';
+import type { FrequencyRenderer } from '../../../../component-kit-api/src/index';
+
+const selectedFrequency = vi.hoisted(() => ({ current: undefined as unknown }));
+vi.mock('../../../component-kits/activation', () => ({
+  getSelectedFrequencyReadout: () => selectedFrequency.current,
+}));
+
 import StandardFrequencyReadout from '../StandardFrequencyReadout.svelte';
-import AlternateFrequencyReadoutHarness from './AlternateFrequencyReadoutHarness.svelte';
+import AlternateFrequencyReadoutHarness, {
+  clearRetainedInteractions, retainedInteractions,
+} from './AlternateFrequencyReadoutHarness.svelte';
 import { projectFrequencyReadout } from '../frequency-readout';
 import FrequencyDisplay from '../../../components-v2/display/FrequencyDisplay.svelte';
 
@@ -16,9 +25,16 @@ function mountReadout(props: ComponentProps<typeof StandardFrequencyReadout>): H
   return target;
 }
 
+beforeEach(() => {
+  selectedFrequency.current = undefined;
+  clearRetainedInteractions();
+});
+
 afterEach(() => {
   mounted.forEach((component) => unmount(component));
   mounted.length = 0;
+  selectedFrequency.current = undefined;
+  clearRetainedInteractions();
   document.body.innerHTML = '';
 });
 
@@ -119,30 +135,32 @@ describe('StandardFrequencyReadout', () => {
 });
 
 describe('alternate frequency renderer', () => {
-  it('uses the shared behavior while keeping pending display out of arithmetic', () => {
-    const onFreqChange = vi.fn();
+  it('receives the real passive interaction and stays inert after teardown', () => {
+    selectedFrequency.current = AlternateFrequencyReadoutHarness as FrequencyRenderer;
     const target = document.createElement('div');
     document.body.appendChild(target);
-    mounted.push(mount(AlternateFrequencyReadoutHarness, {
+    mounted.push(mount(FrequencyDisplay, {
       target,
-      props: {
-        confirmedHz: 14_250_000,
-        pendingDisplayHz: 14_260_000,
-        onFreqChange,
-      },
+      props: { freq: 14_250_000, compact: true, active: false, receiver: 'sub' },
     }));
     flushSync();
 
     const root = target.querySelector<HTMLElement>('[data-alternate-frequency-readout]')!;
-    const oneKhz = target.querySelector<HTMLButtonElement>('[data-multiplier="1000"]')!;
-    expect(root.dataset.source).toBe('pending');
-    expect(Array.from(target.querySelectorAll('button')).map((digit) => digit.textContent).join('')).toBe('14260000');
-
-    oneKhz.click();
-    oneKhz.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true, cancelable: true }));
-    flushSync();
-
-    expect(onFreqChange).toHaveBeenCalledExactlyOnceWith(14_251_000);
-    expect(onFreqChange).not.toHaveBeenCalledWith(14_261_000);
+    const interaction = retainedInteractions()[0];
+    const digit = projectFrequencyReadout({ confirmedHz: 14_250_000 }).digits[0];
+    expect(root.dataset.presentation).toBe('passive');
+    expect(root.dataset.compact).toBe('true');
+    expect(root.dataset.active).toBe('false');
+    expect(root.dataset.receiver).toBe('sub');
+    expect(root.dataset.vfoFreqHook).toBe('false');
+    expect(Array.from(target.querySelectorAll('button')).map((digit) => digit.textContent).join('')).toBe('14250000');
+    const wheel = new WheelEvent('wheel', { deltaY: -1, cancelable: true });
+    interaction.handleDigitClick(digit, new MouseEvent('click'));
+    interaction.handleWheel(digit, wheel);
+    interaction.handleKeyDown(new KeyboardEvent('keydown', { key: 'ArrowUp', cancelable: true }));
+    expect(wheel.defaultPrevented).toBe(false);
+    expect(interaction.inert).toBe(true);
+    unmount(mounted.pop()!);
+    expect(interaction.inert).toBe(true);
   });
 });

--- a/frontend/src/primitives/frequency/frequency-interaction.svelte.ts
+++ b/frontend/src/primitives/frequency/frequency-interaction.svelte.ts
@@ -24,6 +24,14 @@ export interface FrequencyInteraction {
   isHovered(digit: DigitInfo): boolean;
 }
 
+export interface FrequencyInteractionLease {
+  readonly interaction: FrequencyInteraction;
+  revoke(): void;
+}
+
+const resetInteraction = new WeakMap<FrequencyInteraction, () => void>();
+const activeRevocation = new WeakMap<FrequencyInteraction, () => void>();
+
 export function createFrequencyInteraction(
   current: FrequencyInteractionInput,
 ): FrequencyInteraction {
@@ -78,7 +86,12 @@ export function createFrequencyInteraction(
     hoveredDigitIndex = null;
   }
 
-  return {
+  function reset(): void {
+    selectedDigitIndex = null;
+    hoveredDigitIndex = null;
+  }
+
+  const interaction: FrequencyInteraction = {
     get inert() { return inert; },
     get selectedDigitIndex() { return selectedDigitIndex; },
     get hoveredDigitIndex() { return hoveredDigitIndex; },
@@ -90,4 +103,39 @@ export function createFrequencyInteraction(
     isSelected: (digit) => selectedDigitIndex === digit.digitIndex,
     isHovered: (digit) => hoveredDigitIndex === digit.digitIndex,
   };
+  resetInteraction.set(interaction, reset);
+  return interaction;
+}
+
+export function createFrequencyInteractionLease(
+  owner: FrequencyInteraction,
+  isCurrent: () => boolean,
+): FrequencyInteractionLease {
+  let revoked = false;
+  function active(): boolean {
+    return !revoked && activeRevocation.get(owner) === revoke && isCurrent();
+  }
+  function revoke(): void {
+    if (revoked) return;
+    revoked = true;
+    if (activeRevocation.get(owner) !== revoke) return;
+    activeRevocation.delete(owner);
+    resetInteraction.get(owner)?.();
+  }
+
+  activeRevocation.get(owner)?.();
+  activeRevocation.set(owner, revoke);
+  const interaction: FrequencyInteraction = {
+    get inert() { return !active() || owner.inert; },
+    get selectedDigitIndex() { return active() ? owner.selectedDigitIndex : null; },
+    get hoveredDigitIndex() { return active() ? owner.hoveredDigitIndex : null; },
+    handleWheel(digit, event) { if (active()) owner.handleWheel(digit, event); },
+    handleDigitClick(digit, event) { if (active()) owner.handleDigitClick(digit, event); },
+    handleKeyDown(event) { if (active()) owner.handleKeyDown(event); },
+    handleDigitEnter(digit) { if (active()) owner.handleDigitEnter(digit); },
+    handleDigitLeave() { if (active()) owner.handleDigitLeave(); },
+    isSelected: (digit) => active() && owner.isSelected(digit),
+    isHovered: (digit) => active() && owner.isHovered(digit),
+  };
+  return { interaction, revoke };
 }

--- a/frontend/src/primitives/frequency/frequency-interaction.svelte.ts
+++ b/frontend/src/primitives/frequency/frequency-interaction.svelte.ts
@@ -26,6 +26,7 @@ export interface FrequencyInteraction {
 
 export interface FrequencyInteractionLease {
   readonly interaction: FrequencyInteraction;
+  readonly revoked: boolean;
   revoke(): void;
 }
 
@@ -156,5 +157,5 @@ export function createFrequencyInteractionLease(
     isSelected: (digit) => active() && owner.isSelected(digit),
     isHovered: (digit) => active() && owner.isHovered(digit),
   };
-  return { interaction, revoke };
+  return { interaction, get revoked() { return revoked; }, revoke };
 }

--- a/frontend/src/primitives/frequency/frequency-interaction.svelte.ts
+++ b/frontend/src/primitives/frequency/frequency-interaction.svelte.ts
@@ -112,28 +112,47 @@ export function createFrequencyInteractionLease(
   isCurrent: () => boolean,
 ): FrequencyInteractionLease {
   let revoked = false;
-  function active(): boolean {
-    return !revoked && activeRevocation.get(owner) === revoke && isCurrent();
-  }
-  function revoke(): void {
-    if (revoked) return;
-    revoked = true;
-    if (activeRevocation.get(owner) !== revoke) return;
-    activeRevocation.delete(owner);
+  let resetGeneration = 0;
+  function clearOwner(): void {
+    resetGeneration += 1;
     resetInteraction.get(owner)?.();
   }
+  function deferOwnerReset(): void {
+    const generation = ++resetGeneration;
+    queueMicrotask(() => {
+      if (generation === resetGeneration && revoked && !activeRevocation.has(owner)) clearOwner();
+    });
+  }
+  function latch(resetNow: boolean): void {
+    const owned = activeRevocation.get(owner) === revoke;
+    revoked = true;
+    if (owned) activeRevocation.delete(owner);
+    if (resetNow && (owned || !activeRevocation.has(owner))) clearOwner();
+    else if (!activeRevocation.has(owner)) deferOwnerReset();
+  }
+  function active(resetNow = false): boolean {
+    if (revoked || activeRevocation.get(owner) !== revoke) return false;
+    if (isCurrent()) return true;
+    latch(resetNow);
+    return false;
+  }
+  function revoke(): void {
+    latch(true);
+  }
 
-  activeRevocation.get(owner)?.();
+  const previous = activeRevocation.get(owner);
+  if (previous) previous();
+  else resetInteraction.get(owner)?.();
   activeRevocation.set(owner, revoke);
   const interaction: FrequencyInteraction = {
     get inert() { return !active() || owner.inert; },
     get selectedDigitIndex() { return active() ? owner.selectedDigitIndex : null; },
     get hoveredDigitIndex() { return active() ? owner.hoveredDigitIndex : null; },
-    handleWheel(digit, event) { if (active()) owner.handleWheel(digit, event); },
-    handleDigitClick(digit, event) { if (active()) owner.handleDigitClick(digit, event); },
-    handleKeyDown(event) { if (active()) owner.handleKeyDown(event); },
-    handleDigitEnter(digit) { if (active()) owner.handleDigitEnter(digit); },
-    handleDigitLeave() { if (active()) owner.handleDigitLeave(); },
+    handleWheel(digit, event) { if (active(true)) owner.handleWheel(digit, event); },
+    handleDigitClick(digit, event) { if (active(true)) owner.handleDigitClick(digit, event); },
+    handleKeyDown(event) { if (active(true)) owner.handleKeyDown(event); },
+    handleDigitEnter(digit) { if (active(true)) owner.handleDigitEnter(digit); },
+    handleDigitLeave() { if (active(true)) owner.handleDigitLeave(); },
     isSelected: (digit) => active() && owner.isSelected(digit),
     isHovered: (digit) => active() && owner.isHovered(digit),
   };

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -142,6 +142,7 @@
      */
     indicatorReceiver?: ReceiverId;
     continuitySession?: MeterContinuitySession | null;
+    frequencyLifetimeKey?: string;
     /**
      * MOR-1321 (v3-rework slice S3a) — the VFO-scoped ACTIONS the legacy
      * `VfoOps` bridge carried and the semantic deck lost at MOR-1313: equalize
@@ -180,6 +181,7 @@
     pendingFrequencyHz,
     indicatorReceiver,
     continuitySession,
+    frequencyLifetimeKey,
     onEqualizeVfos,
     onSwapVfos,
     onQuickSplit,
@@ -598,7 +600,7 @@
               freq={vfo.frequencyHz}
               {displayHz}
               disabled={readoutDisabled(vfo)}
-              contextKey={`${viewModel.topologyId}:${vfo.receiver}:${slotKey(vfo.slot)}`}
+              contextKey={`${frequencyLifetimeKey ?? 'unscoped'}:${viewModel.topologyId}:${vfo.receiver}:${slotKey(vfo.slot)}`}
               pendingDisplayHz={pendingHz}
               pendingAnnouncement={pendingHz !== null ? t('core.vfo.freq.pendingAnnouncement') : undefined}
               compact={appearance === 'semantic'}

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -904,7 +904,7 @@
           pendingDisplayHz={dominant ? pendingFrequencyHz?.[receiver] ?? null : null}
           frequencyState={dominant?.display?.frequencyHz.state ?? (dominant?.frequencyHz == null ? 'unknown' : 'current')}
           staleReason={t('core.rxTx.target.reason.stale')}
-          contextKey={`${viewModel.topologyId}:${receiver}:${dominant ? slotKey(dominant.slot) : 'unknown'}`}
+          contextKey={`${frequencyLifetimeKey ?? 'unscoped'}:${viewModel.topologyId}:${receiver}:${dominant ? slotKey(dominant.slot) : 'unknown'}`}
           frequencyDisabled={!dominant || readoutDisabled(dominant)}
           mode={dominant ? displayValue(dominant.display?.mode, dominant.mode) : null}
           filter={dominant ? displayValue(dominant.display?.filter, dominant.filter) : null}


### PR DESCRIPTION
## Summary

- mount the configured frequency renderer in interactive and passive seats while retaining the built-in default
- keep stale renderer facades permanently inert across renderer, VFO context, control-session epoch, provider generation, and teardown boundaries
- recover a mounted interactive seat with a fresh host-private lease after an observed context A → B → A mismatch
- propagate the existing frequency lifetime key into the live Standard VFO composition
- preserve confirmed-Hz arithmetic, deliberate digit arming, pending display-only behavior, native markup/ARIA fallback, and public API v1 shapes

Linear owner: https://linear.app/morozsm/issue/MOR-2425

P2a dependency is accepted in main as `35e2b95a41991d1bb6bb9c3ca7bc672e7c50c71d`. PR #3284 is not a dependency and no VFO operation code is changed.

## Correction history

Two independent exact-head reviews were BLOCKED and remain part of the record:

1. `82568b3cf88e99bc431f7bc40a5a0cf7da87aed9`: stale facade could revive after A → B → A.
2. `81fb6789d8a4eabb406e3c3b81fbb8e4d64914e8`: stale facade stayed revoked, but the mounted seat could remain attached to it after a no-flush A → B → A sequence.

After those two negative reviews, the user explicitly authorized one additional bounded correction/review/check cycle with “продолжай”. Candidate `e185aed04356eb071347e6ae349b3e1d7667e238` exposes only the already-latched private lease revocation bit to the existing host effect, rotates that lease even when the final identity returns to A, and prefixes the live Standard caller with the existing frequency lifetime key.

Scope is exactly five correction paths and 28 correction A+D; the whole PR remains 532 A+D across the original nine leased paths. The unresolved fully unobserved/coalesced topology-publication A → B → A question is not claimed by this correction.

## Verification

Accepted-main baseline: natural quick run `34053557527` succeeded at `1d04bcc75ca04c59d195431123182632c42f89eb`.

Meaningful second-correction RED on frozen `81fb6789d8a4eabb406e3c3b81fbb8e4d64914e8`: the mounted external-renderer test failed 1/16 because the post-flush facade was still the original revoked facade.

Focused GREEN on `e185aed04356eb071347e6ae349b3e1d7667e238`:

- three focused Vitest files — 46 passed
- `npm run check` — 0 errors, 0 warnings
- scoped ESLint over the five correction paths — passed
- `npm run verify:component-kit-api` — passed
- `git diff --check` — passed

The prior natural quick/visual successes covered `81fb6789d8a4eabb406e3c3b81fbb8e4d64914e8`, not this corrected head. This Ready head requires its one natural required run and a fresh independent exact-head review.

No full suite, workflow rerun, deployment, hardware validation, or merge was performed.
