### PR TITLE
test(MOR-2425): publish receiver authority in fixtures

### DIFF
--- a/frontend/fixtures/stubs/runtime.ts
+++ b/frontend/fixtures/stubs/runtime.ts
@@ -28,6 +28,12 @@ const DEFAULT_SCOPE_STATUS = {
   lifecycle: 'inactive' as const, transport: 'disconnected' as const, frameSeen: false,
 };
 const FIXTURE_CONTROL_SESSION = Object.freeze({ state: 'connected' as const, epoch: 1 });
+type FixtureAuthoritySubscriber = (next: Readonly<{
+  state: typeof harness.state;
+  caps: typeof harness.caps;
+  session: typeof FIXTURE_CONTROL_SESSION;
+}>) => void;
+const fixtureAuthoritySubscribers = new Set<FixtureAuthoritySubscriber>();
 
 type FixturePresentationResource = 'hardware-scope' | 'audio-fft';
 type FixturePresentationLease = Readonly<{
@@ -106,6 +112,11 @@ export const runtime = {
   get controlSession() { return FIXTURE_CONTROL_SESSION; },
   subscribeControlSession(_handler: (next: typeof FIXTURE_CONTROL_SESSION) => void) {
     return () => {};
+  },
+  subscribeControlAuthority(handler: FixtureAuthoritySubscriber) {
+    fixtureAuthoritySubscribers.add(handler);
+    handler(Object.freeze({ state: harness.state, caps: harness.caps, session: FIXTURE_CONTROL_SESSION }));
+    return () => { fixtureAuthoritySubscribers.delete(handler); };
   },
   get audio() {
     const { rxEnabled, volume, muted } = harness.audioRuntime;

--- a/frontend/src/components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts
@@ -30,6 +30,7 @@ const h = vi.hoisted(() => {
   const box = {
     state: null as unknown,
     caps: null as unknown,
+    authoritySubscribers: new Set<(next: { state: unknown; caps: unknown; session: ControlSessionSnapshot }) => void>(),
     audioFft: false,
     /** [resource, consumer] pairs, in order, against the fake App session. */
     acquired: [] as [string, string][],
@@ -86,6 +87,14 @@ const h = vi.hoisted(() => {
         return {
           get state() { subscribe(); return h.state; },
           get caps() { subscribe(); return h.caps; },
+          subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
+            h.authoritySubscribers.add(handler);
+            handler({
+              state: h.state, caps: h.caps,
+              session: { state: 'disconnected', epoch: -1 },
+            });
+            return () => { h.authoritySubscribers.delete(handler); };
+          },
           get scope() { return h.scope; },
           connectionStatus: 'disconnected',
           controlSession: Object.freeze({ state: 'disconnected', epoch: -1 }) satisfies ControlSessionSnapshot,
@@ -107,6 +116,14 @@ const h = vi.hoisted(() => {
     },
   };
 });
+
+function publishAuthority(): void {
+  const next = {
+    state: h.state, caps: h.caps,
+    session: { state: 'disconnected' as const, epoch: -1 },
+  };
+  for (const subscriber of h.authoritySubscribers) subscriber(next);
+}
 
 vi.mock('../../../lib/local-extensions/LocalExtensionsHost.svelte', async () => {
   const stub = await import('./SpectrumPanelStub.svelte');
@@ -281,6 +298,7 @@ beforeEach(() => {
 
 afterEach(() => {
   mounted.forEach((c) => unmount(c));
+  expect(h.authoritySubscribers.size).toBe(0);
   document.body.innerHTML = '';
   vi.unstubAllGlobals();
 });
@@ -406,6 +424,7 @@ describe('no dead-panel regression in the retained legacy glass (MOR-557 class)'
     expect(digits()).toBe('14.250.000');
 
     h.state = liveState(21300000);
+    publishAuthority();
     h.notify();
     flushSync();
     expect(digits()).toBe('21.300.000');
@@ -420,6 +439,7 @@ describe('no dead-panel regression in the retained legacy glass (MOR-557 class)'
     expect(labels()).not.toContain('TUNE');
 
     h.caps = capsFor('2/main_sub', ['tuner']);
+    publishAuthority();
     h.notify();
     flushSync();
     expect(labels()).toContain('TUNE');

--- a/frontend/src/components-v2/wiring/__tests__/cw-keyer-zone-lifecycle.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/cw-keyer-zone-lifecycle.component.test.ts
@@ -39,6 +39,7 @@ import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
+  authoritySubscribers: new Set<(next: { state: unknown; caps: unknown; session: { state: 'connected'; epoch: 1 } }) => void>(),
   audio: { muted: false, rxEnabled: true, volume: 42 },
   txController: null as ManagedAppTxController | null,
 }));
@@ -62,6 +63,11 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
+      h.authoritySubscribers.add(handler);
+      handler({ state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 } });
+      return () => { h.authoritySubscribers.delete(handler); };
+    },
     get audio() { return h.audio; },
     get connectionAudio() { return true; },
     get rxEnabled() { return true; },
@@ -176,6 +182,7 @@ function render(plan: SurfacePlan): HTMLDivElement {
 function tearDown(): void {
   if (component) unmount(component);
   component = null;
+  expect(h.authoritySubscribers.size).toBe(0);
   target.remove();
 }
 

--- a/frontend/src/components-v2/wiring/__tests__/design-language-selector-reachability.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/design-language-selector-reachability.component.test.ts
@@ -102,6 +102,7 @@ import MetersSurface from '../../../semantic/MetersSurface.svelte';
 const h = vi.hoisted(() => ({
   state: null as ServerState | null,
   caps: null as Capabilities | null,
+  authoritySubscribers: new Set<(next: { state: ServerState | null; caps: Capabilities | null; session: { state: 'connected'; epoch: 1 } }) => void>(),
   txController: null as ManagedAppTxController | null,
 }));
 vi.mock('$lib/runtime', () => ({
@@ -109,6 +110,11 @@ vi.mock('$lib/runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
+      h.authoritySubscribers.add(handler);
+      handler({ state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 } });
+      return () => { h.authoritySubscribers.delete(handler); };
+    },
     get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
     get connectionAudio() { return false; },
     get defaultScopeStatus() {
@@ -338,6 +344,7 @@ const SCENES: readonly Scene[] = [
       const { cleanup } = mountInto(SemanticRadioSurfaces, { strips: 'dual' });
       return { cleanup: () => {
         cleanup();
+        expect(h.authoritySubscribers.size).toBe(0);
         expect(txHarness.listenerCount()).toBe(0);
         expect(txHarness.trace()).toEqual([]);
         h.state = null; h.caps = null; h.txController = null;

--- a/frontend/src/components-v2/wiring/__tests__/semantic-antenna-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-antenna-wiring.component.test.ts
@@ -33,6 +33,7 @@ import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
+  authoritySubscribers: new Set<(next: { state: unknown; caps: unknown; session: { state: 'connected'; epoch: 1 } }) => void>(),
   txController: null as ManagedAppTxController | null,
   audio: { muted: false, rxEnabled: true, volume: 42 },
   audioConnected: true,
@@ -66,6 +67,11 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
+      h.authoritySubscribers.add(handler);
+      handler({ state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 } });
+      return () => { h.authoritySubscribers.delete(handler); };
+    },
     get audio() { return h.audio; },
     get connectionAudio() { return h.audioConnected; },
     get rxEnabled() { return true; },
@@ -171,6 +177,7 @@ beforeEach(() => {
 afterEach(() => {
   if (component) unmount(component);
   component = null;
+  expect(h.authoritySubscribers.size).toBe(0);
   expect(txHarness.listenerCount()).toBe(0);
   expect(txHarness.trace()).toEqual([]);
   document.body.innerHTML = '';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -34,6 +34,7 @@ import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
+  authoritySubscribers: new Set<(next: { state: unknown; caps: unknown; session: { state: 'connected'; epoch: 1 } }) => void>(),
   txController: null as ManagedAppTxController | null,
   audio: { muted: false, rxEnabled: true, volume: 42 },
   audioConnected: true,
@@ -72,6 +73,11 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
+      h.authoritySubscribers.add(handler);
+      handler({ state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 } });
+      return () => { h.authoritySubscribers.delete(handler); };
+    },
     get audio() { return h.audio; },
     get connectionAudio() { return h.audioConnected; },
     get rxEnabled() { return h.rxEnabled; },
@@ -158,6 +164,12 @@ let target: HTMLDivElement;
 let component: ReturnType<typeof mount> | null = null;
 let txHarness: ManagedAppTxHarness;
 
+function publishAuthority(): void {
+  for (const subscriber of h.authoritySubscribers) {
+    subscriber({ state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 } });
+  }
+}
+
 function render(props: { strips?: 'single' | 'dual' } = {}): void {
   target = document.createElement('div');
   document.body.appendChild(target);
@@ -188,6 +200,7 @@ beforeEach(() => {
 afterEach(() => {
   if (component) unmount(component);
   component = null;
+  expect(h.authoritySubscribers.size).toBe(0);
   expect(txHarness.listenerCount()).toBe(0);
   expect(txHarness.trace()).toEqual([]);
   document.body.innerHTML = '';
@@ -407,6 +420,7 @@ describe('the band surface composes the shipped command vocabulary', () => {
     const before = el('surface')!.outerHTML;
     txHarness.emitServerSnapshot({ intent: 'transmit', observedPtt: 'on' });
     h.state = liveState({ ptt: true } as Partial<ServerState>);
+    publishAuthority();
     flushSync();
     expect(el('surface')!.outerHTML).toBe(before);
   });

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -21,6 +21,7 @@ import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
+  authoritySubscribers: new Set<(next: { state: unknown; caps: unknown; session: { state: 'connected'; epoch: 1 } }) => void>(),
   txController: null as ManagedAppTxController | null,
   noop: vi.fn(),
   nrMode: vi.fn(),
@@ -41,6 +42,11 @@ vi.mock('$lib/runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
+      h.authoritySubscribers.add(handler);
+      handler({ state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 } });
+      return () => { h.authoritySubscribers.delete(handler); };
+    },
     // MOR-1279 slice 3B: the wiring now also hands the adapter an App-owned
     // RX-audio snapshot (the FOURTH argument). Muted with no browser stream
     // keeps every fixture below off the rxAudio path — this file tests dsp.
@@ -254,6 +260,7 @@ beforeEach(() => {
 afterEach(() => {
   if (component) unmount(component);
   component = null;
+  expect(h.authoritySubscribers.size).toBe(0);
   expect(txHarness.listenerCount()).toBe(0);
   expect(txHarness.trace()).toEqual([]);
   document.body.innerHTML = '';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-lcd-display-frame-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-lcd-display-frame-wiring.component.test.ts
@@ -19,6 +19,7 @@ type Authority = Readonly<{
 }>;
 
 const h = vi.hoisted(() => ({
+  authoritySubscribers: new Set<(next: { state: unknown; caps: unknown; session: { state: 'connected'; epoch: 1 } }) => void>(),
   events: [] as string[],
   hostInstances: [] as Array<{
     authorities: Array<Authority | null>;
@@ -103,6 +104,11 @@ vi.mock('$lib/runtime', async () => {
       onTxAudioDied: () => () => {},
       get state() { return radio.current; },
       get caps() { return getCapabilities(); },
+      subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
+        h.authoritySubscribers.add(handler);
+        handler({ state: radio.current, caps: getCapabilities(), session: { state: 'connected', epoch: 1 } });
+        return () => { h.authoritySubscribers.delete(handler); };
+      },
       get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
       get connectionAudio() { return false; },
       get defaultScopeStatus() {
@@ -135,7 +141,7 @@ vi.mock('$lib/runtime/tx-controller/managed-app-host', () => ({
 }));
 
 import { radio, resetRadioState } from '$lib/stores/radio.svelte';
-import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
+import { clearCapabilities, getCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
 
@@ -182,6 +188,11 @@ const readonlyDisplay = createRawSnippet<[RadioViewModel, LcdSpectrumFrame?]>(
     return { render: () => '<output data-testid="lcd-display"></output>' };
   },
 ) as Snippet<[RadioViewModel, LcdSpectrumFrame?]>;
+
+function publishAuthority(): void {
+  const next = { state: radio.current, caps: getCapabilities(), session: { state: 'connected' as const, epoch: 1 as const } };
+  for (const subscriber of h.authoritySubscribers) subscriber(next);
+}
 
 const audioFrame: LcdSpectrumFrame = Object.freeze({
   source: 'audio-fft', receiver: 'MAIN', freshness: 'fresh',
@@ -232,6 +243,7 @@ afterEach(() => {
   component?.$destroy();
   component = null;
   flushSync();
+  expect(h.authoritySubscribers.size).toBe(0);
   resetRadioState();
   clearCapabilities();
   vi.restoreAllMocks();
@@ -284,11 +296,13 @@ describe('MOR-2329 semantic LCD display-frame binding', () => {
     expect(h.events).toEqual(['acquire:hardware-scope']);
 
     radio.current = liveState(8, 'SUB');
+    publishAuthority();
     flushSync();
     expect(host.authorities.at(-1)).toBeNull();
     expect(h.events).toEqual(['acquire:hardware-scope']);
 
     expect(setCapabilities(liveCaps(8))).toBe(true);
+    publishAuthority();
     flushSync();
     expect(host.authorities.at(-1)).toEqual({
       source: 'hardware', receiver: 'SUB', providerGeneration: 8,

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -30,6 +30,7 @@ const h = vi.hoisted(() => ({
   txController: null as ManagedAppTxController | null,
   session: { state: 'connected', epoch: 1 } as ControlSessionSnapshot,
   sessionSubscriber: null as ((next: ControlSessionSnapshot) => void) | null,
+  authoritySubscribers: new Set<(next: { state: unknown; caps: unknown; session: ControlSessionSnapshot }) => void>(),
   noop: vi.fn(),
 }));
 
@@ -42,6 +43,11 @@ vi.mock('$lib/runtime', () => ({
     subscribeControlSession(handler: (next: ControlSessionSnapshot) => void) {
       h.sessionSubscriber = handler;
       return () => { if (h.sessionSubscriber === handler) h.sessionSubscriber = null; };
+    },
+    subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
+      h.authoritySubscribers.add(handler);
+      handler({ state: h.state, caps: h.caps, session: h.session });
+      return () => { h.authoritySubscribers.delete(handler); };
     },
     // MOR-1279 slice 3B: the wiring now also hands the adapter an
     // App-owned RX-audio snapshot (the FOURTH argument). Muted with no
@@ -213,12 +219,14 @@ function render(props: { strips?: 'single' | 'dual' } = {}): void {
 
 function push(next: ManagedAppTxServerSnapshot): void {
   txHarness.emitServerSnapshot(next);
+  for (const subscriber of h.authoritySubscribers) subscriber({ state: h.state, caps: h.caps, session: h.session });
   flushSync();
 }
 
 function pushSession(next: ControlSessionSnapshot): void {
   h.session = next;
   h.sessionSubscriber?.(next);
+  for (const subscriber of h.authoritySubscribers) subscriber({ state: h.state, caps: h.caps, session: h.session });
   flushSync();
 }
 
@@ -257,6 +265,7 @@ beforeEach(() => {
 afterEach(() => {
   if (component) unmount(component);
   component = null;
+  expect(h.authoritySubscribers.size).toBe(0);
   expect(txHarness.listenerCount()).toBe(0);
   expect(txHarness.trace()).toEqual([]);
   expect(h.sessionSubscriber).toBeNull();

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -63,6 +63,7 @@ const h = vi.hoisted(() => ({
   ipPlus: vi.fn(),
   session: { state: 'connected', epoch: 7 } as TestControlSession,
   sessionListeners: new Set<(next: TestControlSession) => void>(),
+  authorityListeners: new Set<(next: { state: unknown; caps: unknown; session: TestControlSession }) => void>(),
   sentCommands: [] as Array<{
     name: string; params: Record<string, unknown>; id: string; originalEpoch: number;
   }>,
@@ -107,6 +108,11 @@ vi.mock('$lib/runtime', () => ({
     subscribeControlSession(handler: (next: typeof h.session) => void) {
       h.sessionListeners.add(handler); return () => h.sessionListeners.delete(handler);
     },
+    subscribeControlAuthority(handler: (next: { state: unknown; caps: unknown; session: TestControlSession }) => void) {
+      h.authorityListeners.add(handler);
+      handler({ state: h.state, caps: h.caps, session: h.session });
+      return () => { h.authorityListeners.delete(handler); };
+    },
     // MOR-1312 slice 12B (rebase fix): the wiring now also hands the adapter
     // a scope-display snapshot (the FIFTH argument). This file tests
     // rfFrontEnd, so this stays on its pre-1312 path regardless of these
@@ -124,6 +130,11 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
   runtime: {
     get state() { return h.state; },
     get caps() { return h.caps; },
+    subscribeControlAuthority(handler: (next: { state: unknown; caps: unknown; session: TestControlSession }) => void) {
+      h.authorityListeners.add(handler);
+      handler({ state: h.state, caps: h.caps, session: h.session });
+      return () => { h.authorityListeners.delete(handler); };
+    },
   },
 }));
 vi.mock('$lib/runtime/tx-controller/managed-app-host', () => ({
@@ -310,6 +321,11 @@ const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T
 const el = (id: string) => q<HTMLElement>(`[data-testid="rf-front-end-${id}"]`);
 let acceptedState: ServerState;
 
+function publishAuthority(): void {
+  const next = { state: h.state, caps: h.caps, session: h.session };
+  for (const listener of h.authorityListeners) listener(next);
+}
+
 function acceptedStoreState(state: ServerState): ServerState {
   const receiver = (value: ServerState['main']) => ({
     ...value,
@@ -368,6 +384,7 @@ function observedMainLevels(
     fieldStatus: next.fieldStatus,
   };
   expect(setRadioState(acceptedState)).toBe(true);
+  publishAuthority();
   return next;
 }
 
@@ -405,6 +422,7 @@ afterEach(() => {
   expect(txHarness.listenerCount()).toBe(0);
   expect(txHarness.trace()).toEqual([]);
   expect(h.sessionListeners.size).toBe(0);
+  expect(h.authorityListeners.size).toBe(0);
   resetCommandLifecycle();
   resetRadioState();
   clearCapabilities();
@@ -541,6 +559,7 @@ describe('the surface mounts only when the view model carries the group', () => 
     txHarness.emitServerSnapshot({ intent: 'transmit', observedPtt: 'on' });
     h.state = liveState(true);
     (h.state as unknown as { ptt: boolean }).ptt = true;
+    publishAuthority();
     flushSync();
     expect(el('surface')!.outerHTML).toBe(before);
   });
@@ -614,6 +633,7 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
 
     h.session = { state: 'disconnected', epoch: 8 };
     for (const listener of h.sessionListeners) listener(h.session);
+    publishAuthority();
     flushSync();
     expect([rfInput.disabled, sqlInput.disabled]).toEqual([true, true]);
     expect(el('rfGain')!.textContent).toContain('?');
@@ -621,6 +641,7 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
 
     h.session = { state: 'connected', epoch: 9 };
     for (const listener of h.sessionListeners) listener(h.session);
+    publishAuthority();
     flushSync();
     expect([rfInput.disabled, sqlInput.disabled]).toEqual([false, false]);
     expect(rfInput.valueAsNumber).toBe(0.8);

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
@@ -36,6 +36,7 @@ import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
+  authoritySubscribers: new Set<(next: { state: unknown; caps: unknown; session: { state: 'connected'; epoch: 1 } }) => void>(),
   txController: null as ManagedAppTxController | null,
   audio: { muted: false, rxEnabled: true, volume: 42 },
   audioConnected: true,
@@ -82,6 +83,11 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
+      h.authoritySubscribers.add(handler);
+      handler({ state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 } });
+      return () => { h.authoritySubscribers.delete(handler); };
+    },
     get audio() { return h.audio; },
     get connectionAudio() { return h.audioConnected; },
     get rxEnabled() { return h.rxEnabled; },
@@ -175,6 +181,12 @@ let target: HTMLDivElement;
 let component: ReturnType<typeof mount> | null = null;
 let txHarness: ManagedAppTxHarness;
 
+function publishAuthority(): void {
+  for (const subscriber of h.authoritySubscribers) {
+    subscriber({ state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 } });
+  }
+}
+
 function render(props: { strips?: 'single' | 'dual' } = {}, plan?: SurfacePlan): void {
   target = document.createElement('div');
   document.body.appendChild(target);
@@ -209,6 +221,7 @@ beforeEach(() => {
 afterEach(() => {
   if (component) unmount(component);
   component = null;
+  expect(h.authoritySubscribers.size).toBe(0);
   expect(txHarness.listenerCount()).toBe(0);
   expect(txHarness.trace()).toEqual([]);
   document.body.innerHTML = '';
@@ -382,6 +395,7 @@ describe('common MOD-input selector reaches the existing mode handler (MOR-2366)
         ...state,
         fieldStatus: { ...state.fieldStatus, [path]: { ...fresh, availability: 'missing' } },
       };
+      publishAuthority();
       selectSource(3);
       expect(sendCommand).not.toHaveBeenCalled();
     },
@@ -399,6 +413,7 @@ describe('common MOD-input selector reaches the existing mode handler (MOR-2366)
     render();
     const state = liveState();
     h.state = { ...state, main: { ...state.main, dataMode } };
+    publishAuthority();
     selectSource(3);
     expect(sendCommand).not.toHaveBeenCalled();
   });
@@ -504,6 +519,7 @@ describe('the surface mounts only when the view model carries the group', () => 
     const before = el('surface')!.outerHTML;
     txHarness.emitServerSnapshot({ intent: 'transmit', observedPtt: 'on' });
     h.state = liveState({ ptt: true } as Partial<ServerState>);
+    publishAuthority();
     flushSync();
     expect(el('surface')!.outerHTML).toBe(before);
   });

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -14,6 +14,7 @@ type Snapshot = {
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
+  authoritySubscribers: new Set<(next: { state: unknown; caps: unknown; session: { state: 'connected'; epoch: 1 } }) => void>(),
   snapshot: null as unknown,
   listeners: new Set<(next: unknown) => void>(),
   start: vi.fn(),
@@ -39,6 +40,11 @@ vi.mock('$lib/runtime', () => ({
   runtime: {
     get state() { return h.state; },
     get caps() { return h.caps; },
+    subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
+      h.authoritySubscribers.add(handler);
+      handler({ state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 } });
+      return () => { h.authoritySubscribers.delete(handler); };
+    },
     // MOR-1279 slice 3B: the wiring now also hands the adapter an
     // App-owned RX-audio snapshot (the FOURTH argument). Muted with no
     // browser stream keeps every fixture below on its pre-1279 path.
@@ -234,6 +240,7 @@ beforeEach(() => {
 afterEach(() => {
   if (component) unmount(component);
   component = null;
+  expect(h.authoritySubscribers.size).toBe(0);
   document.body.innerHTML = '';
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
@@ -51,6 +51,7 @@ const LIVE_SCOPE_STATUS: ScopeStatus = {
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
+  authoritySubscribers: new Set<(next: { state: unknown; caps: unknown; session: { state: 'connected'; epoch: 1 } }) => void>(),
   txController: null as ManagedAppTxController | null,
   noop: vi.fn(),
   scopeStatus: {
@@ -66,6 +67,11 @@ vi.mock('$lib/runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
+      h.authoritySubscribers.add(handler);
+      handler({ state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 } });
+      return () => { h.authoritySubscribers.delete(handler); };
+    },
     get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
     get connectionAudio() { return false; },
     // MOR-1312 slice 12B: the wiring's `scopeDisplaySnapshot` (the FIFTH
@@ -227,6 +233,7 @@ beforeEach(() => {
 afterEach(() => {
   if (component) unmount(component);
   component = null;
+  expect(h.authoritySubscribers.size).toBe(0);
   expect(txHarness.listenerCount()).toBe(0);
   expect(txHarness.trace()).toEqual([]);
   document.body.innerHTML = '';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -17,6 +17,7 @@ const h = vi.hoisted(() => ({
   txAuxFeedback: vi.fn(),
   session: { state: 'connected', epoch: 1 } as ControlSessionSnapshot,
   sessionSubscriber: null as ((next: ControlSessionSnapshot) => void) | null,
+  authoritySubscribers: new Set<(next: { state: ServerState | null; caps: Capabilities | null; session: ControlSessionSnapshot }) => void>(),
 }));
 const selectedFrequency = vi.hoisted(() => ({ current: undefined as unknown }));
 const group = new Proxy({}, { get: () => h.noop });
@@ -33,6 +34,11 @@ vi.mock('$lib/runtime', () => ({
     subscribeControlSession(handler: (next: ControlSessionSnapshot) => void) {
       h.sessionSubscriber = handler;
       return () => { if (h.sessionSubscriber === handler) h.sessionSubscriber = null; };
+    },
+    subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
+      h.authoritySubscribers.add(handler);
+      handler({ state: h.state, caps: h.caps, session: h.session });
+      return () => { h.authoritySubscribers.delete(handler); };
     },
     get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
     get connectionAudio() { return false; },
@@ -125,7 +131,9 @@ function render(
   component = mount(SemanticRadioSurfaces, { target, props }); flushSync();
 }
 function pushSession(next: ControlSessionSnapshot): void {
-  h.session = next; h.sessionSubscriber?.(next); flushSync();
+  h.session = next; h.sessionSubscriber?.(next);
+  for (const subscriber of h.authoritySubscribers) subscriber({ state: h.state, caps: h.caps, session: h.session });
+  flushSync();
 }
 function pushMeter(value: number, providerGeneration = 1): void {
   const next = state({ providerGeneration });
@@ -133,6 +141,7 @@ function pushMeter(value: number, providerGeneration = 1): void {
   h.state = next;
   h.caps = { ...caps('main_sub', 2), providerGeneration };
   txHarness.emitServerSnapshot({});
+  for (const subscriber of h.authoritySubscribers) subscriber({ state: h.state, caps: h.caps, session: h.session });
   flushSync();
 }
 const rowReceivers = (root: ParentNode) => [...root.querySelectorAll<HTMLElement>('[data-testid="vfo-indicator-row"]')]
@@ -184,6 +193,7 @@ afterEach(() => {
   expect(txHarness.listenerCount()).toBe(0);
   expect(txHarness.trace()).toEqual([]);
   expect(h.sessionSubscriber).toBeNull();
+  expect(h.authoritySubscribers.size).toBe(0);
   selectedFrequency.current = undefined;
   clearRetainedInteractions();
   document.body.innerHTML = '';

--- a/frontend/src/components-v2/wiring/__tests__/single-receiver-active-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/single-receiver-active-wiring.component.test.ts
@@ -32,6 +32,7 @@ import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
+  authoritySubscribers: new Set<(next: { state: unknown; caps: unknown; session: { state: 'connected'; epoch: 1 } }) => void>(),
   txController: null as ManagedAppTxController | null,
 }));
 
@@ -67,6 +68,11 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
+      h.authoritySubscribers.add(handler);
+      handler({ state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 } });
+      return () => { h.authoritySubscribers.delete(handler); };
+    },
     get audio() { return { muted: false, rxEnabled: true, volume: 42 }; },
     get connectionAudio() { return true; },
     get rxEnabled() { return true; },
@@ -204,6 +210,7 @@ beforeEach(() => {
 afterEach(() => {
   if (component) unmount(component);
   component = null;
+  expect(h.authoritySubscribers.size).toBe(0);
   expect(txHarness.trace()).toEqual([]);
   document.body.innerHTML = '';
 });


### PR DESCRIPTION
Root-authorized file-only exception: 15 code paths + 0 regenerated baselines = 15 files; hard 1000 A+D unchanged; actual diff 168 A+D.

`ReceiverInstrumentHost` requires the existing synchronous `runtime.subscribeControlAuthority` contract. This change updates only the mocked and visual-fixture runtimes in the leased test paths so they publish the current state, capabilities, and control session synchronously on subscribe, fan out explicit post-mount mutations before the existing render flush, and remove exact subscriptions on cleanup.

The two leased real-runtime consumers, `semantic-discrete-pending-wiring.component.test.ts` and `semantic-pbt-continuity.component.test.ts`, needed no edits because their existing store and session publishers already exercise the production contract. Six locked doubles remain pending in the ReceiverHost/L1 integration: semantic desktop migration, semantic CW keyer wiring, semantic RIT/XIT scan wiring, semantic scope projection, semantic TX auxiliary wiring, and DualSdrFaceSkin.

The visual fixture harness mutates state and capabilities only in `frontend/fixtures/main.ts` before its layout mount, so the synchronous initial callback observes the current values; it has no post-mount state/capability mutation path. The zero-subscriber cleanup assertions are regression guards for the ReceiverHost integration and do not claim every existing test currently subscribes when no finite appearance is selected.

Validation:

- Fresh isolated `npm ci`
- `npm run check`: 0 errors, 0 warnings
- Focused Vitest: 16 files passed, 288 tests passed
- `git diff --check`

Linear: MOR-2425
