### PR TITLE
MOR-2425: centralize S-meter signal projection

### DIFF
--- a/frontend/src/components-v2/meters/LinearSMeter.svelte
+++ b/frontend/src/components-v2/meters/LinearSMeter.svelte
@@ -54,7 +54,6 @@
   import { DEFAULT_METER_DISPLAY } from './meter-display';
   import {
     projectSignalMeter,
-    rawToSegments,
     type SignalMeterProjection,
   } from './smeter-scale';
 
@@ -120,10 +119,8 @@
   const isWideVfoVariant = $derived(variant === 'vfo-wide');
 
   // ── Segment geometry ────────────────────────────────────────────────────────
-  // `smeter-scale.ts`'s rawToSegments and projected motion fractions use a
-  // fixed 0-20 source domain, independent of how many visual segments this
-  // component draws. RAW_SEGMENT_DOMAIN keeps dense raw ticks on that source
-  // scale while the projection feeds normalized display motion below.
+  // Projected fractions are independent of how many visual segments this
+  // component draws; this component only maps them onto its local geometry.
   const RAW_SEGMENT_DOMAIN = 20;
   const SEG_COUNT = $derived(display.segmentCount);
   const SEG_GAP = $derived(display.segmentGapPx);
@@ -139,12 +136,6 @@
 
   function fractionToX(fraction: number): number {
     return BAR_X + fraction * SEG_COUNT * (SEG_W + SEG_GAP);
-  }
-
-  // x position (from bar left) for a given raw value — rawToSegments(raw) is
-  // on the fixed RAW_SEGMENT_DOMAIN, rescaled here onto SEG_COUNT segments.
-  function rawToX(raw: number): number {
-    return fractionToX(rawToSegments(raw) / RAW_SEGMENT_DOMAIN);
   }
 
   // Index of the first visual segment at or above the projected S9 anchor,
@@ -246,58 +237,6 @@
 
   // ── Label marks ─────────────────────────────────────────────────────────────
   let labelMarks = $derived(signalProjection.marks);
-
-  // ── Tick marks ──────────────────────────────────────────────────────────────
-  // Generate dense ticks: 9 subdivisions between each labeled S-unit position,
-  // with the 5th tick (midpoint) slightly taller.
-  type TickKind = 'major' | 'mid' | 'minor';
-  interface Tick { raw: number; kind: TickKind; color: string }
-
-  function generateTicks(): Tick[] {
-    const ticks: Tick[] = [];
-    const anchors = signalProjection.marks.map((m) => ({ raw: m.raw, actual: m.actual }));
-    const first = anchors[0];
-
-    if (!first || first.raw > 0) {
-      anchors.unshift({ raw: 0, actual: -54 });
-    }
-
-    function colorForActual(actual: number): string {
-      if (actual <= 0) return 'var(--v2-text-bright)';
-      if (actual <= 20) return 'var(--v2-accent-yellow)';
-      if (actual <= 40) return 'var(--v2-accent-orange-alt)';
-      return 'var(--v2-accent-red-alt)';
-    }
-
-    function addSubdivisions(startRaw: number, endRaw: number, startActual: number, endActual: number) {
-      // Major tick at start
-      ticks.push({ raw: startRaw, kind: 'major', color: colorForActual(startActual) });
-      // 9 subdivision ticks between start and end
-      const step = (endRaw - startRaw) / 10;
-      const actualStep = (endActual - startActual) / 10;
-      for (let j = 1; j <= 9; j++) {
-        const raw = startRaw + step * j;
-        const kind: TickKind = j === 5 ? 'mid' : 'minor';
-        ticks.push({ raw, kind, color: colorForActual(startActual + actualStep * j) });
-      }
-    }
-
-    for (let i = 0; i < anchors.length - 1; i++) {
-      addSubdivisions(
-        anchors[i].raw,
-        anchors[i + 1].raw,
-        anchors[i].actual,
-        anchors[i + 1].actual,
-      );
-    }
-    // Final tick at max
-    const last = anchors[anchors.length - 1];
-    ticks.push({ raw: last.raw, kind: 'major', color: colorForActual(last.actual) });
-
-    return ticks;
-  }
-
-  let tickMarks = $derived(generateTicks());
 
   // ── Layout (switches between full / compact) ────────────────────────────────
   //   When label is present: label at top → meter shifted down
@@ -501,8 +440,8 @@
   {/each}
 
   <!-- Tick marks -->
