### PR TITLE
feat(MOR-2425): publish RX audio target authority

### DIFF
--- a/frontend/src/lib/runtime/__tests__/frontend-runtime.isolated.test.ts
+++ b/frontend/src/lib/runtime/__tests__/frontend-runtime.isolated.test.ts
@@ -78,6 +78,8 @@ vi.mock('$lib/stores/connection.svelte', () => ({
 
 vi.mock('$lib/stores/audio.svelte', () => ({
   getAudioState: vi.fn(() => ({})),
+  getRxAudioTargetSnapshot: vi.fn(() => Object.freeze({ muted: false, rxEnabled: false })),
+  subscribeRxAudioTarget: vi.fn(),
   setVolume: vi.fn(),
   setMuted: vi.fn(),
   toggleMute: vi.fn(),
@@ -119,6 +121,7 @@ import { connect, getChannel, getControlSession, onControlSessionTransition, onM
 import { getCapabilities, setCapabilities, subscribeCapabilities } from '$lib/stores/capabilities.svelte';
 import { radio, subscribeRadioState } from '$lib/stores/radio.svelte';
 import { audioManager } from '$lib/audio/audio-manager';
+import { getRxAudioTargetSnapshot, subscribeRxAudioTarget } from '$lib/stores/audio.svelte';
 import { clearLegacyPendingModInputRestore } from '../adapters/mod-input-auto.svelte';
 import { PresentationResourceHost } from '../resource-host';
 import { presentationResources } from '../frontend-runtime';
@@ -164,21 +167,25 @@ describe('FrontendRuntime control-session facade (MOR-1723)', () => {
     expect(connect).not.toHaveBeenCalled(); expect(sendRaw).not.toHaveBeenCalled();
   });
 
-  it('fans in every state, capability, and session publication synchronously and disposes once', async () => {
+  it('fans in every state, capability, session, and RX target publication synchronously and disposes once', async () => {
     const runtime = await freshRuntime();
     const initialState = { stateRevision: 1 } as any;
     const initialCaps = { providerGeneration: 7 } as any;
     const initialSession = { state: 'connected' as const, epoch: 4 };
+    const initialRxAudioTarget = Object.freeze({ muted: false, rxEnabled: false });
     radio.current = initialState;
     vi.mocked(getCapabilities).mockReturnValue(initialCaps);
     vi.mocked(getControlSession).mockReturnValue(initialSession);
+    vi.mocked(getRxAudioTargetSnapshot).mockReturnValue(initialRxAudioTarget);
 
     let stateSubscriber!: Parameters<typeof subscribeRadioState>[0];
     let capabilitySubscriber!: Parameters<typeof subscribeCapabilities>[0];
     let sessionSubscriber!: (next: { state: 'connected' | 'reconnecting'; epoch: number }) => void;
+    let rxAudioTargetSubscriber!: Parameters<typeof subscribeRxAudioTarget>[0];
     const stopState = vi.fn();
     const stopCapabilities = vi.fn();
     const stopSession = vi.fn();
+    const stopRxAudioTarget = vi.fn();
     vi.mocked(subscribeRadioState).mockImplementation((subscriber) => {
       stateSubscriber = subscriber;
       subscriber(initialState);
@@ -193,6 +200,11 @@ describe('FrontendRuntime control-session facade (MOR-1723)', () => {
       sessionSubscriber = subscriber as typeof sessionSubscriber;
       return stopSession;
     });
+    vi.mocked(subscribeRxAudioTarget).mockImplementation((subscriber) => {
+      rxAudioTargetSubscriber = subscriber;
+      subscriber(initialRxAudioTarget);
+      return stopRxAudioTarget;
+    });
 
     const subscriber = vi.fn();
     const stop = runtime.subscribeControlAuthority(subscriber);
@@ -201,6 +213,7 @@ describe('FrontendRuntime control-session facade (MOR-1723)', () => {
       state: initialState,
       caps: initialCaps,
       session: initialSession,
+      rxAudioTarget: initialRxAudioTarget,
     });
 
     const middleCaps = { providerGeneration: 7, topology: 'B' } as any;
@@ -223,11 +236,33 @@ describe('FrontendRuntime control-session facade (MOR-1723)', () => {
       state: nextState,
       caps: finalCaps,
       session: initialSession,
+      rxAudioTarget: initialRxAudioTarget,
     });
     expect(subscriber).toHaveBeenNthCalledWith(5, {
       state: nextState,
       caps: finalCaps,
       session: { state: 'reconnecting', epoch: 5 },
+      rxAudioTarget: initialRxAudioTarget,
+    });
+
+    const mutedTarget = Object.freeze({ muted: true, rxEnabled: false });
+    const liveTarget = Object.freeze({ muted: false, rxEnabled: true });
+    vi.mocked(getRxAudioTargetSnapshot).mockReturnValue(mutedTarget);
+    rxAudioTargetSubscriber(mutedTarget);
+    vi.mocked(getRxAudioTargetSnapshot).mockReturnValue(liveTarget);
+    rxAudioTargetSubscriber(liveTarget);
+    vi.mocked(getRxAudioTargetSnapshot).mockReturnValue(initialRxAudioTarget);
+    rxAudioTargetSubscriber(initialRxAudioTarget);
+    expect(subscriber.mock.calls.slice(-3).map(([publication]) => publication.rxAudioTarget)).toEqual([
+      mutedTarget,
+      liveTarget,
+      initialRxAudioTarget,
+    ]);
+    expect(subscriber).toHaveBeenLastCalledWith({
+      state: nextState,
+      caps: finalCaps,
+      session: { state: 'reconnecting', epoch: 5 },
+      rxAudioTarget: initialRxAudioTarget,
     });
 
     stop();
@@ -235,13 +270,49 @@ describe('FrontendRuntime control-session facade (MOR-1723)', () => {
     expect(stopState).toHaveBeenCalledTimes(1);
     expect(stopCapabilities).toHaveBeenCalledTimes(1);
     expect(stopSession).toHaveBeenCalledTimes(1);
+    expect(stopRxAudioTarget).toHaveBeenCalledTimes(1);
     stateSubscriber(nextState);
     capabilitySubscriber(finalCaps);
     sessionSubscriber({ state: 'connected', epoch: 6 });
-    expect(subscriber).toHaveBeenCalledTimes(5);
+    rxAudioTargetSubscriber(initialRxAudioTarget);
+    expect(subscriber).toHaveBeenCalledTimes(8);
     radio.current = null;
     vi.mocked(getCapabilities).mockReturnValue(null);
     vi.mocked(getControlSession).mockReturnValue({ state: 'disconnected', epoch: 0 });
+  });
+
+  it('cleans up earlier authority sources when RX target subscription setup fails', async () => {
+    const runtime = await freshRuntime();
+    const stopState = vi.fn();
+    const stopCapabilities = vi.fn();
+    const failure = new Error('RX target subscribe failed');
+    vi.mocked(subscribeRadioState).mockReturnValue(stopState);
+    vi.mocked(subscribeCapabilities).mockReturnValue(stopCapabilities);
+    vi.mocked(subscribeRxAudioTarget).mockImplementation(() => { throw failure; });
+
+    expect(() => runtime.subscribeControlAuthority(vi.fn())).toThrow(failure);
+    expect(stopCapabilities).toHaveBeenCalledTimes(1);
+    expect(stopState).toHaveBeenCalledTimes(1);
+    vi.mocked(subscribeRadioState).mockImplementation(() => () => {});
+    vi.mocked(subscribeRxAudioTarget).mockImplementation(() => () => {});
+    vi.mocked(getCapabilities).mockReturnValue(null);
+  });
+
+  it('cleans up every authority source when the initial complete publication fails', async () => {
+    const runtime = await freshRuntime();
+    const stops = [vi.fn(), vi.fn(), vi.fn(), vi.fn()];
+    vi.mocked(subscribeRadioState).mockReturnValue(stops[0]!);
+    vi.mocked(subscribeCapabilities).mockReturnValue(stops[1]!);
+    vi.mocked(subscribeRxAudioTarget).mockReturnValue(stops[2]!);
+    vi.mocked(onControlSessionTransition).mockReturnValue(stops[3]!);
+    const failure = new Error('initial publication failed');
+
+    expect(() => runtime.subscribeControlAuthority(() => { throw failure; })).toThrow(failure);
+    expect(stops.every((stop) => stop.mock.calls.length === 1)).toBe(true);
+
+    vi.mocked(subscribeRadioState).mockImplementation(() => () => {});
+    vi.mocked(subscribeRxAudioTarget).mockImplementation(() => () => {});
+    vi.mocked(onControlSessionTransition).mockImplementation(() => () => {});
   });
 });
 

--- a/frontend/src/lib/runtime/frontend-runtime.ts
+++ b/frontend/src/lib/runtime/frontend-runtime.ts
@@ -23,7 +23,14 @@ import {
   getRadioStatus,
   getRadioPowerOn,
 } from '$lib/stores/connection.svelte';
-import { getAudioState, setVolume, setMuted, toggleMute } from '$lib/stores/audio.svelte';
+import {
+  getAudioState,
+  getRxAudioTargetSnapshot,
+  setVolume,
+  setMuted,
+  subscribeRxAudioTarget,
+  toggleMute,
+} from '$lib/stores/audio.svelte';
 import * as transport from '$lib/transport/ws-client';
 import { fetchInfo } from '$lib/transport/http-client';
 import { audioManager } from '$lib/audio/audio-manager';
@@ -41,6 +48,7 @@ import type { Capabilities } from '$lib/types/capabilities';
 import type { WsIncoming } from '$lib/types/protocol';
 import type { ConnectionState } from '$lib/transport/ws-client';
 import type { ControlSessionTransition } from '$lib/transport/ws-client';
+import type { RxAudioTargetSnapshot } from '$lib/stores/audio.svelte';
 export const presentationResources = new PresentationResourceHost<unknown>('app');
 // ── Types ──
 
@@ -71,6 +79,7 @@ export interface ControlAuthorityPublication {
   readonly state: ServerState | null;
   readonly caps: Capabilities | null;
   readonly session: ControlSessionSnapshot;
+  readonly rxAudioTarget: RxAudioTargetSnapshot;
 }
 export type ControlAuthoritySubscriber = (next: ControlAuthorityPublication) => void;
 const CLOSED_CONTROL_SESSION: ControlSessionSnapshot = Object.freeze({ state: 'disconnected', epoch: -1 });
@@ -161,12 +170,18 @@ class FrontendRuntime {
     let initializing = true;
     const publish = (session: ControlSessionSnapshot) => {
       if (!active || initializing) return;
-      handler(Object.freeze({ state: this.state, caps: this.caps, session }));
+      handler(Object.freeze({
+        state: this.state,
+        caps: this.caps,
+        session,
+        rxAudioTarget: getRxAudioTargetSnapshot(),
+      }));
     };
     const stops: Array<() => void> = [];
     try {
       stops.push(subscribeRadioState(() => publish(this.controlSession)));
       stops.push(subscribeCapabilities(() => publish(this.controlSession)));
+      stops.push(subscribeRxAudioTarget(() => publish(this.controlSession)));
       stops.push(this.subscribeControlSession(publish));
       initializing = false;
       publish(this.controlSession);

--- a/frontend/src/lib/stores/__tests__/audio.test.ts
+++ b/frontend/src/lib/stores/__tests__/audio.test.ts
@@ -95,4 +95,48 @@ describe('audio store', () => {
       expect(store.getAudioState().bridgeRunning).toBe(false);
     });
   });
+
+  it('publishes frozen RX target changes synchronously and excludes no-ops and audio noise', () => {
+    const seen: Array<{ muted: boolean; rxEnabled: boolean }> = [];
+    const unsubscribe = store.subscribeRxAudioTarget((snapshot) => {
+      expect(Object.isFrozen(snapshot)).toBe(true);
+      seen.push(snapshot);
+    });
+
+    expect(seen).toEqual([{ muted: false, rxEnabled: false }]);
+    store.setMuted(true);
+    expect(seen.at(-1)).toEqual({ muted: true, rxEnabled: false });
+    store.setMuted(false);
+    expect(seen.at(-1)).toEqual({ muted: false, rxEnabled: false });
+    store.setRxEnabled(true);
+    expect(seen.at(-1)).toEqual({ muted: false, rxEnabled: true });
+    store.setRxEnabled(false);
+    expect(seen.at(-1)).toEqual({ muted: false, rxEnabled: false });
+    store.toggleMute();
+    expect(seen.at(-1)).toEqual({ muted: true, rxEnabled: false });
+
+    const publications = seen.length;
+    store.setMuted(true);
+    store.setRxEnabled(false);
+    store.setVolume(23);
+    store.setTxEnabled(true);
+    store.setMicEnabled(true);
+    store.setBridgeRunning(true);
+    store.setTxCodecFallback(true);
+    expect(seen).toHaveLength(publications);
+
+    unsubscribe();
+    unsubscribe();
+    store.setMuted(false);
+    expect(seen).toHaveLength(publications);
+  });
+
+  it('removes a subscriber whose synchronous initial delivery fails', () => {
+    const failure = new Error('initial delivery failed');
+    const subscriber = vi.fn(() => { throw failure; });
+
+    expect(() => store.subscribeRxAudioTarget(subscriber)).toThrow(failure);
+    store.toggleMute();
+    expect(subscriber).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/lib/stores/audio.svelte.ts
+++ b/frontend/src/lib/stores/audio.svelte.ts
@@ -12,6 +12,48 @@ let audioState = $state({
   txCodecFallback: false,
 });
 
+export interface RxAudioTargetSnapshot {
+  readonly muted: boolean;
+  readonly rxEnabled: boolean;
+}
+
+export type RxAudioTargetSubscriber = (next: RxAudioTargetSnapshot) => void;
+const rxAudioTargetSubscribers = new Set<RxAudioTargetSubscriber>();
+
+export function getRxAudioTargetSnapshot(): RxAudioTargetSnapshot {
+  return Object.freeze({
+    muted: audioState.muted,
+    rxEnabled: audioState.rxEnabled,
+  });
+}
+
+function notifyRxAudioTargetSubscribers(): void {
+  const snapshot = getRxAudioTargetSnapshot();
+  for (const subscriber of rxAudioTargetSubscribers) {
+    try {
+      subscriber(snapshot);
+    } catch (error) {
+      console.warn('RX audio target subscriber failed', error);
+    }
+  }
+}
+
+export function subscribeRxAudioTarget(subscriber: RxAudioTargetSubscriber): () => void {
+  rxAudioTargetSubscribers.add(subscriber);
+  try {
+    subscriber(getRxAudioTargetSnapshot());
+  } catch (error) {
+    rxAudioTargetSubscribers.delete(subscriber);
+    throw error;
+  }
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    rxAudioTargetSubscribers.delete(subscriber);
+  };
+}
+
 export function getAudioState(): typeof audioState {
   return audioState;
 }
@@ -22,14 +64,19 @@ export function setVolume(v: number): void {
 
 export function toggleMute(): void {
   audioState.muted = !audioState.muted;
+  notifyRxAudioTargetSubscribers();
 }
 
 export function setMuted(v: boolean): void {
+  if (audioState.muted === v) return;
   audioState.muted = v;
+  notifyRxAudioTargetSubscribers();
 }
 
 export function setRxEnabled(v: boolean): void {
+  if (audioState.rxEnabled === v) return;
   audioState.rxEnabled = v;
+  notifyRxAudioTargetSubscribers();
 }
 
 export function setTxEnabled(v: boolean): void {


### PR DESCRIPTION
## Problem

RX AF command authority can change through mute and live-monitor writers outside the semantic audio surface, while the existing control-authority publication only reports radio state, capabilities, and session. Those changes therefore cannot be observed synchronously, including an A→B→A sequence in one call stack.

This adds a frozen `{ muted, rxEnabled }` snapshot and synchronous subscriber to the existing audio store, publishing only changed mute/RX-target setters. `FrontendRuntime.subscribeControlAuthority` now includes that required snapshot in its existing fan-in and cleanup guard. Volume, TX, mic, bridge, and codec changes remain excluded.

Linear: MOR-2425

## Validation

- `npx vitest run src/lib/stores/__tests__/audio.test.ts src/lib/runtime/__tests__/frontend-runtime.isolated.test.ts` (42 passed)
- `npm run check` (0 errors, 0 warnings)
- `npx eslint src/lib/stores/audio.svelte.ts src/lib/stores/__tests__/audio.test.ts src/lib/runtime/frontend-runtime.ts src/lib/runtime/__tests__/frontend-runtime.isolated.test.ts`
- `git diff --check`
