### PR TITLE
MOR-2425: add revocable finite renderer seats

### DIFF
--- a/frontend/src/primitives/control-instruments/ControlInstrumentRendererHost.svelte
+++ b/frontend/src/primitives/control-instruments/ControlInstrumentRendererHost.svelte
@@ -1,0 +1,16 @@
+<script lang="ts" generics="Lease extends { dispose(): void }, Seat extends FiniteRendererSeat<Lease>">
+  import { onDestroy, untrack, type Component } from 'svelte';
+  import type { FiniteRendererSeat } from './control-instrument-renderer.svelte';
+
+  interface Props {
+    seat: Seat;
+    renderer: Component<{ lease: Lease }>;
+  }
+
+  let { seat, renderer: Renderer }: Props = $props();
+  // The keyed parent makes renderer/context replacement an instance boundary.
+  const lease = untrack(() => seat.attachRenderer());
+  onDestroy(() => lease.dispose());
+</script>
+
+<Renderer {lease} />

--- a/frontend/src/primitives/control-instruments/__tests__/control-instrument-renderer.test.ts
+++ b/frontend/src/primitives/control-instruments/__tests__/control-instrument-renderer.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createAbsoluteChoiceRendererSeat,
+  createActionRendererSeat,
+  createChoiceRendererSeat,
+  createFiniteRendererContext,
+  createToggleRendererSeat,
+  type ControlOption,
+  type FiniteRendererContext,
+} from '../control-instrument-renderer.svelte';
+import type { InstrumentField } from '../control-instrument-behavior';
+
+const field = <T>(value: T): InstrumentField<T> => ({
+  availability: { structural: true, operational: true },
+  reading: { status: 'known', value },
+});
+const unknown = <T>(): InstrumentField<T> => ({
+  availability: { structural: true, operational: true }, reading: { status: 'unknown' },
+});
+
+describe('finite renderer leases', () => {
+  it('permanently refuses a retained A1 callback after A-B-A without cleanup', () => {
+    let context = createFiniteRendererContext();
+    let current = field(1);
+    const invoke = vi.fn();
+    const seat = createActionRendererSeat(() => ({ context, field: current, label: '+', invoke }));
+    const stale = seat.attachRenderer();
+
+    context = createFiniteRendererContext();
+    context = createFiniteRendererContext();
+    stale.invoke();
+    expect(stale.active).toBe(false);
+    expect(invoke).not.toHaveBeenCalled();
+
+    const replacement = seat.attachRenderer();
+    replacement.invoke();
+    expect(replacement.active).toBe(true);
+    expect(invoke).toHaveBeenCalledOnce();
+  });
+
+  it('keeps simultaneous leases independent and destroys all only with the seat', () => {
+    const context = createFiniteRendererContext();
+    const invoke = vi.fn();
+    const seat = createActionRendererSeat(() => ({ context, field: field(1), label: 'Run', invoke }));
+    const first = seat.attachRenderer();
+    const second = seat.attachRenderer();
+    expect(first.active).toBe(true);
+    expect(second.active).toBe(true);
+    first.dispose();
+    second.invoke();
+    expect(first.active).toBe(false);
+    expect(second.active).toBe(true);
+    expect(invoke).toHaveBeenCalledOnce();
+    seat.destroy();
+    expect(second.active).toBe(false);
+    second.invoke();
+    expect(invoke).toHaveBeenCalledOnce();
+  });
+
+  it('re-reads current toggle truth and carries no unsourced evidence', () => {
+    const context = createFiniteRendererContext();
+    let current = field(false);
+    const invoke = vi.fn();
+    const seat = createToggleRendererSeat(() => ({ context, field: current, label: 'Hold', invoke }));
+    const lease = seat.attachRenderer();
+    expect(lease.view).toEqual({ label: 'Hold', available: true, confirmed: false });
+    current = field(true);
+    expect(lease.view?.confirmed).toBe(true);
+    expect('defaultValue' in lease.view!).toBe(false);
+    expect('requested' in lease.view!).toBe(false);
+    expect('feedback' in lease.view!).toBe(false);
+    lease.invoke();
+    expect(invoke).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  it('carries a supplied default only as presentation metadata', () => {
+    const context = createFiniteRendererContext();
+    const seat = createToggleRendererSeat(() => ({
+      context, field: field(true), label: 'Dual', defaultValue: false, invoke: vi.fn(),
+    }));
+    expect(seat.attachRenderer().view?.defaultValue).toBe(false);
+  });
+
+  it('keeps exact reading, admitted selection and disabled-option admission distinct', () => {
+    const context = createFiniteRendererContext();
+    let current = field('DATA2');
+    let options: readonly ControlOption<string>[] = [
+      { value: 'OFF', label: 'Off' }, { value: 'DATA1', label: 'Data 1', disabled: true },
+    ];
+    const invoke = vi.fn();
+    const seat = createChoiceRendererSeat(() => ({
+      context, field: current, label: 'Data', options, invoke,
+    }));
+    const lease = seat.attachRenderer();
+    expect(lease.view?.reading).toEqual({ status: 'known', value: 'DATA2' });
+    expect(lease.view?.selected).toBeUndefined();
+    expect('defaultValue' in lease.view!).toBe(false);
+    lease.invoke('DATA1');
+    lease.invoke('outside');
+    expect(invoke).not.toHaveBeenCalled();
+    options = [{ value: 'OFF', label: 'Off' }, { value: 'DATA1', label: 'Data 1' }];
+    lease.invoke('DATA1');
+    expect(invoke).toHaveBeenCalledExactlyOnceWith('DATA1');
+    current = unknown();
+    expect(lease.view?.reading).toEqual({ status: 'unknown' });
+  });
+
+  it('keeps an unknown absolute choice actionable through the existing binding', () => {
+    const context = createFiniteRendererContext();
+    const invoke = vi.fn();
+    const seat = createAbsoluteChoiceRendererSeat(() => ({
+      context, reading: { status: 'unknown' }, available: true, label: 'Band',
+      options: [{ value: 20, label: '20 m' }], invoke,
+    }));
+    const lease = seat.attachRenderer();
+    expect(lease.view?.available).toBe(true);
+    expect(lease.view?.selected).toBeUndefined();
+    lease.invoke(20);
+    expect(invoke).toHaveBeenCalledExactlyOnceWith(20);
+  });
+
+  it('requires a real non-null context and latches mismatch before behavior reads', () => {
+    let context: FiniteRendererContext | null = null;
+    const readField = vi.fn(() => field(1));
+    const seat = createActionRendererSeat(() => ({
+      context, get field() { return readField(); }, label: 'Run', invoke: vi.fn(),
+    }));
+    const lease = seat.attachRenderer();
+    expect(lease.active).toBe(false);
+    context = createFiniteRendererContext();
+    expect(lease.view).toBeUndefined();
+    expect(readField).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/primitives/control-instruments/__tests__/control-instrument-renderer.test.ts
+++ b/frontend/src/primitives/control-instruments/__tests__/control-instrument-renderer.test.ts
@@ -131,4 +131,38 @@ describe('finite renderer leases', () => {
     expect(lease.view).toBeUndefined();
     expect(readField).not.toHaveBeenCalled();
   });
+
+  it('does not project a field choice before null or stale context admission', () => {
+    let context: FiniteRendererContext | null = null;
+    const readField = vi.fn(() => field('A'));
+    const seat = createChoiceRendererSeat(() => ({
+      context, get field() { return readField(); }, label: 'Mode',
+      options: [{ value: 'A', label: 'A' }], invoke: vi.fn(),
+    }));
+    const nullLease = seat.attachRenderer();
+    expect(nullLease.view).toBeUndefined();
+    nullLease.invoke('A');
+    expect(readField).not.toHaveBeenCalled();
+
+    context = createFiniteRendererContext();
+    const stale = seat.attachRenderer();
+    readField.mockClear();
+    context = createFiniteRendererContext();
+    context = createFiniteRendererContext();
+    expect(stale.view).toBeUndefined();
+    stale.invoke('A');
+    expect(readField).not.toHaveBeenCalled();
+  });
+
+  it('does not read an absolute choice before context admission', () => {
+    const readReading = vi.fn(() => ({ status: 'unknown' as const }));
+    const seat = createAbsoluteChoiceRendererSeat(() => ({
+      context: null, get reading() { return readReading(); }, available: true, label: 'Band',
+      options: [{ value: 20, label: '20 m' }], invoke: vi.fn(),
+    }));
+    const lease = seat.attachRenderer();
+    expect(lease.view).toBeUndefined();
+    lease.invoke(20);
+    expect(readReading).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte
+++ b/frontend/src/primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte
@@ -1,0 +1,59 @@
+<script module lang="ts">
+  export const retainedInvocations = new Map<string, (value?: unknown) => void>();
+  export const resetRetainedInvocations = () => retainedInvocations.clear();
+</script>
+
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type {
+    ActionRendererLease, ChoiceRendererLease, ToggleRendererLease,
+  } from '../../control-instrument-renderer.svelte';
+
+  type Lease = ActionRendererLease | ToggleRendererLease | ChoiceRendererLease<unknown>;
+  let { lease }: { lease: Lease } = $props();
+  let view = $derived(lease.view);
+
+  function invoke(value?: unknown): void {
+    const current = lease.view;
+    if (current && 'options' in current) {
+      (lease as ChoiceRendererLease<unknown>).invoke(value);
+    } else {
+      (lease as ActionRendererLease | ToggleRendererLease).invoke();
+    }
+  }
+
+  onMount(() => {
+    const label = lease.view?.label;
+    if (label) retainedInvocations.set(label, invoke);
+  });
+</script>
+
+{#if view}
+  {#if 'options' in view}
+    <div
+      role="radiogroup" aria-label={view.accessibleLabel ?? view.label}
+      data-reading={view.reading.status === 'known' ? String(view.reading.value) : 'unknown'}
+      data-testid={`external-${view.label}`}
+    >
+      {#each view.options as option (option.value)}
+        <button
+          type="button" role="radio" aria-checked={Object.is(view.selected, option.value)}
+          disabled={!view.available || option.disabled === true}
+          data-testid={`external-${view.label}-${option.value}`}
+          onclick={() => invoke(option.value)}
+        >{option.label}</button>
+      {/each}
+    </div>
+  {:else if 'confirmed' in view}
+    <button
+      type="button" aria-pressed={view.confirmed} disabled={!view.available}
+      aria-label={view.accessibleLabel ?? view.label} data-testid={`external-${view.label}`}
+      onclick={() => invoke()}
+    >{view.label}</button>
+  {:else}
+    <button
+      type="button" disabled={!view.available} aria-label={view.accessibleLabel ?? view.label}
+      data-testid={`external-${view.label}`} onclick={() => invoke()}
+    >{view.label}</button>
+  {/if}
+{/if}

--- a/frontend/src/primitives/control-instruments/control-instrument-renderer.svelte.ts
+++ b/frontend/src/primitives/control-instruments/control-instrument-renderer.svelte.ts
@@ -225,7 +225,6 @@ export function createToggleRendererSeat<Feedback = never>(
 }
 
 function createChoiceLease<T, Feedback, Input extends RendererInput & {
-  readonly reading: InstrumentReading<T>;
   readonly options: readonly ControlOption<T>[];
   readonly defaultValue?: T;
   readonly requested?: RequestedTarget<T>;
@@ -233,13 +232,14 @@ function createChoiceLease<T, Feedback, Input extends RendererInput & {
 }>(
   guard: LeaseGuard<Input>,
   behavior: ReturnType<typeof bindChoiceInstrument<T, Feedback>>,
+  readingOf: (input: Input) => InstrumentReading<T>,
 ): ChoiceRendererLease<T, Feedback> {
   return {
     get active() { return guard.current() !== undefined; },
     get view() {
       const input = guard.current();
       return input === undefined ? undefined : {
-        ...labelView(input), available: behavior.available, reading: input.reading,
+        ...labelView(input), available: behavior.available, reading: readingOf(input),
         selected: behavior.selected, options: input.options,
         ...(input.defaultValue === undefined ? {} : { defaultValue: input.defaultValue }),
         ...(input.requested === undefined ? {} : { requested: input.requested }),
@@ -266,11 +266,9 @@ export function createChoiceRendererSeat<T, Feedback = never>(
       feedback: input.feedback, invoke: input.invoke,
     };
   });
-  const read = () => {
-    const input = readCurrent();
-    return { ...input, reading: input.field?.reading ?? { status: 'unknown' as const } };
-  };
-  return createSeat(read, guard => createChoiceLease(guard, behavior));
+  return createSeat(readCurrent, guard => createChoiceLease(
+    guard, behavior, input => input.field?.reading ?? { status: 'unknown' },
+  ));
 }
 
 export function createAbsoluteChoiceRendererSeat<T, Feedback = never>(
@@ -285,5 +283,5 @@ export function createAbsoluteChoiceRendererSeat<T, Feedback = never>(
       feedback: input.feedback, invoke: input.invoke,
     };
   });
-  return createSeat(readCurrent, guard => createChoiceLease(guard, behavior));
+  return createSeat(readCurrent, guard => createChoiceLease(guard, behavior, input => input.reading));
 }

--- a/frontend/src/primitives/control-instruments/control-instrument-renderer.svelte.ts
+++ b/frontend/src/primitives/control-instruments/control-instrument-renderer.svelte.ts
@@ -1,0 +1,289 @@
+import type { Component } from 'svelte';
+import {
+  bindAbsoluteChoiceInstrument,
+  bindActionInstrument,
+  bindChoiceInstrument,
+  bindToggleInstrument,
+  type InstrumentField,
+  type InstrumentReading,
+} from './control-instrument-behavior';
+
+declare const finiteRendererContextBrand: unique symbol;
+export type FiniteRendererContext = Readonly<{ [finiteRendererContextBrand]: true }>;
+
+export const createFiniteRendererContext = (): FiniteRendererContext =>
+  Object.freeze({}) as FiniteRendererContext;
+
+export interface ControlLabel {
+  readonly label: string;
+  readonly accessibleLabel?: string;
+  readonly title?: string;
+}
+
+export interface ControlOption<T> {
+  readonly value: T;
+  readonly label: string;
+  readonly disabled?: boolean;
+}
+
+export interface RequestedTarget<T> {
+  readonly kind: 'requested-target';
+  readonly target: T;
+}
+
+interface RendererInput extends ControlLabel {
+  readonly context: FiniteRendererContext | null;
+}
+
+interface FieldRendererInput<T, Feedback> extends RendererInput {
+  readonly field: InstrumentField<T> | undefined;
+  readonly blocked?: boolean;
+  readonly feedback?: Feedback;
+}
+
+export interface ActionRendererInput<T, Feedback = never> extends FieldRendererInput<T, Feedback> {
+  readonly invoke: () => void;
+}
+
+export interface ToggleRendererInput<Feedback = never> extends FieldRendererInput<boolean, Feedback> {
+  readonly defaultValue?: boolean;
+  readonly requested?: RequestedTarget<boolean>;
+  readonly invoke: (next: boolean) => void;
+}
+
+export interface ChoiceRendererInput<T, Feedback = never> extends FieldRendererInput<T, Feedback> {
+  readonly options: readonly ControlOption<T>[];
+  readonly defaultValue?: T;
+  readonly requested?: RequestedTarget<T>;
+  readonly invoke: (value: T) => void;
+}
+
+export interface AbsoluteChoiceRendererInput<T, Feedback = never> extends RendererInput {
+  readonly reading: InstrumentReading<T>;
+  readonly available: boolean;
+  readonly blocked?: boolean;
+  readonly options: readonly ControlOption<T>[];
+  readonly defaultValue?: T;
+  readonly requested?: RequestedTarget<T>;
+  readonly feedback?: Feedback;
+  readonly invoke: (value: T) => void;
+}
+
+export interface ActionRendererView<Feedback = unknown> extends ControlLabel {
+  readonly available: boolean;
+  readonly feedback?: Feedback;
+}
+
+export interface ToggleRendererView<Feedback = unknown> extends ControlLabel {
+  readonly available: boolean;
+  readonly confirmed: boolean | undefined;
+  readonly defaultValue?: boolean;
+  readonly requested?: RequestedTarget<boolean>;
+  readonly feedback?: Feedback;
+}
+
+export interface ChoiceRendererView<T, Feedback = unknown> extends ControlLabel {
+  readonly available: boolean;
+  readonly reading: InstrumentReading<T>;
+  readonly selected: T | undefined;
+  readonly options: readonly ControlOption<T>[];
+  readonly defaultValue?: T;
+  readonly requested?: RequestedTarget<T>;
+  readonly feedback?: Feedback;
+}
+
+export interface FiniteRendererLease<View> {
+  readonly active: boolean;
+  readonly view: View | undefined;
+  dispose(): void;
+}
+
+export interface ActionRendererLease<Feedback = unknown>
+  extends FiniteRendererLease<ActionRendererView<Feedback>> {
+  invoke(): void;
+}
+
+export interface ToggleRendererLease<Feedback = unknown>
+  extends FiniteRendererLease<ToggleRendererView<Feedback>> {
+  invoke(): void;
+}
+
+export interface ChoiceRendererLease<T, Feedback = unknown>
+  extends FiniteRendererLease<ChoiceRendererView<T, Feedback>> {
+  invoke(value: T): void;
+}
+
+export interface FiniteRendererSeat<Lease> {
+  attachRenderer(): Lease;
+  destroy(): void;
+}
+
+export type ActionRendererSeat<Feedback = unknown> = FiniteRendererSeat<ActionRendererLease<Feedback>>;
+export type ToggleRendererSeat<Feedback = unknown> = FiniteRendererSeat<ToggleRendererLease<Feedback>>;
+export type ChoiceRendererSeat<T, Feedback = unknown> = FiniteRendererSeat<ChoiceRendererLease<T, Feedback>>;
+
+export interface ActionRendererProps { readonly lease: ActionRendererLease }
+export interface ToggleRendererProps { readonly lease: ToggleRendererLease }
+export interface ChoiceRendererProps<T> { readonly lease: ChoiceRendererLease<T> }
+
+export interface FiniteControlAppearance<T = unknown> {
+  readonly action: Component<ActionRendererProps>;
+  readonly toggle: Component<ToggleRendererProps>;
+  readonly choice: Component<ChoiceRendererProps<T>>;
+}
+
+interface LeaseGuard<Input extends RendererInput> {
+  current(): Input | undefined;
+  dispose(): void;
+}
+
+function createSeat<Input extends RendererInput, Lease>(
+  readCurrent: () => Input,
+  createLease: (guard: LeaseGuard<Input>) => Lease,
+): FiniteRendererSeat<Lease> {
+  let destroyed = false;
+  const revokers = new Set<() => void>();
+  return {
+    attachRenderer() {
+      const captured = readCurrent().context;
+      let revoked = captured === null;
+      const revoke = () => {
+        if (revoked) return;
+        revoked = true;
+        revokers.delete(revoke);
+      };
+      if (!revoked) revokers.add(revoke);
+      return createLease({
+        current() {
+          if (destroyed || revoked) return undefined;
+          const current = readCurrent();
+          if (current.context === null || !Object.is(current.context, captured)) {
+            revoke();
+            return undefined;
+          }
+          return current;
+        },
+        dispose: revoke,
+      });
+    },
+    destroy() {
+      if (destroyed) return;
+      destroyed = true;
+      for (const revoke of [...revokers]) revoke();
+    },
+  };
+}
+
+const labelView = (input: ControlLabel): ControlLabel => ({
+  label: input.label,
+  ...(input.accessibleLabel === undefined ? {} : { accessibleLabel: input.accessibleLabel }),
+  ...(input.title === undefined ? {} : { title: input.title }),
+});
+
+const feedbackView = <Feedback>(feedback: Feedback | undefined) =>
+  feedback === undefined ? {} : { feedback };
+
+export function createActionRendererSeat<T, Feedback = never>(
+  readCurrent: () => ActionRendererInput<T, Feedback>,
+): ActionRendererSeat<Feedback> {
+  const behavior = bindActionInstrument<T, Feedback>(() => readCurrent());
+  return createSeat(readCurrent, (guard) => ({
+    get active() { return guard.current() !== undefined; },
+    get view() {
+      const input = guard.current();
+      return input === undefined ? undefined : {
+        ...labelView(input), available: behavior.available, ...feedbackView(behavior.feedback),
+      };
+    },
+    invoke() {
+      if (guard.current() !== undefined) behavior.invoke();
+    },
+    dispose: guard.dispose,
+  }));
+}
+
+export function createToggleRendererSeat<Feedback = never>(
+  readCurrent: () => ToggleRendererInput<Feedback>,
+): ToggleRendererSeat<Feedback> {
+  const behavior = bindToggleInstrument<Feedback>(() => readCurrent());
+  return createSeat(readCurrent, (guard) => ({
+    get active() { return guard.current() !== undefined; },
+    get view() {
+      const input = guard.current();
+      return input === undefined ? undefined : {
+        ...labelView(input), available: behavior.available, confirmed: behavior.confirmed,
+        ...(input.defaultValue === undefined ? {} : { defaultValue: input.defaultValue }),
+        ...(input.requested === undefined ? {} : { requested: input.requested }),
+        ...feedbackView(behavior.feedback),
+      };
+    },
+    invoke() {
+      if (guard.current() !== undefined) behavior.invoke();
+    },
+    dispose: guard.dispose,
+  }));
+}
+
+function createChoiceLease<T, Feedback, Input extends RendererInput & {
+  readonly reading: InstrumentReading<T>;
+  readonly options: readonly ControlOption<T>[];
+  readonly defaultValue?: T;
+  readonly requested?: RequestedTarget<T>;
+  readonly feedback?: Feedback;
+}>(
+  guard: LeaseGuard<Input>,
+  behavior: ReturnType<typeof bindChoiceInstrument<T, Feedback>>,
+): ChoiceRendererLease<T, Feedback> {
+  return {
+    get active() { return guard.current() !== undefined; },
+    get view() {
+      const input = guard.current();
+      return input === undefined ? undefined : {
+        ...labelView(input), available: behavior.available, reading: input.reading,
+        selected: behavior.selected, options: input.options,
+        ...(input.defaultValue === undefined ? {} : { defaultValue: input.defaultValue }),
+        ...(input.requested === undefined ? {} : { requested: input.requested }),
+        ...feedbackView(input.feedback),
+      };
+    },
+    invoke(value) {
+      const input = guard.current();
+      const option = input?.options.find(candidate => Object.is(candidate.value, value));
+      if (option !== undefined && option.disabled !== true) behavior.invoke(value);
+    },
+    dispose: guard.dispose,
+  };
+}
+
+export function createChoiceRendererSeat<T, Feedback = never>(
+  readCurrent: () => ChoiceRendererInput<T, Feedback>,
+): ChoiceRendererSeat<T, Feedback> {
+  const behavior = bindChoiceInstrument<T, Feedback>(() => {
+    const input = readCurrent();
+    return {
+      field: input.field, blocked: input.blocked,
+      choices: input.options.map(option => option.value),
+      feedback: input.feedback, invoke: input.invoke,
+    };
+  });
+  const read = () => {
+    const input = readCurrent();
+    return { ...input, reading: input.field?.reading ?? { status: 'unknown' as const } };
+  };
+  return createSeat(read, guard => createChoiceLease(guard, behavior));
+}
+
+export function createAbsoluteChoiceRendererSeat<T, Feedback = never>(
+  readCurrent: () => AbsoluteChoiceRendererInput<T, Feedback>,
+): ChoiceRendererSeat<T, Feedback> {
+  const behavior = bindAbsoluteChoiceInstrument<T, Feedback>(() => {
+    const input = readCurrent();
+    return {
+      choices: input.options.map(option => option.value),
+      selected: input.reading.status === 'known' ? input.reading.value : undefined,
+      available: input.available, blocked: input.blocked,
+      feedback: input.feedback, invoke: input.invoke,
+    };
+  });
+  return createSeat(readCurrent, guard => createChoiceLease(guard, behavior));
+}

--- a/frontend/src/semantic/ScopeControlsSurface.svelte
+++ b/frontend/src/semantic/ScopeControlsSurface.svelte
@@ -67,12 +67,19 @@
 </script>
 
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import {
     bindActionInstrument, bindChoiceInstrument, bindToggleInstrument,
   } from '../primitives/control-instruments/control-instrument-behavior';
+  import ControlInstrumentRendererHost from '../primitives/control-instruments/ControlInstrumentRendererHost.svelte';
+  import {
+    createActionRendererSeat, createChoiceRendererSeat, createToggleRendererSeat,
+    type ActionRendererSeat, type ChoiceRendererSeat, type FiniteControlAppearance,
+    type FiniteRendererContext, type ToggleRendererSeat,
+  } from '../primitives/control-instruments/control-instrument-renderer.svelte';
   import type { RadioViewModel } from './radio-view-model';
 
-  interface Props {
+  interface ExistingProps {
     view: RadioViewModel;
     onToggleChange?: (field: ScopeToggleField, next: boolean) => void;
     onChoiceChange?: (field: ScopeChoiceField, value: number) => void;
@@ -80,8 +87,13 @@
     onSpeedChange?: (speed: number) => void;
     onRefChange?: (ref: number) => void;
   }
+  type RendererSelection =
+    | { finiteAppearance?: undefined; rendererContext?: undefined }
+    | { finiteAppearance: FiniteControlAppearance<number>; rendererContext: FiniteRendererContext };
+  type Props = ExistingProps & RendererSelection;
   let {
     view, onToggleChange, onChoiceChange, onSpanChange, onSpeedChange, onRefChange,
+    finiteAppearance, rendererContext,
   }: Props = $props();
 
   /** Absent group ⇒ this surface renders nothing (S0 optional-group doctrine). */
@@ -122,34 +134,88 @@
       return { field, invoke: () => onRefChange?.(clampRef(numberOf(field!, 0), delta)) };
     });
   }
+
+  const toggleSeats = new Map<ScopeToggleField, ToggleRendererSeat>();
+  const choiceSeats = new Map<ScopeChoiceField, ChoiceRendererSeat<number>>();
+  const actionSeats = new Map<string, ActionRendererSeat>();
+  function toggleSeat(field: ScopeToggleField, label: string): ToggleRendererSeat {
+    let seat = toggleSeats.get(field);
+    if (!seat) {
+      seat = createToggleRendererSeat(() => ({
+        context: rendererContext ?? null, field: sc?.[field], label,
+        invoke: (next) => onToggleChange?.(field, next),
+      }));
+      toggleSeats.set(field, seat);
+    }
+    return seat;
+  }
+  function choiceSeat(field: ScopeChoiceField, label: string, options: readonly (readonly [number, string])[]) {
+    let seat = choiceSeats.get(field);
+    if (!seat) {
+      seat = createChoiceRendererSeat(() => ({
+        context: rendererContext ?? null, field: sc?.[field], label,
+        options: options.map(([value, optionLabel]) => ({ value, label: optionLabel })),
+        invoke: (value) => onChoiceChange?.(field, value),
+      }));
+      choiceSeats.set(field, seat);
+    }
+    return seat;
+  }
+  function actionSeat(field: 'span' | 'speed' | 'refDb', delta: -5 | -1 | 1 | 5, label: string) {
+    const key = `${field}:${delta}`;
+    let seat = actionSeats.get(key);
+    if (!seat) {
+      seat = createActionRendererSeat(() => ({
+        context: rendererContext ?? null, field: sc?.[field], label: delta < 0 ? '−' : '+',
+        accessibleLabel: `${delta < 0 ? 'Decrease' : 'Increase'} ${label}`,
+        invoke: () => {
+          const current = numberOf(sc![field], field === 'span' ? 3 : field === 'speed' ? 1 : 0);
+          if (field === 'span') onSpanChange?.(clampSpan(current, delta as -1 | 1));
+          else if (field === 'speed') onSpeedChange?.(clampSpeed(current, delta as -1 | 1));
+          else onRefChange?.(clampRef(current, delta as -5 | 5));
+        },
+      }));
+      actionSeats.set(key, seat);
+    }
+    return seat;
+  }
+  onDestroy(() => {
+    for (const seat of [...toggleSeats.values(), ...choiceSeats.values(), ...actionSeats.values()]) seat.destroy();
+  });
 </script>
 
 {#if sc}
   <section class="scope-controls-surface" data-testid="scope-controls-surface" aria-label="Scope controls">
     {#if sc.mode.availability.structural}
       {@const behavior = choiceInstrument('mode', MODE_BUTTONS.map(([value]) => value))}
-      <div class="scope-row" role="radiogroup" aria-label="Scope mode" data-testid="scope-mode">
-        {#each MODE_BUTTONS as [v, label] (v)}
-          <button
-            type="button" role="radio" class="scope-choice" data-testid={`scope-mode-${v}`}
-            aria-checked={behavior.isSelected(v)}
-            disabled={!behavior.available} onclick={() => behavior.invoke(v)}
-          >{label}</button>
-        {/each}
+      <div class="scope-row" role={finiteAppearance && rendererContext ? undefined : 'radiogroup'} aria-label="Scope mode" data-testid="scope-mode">
+        {#if finiteAppearance && rendererContext}
+          {#key rendererContext}{#key finiteAppearance.choice}<ControlInstrumentRendererHost
+            seat={choiceSeat('mode', 'Scope mode', MODE_BUTTONS)} renderer={finiteAppearance.choice}
+          />{/key}{/key}
+        {:else}{#each MODE_BUTTONS as [v, label] (v)}
+            <button type="button" role="radio" class="scope-choice" data-testid={`scope-mode-${v}`}
+              aria-checked={behavior.isSelected(v)} disabled={!behavior.available}
+              onclick={() => behavior.invoke(v)}>{label}</button>
+          {/each}
+        {/if}
       </div>
     {/if}
 
     {#each CHOICES as [field, label, options] (field)}
       {#if (field !== 'edge' || edgeApplicable) && sc[field].availability.structural}
         {@const behavior = choiceInstrument(field, options.map(([value]) => value))}
-        <div class="scope-row" role="radiogroup" aria-label={label} data-testid={`scope-${field}`}>
-          {#each options as [v, optLabel] (v)}
-            <button
-              type="button" role="radio" class="scope-choice" data-testid={`scope-${field}-${v}`}
-              aria-checked={behavior.isSelected(v)}
-              disabled={!behavior.available} onclick={() => behavior.invoke(v)}
-            >{optLabel}</button>
-          {/each}
+        <div class="scope-row" role={finiteAppearance && rendererContext ? undefined : 'radiogroup'} aria-label={label} data-testid={`scope-${field}`}>
+          {#if finiteAppearance && rendererContext}
+            {#key rendererContext}{#key finiteAppearance.choice}<ControlInstrumentRendererHost
+              seat={choiceSeat(field, label, options)} renderer={finiteAppearance.choice}
+            />{/key}{/key}
+          {:else}{#each options as [v, optLabel] (v)}
+              <button type="button" role="radio" class="scope-choice" data-testid={`scope-${field}-${v}`}
+                aria-checked={behavior.isSelected(v)} disabled={!behavior.available}
+                onclick={() => behavior.invoke(v)}>{optLabel}</button>
+            {/each}
+          {/if}
         </div>
       {/if}
     {/each}
@@ -159,11 +225,19 @@
       {@const increment = spanInstrument(1)}
       <div class="scope-stepper" data-testid="scope-span">
         <span class="scope-name">SPAN</span>
-        <button type="button" disabled={!decrement.available} onclick={() => decrement.invoke()}>-</button>
+        {#if finiteAppearance && rendererContext}
+          {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
+            seat={actionSeat('span', -1, 'scope span')} renderer={finiteAppearance.action}
+          />{/key}{/key}
+        {:else}<button type="button" disabled={!decrement.available} onclick={() => decrement.invoke()}>-</button>{/if}
         <output data-testid="scope-span-value">
           {usable(sc.span) ? (SPAN_LABELS[numberOf(sc.span, 3)] ?? '?') : UNKNOWN_TEXT}
         </output>
-        <button type="button" disabled={!increment.available} onclick={() => increment.invoke()}>+</button>
+        {#if finiteAppearance && rendererContext}
+          {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
+            seat={actionSeat('span', 1, 'scope span')} renderer={finiteAppearance.action}
+          />{/key}{/key}
+        {:else}<button type="button" disabled={!increment.available} onclick={() => increment.invoke()}>+</button>{/if}
       </div>
     {/if}
 
@@ -172,11 +246,19 @@
       {@const increment = speedInstrument(1)}
       <div class="scope-stepper" data-testid="scope-speed">
         <span class="scope-name">SPEED</span>
-        <button type="button" disabled={!decrement.available} onclick={() => decrement.invoke()}>-</button>
+        {#if finiteAppearance && rendererContext}
+          {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
+            seat={actionSeat('speed', -1, 'scope speed')} renderer={finiteAppearance.action}
+          />{/key}{/key}
+        {:else}<button type="button" disabled={!decrement.available} onclick={() => decrement.invoke()}>-</button>{/if}
         <output data-testid="scope-speed-value">
           {usable(sc.speed) ? (SPEED_LABELS[numberOf(sc.speed, 1)] ?? '?') : UNKNOWN_TEXT}
         </output>
-        <button type="button" disabled={!increment.available} onclick={() => increment.invoke()}>+</button>
+        {#if finiteAppearance && rendererContext}
+          {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
+            seat={actionSeat('speed', 1, 'scope speed')} renderer={finiteAppearance.action}
+          />{/key}{/key}
+        {:else}<button type="button" disabled={!increment.available} onclick={() => increment.invoke()}>+</button>{/if}
       </div>
     {/if}
 
@@ -185,20 +267,31 @@
       {@const increment = refInstrument(5)}
       <div class="scope-stepper" data-testid="scope-ref">
         <span class="scope-name">REF</span>
-        <button type="button" disabled={!decrement.available} onclick={() => decrement.invoke()}>-</button>
+        {#if finiteAppearance && rendererContext}
+          {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
+            seat={actionSeat('refDb', -5, 'scope reference')} renderer={finiteAppearance.action}
+          />{/key}{/key}
+        {:else}<button type="button" disabled={!decrement.available} onclick={() => decrement.invoke()}>-</button>{/if}
         <output data-testid="scope-ref-value">{textOf(sc.refDb)}</output>
-        <button type="button" disabled={!increment.available} onclick={() => increment.invoke()}>+</button>
+        {#if finiteAppearance && rendererContext}
+          {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
+            seat={actionSeat('refDb', 5, 'scope reference')} renderer={finiteAppearance.action}
+          />{/key}{/key}
+        {:else}<button type="button" disabled={!increment.available} onclick={() => increment.invoke()}>+</button>{/if}
       </div>
     {/if}
 
     {#each TOGGLES as [field, label] (field)}
       {#if sc[field].availability.structural}
         {@const behavior = toggleInstrument(field)}
-        <button
-          type="button" class="scope-toggle" data-testid={`scope-${field}`}
-          aria-pressed={behavior.confirmed} disabled={!behavior.available}
-          onclick={() => behavior.invoke()}
-        >{label}: {textOf(sc[field])}</button>
+        {#if finiteAppearance && rendererContext}
+          {#key rendererContext}{#key finiteAppearance.toggle}<ControlInstrumentRendererHost
+            seat={toggleSeat(field, label)} renderer={finiteAppearance.toggle}
+          />{/key}{/key}
+        {:else}<button type="button" class="scope-toggle" data-testid={`scope-${field}`}
+            aria-pressed={behavior.confirmed} disabled={!behavior.available}
+            onclick={() => behavior.invoke()}>{label}: {textOf(sc[field])}</button>
+        {/if}
       {/if}
     {/each}
   </section>

--- a/frontend/src/semantic/__tests__/ScopeControlsSurface.test.ts
+++ b/frontend/src/semantic/__tests__/ScopeControlsSurface.test.ts
@@ -20,6 +20,12 @@ import { flushSync, mount, unmount } from 'svelte';
 import ScopeControlsSurface, {
   CHOICES, TOGGLES, UNKNOWN_TEXT, type ScopeChoiceField, type ScopeToggleField,
 } from '../ScopeControlsSurface.svelte';
+import FiniteControlRendererFixture, {
+  resetRetainedInvocations, retainedInvocations,
+} from '../../primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte';
+import {
+  createFiniteRendererContext, type FiniteControlAppearance,
+} from '../../primitives/control-instruments/control-instrument-renderer.svelte';
 import { topologyFixtures, withScopeControls } from '../fixtures/topologies';
 import type { Availability, RadioViewModel, ScopeControlsField, ScopeControlsViewModel } from '../radio-view-model';
 
@@ -38,7 +44,7 @@ const withSc = (over: Partial<ScopeControlsViewModel>): RadioViewModel => {
 
 let target: HTMLDivElement;
 beforeEach(() => { target = document.createElement('div'); document.body.appendChild(target); });
-afterEach(() => { target.remove(); });
+afterEach(() => { resetRetainedInvocations(); target.remove(); });
 
 type Handlers = {
   onToggleChange?: (field: ScopeToggleField, next: boolean) => void;
@@ -322,5 +328,56 @@ describe('carry-forward (2): receiver is the ONE MAIN/SUB control', () => {
     flushSync();
     expect(onChoiceChange).toHaveBeenCalledExactlyOnceWith('receiver', 1);
     r.dispose();
+  });
+});
+
+describe('external finite appearance', () => {
+  const fixture = FiniteControlRendererFixture as FiniteControlAppearance['action'];
+  const appearance = {
+    action: fixture,
+    toggle: FiniteControlRendererFixture as FiniteControlAppearance['toggle'],
+    choice: FiniteControlRendererFixture as FiniteControlAppearance['choice'],
+  } satisfies FiniteControlAppearance;
+
+  it('uses host labels and the existing Scope action/toggle/choice intents', () => {
+    const onSpanChange = vi.fn(), onToggleChange = vi.fn(), onChoiceChange = vi.fn();
+    const component = mount(ScopeControlsSurface, { target, props: {
+      view: withSc({ mode: known(0), span: known(3), hold: known(false), centerType: known(1) }),
+      finiteAppearance: appearance, rendererContext: createFiniteRendererContext(),
+      onSpanChange, onToggleChange, onChoiceChange,
+    } });
+    flushSync();
+    (target.querySelector('[aria-label="Increase scope span"]') as HTMLButtonElement).click();
+    (target.querySelector('[data-testid="external-HOLD"]') as HTMLButtonElement).click();
+    (target.querySelector('[data-testid="external-Scope center type-2"]') as HTMLButtonElement).click();
+    expect(onSpanChange).toHaveBeenCalledExactlyOnceWith(4);
+    expect(onToggleChange).toHaveBeenCalledExactlyOnceWith('hold', true);
+    expect(onChoiceChange).toHaveBeenCalledExactlyOnceWith('centerType', 2);
+    unmount(component);
+  });
+
+  it('refuses a retained callback after the external renderer unmounts', () => {
+    const onToggleChange = vi.fn();
+    const rendererContext = createFiniteRendererContext();
+    const component = mount(ScopeControlsSurface, { target, props: {
+      view: withSc({ hold: known(false) }), finiteAppearance: appearance, rendererContext, onToggleChange,
+    } });
+    flushSync();
+    const retained = retainedInvocations.get('HOLD')!;
+    unmount(component);
+    retained();
+    expect(onToggleChange).not.toHaveBeenCalled();
+  });
+
+  it('preserves an out-of-list canonical reading without selecting an option', () => {
+    const component = mount(ScopeControlsSurface, { target, props: {
+      view: withSc({ centerType: known(99) }), finiteAppearance: appearance,
+      rendererContext: createFiniteRendererContext(),
+    } });
+    flushSync();
+    const group = target.querySelector('[data-testid="external-Scope center type"]')!;
+    expect(group.getAttribute('data-reading')).toBe('99');
+    expect(group.querySelector('[aria-checked="true"]')).toBeNull();
+    unmount(component);
   });
 });


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-2425/expose-a-supported-v3-host-boundary-for-independently-installed

## Summary
- add independently revocable action, toggle, field-choice, and absolute-choice renderer seats around the existing control-instrument behavior bindings
- require an explicit caller-owned opaque context for the optional external ScopeControls appearance; keep the native path unchanged
- expose host labels, exact readings, admitted selection, optional defaults/requested/feedback, and enforce disabled choices at invocation

## Lifetime contract
- every read and invoke checks the current never-reused context token synchronously
- field-backed and absolute choice readings are projected only after raw context admission
- a mismatch permanently revokes only that renderer lease
- attaching or disposing one same-context renderer does not revoke a neighbor
- appearance/context keyed hosts attach a fresh lease and dispose only their own lease

## Verification
- initial RED: the two new/extended suites failed because the renderer-seat module did not exist
- correction RED: null-context field choice called its field getter twice before refusal
- focused Vitest: 4 files, 60 tests passed
- svelte-check plus TypeScript: 0 errors, 0 warnings
- changed-path ESLint: passed
- diff: 6 files, 709 additions, 29 deletions (738 A+D)

Accepted-base evidence: quick run 34053557527 succeeded at 1d04bcc75ca04c59d195431123182632c42f89eb with frontend=true, core=false, ci=false; 435 files / 10,620 Vitest tests, 87 i18n Playwright tests, and 65 fixture captures.

## Deliberate boundary
This is FC-1a only. It does not edit SemanticRadioSurfaces, VfoSurface, package exports, registration, or activation. Live wiring/token publication remains FC-1b after the current frequency file lease releases.

## Correction cycle
Independent review on the prior head found that field-choice exact-reading projection spread and dereferenced the raw input before context admission. Head 34b38defc guards the raw ChoiceRendererInput first and projects reading only from the admitted input, preserving bindChoiceInstrument as the behavior owner.

## Cohesion
The six files form one renderer-lifetime boundary: shared seats, their Svelte host, one actual Scope surface integration, and the primitive/component regressions for that same contract. The 738 changed lines exceed the soft size threshold but remain within the hard ceiling; splitting the host from its surface witness would leave the lifetime behavior unproven.

