### PR TITLE
feat(MOR-2425): wire finite controls to live Scope authority

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -15,6 +15,7 @@
   import { onDestroy, untrack, type Snippet } from 'svelte';
   import { t } from '$lib/i18n';
   import { presentationResources, runtime } from '$lib/runtime';
+  import * as componentKitActivation from '../../component-kits/activation';
   import { ScopeFrameHost, type ScopeFramePresentation } from '$lib/runtime/scope-frame-host';
   import { EMPTY_SCOPE_PASSBAND_DISPLAY, projectScopePassbandDisplay } from '$lib/runtime/adapters/scope-passband-display';
   import type { ManagedScopeRegion } from '$lib/runtime/adapters/scope-display-projection';
@@ -46,7 +47,11 @@
   import FilterSurface from '../../semantic/FilterSurface.svelte';
   import MetersSurface from '../../semantic/MetersSurface.svelte';
   import type { MeterContinuitySession } from '../../primitives/meters/meter-ballistics.svelte';
-  import type { RadioViewModel } from '../../semantic/radio-view-model';
+  import {
+    createFiniteRendererContext,
+    type FiniteRendererContext,
+  } from '../../primitives/control-instruments/control-instrument-renderer.svelte';
+  import type { RadioViewModel, VfoSlot } from '../../semantic/radio-view-model';
   import RfFrontEndSurface, {
     type RfFrontEndLevelField, type RfFrontEndToggleField,
   } from '../../semantic/RfFrontEndSurface.svelte';
@@ -483,6 +488,73 @@
       toRadioViewModel(runtime.state, runtime.caps, txState, rxAudioSnapshot, scopeDisplaySnapshot),
     ),
   );
+
+  type ScopeFiniteAuthority = Readonly<{
+    sessionEpoch: number;
+    providerGeneration: number;
+    topologyId: string;
+    activeReceiver: 'MAIN' | 'SUB' | 'unknown';
+    activeSlots: readonly string[];
+  }>;
+  const slotIdentity = (slot: VfoSlot): string => {
+    if (slot.kind === 'slotted') return `slotted:${slot.id}`;
+    if (slot.kind === 'relative') return `relative:${slot.role}`;
+    return slot.kind;
+  };
+  function scopeFiniteAuthority(
+    state: typeof runtime.state,
+    caps: typeof runtime.caps,
+    session: typeof runtime.controlSession,
+  ): ScopeFiniteAuthority | null {
+    const stateGeneration = state?.providerGeneration;
+    const capsGeneration = caps?.providerGeneration;
+    if (session.state !== 'connected' || !Number.isSafeInteger(session.epoch) || session.epoch < 0
+      || !Number.isSafeInteger(stateGeneration) || stateGeneration! < 0
+      || stateGeneration !== capsGeneration) return null;
+    const model = toRadioViewModel(state, caps);
+    if (model?.scopeControls === undefined) return null;
+    const receivers = [...new Set(model.vfos.map(vfo => vfo.receiver))];
+    return Object.freeze({
+      sessionEpoch: session.epoch,
+      providerGeneration: stateGeneration as number,
+      topologyId: model.topologyId,
+      activeReceiver: model.activeReceiver.status === 'known'
+        ? model.activeReceiver.receiver : 'unknown',
+      activeSlots: Object.freeze(receivers.map((receiver) => {
+        const active = model.vfos.filter(vfo => vfo.receiver === receiver && vfo.isActiveSlot);
+        return active.length === 1
+          ? `${receiver}:${slotIdentity(active[0]!.slot)}` : `${receiver}:unknown`;
+      })),
+    });
+  }
+  const sameScopeFiniteAuthority = (
+    left: ScopeFiniteAuthority | null | undefined,
+    right: ScopeFiniteAuthority | null,
+  ): boolean => left !== undefined && (
+    left === null || right === null ? left === right
+      : left.sessionEpoch === right.sessionEpoch
+        && left.providerGeneration === right.providerGeneration
+        && left.topologyId === right.topologyId
+        && left.activeReceiver === right.activeReceiver
+        && left.activeSlots.length === right.activeSlots.length
+        && left.activeSlots.every((slot, index) => slot === right.activeSlots[index])
+  );
+  const readSelectedFiniteAppearance = 'getSelectedFiniteControlAppearance' in componentKitActivation
+    ? componentKitActivation.getSelectedFiniteControlAppearance : undefined;
+  const selectedFiniteAppearance = readSelectedFiniteAppearance?.();
+  let finiteRendererContext = $state.raw<FiniteRendererContext | null>(null);
+  let lastScopeFiniteAuthority: ScopeFiniteAuthority | null | undefined;
+  const unsubscribeScopeFiniteAuthority = selectedFiniteAppearance === undefined ? undefined
+    : runtime.subscribeControlAuthority((publication) => {
+      const next = scopeFiniteAuthority(publication.state, publication.caps, publication.session);
+      if (sameScopeFiniteAuthority(lastScopeFiniteAuthority, next)) return;
+      lastScopeFiniteAuthority = next;
+      finiteRendererContext = next === null ? null : createFiniteRendererContext();
+    });
+  onDestroy(() => unsubscribeScopeFiniteAuthority?.());
+  let scopeFiniteRendererSelection = $derived(selectedFiniteAppearance === undefined
+    ? {} : { finiteAppearance: selectedFiniteAppearance, rendererContext: finiteRendererContext });
+
   let managedScope = $derived(displayFrameSource === 'hardware' && regions && regionContent !== undefined);
   let scopeDemanded = $state(true);
   let scopePresentation = $state.raw<ScopeFramePresentation | null>(null);
