### PR TITLE
MOR-2425: extract reusable bar meter projection

### DIFF
--- a/frontend/src/semantic/MetersSurface.svelte
+++ b/frontend/src/semantic/MetersSurface.svelte
@@ -1,53 +1,13 @@
 <script module lang="ts">
-  import { projectTxMeterDisplay } from './tx-meter-display';
-  import type { DisplayObservedMeterField, MeterRfState, MeterField, MetersViewModel } from './radio-view-model';
-  import {
-    alcLevel, compLevel, formatAlc, formatAmps, formatCompDb, formatPowerWatts,
-    formatVolts, idLevel, isAlcFault, isSwrFault, normalizePower,
-    swrLevel, vdLevel,
-  } from '../components-v2/panels/meter-utils';
+  import type { DisplayObservedMeterField, MeterRfState, MeterField } from './radio-view-model';
+  import { isSwrFault, swrLevel } from '../components-v2/panels/meter-utils';
   import {
     projectSignalMeter,
     type SignalMeterProjection,
   } from '../components-v2/meters/smeter-scale';
   import { renderSlot } from './design-language-renderers';
   import type { LowerScaleDescriptor } from '../components-v2/meters/LinearSMeter.svelte';
-
-  type BarKey = Exclude<keyof MetersViewModel, 'rfState' | 'signal'>;
-  type Scale = readonly [BarKey, string, (raw: number) => number, (raw: number) => string, boolean];
-
-  /** `[field, label, level, format, showPeak]` for the FIVE remaining bar
-   *  meters, in the shipped dock's priority order. `swr` is absent as of
-   *  MOR-2250 (PR 2 of 2) — it now renders on the shared lower scale row
-   *  inside `LinearSMeter` (see `swrLowerScale` below) instead of through
-   *  `BarGauge`, so it must appear exactly once, never zero or two times.
-   *  The level/format pairs are `meter-utils`' own calibrated functions —
-   *  the same ones `MetersDockPanel` uses — so the two can never disagree
-   *  about what a raw sample means. `showPeak` (MOR-1282) mirrors the
-   *  dock's own `PeakKey` set restricted to what remains here (Po/ALC/Id) —
-   *  Vd (a continuous supply rail) and COMP were never peak-held there
-   *  either. `signal` is absent because it has its own component
-   *  (`LinearSMeter`, below). */
-  export const METER_BARS = [
-    ['power', 'Po', normalizePower, formatPowerWatts, true],
-    ['alc', 'ALC', alcLevel, formatAlc, true],
-    ['drainCurrent', 'Id', idLevel, formatAmps, true],
-    ['drainVoltage', 'Vd', vdLevel, formatVolts, false],
-    ['compression', 'COMP', compLevel, formatCompDb, false],
-  ] as const satisfies readonly Scale[];
-
-  /**
-   * MOR-1345: fields with an over-threshold FAULT — the SAME `isAlcFault`
-   * predicate `MetersDockPanel`'s border reads, imported (not copied) so the
-   * two surfaces can never disagree about what counts as a fault. Only ALC
-   * has a threshold among the remaining `METER_BARS` fields, and this
-   * surface invents none — an absent entry means "never faults". SWR's own
-   * fault predicate (`isSwrFault`) is still imported above, but is now
-   * consumed directly by `swrLowerScale`, not through this map.
-   */
-  const FAULT_CHECKS: Partial<Record<BarKey, (raw: number) => boolean>> = {
-    alc: isAlcFault,
-  };
+  import { projectTxMeterPresentation } from './bar-meter-projector';
 
   /** Level 1 — does this radio HAVE the meter at all. */
   const present = (f: MeterField): boolean => f.availability.structural;
@@ -74,23 +34,8 @@
     { value: 1, label: '∞' },
   ] as const;
 
