### PR TITLE
MOR-2425: add form-neutral TX aux scalar seats

### DIFF
--- a/frontend/src/semantic/TxAuxScalarHost.svelte
+++ b/frontend/src/semantic/TxAuxScalarHost.svelte
@@ -21,6 +21,7 @@
     type TxAuxFeedbackLevelField,
     type TxAuxLevelFeedback,
     type TxAuxLevelField,
+    type TxAuxScalarPresentation,
     type TxAuxScalarHandles,
   } from './tx-aux-scalar';
 
@@ -125,6 +126,18 @@
     field, statusPresentation(field),
   ])) as Record<TxAuxFeedbackLevelField, Readonly<HBarIssuedStatusPresentation>>;
 
+  function retireHBarStatus(
+    _node: HTMLElement,
+    placement: Readonly<{ field: TxAuxLevelField; form: 'hbar' | 'knob' }>,
+  ) {
+    const retire = (next: typeof placement) => {
+      if (next.form !== 'knob' || next.field === 'rfPower') return;
+      issuedStatus[next.field] = null;
+    };
+    retire(placement);
+    return { update: retire };
+  }
+
   function canonical(field: TxAuxLevelField): number | null {
     if (field !== 'rfPower' && levelFeedback !== undefined) {
       const feedback = levelFeedback[field];
@@ -158,9 +171,14 @@
   });
 </script>
 
-{#snippet scalar(field: TxAuxLevelField)}
+{#snippet scalar(
+  field: TxAuxLevelField,
+  presentation?: Readonly<TxAuxScalarPresentation>,
+)}
   {@const current = txAux?.[field]}
   {#if current?.availability.structural}
+    {@const explicitPresentation = presentation !== undefined}
+    {@const form = presentation?.form ?? 'hbar'}
     {@const [, label, min, max, step] = row(field)}
     {@const currentStatus = field === 'rfPower' ? '' : status(field)}
     {@const currentFeedback = field === 'rfPower' ? undefined : levelFeedback?.[field]}
@@ -171,8 +189,10 @@
     }}
     <div
       class="tx-aux-level"
+      class:tx-aux-level--presented={explicitPresentation}
       data-testid={`tx-aux-${field}`}
       data-field={field}
+      data-scalar-form={form}
       data-disabled-reason={disabledReason === undefined ? undefined : 'field-not-observed'}
       data-feedback-control={currentFeedback?.scope.control}
       data-min={min}
@@ -180,45 +200,73 @@
       data-step={step}
       aria-busy={currentFeedback?.busy}
       title={disabledReason}
+      use:retireHBarStatus={{ field, form }}
     >
