### PR TITLE
feat(MOR-2425): add scalar accessibility presentation

### DIFF
--- a/frontend/src/components-v2/controls/value-control/BipolarRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/BipolarRenderer.svelte
@@ -16,6 +16,7 @@
   import {
     projectScalarRenderPresentation,
     type LegacyReadingPresentation,
+    type ScalarAccessibilityPresentation,
   } from './scalar-render-presentation';
 
   interface Props {
@@ -34,6 +35,7 @@
     unit?: string;
     shortcutHint?: string | null;
     title?: string | null;
+    accessibility?: ScalarAccessibilityPresentation;
     legacy?: LegacyReadingPresentation;
   }
 
@@ -53,6 +55,7 @@
     unit = '',
     shortcutHint = null,
     title = null,
+    accessibility,
     legacy,
   }: Props = $props();
 
@@ -115,7 +118,7 @@
     );
     return extent > 0 ? Math.abs(renderedValue - center) / extent : 0;
   });
-  let renderPresentation = $derived(projectScalarRenderPresentation(view, legacy));
+  let renderPresentation = $derived(projectScalarRenderPresentation(view, legacy, accessibility));
 
   function handlePointerDown(e: PointerEvent) {
     if (!containerEl) return;
@@ -207,6 +210,7 @@
     aria-valuemin={view.domainValid ? view.domain.min : undefined}
     aria-valuemax={view.domainValid ? view.domain.max : undefined}
     aria-valuenow={view.domainValid ? view.canonical ?? undefined : undefined}
+    aria-valuetext={accessibility?.valueText?.trim() ? accessibility.valueText : undefined}
     aria-disabled={!view.editable}
     aria-busy={renderPresentation.attributes['aria-busy']}
     aria-describedby={renderPresentation.description !== null ? feedbackDescriptionId : undefined}

--- a/frontend/src/components-v2/controls/value-control/DiscreteRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/DiscreteRenderer.svelte
@@ -16,6 +16,7 @@
   import {
     projectScalarRenderPresentation,
     type LegacyReadingPresentation,
+    type ScalarAccessibilityPresentation,
   } from './scalar-render-presentation';
 
   interface Props {
@@ -40,6 +41,7 @@
     /** Visual style for discrete step marks. */
     tickStyle?: 'ruler' | 'led' | 'notch';
     dimmed?: boolean;
+    accessibility?: ScalarAccessibilityPresentation;
     legacy?: LegacyReadingPresentation;
   }
 
@@ -63,6 +65,7 @@
     showAllTicks = true,
     tickStyle = 'notch',
     dimmed,
+    accessibility,
     legacy,
   }: Props = $props();
 
@@ -117,7 +120,7 @@
     ? unknownDisplay ?? (displayFn ? displayFn(Number.NaN) : '—')
     : displayFn ? displayFn(renderedValue)
       : `${renderedValue}${unit ? '\u00a0' + unit : ''}`);
