### PR TITLE
fix(MOR-2425): bind rendered metadata to committed presentation

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -78,6 +78,12 @@
     hasAnyScope: hasAnyScope(),
   }));
 
+  type CommittedPresentation =
+    | { id: SkinId; component: InstrumentHandlesPresentation; hostMode: 'instrument-handles' }
+    | { id: SkinId; component: SelfContainedPresentation; hostMode: 'self-contained' };
+  let presentation = $state<CommittedPresentation | null>(null);
+  let committedSkinId = $derived<SkinId | null>(presentation?.id ?? null);
+
   // MOR-1081: the workspace's `designLanguage` is the ONLY source the
   // `[data-design-language]` activation attribute (MOR-1278) is written from,
   // and this is its only writer — the MOR-1275 renderer wiring and the
@@ -94,9 +100,16 @@
   // rules arrive with the cutover — and it is absent entirely wherever the
   // language is not active, so no shipped v2 skin sees a new attribute.
   $effect(() => {
+    const layoutId = committedSkinId;
+    if (layoutId === null) {
+      delete document.documentElement.dataset.designLanguage;
+      delete document.documentElement.dataset.languageMode;
+      delete document.documentElement.dataset.density;
+      return;
+    }
     const stored = getDesignLanguage(getWorkspace().designLanguage);
     let language = stored;
-    let activated = designLanguageActivation(stored, skinId);
+    let activated = designLanguageActivation(stored, layoutId);
     if (activated === null) {
       // The stored preference cannot activate on the resolved skin
       // (e.g. `segmentline` off `peer-split`, or the default `studioline` ON
@@ -108,7 +121,7 @@
       // falls back, so leaving `peer-split` restores it without a re-choice.
       for (const id of listDesignLanguageIds()) {
         const candidate = getDesignLanguage(id);
-        const candidateActivated = designLanguageActivation(candidate, skinId);
+        const candidateActivated = designLanguageActivation(candidate, layoutId);
         if (candidateActivated !== null) {
           language = candidate;
           activated = candidateActivated;
@@ -124,7 +137,7 @@
       const theme = getAvailableThemes().find(({ id }) => id === getWorkspace().theme);
       document.documentElement.dataset.languageMode = theme?.category === 'light' ? 'light' : 'dark';
     }
-    const density = densityActivation(language, skinId, getWorkspace().density);
+    const density = densityActivation(language, layoutId, getWorkspace().density);
     if (density === null) delete document.documentElement.dataset.density;
     else document.documentElement.dataset.density = density;
   });
@@ -133,7 +146,9 @@
   // against the ACTIVE layout manifest and handed down as a getter.
   // A getter, so a consumer's `$derived` re-runs when either input changes.
   provideSurfacePlan(() => {
-    const manifest = getLayout(skinId);
+    const layoutId = committedSkinId;
+    if (layoutId === null) return null;
+    const manifest = getLayout(layoutId);
     return manifest === undefined ? null : resolveSurfacePlan(manifest, getWorkspace());
   });
 
@@ -149,10 +164,6 @@
   // loader is in flight, so a switch never blanks the operator's screen and
   // never replays bootstrap, transport, audio or TX ownership — all of which
   // live above this seam (MOR-973, MOR-1008, MOR-1059).
-  type CommittedPresentation =
-    | { id: SkinId; component: InstrumentHandlesPresentation; hostMode: 'instrument-handles' }
-    | { id: SkinId; component: SelfContainedPresentation; hostMode: 'self-contained' };
-  let presentation = $state<CommittedPresentation | null>(null);
   let presentationFailed = $state(false);
   let HostedPresentation = $derived(
     presentation?.hostMode === 'instrument-handles' ? presentation.component : null,

--- a/frontend/src/__tests__/design-language-activation.component.test.ts
+++ b/frontend/src/__tests__/design-language-activation.component.test.ts
@@ -38,11 +38,17 @@
  *     `desktop-v2` is resolved.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { flushSync, mount, unmount } from 'svelte';
-import { getWorkspace, initWorkspaceStore, setDesignLanguage, setLayout } from '../presentation/workspace/store.svelte';
+import { flushSync, mount, tick, unmount } from 'svelte';
+import {
+  getWorkspace, initWorkspaceStore, setDensity, setDesignLanguage, setLayout,
+} from '../presentation/workspace/store.svelte';
 
 const h = vi.hoisted(() => ({
-  pending: [] as Array<{ id: string; resolve: (c: unknown) => void }>,
+  pending: [] as Array<{
+    id: string;
+    resolve: (c: unknown) => void;
+    reject: (error: unknown) => void;
+  }>,
   loadSkin: vi.fn(),
   plan: vi.fn(),
   bootstrap: vi.fn(),
@@ -101,6 +107,7 @@ vi.mock('../lib/local-extensions/LocalExtensionsHost.svelte', async () => {
 });
 
 import App from '../App.svelte';
+import LayoutStub from './LayoutStub.svelte';
 
 /**
  * `App.svelte`'s own top-level `initWorkspaceStore()` call is inside its
@@ -133,7 +140,7 @@ beforeEach(() => {
   h.provide.mockImplementation(() => h.txHost);
   h.bootstrap.mockResolvedValue(vi.fn());
   h.loadSkin.mockImplementation(
-    (id: string) => new Promise((resolve) => { h.pending.push({ id, resolve }); }),
+    (id: string) => new Promise((resolve, reject) => { h.pending.push({ id, resolve, reject }); }),
   );
   h.plan.mockReturnValue([]);
 });
@@ -147,53 +154,108 @@ afterEach(() => {
 });
 
 describe('segmentline activation, in a rendered App', () => {
-  it('A: segmentline explicitly selected, peer-split resolved -> [data-design-language="segmentline"]', () => {
+  async function settle(): Promise<void> {
+    for (let index = 0; index < 4; index++) await Promise.resolve();
+    await tick();
+    flushSync();
+  }
+  async function complete(id: string): Promise<void> {
+    const index = h.pending.findLastIndex((entry) => entry.id === id);
+    if (index < 0) throw new Error(`no pending load for ${id}`);
+    h.pending.splice(index, 1)[0].resolve(LayoutStub);
+    await settle();
+  }
+  async function fail(id: string): Promise<void> {
+    const index = h.pending.findLastIndex((entry) => entry.id === id);
+    if (index < 0) throw new Error(`no pending load for ${id}`);
+    h.pending.splice(index, 1)[0].reject(new Error(`failed ${id}`));
+    await settle();
+  }
+  function setWidth(width: number): void {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: width });
+    window.dispatchEvent(new Event('resize'));
+    flushSync();
+  }
+
+  it('A: activates metadata only after the selected presentation commits', async () => {
     const instance = mountApp();
 
     setLayout('peer-split');
     setDesignLanguage('segmentline');
     flushSync();
 
+    expect(document.documentElement.dataset.designLanguage).toBeUndefined();
+    expect(document.documentElement.dataset.languageMode).toBeUndefined();
+    expect(document.documentElement.dataset.density).toBeUndefined();
+
+    await complete('peer-split');
     expect(document.documentElement.dataset.designLanguage).toBe('segmentline');
 
     unmount(instance);
   });
 
-  it('B: selecting only the peer-split LAYOUT (no explicit language) still activates segmentline', () => {
+  it('B: selecting only the peer-split LAYOUT (no explicit language) still activates segmentline', async () => {
     const instance = mountApp();
     expect(getWorkspace().designLanguage).toBe('studioline'); // the DEFAULT_WORKSPACE value
 
     setLayout('peer-split');
     flushSync();
 
+    expect(document.documentElement.dataset.designLanguage).toBeUndefined();
+    await complete('peer-split');
     expect(document.documentElement.dataset.designLanguage).toBe('segmentline');
 
     unmount(instance);
   });
 
-  it('C: segmentline stored + a skin it cannot activate on still yields a styled surface, and the stored preference survives the round trip', () => {
+  it('C: pending and failed replacement keeps committed language/density while workspace updates', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const instance = mountApp();
 
     setLayout('peer-split');
-    setDesignLanguage('segmentline');
+    setDensity('dense');
+    flushSync();
+    await complete('peer-split');
+    expect(document.documentElement.dataset.designLanguage).toBe('segmentline');
+    expect(document.documentElement.dataset.density).toBe('comfortable');
+    const committedLanguageMode = document.documentElement.dataset.languageMode;
+    expect(committedLanguageMode).toBeDefined();
+
+    setWidth(390); // requests mobile, which has no compatible design language
+
+    // The requested mobile presentation is still pending. Its absent language
+    // must not clear metadata from the committed peer-split face.
+    expect(document.documentElement.dataset.designLanguage).toBe('segmentline');
+    expect(document.documentElement.dataset.languageMode).toBe(committedLanguageMode);
+    expect(document.documentElement.dataset.density).toBe('comfortable');
+    expect(getWorkspace().designLanguage).toBe('studioline');
+
+    // A workspace update while B is pending still resolves against committed A.
+    setDensity('comfortable');
+    flushSync();
+    expect(document.documentElement.dataset.density).toBe('comfortable');
+    setDensity('dense');
     flushSync();
     expect(document.documentElement.dataset.designLanguage).toBe('segmentline');
+    expect(document.documentElement.dataset.density).toBe('comfortable');
 
-    setLayout('standard'); // resolves to desktop-v2, which segmentline declares incompatible
-    flushSync();
+    await fail('mobile');
+    expect(consoleError).toHaveBeenCalledWith(
+      '[rigplane] presentation "mobile" failed to load:', expect.any(Error),
+    );
+    expect(document.documentElement.dataset.designLanguage).toBe('segmentline');
+    expect(document.documentElement.dataset.languageMode).toBe(committedLanguageMode);
+    expect(document.documentElement.dataset.density).toBe('comfortable');
 
-    // Styled, not absent — the operator must never see an unstyled surface as
-    // a result of a stored preference.
+    // A later successful desktop request commits component metadata together.
+    setLayout('standard');
+    setWidth(1200);
+    await complete('desktop-v2');
     expect(document.documentElement.dataset.designLanguage).toBe('studioline');
-    // The hard boundary: resolution never rewrites the STORED preference.
-    expect(getWorkspace().designLanguage).toBe('segmentline');
-
-    setLayout('peer-split');
-    flushSync();
-
-    // No re-choice needed: the untouched stored preference reactivates on its own.
-    expect(document.documentElement.dataset.designLanguage).toBe('segmentline');
+    expect(document.documentElement.dataset.density).toBe('dense');
+    expect(getWorkspace().designLanguage).toBe('studioline');
 
     unmount(instance);
+    consoleError.mockRestore();
   });
 });

--- a/frontend/src/__tests__/design-language-activation.component.test.ts
+++ b/frontend/src/__tests__/design-language-activation.component.test.ts
@@ -159,14 +159,21 @@ describe('segmentline activation, in a rendered App', () => {
     await tick();
     flushSync();
   }
+  function pendingIndex(id: string): number {
+    for (let index = h.pending.length - 1; index >= 0; index -= 1) {
+      if (h.pending[index]?.id === id) return index;
+    }
+    return -1;
+  }
+
   async function complete(id: string): Promise<void> {
-    const index = h.pending.findLastIndex((entry) => entry.id === id);
+    const index = pendingIndex(id);
     if (index < 0) throw new Error(`no pending load for ${id}`);
     h.pending.splice(index, 1)[0].resolve(LayoutStub);
     await settle();
   }
   async function fail(id: string): Promise<void> {
-    const index = h.pending.findLastIndex((entry) => entry.id === id);
+    const index = pendingIndex(id);
     if (index < 0) throw new Error(`no pending load for ${id}`);
     h.pending.splice(index, 1)[0].reject(new Error(`failed ${id}`));
     await settle();

--- a/frontend/src/__tests__/lazy-presentation.component.test.ts
+++ b/frontend/src/__tests__/lazy-presentation.component.test.ts
@@ -36,6 +36,7 @@ const h = vi.hoisted(() => ({
   provide: vi.fn(),
   registerBarrier: vi.fn(),
   txHost: undefined as { refreshAuthority: ReturnType<typeof vi.fn>; dispose: ReturnType<typeof vi.fn> } | undefined,
+  surfacePlanSource: undefined as (() => ReadonlyMap<string, readonly string[]> | null) | undefined,
 }));
 
 // The presentation subtree under test is the *loader result*, so the skin
@@ -50,6 +51,16 @@ vi.mock('../skins/registry', () => ({
 vi.mock('../components-v2/wiring/SemanticRadioSurfaces.svelte', async () => ({
   default: (await import('./LayoutStub.svelte')).default,
 }));
+vi.mock('../presentation/workspace/resolution', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../presentation/workspace/resolution')>();
+  return {
+    ...actual,
+    provideSurfacePlan: (source: () => ReadonlyMap<string, readonly string[]> | null) => {
+      h.surfacePlanSource = source;
+      actual.provideSurfacePlan(source as Parameters<typeof actual.provideSurfacePlan>[0]);
+    },
+  };
+});
 
 vi.mock('../lib/runtime/frontend-runtime', () => ({
   runtime: {
@@ -128,6 +139,12 @@ const mountedSkin = (): string | null =>
 const mountedCount = () => document.querySelectorAll('.layout-stub').length;
 const globalHost = () => document.querySelector('.spectrum-panel-stub');
 const errorSurface = () => document.querySelector('[data-testid="presentation-load-error"]');
+const surfacePlanSnapshot = (): string | null => {
+  const plan = h.surfacePlanSource?.();
+  return plan === null || plan === undefined
+    ? null
+    : JSON.stringify(Array.from(plan, ([zone, surfaces]) => [zone, [...surfaces]]));
+};
 
 /** Drain the microtask queue past App's post-commit `await tick()`. */
 async function settle(): Promise<void> {
@@ -180,6 +197,7 @@ beforeEach(() => {
   h.releasedLeases.length = 0;
   h.demand.clear();
   h.resourcesEnded = false;
+  h.surfacePlanSource = undefined;
   document.body.innerHTML = '';
   Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1200 });
   Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
@@ -534,6 +552,41 @@ describe('identity preserved across a presentation switch', () => {
 });
 
 describe('presentation loader failure', () => {
+  it('keeps the committed surface plan during a delayed and failed switch', async () => {
+    const instance = mountApp();
+    await settle();
+
+    // Before the first presentation commits, no requested manifest configures
+    // a component that is not on screen yet.
+    expect(surfacePlanSnapshot()).toBeNull();
+    completeLoad('desktop-v2');
+    await settle();
+    const desktopPlan = surfacePlanSnapshot();
+    expect(desktopPlan).not.toBeNull();
+
+    selectSkin('mobile');
+    await settle();
+    expect(mountedSkin()).toBe('desktop-v2');
+    expect(surfacePlanSnapshot()).toBe(desktopPlan);
+
+    failLoad('mobile');
+    await settle();
+    expect(mountedSkin()).toBe('desktop-v2');
+    expect(surfacePlanSnapshot()).toBe(desktopPlan);
+
+    // A later successful request changes component and plan together.
+    selectSkin('desktop-v2');
+    await settle();
+    selectSkin('mobile');
+    await settle();
+    completeLoad('mobile');
+    await settle();
+    expect(mountedSkin()).toBe('mobile');
+    expect(surfacePlanSnapshot()).not.toBe(desktopPlan);
+
+    unmount(instance);
+  });
+
   // MUTATION KILLED: clearing the committed presentation (or tearing the
   // runtime down) when a switch fails to load. The operator would lose the
   // working screen because an unrelated chunk 404'd.


### PR DESCRIPTION
## Result

Rendered presentation metadata now follows the committed presentation rather than an in-flight requested skin. A slow, failed, or stale replacement leaves the outgoing component, surface plan, design language, language mode, and density coherent until a current loader generation commits.

Linear: MOR-2425

## Scope

- separate requested loader identity from committed rendered identity inside App
- expose no surface plan or root design metadata before the first successful presentation commit
- retain the existing loader generation guard, last-known-good component, resource bridge, and host branches
- add mounted App coverage for delayed/failed replacement, initial null, workspace updates during a pending load, successful coherent commit, and existing resource continuity

This PR does not freeze or expose the external face SDK, change component-kit activation, or touch receiver, audio, TX, or semantic host files.

## RED / GREEN

Before the App correction, the focused tests failed in four places: requested peer-split metadata activated before any component committed, and the requested mobile/desktop plan and language changed while the outgoing presentation remained mounted.

After the correction:

- focused Vitest: 3 files, 28 tests passed
- npm run check: passed with zero errors
- scoped ESLint over App and both changed tests: passed
- git diff --check: passed

The first natural quick run identified use of an array helper newer than the CI TypeScript target in test-only code. Head 32f3cb5d8c2113ecac126993f2bdac838534c577 replaces it with a compatible reverse scan; the same focused tests, type checks, and lint pass locally, and this final head has its own natural CI cycle.

No broad local suite, visual baseline update, SDK version change, hardware run, deployment, or merge was performed.

## Size

3 files, 158 additions and 25 deletions, 183 A+D. The fourth released resource-test path did not need an edit; its existing cases pass and retain the incoming real-demand-only bridge contract.

## Final acceptance evidence

Exact head `32f3cb5d8c2113ecac126993f2bdac838534c577`: natural quick `34073568374` SUCCESS; natural visual `34073568430` SUCCESS. The independent [exact-head PASS](https://github.com/rigplane/rigplane-core/pull/3306#issuecomment-5563794708) is bound to this head. Root has read the complete independent report and all three changed files. Required canonical quick and Agent Review Gate are green. The former test-only TypeScript-target failure and correction remain recorded above.