@@ -1475,6 +1547,7 @@
   {#snippet scopeControlsSurface()}
     {#if view?.scopeControls}
       <ScopeControlsSurface
+        {...scopeFiniteRendererSelection}
         {view}
         onToggleChange={(field, next) => SCOPE_TOGGLE_INTENT[field](next)}
         onChoiceChange={(field, value) => SCOPE_CHOICE_INTENT[field](value)}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
@@ -25,6 +25,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRawSnippet, flushSync, mount, unmount, type Snippet } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
 import SpectrumPanelStub from '../../layout/__tests__/SpectrumPanelStub.svelte';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
@@ -34,6 +35,11 @@ import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
+  live: null as unknown,
+  selectedFiniteAppearance: undefined as unknown,
+  controlSession: { state: 'connected', epoch: 1 } as { state: string; epoch: number },
+  controlSessionSubscriber: null as ((next: { state: string; epoch: number }) => void) | null,
+  authoritySubscriber: null as ((next: { state: unknown; caps: unknown; session: { state: string; epoch: number } }) => void) | null,
   txController: null as ManagedAppTxController | null,
   audio: { muted: true, rxEnabled: false, volume: 0 },
   audioConnected: false,
@@ -41,6 +47,11 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
+vi.mock('../../../component-kits/activation', () => ({
+  getSelectedFiniteControlAppearance: () => h.selectedFiniteAppearance,
+  getSelectedFrequencyReadout: () => undefined,
+  getSelectedScalarAppearance: () => undefined,
+}));
 vi.mock('$lib/runtime/commands/radio-intents', async () => {
   const { sendCommand } = await import('$lib/transport/ws-client');
   return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
@@ -48,8 +59,22 @@ vi.mock('$lib/runtime/commands/radio-intents', async () => {
 vi.mock('$lib/runtime', () => ({
   runtime: {
     onTxAudioDied: () => () => {},
-    get state() { return h.state; },
-    get caps() { return h.caps; },
+    get state() { return (h.live as Map<string, unknown> | null)?.get('state') ?? h.state; },
+    get caps() { return (h.live as Map<string, unknown> | null)?.get('caps') ?? h.caps; },
+    get controlSession() { return h.controlSession; },
+    subscribeControlSession(handler: (next: { state: string; epoch: number }) => void) {
+      h.controlSessionSubscriber = handler;
+      return () => { if (h.controlSessionSubscriber === handler) h.controlSessionSubscriber = null; };
+    },
+    subscribeControlAuthority(handler: typeof h.authoritySubscriber) {
+      h.authoritySubscriber = handler;
+      handler?.({
+        state: (h.live as Map<string, unknown> | null)?.get('state') ?? h.state,
+        caps: (h.live as Map<string, unknown> | null)?.get('caps') ?? h.caps,
+        session: h.controlSession,
+      });
+      return () => { if (h.authoritySubscriber === handler) h.authoritySubscriber = null; };
+    },
     get audio() { return h.audio; },
     get connectionAudio() { return h.audioConnected; },
     // MOR-1312 slice 12B: the wiring now also hands the adapter a
@@ -78,6 +103,10 @@ import { setCapabilities } from '$lib/stores/capabilities.svelte';
 import { getRadioState, resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
+import FiniteControlRendererFixture, {
+  resetRetainedInvocations, retainedInvocations,
+} from '../../../primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte';
+import type { FiniteControlAppearance } from '../../../primitives/control-instruments/control-instrument-renderer.svelte';
 // MOR-1370 (S6b-2): the REAL manifests + the REAL resolution seam, mirroring
 // `semantic-scope-display-wiring.component.test.ts`'s "MOR-1365 (S6a)"
 // section — the only way to prove the `scope-controls` zone binding and the
@@ -161,16 +190,47 @@ const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T
 const el = (id: string) => q<HTMLElement>(`[data-testid="${id}"]`);
 function useState(state: ServerState): void {
   h.state = state;
+  (h.live as SvelteMap<string, unknown> | null)?.set('state', state);
   resetRadioState();
   setRadioState(state);
 }
 
+function useCaps(caps: Capabilities): void {
+  h.caps = caps;
+  (h.live as SvelteMap<string, unknown> | null)?.set('caps', caps);
+  setCapabilities(caps);
+}
+
+function publishAuthority(
+  state: ServerState,
+  caps: Capabilities = h.caps as Capabilities,
+  session: { state: string; epoch: number } = h.controlSession,
+): void {
+  h.state = state;
+  h.caps = caps;
+  h.controlSession = session;
+  (h.live as SvelteMap<string, unknown>).set('state', state);
+  (h.live as SvelteMap<string, unknown>).set('caps', caps);
+  h.authoritySubscriber?.({ state, caps, session });
+}
+
+const finiteFixture = FiniteControlRendererFixture as FiniteControlAppearance['action'];
+const finiteAppearance = {
+  action: finiteFixture,
+  toggle: FiniteControlRendererFixture as FiniteControlAppearance['toggle'],
+  choice: FiniteControlRendererFixture as FiniteControlAppearance['choice'],
+} satisfies FiniteControlAppearance;
+
 beforeEach(() => {
+  h.live = new SvelteMap<string, unknown>();
+  h.selectedFiniteAppearance = undefined;
+  h.controlSession = { state: 'connected', epoch: 1 };
+  h.controlSessionSubscriber = null;
+  h.authoritySubscriber = null;
   txHarness = new ManagedAppTxHarness();
   h.txController = txHarness.controller;
-  setCapabilities(liveCaps(SCOPE_TAGS));
+  useCaps(liveCaps(SCOPE_TAGS));
   useState(liveState());
-  h.caps = liveCaps(SCOPE_TAGS);
   h.audio = { muted: true, rxEnabled: false, volume: 0 };
   h.audioConnected = false;
   h.guardVisible = false;
@@ -180,6 +240,7 @@ beforeEach(() => {
 afterEach(() => {
   if (component) unmount(component);
   component = null;
+  resetRetainedInvocations();
   expect(txHarness.listenerCount()).toBe(0);
   expect(txHarness.trace()).toEqual([]);
   document.body.innerHTML = '';
@@ -275,11 +336,193 @@ describe('the surface intents reach the shipped scope command vocabulary', () =>
   });
 });
 
+describe('selected finite Scope authority lifetime (MOR-2425)', () => {
+  const withSlot = (state: ServerState, receiver: 'main' | 'sub', activeSlot: 'A' | 'B') => ({
+    ...state,
+    [receiver]: { ...state[receiver], activeSlot },
+  } as ServerState);
+
+  it('revokes retained A1 synchronously on unobserved A→B→A before flush, then admits only fresh A3', () => {
+    h.selectedFiniteAppearance = finiteAppearance;
+    const a1 = liveState();
+    render();
+    const retainedA1 = {
+      action: retainedInvocations.get('+')!,
+      toggle: retainedInvocations.get('HOLD')!,
+      choice: retainedInvocations.get('Scope center type')!,
+    };
+    expect(Object.values(retainedA1).every(callback => typeof callback === 'function')).toBe(true);
+
+    const b2 = withSlot({ ...a1, stateRevision: 2 } as ServerState, 'main', 'B');
+    const a3 = { ...a1, stateRevision: 3 } as ServerState;
+    publishAuthority(b2);
+    publishAuthority(a3);
+    resetRadioState();
+    setRadioState(a3);
+
+    retainedA1.action();
+    retainedA1.toggle();
+    retainedA1.choice(1);
+    expect(sendCommand).not.toHaveBeenCalled();
+
+    flushSync();
+    const retainedA3 = {
+      action: retainedInvocations.get('+')!,
+      toggle: retainedInvocations.get('HOLD')!,
+      choice: retainedInvocations.get('Scope center type')!,
+    };
+    for (const kind of ['action', 'toggle', 'choice'] as const) {
+      expect(retainedA3[kind]).not.toBe(retainedA1[kind]);
+    }
+    retainedA3.action();
+    retainedA3.toggle();
+    retainedA3.choice(1);
+    expect(vi.mocked(sendCommand).mock.calls).toEqual([
+      ['set_scope_ref', { ref: 0 }],
+      ['set_scope_hold', { on: true }],
+      ['set_scope_center_type', { center_type: 1 }],
+    ]);
+    retainedA1.action();
+    retainedA1.toggle();
+    retainedA1.choice(2);
+    expect(sendCommand).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([
+    ['session', (state: ServerState, caps: Capabilities) => ({ state, caps, session: { state: 'connected', epoch: 2 } })],
+    ['provider', (state: ServerState, caps: Capabilities) => ({
+      state: { ...state, providerGeneration: 32 } as ServerState,
+      caps: { ...caps, providerGeneration: 32 } as Capabilities,
+      session: h.controlSession,
+    })],
+    ['topology', (state: ServerState, caps: Capabilities) => ({
+      state,
+      caps: { ...caps, vfoScheme: 'ab_shared', receivers: 2 } as Capabilities,
+      session: h.controlSession,
+    })],
+    ['active receiver', (state: ServerState, caps: Capabilities) => ({
+      state: { ...state, active: 'SUB' } as ServerState, caps, session: h.controlSession,
+    })],
+    ['active slot', (state: ServerState, caps: Capabilities) => ({
+      state: withSlot(state, 'main', 'B'), caps, session: h.controlSession,
+    })],
+  ] as const)('rotates the lease when %s authority changes', (_axis, replacement) => {
+    h.selectedFiniteAppearance = finiteAppearance;
+    render();
+    const first = retainedInvocations.get('HOLD')!;
+    const next = replacement(h.state as ServerState, h.caps as Capabilities);
+    publishAuthority(next.state, next.caps, next.session);
+    flushSync();
+    expect(retainedInvocations.get('HOLD')).not.toBe(first);
+    first();
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('keeps unknown receiver and active slots authoritative for readable global Scope controls', () => {
+    const state = liveState();
+    state.fieldStatus!.active = { ...fresh, observed: false, freshness: 'unknown', availability: 'missing' };
+    state.fieldStatus!['main.activeSlot'] = { ...fresh, observed: false, freshness: 'unknown', availability: 'missing' };
+    state.fieldStatus!['sub.activeSlot'] = { ...fresh, observed: false, freshness: 'unknown', availability: 'missing' };
+    useState(state);
+    h.selectedFiniteAppearance = finiteAppearance;
+    render();
+
+    const hold = el('external-HOLD') as HTMLButtonElement;
+    expect(hold).not.toBeNull();
+    expect(hold.disabled).toBe(false);
+    hold.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_scope_hold', { on: true });
+  });
+
+  it('keeps the chosen external appearance inert through disconnect and creates a fresh lease on return', () => {
+    h.selectedFiniteAppearance = finiteAppearance;
+    render();
+    const connected = retainedInvocations.get('HOLD')!;
+
+    publishAuthority(h.state as ServerState, h.caps as Capabilities, { state: 'disconnected', epoch: 1 });
+    connected();
+    expect(sendCommand).not.toHaveBeenCalled();
+    flushSync();
+    expect(el('scope-hold')).toBeNull();
+    expect(el('external-HOLD')).toBeNull();
+
+    publishAuthority(h.state as ServerState, h.caps as Capabilities, { state: 'connected', epoch: 2 });
+    flushSync();
+    const returned = retainedInvocations.get('HOLD')!;
+    expect(returned).not.toBe(connected);
+    returned();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_scope_hold', { on: true });
+  });
+
+  it.each([
+    ['provider mismatch', (state: ServerState, caps: Capabilities) => ({
+      state, caps: { ...caps, providerGeneration: 99 } as Capabilities,
+    })],
+    ['invalid topology', (state: ServerState, caps: Capabilities) => ({
+      state, caps: { ...caps, receivers: 1 } as Capabilities,
+    })],
+    ['absent Scope group', (state: ServerState, caps: Capabilities) => ({
+      state, caps: liveCaps(NO_SCOPE_TAGS),
+    })],
+  ] as const)('revokes on %s without exposing native fallback controls', (_reason, invalidate) => {
+    h.selectedFiniteAppearance = finiteAppearance;
+    render();
+    const retained = retainedInvocations.get('HOLD')!;
+    const invalid = invalidate(h.state as ServerState, h.caps as Capabilities);
+    publishAuthority(invalid.state, invalid.caps);
+    retained();
+    expect(sendCommand).not.toHaveBeenCalled();
+    flushSync();
+    expect(el('scope-hold')).toBeNull();
+  });
+
+  it('preserves the lease across irrelevant value updates while refreshing its view', () => {
+    h.selectedFiniteAppearance = finiteAppearance;
+    render();
+    const retained = retainedInvocations.get('HOLD')!;
+    const changed = liveState({
+      stateRevision: 2,
+      scopeControls: { ...liveState().scopeControls!, hold: true },
+      main: { ...liveState().main!, freqHz: 14251000 },
+    });
+    publishAuthority(changed);
+    flushSync();
+    expect(retainedInvocations.get('HOLD')).toBe(retained);
+    expect((el('external-HOLD') as HTMLButtonElement).getAttribute('aria-pressed')).toBe('true');
+
+    const unavailable = liveState({ stateRevision: 3 });
+    unavailable.fieldStatus!['scopeControls.hold'] = {
+      ...fresh, observed: false, freshness: 'unknown', availability: 'missing',
+    };
+    publishAuthority(unavailable);
+    flushSync();
+    expect(retainedInvocations.get('HOLD')).toBe(retained);
+    expect((el('external-HOLD') as HTMLButtonElement).disabled).toBe(true);
+
+    const telemetry = liveState({
+      stateRevision: 4, freshnessRevision: 9, updatedAt: '2026-08-09T00:00:01Z',
+      main: { ...liveState().main!, mode: 'LSB', freqHz: 14252000 },
+      powerMeter: 45,
+    });
+    publishAuthority(telemetry);
+    flushSync();
+    expect(retainedInvocations.get('HOLD')).toBe(retained);
+  });
+
+  it('leaves the native Scope path unchanged when no appearance is selected', () => {
+    render();
+    expect(el('scope-hold')).not.toBeNull();
+    expect(el('external-HOLD')).toBeNull();
+    expect(h.authoritySubscriber).toBeNull();
+  });
+});
+
 /* ── (b) MOUNTING CANON: single bare, dual absent ─────────────────────── */
 
 describe('the surface mounts only in the single composition, never in dual', () => {
   it('renders no scope-controls surface for a radio without the scope capability', () => {
-    h.caps = liveCaps(NO_SCOPE_TAGS);
+    useCaps(liveCaps(NO_SCOPE_TAGS));
     render();
     expect(el('scope-controls-surface')).toBeNull();
   });
@@ -431,7 +674,7 @@ describe('SDR hosted semantic scope controls (MOR-2358)', () => {
   });
 
   it('removes unsupported receiver leaves while keeping the supported surface hosted', () => {
-    h.caps = liveCaps(['scope']); hosted();
+    useCaps(liveCaps(['scope'])); hosted();
     expect(target.querySelectorAll('[data-testid="scope-controls-surface"]')).toHaveLength(1);
     expect(el('scope-controls-surface')!.closest('[data-testid="scope-toolbar-host"]')).not.toBeNull();
     expect(el('scope-dual')).toBeNull(); expect(el('scope-receiver')).toBeNull();

--- a/frontend/src/lib/runtime/__tests__/frontend-runtime.isolated.test.ts
+++ b/frontend/src/lib/runtime/__tests__/frontend-runtime.isolated.test.ts
@@ -50,6 +50,7 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
 
 vi.mock('$lib/stores/radio.svelte', () => ({
   radio: { current: null },
+  subscribeRadioState: vi.fn(),
   // `panel-commands.ts` (a frozen A09b seam) reads these directly.
   getRadioState: vi.fn(() => null),
   getActiveReceiver: vi.fn(() => null),
@@ -115,7 +116,8 @@ vi.mock('./system-controller', async () => {
 
 import { fetchCapabilities } from '$lib/transport/http-client';
 import { connect, getChannel, getControlSession, onControlSessionTransition, onMessage, sendRaw } from '$lib/transport/ws-client';
-import { setCapabilities, subscribeCapabilities } from '$lib/stores/capabilities.svelte';
+import { getCapabilities, setCapabilities, subscribeCapabilities } from '$lib/stores/capabilities.svelte';
+import { radio, subscribeRadioState } from '$lib/stores/radio.svelte';
 import { audioManager } from '$lib/audio/audio-manager';
 import { clearLegacyPendingModInputRestore } from '../adapters/mod-input-auto.svelte';
 import { PresentationResourceHost } from '../resource-host';
@@ -160,6 +162,86 @@ describe('FrontendRuntime control-session facade (MOR-1723)', () => {
     const handler = vi.fn(); expect(runtime.subscribeControlSession(handler)).toBe(disposer);
     expect(onControlSessionTransition).toHaveBeenCalledWith(handler);
     expect(connect).not.toHaveBeenCalled(); expect(sendRaw).not.toHaveBeenCalled();
+  });
+
+  it('fans in every state, capability, and session publication synchronously and disposes once', async () => {
+    const runtime = await freshRuntime();
+    const initialState = { stateRevision: 1 } as any;
+    const initialCaps = { providerGeneration: 7 } as any;
+    const initialSession = { state: 'connected' as const, epoch: 4 };
+    radio.current = initialState;
+    vi.mocked(getCapabilities).mockReturnValue(initialCaps);
+    vi.mocked(getControlSession).mockReturnValue(initialSession);
+
+    let stateSubscriber!: Parameters<typeof subscribeRadioState>[0];
+    let capabilitySubscriber!: Parameters<typeof subscribeCapabilities>[0];
+    let sessionSubscriber!: (next: { state: 'connected' | 'reconnecting'; epoch: number }) => void;
+    const stopState = vi.fn();
+    const stopCapabilities = vi.fn();
+    const stopSession = vi.fn();
+    vi.mocked(subscribeRadioState).mockImplementation((subscriber) => {
+      stateSubscriber = subscriber;
+      subscriber(initialState);
+      return stopState;
+    });
+    vi.mocked(subscribeCapabilities).mockImplementation((subscriber) => {
+      capabilitySubscriber = subscriber;
+      subscriber(initialCaps);
+      return stopCapabilities;
+    });
+    vi.mocked(onControlSessionTransition).mockImplementation((subscriber) => {
+      sessionSubscriber = subscriber as typeof sessionSubscriber;
+      return stopSession;
+    });
+
+    const subscriber = vi.fn();
+    const stop = runtime.subscribeControlAuthority(subscriber);
+    expect(subscriber).toHaveBeenCalledTimes(1);
+    expect(subscriber).toHaveBeenLastCalledWith({
+      state: initialState,
+      caps: initialCaps,
+      session: initialSession,
+    });
+
+    const middleCaps = { providerGeneration: 7, topology: 'B' } as any;
+    const finalCaps = { providerGeneration: 7, revision: 2 } as any;
+    vi.mocked(getCapabilities).mockReturnValue(middleCaps);
+    capabilitySubscriber(middleCaps);
+    vi.mocked(getCapabilities).mockReturnValue(finalCaps);
+    capabilitySubscriber(finalCaps);
+    expect(subscriber.mock.calls.slice(-2).map(([publication]) => publication.caps)).toEqual([
+      middleCaps,
+      finalCaps,
+    ]);
+
+    const nextState = { stateRevision: 2 } as any;
+    radio.current = nextState;
+    stateSubscriber(nextState);
+    vi.mocked(getControlSession).mockReturnValue({ state: 'reconnecting', epoch: 5 });
+    sessionSubscriber({ state: 'reconnecting', epoch: 5 });
+    expect(subscriber).toHaveBeenNthCalledWith(4, {
+      state: nextState,
+      caps: finalCaps,
+      session: initialSession,
+    });
+    expect(subscriber).toHaveBeenNthCalledWith(5, {
+      state: nextState,
+      caps: finalCaps,
+      session: { state: 'reconnecting', epoch: 5 },
+    });
+
+    stop();
+    stop();
+    expect(stopState).toHaveBeenCalledTimes(1);
+    expect(stopCapabilities).toHaveBeenCalledTimes(1);
+    expect(stopSession).toHaveBeenCalledTimes(1);
+    stateSubscriber(nextState);
+    capabilitySubscriber(finalCaps);
+    sessionSubscriber({ state: 'connected', epoch: 6 });
+    expect(subscriber).toHaveBeenCalledTimes(5);
+    radio.current = null;
+    vi.mocked(getCapabilities).mockReturnValue(null);
+    vi.mocked(getControlSession).mockReturnValue({ state: 'disconnected', epoch: 0 });
   });
 });
 

--- a/frontend/src/lib/runtime/frontend-runtime.ts
+++ b/frontend/src/lib/runtime/frontend-runtime.ts
@@ -11,7 +11,7 @@
  * @see docs/plans/2026-04-12-target-frontend-architecture.md
  */
 
-import { radio } from '$lib/stores/radio.svelte';
+import { radio, subscribeRadioState } from '$lib/stores/radio.svelte';
 import { getCapabilities, subscribeCapabilities } from '$lib/stores/capabilities.svelte';
 import {
   getConnectionStatus,
@@ -67,6 +67,12 @@ export interface DefaultScopeStatus {
 }
 export type ControlSessionSnapshot = Readonly<ControlSessionTransition>;
 export type ControlSessionSubscriber = (next: ControlSessionSnapshot) => void;
+export interface ControlAuthorityPublication {
+  readonly state: ServerState | null;
+  readonly caps: Capabilities | null;
+  readonly session: ControlSessionSnapshot;
+}
+export type ControlAuthoritySubscriber = (next: ControlAuthorityPublication) => void;
 const CLOSED_CONTROL_SESSION: ControlSessionSnapshot = Object.freeze({ state: 'disconnected', epoch: -1 });
 
 // ── Runtime class ──
@@ -143,6 +149,37 @@ class FrontendRuntime {
   }
   subscribeControlSession(handler: ControlSessionSubscriber): () => void {
     return 'onControlSessionTransition' in transport ? transport.onControlSessionTransition(handler) : () => undefined;
+  }
+
+  /**
+   * Synchronous fan-in for sources that jointly establish command authority.
+   * It deliberately retains no derived state: every source publication reads
+   * the other two sources and publishes their current references immediately.
+   */
+  subscribeControlAuthority(handler: ControlAuthoritySubscriber): () => void {
+    let active = true;
+    let initializing = true;
+    const publish = (session: ControlSessionSnapshot) => {
+      if (!active || initializing) return;
+      handler(Object.freeze({ state: this.state, caps: this.caps, session }));
+    };
+    const stops: Array<() => void> = [];
+    try {
+      stops.push(subscribeRadioState(() => publish(this.controlSession)));
+      stops.push(subscribeCapabilities(() => publish(this.controlSession)));
+      stops.push(this.subscribeControlSession(publish));
+      initializing = false;
+      publish(this.controlSession);
+    } catch (error) {
+      active = false;
+      for (const stop of stops.reverse()) stop();
+      throw error;
+    }
+    return () => {
+      if (!active) return;
+      active = false;
+      for (const stop of stops.reverse()) stop();
+    };
   }
 
   /** Radio capabilities (modes, filters, features, etc.) */

--- a/frontend/src/semantic/ScopeControlsSurface.svelte
+++ b/frontend/src/semantic/ScopeControlsSurface.svelte
@@ -89,7 +89,7 @@
   }
   type RendererSelection =
     | { finiteAppearance?: undefined; rendererContext?: undefined }
-    | { finiteAppearance: FiniteControlAppearance<number>; rendererContext: FiniteRendererContext };
+    | { finiteAppearance: FiniteControlAppearance<number>; rendererContext: FiniteRendererContext | null };
   type Props = ExistingProps & RendererSelection;
   let {
     view, onToggleChange, onChoiceChange, onSpanChange, onSpeedChange, onRefChange,
@@ -188,8 +188,8 @@
   <section class="scope-controls-surface" data-testid="scope-controls-surface" aria-label="Scope controls">
     {#if sc.mode.availability.structural}
       {@const behavior = choiceInstrument('mode', MODE_BUTTONS.map(([value]) => value))}
-      <div class="scope-row" role={finiteAppearance && rendererContext ? undefined : 'radiogroup'} aria-label="Scope mode" data-testid="scope-mode">
-        {#if finiteAppearance && rendererContext}
+      <div class="scope-row" role={finiteAppearance ? undefined : 'radiogroup'} aria-label="Scope mode" data-testid="scope-mode">
+        {#if finiteAppearance}
           {#key rendererContext}{#key finiteAppearance.choice}<ControlInstrumentRendererHost
             seat={choiceSeat('mode', 'Scope mode', MODE_BUTTONS)} renderer={finiteAppearance.choice}
           />{/key}{/key}
@@ -205,8 +205,8 @@
     {#each CHOICES as [field, label, options] (field)}
       {#if (field !== 'edge' || edgeApplicable) && sc[field].availability.structural}
         {@const behavior = choiceInstrument(field, options.map(([value]) => value))}
-        <div class="scope-row" role={finiteAppearance && rendererContext ? undefined : 'radiogroup'} aria-label={label} data-testid={`scope-${field}`}>
-          {#if finiteAppearance && rendererContext}
+        <div class="scope-row" role={finiteAppearance ? undefined : 'radiogroup'} aria-label={label} data-testid={`scope-${field}`}>
+          {#if finiteAppearance}
             {#key rendererContext}{#key finiteAppearance.choice}<ControlInstrumentRendererHost
               seat={choiceSeat(field, label, options)} renderer={finiteAppearance.choice}
             />{/key}{/key}
@@ -225,7 +225,7 @@
       {@const increment = spanInstrument(1)}
       <div class="scope-stepper" data-testid="scope-span">
         <span class="scope-name">SPAN</span>
-        {#if finiteAppearance && rendererContext}
+        {#if finiteAppearance}
           {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
             seat={actionSeat('span', -1, 'scope span')} renderer={finiteAppearance.action}
           />{/key}{/key}
@@ -233,7 +233,7 @@
         <output data-testid="scope-span-value">
           {usable(sc.span) ? (SPAN_LABELS[numberOf(sc.span, 3)] ?? '?') : UNKNOWN_TEXT}
         </output>
-        {#if finiteAppearance && rendererContext}
+        {#if finiteAppearance}
           {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
             seat={actionSeat('span', 1, 'scope span')} renderer={finiteAppearance.action}
           />{/key}{/key}
@@ -246,7 +246,7 @@
       {@const increment = speedInstrument(1)}
       <div class="scope-stepper" data-testid="scope-speed">
         <span class="scope-name">SPEED</span>
-        {#if finiteAppearance && rendererContext}
+        {#if finiteAppearance}
           {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
             seat={actionSeat('speed', -1, 'scope speed')} renderer={finiteAppearance.action}
           />{/key}{/key}
@@ -254,7 +254,7 @@
         <output data-testid="scope-speed-value">
           {usable(sc.speed) ? (SPEED_LABELS[numberOf(sc.speed, 1)] ?? '?') : UNKNOWN_TEXT}
         </output>
-        {#if finiteAppearance && rendererContext}
+        {#if finiteAppearance}
           {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
             seat={actionSeat('speed', 1, 'scope speed')} renderer={finiteAppearance.action}
           />{/key}{/key}
@@ -267,13 +267,13 @@
       {@const increment = refInstrument(5)}
       <div class="scope-stepper" data-testid="scope-ref">
         <span class="scope-name">REF</span>
-        {#if finiteAppearance && rendererContext}
+        {#if finiteAppearance}
           {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
             seat={actionSeat('refDb', -5, 'scope reference')} renderer={finiteAppearance.action}
           />{/key}{/key}
         {:else}<button type="button" disabled={!decrement.available} onclick={() => decrement.invoke()}>-</button>{/if}
         <output data-testid="scope-ref-value">{textOf(sc.refDb)}</output>
-        {#if finiteAppearance && rendererContext}
+        {#if finiteAppearance}
           {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
             seat={actionSeat('refDb', 5, 'scope reference')} renderer={finiteAppearance.action}
           />{/key}{/key}
@@ -284,7 +284,7 @@
     {#each TOGGLES as [field, label] (field)}
       {#if sc[field].availability.structural}
         {@const behavior = toggleInstrument(field)}
-        {#if finiteAppearance && rendererContext}
+        {#if finiteAppearance}
           {#key rendererContext}{#key finiteAppearance.toggle}<ControlInstrumentRendererHost
             seat={toggleSeat(field, label)} renderer={finiteAppearance.toggle}
           />{/key}{/key}

--- a/frontend/src/semantic/__tests__/ScopeControlsSurface.test.ts
+++ b/frontend/src/semantic/__tests__/ScopeControlsSurface.test.ts
@@ -369,6 +369,18 @@ describe('external finite appearance', () => {
     expect(onToggleChange).not.toHaveBeenCalled();
   });
 
+  it('keeps the selected external appearance inert instead of falling back to native controls', () => {
+    const component = mount(ScopeControlsSurface, { target, props: {
+      view: withSc({ hold: known(false) }), finiteAppearance: appearance, rendererContext: null,
+    } });
+    flushSync();
+    expect(target.querySelector('[data-testid="scope-controls-surface"]')).not.toBeNull();
+    expect(target.querySelector('[data-testid="scope-hold"]')).toBeNull();
+    expect(target.querySelector('[data-testid="external-HOLD"]')).toBeNull();
+    expect(retainedInvocations.size).toBe(0);
+    unmount(component);
+  });
+
   it('preserves an out-of-list canonical reading without selecting an option', () => {
     const component = mount(ScopeControlsSurface, { target, props: {
       view: withSc({ centerType: known(99) }), finiteAppearance: appearance,


### PR DESCRIPTION
Linear: MOR-2425

Summary:
- add a synchronous FrontendRuntime fan-in over accepted radio state, capabilities, and control-session publications
- derive Scope finite-renderer authority from session, provider generation, topology, active receiver, and per-receiver active-slot identity
- keep a selected external appearance selected but inert whenever authority is null, with no native fallback
- rotate retained action, toggle, and choice callbacks on relevant authority changes, including same-turn A-B-A

Safety and scope:
- unknown active receiver or slot remains valid for readable global Scope commands
- Scope field availability and telemetry updates do not rotate authority
- no clock, counter, tuple-token cache, router, backend, frequency, layout, or component-kit API changes
- does not claim to close the separate frequency retained-callback gap

Verification:
- focused Vitest matrix: 120 passed
- npm run check: 0 errors, 0 warnings
- ESLint on the six leased paths: clean
- git diff --check: clean
- adjacent semantic VFO wiring compatibility: 23 passed