### PR TITLE
MOR-2425: normalize meter motion fractions

### DIFF
--- a/frontend/src/components-v2/meters/BarGauge.svelte
+++ b/frontend/src/components-v2/meters/BarGauge.svelte
@@ -88,7 +88,7 @@
   $effect(() => {
     const continuitySource = source;
     const continuitySession = session;
-    const smoothTarget = value === null ? null : valueToSegments(value, SEG_COUNT);
+    const smoothTarget = value === null ? null : valueToSegments(value, SEG_COUNT) / SEG_COUNT;
     untrack(() => ballistics.sync({
       sample: value, smoothTarget, peakEnabled: showPeak,
       source: continuitySource, session: continuitySession,
@@ -113,11 +113,12 @@
 
   // ── Reactive display values ─────────────────────────────────────────────────
   const measuredFault = $derived(value !== null && fault);
-  let fullSegs = $derived(value === null ? 0 : Math.floor(ballistics.view.smoothedValue));
+  let smoothedSegs = $derived(ballistics.view.smoothedValue * SEG_COUNT);
+  let fullSegs = $derived(value === null ? 0 : Math.floor(smoothedSegs));
   let fracSeg  = $derived(
     value === null
       ? 0
-      : ballistics.view.smoothedValue - Math.floor(ballistics.view.smoothedValue),
+      : smoothedSegs - Math.floor(smoothedSegs),
   );
 </script>
 

--- a/frontend/src/components-v2/meters/LinearSMeter.svelte
+++ b/frontend/src/components-v2/meters/LinearSMeter.svelte
@@ -163,10 +163,10 @@
   // Samples the 20-entry ramp above by fraction of SEG_COUNT, so a non-20
   // segment count still walks the same color progression start-to-end.
   // MOR-2214: at SEG_COUNT === 1 there is no second segment to interpolate
-  // `i / (SEG_COUNT - 1)` against (division by zero). `smoother.value` is
-  // already on the SEG_COUNT-wide domain (see its `.update()` call below),
-  // so `smoother.value / SEG_COUNT` is the reading's own fill fraction —
-  // the single segment samples the ramp by THAT instead of by index, so it
+  // `i / (SEG_COUNT - 1)` against (division by zero). `smoothedSegs` is the
+  // normalized smoother value projected onto the local visual domain, so
+  // dividing it by SEG_COUNT recovers the reading's fill fraction. The
+  // single segment samples the ramp by that value instead of by index, so it
   // still reports strong/over-range readings in the ramp's hot colors
   // rather than collapsing every reading to one fixed color.
   function activeColor(i: number): string {
@@ -346,14 +346,14 @@
     ticker: { kind: 'animation-frame' },
     peak: createFrameStepPeakStrategy({
       holdMilliseconds: 1000,
-      decrementPerFrame: () => PEAK_DECAY_FRACTION * SEG_COUNT * 16.67,
+      decrementPerFrame: () => PEAK_DECAY_FRACTION * 16.67,
     }),
   });
 
   $effect(() => {
     const current = value === null || !mainPresent
       ? null
-      : (calibratedToSegments(value) / RAW_SEGMENT_DOMAIN) * SEG_COUNT;
+      : calibratedToSegments(value) / RAW_SEGMENT_DOMAIN;
     const currentSource = source;
     const currentSession = session;
     untrack(() => ballistics.sync({
@@ -367,8 +367,8 @@
     return () => ballistics.stop();
   });
 
-  let smoothedSegs = $derived(ballistics.view.smoothedValue);
-  let peakSegs = $derived(ballistics.view.peakValue ?? 0);
+  let smoothedSegs = $derived(ballistics.view.smoothedValue * SEG_COUNT);
+  let peakSegs = $derived((ballistics.view.peakValue ?? 0) * SEG_COUNT);
   // Peak X position for the vertical indicator line
   let peakX = $derived(BAR_X + peakSegs * (SEG_W + SEG_GAP));
   // Only show peak line if it's meaningfully ahead of current bar
@@ -394,7 +394,7 @@
   const SDR_CELLS = 40;
   const SDR_CELL_WIDTH = 328 / SDR_CELLS;
   const SDR_SUB_WIDTH = (SDR_CELL_WIDTH - 2 - 0.5) / 2;
-  const sdrFill = $derived(((value === null ? 0 : smoother.value) / SEG_COUNT) * SDR_CELLS * 2);
+  const sdrFill = $derived((value === null ? 0 : smoother.value) * SDR_CELLS * 2);
   const sdrS9 = $derived((rawToSegments(getS9Raw()) / RAW_SEGMENT_DOMAIN) * SDR_CELLS * 2);
   function sdrColor(index: number): string {
     const aboveS9 = index >= sdrS9;

--- a/frontend/src/components-v2/meters/__tests__/BarGauge.peakhold.svelte.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/BarGauge.peakhold.svelte.test.ts
@@ -119,6 +119,40 @@ describe('BarGauge peak-hold marker (MOR-1282)', () => {
     flushSync();
     expect(markerCount(t)).toBe(0);
   });
+
+  it('clamps rendered fill while retaining an over-range peak sample through decay', () => {
+    const { t, state } = mountReactive({
+      value: 1.5, label: 'Po', displayValue: '150W', showPeak: true,
+    });
+    vi.advanceTimersByTime(600);
+    flushSync();
+    expect(fillCount(t)).toBe(10);
+    expect(markerX(t)).toBe(253);
+
+    state.value = 1.6;
+    state.displayValue = '160W';
+    flushSync();
+    state.value = 0;
+    state.displayValue = '0W';
+    flushSync();
+    vi.advanceTimersByTime(300);
+    flushSync();
+
+    // The freshly retained 1.6 sample has only decayed to 1.28, so visual clamping
+    // keeps the marker at the right edge. Clamping the peak sample itself
+    // to 1 would instead move the marker inward on this first decay step.
+    expect(markerX(t)).toBe(253);
+  });
+
+  it('clamps below-range smoothing and peak projection at the left edge', () => {
+    const { t } = mountReactive({
+      value: -0.5, label: 'Po', displayValue: '0W', showPeak: true,
+    });
+    vi.advanceTimersByTime(100);
+    flushSync();
+    expect(fillCount(t)).toBe(0);
+    expect(markerX(t)).toBe(43);
+  });
 });
 
 it('null empties immediately and clears old fill/peak before a smaller sample', () => {

--- a/frontend/src/components-v2/meters/__tests__/BarGauge.reduced-motion.svelte.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/BarGauge.reduced-motion.svelte.test.ts
@@ -51,6 +51,8 @@ let components: ReturnType<typeof mount>[] = [];
 let roots: HTMLElement[] = [];
 let setIntervalSpy: ReturnType<typeof vi.spyOn>;
 let clearIntervalSpy: ReturnType<typeof vi.spyOn>;
+let activeFrames: Set<number>;
+let nextFrameId: number;
 
 beforeEach(() => {
   components = [];
@@ -59,6 +61,16 @@ beforeEach(() => {
   vi.setSystemTime(0);
   setIntervalSpy = vi.spyOn(window, 'setInterval');
   clearIntervalSpy = vi.spyOn(window, 'clearInterval');
+  activeFrames = new Set();
+  nextFrameId = 0;
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => {
+    const id = ++nextFrameId;
+    activeFrames.add(id);
+    return id;
+  });
+  vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id) => {
+    activeFrames.delete(id);
+  });
 });
 
 afterEach(() => {
@@ -67,10 +79,15 @@ afterEach(() => {
   components = [];
   roots = [];
   vi.useRealTimers();
+  vi.restoreAllMocks();
 });
 
 function netActiveIntervals(): number {
   return setIntervalSpy.mock.calls.length - clearIntervalSpy.mock.calls.length;
+}
+
+function netActiveFrames(): number {
+  return activeFrames.size;
 }
 
 function mountReactive(props: Record<string, unknown>) {
@@ -97,6 +114,7 @@ describe('BarGauge — prefers-reduced-motion peak marker (MOR-1282, mirrors MOR
     try {
       mountReactive({ value: 1.0, label: 'Po', displayValue: '100W', showPeak: true });
       expect(netActiveIntervals()).toBe(0);
+      expect(netActiveFrames()).toBe(0);
     } finally {
       restore();
     }
@@ -107,6 +125,18 @@ describe('BarGauge — prefers-reduced-motion peak marker (MOR-1282, mirrors MOR
     try {
       mountReactive({ value: 1.0, label: 'Po', displayValue: '100W', showPeak: true });
       expect(netActiveIntervals()).toBe(1);
+      expect(netActiveFrames()).toBe(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it('keeps the smoother frame without starting a peak interval when showPeak is false', () => {
+    const { restore } = mockReducedMotion(false);
+    try {
+      mountReactive({ value: 1.0, label: 'Po', displayValue: '100W', showPeak: false });
+      expect(netActiveFrames()).toBe(1);
+      expect(netActiveIntervals()).toBe(0);
     } finally {
       restore();
     }
@@ -159,6 +189,7 @@ describe('BarGauge — prefers-reduced-motion peak marker (MOR-1282, mirrors MOR
 
       setMatches(true);
       expect(netActiveIntervals()).toBe(0);
+      expect(netActiveFrames()).toBe(0);
     } finally {
       restore();
     }
@@ -172,6 +203,7 @@ describe('BarGauge — prefers-reduced-motion peak marker (MOR-1282, mirrors MOR
 
       setMatches(false);
       expect(netActiveIntervals()).toBe(1);
+      expect(netActiveFrames()).toBe(1);
     } finally {
       restore();
     }
@@ -183,13 +215,28 @@ describe('BarGauge — prefers-reduced-motion peak marker (MOR-1282, mirrors MOR
       const { component } = mountReactive({
         value: 1.0, label: 'Po', displayValue: '100W', showPeak: true,
       });
-      expect(listenerCount()).toBeGreaterThan(0);
+      expect(listenerCount()).toBe(2);
       expect(netActiveIntervals()).toBe(1);
+      expect(netActiveFrames()).toBe(1);
 
       unmount(component);
       components = components.filter((c) => c !== component);
       expect(listenerCount()).toBe(0);
       expect(netActiveIntervals()).toBe(0);
+      expect(netActiveFrames()).toBe(0);
+
+      const remounted = mountReactive({
+        value: 0.5, label: 'Po', displayValue: '50W', showPeak: true,
+      });
+      expect(listenerCount()).toBe(2);
+      expect(netActiveIntervals()).toBe(1);
+      expect(netActiveFrames()).toBe(1);
+
+      unmount(remounted.component);
+      components = components.filter((c) => c !== remounted.component);
+      expect(listenerCount()).toBe(0);
+      expect(netActiveIntervals()).toBe(0);
+      expect(netActiveFrames()).toBe(0);
     } finally {
       restore();
     }

--- a/frontend/src/components-v2/meters/__tests__/LinearSMeter.display.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/LinearSMeter.display.test.ts
@@ -1,6 +1,8 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
 import type { ComponentProps } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
 import type { Capabilities } from '$lib/types/capabilities';
 import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
 import LinearSMeter from '../LinearSMeter.svelte';
@@ -52,6 +54,18 @@ function mountMeter(props: ComponentProps<typeof LinearSMeter>) {
   return target;
 }
 
+function mountReactiveMeter(props: ComponentProps<typeof LinearSMeter>) {
+  const state: ComponentProps<typeof LinearSMeter> = proxy({ ...props });
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  roots.push(target);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const component = mount(LinearSMeter as any, { target, props: state });
+  flushSync();
+  components.push(component);
+  return { target, state };
+}
+
 afterEach(() => {
   components.forEach((component) => unmount(component));
   roots.forEach((root) => root.remove());
@@ -62,6 +76,25 @@ afterEach(() => {
 
 function segmentRects(target: HTMLElement): SVGRectElement[] {
   return Array.from(target.querySelectorAll('[data-segment]')) as SVGRectElement[];
+}
+
+function renderedFillFraction(target: HTMLElement): number {
+  const segments = segmentRects(target);
+  const fills = Array.from(target.querySelectorAll('[data-meter-fill]')) as SVGRectElement[];
+  const last = fills.at(-1);
+  if (!last) return 0;
+  const index = Number(last.getAttribute('data-meter-fill'));
+  const segmentWidth = Number(segments[index].getAttribute('width'));
+  return (index + Number(last.getAttribute('width')) / segmentWidth) / segments.length;
+}
+
+function renderedPeakFraction(target: HTMLElement): number | null {
+  const segments = segmentRects(target);
+  const peak = target.querySelector('[data-meter-peak]');
+  if (!peak || segments.length < 2) return null;
+  const barX = Number(segments[0].getAttribute('x'));
+  const pitch = Number(segments[1].getAttribute('x')) - barX;
+  return (Number(peak.getAttribute('x1')) - barX) / (pitch * segments.length);
 }
 
 // MOR-2250 added `toneBelowS9`/`toneAboveS9` to `MeterDisplay`; these
@@ -116,6 +149,38 @@ describe('LinearSMeter display prop', () => {
 
     expect(firstAboveS9).toBe(Math.round((11 / 20) * 12));
     expect(firstAboveS9).not.toBe(11);
+  });
+
+  it('remaps retained fill and peak fractions when segmentCount changes without a new reading', () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }) as unknown as typeof window.matchMedia;
+    try {
+      const { target, state } = mountReactiveMeter({
+        value: 0,
+        display: geometry(20, 1),
+      });
+
+      state.value = -27;
+      flushSync();
+      expect(renderedFillFraction(target)).toBeCloseTo(5.5 / 20);
+      expect(renderedPeakFraction(target)).toBeCloseTo(11 / 20);
+
+      state.display = geometry(12, 3);
+      flushSync();
+      expect(renderedFillFraction(target)).toBeCloseTo(5.5 / 20);
+      expect(renderedPeakFraction(target)).toBeCloseTo(11 / 20);
+
+      state.display = geometry(20, 1);
+      flushSync();
+      expect(renderedFillFraction(target)).toBeCloseTo(5.5 / 20);
+      expect(renderedPeakFraction(target)).toBeCloseTo(11 / 20);
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
   });
 
   // MOR-2214 fix cycle 2: at segmentCount: 1 the single segment's own fill

--- a/frontend/src/components-v2/meters/__tests__/LinearSMeter.reduced-motion.svelte.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/LinearSMeter.reduced-motion.svelte.test.ts
@@ -172,8 +172,8 @@ describe('LinearSMeter — prefers-reduced-motion (MOR-1233)', () => {
     const { restore } = mockReducedMotion(false);
     try {
       mountReactive({ value: 20 });
-      // Ballistics smoother + peak-hold decay loop each schedule a frame.
-      expect(rafSpy).toHaveBeenCalled();
+      // Ballistics smoother + peak-hold decay loop each schedule one frame.
+      expect(rafSpy).toHaveBeenCalledTimes(2);
     } finally {
       restore();
     }
@@ -388,7 +388,7 @@ describe('LinearSMeter — runtime prefers-reduced-motion flips (MOR-1233 fix cy
       const { component } = mountReactive({ value: 20 });
       flushSync();
       // Ballistics smoother + peak-hold each register their own listener.
-      expect(listenerCount()).toBeGreaterThanOrEqual(2);
+      expect(listenerCount()).toBe(2);
 
       unmount(component);
       components = components.filter((c) => c !== component);

--- a/frontend/src/lib/utils/__tests__/smoothing.isolated.test.ts
+++ b/frontend/src/lib/utils/__tests__/smoothing.isolated.test.ts
@@ -52,6 +52,53 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+it('preserves proportional attack and release trajectories for scaled targets at identical timestamps', () => {
+  const { restore } = mockReducedMotion(false);
+  let frameId = 0;
+  let pending: FrameRequestCallback[] = [];
+  vi.spyOn(performance, 'now').mockReturnValue(0);
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+    pending.push(callback);
+    return ++frameId;
+  });
+  vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+
+  function trajectory(scale: number): number[] {
+    pending = [];
+    const smoother = createSmoother(0.12, 0.32, 0);
+    const samples: number[] = [];
+    const advance = (now: number) => {
+      const callback = pending.shift();
+      expect(callback).toBeDefined();
+      callback!(now);
+      samples.push(smoother.value);
+    };
+
+    smoother.update(10 * scale);
+    smoother.start();
+    advance(16.67);
+    advance(33.34);
+    advance(50.01);
+    smoother.update(2 * scale);
+    advance(66.68);
+    advance(83.35);
+    advance(100.02);
+    smoother.stop();
+    return samples;
+  }
+
+  try {
+    const base = trajectory(1);
+    const scaled = trajectory(7);
+    expect(scaled).toHaveLength(base.length);
+    scaled.forEach((value, index) => {
+      expect(value).toBeCloseTo(base[index] * 7, 10);
+    });
+  } finally {
+    restore();
+  }
+});
+
 describe('createSmoother — prefers-reduced-motion (MOR-1233)', () => {
   it('snaps value directly to target on update() when reduced motion is preferred', () => {
     const { restore } = mockReducedMotion(true);


### PR DESCRIPTION
LinearSMeter stored smoother and peak state in its current visual segment domain, so changing only `display.segmentCount` distorted retained motion. This change keeps Linear motion in calibrated fractions and projects it into the active geometry at render time; BarGauge now smooths the same clamped fraction while preserving its existing raw level sample and over-range peak history.

The seven files are one cohesive motion/parity unit: the two live single-meter consumers plus focused proofs for dynamic geometry, scale-equivariant smoothing, deliberate Bar peak policy, reduced-motion scheduling, and teardown. The generic ballistics engine, group meters, calibration, SDK, and semantic surfaces are unchanged.

Linear: https://linear.app/morozsm/issue/MOR-2425/expose-a-supported-v3-host-boundary-for-independently-installed

Compatibility: no public API, configuration, calibration, or wire behavior changes.

Validation:

- RED: `LinearSMeter.display.test.ts` — 7 passed, 1 failed; after a display-only 20→12 segment change, the held peak moved from 0.55 to 0.9166667 of the bar.
- GREEN: eight focused meter/smoothing files — 165 passed, 0 failed.
- Focused ESLint on all seven leased files — passed.
- `npm run check` — 0 errors, 0 warnings.
- Accepted baseline: main `323bc3a277ab33c58eb8575504b004707cb517eb`, natural quick run `34055300296` SUCCESS; frontend block ran 437 files / 10,676 tests and 87 i18n visual-smoke tests.
- Diff: 7 code files, 211 additions + 17 deletions; no regenerated baselines.

