### PR TITLE
feat(MOR-2425): expose pair issued status presentation

### DIFF
--- a/frontend/src/components-v2/controls/value-control/DualParamRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/DualParamRenderer.svelte
@@ -7,6 +7,10 @@
     ContinuousPairView,
   } from '../../../primitives/scalar/continuous-pair.svelte';
   import { clamp } from '../../../primitives/scalar/value-control-core';
+  import type {
+    DualParamIssuedStatusPresentation,
+    DualParamLane,
+  } from './dual-param-issued-status';
   import './value-control.css';
 
   interface Props {
@@ -20,6 +24,7 @@
     variant?: 'modern' | 'hardware' | 'hardware-illuminated';
     shortcutHint?: string | null;
     title?: string | null;
+    issuedStatusPresentation?: Readonly<DualParamIssuedStatusPresentation>;
   }
 
   let {
@@ -33,6 +38,7 @@
     variant = 'hardware-illuminated',
     shortcutHint = null,
     title = null,
+    issuedStatusPresentation,
   }: Props = $props();
 
   let containerEl: HTMLDivElement | null = $state(null);
@@ -90,6 +96,27 @@
     ? undefined : Math.round(view.position * 100));
   let rfLane = $derived(view?.lanes.rf ?? null);
   let sqlLane = $derived(view?.lanes.sql ?? null);