-  function txPresentation(f: DisplayObservedMeterField, rfState: MeterRfState) {
-    const projected = projectTxMeterDisplay(f, rfState);
-    if (!projected.supported) return { value: null, text: '?', description: 'Not observed' };
-    const { relevance, observation } = projected;
-    if (relevance === 'idle') return { value: null, text: 'IDLE', description: 'Not measuring in RX' };
-    const cue = relevance === 'indeterminate' ? 'RF relevance indeterminate. ' : '';
-    return {
-      value: observation.state === 'current' ? observation.value : null,
-      text: observation.state === 'stale' ? 'STALE' : observation.state === 'current'
-        ? (relevance === 'indeterminate' ? ' ?' : '') : '?',
-      description: cue + (observation.state === 'stale' ? 'Stale observation'
-        : observation.state === 'current' ? 'Current observation' : 'Not observed'),
-    };
-  }
-
   function swrLowerScale(f: DisplayObservedMeterField, rfState: MeterRfState): LowerScaleDescriptor {
-    const state = txPresentation(f, rfState);
+    const state = projectTxMeterPresentation(f, rfState);
     return {
       label: 'SWR', ticks: SWR_LOWER_SCALE_TICKS,
       valueFraction: state.value === null ? 0 : swrLevel(state.value),
@@ -127,6 +72,7 @@
   import type { RadioViewModel } from './radio-view-model';
   import type { MeterContinuitySession } from '../primitives/meters/meter-ballistics.svelte';
   import { RF_LABEL, RF_MARK } from './rx-tx-surface';
+  import { projectBarMeters } from './bar-meter-projector';
 
   interface Props {
     view: RadioViewModel;
@@ -142,6 +88,7 @@
   let signalProjection = $derived(projectSignalMeter(
     meters && observed(meters.signal) ? rawOf(meters.signal) : null,
   ));
+  let barMeters = $derived(projectBarMeters(view));
 
   /**
    * The active design language's `meters` descriptor for this render, or
@@ -155,15 +102,6 @@
    */
   let display = $derived(meters ? signalDisplay(signalProjection) : null);
 
-  /** The COMP gate is the MOR-1244 `txAux.compressor` FACT, deliberately NOT
-   *  `meters.compression.availability`: a radio can keep reporting a
-   *  compression meter while the compressor is switched off, and that reading
-   *  measures nothing. Fail-closed — an unobserved compressor, or a radio with
-   *  no txAux group at all, never opens the gate. */
-  let compressorOn = $derived(
-    view.txAux?.compressor.reading.status === 'known'
-      && view.txAux.compressor.reading.value === true,
-  );
 </script>
 
 {#if meters}
@@ -195,37 +133,30 @@
       </div>
     {/if}
 
-    {#each METER_BARS as [field, label, level, format, showPeak] (field)}
-      {#if present(meters[field]) && (field !== 'compression' || compressorOn)}
-        {@const tx = field === 'power' || field === 'alc' ? txPresentation(meters[field], meters.rfState) : null}
-        {@const isObserved = tx ? tx.value !== null : observed(meters[field])}
-        {@const raw = tx ? tx.value ?? 0 : rawOf(meters[field])}
-        {@const fault = isObserved && meters[field].relevant
-          && (FAULT_CHECKS[field]?.(raw) ?? false)}
+    {#each barMeters as bar (bar.key)}
         <div
-          class="meter-tile" data-meter-tile data-meter={field} data-testid={`meter-${field}`}
-          data-relevant={meters[field].relevant} data-observed={isObserved} data-fault={fault}
-          role="group" aria-label={`${label} meter`}
+          class="meter-tile" data-meter-tile data-meter={bar.key} data-testid={`meter-${bar.key}`}
+          data-relevant={bar.relevant} data-observed={bar.observed} data-fault={bar.fault}
+          role="group" aria-label={`${bar.label} meter`}
         >
-          {#if isObserved || tx}
+          {#if bar.gauge}
             <!-- MOR-2255: `zones` comes from the SAME `display` descriptor
                  the S-meter above reads, so every gauge on this surface is
                  painted by one language. `undefined` (no language, or a
                  descriptor without the quintet) falls back to `BarGauge`'s
                  own `DEFAULT_ZONES`. -->
             <BarGauge
-              value={isObserved ? level(raw) : null} {label}
-              displayValue={tx ? (isObserved ? format(raw) + tx.text : tx.text) : format(raw)}
-              accessibleDescription={tx ? `${label}: ${tx.description}${isObserved ? `. ${format(raw)}` : ''}` : undefined}
-              compact showPeak={showPeak && isObserved} {fault}
+              value={bar.motionFraction} label={bar.label}
+              displayValue={bar.displayText}
+              accessibleDescription={bar.accessibleDescription}
+              compact showPeak={bar.showPeak} fault={bar.fault}
               zones={display?.display?.zones}
-              source={meters[field].source} session={continuitySession}
+              source={bar.source} session={continuitySession}
             />
           {:else}
-            <span class="meter-unknown">{label} ?</span>
+            <span class="meter-unknown">{bar.displayText}</span>
           {/if}
         </div>
-      {/if}
     {/each}
   </section>
 {/if}

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -28,7 +28,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 // @ts-expect-error -- Svelte does not publish types for its reactive test harness.
 import { proxy } from 'svelte/internal/client';
-import MetersSurface, { METER_BARS } from '../MetersSurface.svelte';
+import MetersSurface from '../MetersSurface.svelte';
+import { projectBarMeters, type BarMeterKey } from '../bar-meter-projector';
 import { topologyFixtures, withMeters, withTxAux } from '../fixtures/topologies';
 import type {
   Availability, MeterField, MeterRfState, MetersViewModel, RadioViewModel,
@@ -79,13 +80,16 @@ const SOURCE = readFileSync('src/semantic/MetersSurface.svelte', 'utf8')
   .replace(/<!--[\s\S]*?-->/g, '')
   .replace(/\/\*[\s\S]*?\*\//g, '')
   .replace(/^\s*\/\/.*$/gm, '');
+const PROJECTOR_SOURCE = readFileSync('src/semantic/bar-meter-projector.ts', 'utf8');
 
 const AVAIL: Availability = { structural: true, operational: true };
 const RF_STATES: readonly MeterRfState[] = ['receiving', 'transmitting', 'uncertain', 'unknown'];
 
 /** Every meter field this surface can render, S first. */
 type MeterKey = Exclude<keyof MetersViewModel, 'rfState'>;
-const BAR_KEYS = METER_BARS.map(([field]) => field);
+const BAR_KEYS = [
+  'power', 'alc', 'drainCurrent', 'drainVoltage', 'compression',
+] as const satisfies readonly BarMeterKey[];
 const ALL_KEYS: readonly MeterKey[] = ['signal', ...BAR_KEYS] as readonly MeterKey[];
 
 /** `1/single` + a fully-observed meters group + a fully-observed txAux group,
@@ -289,7 +293,7 @@ describe('relevance is read from the facts, not recomputed', () => {
     ['receiving', 'power', true],
     // MOR-2250 (PR 2 of 2): was 'swr' — SWR no longer has its own tile (it
     // renders on the shared lower-scale row instead), so this row now
-    // exercises 'compression', the remaining `METER_BARS` field this table
+    // exercises 'compression', the remaining projected bar field this table
     // had not already covered.
     ['receiving', 'compression', true],
     ['transmitting', 'signal', true],
@@ -493,7 +497,7 @@ describe('motion and forced-colors mechanisms are reused, not forked', () => {
   // data attributes all do.
   it('encodes state as text and attributes, never colour alone', () => {
     // MOR-2250 (PR 2 of 2): was 'swr' — SWR no longer has its own tile, so
-    // this now exercises 'alc', an unrelated `METER_BARS` field the '?'
+    // this now exercises 'alc', an unrelated projected bar field the '?'
     // placeholder property applies to identically.
     const view = withField(base('transmitting'), 'alc', { unknown: true });
     withSurface(view, (s) => {
@@ -514,8 +518,8 @@ describe('the meter table matches the shipped dock', () => {
   // level and its number from `components-v2/panels/meter-utils` — the same
   // calibrated functions MetersDockPanel uses — so the two never disagree
   // about what 0.6 on the SWR meter means.
-  // MOR-2250 (PR 2 of 2): `ALL_KEYS` (derived from `METER_BARS` + 'signal')
-  // is now six, not seven — 'swr' left `METER_BARS` for the shared
+  // MOR-2250 (PR 2 of 2): `ALL_KEYS` (the five bar keys plus 'signal')
+  // is now six, not seven — 'swr' left the standalone bar list for the shared
   // lower-scale row inside `LinearSMeter`, so it no longer has a tile of its
   // own for `ALL_KEYS`/`s.tile` purposes. It still exists as a real
   // `MeterField` in the fact group, so this test adds it back explicitly to
@@ -530,13 +534,14 @@ describe('the meter table matches the shipped dock', () => {
   });
 
   it('reads its levels and formatters from the shipped meter-utils', () => {
-    expect(SOURCE).toMatch(/from '\.\.\/components-v2\/panels\/meter-utils'/);
+    expect(PROJECTOR_SOURCE).toMatch(/from '\.\.\/components-v2\/panels\/meter-utils'/);
+    expect(SOURCE).toMatch(/from '\.\/bar-meter-projector'/);
   });
 
   // MOR-2250 (PR 2 of 2): 'SWR' dropped from the expected list — it left
-  // `METER_BARS` for the shared lower-scale row.
+  // the standalone bar list for the shared lower-scale row.
   it('labels each bar with the dock\'s own short name', () => {
-    expect(METER_BARS.map(([, label]) => label))
+    expect(projectBarMeters(base('transmitting')).map(({ label }) => label))
       .toEqual(['Po', 'ALC', 'Id', 'Vd', 'COMP']);
   });
 });
@@ -547,23 +552,24 @@ describe('BarGauge peak channel (MOR-1282)', () => {
   it('forwards each keyed bar field source and the existing surface session', () => {
     const calls = [...SOURCE.matchAll(/<BarGauge([\s\S]*?)\/>/g)];
     expect(calls).toHaveLength(1);
-    expect(calls[0][1]).toMatch(/source=\{meters\[field\]\.source\}/);
+    expect(calls[0][1]).toMatch(/source=\{bar\.source\}/);
     expect(calls[0][1]).toMatch(/session=\{continuitySession\}/);
-    expect(METER_BARS.map(([field]) => field)).toEqual([
+    expect(projectBarMeters(base('transmitting')).map(({ key }) => key)).toEqual([
       'power', 'alc', 'drainCurrent', 'drainVoltage', 'compression',
     ]);
   });
 
   // MUTATION KILLED: enabling (or dropping) the peak flag on the wrong
   // meters. Matches the dock's own peak-held set RESTRICTED to what
-  // `METER_BARS` still carries post-MOR-2250 (PR 2 of 2) — SWR left this
+  // the five projected bars still carry post-MOR-2250 (PR 2 of 2) — SWR left this
   // table for the shared lower-scale row, and this PR does not give that row
   // a peak-hold marker (not asked for, not implemented — MetersDockPanel
   // itself, untouched, still peak-holds its own SWR bar). Vd (continuous
   // supply rail) and COMP were never peak-held there either, so the surface
   // must not invent peak-hold for them.
   it('enables the peak marker on exactly the meters the dock peak-holds (Po/ALC/Id)', () => {
-    const withPeak = METER_BARS.filter(([, , , , showPeak]) => showPeak).map(([field]) => field);
+    const withPeak = projectBarMeters(base('transmitting'))
+      .filter(({ showPeak }) => showPeak).map(({ key }) => key);
     expect(withPeak).toEqual(['power', 'alc', 'drainCurrent']);
   });
 
@@ -914,13 +920,13 @@ describe('SWR/ALC fault highlighting reuses the dock\'s own threshold', () => {
     });
   });
 
-  // MUTATION KILLED: either surface reimplementing the threshold instead of
-  // importing the shared predicates — the same instrument as the PEAK_DECAY_MS
-  // parity test above (block 10), now for `isSwrFault`/`isAlcFault`.
-  it('both MetersSurface and MetersDockPanel import isSwrFault/isAlcFault from the shared meter-utils module', () => {
+  // MUTATION KILLED: either surface/projector reimplementing the threshold
+  // instead of importing the shared predicates — the same instrument as the
+  // PEAK_DECAY_MS parity test above (block 10).
+  it('the surface, projector, and MetersDockPanel import their fault predicates from shared meter-utils', () => {
     const dockSource = readFileSync('src/components-v2/panels/MetersDockPanel.svelte', 'utf8');
     expect(SOURCE).toMatch(/import\s*\{[^}]*isSwrFault[^}]*\}\s*from\s*'\.\.\/components-v2\/panels\/meter-utils'/);
-    expect(SOURCE).toMatch(/import\s*\{[^}]*isAlcFault[^}]*\}\s*from\s*'\.\.\/components-v2\/panels\/meter-utils'/);
+    expect(PROJECTOR_SOURCE).toMatch(/import\s*\{[^}]*isAlcFault[^}]*\}\s*from\s*'\.\.\/components-v2\/panels\/meter-utils'/);
     expect(dockSource).toMatch(/import\s*\{[^}]*isSwrFault[^}]*\}\s*from\s*'\.\/meter-utils'/);
     expect(dockSource).toMatch(/import\s*\{[^}]*isAlcFault[^}]*\}\s*from\s*'\.\/meter-utils'/);
     expect(SOURCE).not.toMatch(/function\s+isSwrFault|function\s+isAlcFault/);
@@ -942,10 +948,10 @@ describe('the SWR shared lower-scale row (MOR-2250, PR 2 of 2)', () => {
   // MUTATION KILLED: SWR rendering through BOTH the old BarGauge path and
   // the new shared row (double-rendering), or through NEITHER (silently
   // dropped). It must render exactly once.
-  it('swr no longer renders through the BarGauge/METER_BARS path — it renders once, on the shared lower-scale row', () => {
+  it('swr no longer renders through the BarGauge projection path — it renders once, on the shared lower-scale row', () => {
     withSurface(base('transmitting'), (s) => {
       expect(s.tile('swr')).toBeNull();
-      expect(METER_BARS.map(([field]) => field)).not.toContain('swr');
+      expect(projectBarMeters(base('transmitting')).map(({ key }) => key)).not.toContain('swr');
       expect(s.signalSvg()!.querySelector('[data-lower-row-label]')?.textContent).toBe('SWR');
     });
   });
@@ -1259,8 +1265,12 @@ it('uses current display calibration while preserving VD/ID/COMP through RX idle
     const component = mount(MetersSurface, { target, props });
     flushSync();
     try {
-      expect(target.querySelector('[data-meter="power"]')?.textContent).toContain('50W');
-      expect(target.querySelectorAll('[data-meter="power"] [data-gauge-fill]')).toHaveLength(3);
+      const projected = projectBarMeters(view).find(({ key }) => key === 'power')!;
+      expect(projected).toMatchObject({ motionFraction: 0.25, displayText: '50W', gauge: true });
+      expect(target.querySelector('[data-meter="power"]')?.textContent)
+        .toContain(projected.displayText);
+      expect(target.querySelectorAll('[data-meter="power"] [data-gauge-fill]'))
+        .toHaveLength(Math.ceil(projected.motionFraction! * 10));
       const other = ['drainVoltage', 'drainCurrent', 'compression'].map((key) =>
         target.querySelector(`[data-meter="${key}"]`)!.outerHTML);
       props.view = { ...props.view, meters: { ...props.view.meters!, rfState: 'receiving',

--- a/frontend/src/semantic/__tests__/bar-meter-projector.test.ts
+++ b/frontend/src/semantic/__tests__/bar-meter-projector.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
+import { topologyFixtures, withMeters, withTxAux } from '../fixtures/topologies';
+import type {
+  DisplayObservation,
+  MeterRfState,
+  MeterSourceIdentity,
+  MetersViewModel,
+  RadioViewModel,
+} from '../radio-view-model';
+import { projectBarMeters, type BarMeterKey } from '../bar-meter-projector';
+
+function base(rfState: MeterRfState = 'transmitting'): RadioViewModel {
+  const view = withMeters(withTxAux(topologyFixtures['1/single']), rfState);
+  view.txAux!.compressor = {
+    reading: { status: 'known', value: true },
+    availability: { structural: true, operational: true },
+  };
+  return view;
+}
+
+function setMeter(
+  view: RadioViewModel,
+  key: BarMeterKey,
+  changes: Partial<MetersViewModel[BarMeterKey]>,
+): void {
+  view.meters![key] = { ...view.meters![key], ...changes };
+}
+
+function setDisplay(
+  view: RadioViewModel,
+  key: 'power' | 'alc',
+  display: DisplayObservation<number>,
+): void {
+  setMeter(view, key, { display });
+}
+
+function calibratedCaps(): Capabilities {
+  return {
+    model: 'bar-projector-test',
+    scope: false,
+    audio: false,
+    tx: true,
+    capabilities: ['tx'],
+    receivers: 1,
+    vfoScheme: 'single',
+    freqRanges: [],
+    modes: [],
+    filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: [] },
+    webrtc: { available: false, enabled: false },
+    txBands: null,
+    stateContractVersion: 1,
+    providerGeneration: 0,
+    meterCalibrations: {
+      power: [
+        { raw: 0, actual: 0, label: '0' },
+        { raw: 255, actual: 200, label: '200' },
+      ],
+      alc: [
+        { raw: 0, actual: 0, label: '0' },
+        { raw: 120, actual: 1, label: '1' },
+      ],
+    },
+  };
+}
+
+afterEach(() => clearCapabilities());
+
+describe('projectBarMeters', () => {
+  it('projects the five real rows in priority order with only consumed fields', () => {
+    const view = base();
+    const source = {
+      providerGeneration: 7,
+      scope: 'radio',
+      receiver: null,
+      path: 'powerMeter',
+    } as const satisfies MeterSourceIdentity;
+    setMeter(view, 'power', { reading: { status: 'known', value: 128 }, source });
+    setMeter(view, 'alc', { source: null });
+
+    const projected = projectBarMeters(view);
+    expect(projected.map(({ key, label }) => ({ key, label }))).toEqual([
+      { key: 'power', label: 'Po' },
+      { key: 'alc', label: 'ALC' },
+      { key: 'drainCurrent', label: 'Id' },
+      { key: 'drainVoltage', label: 'Vd' },
+      { key: 'compression', label: 'COMP' },
+    ]);
+    expect(Object.keys(projected[0]).sort()).toEqual([
+      'accessibleDescription', 'displayText', 'fault', 'gauge', 'key', 'label',
+      'motionFraction', 'observed', 'relevant', 'showPeak', 'source',
+    ]);
+    expect(projected[0]).toMatchObject({
+      motionFraction: 128 / 255,
+      displayText: '128 raw',
+      accessibleDescription: 'Po: Current observation. 128 raw',
+      observed: true,
+      gauge: true,
+      showPeak: true,
+    });
+    expect(projected[0].source).toBe(source);
+    expect(projected[1].source).toBeNull();
+    expect(projected[2].source).toBeUndefined();
+  });
+
+  it('uses calibrated power and ALC values once and preserves a current zero', () => {
+    setCapabilities(calibratedCaps());
+    const view = base();
+    setMeter(view, 'power', { reading: { status: 'unknown' } });
+    setDisplay(view, 'power', { state: 'current', value: 50 });
+    setDisplay(view, 'alc', { state: 'current', value: 0.95 });
+
+    const projected = projectBarMeters(view);
+    expect(projected.find(({ key }) => key === 'power')).toMatchObject({
+      motionFraction: 0.25,
+      displayText: '50W',
+      observed: true,
+      gauge: true,
+    });
+    expect(projected.find(({ key }) => key === 'alc')).toMatchObject({
+      motionFraction: 0.95,
+      displayText: '95%',
+      fault: true,
+    });
+
+    setDisplay(view, 'power', { state: 'current', value: 0 });
+    expect(projectBarMeters(view).find(({ key }) => key === 'power')).toMatchObject({
+      motionFraction: 0,
+      displayText: '0W',
+      observed: true,
+      gauge: true,
+    });
+  });
+
+  it('keeps stale, unknown, idle, and indeterminate TX observations distinct', () => {
+    const view = base();
+    setDisplay(view, 'power', { state: 'stale', value: 170 });
+    expect(projectBarMeters(view)[0]).toMatchObject({
+      motionFraction: null,
+      displayText: 'STALE',
+      accessibleDescription: 'Po: Stale observation',
+      observed: false,
+      gauge: true,
+      showPeak: false,
+    });
+
+    setDisplay(view, 'power', { state: 'unknown', reason: 'not-observed' });
+    expect(projectBarMeters(view)[0]).toMatchObject({
+      motionFraction: null,
+      displayText: '?',
+      accessibleDescription: 'Po: Not observed',
+      observed: false,
+      gauge: true,
+    });
+
+    view.meters!.rfState = 'receiving';
+    setMeter(view, 'power', { relevant: false });
+    setDisplay(view, 'power', { state: 'current', value: 170 });
+    expect(projectBarMeters(view)[0]).toMatchObject({
+      motionFraction: null,
+      displayText: 'IDLE',
+      accessibleDescription: 'Po: Not measuring in RX',
+      observed: false,
+      gauge: true,
+    });
+
+    view.meters!.rfState = 'unknown';
+    setMeter(view, 'power', { relevant: true });
+    expect(projectBarMeters(view)[0]).toMatchObject({
+      motionFraction: 170 / 255,
+      displayText: '170 raw ?',
+      accessibleDescription: 'Po: RF relevance indeterminate. Current observation. 170 raw',
+      observed: true,
+      gauge: true,
+    });
+  });
+
+  it('keeps TX rows mounted while plain unknown rows use the unknown span', () => {
+    const view = base();
+    for (const key of ['power', 'drainCurrent'] as const) {
+      setMeter(view, key, {
+        reading: { status: 'unknown' },
+        availability: { structural: true, operational: false },
+      });
+    }
+
+    expect(projectBarMeters(view).find(({ key }) => key === 'power')).toMatchObject({
+      gauge: true,
+      observed: false,
+      motionFraction: null,
+      displayText: '?',
+    });
+    expect(projectBarMeters(view).find(({ key }) => key === 'drainCurrent')).toMatchObject({
+      gauge: false,
+      observed: false,
+      motionFraction: null,
+      displayText: 'Id ?',
+    });
+  });
+
+  it('expresses absence by list membership and fails the COMP gate closed', () => {
+    const view = base();
+    setMeter(view, 'drainVoltage', {
+      availability: { structural: false, operational: false },
+    });
+    view.txAux!.compressor = {
+      reading: { status: 'unknown' },
+      availability: { structural: true, operational: true },
+    };
+
+    expect(projectBarMeters(view).map(({ key }) => key)).toEqual([
+      'power', 'alc', 'drainCurrent',
+    ]);
+    view.txAux!.compressor = {
+      reading: { status: 'known', value: false },
+      availability: { structural: true, operational: true },
+    };
+    expect(projectBarMeters(view).some(({ key }) => key === 'compression')).toBe(false);
+  });
+
+  it('asserts an ALC fault only for an observed relevant calibrated reading', () => {
+    setCapabilities(calibratedCaps());
+    const view = base();
+    setDisplay(view, 'alc', { state: 'current', value: 0.95 });
+    expect(projectBarMeters(view).find(({ key }) => key === 'alc')?.fault).toBe(true);
+
+    setMeter(view, 'alc', { relevant: false });
+    expect(projectBarMeters(view).find(({ key }) => key === 'alc')?.fault).toBe(false);
+
+    setMeter(view, 'alc', { relevant: true });
+    setDisplay(view, 'alc', { state: 'stale', value: 0.95 });
+    expect(projectBarMeters(view).find(({ key }) => key === 'alc')?.fault).toBe(false);
+  });
+});

--- a/frontend/src/semantic/bar-meter-projector.ts
+++ b/frontend/src/semantic/bar-meter-projector.ts
@@ -1,0 +1,121 @@
+import {
+  alcLevel,
+  compLevel,
+  formatAlc,
+  formatAmps,
+  formatCompDb,
+  formatPowerWatts,
+  formatVolts,
+  idLevel,
+  isAlcFault,
+  normalizePower,
+  vdLevel,
+} from '../components-v2/panels/meter-utils';
+import { projectTxMeterDisplay } from './tx-meter-display';
+import type {
+  DisplayObservedMeterField,
+  MeterRfState,
+  MeterSourceIdentity,
+  MetersViewModel,
+  RadioViewModel,
+} from './radio-view-model';
+
+export type BarMeterKey = Exclude<keyof MetersViewModel, 'rfState' | 'signal' | 'swr'>;
+
+export interface BarMeterProjection {
+  readonly key: BarMeterKey;
+  readonly label: string;
+  readonly relevant: boolean;
+  readonly observed: boolean;
+  readonly motionFraction: number | null;
+  readonly displayText: string;
+  readonly accessibleDescription: string | undefined;
+  readonly fault: boolean;
+  readonly showPeak: boolean;
+  readonly source: MeterSourceIdentity | null | undefined;
+  readonly gauge: boolean;
+}
+
+type BarDefinition = readonly [
+  BarMeterKey,
+  string,
+  (value: number) => number,
+  (value: number) => string,
+  boolean,
+];
+
+const BAR_DEFINITIONS = [
+  ['power', 'Po', normalizePower, formatPowerWatts, true],
+  ['alc', 'ALC', alcLevel, formatAlc, true],
+  ['drainCurrent', 'Id', idLevel, formatAmps, true],
+  ['drainVoltage', 'Vd', vdLevel, formatVolts, false],
+  ['compression', 'COMP', compLevel, formatCompDb, false],
+] as const satisfies readonly BarDefinition[];
+
+const FAULT_CHECKS: Partial<Record<BarMeterKey, (value: number) => boolean>> = {
+  alc: isAlcFault,
+};
+
+const observed = (field: DisplayObservedMeterField): boolean =>
+  field.availability.operational && field.reading.status === 'known';
+
+const reading = (field: DisplayObservedMeterField): number =>
+  field.reading.status === 'known' ? field.reading.value : 0;
+
+export function projectTxMeterPresentation(
+  field: DisplayObservedMeterField,
+  rfState: MeterRfState,
+) {
+  const projected = projectTxMeterDisplay(field, rfState);
+  if (!projected.supported) return { value: null, text: '?', description: 'Not observed' };
+  const { relevance, observation } = projected;
+  if (relevance === 'idle') {
+    return { value: null, text: 'IDLE', description: 'Not measuring in RX' };
+  }
+  const cue = relevance === 'indeterminate' ? 'RF relevance indeterminate. ' : '';
+  return {
+    value: observation.state === 'current' ? observation.value : null,
+    text: observation.state === 'stale' ? 'STALE' : observation.state === 'current'
+      ? (relevance === 'indeterminate' ? ' ?' : '') : '?',
+    description: cue + (observation.state === 'stale' ? 'Stale observation'
+      : observation.state === 'current' ? 'Current observation' : 'Not observed'),
+  };
+}
+
+export function projectBarMeters(view: RadioViewModel): readonly BarMeterProjection[] {
+  const meters = view.meters;
+  if (!meters) return [];
+  const compressorOn = view.txAux?.compressor.reading.status === 'known'
+    && view.txAux.compressor.reading.value === true;
+
+  return BAR_DEFINITIONS.flatMap(([key, label, level, format, peakEligible]) => {
+    const field = meters[key];
+    if (!field.availability.structural || (key === 'compression' && !compressorOn)) return [];
+
+    const tx = key === 'power' || key === 'alc'
+      ? projectTxMeterPresentation(field, meters.rfState)
+      : null;
+    const isObserved = tx ? tx.value !== null : observed(field);
+    const value = tx ? tx.value ?? 0 : reading(field);
+    const gauge = isObserved || tx !== null;
+    const displayText = gauge
+      ? tx ? (isObserved ? format(value) + tx.text : tx.text) : format(value)
+      : `${label} ?`;
+
+    return [{
+      key,
+      label,
+      relevant: field.relevant,
+      observed: isObserved,
+      motionFraction: isObserved ? level(value) : null,
+      displayText,
+      accessibleDescription: tx
+        ? `${label}: ${tx.description}${isObserved ? `. ${format(value)}` : ''}`
+        : undefined,
+      fault: isObserved && field.relevant && (FAULT_CHECKS[key]?.(value) ?? false),
+      showPeak: peakEligible && isObserved,
+      source: field.source,
+      gauge,
+    }];
+  });
+}


### PR DESCRIPTION
## Scope

- Linked issue / task: [MOR-2425](https://linear.app/rigplane/issue/MOR-2425)
- Compatibility impact: none

Extracts the five existing bar-row presentation decisions from `MetersSurface` into a reusable semantic projector. The mounted surface now consumes the same projected order, motion fractions, display and accessibility text, fault/peak decisions, source identity, and gauge-versus-plain-unknown choice while continuing to pass its existing continuity session and design-language zones directly to `BarGauge`. The surviving SWR lower scale shares the relocated TX presentation helper and remains outside the bar projection.

## Verification

- [x] Relevant local tests or checks run
- [x] Public/open-core boundary checked
- [x] Release or migration impact documented if applicable

The existing mounted surface was green before extraction (142 tests). The new independent-projector test first failed because the production boundary did not exist (module-resolution RED, zero tests; no behavioral defect claimed), then passed after implementation.

- Projector + mounted MetersSurface: 148 passed
- Meter contract, no-double-conversion, TX display, and retained BarGauge suites: 133 passed
- `npm run check`: 0 errors, 0 warnings
- Scoped ESLint: passed
- `git diff --check`: passed
- Natural exact-head quick: 440 files / 10,737 tests passed; Svelte 0/0; i18n 87; captures 65/0
- Natural exact-head visual: passed
- Canonical exact-head Agent Review Gate: passed

## Agent Review

- [x] Independent agent review comment posted before merge
- Reviewer: independent Codex verifier
- Result: `Agent Review: PASS 91dbbf6074d2a4aa7a38dbc861e2a4779bce50a2` — no findings

## Notes

- Out of scope / follow-ups: public SDK activation, SRS, layouts, CSS baselines, meter profiles, BarGauge/Linear/ballistics changes, backend and deployment.
- The accepted base was `65b9af5c12ac1578730b87fb3768fb2d46b1a71f`; aggregate main quick run `34062313382` passed (439 files, 10,731 tests; Svelte 0/0; i18n 87; captures 65/0).