-  let renderPresentation = $derived(projectScalarRenderPresentation(view, legacy));
+  let renderPresentation = $derived(projectScalarRenderPresentation(view, legacy, accessibility));
   let currentStatusDescription = $derived(
     renderPresentation.currentStatus === null
       ? renderPresentation.error
@@ -265,6 +268,7 @@
     aria-valuemin={view.domainValid ? view.domain.min : undefined}
     aria-valuemax={view.domainValid ? view.domain.max : undefined}
     aria-valuenow={view.domainValid ? view.canonical ?? undefined : undefined}
+    aria-valuetext={accessibility?.valueText?.trim() ? accessibility.valueText : undefined}
     aria-disabled={!view.editable}
     aria-busy={renderPresentation.attributes['aria-busy']}
     aria-describedby={feedbackDescriptionIds}

--- a/frontend/src/components-v2/controls/value-control/HBarRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/HBarRenderer.svelte
@@ -33,6 +33,7 @@
     unit = '',
     shortcutHint = null,
     title = null,
+    accessibility,
     legacy,
     valueProjection,
     issuedStatusPresentation,
@@ -98,7 +99,9 @@
   let displayValue = $derived(renderedValue === null
     ? unknownDisplay ?? (displayFn ? displayFn(Number.NaN) : '—')
     : displayFn ? displayFn(renderedValue) : `${renderedValue}${unit ? '\u00a0' + unit : ''}`);
-  let renderPresentation = $derived(view == null ? null : projectScalarRenderPresentation(view, legacy));
+  let renderPresentation = $derived(
+    view == null ? null : projectScalarRenderPresentation(view, legacy, accessibility),
+  );
   $effect(() => {
     const snapshot = view;
     if (issuedStatusPresentation === undefined || snapshot == null
@@ -237,7 +240,9 @@
     aria-valuemin={view.domainValid ? view.domain.min : undefined}
     aria-valuemax={view.domainValid ? view.domain.max : undefined}
     aria-valuenow={ariaValueNow}
-    aria-valuetext={valueProjection === undefined ? undefined : displayValue}
+    aria-valuetext={accessibility?.valueText?.trim()
+      ? accessibility.valueText
+      : valueProjection === undefined ? undefined : displayValue}
     aria-disabled={!view.editable}
     aria-busy={renderPresentation.attributes['aria-busy']}
     aria-describedby={renderPresentation.description !== null ? feedbackDescriptionId : undefined}

--- a/frontend/src/components-v2/controls/value-control/KnobRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/KnobRenderer.svelte
@@ -17,6 +17,7 @@
   import {
     projectScalarRenderPresentation,
     type LegacyReadingPresentation,
+    type ScalarAccessibilityPresentation,
   } from './scalar-render-presentation';
 
   interface Props {
@@ -38,6 +39,7 @@
     unit?: string;
     shortcutHint?: string | null;
     title?: string | null;
+    accessibility?: ScalarAccessibilityPresentation;
     legacy?: LegacyReadingPresentation;
   }
 
@@ -60,6 +62,7 @@
     unit = '',
     shortcutHint = null,
     title = null,
+    accessibility,
     legacy,
   }: Props = $props();
 
@@ -134,7 +137,7 @@
   let displayValue = $derived(renderedValue === null
     ? unknownDisplay ?? (displayFn ? displayFn(Number.NaN) : '—')
     : displayFn ? displayFn(renderedValue) : String(renderedValue) + (unit ? unit : ''));
-  let renderPresentation = $derived(projectScalarRenderPresentation(view, legacy));
+  let renderPresentation = $derived(projectScalarRenderPresentation(view, legacy, accessibility));
 
   function handlePointerDown(e: PointerEvent) {
     const token = lease.beginPointer();
@@ -220,6 +223,7 @@
     aria-valuemin={view.domainValid ? view.domain.min : undefined}
     aria-valuemax={view.domainValid ? view.domain.max : undefined}
     aria-valuenow={view.domainValid ? view.canonical ?? undefined : undefined}
+    aria-valuetext={accessibility?.valueText?.trim() ? accessibility.valueText : undefined}
     aria-disabled={!view.editable}
     aria-busy={renderPresentation.attributes['aria-busy']}
     aria-describedby={renderPresentation.description !== null ? feedbackDescriptionId : undefined}

--- a/frontend/src/components-v2/controls/value-control/ValueControl.svelte
+++ b/frontend/src/components-v2/controls/value-control/ValueControl.svelte
@@ -5,7 +5,10 @@
   import KnobRenderer from './KnobRenderer.svelte';
   import DiscreteRenderer from './DiscreteRenderer.svelte';
   import { getSelectedScalarAppearance } from '../../../component-kits/activation';
-  import type { LegacyReadingPresentation } from './scalar-render-presentation';
+  import type {
+    LegacyReadingPresentation,
+    ScalarAccessibilityPresentation,
+  } from './scalar-render-presentation';
   import type {
     HBarIssuedStatusPresentation,
     HBarValueProjection,
@@ -44,6 +47,7 @@
     unit?: string;
     shortcutHint?: string | null;
     title?: string | null;
+    accessibility?: ScalarAccessibilityPresentation;
     skin?: Skin;
     valueProjection?: Readonly<HBarValueProjection>;
     issuedStatusPresentation?: Readonly<HBarIssuedStatusPresentation>;
@@ -121,6 +125,7 @@
     unit = '',
     shortcutHint = null,
     title = null,
+    accessibility,
     onchange,
     skin,
     valueProjection,
@@ -237,6 +242,7 @@
     unit,
     shortcutHint,
     title,
+    accessibility,
     legacy,
   });
   let knobProps = $derived({ ...rendererProps, arcAngle, tickCount, tickLabels });
@@ -274,14 +280,14 @@
     binding={scalarBinding} {label} {displayFn} {unknownDisplay}
     {fillColor} {fillGradient} {trackColor}
     {accentColor} {showValue} {showLabel} {compact} {variant} {unit} {shortcutHint} {title}
-    {legacy} {valueProjection} {issuedStatusPresentation}
+    {accessibility} {legacy} {valueProjection} {issuedStatusPresentation}
   />
 {:else if renderer === 'bipolar'}
   <BipolarRenderer
     binding={scalarBinding} {label} {displayFn} {unknownDisplay}
     {fillColor} {fillGradient} {trackColor}
     {accentColor} {showValue} {showLabel} {compact} {variant} {unit} {shortcutHint} {title}
-    {legacy}
+    {accessibility} {legacy}
   />
 {:else if renderer === 'knob'}
   <KnobRenderer {...knobProps} />

--- a/frontend/src/components-v2/controls/value-control/__tests__/ExternalScalarRendererFixture.svelte
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ExternalScalarRendererFixture.svelte
@@ -28,6 +28,7 @@
     unit,
     shortcutHint,
     title,
+    accessibility,
     legacy,
     valueProjection,
     issuedStatusPresentation,
@@ -93,6 +94,8 @@
   data-unit={unit ?? ''}
   data-shortcut-hint={shortcutHint ?? ''}
   data-title={title ?? ''}
+  data-accessibility-description={accessibility?.description ?? ''}
+  data-accessibility-value-text={accessibility?.valueText ?? ''}
   data-legacy-phase={legacy?.phase ?? ''}
   data-legacy-busy={String(legacy?.busy)}
   data-legacy-description={legacy?.description ?? ''}

--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
@@ -207,6 +207,91 @@ function knobCommandBinding(
   );
 }
 
+describe('ValueControl scalar accessibility presentation', () => {
+  it.each(['hbar', 'bipolar', 'knob', 'discrete'] as const)(
+    'places descriptive metadata on the actual %s slider and withdraws it without commands',
+    (renderer) => {
+      const onChange = vi.fn();
+      const { state, target } = mountReactive({
+        ...baseProps,
+        renderer,
+        accessibility: {
+          description: 'Canonical receiver gain',
+          valueText: '20 percent; device idle',
+        },
+        onChange,
+      });
+      const control = slider(target);
+
+      expect(control.getAttribute('aria-valuetext')).toBe('20 percent; device idle');
+      const descriptionId = control.getAttribute('aria-describedby');
+      expect(descriptionId).not.toBeNull();
+      expect(target.querySelector(`#${descriptionId}`)?.textContent)
+        .toBe('Canonical receiver gain');
+      expect(onChange).not.toHaveBeenCalled();
+
+      state.accessibility = { description: null, valueText: null };
+      flushSync();
+      expect(control.getAttribute('aria-valuetext')).toBeNull();
+      expect(control.getAttribute('aria-describedby')).toBeNull();
+      expect(onChange).not.toHaveBeenCalled();
+    },
+  );
+
+  it('updates host context without reading truth or replacing command feedback facts', () => {
+    const request = vi.fn();
+    const owner = commandBinding(request, {
+      phase: 'failed',
+      busy: false,
+      outcome: { phase: 'failed', error: 'radio rejected' },
+      transitionId: 'accessibility-failed',
+    });
+    let viewReads = 0;
+    const binding = countViewReads(owner, () => { viewReads += 1; });
+    const { state, target } = mountReactive({
+      binding,
+      label: 'Filter width',
+      renderer: 'hbar',
+      accessibility: {
+        description: 'Canonical 20 Hz; device rejected the latest request',
+        valueText: '20 Hz; failed request for 30 Hz',
+      },
+    });
+    const readsAfterMount = viewReads;
+    const control = slider(target);
+    const descriptionText = () => target.querySelector(
+      `#${control.getAttribute('aria-describedby')}`,
+    )?.textContent;
+
+    expect(descriptionText()).toBe('30 Hz. Canonical 20 Hz; device rejected the latest request');
+    expect(control.getAttribute('aria-valuetext')).toBe('20 Hz; failed request for 30 Hz');
+    expect(control.getAttribute('data-command-phase')).toBe('failed');
+    expect(target.querySelector('[data-control-feedback-status]')?.textContent)
+      .toBe('Failed: 30 Hz: radio rejected');
+    expect(target.querySelectorAll('[data-control-feedback-status]')).toHaveLength(1);
+
+    state.accessibility = {
+      description: 'Canonical 20 Hz; retry available',
+      valueText: '20 Hz; retry available',
+    };
+    flushSync();
+    expect(descriptionText()).toBe('30 Hz. Canonical 20 Hz; retry available');
+    expect(control.getAttribute('aria-valuetext')).toBe('20 Hz; retry available');
+    expect(viewReads).toBe(readsAfterMount);
+    expect(request).not.toHaveBeenCalled();
+
+    state.accessibility = undefined;
+    flushSync();
+    expect(descriptionText()).toBe('30 Hz');
+    expect(control.getAttribute('aria-valuetext')).toBeNull();
+    expect(target.querySelector('[data-control-feedback-status]')?.textContent)
+      .toBe('Failed: 30 Hz: radio rejected');
+    expect(viewReads).toBe(readsAfterMount);
+    expect(request).not.toHaveBeenCalled();
+    owner.destroy();
+  });
+});
+
 describe('ValueControl controlled HBar rendering', () => {
   it.each([
     ['built-in', undefined],
@@ -1478,6 +1563,10 @@ describe('ValueControl external scalar appearances', () => {
       unit: 'dB',
       shortcutHint: 'Alt+S',
       title: 'Scalar title',
+      accessibility: {
+        description: 'Canonical scalar control',
+        valueText: '20 units; device idle',
+      },
       feedbackPhase: 'failed',
       feedbackBusy: false,
       feedbackDescription: 'Legacy description',
@@ -1500,6 +1589,8 @@ describe('ValueControl external scalar appearances', () => {
     expect(control.getAttribute('data-unit')).toBe('dB');
     expect(control.getAttribute('data-shortcut-hint')).toBe('Alt+S');
     expect(control.getAttribute('data-title')).toBe('Scalar title');
+    expect(control.getAttribute('data-accessibility-description')).toBe('Canonical scalar control');
+    expect(control.getAttribute('data-accessibility-value-text')).toBe('20 units; device idle');
     expect(control.getAttribute('data-legacy-phase')).toBe('failed');
     expect(control.getAttribute('data-legacy-busy')).toBe('false');
     expect(control.getAttribute('data-legacy-description')).toBe('Legacy description');

--- a/frontend/src/components-v2/controls/value-control/__tests__/scalar-render-presentation.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/scalar-render-presentation.test.ts
@@ -94,6 +94,38 @@ describe('projectScalarRenderPresentation', () => {
     });
   });
 
+  it('supplements command target description without replacing owner status or error truth', () => {
+    const view = commandView();
+
+    expect(projectScalarRenderPresentation(view, undefined, {
+      description: 'Canonical 20 Hz; awaiting device confirmation',
+      valueText: '20 Hz; awaiting confirmation of 30 Hz',
+    })).toEqual({
+      source: 'command-owner',
+      attributes: view.presentation?.attributes,
+      description: '30 Hz. Canonical 20 Hz; awaiting device confirmation',
+      currentStatus: 'Awaiting confirmation: 30 Hz',
+      status: 'Awaiting confirmation: 30 Hz',
+      error: 'radio rejected',
+    });
+  });
+
+  it('projects only non-empty descriptive metadata for an undecorated reading', () => {
+    expect(projectScalarRenderPresentation(readingView(), undefined, {
+      description: 'Canonical receiver gain',
+      valueText: '20 percent',
+    })).toMatchObject({
+      source: 'none',
+      description: 'Canonical receiver gain',
+      status: null,
+      error: null,
+    });
+    expect(projectScalarRenderPresentation(readingView(), undefined, {
+      description: null,
+      valueText: null,
+    })).toEqual(projectScalarRenderPresentation(readingView()));
+  });
+
   it('preserves arbitrary legacy reading decoration verbatim', () => {
     const legacy: LegacyReadingPresentation = {
       phase: 'caller-authored-phase',

--- a/frontend/src/components-v2/controls/value-control/scalar-render-presentation.ts
+++ b/frontend/src/components-v2/controls/value-control/scalar-render-presentation.ts
@@ -9,6 +9,11 @@ export interface LegacyReadingPresentation {
   readonly status: string | null;
 }
 
+export type ScalarAccessibilityPresentation = Readonly<{
+  description?: string | null;
+  valueText?: string | null;
+}>;
+
 export interface ScalarRenderPresentation {
   readonly source: 'command-owner' | 'legacy-reading' | 'none';
   readonly attributes: Readonly<{
@@ -33,15 +38,32 @@ const NONE: Readonly<ScalarRenderPresentation> = Object.freeze({
   error: null,
 });
 
+function supplementDescription(
+  existing: string | null,
+  supplemental: string | null,
+): string | null {
+  if (supplemental === null) return existing;
+  return existing === null || existing.length === 0
+    ? supplemental
+    : `${existing}. ${supplemental}`;
+}
+
 export function projectScalarRenderPresentation(
   view: Readonly<ContinuousScalarView>,
   legacy?: Readonly<LegacyReadingPresentation>,
+  accessibility?: ScalarAccessibilityPresentation,
 ): Readonly<ScalarRenderPresentation> {
+  const supplementalDescription = accessibility?.description?.trim()
+    ? accessibility.description
+    : null;
   if (view.evidence === 'command-feedback') {
     return Object.freeze({
       source: 'command-owner',
       attributes: view.presentation.attributes,
-      description: view.presentation.targetDescription,
+      description: supplementDescription(
+        view.presentation.targetDescription,
+        supplementalDescription,
+      ),
       currentStatus: view.presentation.currentStatus,
       status: view.announcement,
       error: view.error,
@@ -52,14 +74,18 @@ export function projectScalarRenderPresentation(
     && legacy.busy === undefined
     && legacy.description === null
     && legacy.status === null
-  )) return NONE;
+  )) {
+    return supplementalDescription === null
+      ? NONE
+      : Object.freeze({ ...NONE, description: supplementalDescription });
+  }
   return Object.freeze({
     source: 'legacy-reading',
     attributes: Object.freeze({
       'data-command-phase': legacy.phase,
       'aria-busy': legacy.busy,
     }),
-    description: legacy.description,
+    description: supplementDescription(legacy.description, supplementalDescription),
     currentStatus: null,
     status: legacy.status,
     error: null,

--- a/frontend/src/components-v2/controls/value-control/skin.ts
+++ b/frontend/src/components-v2/controls/value-control/skin.ts
@@ -11,7 +11,10 @@ import type {
   ContinuousScalarView,
 } from '../../../primitives/scalar/continuous-scalar.svelte';
 import type { PoliteControlAnnouncement } from '../../../primitives/control-feedback/control-feedback-presentation';
-import type { LegacyReadingPresentation } from './scalar-render-presentation';
+import type {
+  LegacyReadingPresentation,
+  ScalarAccessibilityPresentation,
+} from './scalar-render-presentation';
 
 /** Binding and presentation inputs shared by every appearance renderer. */
 export interface SkinRendererProps {
@@ -30,6 +33,7 @@ export interface SkinRendererProps {
   unit?: string;
   shortcutHint?: string | null;
   title?: string | null;
+  accessibility?: ScalarAccessibilityPresentation;
   legacy?: LegacyReadingPresentation;
 }
 


### PR DESCRIPTION
Linear: MOR-2425

## Summary

- add one optional renderer-neutral `accessibility` presentation input to `ValueControl` and `SkinRendererProps`
- carry descriptive metadata to the actual slider in all four built-in renderers and unchanged props to configured external appearances
- supplement existing command-target descriptions while preserving command status/error ownership and existing absent-metadata fallbacks

## Compatibility

This is additive and optional. Existing callers, external appearances, command authority, renderer leases, announcements, and per-renderer ARIA fallbacks are unchanged when `accessibility` is absent or null. No component-kit API version or export changed.

## Focused evidence

- RED: 11 new focused failures with 76 existing passes before implementation
- GREEN: `npx vitest run src/components-v2/controls/value-control/__tests__/scalar-render-presentation.test.ts src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts` — 87 passed
- `npm run check` — 0 errors, 0 warnings
- scoped ESLint over the 10 changed paths — clean
- `npm run verify:component-kit-api` — portable package verification OK
- no local full suite; natural PR `quick` and path-selected `visual` are the final suite evidence

## Scope

10 files / 203 changed lines. This crosses the six-file soft threshold because the single shared presentation contract must be forwarded by the facade, rendered by all four built-ins, exposed to the external-renderer fixture, and proven by the two focused test suites. All paths stay inside the exact ValueControl lease.