### PR TITLE
feat(MOR-2425): add rendered-range scalar policies

### DIFF
--- a/frontend/src/primitives/scalar/__tests__/continuous-pair.test.ts
+++ b/frontend/src/primitives/scalar/__tests__/continuous-pair.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   createContinuousPair,
   createLegacyContinuousPairPolicy,
+  createRenderedNativeRangeContinuousPairPolicy,
   nativeRangeContinuousPairPolicy,
   type ContinuousPairInput,
 } from '../continuous-pair.svelte';
@@ -188,6 +189,101 @@ describe('continuous pair request reconciliation', () => {
 });
 
 describe('continuous pair delegates one scalar lifetime', () => {
+  it('retains rendered-native axis steps while crossing the center dead zone', () => {
+    const { pair, requestRf, requestSql } = readingSetup(
+      createRenderedNativeRangeContinuousPairPolicy(),
+    );
+    const lease = pair.attachRenderer();
+    const axisDrafts: Array<number | null> = [];
+
+    for (let press = 0; press < 6; press += 1) {
+      expect(lease.key({ key: 'ArrowRight', fine: false })).toBe(true);
+      axisDrafts.push(pair.view.axisDraft);
+    }
+
+    expect(axisDrafts).toEqual([0.51, 0.52, 0.53, 0.54, 0.55, 0.56]);
+    expect(requestRf).not.toHaveBeenCalled();
+    expect(requestSql.mock.calls).toEqual([[0.02], [0.04]]);
+  });
+
+  it('continues rendered-native keyboard input from the normalized pointer axis', () => {
+    const { pair, requestRf, requestSql } = readingSetup(
+      createRenderedNativeRangeContinuousPairPolicy(),
+    );
+    const lease = pair.attachRenderer();
+    const token = lease.beginPointer()!;
+
+    lease.pointer(token, 0.513);
+    lease.endPointer(token);
+    expect(pair.view).toMatchObject({ axisDraft: 0.51, displayedPosition: 0.51 });
+    expect(requestRf).not.toHaveBeenCalled();
+    expect(requestSql).not.toHaveBeenCalled();
+
+    expect(lease.key({ key: 'ArrowRight', fine: false })).toBe(true);
+    expect(pair.view).toMatchObject({ axisDraft: 0.52, displayedPosition: 0.52 });
+    expect(requestRf).not.toHaveBeenCalled();
+    expect(requestSql).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['ArrowLeft', false, 0.49, [], []],
+    ['ArrowDown', true, 0.49, [], []],
+    ['ArrowRight', true, 0.51, [], []],
+    ['ArrowUp', false, 0.51, [], []],
+    ['Home', false, 0, [[0]], []],
+    ['End', false, 1, [], [[1]]],
+  ] as const)('handles rendered-native %s on the axis lattice', (key, fine, axis, rf, sql) => {
+    const setup = readingSetup(createRenderedNativeRangeContinuousPairPolicy());
+    const lease = setup.pair.attachRenderer();
+
+    expect(lease.key({ key, fine })).toBe(true);
+    expect(setup.pair.view.axisDraft).toBe(axis);
+    expect(setup.requestRf.mock.calls).toEqual(rf);
+    expect(setup.requestSql.mock.calls).toEqual(sql);
+  });
+
+  it('keeps rendered-native wheel immediate and reset inert', () => {
+    const { pair, requestRf, requestSql } = readingSetup(
+      createRenderedNativeRangeContinuousPairPolicy(),
+      { sql: { reading: { status: 'known', value: 0.5 }, availability: 'available' } },
+    );
+    const lease = pair.attachRenderer();
+
+    lease.wheel({ direction: 1, fine: true });
+    lease.reset();
+    expect(requestRf).not.toHaveBeenCalled();
+    expect(requestSql).toHaveBeenCalledExactlyOnceWith(0.52);
+    expect(pair.view).toMatchObject({ axisDraft: null, interaction: 'idle' });
+
+    const axis = createRenderedNativeRangeContinuousPairPolicy().axis!;
+    expect(axis.key(Number.NaN, { key: 'Home', fine: false }, DOMAIN)).toBeNull();
+    expect(axis.wheel(Number.POSITIVE_INFINITY, { direction: 1, fine: false }, DOMAIN)).toBeNull();
+    expect(axis.normalize(0.5, { ...DOMAIN, max: DOMAIN.min })).toBeNull();
+  });
+
+  it('makes rendered-native unknown authority inert and cancels state on replacement', () => {
+    const policy = createRenderedNativeRangeContinuousPairPolicy();
+    const unknown = readingSetup(policy, {
+      rf: { reading: { status: 'unknown' }, availability: 'available' },
+    });
+    const unknownLease = unknown.pair.attachRenderer();
+    expect(unknownLease.key({ key: 'ArrowRight', fine: false })).toBe(false);
+    expect(unknownLease.beginPointer()).toBeNull();
+    expect(unknown.requestRf).not.toHaveBeenCalled();
+    expect(unknown.requestSql).not.toHaveBeenCalled();
+
+    const healthy = readingSetup(policy);
+    const stale = healthy.pair.attachRenderer();
+    expect(stale.key({ key: 'ArrowRight', fine: false })).toBe(true);
+    expect(healthy.pair.view.axisDraft).toBe(0.51);
+    const replacement = healthy.pair.attachRenderer();
+    expect(healthy.pair.view.axisDraft).toBeNull();
+    expect(stale.key({ key: 'ArrowRight', fine: false })).toBe(false);
+    expect(replacement.key({ key: 'ArrowRight', fine: false })).toBe(true);
+    healthy.update({ ownerKey: 'rf-sql:sub' });
+    expect(healthy.pair.view.axisDraft).toBeNull();
+  });
+
   it('keeps native input immediate and omits legacy wheel, key and reset behavior', () => {
     const { pair, requestRf, requestSql } = readingSetup();
     const lease = pair.attachRenderer();

--- a/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
+++ b/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
@@ -6,6 +6,7 @@ import {
   createDiscreteContinuousScalarPolicy,
   createHBarContinuousScalarPolicy,
   createKnobContinuousScalarPolicy,
+  createRenderedNativeRangeContinuousScalarPolicy,
   nativeRangeContinuousScalarPolicy,
   type CommandScalarFeedback,
   type ContinuousScalarInput,
@@ -458,6 +459,31 @@ describe('continuous scalar source policies', () => {
     });
     ambiguous.scalar.attachRenderer().nativeInput(1_000_000_000_000.0004);
     expect(ambiguous.request).toHaveBeenCalledExactlyOnceWith(1_000_000_000_000.0005);
+  });
+
+  it('gives a rendered native range its lattice and explicit interactions', () => {
+    const { scalar, request } = readingSetup(
+      createRenderedNativeRangeContinuousScalarPolicy(),
+      { domain: NORMALIZED_DOMAIN, reading: { status: 'known', value: 0.5 } },
+    );
+    const lease = scalar.attachRenderer();
+    const token = lease.beginPointer()!;
+
+    lease.pointer(token, 0.513);
+    lease.endPointer(token);
+    expect(scalar.view).toMatchObject({ draft: 0.51, interactionBase: 0.51 });
+
+    for (const [key, fine] of [
+      ['ArrowRight', true], ['ArrowUp', false], ['ArrowDown', false],
+      ['ArrowLeft', false], ['Home', false], ['End', false],
+    ] as const) expect(lease.key({ key, fine })).toBe(true);
+    lease.reset();
+    lease.wheel({ direction: -1, fine: true });
+
+    expect(request.mock.calls).toEqual([
+      [0.51], [0.52], [0.53], [0.52], [0.51], [0], [1], [0.99],
+    ]);
+    expect(scalar.view).toMatchObject({ draft: null, interaction: 'idle' });
   });
 
   it.each([

--- a/frontend/src/primitives/scalar/continuous-pair.svelte.ts
+++ b/frontend/src/primitives/scalar/continuous-pair.svelte.ts
@@ -21,6 +21,8 @@ import {
   dualParamNormXFromValues,
   dualParamStepAlongAxis,
   dualParamValuesFromNormX,
+  handleKeyboardStep,
+  positionToValue,
 } from './value-control-core';
 
 export interface ContinuousPairValues {
@@ -62,9 +64,17 @@ export type ContinuousPairInput =
   | ReadingContinuousPairInput
   | CommandFeedbackContinuousPairInput;
 
+export interface ContinuousPairAxisPolicy {
+  normalize(axis: number, domain: ScalarDomain): number | null;
+  wheel(currentAxis: number, event: ScalarStepInput, domain: ScalarDomain): number | null;
+  key(currentAxis: number, event: ScalarKeyInput, domain: ScalarDomain): number | null;
+  reset(domain: ScalarDomain): number | null;
+}
+
 export interface ContinuousPairPolicy {
   readonly name: string;
   readonly preview: 'optimistic' | 'confirmed';
+  readonly axis?: Readonly<ContinuousPairAxisPolicy>;
   wheel(
     current: Readonly<ContinuousPairValues>,
     event: ScalarStepInput,
@@ -91,6 +101,49 @@ const nativePolicy: ContinuousPairPolicy = {
 };
 export const nativeRangeContinuousPairPolicy: Readonly<ContinuousPairPolicy> =
   Object.freeze(nativePolicy);
+
+function normalizedAxisStep(domain: ScalarDomain): number | null {
+  const span = domain.max - domain.min;
+  if (!Number.isFinite(domain.min) || !Number.isFinite(domain.max) || span <= 0
+    || !Number.isFinite(domain.step) || domain.step <= 0) return null;
+  const step = domain.step / span;
+  return Number.isFinite(step) && step > 0 ? step : null;
+}
+
+function normalizeRenderedNativeAxis(axis: number, domain: ScalarDomain): number | null {
+  const step = normalizedAxisStep(domain);
+  return step === null || !Number.isFinite(axis) ? null : positionToValue(axis, 0, 1, step);
+}
+
+export function createRenderedNativeRangeContinuousPairPolicy(): Readonly<ContinuousPairPolicy> {
+  const axis: ContinuousPairAxisPolicy = {
+    normalize: normalizeRenderedNativeAxis,
+    wheel: (current, event, domain) => {
+      const step = normalizedAxisStep(domain);
+      return step === null || !Number.isFinite(current) ? null : handleKeyboardStep(
+        current, event.direction > 0 ? 'ArrowRight' : 'ArrowLeft', step, 1, 0, 1, false,
+      );
+    },
+    key: (current, event, domain) => {
+      const step = normalizedAxisStep(domain);
+      return step === null || !Number.isFinite(current) ? null : handleKeyboardStep(
+        current, event.key, step, 1, 0, 1, false,
+      );
+    },
+    reset: () => null,
+  };
+  const policy: ContinuousPairPolicy = {
+    name: 'rendered-native-range-pair',
+    preview: 'optimistic',
+    axis: Object.freeze(axis),
+    wheel: () => null,
+    key: () => null,
+    reset: () => null,
+    dispatch: () => 'immediate',
+    wheelIdleMs: 0,
+  };
+  return Object.freeze(policy);
+}
 
 export function createLegacyContinuousPairPolicy(
   options: Readonly<{ keyboardDebounceMs: number }>,
@@ -418,21 +471,29 @@ export function createContinuousPair(
   const scalarPolicy: ContinuousScalarPolicy = {
     name: policy.name,
     preview: policy.preview,
-    normalize: (value) => Number.isFinite(value) ? clamp(value, 0, 1) : null,
-    wheel: (_axis, event) => {
+    normalize: (value) => {
+      if (policy.axis === undefined) return Number.isFinite(value) ? clamp(value, 0, 1) : null;
+      const normalized = policy.axis.normalize(value, current().domain);
+      if (normalized !== null) projectedCandidate = null;
+      return normalized;
+    },
+    wheel: (axis, event) => {
       const input = current();
+      if (policy.axis !== undefined) return policy.axis.wheel(axis, event, input.domain);
       const pair = effectivePair(input);
       const values = pair === null ? null : policy.wheel(pair, event, input.domain);
       return values === null ? null : rememberCandidate(values, input, 'wheel');
     },
-    key: (_axis, event) => {
+    key: (axis, event) => {
       const input = current();
+      if (policy.axis !== undefined) return policy.axis.key(axis, event, input.domain);
       const pair = effectivePair(input);
       const values = pair === null ? null : policy.key(pair, event, input.domain);
       return values === null ? null : rememberCandidate(values, input, 'keyboard');
     },
     reset: () => {
       const input = current();
+      if (policy.axis !== undefined) return policy.axis.reset(input.domain);
       const values = policy.reset(input.domain);
       return values === null ? null : rememberCandidate(values, input, 'reset');
     },

--- a/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
+++ b/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
@@ -381,6 +381,26 @@ const nativeRangePolicy: ContinuousScalarPolicy = {
 export const nativeRangeContinuousScalarPolicy: Readonly<ContinuousScalarPolicy> =
   Object.freeze(nativeRangePolicy);
 
+export function createRenderedNativeRangeContinuousScalarPolicy(): Readonly<ContinuousScalarPolicy> {
+  const policy: ContinuousScalarPolicy = {
+    name: 'rendered-native-range',
+    preview: 'optimistic',
+    normalize: nativeRangePolicy.normalize,
+    wheel: (current, event, domain) => snap(
+      current + event.direction * domain.step, domain, domain.step,
+    ),
+    key: (current, event, domain) => handleKeyboardStep(
+      current, event.key, domain.step, 1, domain.min, domain.max, false,
+    ),
+    reset: () => null,
+    dispatch: () => 'immediate',
+    dispatchesCanonical: () => true,
+    wheelIdleMs: 0,
+    describeTarget: String,
+  };
+  return Object.freeze(policy);
+}
+
 type AuthorityIdentity = readonly (string | number | boolean | null | undefined)[];
 type LocalCommandRequest = Readonly<{
   source: ScalarSource;


### PR DESCRIPTION
## Summary

- add host-selectable rendered-range scalar and pair policies while leaving browser-native, HBar, and legacy pair behavior unchanged
- add an optional pair axis-policy hook that consumes the persistent scalar owner actual axis and normalizes pointer input on the native domain lattice
- cover the real binding dead-zone trace, pointer `.513` followed by keyboard input, all six range keys, authority and renderer replacement, reset, and wheel behavior

## Mechanical adjudication

The lane-invert/step/forward proposal was rejected because the RF/SQL center dead zone maps multiple axis positions to `{rf: 1, sql: 0}` and inverse mapping loses that progress. A pair factory alone also could not replace the adapter clamp with native lattice normalization. The approved option (a) uses the existing scalar owner axis through an optional hook; `requestAxis` remains the only forward lane projection, no accumulator/timer/manager/math module was added, and the no-hook fallback remains unchanged.

Wheel is an explicit additive v3 interaction: one ordinary domain/axis step per direction, dispatched immediately, with Shift ignored. This is not claimed as preserved browser wheel behavior. Reset remains inert.

## Scope

Exact head: `9e1ec613bd1a11a2020a58f0f4271140939554f8`

Four leased files only: 206 insertions, 3 deletions, 209 A+D. No renderer, semantic host, SRS, SDK, legacy panel, baseline, or component-kit API changes.

## Verification

- focused scalar/pair Vitest: 110 passed
- leased-file ESLint: zero findings
- `npm run check`: 0 errors, 0 warnings
- natural [quick run 34075164619](https://github.com/rigplane/rigplane-core/actions/runs/34075164619): `SUCCESS` on the exact head
- affected [visual run 34075164682](https://github.com/rigplane/rigplane-core/actions/runs/34075164682): `SUCCESS` on the exact head
- canonical [Agent Review Gate run 34075619020](https://github.com/rigplane/rigplane-core/actions/runs/34075619020): `SUCCESS`, with required status published for the exact head
- trusted independent [PASS comment 5564066161](https://github.com/rigplane/rigplane-core/pull/3307#issuecomment-5564066161): exact-head PASS

Linear: MOR-2425