### PR TITLE
MOR-2425: retain frequency binding across renderers

### DIFF
--- a/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
+++ b/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
@@ -12,9 +12,11 @@ vi.mock('../../../component-kits/activation', () => ({
 }));
 
 import FrequencyDisplayInteractive from '../../../primitives/frequency/FrequencyDisplayInteractive.svelte';
+import FrequencyRendererSeat from '../../../primitives/frequency/FrequencyRendererSeat.svelte';
 import AlternateFrequencyReadoutHarness, {
   clearRetainedInteractions, retainedInteractions,
 } from '../../../primitives/frequency/__tests__/AlternateFrequencyReadoutHarness.svelte';
+import { createFrequencyInstrumentBinding } from '../../../primitives/frequency/frequency-instrument.svelte';
 import {
   createFrequencyInteraction,
   createFrequencyInteractionLease,
@@ -146,6 +148,101 @@ function interactionOwner(options: { disabled?: boolean; onFreqChange?: (hz: num
 }
 
 describe('frequency renderer lifetime', () => {
+  it('retains one binding while opaque authority and renderer instances are replaced', async () => {
+    selectedFrequency.current = AlternateFrequencyReadoutHarness as FrequencyRenderer;
+    const a1 = {};
+    const b2 = {};
+    const a3 = {};
+    const state = writable<{ context: object | null; confirmedHz: number | null }>({
+      context: a1,
+      confirmedHz: 14_250_000,
+    });
+    const live = fromStore(state);
+    const onFreqChange = vi.fn();
+    let binding!: ReturnType<typeof createFrequencyInstrumentBinding>;
+    roots.push($effect.root(() => {
+      binding = createFrequencyInstrumentBinding({
+        get confirmedHz() { return live.current.confirmedHz; },
+        get pendingDisplayHz() { return 14_260_000; },
+        pendingAnnouncement: 'Pending',
+        disabled: false,
+        get context() { return live.current.context; },
+        receiver: 'main',
+        minFreq: 0,
+        maxFreq: 999_000_000,
+        onFreqChange,
+      });
+    }));
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    components.push(mount(FrequencyRendererSeat, {
+      target,
+      props: {
+        binding,
+        presentation: 'interactive',
+        compact: true,
+        active: false,
+        receiver: 'main',
+        vfoFreqHook: false,
+      },
+    }));
+    flushSync();
+
+    expect(target.querySelector('[data-alternate-frequency-readout]')).toMatchObject({
+      dataset: {
+        source: 'pending',
+        presentation: 'interactive',
+        compact: 'true',
+        active: 'false',
+        receiver: 'main',
+        vfoFreqHook: 'false',
+      },
+    });
+    const digit = binding.model.digits.find((candidate) => candidate.multiplier === 1_000)!;
+    const first = retainedInteractions()[0];
+    first.handleDigitClick(digit, new MouseEvent('click'));
+
+    state.set({ context: b2, confirmedHz: 14_250_000 });
+    state.set({ context: a3, confirmedHz: 14_250_000 });
+    const staleWheel = new WheelEvent('wheel', { deltaY: -1, cancelable: true });
+    first.handleWheel(digit, staleWheel);
+    expect(staleWheel.defaultPrevented).toBe(false);
+    expect(first.inert).toBe(true);
+    expect(onFreqChange).not.toHaveBeenCalled();
+
+    flushSync();
+    const second = retainedInteractions().at(-1)!;
+    expect(second).not.toBe(first);
+    expect(second.selectedDigitIndex).toBeNull();
+    second.handleDigitClick(digit, new MouseEvent('click'));
+    second.handleKeyDown(new KeyboardEvent('keydown', { key: 'ArrowUp', cancelable: true }));
+    expect(onFreqChange).toHaveBeenCalledExactlyOnceWith(14_251_000);
+
+    selectedFrequency.current = undefined;
+    state.set({ context: {}, confirmedHz: 14_250_000 });
+    flushSync();
+    expect(target.querySelector('[data-alternate-frequency-readout]')).toBeNull();
+    expect(target.querySelector('.freq')).not.toBeNull();
+    expect(second.inert).toBe(true);
+
+    selectedFrequency.current = AlternateFrequencyReadoutHarness as FrequencyRenderer;
+    state.set({ context: null, confirmedHz: 14_250_000 });
+    flushSync();
+    expect(target.querySelector('[data-alternate-frequency-readout]')).not.toBeNull();
+    const selectedButInert = retainedInteractions().at(-1)!;
+    const nullWheel = new WheelEvent('wheel', { deltaY: -1, cancelable: true });
+    selectedButInert.handleDigitClick(digit, new MouseEvent('click'));
+    selectedButInert.handleWheel(digit, nullWheel);
+    expect(nullWheel.defaultPrevented).toBe(false);
+    expect(selectedButInert.inert).toBe(true);
+    expect(onFreqChange).toHaveBeenCalledTimes(1);
+
+    const component = components.pop()!;
+    unmount(component);
+    await Promise.resolve();
+    expect(selectedButInert.inert).toBe(true);
+  });
+
   it('revokes the actual external renderer across replacement, context A-B-A, and unmount', async () => {
     selectedFrequency.current = AlternateFrequencyReadoutHarness as FrequencyRenderer;
     const context = writable('A');

--- a/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
+++ b/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
@@ -1,11 +1,6 @@
 <script lang="ts">
-  import { onDestroy, untrack } from 'svelte';
-  import { getSelectedFrequencyReadout } from '../../component-kits/activation';
-  import StandardFrequencyReadout from './StandardFrequencyReadout.svelte';
-  import {
-    createFrequencyInteraction, createFrequencyInteractionLease,
-  } from './frequency-interaction.svelte';
-  import { projectFrequencyReadout } from './frequency-readout';
+  import FrequencyRendererSeat from './FrequencyRendererSeat.svelte';
+  import { createFrequencyInstrumentBinding } from './frequency-instrument.svelte';
 
   interface Props {
     /**
@@ -84,65 +79,26 @@
     vfoFreqHook = true,
   }: Props = $props();
 
-  let model = $derived(projectFrequencyReadout({
-    confirmedHz: freq,
-    displayHz,
-    pendingDisplayHz,
-    pendingAnnouncement,
-  }));
-  const owner = createFrequencyInteraction({
+  let bindingContext = $derived.by(() => ({ contextKey, receiver }));
+  const binding = createFrequencyInstrumentBinding({
     get confirmedHz() { return freq; },
-    get digits() { return model.digits; },
+    get displayHz() { return displayHz; },
+    get pendingDisplayHz() { return pendingDisplayHz; },
+    get pendingAnnouncement() { return pendingAnnouncement; },
     get disabled() { return disabled; },
-    get contextKey() { return contextKey; },
+    get context() { return bindingContext; },
     get receiver() { return receiver; },
     get minFreq() { return minFreq; },
     get maxFreq() { return maxFreq; },
     get onFreqChange() { return onFreqChange; },
   });
-  let selectedRenderer = $derived.by(() => {
-    void contextKey;
-    return getSelectedFrequencyReadout();
-  });
-  let attachedContextKey = untrack(() => contextKey);
-  let attachedRenderer = untrack(() => selectedRenderer);
-  const attachLease = (key: string | undefined, renderer: typeof selectedRenderer) => createFrequencyInteractionLease(
-    owner,
-    () => Object.is(contextKey, key) && getSelectedFrequencyReadout() === renderer,
-  );
-  let lease = $state.raw(attachLease(attachedContextKey, attachedRenderer));
-  $effect.pre(() => {
-    const nextContextKey = contextKey;
-    const nextRenderer = selectedRenderer;
-    if (Object.is(nextContextKey, attachedContextKey)
-      && nextRenderer === attachedRenderer && !lease.revoked) return;
-    lease.revoke();
-    attachedContextKey = nextContextKey;
-    attachedRenderer = nextRenderer;
-    lease = attachLease(nextContextKey, nextRenderer);
-  });
-  onDestroy(() => lease.revoke());
 </script>
 
-{#if selectedRenderer}
-  {@const Renderer = selectedRenderer}
-  <Renderer
-    {model}
-    presentation="interactive"
-    interaction={lease.interaction}
-    {compact}
-    {active}
-    {receiver}
-    {vfoFreqHook}
-  />
-{:else}
-  <StandardFrequencyReadout
-    {model}
-    presentation="interactive"
-    interaction={lease.interaction}
-    {compact}
-    {active}
-    {receiver}
-    {vfoFreqHook}
-  />
-{/if}
+<FrequencyRendererSeat
+  {binding}
+  presentation="interactive"
+  {compact}
+  {active}
+  {receiver}
+  {vfoFreqHook}
+/>

--- a/frontend/src/primitives/frequency/FrequencyRendererSeat.svelte
+++ b/frontend/src/primitives/frequency/FrequencyRendererSeat.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import { onDestroy, untrack } from 'svelte';
+  import type { FrequencyRenderer } from '../../../component-kit-api/src/index';
+  import { getSelectedFrequencyReadout } from '../../component-kits/activation';
+  import StandardFrequencyReadout from './StandardFrequencyReadout.svelte';
+  import type { FrequencyInstrumentBinding } from './frequency-instrument.svelte';
+
+  interface Props {
+    binding: FrequencyInstrumentBinding;
+    presentation: 'interactive' | 'passive';
+    compact: boolean;
+    active: boolean;
+    receiver: 'main' | 'sub';
+    vfoFreqHook: boolean;
+  }
+
+  let {
+    binding,
+    presentation,
+    compact,
+    active,
+    receiver,
+    vfoFreqHook,
+  }: Props = $props();
+
+  let attachedBinding = untrack(() => binding);
+  let attachedContext = untrack(() => attachedBinding.context);
+  let attachedRenderer = untrack(() => getSelectedFrequencyReadout());
+  let selectedRenderer = $state.raw<FrequencyRenderer | undefined>(attachedRenderer);
+  const attachLease = (
+    owner: FrequencyInstrumentBinding,
+    renderer: FrequencyRenderer | undefined,
+  ) => owner.attachRenderer(
+    () => Object.is(binding, owner) && getSelectedFrequencyReadout() === renderer,
+  );
+  let lease = $state.raw(attachLease(attachedBinding, attachedRenderer));
+
+  $effect.pre(() => {
+    const nextBinding = binding;
+    const nextContext = nextBinding.context;
+    const nextRenderer = getSelectedFrequencyReadout();
+    if (Object.is(nextBinding, attachedBinding)
+      && Object.is(nextContext, attachedContext)
+      && nextRenderer === attachedRenderer
+      && !lease.revoked) return;
+    lease.revoke();
+    attachedBinding = nextBinding;
+    attachedContext = nextContext;
+    attachedRenderer = nextRenderer;
+    selectedRenderer = nextRenderer;
+    lease = attachLease(nextBinding, nextRenderer);
+  });
+
+  onDestroy(() => lease.revoke());
+</script>
+
+{#if selectedRenderer}
+  {@const Renderer = selectedRenderer}
+  <Renderer
+    model={binding.model}
+    interaction={lease.interaction}
+    {presentation}
+    {compact}
+    {active}
+    {receiver}
+    {vfoFreqHook}
+  />
+{:else}
+  <StandardFrequencyReadout
+    model={binding.model}
+    interaction={lease.interaction}
+    {presentation}
+    {compact}
+    {active}
+    {receiver}
+    {vfoFreqHook}
+  />
+{/if}

--- a/frontend/src/primitives/frequency/frequency-instrument.svelte.ts
+++ b/frontend/src/primitives/frequency/frequency-instrument.svelte.ts
@@ -1,0 +1,60 @@
+import {
+  createFrequencyInteraction,
+  createFrequencyInteractionLease,
+  type FrequencyInteractionLease,
+} from './frequency-interaction.svelte';
+import {
+  projectFrequencyReadout,
+  type FrequencyReadoutModel,
+} from './frequency-readout';
+
+export interface FrequencyInstrumentInput {
+  readonly confirmedHz: number | null;
+  readonly displayHz?: number | null;
+  readonly pendingDisplayHz?: number | null;
+  readonly pendingAnnouncement?: string;
+  readonly disabled: boolean;
+  readonly context: object | null;
+  readonly receiver: 'main' | 'sub';
+  readonly minFreq: number;
+  readonly maxFreq: number;
+  readonly onFreqChange?: (frequencyHz: number) => void;
+}
+
+export interface FrequencyInstrumentBinding {
+  readonly context: object | null;
+  readonly model: FrequencyReadoutModel;
+  attachRenderer(isCurrent: () => boolean): FrequencyInteractionLease;
+}
+
+export function createFrequencyInstrumentBinding(
+  current: FrequencyInstrumentInput,
+): FrequencyInstrumentBinding {
+  const model = $derived.by(() => projectFrequencyReadout({
+    confirmedHz: current.confirmedHz,
+    displayHz: current.displayHz,
+    pendingDisplayHz: current.pendingDisplayHz,
+    pendingAnnouncement: current.pendingAnnouncement,
+  }));
+  const interaction = createFrequencyInteraction({
+    get confirmedHz() { return current.confirmedHz; },
+    get digits() { return model.digits; },
+    get disabled() { return current.disabled; },
+    get receiver() { return current.receiver; },
+    get minFreq() { return current.minFreq; },
+    get maxFreq() { return current.maxFreq; },
+    get onFreqChange() { return current.onFreqChange; },
+  });
+
+  return {
+    get context() { return current.context; },
+    get model() { return model; },
+    attachRenderer(isCurrent) {
+      const context = current.context;
+      return createFrequencyInteractionLease(
+        interaction,
+        () => context !== null && Object.is(current.context, context) && isCurrent(),
+      );
+    },
+  };
+}


### PR DESCRIPTION
MOR-2425 needs frequency interaction state to outlive replaceable renderer instances. `FrequencyDisplayInteractive` previously assembled its model, interaction owner, renderer selection, and lease inside the renderer-facing component, so replacing that presentation also replaced the owner.

This extracts a getter-backed `FrequencyInstrumentBinding` that owns the existing projector and interaction, plus a `FrequencyRendererSeat` that acquires and revokes the existing interaction lease for one renderer instance. The current interactive display remains the production compatibility wrapper, selected external appearances remain selected even when authority is null, and pending frequency remains display-only while gesture arithmetic uses confirmed Hz.

The focused retained-owner witness uses distinct opaque A1/B2/A3 contexts. It proves a no-read B2 transition permanently makes the A1 callbacks inert without consuming the wheel event, then proves a fresh lease over the same binding can issue one confirmed-based command. Removing the binding's context equality guard made that assertion fail at `staleWheel.defaultPrevented`; restoring it returns the focused checks to green.

Validation:

- `npx vitest run src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts src/primitives/frequency/__tests__/StandardFrequencyReadout.isolated.test.ts` — 24 passed
- `npx vitest run src/components-v2/layout/__tests__/KeyboardHandler.test.ts -t 'digit routing from a bare FrequencyDisplayInteractive mount'` — 2 passed, 35 skipped
- `npx vitest run src/semantic/__tests__/VfoSurface.test.ts -t 'pending-target affordance|per-digit tuning \\(MOR-1322\\)'` — 32 passed, 132 skipped
- `npm run check` — 0 errors, 0 warnings
- scoped ESLint over the four changed paths — 0 violations
- `git diff --cached --check` — clean

This is the authorized V1-FB assembly/seat packet only. Persistent MAIN/SUB receiver-host adoption and the full MOR-2425 goal remain open for the later V1-RH packet.