+  let rfStatusText = $derived(issuedStatusPresentation === undefined
+    ? rfLane?.announcement ?? null : issuedStatusPresentation.rf.text);
+  let sqlStatusText = $derived(issuedStatusPresentation === undefined
+    ? sqlLane?.announcement ?? null : issuedStatusPresentation.sql.text);
+
+  $effect(() => {
+    const snapshot = view;
+    if (issuedStatusPresentation === undefined || snapshot === null) return;
+    for (const lane of ['rf', 'sql'] as const satisfies readonly DualParamLane[]) {
+      const laneView = snapshot.lanes[lane];
+      if (laneView.evidence !== 'command-feedback') continue;
+      const output = issuedStatusPresentation[lane];
+      const announcement = laneView.presentation.politeAnnouncement;
+      if (announcement !== null) {
+        const text = untrack(() => output.format({ lane, view: snapshot, laneView, announcement }));
+        untrack(() => output.accept(text));
+      } else if (laneView.feedback.transitionId === null) {
+        untrack(() => output.accept(null));
+      }
+    }
+  });
 
   function normX(clientX: number): number | null {
     if (!containerEl) return null;
@@ -239,11 +266,11 @@
     <span class="axis-gap"></span>
     <span class="axis-sql">{sqlLabel}</span>
   </div>
-  {#if rfLane?.announcement}
-    <span class="sr-only" role="status" aria-live="polite" aria-atomic="true" data-control-feedback-status>{rfLane.announcement}</span>
+  {#if rfStatusText}
+    <span class="sr-only" role="status" aria-live="polite" aria-atomic="true" data-control-feedback-status>{rfStatusText}</span>
   {/if}
-  {#if sqlLane?.announcement}
-    <span class="sr-only" role="status" aria-live="polite" aria-atomic="true" data-control-feedback-status>{sqlLane.announcement}</span>
+  {#if sqlStatusText}
+    <span class="sr-only" role="status" aria-live="polite" aria-atomic="true" data-control-feedback-status>{sqlStatusText}</span>
   {/if}
 </div>
 {/if}

--- a/frontend/src/components-v2/controls/value-control/__tests__/DualParamRenderer.controlled.svelte.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/DualParamRenderer.controlled.svelte.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import DualParamRenderer from '../DualParamRenderer.svelte';
+import type { DualParamIssuedStatusPresentation } from '../dual-param-issued-status';
 import {
+  createContinuousPair,
+  nativeRangeContinuousPairPolicy,
+  type CommandFeedbackContinuousPairInput,
   type ContinuousPairBinding,
   type ContinuousPairInput,
   type ContinuousPairLaneView,
@@ -83,7 +87,111 @@ function slider(target: HTMLElement): HTMLElement {
   return target.querySelector('[role="slider"]') as HTMLElement;
 }
 
+function commandFeedback(
+  control: string,
+  confirmed: number,
+  over: Partial<CommandScalarFeedback>,
+): CommandScalarFeedback {
+  return {
+    confirmed, target: null, requestedTarget: null, phase: 'idle', busy: false,
+    availability: 'available', outcome: null, lifecycleId: null, transitionId: null,
+    providerGeneration: 3, sessionEpoch: 7, scope: { control, receiver: 0 },
+    repeatPolicy: 'latest-target-wins', ...over,
+  };
+}
+
+function commandPairInput(
+  rf: Partial<CommandScalarFeedback>,
+  sql: Partial<CommandScalarFeedback>,
+): CommandFeedbackContinuousPairInput {
+  return {
+    evidence: 'command-feedback', enabled: true,
+    domain: { min: 0, max: 1, step: 0.01, defaultValue: null, fineStepDivisor: 10 },
+    requestRf: vi.fn(), requestSql: vi.fn(),
+    rf: { command: 'set_rf_gain', feedback: commandFeedback('rf-gain', 0.5, rf) },
+    sql: { command: 'set_squelch', feedback: commandFeedback('squelch', 0.2, sql) },
+  };
+}
+
 describe('binding-only DualParamRenderer', () => {
+  it('issues actual pair transitions once through independent external lane presentations', () => {
+    const state = $state({ input: commandPairInput({
+      target: 0.55, phase: 'submitted', busy: true,
+      lifecycleId: 'rf-1', transitionId: 'rf-submitted',
+    }, {
+      requestedTarget: 0.3, phase: 'failed',
+      outcome: { phase: 'failed', error: 'radio rejected' },
+      lifecycleId: 'sql-1', transitionId: 'sql-failed',
+    }) });
+    const pair = createContinuousPair(() => state.input, nativeRangeContinuousPairPolicy);
+    let ownerViewReads = 0;
+    const binding: ContinuousPairBinding = {
+      get view() { ownerViewReads += 1; return pair.view; },
+      attachRenderer: () => pair.attachRenderer(),
+      cancel: reason => pair.cancel(reason),
+      destroy: () => pair.destroy(),
+    };
+    const acceptRf = vi.fn();
+    const acceptSql = vi.fn();
+    const presentation = {
+      rf: {
+        text: null,
+        format: vi.fn(({ lane, laneView, announcement }) =>
+          `${lane}:${laneView.phase}:${announcement.message}`),
+        accept: acceptRf,
+      },
+      sql: {
+        text: null,
+        format: vi.fn(({ lane, laneView, announcement }) =>
+          `${lane}:${laneView.phase}:${announcement.message}`),
+        accept: acceptSql,
+      },
+    } satisfies DualParamIssuedStatusPresentation;
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    mounted.push(mount(DualParamRenderer, {
+      target, props: { binding, issuedStatusPresentation: presentation },
+    }));
+    flushSync();
+
+    expect(ownerViewReads).toBe(0);
+    expect(presentation.rf.format).toHaveBeenCalledOnce();
+    expect(presentation.sql.format).toHaveBeenCalledOnce();
+    expect(acceptRf).toHaveBeenCalledExactlyOnceWith(
+      'rf:submitted:Submitting: 0.55',
+    );
+    expect(acceptSql).toHaveBeenCalledExactlyOnceWith(
+      'sql:failed:Failed: 0.3',
+    );
+    expect(target.querySelectorAll('[data-control-feedback-status]')).toHaveLength(0);
+
+    state.input = commandPairInput({}, {});
+    flushSync();
+    expect(acceptRf).toHaveBeenLastCalledWith(null);
+    expect(acceptSql).toHaveBeenLastCalledWith(null);
+    expect(presentation.rf.format).toHaveBeenCalledOnce();
+    expect(presentation.sql.format).toHaveBeenCalledOnce();
+  });
+
+  it('preserves default local output for actual stateful pair announcements', () => {
+    const input = commandPairInput({
+      target: 0.55, phase: 'submitted', busy: true,
+      lifecycleId: 'rf-1', transitionId: 'rf-submitted',
+    }, {
+      requestedTarget: 0.3, phase: 'failed',
+      outcome: { phase: 'failed', error: 'radio rejected' },
+      lifecycleId: 'sql-1', transitionId: 'sql-failed',
+    });
+    const pair = createContinuousPair(() => input, nativeRangeContinuousPairPolicy);
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    mounted.push(mount(DualParamRenderer, { target, props: { binding: pair } }));
+    flushSync();
+
+    expect([...target.querySelectorAll('[data-control-feedback-status]')]
+      .map(status => status.textContent)).toEqual(['Submitting: 0.55', 'Failed: 0.3']);
+  });
+
   it('owns one lease, forwards every gesture, and disposes leases without destroying owners', async () => {
     const first = fakeBinding(11);
     const second = fakeBinding(22);

--- a/frontend/src/components-v2/controls/value-control/dual-param-issued-status.ts
+++ b/frontend/src/components-v2/controls/value-control/dual-param-issued-status.ts
@@ -1,0 +1,28 @@
+import type { PoliteControlAnnouncement } from '../../../primitives/control-feedback/control-feedback-presentation';
+import type {
+  ContinuousPairLaneView,
+  ContinuousPairView,
+} from '../../../primitives/scalar/continuous-pair.svelte';
+
+export type DualParamLane = 'rf' | 'sql';
+
+export interface DualParamIssuedStatusSnapshot {
+  readonly lane: DualParamLane;
+  readonly view: Readonly<ContinuousPairView>;
+  readonly laneView: Readonly<Extract<
+    ContinuousPairLaneView,
+    { evidence: 'command-feedback' }
+  >>;
+  readonly announcement: Readonly<PoliteControlAnnouncement>;
+}
+
+export interface DualParamLaneIssuedStatusPresentation {
+  readonly text: string | null;
+  format(snapshot: Readonly<DualParamIssuedStatusSnapshot>): string;
+  accept(text: string | null): void;
+}
+
+export interface DualParamIssuedStatusPresentation {
+  readonly rf: Readonly<DualParamLaneIssuedStatusPresentation>;
+  readonly sql: Readonly<DualParamLaneIssuedStatusPresentation>;
+}


### PR DESCRIPTION
RF and SQL issued announcements now have independent presentation outputs that a persistent host can retain across renderer replacement. The renderer forwards its existing lease snapshot once; a second stateful read would consume the announcement before delivery.

This is the pair-status prerequisite for MOR-2425's persistent RF host. Actual live RF host migration and external SDK export remain separate work. The three-file delta is 167 additions and 4 deletions (171 A+D); scalar/pair primitives, commands, semantic composition and visual baselines are unchanged.

Validation: focused real-pair suite4/4, changed-file ESLint, svelte-check and diff-check passed. The new test failed before implementation because neither external formatter was invoked. Independent review reproduced the forbidden second binding.view read: one test failed and the RF formatter received zero callbacks. Harmless lane-order reversal remained4/4 green.

Exact head: ff9bf10c35f97d2437f7ca492693eb58c8dc260a. Natural quick34072592339 SUCCESS; visual34072592370 SUCCESS. Independent exact-head PASS: https://github.com/rigplane/rigplane-core/pull/3304#issuecomment-5563712366. Root read the full report and code delta; canonical Agent Review Gate is PASS. The observer-only quick-v2 status may lag the completed canonical workflow and is not acceptance evidence.
