### PR TITLE
MOR-2425: add transformed DSP feedback foundation

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/dsp-command-feedback.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/dsp-command-feedback.isolated.test.ts
@@ -10,6 +10,7 @@ const h = vi.hoisted(() => ({
   session: { state: 'connected' as 'connected' | 'disconnected', epoch: 7 },
   active: 'MAIN' as 'MAIN' | 'SUB' | null,
   operational: true,
+  indicatorCount: 1,
   stateReads: 0, capsReads: 0, commandReads: 0, sessionReads: 0,
 }));
 
@@ -30,44 +31,56 @@ vi.mock('$lib/runtime/adapters/radio-view-model-adapter', () => ({
     ? { activeReceiver: { status: 'unknown' }, receiverIndicators: [] }
     : {
       activeReceiver: { status: 'known', receiver: h.active },
-      receiverIndicators: [{
+      receiverIndicators: Array.from({ length: h.indicatorCount }, () => ({
         receiver: h.active,
         availability: { structural: true, operational: h.operational },
-      }],
+      })),
     },
 }));
 
 import { DSP_COMMAND_DESCRIPTORS, type DspCommandFeedbackField } from '$lib/stores/commands.svelte';
-import { getDspControlFeedback } from '../panel-adapters';
+import {
+  getDspControlFeedback,
+  projectDspControlFeedbackToDisplay,
+  type ControlFeedback,
+} from '../panel-adapters';
 
 const FIELDS = [
-  'nbLevel', 'nbWidth', 'notchFilter', 'manualNotchWidth', 'agcTimeConstant',
+  'nbLevel', 'nbWidth', 'nrLevel', 'nbDepth',
+  'notchFilter', 'manualNotchWidth', 'agcTimeConstant',
 ] as const satisfies readonly DspCommandFeedbackField[];
 const VALUES: Readonly<Record<DspCommandFeedbackField, number>> = {
-  nbLevel: 60, nbWidth: 70, notchFilter: -80, manualNotchWidth: 3, agcTimeConstant: 900,
+  nbLevel: 60, nbWidth: 70, nrLevel: 128, nbDepth: 5,
+  notchFilter: -80, manualNotchWidth: 3, agcTimeConstant: 900,
 };
 const fresh = (marker = 5) => ({
   storePath: 'fixture', observed: true, freshness: 'fresh' as const,
   availability: 'available' as const, lastObservedMonotonic: marker,
 });
 const state = (over: Record<string, unknown> = {}): ServerState => ({
-  stateContractVersion: 1, providerGeneration: 3, active: 'MAIN', nbWidth: VALUES.nbWidth,
+  stateContractVersion: 1, providerGeneration: 3, active: 'MAIN',
+  nbWidth: VALUES.nbWidth, nbDepth: VALUES.nbDepth,
   main: {
-    nbLevel: VALUES.nbLevel, notchFilter: VALUES.notchFilter,
+    nbLevel: VALUES.nbLevel, nrLevel: VALUES.nrLevel, notchFilter: VALUES.notchFilter,
     manualNotchWidth: VALUES.manualNotchWidth, agcTimeConstant: VALUES.agcTimeConstant,
   },
-  sub: { nbLevel: 61, notchFilter: -81, manualNotchWidth: 4, agcTimeConstant: 901 },
+  sub: {
+    nbLevel: 61, nrLevel: 129, notchFilter: -81,
+    manualNotchWidth: 4, agcTimeConstant: 901,
+  },
   fieldStatus: {
-    nbWidth: fresh(), 'main.nbLevel': fresh(), 'main.notchFilter': fresh(),
+    nbWidth: fresh(), nbDepth: fresh(),
+    'main.nbLevel': fresh(), 'main.nrLevel': fresh(), 'main.notchFilter': fresh(),
     'main.manualNotchWidth': fresh(), 'main.agcTimeConstant': fresh(),
-    'sub.nbLevel': fresh(), 'sub.notchFilter': fresh(),
+    'sub.nbLevel': fresh(), 'sub.nrLevel': fresh(), 'sub.notchFilter': fresh(),
     'sub.manualNotchWidth': fresh(), 'sub.agcTimeConstant': fresh(),
   },
   ...over,
 } as unknown as ServerState);
 const caps = (over: Record<string, unknown> = {}): Capabilities => ({
   stateContractVersion: 1, providerGeneration: 3, receivers: 1, vfoScheme: 'single',
-  capabilities: ['nb', 'notch', 'agc'], controls: { nb_depth: { min: 0, max: 255, step: 1 } },
+  capabilities: ['nb', 'nr', 'notch', 'agc'],
+  controls: { nb_depth: { raw_min: 0, raw_max: 9, display_min: 1, display_max: 10 } },
   ...over,
 } as unknown as Capabilities);
 const connected = { state: 'connected' as const, epoch: 7 };
