### PR TITLE
MOR-2425: extract signal meter motion binding

### DIFF
--- a/frontend/src/components-v2/meters/LinearSMeter.svelte
+++ b/frontend/src/components-v2/meters/LinearSMeter.svelte
@@ -43,15 +43,16 @@
 
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
-  import { createSmoother, prefersReducedMotion, onReducedMotionChange } from '$lib/utils/smoothing.svelte';
-  import {
-    createFrameStepPeakStrategy,
-    createMeterBallistics,
-    type MeterContinuitySession,
-    type MeterSourceIdentity,
+  import type {
+    MeterContinuitySession,
+    MeterSourceIdentity,
   } from '../../primitives/meters/meter-ballistics.svelte';
   import type { MeterDisplay } from '../../presentation/languages/contract';
   import { DEFAULT_METER_DISPLAY } from './meter-display';
+  import {
+    createSignalMeterMotion,
+    type SignalMeterFrame,
+  } from './signal-meter-motion.svelte';
   import {
     projectSignalMeter,
     type SignalMeterProjection,
@@ -86,16 +87,66 @@
      * sibling `data-main-relevant` / `data-lower-relevant` groups below.
      */
     relevant?: boolean;
-    source?: MeterSourceIdentity | null;
-    session?: MeterContinuitySession | null;
   }
 
-  type SignalInput =
+  type LocalSignalInput = (
     | { projection: SignalMeterProjection; value?: never }
-    | { projection?: never; value: number | null };
+    | { projection?: never; value: number | null }
+  ) & {
+    frame?: never;
+    source?: MeterSourceIdentity | null;
+    session?: MeterContinuitySession | null;
+  };
+  type HostFrameInput = {
+    frame: SignalMeterFrame;
+    projection?: never;
+    value?: never;
+    source?: never;
+    session?: never;
+  };
+  type SignalInput = LocalSignalInput | HostFrameInput;
   type Props = CommonLinearMeterProps & SignalInput;
 
+  type InputMode = 'local' | 'frame';
+
+  function hasOwn(value: object, key: string): boolean {
+    return Object.prototype.hasOwnProperty.call(value, key);
+  }
+
+  function resolveInputMode(current: Props): InputMode {
+    const hasFrame = hasOwn(current, 'frame');
+    const hasProjection = hasOwn(current, 'projection');
+    const hasValue = hasOwn(current, 'value');
+    if (Number(hasFrame) + Number(hasProjection) + Number(hasValue) !== 1) {
+      throw new TypeError('LinearSMeter requires exactly one of frame, projection, or value');
+    }
+    if (hasFrame) {
+      if (current.frame === undefined) {
+        throw new TypeError('LinearSMeter frame must be defined when supplied');
+      }
+      if (hasOwn(current, 'source') || hasOwn(current, 'session')) {
+        throw new TypeError('LinearSMeter frame owns source and session continuity');
+      }
+      return 'frame';
+    }
+    if (hasProjection && current.projection === undefined) {
+      throw new TypeError('LinearSMeter projection must be defined when supplied');
+    }
+    if (hasValue && current.value === undefined) {
+      throw new TypeError('LinearSMeter value must be a number or null when supplied');
+    }
+    return 'local';
+  }
+
   let props: Props = $props();
+  const initialInputMode = untrack(() => resolveInputMode(props));
+  const inputMode = $derived.by(() => {
+    const current = resolveInputMode(props);
+    if (current !== initialInputMode) {
+      throw new TypeError('LinearSMeter input mode cannot change after mount');
+    }
+    return current;
+  });
   const compact = $derived(props.compact ?? false);
   const label = $derived(props.label);
   const variant = $derived(props.variant);
@@ -103,15 +154,11 @@
   const lowerScale = $derived(props.lowerScale);
   const relevant = $derived(props.relevant ?? true);
   const mainPresent = $derived(props.mainPresent ?? true);
-  const source = $derived(props.source);
-  const session = $derived(props.session);
   const signalProjection = $derived.by((): SignalMeterProjection => {
-    const hasProjection = Object.prototype.hasOwnProperty.call(props, 'projection');
-    const hasValue = Object.prototype.hasOwnProperty.call(props, 'value');
-    if (hasProjection === hasValue) {
-      throw new TypeError('LinearSMeter requires exactly one of projection or value');
+    if (inputMode === 'frame') return (props as HostFrameInput).frame.projection;
+    if (hasOwn(props, 'projection')) {
+      return (props as LocalSignalInput & { projection: SignalMeterProjection }).projection;
     }
-    if (hasProjection) return (props as { projection: SignalMeterProjection }).projection;
     return projectSignalMeter((props as { value: number | null }).value);
   });
 
@@ -278,47 +325,40 @@
     lowerScale ? LOWER_TRACK_Y + LOWER_TRACK_H + SCALE_LABEL_Y : TRACK_Y + TRACK_H + SCALE_LABEL_Y,
   );
 
-  // ── Smoother ────────────────────────────────────────────────────────────────
-  // MOR-481: keep the fast attack (0.06) but shorten the release τ to ~100 ms
-  // so the bar fill tracks the (raw) numeric readout instead of lagging it on
-  // downward steps. The previous 0.25 (~250 ms) release was visibly behind the
-  // number; AmberSmeter already uses a comparably snappy 0.15 release.
-  const smoother = createSmoother(0.06, 0.1);
-  const PEAK_DECAY_FRACTION = 0.0195 / RAW_SEGMENT_DOMAIN;
-  const ballistics = createMeterBallistics(smoother, {
-    now: () => performance.now(),
-    requestFrame: (callback) => requestAnimationFrame(callback),
-    cancelFrame: (id) => cancelAnimationFrame(id),
-    setInterval: (callback, milliseconds) => setInterval(callback, milliseconds),
-    clearInterval: (id) => clearInterval(id),
-    prefersReducedMotion,
-    onReducedMotionChange,
-  }, {
-    peakSource: 'smoothed',
-    ticker: { kind: 'animation-frame' },
-    peak: createFrameStepPeakStrategy({
-      holdMilliseconds: 1000,
-      decrementPerFrame: () => PEAK_DECAY_FRACTION * 16.67,
-    }),
-  });
+  const localMotion = initialInputMode === 'local'
+    ? untrack(() => createSignalMeterMotion({
+        projection: signalProjection,
+        present: mainPresent,
+        source: (props as LocalSignalInput).source,
+        session: (props as LocalSignalInput).session,
+      }))
+    : null;
+  const meterFrame = $derived(
+    inputMode === 'frame' ? (props as HostFrameInput).frame : localMotion!.frame,
+  );
 
   $effect(() => {
-    const current = mainPresent ? signalProjection.motionFraction : null;
-    const currentSource = source;
-    const currentSession = session;
-    untrack(() => ballistics.sync({
-      sample: current, smoothTarget: current, peakEnabled: true,
-      source: currentSource, session: currentSession,
+    if (localMotion === null) return;
+    const currentProjection = signalProjection;
+    const currentPresent = mainPresent;
+    const currentSource = (props as LocalSignalInput).source;
+    const currentSession = (props as LocalSignalInput).session;
+    untrack(() => localMotion.sync({
+      projection: currentProjection,
+      present: currentPresent,
+      source: currentSource,
+      session: currentSession,
     }));
   });
 
   onMount(() => {
-    ballistics.start();
-    return () => ballistics.stop();
+    if (localMotion === null) return;
+    localMotion.start();
+    return () => localMotion.stop();
   });
 
-  let smoothedSegs = $derived(ballistics.view.smoothedValue * SEG_COUNT);
-  let peakSegs = $derived((ballistics.view.peakValue ?? 0) * SEG_COUNT);
+  let smoothedSegs = $derived(meterFrame.smoothedFraction * SEG_COUNT);
+  let peakSegs = $derived((meterFrame.peakFraction ?? 0) * SEG_COUNT);
   // Peak X position for the vertical indicator line
   let peakX = $derived(BAR_X + peakSegs * (SEG_W + SEG_GAP));
   // Only show peak line if it's meaningfully ahead of current bar
@@ -349,7 +389,7 @@
   const SDR_CELL_WIDTH = 328 / SDR_CELLS;
   const SDR_SUB_WIDTH = (SDR_CELL_WIDTH - 2 - 0.5) / 2;
   const sdrFill = $derived(
-    (signalProjection.motionFraction === null ? 0 : smoother.value) * SDR_CELLS * 2,
+    (signalProjection.motionFraction === null ? 0 : meterFrame.smoothedFraction) * SDR_CELLS * 2,
   );
   const sdrS9 = $derived(signalProjection.s9Fraction * SDR_CELLS * 2);
   function sdrColor(index: number): string {

--- a/frontend/src/components-v2/meters/__tests__/LinearSMeter.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/LinearSMeter.test.ts
@@ -1,8 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { mount, unmount, flushSync } from 'svelte';
 import type { ComponentProps } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
 import type { Capabilities } from '$lib/types/capabilities';
 import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
 
@@ -56,6 +58,7 @@ function makeCaps(overrides: Partial<Capabilities> = {}): Capabilities {
 }
 
 import LinearSMeter from '../LinearSMeter.svelte';
+import type { SignalMeterFrame } from '../signal-meter-motion.svelte';
 import {
   rawToSegments,
   rawToSUnit,
@@ -91,6 +94,7 @@ afterEach(() => {
   components = [];
   roots = [];
   clearCapabilities();
+  vi.restoreAllMocks();
 });
 
 // ── rawToSegments ──────────────────────────────────────────────────────────
@@ -266,21 +270,20 @@ describe('segment rendering logic', () => {
 
 describe('LinearSMeter smoother release τ', () => {
   const source = readFileSync(
-    resolve(process.cwd(), 'src/components-v2/meters/LinearSMeter.svelte'),
+    resolve(process.cwd(), 'src/components-v2/meters/signal-meter-motion.svelte.ts'),
     'utf8',
   );
 
-  it('calls createSmoother with the snappy release τ (0.10), not the slow 0.25', () => {
-    const match = source.match(/createSmoother\(\s*([0-9.]+)\s*,\s*([0-9.]+)/);
-    expect(match).not.toBeNull();
-    const attack = Number(match![1]);
-    const release = Number(match![2]);
+  it('moves the snappy attack/release policy unchanged into the motion binding', () => {
+    const attack = Number(source.match(/ATTACK_SECONDS\s*=\s*([0-9.]+)/)?.[1]);
+    const release = Number(source.match(/RELEASE_SECONDS\s*=\s*([0-9.]+)/)?.[1]);
     // Attack unchanged (fast punch-in).
     expect(attack).toBeCloseTo(0.06, 5);
     // Release reduced from 0.25 → 0.10 so the bar reaches the target within
     // ~150 ms. Anything ≥ 0.25 reintroduces the visible lag (MOR-481).
     expect(release).toBeCloseTo(0.1, 5);
     expect(release).toBeLessThan(0.25);
+    expect(source).toMatch(/createSmoother\(ATTACK_SECONDS, RELEASE_SECONDS\)/);
   });
 });
 
@@ -312,6 +315,88 @@ describe('LinearSMeter calibrated S-meter domain', () => {
     }
   });
 
+  it('renders normal and SDR geometry from every supplied host-frame field', () => {
+    const projection = projectSignalMeter(0);
+    const frame = {
+      projection,
+      smoothedFraction: 0.5,
+      peakFraction: 0.8,
+    } satisfies SignalMeterFrame;
+    const frameOnly = { frame } satisfies ComponentProps<typeof LinearSMeter>;
+    expect(frameOnly.frame).toBe(frame);
+
+    const normal = mountMeter({ frame });
+    expect(normal.textContent).toContain(projection.primaryText);
+    expect(normal.textContent).toContain(projection.secondaryText);
+    expect(normal.querySelectorAll('[data-meter-fill]')).toHaveLength(10);
+    expect(Number(normal.querySelector('[data-meter-peak]')?.getAttribute('x1'))).toBeCloseTo(396);
+
+    const sdr = mountMeter({ frame, variant: 'sdr-screen' });
+    expect(sdr.querySelector('[data-sdr-segment="39"]')?.getAttribute('fill')).toBe('#4FB9EC');
+    expect(sdr.querySelector('[data-sdr-segment="40"]')?.getAttribute('fill')).toBe('#1a2230');
+  });
+
+  it('starts no local motion owner for a host frame while compatibility callers start one', () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as MediaQueryList) as unknown as typeof window.matchMedia;
+    const requestFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1);
+    try {
+      const projection = projectSignalMeter(0);
+      mountMeter({ frame: { projection, smoothedFraction: 0.5, peakFraction: null } });
+      expect(requestFrame).not.toHaveBeenCalled();
+      mountMeter({ projection });
+      expect(requestFrame).toHaveBeenCalledTimes(2);
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+
+  it('rejects frame input combined with local value, projection, source, or session owners', () => {
+    const projection = projectSignalMeter(0);
+    const frame = { projection, smoothedFraction: 0.5, peakFraction: null } satisfies SignalMeterFrame;
+    // @ts-expect-error -- a host frame and local value are exclusive owners.
+    const invalidValue: ComponentProps<typeof LinearSMeter> = { frame, value: 0 };
+    const invalidProjection: ComponentProps<typeof LinearSMeter> = { frame, projection: undefined };
+    const invalidSource: ComponentProps<typeof LinearSMeter> = { frame, source: undefined };
+    // @ts-expect-error -- a defined projection cannot accompany a host frame.
+    const invalidDefinedProjection: ComponentProps<typeof LinearSMeter> = { frame, projection };
+    const definedSource = {
+      providerGeneration: 1, scope: 'receiver', receiver: 'MAIN', path: 'main.sMeter',
+    } as const;
+    // @ts-expect-error -- a host frame owns its source continuity.
+    const invalidDefinedSource: ComponentProps<typeof LinearSMeter> = { frame, source: definedSource };
+    expect(invalidValue.value).toBe(0);
+    expect(invalidProjection).toHaveProperty('projection');
+    expect(invalidSource).toHaveProperty('source');
+    expect(invalidDefinedProjection.projection).toBe(projection);
+    expect(invalidDefinedSource).toHaveProperty('source');
+    expect(() => mountMeter(invalidValue as never)).toThrow(/exactly one of .*frame.*projection.*value/);
+    expect(() => mountMeter(invalidProjection as never)).toThrow(/exactly one of .*frame.*projection.*value/);
+    expect(() => mountMeter(invalidSource as never)).toThrow(/frame owns source and session/);
+    expect(() => mountMeter({ frame, session: null } as never)).toThrow(/frame owns source and session/);
+    expect(() => mountMeter({ frame: undefined } as never)).toThrow(/frame must be defined/);
+  });
+
+  it('rejects a dynamic switch between local-owner and host-frame modes', () => {
+    const projection = projectSignalMeter(0);
+    const frame = { projection, smoothedFraction: 0.5, peakFraction: null } satisfies SignalMeterFrame;
+    const state: ComponentProps<typeof LinearSMeter> = proxy({ value: 0 });
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    const component = mount(LinearSMeter, { target, props: state });
+    flushSync();
+    expect(() => flushSync(() => {
+      delete (state as { value?: number | null }).value;
+      (state as { frame?: SignalMeterFrame }).frame = frame;
+    })).toThrow(/input mode cannot change after mount/);
+    unmount(component);
+    target.remove();
+  });
+
   it('rejects dynamic callers that supply both projection and value', () => {
     const projection = projectSignalMeter(0);
     const projectionOnly = { projection } satisfies ComponentProps<typeof LinearSMeter>;
@@ -322,12 +407,12 @@ describe('LinearSMeter calibrated S-meter domain', () => {
     expect(valueOnly.value).toBe(0);
     expect(invalid).toEqual({ value: 0, projection });
     expect(() => mountMeter({ value: 0, projection } as never))
-      .toThrow(/exactly one of projection or value/);
+      .toThrow(/exactly one of .*projection.*value/);
   });
 
   it('rejects dynamic callers that supply neither projection nor value', () => {
     expect(() => mountMeter({} as never))
-      .toThrow(/exactly one of projection or value/);
+      .toThrow(/exactly one of .*projection.*value/);
   });
 
   it('keeps every dense tick and the S1 label on the supplied projection after calibration replacement', () => {

--- a/frontend/src/components-v2/meters/__tests__/signal-meter-motion.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/signal-meter-motion.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  MeterContinuitySession,
+  MeterSourceIdentity,
+} from '../../../primitives/meters/meter-ballistics.svelte';
+import type { SignalMeterProjection } from '../smeter-scale';
+import { createSignalMeterMotion } from '../signal-meter-motion.svelte';
+
+const MAIN_SOURCE = {
+  providerGeneration: 1,
+  scope: 'receiver',
+  receiver: 'MAIN',
+  path: 'main.sMeter',
+} as const satisfies MeterSourceIdentity;
+const SUB_SOURCE = {
+  providerGeneration: 1,
+  scope: 'receiver',
+  receiver: 'SUB',
+  path: 'sub.sMeter',
+} as const satisfies MeterSourceIdentity;
+const SESSION_1 = { controlSessionEpoch: 1 } as const satisfies MeterContinuitySession;
+const SESSION_2 = { controlSessionEpoch: 2 } as const satisfies MeterContinuitySession;
+
+function projection(
+  motionFraction: number | null,
+  primaryText = motionFraction === null ? 'S ?' : 'S5',
+): SignalMeterProjection {
+  return {
+    motionFraction,
+    primaryText,
+    secondaryText: motionFraction === null ? '' : '\u2212121 dBm',
+    s9Fraction: 0.55,
+    marks: [],
+    ticks: [],
+  };
+}
+
+interface MotionHarness {
+  readonly activeFrames: number;
+  readonly listenerCount: number;
+  setReduced(reduced: boolean): void;
+  restore(): void;
+}
+
+function installMotionHarness(initialReduced = false): MotionHarness {
+  let reduced = initialReduced;
+  let nextFrameId = 1;
+  const frames = new Map<number, FrameRequestCallback>();
+  const listeners = new Set<() => void>();
+  const mql = {
+    get matches() { return reduced; },
+    addEventListener: (_type: string, callback: () => void) => { listeners.add(callback); },
+    removeEventListener: (_type: string, callback: () => void) => { listeners.delete(callback); },
+  } as unknown as MediaQueryList;
+  const originalMatchMedia = window.matchMedia;
+  window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia;
+  const requestFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+    const id = nextFrameId++;
+    frames.set(id, callback);
+    return id;
+  });
+  const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id) => {
+    frames.delete(id);
+  });
+  return {
+    get activeFrames() { return frames.size; },
+    get listenerCount() { return listeners.size; },
+    setReduced(next) {
+      reduced = next;
+      listeners.forEach((callback) => callback());
+    },
+    restore() {
+      window.matchMedia = originalMatchMedia;
+      requestFrame.mockRestore();
+      cancelFrame.mockRestore();
+    },
+  };
+}
+
+let harness: MotionHarness | undefined;
+
+beforeEach(() => {
+  harness = installMotionHarness();
+});
+
+afterEach(() => {
+  harness?.restore();
+  harness = undefined;
+});
+
+describe('createSignalMeterMotion', () => {
+  it('owns exactly the existing smoother and peak schedules with idempotent lifecycle', () => {
+    const binding = createSignalMeterMotion({ projection: projection(0.75), present: true });
+    expect(harness!.activeFrames).toBe(0);
+
+    binding.start();
+    binding.start();
+    expect(harness!.activeFrames).toBe(2);
+    expect(harness!.listenerCount).toBe(2);
+
+    binding.stop();
+    binding.stop();
+    expect(harness!.activeFrames).toBe(0);
+    expect(harness!.listenerCount).toBe(0);
+  });
+
+  it('keeps projection atomic while sample-only updates retain motion history', () => {
+    const high = projection(0.8, 'S9+20');
+    const low = projection(0.2, 'S2');
+    const binding = createSignalMeterMotion({
+      projection: high, present: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    expect(binding.frame.projection).toBe(high);
+    expect(binding.frame.smoothedFraction).toBe(0.8);
+    expect(binding.frame.peakFraction).toBe(0.8);
+
+    binding.sync({ projection: low, present: true, source: MAIN_SOURCE, session: SESSION_1 });
+    expect(binding.frame.projection).toBe(low);
+    expect(binding.frame.smoothedFraction).toBe(0.8);
+    expect(binding.frame.peakFraction).toBe(0.8);
+  });
+
+  it('observes synchronous source and session A-B-A boundaries without a render flush', () => {
+    const binding = createSignalMeterMotion({
+      projection: projection(0.8), present: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    binding.sync({
+      projection: projection(0.2), present: true, source: SUB_SOURCE, session: SESSION_1,
+    });
+    expect(binding.frame.smoothedFraction).toBe(0.2);
+    binding.sync({
+      projection: projection(0.6), present: true, source: MAIN_SOURCE, session: SESSION_2,
+    });
+    expect(binding.frame.smoothedFraction).toBe(0.6);
+    expect(binding.frame.peakFraction).toBe(0.6);
+  });
+
+  it('preserves independent undefined, null, and object continuity semantics', () => {
+    const binding = createSignalMeterMotion({
+      projection: projection(0.7), present: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    binding.sync({ projection: projection(0.3), present: true, source: SUB_SOURCE });
+    expect(binding.frame.smoothedFraction).toBe(0.3);
+    binding.sync({ projection: projection(0.2), present: true, session: SESSION_2 });
+    expect(binding.frame.smoothedFraction).toBe(0.3);
+
+    binding.sync({
+      projection: projection(0.4), present: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    expect(binding.frame.smoothedFraction).toBe(0.4);
+    binding.sync({
+      projection: projection(0.9), present: true, source: null, session: SESSION_1,
+    });
+    expect(binding.frame.smoothedFraction).toBe(0);
+    expect(binding.frame.peakFraction).toBeNull();
+    binding.sync({
+      projection: projection(0.6), present: true, source: MAIN_SOURCE, session: SESSION_1,
+    });
+    binding.sync({
+      projection: projection(0.9), present: true, source: MAIN_SOURCE, session: null,
+    });
+    expect(binding.frame.smoothedFraction).toBe(0);
+    expect(binding.frame.peakFraction).toBeNull();
+  });
+
+  it('keeps known raw projection text but resets motion for unknown or absent samples', () => {
+    const raw = projection(0.4, 'raw 103');
+    const binding = createSignalMeterMotion({ projection: raw, present: true });
+    expect(binding.frame.projection.primaryText).toBe('raw 103');
+
+    const unknown = projection(null);
+    binding.sync({ projection: unknown, present: true });
+    expect(binding.frame.projection).toBe(unknown);
+    expect(binding.frame.smoothedFraction).toBe(0);
+    expect(binding.frame.peakFraction).toBeNull();
+
+    binding.sync({ projection: raw, present: false });
+    expect(binding.frame.projection).toBe(raw);
+    expect(binding.frame.smoothedFraction).toBe(0);
+    expect(binding.frame.peakFraction).toBeNull();
+  });
+
+  it('stops both channels when reduced motion turns on and restores them when it turns off', () => {
+    const binding = createSignalMeterMotion({ projection: projection(0.5), present: true });
+    binding.start();
+    expect(harness!.activeFrames).toBe(2);
+
+    harness!.setReduced(true);
+    expect(harness!.activeFrames).toBe(0);
+    expect(binding.frame.smoothedFraction).toBe(0.5);
+    harness!.setReduced(false);
+    expect(harness!.activeFrames).toBe(2);
+  });
+});

--- a/frontend/src/components-v2/meters/signal-meter-motion.svelte.ts
+++ b/frontend/src/components-v2/meters/signal-meter-motion.svelte.ts
@@ -1,0 +1,86 @@
+import {
+  createSmoother,
+  onReducedMotionChange,
+  prefersReducedMotion,
+} from '$lib/utils/smoothing.svelte';
+import {
+  createFrameStepPeakStrategy,
+  createMeterBallistics,
+  type MeterContinuitySession,
+  type MeterMotionHost,
+  type MeterSourceIdentity,
+} from '../../primitives/meters/meter-ballistics.svelte';
+import type { SignalMeterProjection } from './smeter-scale';
+
+export interface SignalMeterFrame {
+  readonly projection: SignalMeterProjection;
+  readonly smoothedFraction: number;
+  readonly peakFraction: number | null;
+}
+
+export type SignalMeterMotionInput = Readonly<{
+  projection: SignalMeterProjection;
+  present: boolean;
+  source?: MeterSourceIdentity | null;
+  session?: MeterContinuitySession | null;
+}>;
+
+export interface SignalMeterMotionBinding {
+  readonly frame: SignalMeterFrame;
+  sync(input: SignalMeterMotionInput): void;
+  start(): void;
+  stop(): void;
+}
+
+const ATTACK_SECONDS = 0.06;
+const RELEASE_SECONDS = 0.1;
+const PEAK_HOLD_MILLISECONDS = 1000;
+const PEAK_DECREMENT_PER_FRAME = (0.0195 / 20) * 16.67;
+
+const browserMotionHost: MeterMotionHost = {
+  now: () => performance.now(),
+  requestFrame: (callback) => requestAnimationFrame(callback),
+  cancelFrame: (id) => cancelAnimationFrame(id),
+  setInterval: (callback, milliseconds) => setInterval(callback, milliseconds),
+  clearInterval: (id) => clearInterval(id),
+  prefersReducedMotion,
+  onReducedMotionChange,
+};
+
+export function createSignalMeterMotion(
+  initial: SignalMeterMotionInput,
+): SignalMeterMotionBinding {
+  let projection = $state.raw(initial.projection);
+  const smoother = createSmoother(ATTACK_SECONDS, RELEASE_SECONDS);
+  const ballistics = createMeterBallistics(smoother, browserMotionHost, {
+    peakSource: 'smoothed',
+    ticker: { kind: 'animation-frame' },
+    peak: createFrameStepPeakStrategy({
+      holdMilliseconds: PEAK_HOLD_MILLISECONDS,
+      decrementPerFrame: () => PEAK_DECREMENT_PER_FRAME,
+    }),
+  });
+  const frame: SignalMeterFrame = {
+    get projection() { return projection; },
+    get smoothedFraction() { return ballistics.view.smoothedValue; },
+    get peakFraction() { return ballistics.view.peakValue; },
+  };
+  const binding: SignalMeterMotionBinding = {
+    frame,
+    sync(input) {
+      projection = input.projection;
+      const sample = input.present ? input.projection.motionFraction : null;
+      ballistics.sync({
+        sample,
+        smoothTarget: sample,
+        peakEnabled: true,
+        source: input.source,
+        session: input.session,
+      });
+    },
+    start: () => ballistics.start(),
+    stop: () => ballistics.stop(),
+  };
+  binding.sync(initial);
+  return binding;
+}

--- a/frontend/src/primitives/meters/__tests__/meter-ballistics.test.ts
+++ b/frontend/src/primitives/meters/__tests__/meter-ballistics.test.ts
@@ -176,11 +176,17 @@ describe('createMeterBallistics frame-step strategy', () => {
   it('is the shared owner without importing renderer or smoother implementations', () => {
     const primitive = readFileSync('src/primitives/meters/meter-ballistics.svelte.ts', 'utf8');
     expect(primitive).not.toMatch(/components-v2|createSmoother|Math\.exp|calibrated|SEG_COUNT|runtime\//);
-    for (const component of ['LinearSMeter.svelte', 'BarGauge.svelte']) {
-      const source = readFileSync(`src/components-v2/meters/${component}`, 'utf8');
-      expect(source.match(/createMeterBallistics\(/g)).toHaveLength(1);
-      expect(source.match(/createSmoother\(/g)).toHaveLength(1);
-    }
+    const binding = readFileSync('src/components-v2/meters/signal-meter-motion.svelte.ts', 'utf8');
+    expect(binding.match(/createMeterBallistics\(/g)).toHaveLength(1);
+    expect(binding.match(/createSmoother\(/g)).toHaveLength(1);
+
+    const linear = readFileSync('src/components-v2/meters/LinearSMeter.svelte', 'utf8');
+    expect(linear).not.toMatch(/createMeterBallistics\(|createSmoother\(/);
+    expect(linear.match(/createSignalMeterMotion\(/g)).toHaveLength(1);
+
+    const bar = readFileSync('src/components-v2/meters/BarGauge.svelte', 'utf8');
+    expect(bar.match(/createMeterBallistics\(/g)).toHaveLength(1);
+    expect(bar.match(/createSmoother\(/g)).toHaveLength(1);
   });
 
   it('delegates smoothing and clears both outputs when either coordinate is absent', () => {


### PR DESCRIPTION
## Scope

- Linked issue / task: [MOR-2425](https://linear.app/morozsm/issue/MOR-2425/expose-a-supported-v3-host-boundary-for-independently-installed)
- Compatibility impact: none

Extracts the existing Linear S-meter smoother and peak-ballistics assembly into one host-owned signal motion binding. Every current value and projection caller now uses that binding, while the new exclusive frame mode renders host-supplied projection, smoothing, and peak state without allocating or scheduling a local motion owner.

## Verification

- [x] Relevant local tests or checks run
- [x] Public/open-core boundary checked
- [x] Release or migration impact documented if applicable

- 128 focused Vitest tests across Linear meter rendering, display/lower-scale geometry, reduced motion, SDR appearance, signal motion, and shared ballistics
- `npm run check` — 0 errors, 0 warnings
- Scoped ESLint — clean
- Diff hygiene — 5 paths, 476 additions + 65 deletions = 541 changed lines

## Agent Review

- [x] Independent agent review comment posted before merge
- Reviewer: independent Sol/high verifier, `/root/signal_motion_review`
- Result: [PASS at e9cd619dded0d44a4b5f9844aba4a9e7a72c9bae](https://github.com/rigplane/rigplane-core/pull/3296#issuecomment-5562694330)

## Notes

- The runtime receiver host that will retain MAIN/SUB motion owners across presentation replacement remains the separate V1-RH packet.
- No App, SemanticRadioSurfaces, VfoSurface, MetersSurface, public SDK, hardware, or deployment changes.
