### PR TITLE
MOR-2425: publish finite control appearances

### DIFF
--- a/frontend/component-kit-api/fixtures/external-kit/package.json
+++ b/frontend/component-kit-api/fixtures/external-kit/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "sideEffects": false,
   "peerDependencies": {
-    "@rigplane/component-kit-api": "0.1.0",
+    "@rigplane/component-kit-api": "0.2.0",
     "svelte": ">=5.45.2 <6"
   },
   "files": [

--- a/frontend/component-kit-api/fixtures/external-kit/src/index.ts
+++ b/frontend/component-kit-api/fixtures/external-kit/src/index.ts
@@ -3,6 +3,7 @@ import {
   defineComponentKit,
   type ComponentKitDeclaration,
   type DesignLanguageManifest,
+  type FiniteControlAppearance,
   type FrequencyRenderer,
   type InstrumentGroup,
   type LayoutManifest,
@@ -14,6 +15,20 @@ import {
 const component = (() => ({})) as unknown as PresentationComponent;
 const scalarRenderer = (() => ({})) as unknown as NonNullable<ScalarAppearance['hbar']>;
 const frequencyRenderer = (() => ({})) as unknown as FrequencyRenderer;
+const actionRenderer = ((_internals, { lease }) => {
+  void lease.view?.available;
+  return {};
+}) satisfies FiniteControlAppearance['action'];
+const toggleRenderer = ((_internals, { lease }) => {
+  void lease.view?.confirmed;
+  return {};
+}) satisfies FiniteControlAppearance['toggle'];
+const choiceRenderer = ((_internals, { lease }) => {
+  const option = lease.view?.options[0];
+  const request = option === undefined ? undefined : () => lease.invoke(option.value);
+  void request;
+  return {};
+}) satisfies FiniteControlAppearance['choice'];
 
 const language: DesignLanguageManifest = {
   id: 'fixture-line',
@@ -64,6 +79,9 @@ export const fixtureKit: ComponentKitDeclaration = defineComponentKit({
     fixture: { name: 'fixture', hbar: scalarRenderer },
   },
   frequencyReadouts: { fixture: frequencyRenderer },
+  finiteControlAppearances: {
+    fixture: { action: actionRenderer, toggle: toggleRenderer, choice: choiceRenderer },
+  },
   designLanguages: [language],
   layouts: [layout],
   instrumentGroups: [group],

--- a/frontend/component-kit-api/package.json
+++ b/frontend/component-kit-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rigplane/component-kit-api",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "sideEffects": false,

--- a/frontend/component-kit-api/src/index.ts
+++ b/frontend/component-kit-api/src/index.ts
@@ -2,6 +2,22 @@ import type { Component } from 'svelte';
 import type { Skin as HostScalarAppearance } from '../../src/components-v2/controls/value-control/skin';
 import type { FrequencyInteraction as HostFrequencyInteraction } from '../../src/primitives/frequency/frequency-interaction.svelte';
 import type { FrequencyReadoutModel as HostFrequencyReadoutModel } from '../../src/primitives/frequency/frequency-readout';
+import type { InstrumentReading as HostInstrumentReading } from '../../src/primitives/control-instruments/control-instrument-behavior';
+import type {
+  ActionRendererLease as HostActionRendererLease,
+  ActionRendererProps as HostActionRendererProps,
+  ActionRendererView as HostActionRendererView,
+  ChoiceRendererLease as HostChoiceRendererLease,
+  ChoiceRendererProps as HostChoiceRendererProps,
+  ChoiceRendererView as HostChoiceRendererView,
+  ControlLabel as HostControlLabel,
+  ControlOption as HostControlOption,
+  FiniteControlAppearance as HostFiniteControlAppearance,
+  RequestedTarget as HostRequestedTarget,
+  ToggleRendererLease as HostToggleRendererLease,
+  ToggleRendererProps as HostToggleRendererProps,
+  ToggleRendererView as HostToggleRendererView,
+} from '../../src/primitives/control-instruments/control-instrument-renderer.svelte';
 import type { InstrumentGroup as HostInstrumentGroup } from '../../src/presentation/groups/contract';
 import type { DesignLanguageManifest as HostDesignLanguageManifest } from '../../src/presentation/languages/contract';
 import type { LayoutManifest as HostLayoutManifest } from '../../src/presentation/layouts/contract';
@@ -18,6 +34,30 @@ export type LayoutManifest = Omit<HostLayoutManifest, 'loader'>;
 export type InstrumentGroup = HostInstrumentGroup;
 export type PresentationComponent = Awaited<ReturnType<typeof loadSkin>>;
 export type PresentationResources = ReturnType<typeof presentationResourcePlan>;
+export type FiniteChoiceValue = string | number;
+export type FiniteControlReading<T extends FiniteChoiceValue = FiniteChoiceValue> =
+  HostInstrumentReading<T>;
+export type ControlLabel = HostControlLabel;
+export type ControlOption<T extends FiniteChoiceValue = FiniteChoiceValue> = HostControlOption<T>;
+export type RequestedTarget<T extends FiniteChoiceValue = FiniteChoiceValue> =
+  HostRequestedTarget<T>;
+export type ActionRendererView<Feedback = unknown> = HostActionRendererView<Feedback>;
+export type ToggleRendererView<Feedback = unknown> = HostToggleRendererView<Feedback>;
+export type ChoiceRendererView<
+  T extends FiniteChoiceValue = FiniteChoiceValue,
+  Feedback = unknown,
+> = HostChoiceRendererView<T, Feedback>;
+export type ActionRendererLease<Feedback = unknown> = HostActionRendererLease<Feedback>;
+export type ToggleRendererLease<Feedback = unknown> = HostToggleRendererLease<Feedback>;
+export type ChoiceRendererLease<
+  T extends FiniteChoiceValue = FiniteChoiceValue,
+  Feedback = unknown,
+> = HostChoiceRendererLease<T, Feedback>;
+export type ActionRendererProps = HostActionRendererProps;
+export type ToggleRendererProps = HostToggleRendererProps;
+export type ChoiceRendererProps<T extends FiniteChoiceValue = FiniteChoiceValue> =
+  HostChoiceRendererProps<T>;
+export type FiniteControlAppearance = HostFiniteControlAppearance<FiniteChoiceValue>;
 
 export interface FrequencyRendererProps {
   readonly model: Readonly<FrequencyReadoutModel>;
@@ -42,6 +82,7 @@ export interface ComponentKitDeclaration {
   readonly id: string;
   readonly scalarAppearances?: Readonly<Record<string, ScalarAppearance>>;
   readonly frequencyReadouts?: Readonly<Record<string, FrequencyRenderer>>;
+  readonly finiteControlAppearances?: Readonly<Record<string, FiniteControlAppearance>>;
   readonly designLanguages?: readonly DesignLanguageManifest[];
   readonly layouts?: readonly LayoutManifest[];
   readonly instrumentGroups?: readonly InstrumentGroup[];

--- a/frontend/component-kit-api/verify-package.mjs
+++ b/frontend/component-kit-api/verify-package.mjs
@@ -139,7 +139,11 @@ try {
 
   const apiPack = pack(packageRoot, tarballs);
   const fixturePack = pack(fixtureRoot, tarballs);
-  await assertPackedShape(apiPack, packageRoot, ['dist/types/component-kit-api/src/index.d.ts']);
+  await assertPackedShape(apiPack, packageRoot, [
+    'dist/types/component-kit-api/src/index.d.ts',
+    'dist/types/src/primitives/control-instruments/control-instrument-behavior.d.ts',
+    'dist/types/src/primitives/control-instruments/control-instrument-renderer.svelte.d.ts',
+  ]);
   await assertPackedShape(fixturePack, fixtureRoot, ['dist/index.d.ts']);
 
   const apiDeclarations = await assertClosedDeclarations(
@@ -154,6 +158,8 @@ try {
   assert(!apiRuntime.includes('svelte'));
   assert(!apiRuntime.includes('continuous-scalar'));
   assert(!apiRuntime.includes('frequency-interaction'));
+  assert(!apiRuntime.includes('control-instrument-renderer'));
+  assert(!apiRuntime.includes('createFiniteRendererContext'));
 
   await writeFile(path.join(consumer, 'package.json'), JSON.stringify({
     name: 'component-kit-portable-consumer',
@@ -192,24 +198,60 @@ try {
   COMPONENT_KIT_API_VERSION,
   defineComponentKit,
   type ComponentKitDeclaration,
+  type ChoiceRendererProps,
+  type FiniteChoiceValue,
+  type FiniteControlAppearance,
+  type FiniteControlReading,
   type FrequencyRendererProps,
   type LayoutManifest,
   type PresentationDeclaration,
   type ScalarAppearance,
 } from '@rigplane/component-kit-api';
+import type { Component } from 'svelte';
 import fixtureKit from '@rigplane/external-component-kit-fixture';
 
 const declaration: ComponentKitDeclaration = fixtureKit;
 const scalar: ScalarAppearance | undefined = declaration.scalarAppearances?.fixture;
 const layout: LayoutManifest | undefined = declaration.layouts?.[0];
 const presentation: PresentationDeclaration | undefined = declaration.presentations?.[0];
+const finite: FiniteControlAppearance | undefined = declaration.finiteControlAppearances?.fixture;
+const numericChoiceRenderer: Component<ChoiceRendererProps<number>> | undefined = finite?.choice;
+function inspectChoice(props: ChoiceRendererProps<'OFF' | 'DATA1'>):
+  FiniteControlReading<'OFF' | 'DATA1'> | undefined {
+  const view = props.lease.view;
+  if (view === undefined) return undefined;
+  const option = view.options[0]?.value;
+  const supported: FiniteChoiceValue | undefined = option;
+  const optionalEvidence = [view.defaultValue, view.requested, view.feedback] as const;
+  const request = option === undefined ? undefined : () => props.lease.invoke(option);
+  void supported;
+  void optionalEvidence;
+  void request;
+  return view.reading;
+}
 type FrequencyProps = FrequencyRendererProps;
 void (null as FrequencyProps | null);
 void scalar;
 void layout;
 void presentation;
+void numericChoiceRenderer;
+void inspectChoice;
 export const installedKit = defineComponentKit(declaration);
 export const apiVersion = COMPONENT_KIT_API_VERSION;
+`);
+  await writeFile(path.join(consumer, 'src', 'private-root-negative.ts'), `// @ts-expect-error host authority is not a public root export
+import type { FiniteRendererContext } from '@rigplane/component-kit-api';
+// @ts-expect-error host factories are not public root exports
+import type { createFiniteRendererContext, createChoiceRendererSeat } from '@rigplane/component-kit-api';
+// @ts-expect-error declaration-tree subpaths are not exported
+import type { ChoiceRendererInput } from '@rigplane/component-kit-api/dist/types/src/primitives/control-instruments/control-instrument-renderer.svelte';
+
+export type PrivateRootMustStayUnavailable = [
+  FiniteRendererContext,
+  typeof createFiniteRendererContext,
+  typeof createChoiceRendererSeat,
+  ChoiceRendererInput<string>,
+];
 `);
 
   execute('npm', [
@@ -235,6 +277,12 @@ assert.equal(api.defineComponentKit(fixtureKit), fixtureKit);
   ], consumer, true);
   assert.notEqual(deepImport.status, 0);
   assert.match(deepImport.stderr, /ERR_PACKAGE_PATH_NOT_EXPORTED/);
+  const declarationDeepImport = execute(process.execPath, [
+    '--input-type=module', '--eval',
+    "await import('@rigplane/component-kit-api/dist/types/src/primitives/control-instruments/control-instrument-renderer.svelte')",
+  ], consumer, true);
+  assert.notEqual(declarationDeepImport.status, 0);
+  assert.match(declarationDeepImport.stderr, /ERR_PACKAGE_PATH_NOT_EXPORTED/);
 
   const sveltePackages = await installedSveltePackages(path.join(consumer, 'node_modules'));
   assert.equal(sveltePackages.length, 1);
@@ -246,7 +294,7 @@ assert.equal(api.defineComponentKit(fixtureKit), fixtureKit);
     path.join(consumer, 'node_modules', 'svelte', 'package.json'),
     'utf8',
   ));
-  assert.equal(installedApi.version, '0.1.0');
+  assert.equal(installedApi.version, '0.2.0');
   assert.equal(installedApi.peerDependencies.svelte, '>=5.45.2 <6');
 
   console.log('component-kit-api portable package verification: OK');

--- a/frontend/src/component-kits/__tests__/activation.test.ts
+++ b/frontend/src/component-kits/__tests__/activation.test.ts
@@ -1,15 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   ComponentKitDeclaration,
+  FiniteControlAppearance,
   FrequencyRenderer,
   ScalarAppearance,
 } from '../../../component-kit-api/src/index';
 
 const renderer = (() => ({})) as unknown as FrequencyRenderer;
 const scalarRenderer = (() => ({})) as unknown as NonNullable<ScalarAppearance['knob']>;
+const actionRenderer = (() => ({})) as unknown as FiniteControlAppearance['action'];
+const toggleRenderer = (() => ({})) as unknown as FiniteControlAppearance['toggle'];
+const choiceRenderer = (() => ({})) as unknown as FiniteControlAppearance['choice'];
 
 function appearance(name: string): ScalarAppearance {
   return { name, knob: scalarRenderer };
+}
+
+function finiteAppearance(): FiniteControlAppearance {
+  return { action: actionRenderer, toggle: toggleRenderer, choice: choiceRenderer };
 }
 
 function kit(
@@ -55,19 +63,31 @@ describe('component-kit activation transaction', () => {
 
     expect(activation.getSelectedScalarAppearance()).toBeUndefined();
     expect(activation.getSelectedFrequencyReadout()).toBeUndefined();
+    expect(activation.getSelectedFiniteControlAppearance()).toBeUndefined();
   });
 
-  it('loads every kit, then commits selected scalar and frequency renderers', async () => {
+  it('loads every kit, then commits selected scalar, frequency, and finite renderers', async () => {
     const activation = await subject();
-    const declaration = kit('field-kit');
+    const finite = finiteAppearance();
+    const declaration = kit('field-kit', { finiteControlAppearances: { 'field-kit-finite': finite } });
 
     await activation.activateComponentKits(config([declaration], {
       scalarAppearance: 'field-kit-scalar',
       frequencyReadout: 'field-kit-frequency',
+      finiteControlAppearance: 'field-kit-finite',
     }));
 
     expect(activation.getSelectedScalarAppearance()).toEqual(appearance('field-kit scalar'));
     expect(activation.getSelectedFrequencyReadout()).toBe(renderer);
+    expect(activation.getSelectedFiniteControlAppearance()).toEqual(finite);
+    expect(Object.isFrozen(activation.getSelectedFiniteControlAppearance())).toBe(true);
+  });
+
+  it('keeps scalar/frequency-only API 1 declarations compatible', async () => {
+    const activation = await subject();
+    await activation.activateComponentKits(config([kit('legacy-api-one')]));
+
+    expect(activation.getSelectedFiniteControlAppearance()).toBeUndefined();
   });
 
   it('copies declarations and selection before the single commit', async () => {
@@ -103,6 +123,11 @@ describe('component-kit activation transaction', () => {
     ['scalar with a non-component member', { ...kit('bad-scalar-component'), scalarAppearances: { bad: { name: 'Bad', knob: 'nope' } } }],
     ['non-record frequency declarations', { ...kit('bad-frequencies'), frequencyReadouts: [] }],
     ['non-component frequency declaration', { ...kit('bad-frequency'), frequencyReadouts: { bad: 'nope' } }],
+    ['non-record finite declarations', { ...kit('bad-finite-map'), finiteControlAppearances: [] }],
+    ['finite appearance missing a member', { ...kit('bad-finite-missing'), finiteControlAppearances: { bad: { action: actionRenderer, toggle: toggleRenderer } } }],
+    ['finite appearance with an extra member', { ...kit('bad-finite-extra'), finiteControlAppearances: { bad: { ...finiteAppearance(), extra: true } } }],
+    ['finite appearance with a non-component member', { ...kit('bad-finite-component'), finiteControlAppearances: { bad: { ...finiteAppearance(), choice: 'nope' } } }],
+    ['empty finite appearance id', { ...kit('bad-finite-id'), finiteControlAppearances: { '': finiteAppearance() } }],
   ])('rejects %s without committing', async (_name, declaration) => {
     const activation = await subject();
 
@@ -147,6 +172,13 @@ describe('component-kit activation transaction', () => {
         target: selectedAppearance,
       };
     }],
+    ['finite appearance', () => {
+      const selectedAppearance = finiteAppearance();
+      return {
+        configured: config([kit('exact-finite-kit', { finiteControlAppearances: { exact: selectedAppearance } })]),
+        target: selectedAppearance,
+      };
+    }],
   ] as const)('rejects symbol and non-enumerable unknown properties on %s', async (_name, makeCase) => {
     const activation = await subject();
     for (const kind of ['symbol', 'non-enumerable'] as const) {
@@ -187,6 +219,11 @@ describe('component-kit activation transaction', () => {
       Reflect.defineProperty(selectedAppearance, 'name', { value: 'Descriptor', enumerable: false });
       return config([kit('descriptor-scalar-kit', { scalarAppearances: { descriptor: selectedAppearance } })]);
     }],
+    ['finite appearance', () => {
+      const selectedAppearance = finiteAppearance();
+      Reflect.defineProperty(selectedAppearance, 'choice', { value: choiceRenderer, enumerable: false });
+      return config([kit('descriptor-finite-kit', { finiteControlAppearances: { descriptor: selectedAppearance } })]);
+    }],
   ] as const)('rejects a non-enumerable allowed property on %s', async (_name, makeConfig) => {
     const activation = await subject();
 
@@ -205,6 +242,18 @@ describe('component-kit activation transaction', () => {
     expect(getter).not.toHaveBeenCalled();
   });
 
+  it('rejects a finite appearance accessor without invoking it', async () => {
+    const activation = await subject();
+    const finite = finiteAppearance();
+    const getter = vi.fn(() => choiceRenderer);
+    Reflect.defineProperty(finite, 'choice', { get: getter, enumerable: true });
+
+    await expect(activation.activateComponentKits(config([
+      kit('accessor-finite-kit', { finiteControlAppearances: { accessor: finite } }),
+    ]))).rejects.toThrow(/enumerable data property/i);
+    expect(getter).not.toHaveBeenCalled();
+  });
+
   it('allows additional exports on the loader module namespace', async () => {
     const activation = await subject();
 
@@ -218,12 +267,16 @@ describe('component-kit activation transaction', () => {
     ['scalarAppearances', 'non-enumerable'],
     ['frequencyReadouts', 'symbol'],
     ['frequencyReadouts', 'non-enumerable'],
+    ['finiteControlAppearances', 'symbol'],
+    ['finiteControlAppearances', 'non-enumerable'],
   ] as const)('rejects a %s map with a %s entry', async (mapName, kind) => {
     const activation = await subject();
     const declarations: Record<PropertyKey, unknown> = {};
     const key = kind === 'symbol' ? Symbol('hidden') : 'hidden';
     Reflect.defineProperty(declarations, key, {
-      value: mapName === 'scalarAppearances' ? appearance('Hidden') : renderer,
+      value: mapName === 'scalarAppearances'
+        ? appearance('Hidden')
+        : mapName === 'frequencyReadouts' ? renderer : finiteAppearance(),
       enumerable: kind === 'symbol',
     });
 
@@ -247,6 +300,7 @@ describe('component-kit activation transaction', () => {
     ['duplicate kit id', [kit('duplicate-kit'), kit('duplicate-kit')]],
     ['duplicate scalar id', [kit('scalar-a', { scalarAppearances: { shared: appearance('A') } }), kit('scalar-b', { scalarAppearances: { shared: appearance('B') } })]],
     ['duplicate frequency id', [kit('frequency-a', { frequencyReadouts: { shared: renderer } }), kit('frequency-b', { frequencyReadouts: { shared: renderer } })]],
+    ['duplicate finite id', [kit('finite-a', { finiteControlAppearances: { shared: finiteAppearance() } }), kit('finite-b', { finiteControlAppearances: { shared: finiteAppearance() } })]],
   ])('rejects %s across the complete loaded set', async (_name, declarations) => {
     const activation = await subject();
 
@@ -267,6 +321,7 @@ describe('component-kit activation transaction', () => {
   it.each([
     ['scalarAppearance', 'missing-scalar'],
     ['frequencyReadout', 'missing-frequency'],
+    ['finiteControlAppearance', 'missing-finite'],
   ])('rejects an unresolved %s selection', async (property, value) => {
     const activation = await subject();
 

--- a/frontend/src/component-kits/activation.ts
+++ b/frontend/src/component-kits/activation.ts
@@ -1,5 +1,6 @@
 import {
   COMPONENT_KIT_API_VERSION,
+  type FiniteControlAppearance,
   type FrequencyRenderer,
   type ScalarAppearance,
 } from '../../component-kit-api/src/index';
@@ -8,6 +9,7 @@ import { skins as builtInScalarAppearances } from '../components-v2/controls/val
 export interface ComponentKitSelection {
   readonly scalarAppearance?: string;
   readonly frequencyReadout?: string;
+  readonly finiteControlAppearance?: string;
 }
 
 export interface ComponentKitHostConfig {
@@ -18,21 +20,27 @@ export interface ComponentKitHostConfig {
 interface ActiveSnapshot {
   readonly scalarAppearances: ReadonlyMap<string, ScalarAppearance>;
   readonly frequencyReadouts: ReadonlyMap<string, FrequencyRenderer>;
+  readonly finiteControlAppearances: ReadonlyMap<string, FiniteControlAppearance>;
   readonly selectedScalarAppearance?: string;
   readonly selectedFrequencyReadout?: string;
+  readonly selectedFiniteControlAppearance?: string;
 }
 
 const EMPTY_SNAPSHOT: ActiveSnapshot = Object.freeze({
   scalarAppearances: new Map(),
   frequencyReadouts: new Map(),
+  finiteControlAppearances: new Map(),
 });
 const CONFIG_KEYS = ['kits', 'selection'] as const;
-const SELECTION_KEYS = ['scalarAppearance', 'frequencyReadout'] as const;
+const SELECTION_KEYS = [
+  'scalarAppearance', 'frequencyReadout', 'finiteControlAppearance',
+] as const;
 const KIT_KEYS = [
-  'apiVersion', 'id', 'scalarAppearances', 'frequencyReadouts',
+  'apiVersion', 'id', 'scalarAppearances', 'frequencyReadouts', 'finiteControlAppearances',
   'designLanguages', 'layouts', 'instrumentGroups', 'presentations',
 ] as const;
 const APPEARANCE_KEYS = ['name', 'knob', 'hbar', 'bipolar', 'discrete'] as const;
+const FINITE_APPEARANCE_KEYS = ['action', 'toggle', 'choice'] as const;
 const UNSUPPORTED_SECTIONS = [
   'designLanguages', 'layouts', 'instrumentGroups', 'presentations',
 ] as const;
@@ -94,6 +102,21 @@ function copyAppearance(value: unknown, id: string): ScalarAppearance {
   return Object.freeze({ ...value }) as unknown as ScalarAppearance;
 }
 
+function copyFiniteAppearance(value: unknown, id: string): FiniteControlAppearance {
+  if (!isPlainRecord(value)) {
+    throw new ComponentKitActivationError(`Finite control appearance "${id}" must be an object.`);
+  }
+  ownDataEntries(value, `Finite control appearance "${id}"`, FINITE_APPEARANCE_KEYS);
+  for (const slot of FINITE_APPEARANCE_KEYS) {
+    if (typeof value[slot] !== 'function') {
+      throw new ComponentKitActivationError(
+        `Finite control appearance "${id}" member "${slot}" must be a component.`,
+      );
+    }
+  }
+  return Object.freeze({ ...value }) as unknown as FiniteControlAppearance;
+}
+
 function readSelection(value: unknown): ComponentKitSelection {
   if (value === undefined) return {};
   if (!isPlainRecord(value)) {
@@ -117,6 +140,8 @@ function prepareSnapshot(declarations: readonly unknown[], selectionValue: unkno
   }
   const frequencyReadouts = new Map<string, FrequencyRenderer>();
   const frequencyOwners = new Map<string, string>();
+  const finiteControlAppearances = new Map<string, FiniteControlAppearance>();
+  const finiteAppearanceOwners = new Map<string, string>();
   const kitIds = new Set<string>();
 
   for (const value of declarations) {
@@ -174,6 +199,30 @@ function prepareSnapshot(declarations: readonly unknown[], selectionValue: unkno
         frequencyOwners.set(readoutId, `component kit "${id}"`);
       }
     }
+
+    if (value.finiteControlAppearances !== undefined) {
+      if (!isPlainRecord(value.finiteControlAppearances)) {
+        throw new ComponentKitActivationError(
+          `Component kit "${id}" finiteControlAppearances must be a record.`,
+        );
+      }
+      for (const [appearanceId, appearance] of ownDataEntries(
+        value.finiteControlAppearances,
+        `Component kit "${id}" finiteControlAppearances`,
+      )) {
+        requireId(appearanceId, `Component kit "${id}" finite control appearance`);
+        if (finiteAppearanceOwners.has(appearanceId)) {
+          throw new ComponentKitActivationError(
+            `Duplicate finite control appearance "${appearanceId}" conflicts with ${finiteAppearanceOwners.get(appearanceId)}.`,
+          );
+        }
+        finiteControlAppearances.set(
+          appearanceId,
+          copyFiniteAppearance(appearance, appearanceId),
+        );
+        finiteAppearanceOwners.set(appearanceId, `component kit "${id}"`);
+      }
+    }
   }
 
   const selection = readSelection(selectionValue);
@@ -183,11 +232,19 @@ function prepareSnapshot(declarations: readonly unknown[], selectionValue: unkno
   if (selection.frequencyReadout !== undefined && !frequencyReadouts.has(selection.frequencyReadout)) {
     throw new ComponentKitActivationError(`Selected frequency readout "${selection.frequencyReadout}" is not registered.`);
   }
+  if (selection.finiteControlAppearance !== undefined
+    && !finiteControlAppearances.has(selection.finiteControlAppearance)) {
+    throw new ComponentKitActivationError(
+      `Selected finite control appearance "${selection.finiteControlAppearance}" is not registered.`,
+    );
+  }
   return Object.freeze({
     scalarAppearances,
     frequencyReadouts,
+    finiteControlAppearances,
     selectedScalarAppearance: selection.scalarAppearance,
     selectedFrequencyReadout: selection.frequencyReadout,
+    selectedFiniteControlAppearance: selection.finiteControlAppearance,
   });
 }
 
@@ -228,4 +285,10 @@ export function getSelectedFrequencyReadout(): FrequencyRenderer | undefined {
   return snapshot.selectedFrequencyReadout === undefined
     ? undefined
     : snapshot.frequencyReadouts.get(snapshot.selectedFrequencyReadout);
+}
+
+export function getSelectedFiniteControlAppearance(): FiniteControlAppearance | undefined {
+  return snapshot.selectedFiniteControlAppearance === undefined
+    ? undefined
+    : snapshot.finiteControlAppearances.get(snapshot.selectedFiniteControlAppearance);
 }


### PR DESCRIPTION
This 7-file packet is one semantic unit because the public declaration, its single startup activation transaction, and the installed-tarball proof must evolve atomically; splitting them would leave either an accepted but unvalidated declaration or a private-only registry shape. It changes 7 code/config files and 0 regenerated baselines (243 A+D).

Linear owner: MOR-2425

## What changed

- publish finite action, toggle, and string/number choice renderer view/lease/props types from `@rigplane/component-kit-api` without exposing authority contexts, seat factories, or host wrappers
- add optional finite appearance declarations, exact validation, duplicate/selection rejection, immutable copying, and lookup to the existing all-or-nothing startup snapshot
- bump the private package artifact to 0.2.0 while retaining component-kit API contract version 1
- extend the external packed fixture and isolated consumer with direct numeric-seat variance, narrow choice union, private-root/deep-import negatives, closed declarations, inert helper, and single-Svelte proofs

## Scope boundary

This publishes and selects finite appearances but does not wire the selected appearance into live SRS compositions. FC-1b still owns host authority-token publication and the production getter consumer after the frequency lane releases those files. No feedback source, default value, requested target, idle phase, error, or confirmation is synthesized here.

## Focused verification

- first strict TypeScript witness: `FiniteControlAppearance<string | number>` directly assignable to the real `FiniteControlAppearance<number>` Scope seat, without `any`, `unknown`, `never`, factory, or cast
- `npx vitest run src/component-kits/__tests__/activation.test.ts` — 59 passed
- `npm run verify:component-kit-api` — portable install/type/build passed; 26 API declarations, 1 fixture declaration, exactly two runtime exports, one physical Svelte
- `npm run check` — Svelte 0 errors / 0 warnings; TypeScript checks passed
- changed-scope ESLint — 0 errors

New private artifact: `rigplane-component-kit-api-0.2.0.tgz`  
SHA-256: `2931efe632b489d8f49f07b26b17f8fd6822471bb980b5683cbd35c4f1c6c446`

Baseline: aggregate `main` quick run 34059739623 at `66216e542cb714a3957d76d6108316cdee11d09a` passed with 438 frontend files / 10,693 tests and the prior 0.1.0 portable package proof.