@@ -76,10 +89,12 @@ const command = (
 ): CommandLifecycle => {
   const descriptor = DSP_COMMAND_DESCRIPTORS[field];
   const receiver = h.active === 'SUB' ? 1 : 0;
-  const key = field === 'nbLevel' || field === 'nbWidth' ? 'level' : 'value';
+  const key = field === 'nbLevel' || field === 'nbWidth'
+    || field === 'nrLevel' || field === 'nbDepth' ? 'level' : 'value';
+  const global = field === 'nbWidth' || field === 'nbDepth';
   return {
     id: field, name: descriptor.intentName,
-    params: field === 'nbWidth' ? { [key]: target } : { [key]: target, receiver },
+    params: global ? { [key]: target } : { [key]: target, receiver },
     originalEpoch: 7, createdAt: 1, updatedAt: 1, timeoutMs: 5_000,
     status: 'pending', providerGeneration: 3, ...over,
   };
@@ -89,6 +104,7 @@ describe('qualified raw DSP command feedback', () => {
   afterEach(() => {
     h.state = null; h.caps = null; h.commands = [];
     h.session = { state: 'connected', epoch: 7 }; h.active = 'MAIN'; h.operational = true;
+    h.indicatorCount = 1;
     h.stateReads = 0; h.capsReads = 0; h.commandReads = 0; h.sessionReads = 0;
   });
 
@@ -122,15 +138,24 @@ describe('qualified raw DSP command feedback', () => {
     expect(h.sessionReads).toBe(0);
   });
 
-  it('uses canonical SUB receiver fields while NB Width keeps global receiver-zero identity', () => {
+  it('uses canonical SUB receiver fields while NB Width and NB Depth keep global identity', () => {
     h.active = 'SUB';
     h.state = state({ active: 'SUB' });
-    h.caps = caps({ receivers: 2, vfoScheme: 'main_sub', capabilities: ['dual_rx', 'nb', 'notch', 'agc'] });
+    h.caps = caps({
+      receivers: 2, vfoScheme: 'main_sub',
+      capabilities: ['dual_rx', 'nb', 'nr', 'notch', 'agc'],
+    });
+    expect(getDspControlFeedback('nrLevel', connected)).toMatchObject({
+      confirmed: 129, scope: { control: 'nr-level', receiver: 1 },
+    });
     expect(getDspControlFeedback('notchFilter', connected)).toMatchObject({
       confirmed: -81, scope: { control: 'notch-position', receiver: 1 },
     });
     expect(getDspControlFeedback('nbWidth', connected)).toMatchObject({
       confirmed: 70, scope: { control: 'nb-width', receiver: 0 },
+    });
+    expect(getDspControlFeedback('nbDepth', connected)).toMatchObject({
+      confirmed: 5, scope: { control: 'nb-depth', receiver: 0 },
     });
   });
 
@@ -191,7 +216,26 @@ describe('qualified raw DSP command feedback', () => {
     h.caps = caps({ capabilities: ['notch', 'agc'], controls: {} });
     expect(getDspControlFeedback('nbLevel', connected).availability).toBe('unavailable');
     expect(getDspControlFeedback('nbWidth', connected).availability).toBe('unavailable');
+    expect(getDspControlFeedback('nrLevel', connected).availability).toBe('unavailable');
+    h.commands = [command('nbDepth', 7)];
+    expect(getDspControlFeedback('nbDepth', connected)).toMatchObject({
+      availability: 'unavailable', phase: 'unavailable', target: null,
+    });
     expect(getDspControlFeedback('notchFilter', connected).availability).toBe('available');
+  });
+
+  it('fails closed for ambiguous and missing or stale transformed observations', () => {
+    h.state = state(); h.caps = caps(); h.indicatorCount = 2;
+    expect(getDspControlFeedback('nrLevel', connected).availability).toBe('unavailable');
+    h.indicatorCount = 1;
+    h.state = state({
+      fieldStatus: { ...state().fieldStatus, 'main.nrLevel': undefined },
+    });
+    expect(getDspControlFeedback('nrLevel', connected).availability).toBe('unavailable');
+    h.state = state({
+      fieldStatus: { ...state().fieldStatus, nbDepth: { ...fresh(), freshness: 'stale' } },
+    });
+    expect(getDspControlFeedback('nbDepth', connected).availability).toBe('unavailable');
   });
 
   it('drops old provider and session lifecycles after authority replacement', () => {
@@ -204,5 +248,117 @@ describe('qualified raw DSP command feedback', () => {
       providerGeneration: 4, sessionEpoch: 7, confirmed: 70,
       phase: 'idle', target: null, requestedTarget: null, outcome: null,
     });
+  });
+});
+
+const LEGACY_NR_CAPS = caps({
+  controls: {
+    nr_level: { raw_min: 0, raw_max: 255, display_min: 0, display_max: 15 },
+    nb_depth: { raw_min: 0, raw_max: 9, display_min: 1, display_max: 10 },
+  },
+});
+const EXACT_NR_CAPS = caps({
+  controls: {
+    nr_level: {
+      mapping: 'identity', raw_min: 0, raw_max: 10, raw_step: 1, raw_origin: 0,
+      display_min: '0', display_max: '10', display_step: '1', display_origin: '0',
+      display_unit: 'level', quantization: 'reject', restoration: 'exact',
+    },
+    nb_depth: { raw_min: 0, raw_max: 9, display_min: 1, display_max: 10 },
+  },
+});
+
+function rawFeedback(over: Partial<ControlFeedback<number>> = {}): Readonly<ControlFeedback<number>> {
+  return Object.freeze({
+    confirmed: 128, target: 136, requestedTarget: 136,
+    phase: 'awaiting-confirmation', busy: true, availability: 'available',
+    outcome: null, lifecycleId: '[7,"nr"]', transitionId: '[7,"nr","acknowledged"]',
+    providerGeneration: 3, sessionEpoch: 7,
+    scope: Object.freeze({ control: 'nr-level', receiver: 0 as const }),
+    repeatPolicy: 'latest-target-wins', ...over,
+  });
+}
+
+describe('pure transformed DSP feedback projection', () => {
+  afterEach(() => {
+    h.state = null; h.caps = null; h.commands = [];
+    h.session = { state: 'connected', epoch: 7 }; h.active = 'MAIN'; h.operational = true;
+    h.indicatorCount = 1;
+    h.stateReads = 0; h.capsReads = 0; h.commandReads = 0; h.sessionReads = 0;
+  });
+
+  it('keeps a raw NR alias busy until exact confirmation while all display slots equal 8', () => {
+    h.state = state({ main: { ...state().main, nrLevel: 128 } });
+    h.caps = LEGACY_NR_CAPS;
+    h.commands = [command('nrLevel', 136, { status: 'acknowledged' })];
+    const raw = getDspControlFeedback('nrLevel', connected);
+    const display = projectDspControlFeedbackToDisplay('nrLevel', raw, LEGACY_NR_CAPS);
+    expect(display).toMatchObject({
+      confirmed: 8, target: 8, requestedTarget: 8,
+      phase: 'awaiting-confirmation', busy: true, availability: 'available',
+    });
+    expect(raw).toMatchObject({ confirmed: 128, target: 136, requestedTarget: 136, busy: true });
+  });
+
+  it('reuses exact-domain NR and explicit-capability NB Depth mappings', () => {
+    expect(projectDspControlFeedbackToDisplay(
+      'nrLevel', rawFeedback({ confirmed: 4, target: 7, requestedTarget: 7 }), EXACT_NR_CAPS,
+    )).toMatchObject({ confirmed: 4, target: 7, requestedTarget: 7 });
+    expect(projectDspControlFeedbackToDisplay(
+      'nbDepth', rawFeedback({ confirmed: 0, target: 5, requestedTarget: 9 }), LEGACY_NR_CAPS,
+    )).toMatchObject({ confirmed: 1, target: 6, requestedTarget: 10 });
+  });
+
+  it.each([
+    ['nr below exact domain', 'nrLevel', -1, EXACT_NR_CAPS],
+    ['nb below explicit range', 'nbDepth', -1, LEGACY_NR_CAPS],
+    ['nb above explicit range', 'nbDepth', 10, LEGACY_NR_CAPS],
+    ['nb fractional raw', 'nbDepth', 4.5, LEGACY_NR_CAPS],
+    ['nb malformed selected range', 'nbDepth', 5, caps({
+      controls: { nb_depth: { raw_min: 0, raw_max: 9, display_min: 1, display_max: Infinity } },
+    })],
+    ['nb empty selected range', 'nbDepth', 5, caps({
+      controls: { nb_depth: { raw_min: 5, raw_max: 5, display_min: 1, display_max: 10 } },
+    })],
+  ] as const)('fails closed for %s without clamping invalid raw evidence', (
+    _case, field, confirmed, currentCaps,
+  ) => {
+    const raw = rawFeedback({ confirmed, target: null, requestedTarget: null });
+    const display = projectDspControlFeedbackToDisplay(field, raw, currentCaps);
+    expect(display).toMatchObject({
+      confirmed: null, target: null, requestedTarget: null,
+      phase: 'unavailable', busy: false, availability: 'unavailable',
+      outcome: null, lifecycleId: null, transitionId: null,
+      providerGeneration: 3, sessionEpoch: 7,
+      scope: raw.scope, repeatPolicy: raw.repeatPolicy,
+    });
+    expect(raw.confirmed).toBe(confirmed);
+  });
+
+  it.each(['confirmed', 'target', 'requestedTarget'] as const)(
+    'fails closed when the present %s slot cannot be projected',
+    slot => {
+      const raw = rawFeedback({ confirmed: 4, target: 5, requestedTarget: 6, [slot]: 10 });
+      expect(projectDspControlFeedbackToDisplay('nbDepth', raw, LEGACY_NR_CAPS)).toMatchObject({
+        confirmed: null, target: null, requestedTarget: null,
+        phase: 'unavailable', busy: false, availability: 'unavailable',
+      });
+      expect(raw[slot]).toBe(10);
+    },
+  );
+
+  it('maps nullable slots independently and preserves every metadata field and reference', () => {
+    const outcome = Object.freeze({ phase: 'failed' as const, error: 'radio refused' });
+    const scope = Object.freeze({ control: 'nb-depth', receiver: 0 as const });
+    const raw = rawFeedback({
+      confirmed: 5, target: null, requestedTarget: 9,
+      phase: 'failed', busy: false, outcome, scope,
+    });
+    const display = projectDspControlFeedbackToDisplay('nbDepth', raw, LEGACY_NR_CAPS);
+    expect(display).toEqual({ ...raw, confirmed: 6, target: null, requestedTarget: 10 });
+    expect(display.outcome).toBe(outcome);
+    expect(display.scope).toBe(scope);
+    expect(Object.isFrozen(display)).toBe(true);
+    expect([h.stateReads, h.capsReads, h.commandReads, h.sessionReads]).toEqual([0, 0, 0, 0]);
   });
 });

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -116,6 +116,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
       'set_cw_pitch', 'set_key_speed', 'set_mic_gain', 'set_drive_gain',
       'set_vox_gain', 'set_anti_vox_gain', 'set_vox_delay',
       'set_compressor_level', 'set_monitor_gain', 'set_nb_level', 'set_nb_width',
+      'set_nr_level', 'set_nb_depth',
       'set_notch_filter', 'set_manual_notch_width', 'set_agc_time_constant',
     ]);
     expect(RADIO_INTENT_NAMES).toContain(FILTER_WIDTH_COMMAND_DESCRIPTOR.intentName);
@@ -596,6 +597,8 @@ describe('Break-in Delay ControlFeedback projection (MOR-1744)', () => {
       ['set_monitor_gain', TX_AUX_COMMAND_DESCRIPTORS.monitorGain],
       ['set_nb_level', DSP_COMMAND_DESCRIPTORS.nbLevel],
       ['set_nb_width', DSP_COMMAND_DESCRIPTORS.nbWidth],
+      ['set_nr_level', DSP_COMMAND_DESCRIPTORS.nrLevel],
+      ['set_nb_depth', DSP_COMMAND_DESCRIPTORS.nbDepth],
       ['set_notch_filter', DSP_COMMAND_DESCRIPTORS.notchFilter],
       ['set_manual_notch_width', DSP_COMMAND_DESCRIPTORS.manualNotchWidth],
       ['set_agc_time_constant', DSP_COMMAND_DESCRIPTORS.agcTimeConstant],

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -55,6 +55,9 @@ import { currentControlSessionEpoch } from '../commands/radio-intents';
 import type { ServerState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
 import { qualifyDisplayObservation, qualifyRadioDisplayObservation } from './display-observation';
+import {
+  controlRangeFromCapsOrDefault, nbDepthRawToDisplay, projectNrLevel,
+} from '$lib/radio/filter-controls';
 
 // Re-export types for panel imports
 export type {
@@ -501,12 +504,13 @@ export function getTxAuxControlFeedback(
 
 export type DspControlFeedbackField = DspCommandFeedbackField;
 const DSP_FEEDBACK_CAPABILITIES: Readonly<Record<
-  Exclude<DspControlFeedbackField, 'nbWidth'>, string
+  Exclude<DspControlFeedbackField, 'nbWidth' | 'nbDepth'>, string
 >> = Object.freeze({
-  nbLevel: 'nb', notchFilter: 'notch', manualNotchWidth: 'notch', agcTimeConstant: 'agc',
+  nbLevel: 'nb', nrLevel: 'nr',
+  notchFilter: 'notch', manualNotchWidth: 'notch', agcTimeConstant: 'agc',
 });
 
-/** Qualified raw DSP feedback; NB Width alone has stable radio-global identity. */
+/** Qualified raw DSP feedback; NB Width and NB Depth have stable radio-global identity. */
 export function getDspControlFeedback(
   field: DspControlFeedbackField,
   currentControlSession?: ControlSessionSnapshot,
@@ -521,9 +525,11 @@ export function getDspControlFeedback(
   const scope = Object.freeze({
     control: field === 'nbLevel' ? 'nb-level'
       : field === 'nbWidth' ? 'nb-width'
-        : field === 'notchFilter' ? 'notch-position'
-          : field === 'manualNotchWidth' ? 'manual-notch-width' : 'agc-time',
-    receiver: field === 'nbWidth' ? 0 as const : receiver,
+        : field === 'nrLevel' ? 'nr-level'
+          : field === 'nbDepth' ? 'nb-depth'
+            : field === 'notchFilter' ? 'notch-position'
+              : field === 'manualNotchWidth' ? 'manual-notch-width' : 'agc-time',
+    receiver: field === 'nbWidth' || field === 'nbDepth' ? 0 as const : receiver,
   });
   const feedback = projectControlFeedback(
     descriptor, state, commands, scope, epoch, isCommandLifecycleSuperseded,
@@ -541,10 +547,10 @@ export function getDspControlFeedback(
     if (receiverEntries.length !== 1 || !receiverEntries[0].availability.operational) {
       return unavailableControlFeedback(feedback);
     }
-    if (field === 'nbWidth') {
+    if (field === 'nbWidth' || field === 'nbDepth') {
       const observation = qualifyRadioDisplayObservation({
         state, caps, path: field, structural: caps?.controls?.nb_depth != null,
-        value: state?.nbWidth,
+        value: state?.[field],
       });
       return observation.state === 'current' && Number.isSafeInteger(observation.value)
         ? feedback : unavailableControlFeedback(feedback);
@@ -563,6 +569,48 @@ export function getDspControlFeedback(
   } catch {
     return unavailableControlFeedback(feedback);
   }
+}
+
+type TransformedDspControlFeedbackField = 'nrLevel' | 'nbDepth';
+
+function projectDspRawValueToDisplay(
+  field: TransformedDspControlFeedbackField,
+  raw: number,
+  caps: Capabilities | null | undefined,
+): number | null {
+  if (field === 'nrLevel') {
+    const value = projectNrLevel(caps, raw, true).value;
+    return value !== null && Number.isFinite(value) ? value : null;
+  }
+  try {
+    const range = controlRangeFromCapsOrDefault('nb_depth', caps);
+    const values = [range.rawMin, range.rawMax, range.displayMin, range.displayMax];
+    if (!values.every(value => typeof value === 'number' && Number.isFinite(value))
+      || !Number.isSafeInteger(range.rawMin) || !Number.isSafeInteger(range.rawMax)
+      || range.rawMax <= range.rawMin || range.displayMax <= range.displayMin
+      || !Number.isSafeInteger(raw) || raw < range.rawMin || raw > range.rawMax) return null;
+    const display = nbDepthRawToDisplay(raw, range);
+    return Number.isFinite(display) ? display : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Pure raw-to-display projection; descriptor-unit confirmation remains untouched. */
+export function projectDspControlFeedbackToDisplay(
+  field: TransformedDspControlFeedbackField,
+  rawFeedback: Readonly<ControlFeedback<number>>,
+  caps: Capabilities | null | undefined,
+): Readonly<ControlFeedback<number>> {
+  const project = (raw: number | null): number | null | undefined =>
+    raw === null ? null : projectDspRawValueToDisplay(field, raw, caps) ?? undefined;
+  const confirmed = project(rawFeedback.confirmed);
+  const target = project(rawFeedback.target);
+  const requestedTarget = project(rawFeedback.requestedTarget);
+  if (confirmed === undefined || target === undefined || requestedTarget === undefined) {
+    return unavailableControlFeedback(rawFeedback);
+  }
+  return Object.freeze({ ...rawFeedback, confirmed, target, requestedTarget });
 }
 
 type RfSqlFeedbackLane = Readonly<{

--- a/frontend/src/lib/stores/__tests__/commands.test.ts
+++ b/frontend/src/lib/stores/__tests__/commands.test.ts
@@ -316,6 +316,7 @@ describe('command lifecycle store', () => {
         'set_cw_pitch', 'set_key_speed', 'set_mic_gain', 'set_drive_gain',
         'set_vox_gain', 'set_anti_vox_gain', 'set_vox_delay',
         'set_compressor_level', 'set_monitor_gain', 'set_nb_level', 'set_nb_width',
+        'set_nr_level', 'set_nb_depth',
         'set_notch_filter', 'set_manual_notch_width', 'set_agc_time_constant',
       ]);
       expect(rfMain).toEqual({ control: 'rf-gain', receiver: 0 });
@@ -431,6 +432,7 @@ describe('command lifecycle store', () => {
         'set_cw_pitch', 'set_key_speed', 'set_mic_gain', 'set_drive_gain',
         'set_vox_gain', 'set_anti_vox_gain', 'set_vox_delay',
         'set_compressor_level', 'set_monitor_gain', 'set_nb_level', 'set_nb_width',
+        'set_nr_level', 'set_nb_depth',
         'set_notch_filter', 'set_manual_notch_width', 'set_agc_time_constant',
       ]);
       const pitchScope = store.CW_PITCH_COMMAND_DESCRIPTOR.scope({ params: { value: 640 } })!;
@@ -588,6 +590,7 @@ describe('command lifecycle store', () => {
   describe('raw DSP state-backed descriptors', () => {
     const receiverRegistrations = [
       ['nbLevel', 'set_nb_level', 'nb-level', 'level'],
+      ['nrLevel', 'set_nr_level', 'nr-level', 'level'],
       ['notchFilter', 'set_notch_filter', 'notch-position', 'value'],
       ['manualNotchWidth', 'set_manual_notch_width', 'manual-notch-width', 'value'],
       ['agcTimeConstant', 'set_agc_time_constant', 'agc-time', 'value'],
@@ -611,20 +614,28 @@ describe('command lifecycle store', () => {
       expect(descriptor.matches(2047, 2048)).toBe(false);
     });
 
-    it('registers NB Width as one raw global lane with stable receiver-zero identity', () => {
-      const descriptor = store.DSP_COMMAND_DESCRIPTORS.nbWidth;
+    it.each([
+      ['nbWidth', 'set_nb_width', 'nb-width'],
+      ['nbDepth', 'set_nb_depth', 'nb-depth'],
+    ] as const)('registers %s as one raw global lane with stable receiver-zero identity', (
+      field, intentName, control,
+    ) => {
+      const descriptor = store.DSP_COMMAND_DESCRIPTORS[field];
       const scope = descriptor.scope({ params: { level: 255 } })!;
-      expect(descriptor.intentName).toBe('set_nb_width');
-      expect(store.getStateBackedCommandDescriptor('set_nb_width')).toBe(descriptor);
-      expect(scope).toEqual({ control: 'nb-width', receiver: 0 });
-      expect(descriptor.fieldPath(scope)).toBe('nbWidth');
+      expect(descriptor.intentName).toBe(intentName);
+      expect(store.getStateBackedCommandDescriptor(intentName)).toBe(descriptor);
+      expect(scope).toEqual({ control, receiver: 0 });
+      expect(descriptor.fieldPath(scope)).toBe(field);
       expect(descriptor.target({ params: { level: -1 } })).toBe(-1);
-      expect(descriptor.confirmed({ active: 'SUB', nbWidth: 255 } as ServerState, scope)).toBe(255);
+      expect(descriptor.confirmed({ active: 'SUB', [field]: 255 } as unknown as ServerState, scope)).toBe(255);
     });
 
     it('rejects malformed DSP envelopes without coercion or throwing', () => {
       const inherited = Object.create({ level: 10, receiver: 0 }) as Record<string, unknown>;
       const throwing = Object.defineProperty({ receiver: 0 }, 'level', {
+        enumerable: true, get: () => { throw new Error('read'); },
+      });
+      const globalThrowing = Object.defineProperty({}, 'level', {
         enumerable: true, get: () => { throw new Error('read'); },
       });
       const ownKeysTrap = new Proxy({}, { ownKeys: () => { throw new Error('keys'); } });
@@ -636,22 +647,30 @@ describe('command lifecycle store', () => {
       ]) {
         expect(store.DSP_COMMAND_DESCRIPTORS.nbLevel.scope({ params })).toBeNull();
         expect(store.DSP_COMMAND_DESCRIPTORS.nbLevel.target({ params })).toBeNull();
+        expect(store.DSP_COMMAND_DESCRIPTORS.nrLevel.scope({ params })).toBeNull();
+        expect(store.DSP_COMMAND_DESCRIPTORS.nrLevel.target({ params })).toBeNull();
       }
       for (const params of [
-        {}, { level: true }, { level: '10' }, { level: 10.5 },
-        { level: 10, receiver: 0 }, { level: 10, extra: true }, ownKeysTrap,
+        {}, { level: true }, { level: '10' }, { level: Number.NaN },
+        { level: Number.POSITIVE_INFINITY }, { level: 10.5 }, { level: Number.MAX_VALUE },
+        { level: 10, receiver: 0 }, { level: 10, extra: true },
+        { level: 10, [Symbol('extra')]: true }, globalThrowing, ownKeysTrap,
       ]) {
         expect(store.DSP_COMMAND_DESCRIPTORS.nbWidth.scope({ params })).toBeNull();
         expect(store.DSP_COMMAND_DESCRIPTORS.nbWidth.target({ params })).toBeNull();
+        expect(store.DSP_COMMAND_DESCRIPTORS.nbDepth.scope({ params })).toBeNull();
+        expect(store.DSP_COMMAND_DESCRIPTORS.nbDepth.target({ params })).toBeNull();
       }
     });
 
     it.each([
       ['set_nb_level', 'main.nbLevel', 'level', 50, 49, 0],
+      ['set_nr_level', 'sub.nrLevel', 'level', 136, 128, 1],
       ['set_notch_filter', 'sub.notchFilter', 'value', -20, -19, 1],
       ['set_manual_notch_width', 'main.manualNotchWidth', 'value', 3, 2, 0],
       ['set_agc_time_constant', 'sub.agcTimeConstant', 'value', 900, 899, 1],
       ['set_nb_width', 'nbWidth', 'level', 64, 63, null],
+      ['set_nb_depth', 'nbDepth', 'level', 9, 8, null],
     ] as const)('confirms %s only from a newer fresh exact field observation', (
       name, path, param, target, mismatch, receiver,
     ) => {
@@ -659,7 +678,7 @@ describe('command lifecycle store', () => {
         stateContractVersion: 1, providerGeneration: 3, active: receiver === 1 ? 'SUB' : 'MAIN',
         main: receiver === 0 ? { [path.split('.')[1]]: value } : {},
         sub: receiver === 1 ? { [path.split('.')[1]]: value } : {},
-        ...(receiver === null ? { nbWidth: value } : {}),
+        ...(receiver === null ? { [path]: value } : {}),
         fieldStatus: { [path]: {
           observed: true, freshness, availability: 'available', lastObservedMonotonic: marker,
         } },
@@ -678,7 +697,7 @@ describe('command lifecycle store', () => {
       expect(status()).toBe('confirmed');
     });
 
-    it('keeps global NB Width identity fixed while receiver controls and fields stay independent', () => {
+    it('keeps global NB identities fixed while receiver controls and fields stay independent', () => {
       const widthA = store.beginCommand({
         id: 'width-a', name: 'set_nb_width', params: { level: 20 }, originalEpoch: 7,
       });
@@ -689,40 +708,61 @@ describe('command lifecycle store', () => {
         id: 'level-sub', name: 'set_nb_level', params: { level: 40, receiver: 1 }, originalEpoch: 7,
       });
       store.beginCommand({ id: 'width-b', name: 'set_nb_width', params: { level: 50 }, originalEpoch: 7 });
+      const depthA = store.beginCommand({
+        id: 'depth-a', name: 'set_nb_depth', params: { level: 4 }, originalEpoch: 7,
+      });
+      store.beginCommand({ id: 'depth-b', name: 'set_nb_depth', params: { level: 5 }, originalEpoch: 7 });
       expect(store.isCommandLifecycleSuperseded(widthA)).toBe(true);
+      expect(store.isCommandLifecycleSuperseded(depthA)).toBe(true);
       expect(store.isCommandLifecycleSuperseded(levelMain)).toBe(false);
       expect(store.isCommandLifecycleSuperseded(levelSub)).toBe(false);
       expect(store.DSP_COMMAND_DESCRIPTORS.nbWidth.scope({ params: { level: 50 } }))
         .toEqual({ control: 'nb-width', receiver: 0 });
+      expect(store.DSP_COMMAND_DESCRIPTORS.nbDepth.scope({ params: { level: 5 } }))
+        .toEqual({ control: 'nb-depth', receiver: 0 });
     });
 
     it('does not confirm receiver or global DSP commands from the wrong field path', () => {
       emitState({
-        providerGeneration: 3, active: 'SUB', nbWidth: 20,
-        main: { nbLevel: 40 }, sub: { nbLevel: 30 },
+        providerGeneration: 3, active: 'SUB', nbWidth: 20, nbDepth: 4,
+        main: { nbLevel: 40, nrLevel: 136 }, sub: { nbLevel: 30, nrLevel: 128 },
         fieldStatus: {
           nbWidth: { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
+          nbDepth: { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
           'main.nbLevel': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
           'sub.nbLevel': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
+          'main.nrLevel': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
+          'sub.nrLevel': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
         },
       } as unknown as ServerState);
       store.beginCommand({
         id: 'sub-level', name: 'set_nb_level', params: { level: 40, receiver: 1 }, originalEpoch: 7,
       });
       store.beginCommand({ id: 'global-width', name: 'set_nb_width', params: { level: 40 }, originalEpoch: 7 });
+      store.beginCommand({
+        id: 'main-nr', name: 'set_nr_level', params: { level: 128, receiver: 0 }, originalEpoch: 7,
+      });
+      store.beginCommand({ id: 'global-depth', name: 'set_nb_depth', params: { level: 8 }, originalEpoch: 7 });
       store.acknowledgeCommand('sub-level', 7, 7);
       store.acknowledgeCommand('global-width', 7, 7);
+      store.acknowledgeCommand('main-nr', 7, 7);
+      store.acknowledgeCommand('global-depth', 7, 7);
       emitState({
-        providerGeneration: 3, active: 'MAIN', nbWidth: 20,
-        main: { nbLevel: 40 }, sub: { nbLevel: 30 },
+        providerGeneration: 3, active: 'MAIN', nbWidth: 20, nbDepth: 4,
+        main: { nbLevel: 40, nrLevel: 136 }, sub: { nbLevel: 30, nrLevel: 128 },
         fieldStatus: {
           nbWidth: { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 },
+          nbDepth: { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 },
           'main.nbLevel': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 },
           'sub.nbLevel': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
+          'main.nrLevel': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 },
+          'sub.nrLevel': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
         },
       } as unknown as ServerState);
       expect(store.getCommandLifecycle('sub-level', 7)?.status).toBe('acknowledged');
       expect(store.getCommandLifecycle('global-width', 7)?.status).toBe('acknowledged');
+      expect(store.getCommandLifecycle('main-nr', 7)?.status).toBe('acknowledged');
+      expect(store.getCommandLifecycle('global-depth', 7)?.status).toBe('acknowledged');
     });
   });
 });

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -250,10 +250,12 @@ export const TX_AUX_COMMAND_DESCRIPTORS = Object.freeze({
 }) satisfies Readonly<Record<TxAuxCommandFeedbackField, StateBackedCommandDescriptor<number>>>;
 
 export type DspCommandFeedbackField =
-  | 'nbLevel' | 'nbWidth' | 'notchFilter' | 'manualNotchWidth' | 'agcTimeConstant';
-type ReceiverDspCommandFeedbackField = Exclude<DspCommandFeedbackField, 'nbWidth'>;
+  | 'nbLevel' | 'nbWidth' | 'nrLevel' | 'nbDepth'
+  | 'notchFilter' | 'manualNotchWidth' | 'agcTimeConstant';
+type ReceiverDspCommandFeedbackField = Exclude<DspCommandFeedbackField, 'nbWidth' | 'nbDepth'>;
 type ReceiverDspCommandFeedbackIntent =
-  | 'set_nb_level' | 'set_notch_filter' | 'set_manual_notch_width' | 'set_agc_time_constant';
+  | 'set_nb_level' | 'set_nr_level'
+  | 'set_notch_filter' | 'set_manual_notch_width' | 'set_agc_time_constant';
 
 function rawReceiverDspCommandDescriptor(
   intentName: ReceiverDspCommandFeedbackIntent,
@@ -289,9 +291,23 @@ const NB_WIDTH_COMMAND_DESCRIPTOR: StateBackedCommandDescriptor<number> = Object
   matches: (confirmed: number, requested: number) => confirmed === requested,
 });
 
+const nbDepthTarget = (command: Pick<CommandLifecycle, 'params'>): number | null =>
+  exactSafeIntegerTarget(command, 'level');
+const NB_DEPTH_COMMAND_DESCRIPTOR: StateBackedCommandDescriptor<number> = Object.freeze({
+  intentName: 'set_nb_depth', repeatPolicy: 'latest-target-wins',
+  scope: (command: Pick<CommandLifecycle, 'params'>) => nbDepthTarget(command) === null
+    ? null : Object.freeze({ control: 'nb-depth', receiver: 0 }),
+  fieldPath: () => 'nbDepth',
+  target: nbDepthTarget,
+  confirmed: (state: ServerState) => safeInteger(state.nbDepth),
+  matches: (confirmed: number, requested: number) => confirmed === requested,
+});
+
 export const DSP_COMMAND_DESCRIPTORS = Object.freeze({
   nbLevel: rawReceiverDspCommandDescriptor('set_nb_level', 'nb-level', 'nbLevel', 'level'),
   nbWidth: NB_WIDTH_COMMAND_DESCRIPTOR,
+  nrLevel: rawReceiverDspCommandDescriptor('set_nr_level', 'nr-level', 'nrLevel', 'level'),
+  nbDepth: NB_DEPTH_COMMAND_DESCRIPTOR,
   notchFilter: rawReceiverDspCommandDescriptor(
     'set_notch_filter', 'notch-position', 'notchFilter', 'value',
   ),


### PR DESCRIPTION
## Summary

- register exact raw state-backed descriptors for receiver-scoped NR Level and radio-global NB Depth
- extend qualified raw DSP feedback without adding another lifecycle or subscription
- add one pure two-lane display projector that reuses current NR/NB conversion contracts and fails closed on invalid slots

## Verification

- TDD RED: focused three-file Vitest slice failed 20 tests before the production implementation
- GREEN: `npm test -- --run src/lib/stores/__tests__/commands.test.ts src/lib/runtime/adapters/__tests__/dsp-command-feedback.isolated.test.ts src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts` — 157 passed
- `npm run check` — 0 errors, 0 warnings
- scoped ESLint over all five changed files — clean
- `git diff --check` — clean

## Scope

This is the shared feedback foundation only. It does not claim live DSP scalar adoption; MOR-2425 D2 must consume the raw getter and pure display projector in the family wiring. No profiles, handlers, filter conversion owners, subscriptions, timers, or layouts changed.

## Terminal exact-head acceptance

Head: `e05abdc433209f65dc52db98bcbfa5608d6f6ed1`. Five files, 304 additions + 41 deletions = 345 A+D. Natural quick `34077840989` SUCCESS; natural visual `34077840930` SUCCESS. Independent exact-head PASS: https://github.com/rigplane/rigplane-core/pull/3310#issuecomment-5564400876. Root read the complete final diff and both implementation/review reports. The canonical required gate and checks are rechecked immediately before guarded merge; informational metadata observation is not acceptance evidence.