-      <span class="tx-aux-name">{label}</span>
+      <span class="tx-aux-name" class:sr-only={explicitPresentation}
+        aria-hidden={explicitPresentation ? 'true' : undefined}>{label}</span>
       {#if field === 'rfPower'}
         <ValueControl
-          binding={bindings[field]} label="RF Power" renderer="hbar"
+          binding={bindings[field]} label="RF Power" renderer={form}
           displayFn={(value) => formatValue(field, value)}
-          showLabel={false} showValue={false} compact={true} title={disabledReason}
+          showLabel={explicitPresentation ? presentation?.showLabel ?? true : false}
+          showValue={explicitPresentation ? presentation?.showValue ?? true : false}
+          compact={explicitPresentation ? presentation?.compact ?? false : true}
+          title={disabledReason}
           {accessibility}
         />
       {:else}
         <ValueControl
           {...feedbackIntegratedControl}
-          binding={bindings[field]} {label} renderer="hbar"
+          binding={bindings[field]} {label} renderer={form}
           displayFn={(value) => formatValue(field, value)}
-          showLabel={false} showValue={false} compact={true} title={disabledReason}
+          showLabel={explicitPresentation ? presentation?.showLabel ?? true : false}
+          showValue={explicitPresentation ? presentation?.showValue ?? true : false}
+          compact={explicitPresentation ? presentation?.compact ?? false : true}
+          title={disabledReason}
           {accessibility}
-          issuedStatusPresentation={statusPresentations[field as TxAuxFeedbackLevelField]}
+          issuedStatusPresentation={form === 'hbar'
+            ? statusPresentations[field as TxAuxFeedbackLevelField]
+            : undefined}
         />
       {/if}
-      <output data-canonical-value>{formatValue(field, canonical(field))}</output>
+      <output data-canonical-value class:sr-only={explicitPresentation}
+        aria-hidden={explicitPresentation ? 'true' : undefined}
+      >{formatValue(field, canonical(field))}</output>
       {#if currentStatus !== ''}
         <span
           data-command-status
           class:command-pending={currentFeedback?.busy}
-          class:sr-only={currentFeedback?.phase === 'unavailable'}
+          class:sr-only={explicitPresentation || currentFeedback?.phase === 'unavailable'}
         >{currentStatus}</span>
       {/if}
     </div>
   {/if}
 {/snippet}
 
-{#snippet rfPower()}{@render scalar('rfPower')}{/snippet}
-{#snippet micGain()}{@render scalar('micGain')}{/snippet}
-{#snippet driveGain()}{@render scalar('driveGain')}{/snippet}
-{#snippet voxGain()}{@render scalar('voxGain')}{/snippet}
-{#snippet antiVoxGain()}{@render scalar('antiVoxGain')}{/snippet}
-{#snippet voxDelay()}{@render scalar('voxDelay')}{/snippet}
-{#snippet compressorLevel()}{@render scalar('compressorLevel')}{/snippet}
-{#snippet monitorLevel()}{@render scalar('monitorLevel')}{/snippet}
+{#snippet rfPower(presentation?: Readonly<TxAuxScalarPresentation>)}
+  {@render scalar('rfPower', presentation)}
+{/snippet}
+{#snippet micGain(presentation?: Readonly<TxAuxScalarPresentation>)}
+  {@render scalar('micGain', presentation)}
+{/snippet}
+{#snippet driveGain(presentation?: Readonly<TxAuxScalarPresentation>)}
+  {@render scalar('driveGain', presentation)}
+{/snippet}
+{#snippet voxGain(presentation?: Readonly<TxAuxScalarPresentation>)}
+  {@render scalar('voxGain', presentation)}
+{/snippet}
+{#snippet antiVoxGain(presentation?: Readonly<TxAuxScalarPresentation>)}
+  {@render scalar('antiVoxGain', presentation)}
+{/snippet}
+{#snippet voxDelay(presentation?: Readonly<TxAuxScalarPresentation>)}
+  {@render scalar('voxDelay', presentation)}
+{/snippet}
+{#snippet compressorLevel(presentation?: Readonly<TxAuxScalarPresentation>)}
+  {@render scalar('compressorLevel', presentation)}
+{/snippet}
+{#snippet monitorLevel(presentation?: Readonly<TxAuxScalarPresentation>)}
+  {@render scalar('monitorLevel', presentation)}
+{/snippet}
 
 {@render children({
   rfPower, micGain, driveGain, voxGain, antiVoxGain, voxDelay, compressorLevel, monitorLevel,
@@ -235,6 +283,7 @@
 
 <style>
   .tx-aux-level { display: grid; grid-template-columns: 10ch 8rem auto; align-items: center; gap: 0.5rem; }
+  .tx-aux-level--presented { display: inline-flex; min-width: 0; max-width: 100%; }
   .tx-aux-name { white-space: nowrap; }
   .tx-aux-level :global(.vc-hbar) { width: 100%; min-width: 0; }
   .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }

--- a/frontend/src/semantic/__tests__/TxAuxScalarHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/TxAuxScalarHost.isolated.test.ts
@@ -4,7 +4,10 @@ import { flushSync, mount, unmount } from 'svelte';
 import { proxy } from 'svelte/internal/client';
 
 const activation = vi.hoisted(() => ({ selected: undefined as unknown }));
-const scalarCapture = vi.hoisted(() => ({ bindings: [] as unknown[] }));
+const scalarCapture = vi.hoisted(() => ({
+  bindings: [] as unknown[],
+  leases: [] as Array<{ binding: unknown; lease: unknown }>,
+}));
 
 vi.mock('../../component-kits/activation', () => ({
   getSelectedScalarAppearance: () => activation.selected,
@@ -15,6 +18,12 @@ vi.mock('../../primitives/scalar/continuous-scalar.svelte', async (importOrigina
     ...actual,
     createContinuousScalar: (...args: Parameters<typeof actual.createContinuousScalar>) => {
       const binding = actual.createContinuousScalar(...args);
+      const attachRenderer = binding.attachRenderer.bind(binding);
+      binding.attachRenderer = () => {
+        const lease = attachRenderer();
+        scalarCapture.leases.push({ binding, lease });
+        return lease;
+      };
       scalarCapture.bindings.push(binding);
       return binding;
     },
@@ -35,7 +44,9 @@ import type {
   TxAuxFeedbackLevelField,
   TxAuxLevelFeedback,
   TxAuxLevelField,
+  TxAuxScalarPresentation,
 } from '../tx-aux-scalar';
+import { TX_AUX_LEVELS } from '../tx-aux-scalar';
 
 const RX_IDLE: TxAuthoritySnapshot = {
   phase: 'idle', intent: null, radioTx: 'off', txRisk: 'none', fault: null,
@@ -71,6 +82,7 @@ type Props = {
   view: RadioViewModel;
   tx: TxAuthoritySnapshot;
   presentation: 'grouped' | 'independent';
+  scalarPresentation?: Readonly<TxAuxScalarPresentation>;
   levelFeedback?: TxAuxLevelFeedback;
   onLevelChange?: (field: TxAuxLevelField, value: number) => void;
 };
@@ -81,9 +93,10 @@ beforeEach(() => {
   target = document.createElement('div');
   document.body.appendChild(target);
   activation.selected = {
-    name: 'TxAux test appearance', hbar: ExternalScalarRenderer,
+    name: 'TxAux test appearance', hbar: ExternalScalarRenderer, knob: ExternalScalarRenderer,
   } satisfies Skin;
   scalarCapture.bindings = [];
+  scalarCapture.leases = [];
 });
 
 afterEach(() => {
@@ -106,7 +119,18 @@ function render(over: Partial<Props> = {}) {
   const scalar = (field: TxAuxLevelField) => target.querySelector<RendererNode>(
     `[data-testid="tx-aux-${field}"] [data-external-scalar-renderer]`,
   );
-  return { props, onLevelChange, scalar, dispose: () => unmount(component) };
+  const row = (field: TxAuxLevelField) => target.querySelector<HTMLElement>(
+    `[data-testid="tx-aux-${field}"]`,
+  )!;
+  return { props, onLevelChange, scalar, row, dispose: () => unmount(component) };
+}
+
+function currentLease(binding: unknown): ContinuousScalarRendererLease {
+  for (let index = scalarCapture.leases.length - 1; index >= 0; index -= 1) {
+    const entry = scalarCapture.leases[index]!;
+    if (entry.binding === binding) return entry.lease as ContinuousScalarRendererLease;
+  }
+  throw new Error('renderer lease not captured');
 }
 
 describe('TxAuxScalarHost independent composition', () => {
@@ -117,6 +141,14 @@ describe('TxAuxScalarHost independent composition', () => {
     for (const [field] of FEEDBACK_FIELDS) {
       expect(r.scalar(field)?.dataset.evidence).toBe('command-feedback');
     }
+    const zeroArgumentRow = r.row('micGain');
+    expect(zeroArgumentRow.dataset.scalarForm).toBe('hbar');
+    expect(zeroArgumentRow.classList).not.toContain('tx-aux-level--presented');
+    expect(zeroArgumentRow.querySelector('.tx-aux-name')?.classList).not.toContain('sr-only');
+    expect(zeroArgumentRow.querySelector('[data-canonical-value]')?.classList).not.toContain('sr-only');
+    expect(r.scalar('micGain')?.dataset.showLabel).toBe('false');
+    expect(r.scalar('micGain')?.dataset.showValue).toBe('false');
+    expect(r.scalar('micGain')?.dataset.compact).toBe('true');
     expect(scalarCapture.bindings).toHaveLength(8);
     r.dispose();
   });
@@ -169,6 +201,260 @@ describe('TxAuxScalarHost independent composition', () => {
     }
     flushSync();
     expect(r.onLevelChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it.each([
+    ['hbar', 'knob', 'hbar'],
+    ['knob', 'hbar', 'knob'],
+  ] as const)(
+    'retains all bindings and fences stale renderer leases across %s-%s-%s',
+    (first, middle, last) => {
+      activation.selected = undefined;
+      const r = render({
+        presentation: 'independent',
+        scalarPresentation: { form: first },
+      });
+      const bindings = [...scalarCapture.bindings];
+      const firstLeases = bindings.map(currentLease);
+      const pointerTokens = firstLeases.map((lease) => lease.beginPointer());
+
+      r.props.scalarPresentation = {
+        form: middle, compact: true, showLabel: false, showValue: false,
+      };
+      flushSync();
+
+      expect(scalarCapture.bindings).toEqual(bindings);
+      for (const [field] of TX_AUX_LEVELS) {
+        const row = r.row(field);
+        expect(row.dataset.scalarForm).toBe(middle);
+        const renderer = row.querySelector<HTMLElement>(middle === 'knob' ? '.vc-knob' : '.vc-hbar')!;
+        expect(renderer.classList).toContain('compact');
+        expect(renderer.querySelector('.vc-label')).toBeNull();
+        expect(renderer.querySelector('.vc-value, .vc-knob-value')).toBeNull();
+      }
+      for (const [index, lease] of firstLeases.entries()) {
+        const token = pointerTokens[index];
+        if (token !== null) {
+          lease.pointer(token, 1);
+          lease.endPointer(token);
+        }
+        lease.nativeInput(1);
+        lease.wheel({ direction: 1, fine: false });
+        expect(lease.key({ key: 'ArrowRight', fine: false })).toBe(false);
+      }
+      expect(r.onLevelChange).not.toHaveBeenCalled();
+
+      const middleLeases = bindings.map(currentLease);
+      r.props.scalarPresentation = { form: last };
+      flushSync();
+
+      expect(scalarCapture.bindings).toEqual(bindings);
+      expect(target.querySelectorAll(last === 'knob' ? '.vc-knob' : '.vc-hbar')).toHaveLength(8);
+      for (const lease of middleLeases) {
+        lease.nativeInput(1);
+        lease.wheel({ direction: -1, fine: true });
+        expect(lease.key({ key: 'ArrowLeft', fine: false })).toBe(false);
+      }
+      expect(r.onLevelChange).not.toHaveBeenCalled();
+      r.dispose();
+    },
+  );
+
+  it('observes a current callback replacement without recreating bindings', () => {
+    const r = render({
+      presentation: 'independent',
+      scalarPresentation: { form: 'knob' },
+    });
+    const bindings = [...scalarCapture.bindings];
+    const replacement = vi.fn();
+    r.props.onLevelChange = replacement;
+    flushSync();
+
+    r.scalar('micGain')!.click();
+
+    expect(replacement).toHaveBeenCalledExactlyOnceWith('micGain', 129);
+    expect(r.onLevelChange).not.toHaveBeenCalled();
+    expect(scalarCapture.bindings).toEqual(bindings);
+    r.dispose();
+  });
+
+  it.each(['hbar', 'knob'] as const)(
+    'keeps the existing HBar policy for current %s renderer input', (form) => {
+      activation.selected = undefined;
+      const r = render({
+        presentation: 'independent',
+        scalarPresentation: { form },
+      });
+      const micBinding = scalarCapture.bindings[1]!;
+      const lease = currentLease(micBinding);
+
+      expect(lease.key({ key: 'ArrowRight', fine: false })).toBe(true);
+      lease.wheel({ direction: 1, fine: false });
+      lease.nativeInput(129.44);
+      const token = lease.beginPointer();
+      expect(token).not.toBeNull();
+      lease.pointer(token!, 130.06);
+      lease.endPointer(token!);
+      lease.reset();
+
+      expect(r.onLevelChange.mock.calls).toEqual([
+        ['micGain', 129],
+        ['micGain', 132],
+        ['micGain', 129],
+        ['micGain', 130],
+      ]);
+      r.dispose();
+    },
+  );
+
+  it.each(['hbar', 'knob'] as const)(
+    'uses a neutral %s seat with one renderer-owned visible label and value', (form) => {
+      activation.selected = undefined;
+      const r = render({
+        presentation: 'independent',
+        scalarPresentation: { form },
+      });
+      const row = r.row('micGain');
+      const renderer = row.querySelector<HTMLElement>(form === 'knob' ? '.vc-knob' : '.vc-hbar')!;
+      const slider = renderer.querySelector<HTMLElement>('[role="slider"]')!;
+
+      expect(row.classList).toContain('tx-aux-level--presented');
+      expect(row.querySelector('.tx-aux-name')?.classList).toContain('sr-only');
+      expect(row.querySelector('.tx-aux-name')?.getAttribute('aria-hidden')).toBe('true');
+      expect(row.querySelector('[data-canonical-value]')?.classList).toContain('sr-only');
+      expect(renderer.classList).not.toContain('compact');
+      expect(renderer.querySelectorAll('.vc-label')).toHaveLength(1);
+      expect(renderer.querySelectorAll('.vc-value, .vc-knob-value')).toHaveLength(1);
+      expect(slider.getAttribute('aria-label')).toBe('Mic gain');
+      expect(slider.getAttribute('aria-valuetext')).toContain('Mic gain: 50%');
+      r.dispose();
+    },
+  );
+
+  it.each(['hbar', 'knob'] as const)(
+    'keeps canonical, pending, and accessibility evidence on the actual %s slider', (form) => {
+    activation.selected = undefined;
+    const levels = feedbackRecord();
+    const r = render({
+      presentation: 'independent',
+      scalarPresentation: { form, showLabel: false, showValue: false },
+      levelFeedback: {
+        ...levels,
+        micGain: {
+          ...levels.micGain,
+          target: 200,
+          requestedTarget: 200,
+          phase: 'submitted',
+          busy: true,
+          lifecycleId: 'mic-200',
+          transitionId: 'mic-submitted-200',
+        },
+      },
+    });
+    const row = target.querySelector<HTMLElement>('[data-testid="tx-aux-micGain"]')!;
+    const slider = row.querySelector<HTMLElement>('[role="slider"]')!;
+
+    expect(row.classList).toContain('tx-aux-level--presented');
+    expect(row.querySelector('.tx-aux-name')?.classList).toContain('sr-only');
+    expect(row.querySelector('[data-canonical-value]')?.classList).toContain('sr-only');
+    expect(slider.closest(form === 'knob' ? '.vc-knob' : '.vc-hbar')).not.toBeNull();
+    expect(slider.getAttribute('aria-valuenow')).toBe('128');
+    expect(slider.getAttribute('aria-valuetext')).toContain('requested 78%');
+    expect(slider.getAttribute('aria-valuetext')).toContain('confirmed 50%');
+    expect(slider.getAttribute('aria-busy')).toBe('true');
+    expect(slider.dataset.commandPhase).toBe('submitted');
+
+    r.props.levelFeedback = {
+      ...levels,
+      micGain: {
+        ...levels.micGain,
+        requestedTarget: 200,
+        phase: 'failed',
+        lifecycleId: 'mic-200',
+        transitionId: 'mic-failed-200',
+        outcome: { phase: 'failed', error: 'radio refused' },
+      },
+    };
+    flushSync();
+    expect(slider.getAttribute('aria-valuenow')).toBe('128');
+    expect(slider.getAttribute('aria-valuetext')).toContain('radio refused');
+    expect(slider.getAttribute('aria-busy')).toBe('false');
+    expect(slider.dataset.commandPhase).toBe('failed');
+
+    r.props.view = {
+      ...r.props.view,
+      txAux: {
+        ...r.props.view.txAux!,
+        micGain: {
+          reading: { status: 'unknown' },
+          availability: { structural: true, operational: false },
+        },
+      },
+    };
+    r.props.levelFeedback = {
+      ...levels,
+      micGain: {
+        ...levels.micGain,
+        confirmed: null,
+        availability: 'unavailable',
+        phase: 'unavailable',
+      },
+    };
+    flushSync();
+    expect(slider.getAttribute('aria-valuenow')).toBeNull();
+    expect(slider.getAttribute('aria-disabled')).toBe('true');
+    expect(slider.getAttribute('aria-valuetext')).toContain('Mic gain: ?');
+    expect(slider.getAttribute('aria-valuetext')).toContain('unavailable');
+    expect(slider.getAttribute('aria-describedby')).not.toBeNull();
+    r.dispose();
+    },
+  );
+
+  it('uses one announcement lane and retires stale HBar speech on form switches', () => {
+    activation.selected = undefined;
+    const levels = feedbackRecord();
+    const failed = (transitionId: string) => ({
+      ...levels,
+      micGain: {
+        ...levels.micGain,
+        requestedTarget: 200,
+        phase: 'failed' as const,
+        lifecycleId: 'mic-200',
+        transitionId,
+        outcome: { phase: 'failed' as const, error: 'radio refused' },
+      },
+    });
+    const r = render({
+      presentation: 'independent',
+      scalarPresentation: { form: 'hbar' },
+      levelFeedback: failed('mic-failed-hbar'),
+    });
+    const live = () => target.querySelectorAll('[role="status"][aria-live="polite"]');
+
+    expect(live()).toHaveLength(1);
+    expect(target.querySelector('[data-feedback-lane="micGain"]')?.textContent).toContain(
+      'radio refused',
+    );
+
+    r.props.scalarPresentation = { form: 'knob' };
+    flushSync();
+    expect(live()).toHaveLength(0);
+    expect(target.querySelector('[data-feedback-lane="micGain"]')).toBeNull();
+
+    r.props.levelFeedback = failed('mic-failed-knob');
+    flushSync();
+    expect(live()).toHaveLength(1);
+    expect(live()[0]?.textContent).toContain('radio refused');
+
+    r.props.scalarPresentation = { form: 'hbar' };
+    flushSync();
+    expect(live()).toHaveLength(0);
+
+    r.props.levelFeedback = failed('mic-failed-hbar-next');
+    flushSync();
+    expect(live()).toHaveLength(1);
+    expect(target.querySelectorAll('[data-feedback-lane="micGain"]')).toHaveLength(1);
     r.dispose();
   });
 });

--- a/frontend/src/semantic/__tests__/fixtures/TxAuxScalarHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/TxAuxScalarHostFixture.svelte
@@ -6,6 +6,7 @@
   import type {
     TxAuxLevelFeedback,
     TxAuxLevelField,
+    TxAuxScalarPresentation,
     TxAuxScalarHandles,
   } from '../../tx-aux-scalar';
   import type { RadioViewModel } from '../../radio-view-model';
@@ -15,6 +16,7 @@
     view: RadioViewModel;
     tx: TxAuthoritySnapshot;
     presentation: 'grouped' | 'independent';
+    scalarPresentation?: Readonly<TxAuxScalarPresentation>;
     levelFeedback?: TxAuxLevelFeedback;
     onToggle?: (field: TxAuxToggleField) => void;
     onLevelChange?: (field: TxAuxLevelField, value: number) => void;
@@ -22,7 +24,7 @@
   }
 
   let {
-    view, tx, presentation, levelFeedback,
+    view, tx, presentation, scalarPresentation, levelFeedback,
     onToggle, onLevelChange, onAtuTune,
   }: Props = $props();
 </script>
@@ -38,14 +40,14 @@
             {view} {tx} {onToggle} {onAtuTune} scalarHandles={scalars} showScalars={false}
           />
           <section data-testid="independent-tx-aux-scalars">
-            <div data-slot="vox">{@render scalars.voxGain()}</div>
-            <div data-slot="power">{@render scalars.rfPower()}</div>
-            <div data-slot="compressor">{@render scalars.compressorLevel()}</div>
-            <div data-slot="microphone">{@render scalars.micGain()}</div>
-            <div data-slot="drive">{@render scalars.driveGain()}</div>
-            <div data-slot="anti-vox">{@render scalars.antiVoxGain()}</div>
-            <div data-slot="delay">{@render scalars.voxDelay()}</div>
-            <div data-slot="monitor">{@render scalars.monitorLevel()}</div>
+            <div data-slot="vox">{@render scalars.voxGain(scalarPresentation)}</div>
+            <div data-slot="power">{@render scalars.rfPower(scalarPresentation)}</div>
+            <div data-slot="compressor">{@render scalars.compressorLevel(scalarPresentation)}</div>
+            <div data-slot="microphone">{@render scalars.micGain(scalarPresentation)}</div>
+            <div data-slot="drive">{@render scalars.driveGain(scalarPresentation)}</div>
+            <div data-slot="anti-vox">{@render scalars.antiVoxGain(scalarPresentation)}</div>
+            <div data-slot="delay">{@render scalars.voxDelay(scalarPresentation)}</div>
+            <div data-slot="monitor">{@render scalars.monitorLevel(scalarPresentation)}</div>
           </section>
         </div>
       {/if}

--- a/frontend/src/semantic/tx-aux-scalar.ts
+++ b/frontend/src/semantic/tx-aux-scalar.ts
@@ -25,4 +25,17 @@ export type TxAuxLevelFeedback = Readonly<Record<
   Readonly<CommandScalarFeedback>
 >>;
 
-export type TxAuxScalarHandles = Readonly<Record<TxAuxLevelField, Snippet>>;
+export type TxAuxContinuousForm = 'hbar' | 'knob';
+
+export interface TxAuxScalarPresentation {
+  readonly form?: TxAuxContinuousForm;
+  readonly compact?: boolean;
+  readonly showLabel?: boolean;
+  readonly showValue?: boolean;
+}
+
+export type TxAuxScalarHandle = Snippet<[
+  presentation?: Readonly<TxAuxScalarPresentation>,
+]>;
+
+export type TxAuxScalarHandles = Readonly<Record<TxAuxLevelField, TxAuxScalarHandle>>;


### PR DESCRIPTION
## Result

TX-aux now keeps its eight persistent host-owned scalar bindings while each named internal handle can optionally select HBar or knob presentation. An omitted argument retains the shipped HBar row, label, canonical output, compact mode, policy, and status behavior.

Explicit presentation uses one neutral seat. The renderer can show or hide its visual label/value and use compact geometry, while the host still supplies the actual slider label, canonical value text, current feedback, disabled reason, and one polite announcement lane.

Linear: MOR-2425

## Scope

- add internal hbar/knob, compact, showLabel, and showValue presentation typing to the eight existing named handles
- preserve one binding and the existing HBar-derived policy for every field across form replacement
- retire stale HBar-issued speech when a knob renderer takes the seat
- add actual-renderer coverage for both replacement directions, stale pointer/native/key/wheel leases, callback replacement, normalization, reset-null, pending/error/unknown/disabled accessibility, zero-argument compatibility, and announcement uniqueness

No public SDK, SRS/admission, InstrumentComposition, RadioLayout, TX finite, receiver/audio/DSP/RF, registry, or external-kit source changed.

## Mechanism audit

The required pre-implementation mechanics-audit was completed against the four unchanged files at base 8becb9a4d7a246c8f6c4b388fd5edb3c1e49f1fa. The production scope enumerated six original exported declarations, nineteen local host state/helper definitions, and nine snippets. All have live production or focused-test consumers. No dead or parallel scalar owner was found. Binding, policy, normalization, feedback projection, renderer lease, and appearance selection remain the existing shared mechanisms; this PR fills only the form-selection/neutral-seat gap.

## RED / GREEN

Before the host change, the new focused file had 3 expected failures: requested knob calls still mounted the fixed form and no neutral seat existed.

Final local evidence:

- focused Vitest: 2 files, 174 tests passed
- npm run check: zero errors and warnings
- scoped ESLint over the four changed files: passed
- git diff --check: passed

No broad local suite, hardware run, baseline write, deployment, or merge was performed.

## Exact-head CI and review

Final head: c5c011b25b34e43af0d7059b5f8662af2b8a6f04

- natural quick run 34075217551: SUCCESS
- affected visual run 34075217571: SUCCESS
- canonical Agent Review Gate: SUCCESS
- independent exact-head review: PASS in comment 5564015675
- informational quick-v2-observe metadata context remained pending; it is not a canonical acceptance gate

No check was rerun and no merge was performed while recording these terminal results.

## Size

4 files, 380 additions and 30 deletions, 410 A+D. The directly affected TxAuxSurface consumer test needed no edit and is included in the focused 174-test result.