-  {#each tickMarks as t}
-    {@const tx = rawToX(t.raw)}
+  {#each signalProjection.ticks as t}
+    {@const tx = fractionToX(t.fraction)}
     {@const y1 = t.kind === 'major' ? TICK_MAJOR_Y1 : t.kind === 'mid' ? TICK_MID_Y1 : TICK_MINOR_Y1}
     {@const y2 = t.kind === 'major' ? TICK_MAJOR_Y2 : t.kind === 'mid' ? TICK_MID_Y2 : TICK_MINOR_Y2}
     {@const sw = t.kind === 'major' ? 1.2 : t.kind === 'mid' ? 0.9 : 0.6}

--- a/frontend/src/components-v2/meters/LinearSMeter.svelte
+++ b/frontend/src/components-v2/meters/LinearSMeter.svelte
@@ -53,17 +53,12 @@
   import type { MeterDisplay } from '../../presentation/languages/contract';
   import { DEFAULT_METER_DISPLAY } from './meter-display';
   import {
-    calibratedToSegments,
-    calibratedToSUnit,
-    calibratedToDbm,
-    formatDbm,
-    getScaleMarks,
-    getS9Raw,
+    projectSignalMeter,
     rawToSegments,
+    type SignalMeterProjection,
   } from './smeter-scale';
 
-  interface Props {
-    value: number | null;    // calibrated dB relative to S9 from backend state
+  interface CommonLinearMeterProps {
     mainPresent?: boolean;
     compact?: boolean;
     label?: string;
@@ -96,21 +91,39 @@
     session?: MeterContinuitySession | null;
   }
 
-  let {
-    value, compact = false, label, variant, display = DEFAULT_METER_DISPLAY, lowerScale,
-    relevant = true, mainPresent = true, source, session,
-  }: Props = $props();
+  type SignalInput =
+    | { projection: SignalMeterProjection; value?: never }
+    | { projection?: never; value: number | null };
+  type Props = CommonLinearMeterProps & SignalInput;
+
+  let props: Props = $props();
+  const compact = $derived(props.compact ?? false);
+  const label = $derived(props.label);
+  const variant = $derived(props.variant);
+  const display = $derived(props.display ?? DEFAULT_METER_DISPLAY);
+  const lowerScale = $derived(props.lowerScale);
+  const relevant = $derived(props.relevant ?? true);
+  const mainPresent = $derived(props.mainPresent ?? true);
+  const source = $derived(props.source);
+  const session = $derived(props.session);
+  const signalProjection = $derived.by((): SignalMeterProjection => {
+    const hasProjection = Object.prototype.hasOwnProperty.call(props, 'projection');
+    const hasValue = Object.prototype.hasOwnProperty.call(props, 'value');
+    if (hasProjection === hasValue) {
+      throw new TypeError('LinearSMeter requires exactly one of projection or value');
+    }
+    if (hasProjection) return (props as { projection: SignalMeterProjection }).projection;
+    return projectSignalMeter((props as { value: number | null }).value);
+  });
 
   const isVfoVariant = $derived(variant === 'vfo' || variant === 'vfo-wide');
   const isWideVfoVariant = $derived(variant === 'vfo-wide');
 
   // ── Segment geometry ────────────────────────────────────────────────────────
-  // `smeter-scale.ts`'s rawToSegments/calibratedToSegments always report a
-  // position on a fixed 0-20 domain (that file's `rawToSegments` tops out at
-  // 20 for any input, regardless of caller) — independent of how many visual
-  // segments this component draws. RAW_SEGMENT_DOMAIN names that fixed width
-  // so a raw-domain reading can be rescaled onto the `display.segmentCount`
-  // visual domain below.
+  // `smeter-scale.ts`'s rawToSegments and projected motion fractions use a
+  // fixed 0-20 source domain, independent of how many visual segments this
+  // component draws. RAW_SEGMENT_DOMAIN keeps dense raw ticks on that source
+  // scale while the projection feeds normalized display motion below.
   const RAW_SEGMENT_DOMAIN = 20;
   const SEG_COUNT = $derived(display.segmentCount);
   const SEG_GAP = $derived(display.segmentGapPx);
@@ -124,20 +137,20 @@
     return BAR_X + i * (SEG_W + SEG_GAP);
   }
 
+  function fractionToX(fraction: number): number {
+    return BAR_X + fraction * SEG_COUNT * (SEG_W + SEG_GAP);
+  }
+
   // x position (from bar left) for a given raw value — rawToSegments(raw) is
   // on the fixed RAW_SEGMENT_DOMAIN, rescaled here onto SEG_COUNT segments.
   function rawToX(raw: number): number {
-    return BAR_X + (rawToSegments(raw) / RAW_SEGMENT_DOMAIN) * SEG_COUNT * (SEG_W + SEG_GAP);
+    return fractionToX(rawToSegments(raw) / RAW_SEGMENT_DOMAIN);
   }
 
-  // Index of the first visual segment at or above the calibrated S9 anchor.
-  // `rawToSegments(getS9Raw())` is exactly 11 on the raw 0-20 domain — S9 is
-  // the last S-unit knot, so `rawToSegments` (via `rawToSFloat`) resolves it
-  // to exactly (9/9)*11 — rescaled here by SEG_COUNT so this index tracks a
-  // non-20 segment count instead of the fixed literal 11 the
-  // pre-display-prop code used.
+  // Index of the first visual segment at or above the projected S9 anchor,
+  // rescaled by SEG_COUNT so it follows non-20 display geometry.
   const s9SegmentIndex = $derived(
-    Math.round((rawToSegments(getS9Raw()) / RAW_SEGMENT_DOMAIN) * SEG_COUNT),
+    Math.round(signalProjection.s9Fraction * SEG_COUNT),
   );
 
   // ── Colors ──────────────────────────────────────────────────────────────────
@@ -232,7 +245,7 @@
   const lowerFracSeg = $derived(lowerFillSegs - lowerFullSegs);
 
   // ── Label marks ─────────────────────────────────────────────────────────────
-  let labelMarks = $derived(getScaleMarks());
+  let labelMarks = $derived(signalProjection.marks);
 
   // ── Tick marks ──────────────────────────────────────────────────────────────
   // Generate dense ticks: 9 subdivisions between each labeled S-unit position,
@@ -242,7 +255,7 @@
 
   function generateTicks(): Tick[] {
     const ticks: Tick[] = [];
-    const anchors = getScaleMarks().map((m) => ({ raw: m.raw, actual: m.actual }));
+    const anchors = signalProjection.marks.map((m) => ({ raw: m.raw, actual: m.actual }));
     const first = anchors[0];
 
     if (!first || first.raw > 0) {
@@ -351,9 +364,7 @@
   });
 
   $effect(() => {
-    const current = value === null || !mainPresent
-      ? null
-      : calibratedToSegments(value) / RAW_SEGMENT_DOMAIN;
+    const current = mainPresent ? signalProjection.motionFraction : null;
     const currentSource = source;
     const currentSession = session;
     untrack(() => ballistics.sync({
@@ -372,7 +383,9 @@
   // Peak X position for the vertical indicator line
   let peakX = $derived(BAR_X + peakSegs * (SEG_W + SEG_GAP));
   // Only show peak line if it's meaningfully ahead of current bar
-  let showPeak = $derived(value !== null && mainPresent && peakSegs - smoothedSegs > 0.3);
+  let showPeak = $derived(
+    signalProjection.motionFraction !== null && mainPresent && peakSegs - smoothedSegs > 0.3,
+  );
 
   // Peak-line color zones as fractions of the raw 20-segment domain — 15/20
   // and 18/20 are visual gradient stops with no calibration anchor (unlike
@@ -384,18 +397,22 @@
   let peakColor = $derived(peakSegs <= s9SegmentIndex ? 'var(--v2-accent-cyan-bright)' : peakSegs <= peakZoneYellow ? 'var(--v2-accent-yellow)' : peakSegs <= peakZoneOrange ? 'var(--v2-accent-orange-alt)' : 'var(--v2-accent-red-alt)');
 
   // ── Reactive display values ─────────────────────────────────────────────────
-  let fullSegs = $derived(value === null ? 0 : Math.floor(smoothedSegs));
-  let fracSeg  = $derived(value === null ? 0 : smoothedSegs - Math.floor(smoothedSegs));
+  let fullSegs = $derived(signalProjection.motionFraction === null ? 0 : Math.floor(smoothedSegs));
+  let fracSeg  = $derived(
+    signalProjection.motionFraction === null ? 0 : smoothedSegs - Math.floor(smoothedSegs),
+  );
 
-  let displaySUnit = $derived(value === null ? 'S ?' : calibratedToSUnit(value));
-  let displayDbm   = $derived(value === null ? '' : formatDbm(calibratedToDbm(value)));
+  let displaySUnit = $derived(signalProjection.primaryText);
+  let displayDbm   = $derived(signalProjection.secondaryText);
 
   // v2.11.1 SDR SVG geometry; the current calibrated scale still owns positions.
   const SDR_CELLS = 40;
   const SDR_CELL_WIDTH = 328 / SDR_CELLS;
   const SDR_SUB_WIDTH = (SDR_CELL_WIDTH - 2 - 0.5) / 2;
-  const sdrFill = $derived((value === null ? 0 : smoother.value) * SDR_CELLS * 2);
-  const sdrS9 = $derived((rawToSegments(getS9Raw()) / RAW_SEGMENT_DOMAIN) * SDR_CELLS * 2);
+  const sdrFill = $derived(
+    (signalProjection.motionFraction === null ? 0 : smoother.value) * SDR_CELLS * 2,
+  );
+  const sdrS9 = $derived(signalProjection.s9Fraction * SDR_CELLS * 2);
   function sdrColor(index: number): string {
     const aboveS9 = index >= sdrS9;
     return index < sdrFill ? (aboveS9 ? '#FF3030' : '#4FB9EC')
@@ -411,7 +428,7 @@
       <g font-family="Roboto Mono, monospace" font-size="11" fill="var(--v2-text-primary, #C8D4E0)" font-weight="700">
         <text x="4" y="14">{displayDbm === 'uncalibrated' ? 'raw' : 'S'}</text>
         {#each labelMarks as mark}
-          <text x={14 + (rawToSegments(mark.raw) / RAW_SEGMENT_DOMAIN) * 328} y="14"
+          <text x={14 + mark.fraction * 328} y="14"
             text-anchor="middle" fill={mark.actual > 0 ? 'var(--v2-accent-red, #FF4040)' : 'var(--v2-text-primary, #C8D4E0)'}>
             {mark.text.replace(/^S/, '')}
           </text>
@@ -472,7 +489,7 @@
   <!-- Scale labels -->
   {#each labelMarks as m}
     <text
-      x={rawToX(m.raw)}
+      x={fractionToX(m.fraction)}
       y={SCALE_LABEL_Y}
       font-family="'Roboto Mono', monospace"
       font-size={SCALE_LABEL_FS}

--- a/frontend/src/components-v2/meters/__tests__/LinearSMeter.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/LinearSMeter.test.ts
@@ -63,6 +63,7 @@ import {
   formatDbm,
   isSmeterCalibrated,
   calibratedToSUnit,
+  projectSignalMeter,
 } from '../smeter-scale';
 
 beforeEach(() => {
@@ -298,6 +299,61 @@ describe('LinearSMeter calibrated S-meter domain', () => {
 
     expect(text).toContain('S9+20');
     expect(text).toContain('\u221253 dBm');
+  });
+
+  it('accepts a projection directly and keeps legacy value callers on the same projector', () => {
+    const projection = projectSignalMeter(-48);
+    const projected = mountMeter({ projection });
+    const legacy = mountMeter({ value: -48 });
+
+    for (const target of [projected, legacy]) {
+      expect(target.textContent).toContain(projection.primaryText);
+      expect(target.textContent).toContain(projection.secondaryText);
+    }
+  });
+
+  it('rejects dynamic callers that supply both projection and value', () => {
+    const projection = projectSignalMeter(0);
+    const projectionOnly = { projection } satisfies ComponentProps<typeof LinearSMeter>;
+    const valueOnly = { value: 0 } satisfies ComponentProps<typeof LinearSMeter>;
+    // @ts-expect-error -- the public component props make the two inputs exclusive.
+    const invalid: ComponentProps<typeof LinearSMeter> = { value: 0, projection };
+    expect(projectionOnly.projection).toBe(projection);
+    expect(valueOnly.value).toBe(0);
+    expect(invalid).toEqual({ value: 0, projection });
+    expect(() => mountMeter({ value: 0, projection } as never))
+      .toThrow(/exactly one of projection or value/);
+  });
+
+  it('rejects dynamic callers that supply neither projection nor value', () => {
+    expect(() => mountMeter({} as never))
+      .toThrow(/exactly one of projection or value/);
+  });
+
+  it('renders an exact supplied projection without consulting a replacement calibration', () => {
+    const projection = projectSignalMeter(-48);
+    clearCapabilities();
+
+    const projected = mountMeter({ projection });
+    const legacy = mountMeter({ value: -48 });
+    expect(projected.textContent).toContain('S1');
+    expect(projected.textContent).toContain('\u2212121 dBm');
+    expect(projected.textContent).not.toContain('uncalibrated');
+    expect(legacy.textContent).toContain('uncalibrated');
+    expect(legacy.textContent).not.toContain('\u2212121 dBm');
+  });
+
+  it('positions labeled marks from the projection while dense ticks retain the raw facade mapping', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'src/components-v2/meters/LinearSMeter.svelte'),
+      'utf8',
+    );
+    expect(source).toMatch(/labelMarks\s*=\s*\$derived\(signalProjection\.marks\)/);
+    expect(source).toMatch(/x=\{fractionToX\(m\.fraction\)\}/);
+    expect(source).toMatch(
+      /function rawToX\(raw: number\)[\s\S]*?rawToSegments\(raw\)\s*\/\s*RAW_SEGMENT_DOMAIN/,
+    );
+    expect(source).toMatch(/\{@const tx = rawToX\(t\.raw\)\}/);
   });
 });
 

--- a/frontend/src/components-v2/meters/__tests__/LinearSMeter.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/LinearSMeter.test.ts
@@ -330,8 +330,13 @@ describe('LinearSMeter calibrated S-meter domain', () => {
       .toThrow(/exactly one of projection or value/);
   });
 
-  it('renders an exact supplied projection without consulting a replacement calibration', () => {
+  it('keeps every dense tick and the S1 label on the supplied projection after calibration replacement', () => {
     const projection = projectSignalMeter(-48);
+    const beforeReplacement = mountMeter({ projection });
+    const denseTickXs = (target: HTMLElement) => [...target.querySelectorAll<SVGLineElement>('line')]
+      .filter((line) => line.getAttribute('y2') === '38')
+      .map((line) => Number(line.getAttribute('x1')));
+    const expectedTickXs = denseTickXs(beforeReplacement);
     clearCapabilities();
 
     const projected = mountMeter({ projection });
@@ -341,19 +346,26 @@ describe('LinearSMeter calibrated S-meter domain', () => {
     expect(projected.textContent).not.toContain('uncalibrated');
     expect(legacy.textContent).toContain('uncalibrated');
     expect(legacy.textContent).not.toContain('\u2212121 dBm');
+
+    const s1Label = [...projected.querySelectorAll<SVGTextElement>('text')]
+      .find((label) => label.textContent === 'S1')!;
+    const majorTickXs = [...projected.querySelectorAll<SVGLineElement>('line')]
+      .filter((line) => line.getAttribute('y1') === '18' && line.getAttribute('y2') === '38')
+      .map((line) => Number(line.getAttribute('x1')));
+    expect(denseTickXs(projected)).toEqual(expectedTickXs);
+    expect(majorTickXs[1]).toBeCloseTo(Number(s1Label.getAttribute('x')));
   });
 
-  it('positions labeled marks from the projection while dense ticks retain the raw facade mapping', () => {
+  it('positions both labeled marks and dense ticks from the supplied projection fractions', () => {
     const source = readFileSync(
       resolve(process.cwd(), 'src/components-v2/meters/LinearSMeter.svelte'),
       'utf8',
     );
     expect(source).toMatch(/labelMarks\s*=\s*\$derived\(signalProjection\.marks\)/);
     expect(source).toMatch(/x=\{fractionToX\(m\.fraction\)\}/);
-    expect(source).toMatch(
-      /function rawToX\(raw: number\)[\s\S]*?rawToSegments\(raw\)\s*\/\s*RAW_SEGMENT_DOMAIN/,
-    );
-    expect(source).toMatch(/\{@const tx = rawToX\(t\.raw\)\}/);
+    expect(source).toMatch(/\{#each signalProjection\.ticks as t\}/);
+    expect(source).toMatch(/\{@const tx = fractionToX\(t\.fraction\)\}/);
+    expect(source).not.toMatch(/\brawToSegments\b|function rawToX\b/);
   });
 });
 

--- a/frontend/src/components-v2/meters/__tests__/smeter-scale.projection.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/smeter-scale.projection.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
+import { projectSignalMeter } from '../smeter-scale';
+
+const NONUNIFORM_CAL = [
+  { raw: 0, actual: -54, label: 'S0' },
+  { raw: 26, actual: -48, label: 'S1' },
+  { raw: 52, actual: -36, label: 'S3' },
+  { raw: 78, actual: -24, label: 'S5' },
+  { raw: 103, actual: -12, label: 'S7' },
+  { raw: 130, actual: 0, label: 'S9' },
+  { raw: 165, actual: 10, label: 'S9+10' },
+  { raw: 200, actual: 20, label: 'S9+20' },
+  { raw: 240, actual: 40, label: 'S9+40' },
+] as const;
+
+function capabilities(calibrated = true): Capabilities {
+  return {
+    model: 'projection-test',
+    scope: false,
+    audio: false,
+    tx: false,
+    capabilities: [],
+    receivers: 1,
+    vfoScheme: 'single',
+    freqRanges: [],
+    modes: [],
+    filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: [] },
+    webrtc: { available: false, enabled: false },
+    txBands: null,
+    stateContractVersion: 1,
+    providerGeneration: 0,
+    meterCalibrations: calibrated ? { s_meter: [...NONUNIFORM_CAL] } : undefined,
+  };
+}
+
+beforeEach(() => setCapabilities(capabilities()));
+afterEach(() => clearCapabilities());
+
+describe('projectSignalMeter', () => {
+  it('projects one calibrated reading into motion, text, crossover, and labeled marks', () => {
+    const projection = projectSignalMeter(-48);
+
+    expect(Object.keys(projection).sort()).toEqual([
+      'marks', 'motionFraction', 'primaryText', 's9Fraction', 'secondaryText',
+    ]);
+    expect(projection.motionFraction).toBeCloseTo(11 / 9 / 20);
+    expect(projection.primaryText).toBe('S1');
+    expect(projection.secondaryText).toBe('\u2212121 dBm');
+    expect(projection.s9Fraction).toBe(11 / 20);
+    expect(projection.marks.map(({ raw, actual, text }) => ({ raw, actual, text }))).toEqual([
+      { raw: 26, actual: -48, text: 'S1' },
+      { raw: 52, actual: -36, text: 'S3' },
+      { raw: 78, actual: -24, text: 'S5' },
+      { raw: 103, actual: -12, text: 'S7' },
+      { raw: 130, actual: 0, text: 'S9' },
+      { raw: 165, actual: 10, text: '+10' },
+      { raw: 200, actual: 20, text: '+20' },
+      { raw: 240, actual: 40, text: '+40' },
+    ]);
+    expect(Object.keys(projection.marks[0]).sort()).toEqual([
+      'actual', 'color', 'fraction', 'raw', 'text',
+    ]);
+    expect(projection.marks[0].fraction).toBeCloseTo(11 / 9 / 20);
+    expect(projection.marks[4].fraction).toBe(11 / 20);
+    expect(projection.marks.at(-1)?.fraction).toBe(1);
+  });
+
+  it('keeps unknown distinct from a known zero while retaining scale context', () => {
+    const unknown = projectSignalMeter(null);
+    const zero = projectSignalMeter(0);
+
+    expect(unknown).toMatchObject({
+      motionFraction: null,
+      primaryText: 'S ?',
+      secondaryText: '',
+      s9Fraction: 11 / 20,
+    });
+    expect(unknown.marks).toEqual(zero.marks);
+    expect(zero.motionFraction).toBe(11 / 20);
+    expect(zero.primaryText).toBe('S9');
+    expect(zero.secondaryText).toBe('\u221273 dBm');
+  });
+
+  it.each([
+    [-54, 'S0', 0, '\u2212127 dBm'],
+    [-36, 'S3', (3 / 9) * 11 / 20, '\u2212109 dBm'],
+    [10, 'S9+10', (11 + (35 / 110) * 9) / 20, '\u221263 dBm'],
+    [40, 'S9+40', 1, '\u221233 dBm'],
+  ] as const)(
+    'keeps nonuniform calibration aligned at actual=%s',
+    (actual, primaryText, motionFraction, secondaryText) => {
+      expect(projectSignalMeter(actual)).toMatchObject({ primaryText, secondaryText });
+      expect(projectSignalMeter(actual).motionFraction).toBeCloseTo(motionFraction);
+    },
+  );
+
+  it('assigns the existing scale colors without adding a second zone policy', () => {
+    expect(projectSignalMeter(0).marks.map((mark) => mark.color)).toEqual([
+      'var(--v2-text-bright)',
+      'var(--v2-text-bright)',
+      'var(--v2-text-bright)',
+      'var(--v2-text-bright)',
+      'var(--v2-text-bright)',
+      'var(--v2-accent-yellow)',
+      'var(--v2-accent-yellow)',
+      'var(--v2-accent-orange-alt)',
+    ]);
+  });
+
+  it.each([
+    [-999, 0, 'S0', '\u2212127 dBm'],
+    [999, 1, 'S9+40', '\u221233 dBm'],
+  ] as const)(
+    'keeps out-of-range actual=%s on the existing calibrated boundaries',
+    (actual, motionFraction, primaryText, secondaryText) => {
+      expect(projectSignalMeter(actual)).toMatchObject({
+        motionFraction,
+        primaryText,
+        secondaryText,
+      });
+    },
+  );
+
+  it('uses the existing honest raw fallback when no calibration is declared', () => {
+    setCapabilities(capabilities(false));
+
+    const projection = projectSignalMeter(53);
+    expect(projection.motionFraction).toBeCloseTo((53 / 127.5) * 11 / 20);
+    expect(projection.primaryText).toBe('53');
+    expect(projection.secondaryText).toBe('uncalibrated');
+    expect(projection.s9Fraction).toBe(11 / 20);
+    expect(projection.marks).toEqual([]);
+  });
+});

--- a/frontend/src/components-v2/meters/__tests__/smeter-scale.projection.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/smeter-scale.projection.test.ts
@@ -44,25 +44,27 @@ describe('projectSignalMeter', () => {
     const projection = projectSignalMeter(-48);
 
     expect(Object.keys(projection).sort()).toEqual([
-      'marks', 'motionFraction', 'primaryText', 's9Fraction', 'secondaryText',
+      'marks', 'motionFraction', 'primaryText', 's9Fraction', 'secondaryText', 'ticks',
     ]);
     expect(projection.motionFraction).toBeCloseTo(11 / 9 / 20);
     expect(projection.primaryText).toBe('S1');
     expect(projection.secondaryText).toBe('\u2212121 dBm');
     expect(projection.s9Fraction).toBe(11 / 20);
-    expect(projection.marks.map(({ raw, actual, text }) => ({ raw, actual, text }))).toEqual([
-      { raw: 26, actual: -48, text: 'S1' },
-      { raw: 52, actual: -36, text: 'S3' },
-      { raw: 78, actual: -24, text: 'S5' },
-      { raw: 103, actual: -12, text: 'S7' },
-      { raw: 130, actual: 0, text: 'S9' },
-      { raw: 165, actual: 10, text: '+10' },
-      { raw: 200, actual: 20, text: '+20' },
-      { raw: 240, actual: 40, text: '+40' },
+    expect(projection.marks.map(({ actual, text }) => ({ actual, text }))).toEqual([
+      { actual: -48, text: 'S1' },
+      { actual: -36, text: 'S3' },
+      { actual: -24, text: 'S5' },
+      { actual: -12, text: 'S7' },
+      { actual: 0, text: 'S9' },
+      { actual: 10, text: '+10' },
+      { actual: 20, text: '+20' },
+      { actual: 40, text: '+40' },
     ]);
     expect(Object.keys(projection.marks[0]).sort()).toEqual([
-      'actual', 'color', 'fraction', 'raw', 'text',
+      'actual', 'color', 'fraction', 'text',
     ]);
+    expect(Object.keys(projection.ticks[0]).sort()).toEqual(['color', 'fraction', 'kind']);
+    expect(projection.ticks).toHaveLength(81);
     expect(projection.marks[0].fraction).toBeCloseTo(11 / 9 / 20);
     expect(projection.marks[4].fraction).toBe(11 / 20);
     expect(projection.marks.at(-1)?.fraction).toBe(1);
@@ -79,6 +81,7 @@ describe('projectSignalMeter', () => {
       s9Fraction: 11 / 20,
     });
     expect(unknown.marks).toEqual(zero.marks);
+    expect(unknown.ticks).toEqual(zero.ticks);
     expect(zero.motionFraction).toBe(11 / 20);
     expect(zero.primaryText).toBe('S9');
     expect(zero.secondaryText).toBe('\u221273 dBm');
@@ -110,6 +113,35 @@ describe('projectSignalMeter', () => {
     ]);
   });
 
+  it('maps dense subdivisions through hidden calibration knots', () => {
+    const hiddenKnotCal = [
+      { raw: 0, actual: -54, label: 'S0' },
+      { raw: 30, actual: -48, label: 'S1' },
+      { raw: 35, actual: -42, label: 'S2' },
+      { raw: 80, actual: -36, label: 'S3' },
+      { raw: 100, actual: -24, label: 'S5' },
+      { raw: 120, actual: -12, label: 'S7' },
+      { raw: 140, actual: 0, label: 'S9' },
+      { raw: 180, actual: 20, label: 'S9+20' },
+      { raw: 240, actual: 40, label: 'S9+40' },
+    ];
+    setCapabilities({
+      ...capabilities(),
+      meterCalibrations: { s_meter: hiddenKnotCal },
+    });
+
+    const projection = projectSignalMeter(-42);
+    const halfwayBetweenLabeledS1AndS3 = (
+      projection.marks[0].fraction + projection.marks[1].fraction
+    ) / 2;
+    const expectedThroughHiddenS2 = (2 + (55 - 35) / (80 - 35)) / 9 * 11 / 20;
+
+    // Tick 15 is the raw-55 midpoint between labeled S1/raw-30 and S3/raw-80.
+    expect(projection.ticks[15]).toMatchObject({ kind: 'mid' });
+    expect(projection.ticks[15].fraction).toBeCloseTo(expectedThroughHiddenS2);
+    expect(projection.ticks[15].fraction).not.toBeCloseTo(halfwayBetweenLabeledS1AndS3);
+  });
+
   it.each([
     [-999, 0, 'S0', '\u2212127 dBm'],
     [999, 1, 'S9+40', '\u221233 dBm'],
@@ -133,5 +165,8 @@ describe('projectSignalMeter', () => {
     expect(projection.secondaryText).toBe('uncalibrated');
     expect(projection.s9Fraction).toBe(11 / 20);
     expect(projection.marks).toEqual([]);
+    expect(projection.ticks).toEqual([
+      { fraction: 0, kind: 'major', color: 'var(--v2-text-bright)' },
+    ]);
   });
 });

--- a/frontend/src/components-v2/meters/smeter-scale.ts
+++ b/frontend/src/components-v2/meters/smeter-scale.ts
@@ -38,10 +38,15 @@ export interface SmeterMark {
 }
 
 export interface SignalMeterProjectionMark {
-  readonly raw: number;
   readonly actual: number;
   readonly fraction: number;
   readonly text: string;
+  readonly color: string;
+}
+
+export interface SignalMeterProjectionTick {
+  readonly fraction: number;
+  readonly kind: 'major' | 'mid' | 'minor';
   readonly color: string;
 }
 
@@ -51,6 +56,7 @@ export interface SignalMeterProjection {
   readonly secondaryText: string;
   readonly s9Fraction: number;
   readonly marks: readonly SignalMeterProjectionMark[];
+  readonly ticks: readonly SignalMeterProjectionTick[];
 }
 
 const SEGMENT_DOMAIN = 20;
@@ -153,6 +159,61 @@ function scaleMarks(calibration: readonly SmeterCalibrationPoint[]): SmeterMark[
     }));
 }
 
+/** Dense subdivisions projected from the same complete calibration snapshot
+ * as the labels and reading. Hidden calibration knots still shape every
+ * intermediate raw position even though they are not themselves labeled. */
+function scaleTicks(
+  marks: readonly SmeterMark[],
+  calibration: readonly SmeterCalibrationPoint[],
+): SignalMeterProjectionTick[] {
+  const ticks: SignalMeterProjectionTick[] = [];
+  const anchors = marks.map(({ raw, actual }) => ({ raw, actual }));
+  const first = anchors[0];
+
+  if (!first || first.raw > 0) {
+    anchors.unshift({ raw: 0, actual: -54 });
+  }
+
+  function tick(raw: number, actual: number, kind: SignalMeterProjectionTick['kind']) {
+    ticks.push({
+      fraction: rawToSegmentsForCalibration(raw, calibration) / SEGMENT_DOMAIN,
+      kind,
+      color: colorForActual(actual),
+    });
+  }
+
+  function addSubdivisions(
+    startRaw: number,
+    endRaw: number,
+    startActual: number,
+    endActual: number,
+  ) {
+    tick(startRaw, startActual, 'major');
+    const rawStep = (endRaw - startRaw) / 10;
+    const actualStep = (endActual - startActual) / 10;
+    for (let j = 1; j <= 9; j++) {
+      tick(
+        startRaw + rawStep * j,
+        startActual + actualStep * j,
+        j === 5 ? 'mid' : 'minor',
+      );
+    }
+  }
+
+  for (let i = 0; i < anchors.length - 1; i++) {
+    addSubdivisions(
+      anchors[i].raw,
+      anchors[i + 1].raw,
+      anchors[i].actual,
+      anchors[i + 1].actual,
+    );
+  }
+
+  const last = anchors[anchors.length - 1];
+  tick(last.raw, last.actual, 'major');
+  return ticks;
+}
+
 /** Major S-meter marks derived from the active calibration table. */
 export function getScaleMarks(): SmeterMark[] {
   return scaleMarks(getCal());
@@ -165,17 +226,28 @@ export function getScaleMarks(): SmeterMark[] {
  */
 export function projectSignalMeter(value: number | null): SignalMeterProjection {
   const calibration = getCal();
-  const marks = scaleMarks(calibration).map((mark) => ({
-    ...mark,
+  const scale = scaleMarks(calibration);
+  const marks = scale.map((mark) => ({
+    actual: mark.actual,
     fraction: rawToSegmentsForCalibration(mark.raw, calibration) / SEGMENT_DOMAIN,
+    text: mark.text,
+    color: mark.color,
   }));
+  const ticks = scaleTicks(scale, calibration);
   const s9Fraction = rawToSegmentsForCalibration(
     getS9RawForCalibration(calibration),
     calibration,
   ) / SEGMENT_DOMAIN;
 
   if (value === null) {
-    return { motionFraction: null, primaryText: 'S ?', secondaryText: '', s9Fraction, marks };
+    return {
+      motionFraction: null,
+      primaryText: 'S ?',
+      secondaryText: '',
+      s9Fraction,
+      marks,
+      ticks,
+    };
   }
 
   return {
@@ -186,6 +258,7 @@ export function projectSignalMeter(value: number | null): SignalMeterProjection 
     ),
     s9Fraction,
     marks,
+    ticks,
   };
 }
 

--- a/frontend/src/components-v2/meters/smeter-scale.ts
+++ b/frontend/src/components-v2/meters/smeter-scale.ts
@@ -37,6 +37,24 @@ export interface SmeterMark {
   color: string;
 }
 
+export interface SignalMeterProjectionMark {
+  readonly raw: number;
+  readonly actual: number;
+  readonly fraction: number;
+  readonly text: string;
+  readonly color: string;
+}
+
+export interface SignalMeterProjection {
+  readonly motionFraction: number | null;
+  readonly primaryText: string;
+  readonly secondaryText: string;
+  readonly s9Fraction: number;
+  readonly marks: readonly SignalMeterProjectionMark[];
+}
+
+const SEGMENT_DOMAIN = 20;
+
 function getCal(): SmeterCalibrationPoint[] {
   return getSmeterCalibration() ?? [];
 }
@@ -124,9 +142,8 @@ function markText(label: string): string {
   return label;
 }
 
-/** Major S-meter marks derived from the active calibration table. */
-export function getScaleMarks(): SmeterMark[] {
-  return getCal()
+function scaleMarks(calibration: readonly SmeterCalibrationPoint[]): SmeterMark[] {
+  return calibration
     .filter((p) => /^S[13579]$/.test(p.label) || /^S9\+/.test(p.label))
     .map((p) => ({
       raw: p.raw,
@@ -134,6 +151,42 @@ export function getScaleMarks(): SmeterMark[] {
       text: markText(p.label),
       color: colorForActual(p.actual),
     }));
+}
+
+/** Major S-meter marks derived from the active calibration table. */
+export function getScaleMarks(): SmeterMark[] {
+  return scaleMarks(getCal());
+}
+
+/**
+ * Resolve every display-facing S-meter value from one capability snapshot.
+ * The facade remains the only store reader; the pure primitives above own all
+ * calibration, interpolation, labeling, and raw fallback behavior.
+ */
+export function projectSignalMeter(value: number | null): SignalMeterProjection {
+  const calibration = getCal();
+  const marks = scaleMarks(calibration).map((mark) => ({
+    ...mark,
+    fraction: rawToSegmentsForCalibration(mark.raw, calibration) / SEGMENT_DOMAIN,
+  }));
+  const s9Fraction = rawToSegmentsForCalibration(
+    getS9RawForCalibration(calibration),
+    calibration,
+  ) / SEGMENT_DOMAIN;
+
+  if (value === null) {
+    return { motionFraction: null, primaryText: 'S ?', secondaryText: '', s9Fraction, marks };
+  }
+
+  return {
+    motionFraction: calibratedToSegmentsForCalibration(value, calibration) / SEGMENT_DOMAIN,
+    primaryText: calibratedToSUnitForCalibration(value, calibration),
+    secondaryText: formatDbmForCalibration(
+      calibratedToDbmForCalibration(value, calibration),
+    ),
+    s9Fraction,
+    marks,
+  };
 }
 
 /** Format dBm value as display string, e.g. "−67 dBm". Uses Unicode minus. */

--- a/frontend/src/semantic/MetersSurface.svelte
+++ b/frontend/src/semantic/MetersSurface.svelte
@@ -3,9 +3,13 @@
   import type { DisplayObservedMeterField, MeterRfState, MeterField, MetersViewModel } from './radio-view-model';
   import {
     alcLevel, compLevel, formatAlc, formatAmps, formatCompDb, formatPowerWatts,
-    formatVolts, idLevel, isAlcFault, isSwrFault, normalizePower, sLevel,
+    formatVolts, idLevel, isAlcFault, isSwrFault, normalizePower,
     swrLevel, vdLevel,
   } from '../components-v2/panels/meter-utils';
+  import {
+    projectSignalMeter,
+    type SignalMeterProjection,
+  } from '../components-v2/meters/smeter-scale';
   import { renderSlot } from './design-language-renderers';
   import type { LowerScaleDescriptor } from '../components-v2/meters/LinearSMeter.svelte';
 
@@ -99,10 +103,9 @@
   /**
    * MOR-1275: the active design language's `meters` renderer, for the S meter —
    * the one gauge whose grammar those renderers describe (a two-tone track that
-   * hands over at S9). The reading is handed over on the 0..1 UI scale
-   * `meter-utils` already calibrates, with the S9 crossover expressed on the
-   * same scale, so the descriptor's fractions mean what they say; an unobserved
-   * meter passes `null` and stays unknown rather than reading as zero.
+   * hands over at S9). The reading and crossover are the fractions from the
+   * same `SignalMeterProjection` passed to `LinearSMeter`; an unobserved meter
+   * keeps a null motion fraction and stays unknown rather than reading as zero.
    * Annotations only — availability, relevance and the gauge itself remain this
    * surface's decisions.
    *
@@ -110,8 +113,12 @@
    * the slot is called ONCE per render (see `display` below) and read twice,
    * never once per gauge.
    */
-  const signalDisplay = (f: MeterField): ReturnType<typeof renderSlot> =>
-    renderSlot('meters', { value: observed(f) ? sLevel(rawOf(f)) : null, max: 1, s9: sLevel(0) });
+  const signalDisplay = (signalProjection: SignalMeterProjection): ReturnType<typeof renderSlot> =>
+    renderSlot('meters', {
+      value: signalProjection.motionFraction,
+      max: 1,
+      s9: signalProjection.s9Fraction,
+    });
 </script>
 
 <script lang="ts">
@@ -132,6 +139,10 @@
    *  schema had to learn about it. */
   let meters = $derived(view.meters);
 
+  let signalProjection = $derived(projectSignalMeter(
+    meters && observed(meters.signal) ? rawOf(meters.signal) : null,
+  ));
+
   /**
    * The active design language's `meters` descriptor for this render, or
    * `null` when no language is active, the language declares no `meters`
@@ -142,7 +153,7 @@
    * read the SAME descriptor from ONE `renderSlot` call. Each consumer falls
    * back to its own component default when this is `null`.
    */
-  let display = $derived(meters ? signalDisplay(meters.signal) : null);
+  let display = $derived(meters ? signalDisplay(signalProjection) : null);
 
   /** The COMP gate is the MOR-1244 `txAux.compressor` FACT, deliberately NOT
    *  `meters.compression.availability`: a radio can keep reporting a
@@ -173,7 +184,7 @@
         {...display?.attributes ?? {}}
       >
         <LinearSMeter
-          value={observed(meters.signal) ? rawOf(meters.signal) : null} label="S" compact
+          projection={signalProjection} label="S" compact
           mainPresent={present(meters.signal)}
           display={display?.display ?? undefined}
           lowerScale={present(meters.swr) ? swrLowerScale(meters.swr, meters.rfState) : undefined}

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -644,6 +644,63 @@ describe('raw sMeter renders honestly, never a fabricated S-unit (MOR-1451)', ()
   });
 });
 
+describe('the host descriptor and LinearSMeter share one signal projection', () => {
+  const NONUNIFORM_S_METER_CAL = [
+    { raw: 0, actual: -54, label: 'S0' },
+    { raw: 26, actual: -48, label: 'S1' },
+    { raw: 52, actual: -36, label: 'S3' },
+    { raw: 78, actual: -24, label: 'S5' },
+    { raw: 103, actual: -12, label: 'S7' },
+    { raw: 130, actual: 0, label: 'S9' },
+    { raw: 165, actual: 10, label: 'S9+10' },
+    { raw: 200, actual: 20, label: 'S9+20' },
+    { raw: 240, actual: 40, label: 'S9+40' },
+  ];
+
+  it('projects a known nonuniform reading identically into fieldline and the real LinearSMeter, distinct from unknown', () => {
+    const caps = makeFaultCaps();
+    caps.meterCalibrations!.s_meter = NONUNIFORM_S_METER_CAL;
+    setCapabilities(caps);
+    document.documentElement.dataset.designLanguage = 'fieldline';
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }) as unknown as typeof window.matchMedia;
+
+    try {
+      withSurface(withRaw(base(), 'signal', -48), (s) => {
+        const tile = s.tile('signal')!;
+        expect(tile.dataset.dlUnknown).toBe('false');
+        expect(tile.dataset.dlLitCount).toBe('1');
+        expect(tile.querySelectorAll('[data-meter-fill]')).toHaveLength(1);
+        expect(tile.textContent).toContain('\u2212121 dBm');
+      });
+
+      withSurface(withField(base(), 'signal', { unknown: true }), (s) => {
+        const tile = s.tile('signal')!;
+        expect(tile.dataset.dlUnknown).toBe('true');
+        expect(tile.querySelectorAll('[data-meter-fill]')).toHaveLength(0);
+        expect(tile.textContent).toContain('S ?');
+      });
+    } finally {
+      clearCapabilities();
+      delete document.documentElement.dataset.designLanguage;
+      window.matchMedia = originalMatchMedia;
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('creates one projection and reuses its motion and S9 fractions for the descriptor and the exact object for LinearSMeter', () => {
+    expect(SOURCE.match(/\bprojectSignalMeter\(/g)).toHaveLength(1);
+    expect(SOURCE).toMatch(/value:\s*signalProjection\.motionFraction/);
+    expect(SOURCE).toMatch(/s9:\s*signalProjection\.s9Fraction/);
+    expect(SOURCE).toMatch(/<LinearSMeter[\s\S]*?projection=\{signalProjection\}/);
+    expect(SOURCE).not.toMatch(/\bsLevel\(/);
+  });
+});
+
 describe('SWR/ALC fault highlighting reuses the dock\'s own threshold', () => {
   // MOR-1470: fault predicates are only claimable in the calibrated
   // engineering domain (an uncalibrated raw byte never asserts a fault) —

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -657,6 +657,19 @@ describe('the host descriptor and LinearSMeter share one signal projection', () 
     { raw: 240, actual: 40, label: 'S9+40' },
   ];
 
+  const REPLACEMENT_S_METER_CAL = [
+    { raw: 0, actual: -60, label: 'S0' },
+    { raw: 20, actual: -50, label: 'S1' },
+    { raw: 40, actual: -48, label: 'S2' },
+    { raw: 90, actual: -30, label: 'S3' },
+    { raw: 110, actual: -20, label: 'S5' },
+    { raw: 125, actual: -10, label: 'S7' },
+    { raw: 150, actual: 0, label: 'S9' },
+    { raw: 175, actual: 10, label: 'S9+10' },
+    { raw: 200, actual: 20, label: 'S9+20' },
+    { raw: 250, actual: 40, label: 'S9+40' },
+  ];
+
   it('projects a known nonuniform reading identically into fieldline and the real LinearSMeter, distinct from unknown', () => {
     const caps = makeFaultCaps();
     caps.meterCalibrations!.s_meter = NONUNIFORM_S_METER_CAL;
@@ -685,6 +698,64 @@ describe('the host descriptor and LinearSMeter share one signal projection', () 
         expect(tile.textContent).toContain('S ?');
       });
     } finally {
+      clearCapabilities();
+      delete document.documentElement.dataset.designLanguage;
+      window.matchMedia = originalMatchMedia;
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('refreshes descriptor, readout, fill, labels, and dense ticks coherently on a retained capability update', () => {
+    const initialCaps = makeFaultCaps();
+    initialCaps.meterCalibrations!.s_meter = NONUNIFORM_S_METER_CAL;
+    setCapabilities(initialCaps);
+    document.documentElement.dataset.designLanguage = 'fieldline';
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }) as unknown as typeof window.matchMedia;
+
+    const props: { view: RadioViewModel } = proxy({ view: withRaw(base(), 'signal', -48) });
+    const component = mount(MetersSurface, { target, props });
+    flushSync();
+    const tickXs = () => [...target.querySelectorAll<SVGLineElement>('[data-main-relevant] line')]
+      .filter((line) => line.getAttribute('y2') === '36')
+      .map((line) => Number(line.getAttribute('x1')));
+    const labelX = (text: string) => Number([...target.querySelectorAll<SVGTextElement>('text')]
+      .find((label) => label.textContent === text)?.getAttribute('x'));
+
+    try {
+      const tile = target.querySelector<HTMLElement>('[data-testid="meter-signal"]')!;
+      const retainedSvg = tile.querySelector('svg')!;
+      const initialTicks = tickXs();
+      const initialPlus20 = labelX('+20');
+      expect(tile.dataset.dlLitCount).toBe('1');
+      expect(tile.querySelectorAll('[data-meter-fill]')).toHaveLength(1);
+      expect(tile.textContent).toContain('S1');
+
+      const replacementCaps = makeFaultCaps();
+      replacementCaps.meterCalibrations!.s_meter = REPLACEMENT_S_METER_CAL;
+      setCapabilities(replacementCaps);
+      flushSync();
+
+      const replacementTicks = tickXs();
+      const replacementPlus20 = labelX('+20');
+      const majorTickXs = [...tile.querySelectorAll<SVGLineElement>('[data-main-relevant] line')]
+        .filter((line) => line.getAttribute('y1') === '24' && line.getAttribute('y2') === '36')
+        .map((line) => Number(line.getAttribute('x1')));
+      expect(retainedSvg.isConnected).toBe(true);
+      expect(tile.querySelector('svg')).toBe(retainedSvg);
+      expect(tile.dataset.dlLitCount).toBe('2');
+      expect(tile.querySelectorAll('[data-meter-fill]')).toHaveLength(2);
+      expect(tile.textContent).toContain('S2');
+      expect(replacementTicks).not.toEqual(initialTicks);
+      expect(replacementPlus20).not.toBe(initialPlus20);
+      expect(majorTickXs.some((x) => Math.abs(x - replacementPlus20) < 1e-9)).toBe(true);
+      expect(majorTickXs.some((x) => Math.abs(x - labelX('S9')) < 1e-9)).toBe(true);
+    } finally {
+      unmount(component);
       clearCapabilities();
       delete document.documentElement.dataset.designLanguage;
       window.matchMedia = originalMatchMedia;


### PR DESCRIPTION
The semantic meter host normalized S-meter readings with `sLevel`, while `LinearSMeter` used the calibrated S-unit ladder. With a nonuniform profile, the design-language descriptor and the visible meter therefore disagreed about the same reading. This change adds one `SignalMeterProjection` to the existing S-meter facade and passes the same object through `MetersSurface` to both `renderSlot` and `LinearSMeter`.

The projection contains normalized motion, primary and secondary text, the S9 fraction, labeled scale marks, and dense ticks as normalized fractions with their existing kind and color. The facade builds all of them from one calibration snapshot, including full-calibration mapping through hidden S-unit knots. `LinearSMeter` accepts either a projection or its legacy `value` input as an exclusive TypeScript union, rejects invalid dynamic combinations, and routes every existing value caller through the same projector. Existing motion, peak, source/session, lower-scale, reduced-motion, and teardown policies are unchanged.

Linear: https://linear.app/morozsm/issue/MOR-2425/expose-a-supported-v3-host-boundary-for-independently-installed

Compatibility: no public API, SDK, configuration, calibration table, wire behavior, SRS/VFO surface, or visual baseline changes.

Validation:

- Initial behavioral RED: `MetersSurface.test.ts` — 139 passed, 1 failed; for a nonuniform profile at actual -48, fieldline reported 2 lit segments while the real `LinearSMeter` rendered the expected 1.
- Independent review BLOCKED the first head because a retained supplied projection used its own labels and fill but read current calibration for dense tick geometry.
- Correction geometry RED on the blocked head: `LinearSMeter.test.ts` — 48 passed, 1 failed; replacing capabilities moved all 81 dense ticks away from the retained projection and displaced its S1 major tick from its S1 label.
- Corrected focused GREEN: 3 files, 202 passed, 0 failed. This includes hidden-knot geometry and a retained mounted `MetersSurface` capability-update regression.
- Combined corrected M1-S plus retained N1 regression set: 10 files, 323 passed, 0 failed.
- Focused ESLint on all six leased files — passed.
- `npm run check` — 0 errors, 0 warnings.
- Corrected-head natural quick `34061891547` — SUCCESS: 439 files / 10,731 tests, Svelte 0 errors and 0 warnings, 87 i18n tests, and 65 fixture captures with 0 invalid.
- Corrected-head natural visual `34061891574` — SUCCESS: 36 / 36 tests.
- Accepted baseline: main `66216e542cb714a3957d76d6108316cdee11d09a`, natural quick run `34059739623` SUCCESS; frontend block ran 438 files / 10,693 tests, 87 i18n tests, and 65 valid fixture captures.
- Diff: exactly 6 files, 570 additions + 109 deletions (679 A+D); no regenerated baselines.
