### PR TITLE
feat(MOR-2425): add persistent RF host prerequisite

### DIFF
--- a/frontend/src/semantic/RfFrontEndInstrumentHost.svelte
+++ b/frontend/src/semantic/RfFrontEndInstrumentHost.svelte
@@ -117,6 +117,7 @@
     min: RF_FRONT_END_LEVELS[0][2], max: RF_FRONT_END_LEVELS[0][3],
     step: RF_FRONT_END_LEVELS[0][4], defaultValue: null, fineStepDivisor: 10,
   } as const;
+  const feedbackIntegratedControl = { 'feedback-policy': 'feedback-integrated' } as const;
   const currentAuthority = (): RfAuthority | null => published === null ? null : authority(published);
   const presentedAuthority = (): RfAuthority | null => authority(
     presentation, presentation.controlModel,
@@ -363,6 +364,7 @@
       <span class="rf-front-end-name">{label}</span>
       {#key rendererEpoch}
         <ValueControl
+          {...feedbackIntegratedControl}
           binding={binding} {label} renderer="hbar" showLabel={false} showValue={false} compact={true}
           displayFn={valueText} issuedStatusPresentation={scalarIssuedStatuses[field]}
         />

--- a/frontend/src/semantic/RfFrontEndInstrumentHost.svelte
+++ b/frontend/src/semantic/RfFrontEndInstrumentHost.svelte
@@ -1,0 +1,403 @@
+<script lang="ts">
+  import { onDestroy, onMount, untrack, type Snippet } from 'svelte';
+  import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
+  import DualParamRenderer from '../components-v2/controls/value-control/DualParamRenderer.svelte';
+  import { ValueControl } from '../components-v2/controls/value-control';
+  import type {
+    DualParamIssuedStatusPresentation,
+    DualParamIssuedStatusSnapshot,
+    DualParamLane,
+  } from '../components-v2/controls/value-control/dual-param-issued-status';
+  import type {
+    HBarIssuedStatusPresentation,
+    HBarIssuedStatusSnapshot,
+  } from '../components-v2/controls/value-control/skin';
+  import {
+    createContinuousPair,
+    createRenderedNativeRangeContinuousPairPolicy,
+    type ContinuousPairInput,
+    type ContinuousPairView,
+  } from '../primitives/scalar/continuous-pair.svelte';
+  import {
+    createContinuousScalar,
+    createRenderedNativeRangeContinuousScalarPolicy,
+    type CommandScalarFeedback,
+    type ContinuousScalarInput,
+    type ContinuousScalarView,
+  } from '../primitives/scalar/continuous-scalar.svelte';
+  import { formatKnownLevel } from './format-level';
+  import type { RadioViewModel, RfFrontEndField } from './radio-view-model';
+  import {
+    RF_FRONT_END_LEVELS,
+    type RfFrontEndAuthorityPublication,
+    type RfFrontEndInstrumentPresentation,
+    type RfFrontEndLevelField,
+    type RfFrontEndLevelHandles,
+    type RfSqlControlModel,
+    type SubscribeRfFrontEndAuthority,
+  } from './rf-front-end-instruments';
+
+  interface Props {
+    presentation: RfFrontEndInstrumentPresentation;
+    subscribeControlAuthority: SubscribeRfFrontEndAuthority;
+    onLevelChange?: (field: RfFrontEndLevelField, value: number) => void;
+    children: Snippet<[RfFrontEndLevelHandles]>;
+  }
+
+  type Receiver = 'MAIN' | 'SUB';
+  interface RfAuthority {
+    readonly epoch: number;
+    readonly generation: number;
+    readonly topologyId: string;
+    readonly receiver: Receiver;
+    readonly form: RfSqlControlModel;
+  }
+
+  let { presentation, subscribeControlAuthority, onLevelChange, children }: Props = $props();
+  let published = $state.raw<RfFrontEndAuthorityPublication | null>(null);
+  let lastAuthority: RfAuthority | null | undefined;
+  let stop: (() => void) | null = null;
+  let rf = $derived(presentation.view?.rfFrontEnd);
+
+  const safeGeneration = (value: unknown): value is number =>
+    typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+  const usable = (field: RfFrontEndField<unknown> | undefined): boolean =>
+    field?.availability.structural === true
+    && field.availability.operational
+    && field.reading.status === 'known';
+  function formOf(view: RadioViewModel, requested: RfSqlControlModel): RfSqlControlModel {
+    return requested === 'combined'
+      && view.rfFrontEnd?.rfGain.availability.structural === true
+      && view.rfFrontEnd.squelch.availability.structural
+      ? 'combined' : 'separate';
+  }
+  function authority(
+    source: RfFrontEndAuthorityPublication,
+    requested = source.caps?.rfSqlControlModel ?? 'separate',
+  ): RfAuthority | null {
+    const stateGeneration = source.state?.providerGeneration;
+    const capsGeneration = source.caps?.providerGeneration;
+    if (source.session.state !== 'connected'
+      || !safeGeneration(source.session.epoch)
+      || !safeGeneration(stateGeneration)
+      || !safeGeneration(capsGeneration)
+      || stateGeneration !== capsGeneration) return null;
+    const view = toRadioViewModel(source.state, source.caps);
+    if (view === null || view.activeReceiver.status !== 'known') return null;
+    return {
+      epoch: source.session.epoch,
+      generation: stateGeneration,
+      topologyId: view.topologyId,
+      receiver: view.activeReceiver.receiver,
+      form: formOf(view, requested),
+    };
+  }
+  function same(left: RfAuthority | null, right: RfAuthority | null): boolean {
+    if (left === null || right === null) return left === right;
+    return left.epoch === right.epoch
+      && left.generation === right.generation
+      && left.topologyId === right.topologyId
+      && left.receiver === right.receiver
+      && left.form === right.form;
+  }
+  const authorityKey = (value: RfAuthority | null, field?: RfFrontEndLevelField): string =>
+    value === null ? `rf-front-end:inactive:${field ?? 'pair'}` : JSON.stringify([
+      'rf-front-end', field ?? 'pair', value.epoch, value.generation,
+      value.topologyId, value.receiver, value.form,
+    ]);
+
+  let currentForm = $derived(presentation.view === null
+    ? 'separate' : formOf(presentation.view, presentation.controlModel));
+  const laneFor = (field: RfFrontEndLevelField): DualParamLane =>
+    field === 'rfGain' ? 'rf' : 'sql';
+  const PAIR_LANES: readonly DualParamLane[] = ['rf', 'sql'];
+  const row = (field: RfFrontEndLevelField) =>
+    RF_FRONT_END_LEVELS.find(([candidate]) => candidate === field)!;
+  const domain = {
+    min: RF_FRONT_END_LEVELS[0][2], max: RF_FRONT_END_LEVELS[0][3],
+    step: RF_FRONT_END_LEVELS[0][4], defaultValue: null, fineStepDivisor: 10,
+  } as const;
+  const currentAuthority = (): RfAuthority | null => published === null ? null : authority(published);
+  const presentedAuthority = (): RfAuthority | null => authority(
+    presentation, presentation.controlModel,
+  );
+  const authorityCurrent = (): boolean => same(currentAuthority(), presentedAuthority());
+
+  function request(field: RfFrontEndLevelField, value: number): void {
+    if (!authorityCurrent()) return;
+    if (presentation.rfSqlFeedback === undefined) {
+      if (usable(rf?.[field])) onLevelChange?.(field, value);
+    } else if (presentation.rfSqlFeedback !== null) {
+      onLevelChange?.(field, value);
+    }
+  }
+  function pairInput(): Readonly<ContinuousPairInput> {
+    const common = {
+      domain,
+      requestRf: (value: number) => request('rfGain', value),
+      requestSql: (value: number) => request('squelch', value),
+    };
+    const feedback = presentation.rfSqlFeedback;
+    if (feedback === null) return {
+      ...common, evidence: 'reading', enabled: false,
+      ownerKey: authorityKey(currentAuthority()),
+      rf: { reading: { status: 'unknown' }, availability: 'unavailable' },
+      sql: { reading: { status: 'unknown' }, availability: 'unavailable' },
+    };
+    if (feedback !== undefined) return {
+      ...common, evidence: 'command-feedback', rf: feedback.rf, sql: feedback.sql,
+      enabled: authorityCurrent() && currentForm === 'combined' && onLevelChange !== undefined,
+    };
+    const availability = (field: RfFrontEndField<number> | undefined) =>
+      field?.availability.structural && field.availability.operational
+        ? 'available' as const : 'unavailable' as const;
+    return {
+      ...common, evidence: 'reading', ownerKey: authorityKey(currentAuthority()),
+      enabled: authorityCurrent() && currentForm === 'combined' && onLevelChange !== undefined,
+      rf: {
+        reading: rf?.rfGain.reading ?? { status: 'unknown' },
+        availability: availability(rf?.rfGain),
+      },
+      sql: {
+        reading: rf?.squelch.reading ?? { status: 'unknown' },
+        availability: availability(rf?.squelch),
+      },
+    };
+  }
+  function scalarInput(field: RfFrontEndLevelField): Readonly<ContinuousScalarInput> {
+    const common = { domain, request: (value: number) => request(field, value) };
+    const feedback = presentation.rfSqlFeedback;
+    if (feedback === null) return {
+      ...common, evidence: 'reading', enabled: false,
+      ownerKey: authorityKey(currentAuthority(), field), reading: { status: 'unknown' },
+    };
+    if (feedback !== undefined) {
+      const lane = feedback[laneFor(field)];
+      return {
+        ...common, evidence: 'command-feedback', command: lane.command, feedback: lane.feedback,
+        enabled: authorityCurrent() && currentForm === 'separate'
+          && rf?.[field].availability.structural === true && onLevelChange !== undefined,
+      };
+    }
+    const fact = rf?.[field];
+    return {
+      ...common, evidence: 'reading', ownerKey: authorityKey(currentAuthority(), field),
+      enabled: authorityCurrent() && currentForm === 'separate'
+        && usable(fact) && onLevelChange !== undefined,
+      reading: fact?.reading ?? { status: 'unknown' },
+    };
+  }
+
+  const pair = createContinuousPair(pairInput, createRenderedNativeRangeContinuousPairPolicy());
+  const scalars = {
+    rfGain: createContinuousScalar(
+      () => scalarInput('rfGain'), createRenderedNativeRangeContinuousScalarPolicy(),
+    ),
+    squelch: createContinuousScalar(
+      () => scalarInput('squelch'), createRenderedNativeRangeContinuousScalarPolicy(),
+    ),
+  } satisfies Record<RfFrontEndLevelField, ReturnType<typeof createContinuousScalar>>;
+  let pairView = $state.raw<Readonly<ContinuousPairView>>(untrack(() => pair.view));
+  let scalarViews = $state.raw<Record<RfFrontEndLevelField, Readonly<ContinuousScalarView>>>({
+    rfGain: untrack(() => scalars.rfGain.view),
+    squelch: untrack(() => scalars.squelch.view),
+  });
+  $effect(() => { pairView = pair.view; });
+  $effect(() => {
+    scalarViews = { rfGain: scalars.rfGain.view, squelch: scalars.squelch.view };
+  });
+
+  let issuedStatus = $state<Record<RfFrontEndLevelField, string | null>>({
+    rfGain: null, squelch: null,
+  });
+  let rendererEpoch = $state(0);
+  let issuedStatusKey = $state<Record<RfFrontEndLevelField, string>>({
+    rfGain: '', squelch: '',
+  });
+  function acceptStatus(
+    field: RfFrontEndLevelField,
+    feedback: Readonly<CommandScalarFeedback>,
+    transitionId: string,
+    message: string,
+    error: string | null,
+  ): string {
+    issuedStatusKey[field] = JSON.stringify([
+      feedback.providerGeneration ?? null, feedback.sessionEpoch, feedback.scope.control,
+      feedback.scope.receiver, feedback.scope.slot ?? null, transitionId,
+    ]);
+    return error === null ? message : `${message.replace(/[.!?]$/, '')}: ${error}`;
+  }
+  const pairIssuedStatus: Readonly<DualParamIssuedStatusPresentation> = Object.freeze({
+    rf: {
+      get text() { return null; },
+      format: ({ laneView, announcement }: Readonly<DualParamIssuedStatusSnapshot>) => acceptStatus(
+        'rfGain', laneView.feedback, announcement.transitionId,
+        announcement.message, laneView.error,
+      ),
+      accept: (text: string | null) => { issuedStatus.rfGain = text; },
+    },
+    sql: {
+      get text() { return null; },
+      format: ({ laneView, announcement }: Readonly<DualParamIssuedStatusSnapshot>) => acceptStatus(
+        'squelch', laneView.feedback, announcement.transitionId,
+        announcement.message, laneView.error,
+      ),
+      accept: (text: string | null) => { issuedStatus.squelch = text; },
+    },
+  });
+  function scalarIssuedStatus(field: RfFrontEndLevelField): Readonly<HBarIssuedStatusPresentation> {
+    return {
+      get text() { return null; },
+      format({ view, announcement }: Readonly<HBarIssuedStatusSnapshot>) {
+        return acceptStatus(
+          field, view.feedback, announcement.transitionId, announcement.message, view.error,
+        );
+      },
+      accept(text) { issuedStatus[field] = text; },
+    };
+  }
+  const scalarIssuedStatuses = {
+    rfGain: scalarIssuedStatus('rfGain'), squelch: scalarIssuedStatus('squelch'),
+  } satisfies Record<RfFrontEndLevelField, Readonly<HBarIssuedStatusPresentation>>;
+
+  const feedbackIntegration = (): string => presentation.rfSqlFeedback === undefined
+    ? 'compatibility-reading'
+    : presentation.rfSqlFeedback === null ? 'authority-unresolved' : 'command-feedback';
+  const valueText = (value: number | null): string => value === null
+    ? '?' : formatKnownLevel(value, domain.min, domain.max);
+  function pairLaneValue(view: Readonly<ContinuousPairView>, lane: DualParamLane): number | null {
+    const laneView = view.lanes[lane];
+    return view.draft?.[lane]
+      ?? (laneView.evidence === 'command-feedback' ? laneView.feedback.target : null)
+      ?? laneView.canonical;
+  }
+  function scalarValue(view: Readonly<ContinuousScalarView>): number | null {
+    return view.draft
+      ?? (view.evidence === 'command-feedback' ? view.feedback.target : null)
+      ?? view.canonical;
+  }
+  function status(view: Readonly<ContinuousScalarView>): string {
+    if (view.evidence !== 'command-feedback' || view.phase === 'idle') return '';
+    const target = view.feedback.target ?? view.feedback.requestedTarget;
+    return `${view.phase.replaceAll('-', ' ')}${target === null ? '' : `; requested ${valueText(target)}`}`
+      + `; confirmed ${valueText(view.canonical)}${view.error === null ? '' : `; ${view.error}`}`;
+  }
+  function pairStatus(view: Readonly<ContinuousPairView>, lane: DualParamLane): string {
+    const laneView = view.lanes[lane];
+    if (laneView.evidence !== 'command-feedback' || laneView.phase === 'idle') return '';
+    const target = laneView.feedback.target ?? laneView.feedback.requestedTarget;
+    return `${laneView.phase.replaceAll('-', ' ')}${target === null ? '' : `; requested ${valueText(target)}`}`
+      + `; confirmed ${valueText(laneView.canonical)}`
+      + `${laneView.error === null ? '' : `; ${laneView.error}`}`;
+  }
+
+  onMount(() => {
+    stop = subscribeControlAuthority((next) => {
+      const nextAuthority = authority(next);
+      if (lastAuthority !== undefined && !same(lastAuthority, nextAuthority)) {
+        pair.cancel('authority');
+        scalars.rfGain.cancel('authority');
+        scalars.squelch.cancel('authority');
+        pair.attachRenderer().dispose();
+        scalars.rfGain.attachRenderer().dispose();
+        scalars.squelch.attachRenderer().dispose();
+        issuedStatus = { rfGain: null, squelch: null };
+        rendererEpoch += 1;
+      }
+      lastAuthority = nextAuthority;
+      published = next;
+    });
+  });
+  onDestroy(() => {
+    try { stop?.(); } finally {
+      pair.destroy();
+      scalars.rfGain.destroy();
+      scalars.squelch.destroy();
+    }
+  });
+</script>
+
+{#snippet rfSql()}
+  {@const view = pairView}
+  <div
+    class="rf-front-end-level" data-testid="rf-front-end-rf-sql"
+    data-feedback-integration={feedbackIntegration()}
+    data-observed={view.lanes.rf.availability === 'available'
+      && view.lanes.sql.availability === 'available'
+      && view.canonical.rf !== null && view.canonical.sql !== null}
+    data-rf-command-phase={view.lanes.rf.phase ?? undefined}
+    data-sql-command-phase={view.lanes.sql.phase ?? undefined}
+    aria-busy={view.busy}
+  >
+    <span class="rf-front-end-name">RF/SQL</span>
+    {#key rendererEpoch}
+      <DualParamRenderer binding={pair} showValues={false}
+        issuedStatusPresentation={pairIssuedStatus} />
+    {/key}
+    <output data-testid="rf-front-end-rf-sql-rf-value">{valueText(pairLaneValue(view, 'rf'))}</output>
+    /
+    <output data-testid="rf-front-end-rf-sql-sql-value">{valueText(pairLaneValue(view, 'sql'))}</output>
+    {#each PAIR_LANES as lane (lane)}
+      {@const currentStatus = pairStatus(view, lane)}
+      {#if currentStatus !== ''}
+        <output data-testid={`rf-front-end-rf-sql-${lane}-status`}>{currentStatus}</output>
+      {/if}
+    {/each}
+  </div>
+{/snippet}
+
+{#snippet scalar(field: RfFrontEndLevelField)}
+  {@const current = rf?.[field]}
+  {#if current?.availability.structural}
+    {@const binding = scalars[field]}
+    {@const view = scalarViews[field]}
+    {@const [, label] = row(field)}
+    {@const currentStatus = status(view)}
+    <div
+      class="rf-front-end-level" data-testid={`rf-front-end-${field}`}
+      data-feedback-integration={feedbackIntegration()}
+      data-observed={view.canonical !== null}
+      data-command-phase={view.phase ?? undefined}
+      aria-busy={view.busy}
+    >
+      <span class="rf-front-end-name">{label}</span>
+      {#key rendererEpoch}
+        <ValueControl
+          binding={binding} {label} renderer="hbar" showLabel={false} showValue={false} compact={true}
+          displayFn={valueText} issuedStatusPresentation={scalarIssuedStatuses[field]}
+        />
+      {/key}
+      <output>{valueText(scalarValue(view))}</output>
+      {#if currentStatus !== ''}
+        <output data-testid={`rf-front-end-${field}-status`}>{currentStatus}</output>
+      {/if}
+    </div>
+  {/if}
+{/snippet}
+
+{#snippet rfGain()}{@render scalar('rfGain')}{/snippet}
+{#snippet squelch()}{@render scalar('squelch')}{/snippet}
+
+{@render children(currentForm === 'combined'
+  ? { kind: 'combined', rfSql }
+  : { kind: 'separate', rfGain, squelch })}
+
+{#each RF_FRONT_END_LEVELS as [field] (field)}
+  {#if issuedStatus[field] !== null}
+    {#key issuedStatusKey[field]}
+      <span class="sr-only" role="status" aria-live="polite" aria-atomic="true"
+        data-control-feedback-status data-feedback-lane={laneFor(field)}>{issuedStatus[field]}</span>
+    {/key}
+  {/if}
+{/each}
+
+<style>
+  .rf-front-end-level { display: flex; align-items: baseline; gap: 0.5rem; }
+  .rf-front-end-name { min-width: 6ch; }
+  .rf-front-end-level :global(.vc-hbar),
+  .rf-front-end-level :global(.vc-dual) { width: 100%; min-width: 0; }
+  .sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+  }
+</style>

--- a/frontend/src/semantic/RfFrontEndInstrumentHost.svelte
+++ b/frontend/src/semantic/RfFrontEndInstrumentHost.svelte
@@ -122,7 +122,10 @@
   const presentedAuthority = (): RfAuthority | null => authority(
     presentation, presentation.controlModel,
   );
-  const authorityCurrent = (): boolean => same(currentAuthority(), presentedAuthority());
+  const authorityCurrent = (): boolean => {
+    const current = currentAuthority();
+    return current !== null && same(current, presentedAuthority());
+  };
 
   function request(field: RfFrontEndLevelField, value: number): void {
     if (!authorityCurrent()) return;

--- a/frontend/src/semantic/__tests__/RfFrontEndInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/RfFrontEndInstrumentHost.isolated.test.ts
@@ -1,0 +1,397 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
+import type { Capabilities, VfoScheme } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
+
+const activation = vi.hoisted(() => ({ selected: undefined as unknown }));
+const captures = vi.hoisted(() => ({
+  pairs: [] as unknown[], scalars: [] as unknown[], lifecycle: [] as string[],
+}));
+vi.mock('../../component-kits/activation', () => ({
+  getSelectedScalarAppearance: () => activation.selected,
+}));
+vi.mock('../../primitives/scalar/continuous-pair.svelte', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../primitives/scalar/continuous-pair.svelte')>();
+  return {
+    ...actual,
+    createContinuousPair: (...args: Parameters<typeof actual.createContinuousPair>) => {
+      const binding = actual.createContinuousPair(...args);
+      const destroy = binding.destroy.bind(binding);
+      vi.spyOn(binding, 'cancel');
+      vi.spyOn(binding, 'destroy').mockImplementation(() => {
+        captures.lifecycle.push('pair-destroy'); destroy();
+      });
+      captures.pairs.push(binding);
+      return binding;
+    },
+  };
+});
+vi.mock('../../primitives/scalar/continuous-scalar.svelte', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../primitives/scalar/continuous-scalar.svelte')>();
+  return {
+    ...actual,
+    createContinuousScalar: (...args: Parameters<typeof actual.createContinuousScalar>) => {
+      const binding = actual.createContinuousScalar(...args);
+      const destroy = binding.destroy.bind(binding);
+      vi.spyOn(binding, 'cancel');
+      vi.spyOn(binding, 'destroy').mockImplementation(() => {
+        captures.lifecycle.push('scalar-destroy'); destroy();
+      });
+      captures.scalars.push(binding);
+      return binding;
+    },
+  };
+});
+
+import ExternalScalarRenderer from '../../components-v2/controls/value-control/__tests__/ExternalScalarRendererFixture.svelte';
+import type { Skin } from '../../components-v2/controls/value-control/skin';
+import type { ContinuousPairBinding } from '../../primitives/scalar/continuous-pair.svelte';
+import type { ContinuousScalarBinding } from '../../primitives/scalar/continuous-scalar.svelte';
+import Fixture from './fixtures/RfFrontEndInstrumentHostFixture.svelte';
+import type {
+  RfFrontEndAuthorityPublication as Publication,
+  RfFrontEndLevelFeedback,
+  RfSqlControlModel,
+  SubscribeRfFrontEndAuthority,
+} from '../rf-front-end-instruments';
+
+const fresh = {
+  storePath: 'x', observed: true, freshness: 'fresh', availability: 'available',
+  lastObservedMonotonic: 1,
+};
+const observed = () => ({ ...fresh });
+const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
+
+function capabilities(options: {
+  receivers?: number; generation?: number; scheme?: VfoScheme;
+  controlModel?: RfSqlControlModel; omit?: 'rf_gain' | 'squelch';
+} = {}): Capabilities {
+  const receivers = options.receivers ?? 2;
+  const tags = ['audio', 'dual_rx', 'rf_gain', 'squelch']
+    .filter((tag) => tag !== options.omit);
+  return {
+    stateContractVersion: 1, providerGeneration: options.generation ?? 1,
+    model: 'RF-HOST-TEST', scope: false, audio: true, tx: false, capabilities: tags,
+    receivers, vfoScheme: options.scheme ?? (receivers === 2 ? 'main_sub' : 'single'),
+    freqRanges: [], modes: [], filters: [], preValues: [], attValues: [],
+    audioConfig: { sampleRate: 48_000, channels: 1, codecs: [] },
+    webrtc: { available: false, enabled: false }, txBands: null,
+    rfSqlControlModel: options.controlModel ?? 'combined',
+  } as Capabilities;
+}
+
+function state(options: {
+  receivers?: number; generation?: number; active?: 'MAIN' | 'SUB'; activeKnown?: boolean;
+  rfGain?: number; squelch?: number;
+} = {}): ServerState {
+  const receivers = options.receivers ?? 2;
+  const receiver = (freqHz: number) => ({
+    ...slot(freqHz), vfoA: slot(freqHz), vfoB: slot(freqHz + 50_000), activeSlot: 'A',
+    filter: 1, afLevel: 0.5, rfGain: options.rfGain ?? 1, squelch: options.squelch ?? 0,
+    sMeter: 0, att: 0, preamp: 0, nb: false, nr: false,
+  });
+  const paths = ['split', 'dualWatch', 'txTarget', 'main.freqHz', 'main.mode', 'main.filter',
+    'main.activeSlot', 'main.rfGain', 'main.squelch'];
+  if (options.activeKnown !== false) paths.push('active');
+  if (receivers === 2) paths.push('sub.freqHz', 'sub.mode', 'sub.filter', 'sub.activeSlot',
+    'sub.rfGain', 'sub.squelch');
+  return {
+    stateContractVersion: 1, providerGeneration: options.generation ?? 1,
+    revision: 1, stateRevision: 1, freshnessRevision: 1, observationSeq: 1,
+    updatedAt: '2026-09-07T00:00:00Z', active: options.active ?? 'MAIN',
+    ptt: false, split: false, dualWatch: false, tunerStatus: 0,
+    txTarget: { status: 'unknown', reason: 'not-observed' },
+    main: receiver(14_250_000), ...(receivers === 2 ? { sub: receiver(14_300_000) } : {}),
+    connection: {} as ServerState['connection'],
+    fieldStatus: Object.fromEntries(paths.map((path) => [path, observed()])),
+  } as ServerState;
+}
+
+function publication(options: {
+  epoch?: number; generation?: number; capsGeneration?: number; receivers?: number;
+  scheme?: VfoScheme; active?: 'MAIN' | 'SUB'; activeKnown?: boolean;
+  controlModel?: RfSqlControlModel; omit?: 'rf_gain' | 'squelch'; rfGain?: number; squelch?: number;
+  sessionState?: Publication['session']['state'];
+} = {}): Publication {
+  const generation = options.generation ?? 1;
+  const receivers = options.receivers ?? 2;
+  return {
+    state: state({
+      generation, receivers, active: options.active, activeKnown: options.activeKnown,
+      rfGain: options.rfGain, squelch: options.squelch,
+    }),
+    caps: capabilities({
+      generation: options.capsGeneration ?? generation, receivers, scheme: options.scheme,
+      controlModel: options.controlModel, omit: options.omit,
+    }),
+    session: { state: options.sessionState ?? 'connected', epoch: options.epoch ?? 1 },
+  };
+}
+
+type LaneFeedback = RfFrontEndLevelFeedback['rf'];
+function commandFeedback(
+  over: Partial<Record<'rf' | 'sql', Partial<LaneFeedback['feedback']>>> = {},
+): RfFrontEndLevelFeedback {
+  const lane = (name: 'rf' | 'sql', confirmed: number): LaneFeedback => ({
+    command: name === 'rf' ? 'set_rf_gain' : 'set_squelch',
+    feedback: {
+      confirmed, target: null, requestedTarget: null, phase: 'idle', busy: false,
+      availability: 'available', lifecycleId: null, transitionId: null, outcome: null,
+      providerGeneration: 1, sessionEpoch: 1,
+      scope: { control: name === 'rf' ? 'rf-gain' : 'squelch', receiver: 0 },
+      repeatPolicy: 'latest-target-wins', ...over[name],
+    },
+  });
+  return { rf: lane('rf', 0.5), sql: lane('sql', 0.2) };
+}
+
+class Publisher {
+  handlers = new Set<(next: Publication) => void>();
+  constructor(public current: Publication) {}
+  subscribe: SubscribeRfFrontEndAuthority = (handler) => {
+    this.handlers.add(handler); handler(this.current);
+    return () => { captures.lifecycle.push('unsubscribe'); this.handlers.delete(handler); };
+  };
+  emit(next: Publication): void {
+    this.current = next;
+    this.handlers.forEach((handler) => handler(next));
+  }
+}
+
+type Props = {
+  publication: Publication;
+  view: ReturnType<typeof toRadioViewModel>;
+  subscribeControlAuthority: SubscribeRfFrontEndAuthority;
+  controlModel: RfSqlControlModel;
+  rfSqlFeedback?: RfFrontEndLevelFeedback | null;
+  layout: 'grouped' | 'independent';
+  onLevelChange: (field: 'rfGain' | 'squelch', value: number) => void;
+};
+
+let target: HTMLDivElement;
+let mounted: ReturnType<typeof mount>[] = [];
+beforeEach(() => {
+  target = document.createElement('div'); document.body.appendChild(target);
+  activation.selected = { name: 'RF host test', hbar: ExternalScalarRenderer } satisfies Skin;
+  captures.pairs = []; captures.scalars = []; captures.lifecycle = [];
+});
+afterEach(() => {
+  mounted.forEach((component) => unmount(component)); mounted = [];
+  activation.selected = undefined; target.remove();
+});
+
+function render(initial = publication(), rfSqlFeedback?: RfFrontEndLevelFeedback | null) {
+  const publisher = new Publisher(initial);
+  const onLevelChange = vi.fn<Props['onLevelChange']>();
+  const props = proxy<Props>({
+    publication: initial, view: toRadioViewModel(initial.state, initial.caps),
+    subscribeControlAuthority: publisher.subscribe,
+    controlModel: initial.caps?.rfSqlControlModel ?? 'separate',
+    rfSqlFeedback, layout: 'grouped', onLevelChange,
+  });
+  const component = mount(Fixture, { target, props }); mounted.push(component); flushSync();
+  const transition = (next: Publication) => {
+    props.publication = next;
+    props.view = toRadioViewModel(next.state, next.caps);
+    props.controlModel = next.caps?.rfSqlControlModel ?? 'separate';
+    publisher.emit(next);
+  };
+  const setFeedback = (next: RfFrontEndLevelFeedback | null | undefined) => {
+    props.rfSqlFeedback = next;
+  };
+  return { publisher, props, component, onLevelChange, transition, setFeedback };
+}
+
+describe('RfFrontEndInstrumentHost', () => {
+  it('creates and destroys one pair plus its three scalar primitives exactly once', () => {
+    const r = render();
+    const pair = captures.pairs[0] as ContinuousPairBinding;
+    const scalars = [...captures.scalars] as ContinuousScalarBinding[];
+    expect(captures.pairs).toHaveLength(1);
+    expect(captures.scalars).toHaveLength(3);
+    expect(r.publisher.handlers).toHaveLength(1);
+    expect(target.querySelector('[data-handle-kind="combined"]')).not.toBeNull();
+    expect(target.querySelectorAll('[data-slot]')).toHaveLength(1);
+    unmount(r.component); mounted = [];
+    expect(r.publisher.handlers).toHaveLength(0);
+    expect(captures.lifecycle[0]).toBe('unsubscribe');
+    expect(pair.destroy).toHaveBeenCalledOnce();
+    for (const scalar of scalars) expect(scalar.destroy).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ['session', () => publication({ epoch: 2 })],
+    ['session state', () => publication({ sessionState: 'reconnecting' })],
+    ['provider', () => publication({ generation: 2 })],
+    ['provider mismatch', () => publication({ capsGeneration: 2 })],
+    ['topology', () => publication({ scheme: 'ab_shared' })],
+    ['receiver', () => publication({ active: 'SUB' })],
+    ['receiver knowledge', () => publication({ activeKnown: false })],
+    ['effective form', () => publication({ controlModel: 'separate' })],
+  ] as const)('cancels a pointer across synchronous %s A-B-A', (_name, middle) => {
+    const r = render();
+    const binding = captures.pairs[0] as ContinuousPairBinding;
+    const lease = binding.attachRenderer();
+    const token = lease.beginPointer(); expect(token).not.toBeNull();
+
+    r.transition(middle());
+    r.transition(publication());
+    lease.pointer(token!, 1); lease.endPointer(token!);
+    expect(r.onLevelChange).not.toHaveBeenCalled();
+
+    const fresh = binding.attachRenderer();
+    expect(lease.key({ key: 'End', fine: false })).toBe(false);
+    expect(fresh.key({ key: 'End', fine: false })).toBe(true);
+    expect(r.onLevelChange).toHaveBeenCalledExactlyOnceWith('squelch', 1);
+  });
+
+  it('replaces combined with exactly two separate handles without recreating owners', () => {
+    const r = render();
+    const pair = captures.pairs[0] as ContinuousPairBinding;
+    const scalars = [...captures.scalars] as ContinuousScalarBinding[];
+    r.transition(publication({ controlModel: 'separate' })); flushSync();
+
+    expect(target.querySelector('[data-handle-kind="separate"]')).not.toBeNull();
+    expect(target.querySelectorAll('[data-slot]')).toHaveLength(2);
+    expect(captures.pairs).toEqual([pair]);
+    expect(captures.scalars).toEqual(scalars);
+  });
+
+  it('falls back to separate handles and renders only the structurally present field', () => {
+    render(publication({ omit: 'squelch' }));
+    expect(target.querySelector('[data-handle-kind="separate"]')).not.toBeNull();
+    expect(target.querySelectorAll('[role="slider"]')).toHaveLength(1);
+    expect(target.querySelector('[data-testid="rf-front-end-rfGain"]')).not.toBeNull();
+    expect(target.querySelector('[data-testid="rf-front-end-squelch"]')).toBeNull();
+  });
+
+  it('keeps undefined compatibility, explicit null, and authoritative feedback distinct', () => {
+    const r = render();
+    const group = () => target.querySelector<HTMLElement>('[data-testid="rf-front-end-rf-sql"]')!;
+    const slider = () => group().querySelector<HTMLElement>('[role="slider"]')!;
+    expect(group().dataset.feedbackIntegration).toBe('compatibility-reading');
+    expect(group().textContent).toContain('100%');
+    expect(slider().getAttribute('aria-disabled')).toBe('false');
+
+    r.setFeedback(null); flushSync();
+    expect(group().dataset.feedbackIntegration).toBe('authority-unresolved');
+    expect(group().textContent).toContain('? / ?');
+    expect(slider().getAttribute('aria-disabled')).toBe('true');
+
+    r.setFeedback(commandFeedback()); flushSync();
+    expect(group().dataset.feedbackIntegration).toBe('command-feedback');
+    expect(group().textContent).toContain('50% / 20%');
+    expect(slider().getAttribute('aria-disabled')).toBe('false');
+
+    r.setFeedback(commandFeedback({ rf: { availability: 'unavailable' } })); flushSync();
+    expect(group().dataset.observed).toBe('false');
+    expect(slider().getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('keeps one pair announcement outside a keyed renderer replacement', () => {
+    const r = render(publication(), commandFeedback());
+    r.setFeedback(commandFeedback({ rf: {
+      target: 0.75, requestedTarget: 0.75, phase: 'awaiting-confirmation', busy: true,
+      lifecycleId: 'rf-75', transitionId: 'rf-awaiting-75',
+    } }));
+    flushSync();
+    const statuses = () => target.querySelectorAll<HTMLElement>('[data-control-feedback-status]');
+    expect(statuses()).toHaveLength(1);
+    expect(statuses()[0].textContent).toContain('Awaiting confirmation: 0.75');
+    expect(target.querySelector('[data-testid="rf-front-end-rf-sql-rf-status"]')?.textContent)
+      .toContain('requested 75%; confirmed 50%');
+
+    r.props.layout = 'independent'; flushSync();
+    expect(statuses()).toHaveLength(1);
+    expect(statuses()[0].textContent).toContain('Awaiting confirmation: 0.75');
+  });
+
+  it('keeps one failed scalar announcement and its error across renderer replacement', () => {
+    activation.selected = undefined;
+    const initial = publication({ controlModel: 'separate' });
+    const r = render(initial, commandFeedback());
+    r.setFeedback(commandFeedback({ rf: {
+      requestedTarget: 0.4, phase: 'failed', lifecycleId: 'rf-40',
+      transitionId: 'rf-failed-40', outcome: { phase: 'failed', error: 'denied' },
+    } }));
+    flushSync();
+    const statuses = () => target.querySelectorAll<HTMLElement>('[data-control-feedback-status]');
+    expect(statuses()).toHaveLength(1);
+    expect(statuses()[0].textContent).toContain('Failed: 0.4: denied');
+    expect(target.querySelector('[data-testid="rf-front-end-rfGain-status"]')?.textContent)
+      .toContain('requested 40%; confirmed 50%; denied');
+
+    r.props.layout = 'independent'; flushSync();
+    expect(statuses()).toHaveLength(1);
+    expect(statuses()[0].textContent).toContain('Failed: 0.4: denied');
+  });
+
+  it('retires issued status when authority changes', () => {
+    const r = render(publication(), commandFeedback());
+    r.setFeedback(commandFeedback({ rf: {
+      requestedTarget: 0.4, phase: 'failed', lifecycleId: 'rf-40',
+      transitionId: 'rf-failed-40', outcome: { phase: 'failed', error: 'denied' },
+    } }));
+    flushSync();
+    expect(target.querySelectorAll('[data-control-feedback-status]')).toHaveLength(1);
+    r.transition(publication({ generation: 2 })); flushSync();
+    expect(target.querySelectorAll('[data-control-feedback-status]')).toHaveLength(0);
+  });
+
+  it.each(['native', 'key', 'wheel'] as const)('makes stale %s input inert after same-task A-B-A', (kind) => {
+    const r = render();
+    const binding = captures.pairs[0] as ContinuousPairBinding;
+    const stale = binding.attachRenderer();
+    r.transition(publication({ generation: 2 }));
+    r.transition(publication());
+    if (kind === 'native') stale.nativeInput(1);
+    else if (kind === 'key') expect(stale.key({ key: 'End', fine: false })).toBe(false);
+    else stale.wheel({ direction: 1, fine: false });
+    expect(r.onLevelChange).not.toHaveBeenCalled();
+
+    const fresh = binding.attachRenderer();
+    expect(fresh.key({ key: 'End', fine: false })).toBe(true);
+    expect(r.onLevelChange).toHaveBeenCalledExactlyOnceWith('squelch', 1);
+  });
+
+  it.each(['pointer', 'native', 'key', 'wheel'] as const)(
+    'makes a stale standalone scalar %s inert while a fresh lease dispatches', (kind) => {
+      const initial = publication({ controlModel: 'separate' });
+      const r = render(initial);
+      const binding = captures.scalars.at(-1) as ContinuousScalarBinding;
+      const stale = binding.attachRenderer();
+      const token = kind === 'pointer' ? stale.beginPointer() : null;
+      r.transition(publication({ controlModel: 'separate', generation: 2 }));
+      r.transition(initial);
+      if (kind === 'pointer') { stale.pointer(token!, 1); stale.endPointer(token!); }
+      else if (kind === 'native') stale.nativeInput(1);
+      else if (kind === 'key') expect(stale.key({ key: 'End', fine: false })).toBe(false);
+      else stale.wheel({ direction: 1, fine: false });
+      expect(r.onLevelChange).not.toHaveBeenCalled();
+
+      expect(binding.attachRenderer().key({ key: 'End', fine: false })).toBe(true);
+      expect(r.onLevelChange).toHaveBeenCalledExactlyOnceWith('squelch', 1);
+    },
+  );
+
+  it('does not cancel a healthy gesture for ordinary value and feedback updates', () => {
+    const r = render(publication(), commandFeedback());
+    const pair = captures.pairs[0] as ContinuousPairBinding;
+    const scalars = captures.scalars.slice(-2) as ContinuousScalarBinding[];
+    const lease = pair.attachRenderer();
+    const token = lease.beginPointer(); expect(token).not.toBeNull();
+
+    r.transition(publication({ rfGain: 0.8, squelch: 0.1 }));
+    r.setFeedback(commandFeedback({ rf: { confirmed: 0.8 }, sql: { confirmed: 0.1 } }));
+    expect(pair.cancel).not.toHaveBeenCalled();
+    for (const scalar of scalars) expect(scalar.cancel).not.toHaveBeenCalled();
+
+    lease.pointer(token!, 1); lease.endPointer(token!);
+    expect(r.onLevelChange.mock.calls).toEqual([
+      ['rfGain', 1], ['squelch', 1],
+    ]);
+  });
+});

--- a/frontend/src/semantic/__tests__/RfFrontEndInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/RfFrontEndInstrumentHost.isolated.test.ts
@@ -377,6 +377,46 @@ describe('RfFrontEndInstrumentHost', () => {
     },
   );
 
+  it.each([
+    ['combined reading', 'combined', 'disconnected', undefined],
+    ['separate feedback', 'separate', 'reconnecting', commandFeedback()],
+  ] as const)('keeps fresh %s input inert without current authority', (
+    _name, controlModel, sessionState, feedback,
+  ) => {
+    const initial = publication({ controlModel });
+    const r = render(initial, feedback);
+    const binding = controlModel === 'combined'
+      ? captures.pairs[0] as ContinuousPairBinding
+      : captures.scalars.at(-1) as ContinuousScalarBinding;
+
+    r.transition(publication({ controlModel, sessionState })); flushSync();
+    const inactive = [...target.querySelectorAll<HTMLElement>('[role="slider"]')].at(-1)!;
+    expect(inactive.getAttribute('aria-disabled')).toBe('true');
+    expect(binding.attachRenderer().key({ key: 'End', fine: false })).toBe(false);
+    if (controlModel === 'combined') {
+      inactive.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    } else {
+      const node = inactive as HTMLElement & {
+        rendererLease: ReturnType<ContinuousScalarBinding['attachRenderer']>;
+      };
+      expect(node.rendererLease.key({ key: 'End', fine: false })).toBe(false);
+    }
+    expect(r.onLevelChange).not.toHaveBeenCalled();
+
+    r.transition(initial); flushSync();
+    const recovered = [...target.querySelectorAll<HTMLElement>('[role="slider"]')].at(-1)!;
+    expect(recovered.getAttribute('aria-disabled')).toBe('false');
+    if (controlModel === 'combined') {
+      recovered.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    } else {
+      const node = recovered as typeof inactive & {
+        rendererLease: ReturnType<ContinuousScalarBinding['attachRenderer']>;
+      };
+      expect(node.rendererLease.key({ key: 'End', fine: false })).toBe(true);
+    }
+    expect(r.onLevelChange).toHaveBeenCalledExactlyOnceWith('squelch', 1);
+  });
+
   it('does not cancel a healthy gesture for ordinary value and feedback updates', () => {
     const r = render(publication(), commandFeedback());
     const pair = captures.pairs[0] as ContinuousPairBinding;

--- a/frontend/src/semantic/__tests__/fixtures/RfFrontEndInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/RfFrontEndInstrumentHostFixture.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import RfFrontEndInstrumentHost from '../../RfFrontEndInstrumentHost.svelte';
+  import type { RadioViewModel } from '../../radio-view-model';
+  import type {
+    RfFrontEndAuthorityPublication,
+    RfFrontEndLevelFeedback,
+    RfFrontEndLevelField,
+    RfFrontEndLevelHandles,
+    RfSqlControlModel,
+    SubscribeRfFrontEndAuthority,
+  } from '../../rf-front-end-instruments';
+
+  interface Props {
+    publication: RfFrontEndAuthorityPublication;
+    view: RadioViewModel | null;
+    subscribeControlAuthority: SubscribeRfFrontEndAuthority;
+    controlModel: RfSqlControlModel;
+    rfSqlFeedback?: RfFrontEndLevelFeedback | null;
+    layout?: 'grouped' | 'independent';
+    onLevelChange?: (field: RfFrontEndLevelField, value: number) => void;
+  }
+
+  let {
+    publication, view, subscribeControlAuthority, controlModel, rfSqlFeedback,
+    layout = 'grouped', onLevelChange,
+  }: Props = $props();
+  let presentation = $derived({
+    ...publication, view, controlModel, rfSqlFeedback,
+  });
+</script>
+
+<RfFrontEndInstrumentHost
+  {presentation} {subscribeControlAuthority} {onLevelChange}
+>
+  {#snippet children(handles: RfFrontEndLevelHandles)}
+    {#key layout}
+      <section data-layout={layout} data-handle-kind={handles.kind}>
+        {#if handles.kind === 'combined'}
+          <div data-slot="rf-sql">{@render handles.rfSql()}</div>
+        {:else}
+          <div data-slot="rf-gain">{@render handles.rfGain()}</div>
+          <div data-slot="squelch">{@render handles.squelch()}</div>
+        {/if}
+      </section>
+    {/key}
+  {/snippet}
+</RfFrontEndInstrumentHost>

--- a/frontend/src/semantic/rf-front-end-instruments.ts
+++ b/frontend/src/semantic/rf-front-end-instruments.ts
@@ -1,0 +1,43 @@
+import type { Snippet } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import type { CommandFeedbackContinuousPairInput } from '../primitives/scalar/continuous-pair.svelte';
+import type { RadioViewModel } from './radio-view-model';
+
+export const RF_FRONT_END_LEVELS = [
+  ['rfGain', 'RF gain', 0, 1, 0.01],
+  ['squelch', 'Squelch', 0, 1, 0.01],
+] as const;
+
+export type RfFrontEndLevelField = (typeof RF_FRONT_END_LEVELS)[number][0];
+export type RfSqlControlModel = 'separate' | 'combined';
+export type RfFrontEndLevelFeedback = Readonly<
+  Pick<CommandFeedbackContinuousPairInput, 'rf' | 'sql'>
+>;
+
+export interface RfFrontEndControlSession {
+  readonly state: 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
+  readonly epoch: number;
+}
+
+export interface RfFrontEndAuthorityPublication {
+  readonly state: ServerState | null;
+  readonly caps: Capabilities | null;
+  readonly session: RfFrontEndControlSession;
+}
+
+export type SubscribeRfFrontEndAuthority = (
+  handler: (publication: RfFrontEndAuthorityPublication) => void,
+) => () => void;
+
+export type RfFrontEndInstrumentPresentation = Readonly<
+  RfFrontEndAuthorityPublication & {
+    readonly view: RadioViewModel | null;
+    readonly controlModel: RfSqlControlModel;
+    readonly rfSqlFeedback?: RfFrontEndLevelFeedback | null;
+  }
+>;
+
+export type RfFrontEndLevelHandles =
+  | Readonly<{ kind: 'combined'; rfSql: Snippet }>
+  | Readonly<{ kind: 'separate'; rfGain: Snippet; squelch: Snippet }>;


### PR DESCRIPTION
## Summary

- add the persistent RF/SQL host, authority publication contract, and discriminated combined/separate handles
- own one pair and two standalone scalar bindings across renderer replacement
- invalidate stale pointer, native, keyboard, and wheel leases synchronously across authority changes
- require a positive current authority before enabling reading or command-feedback input
- retain one host-owned issued-status lane across presentation replacement

## Scope boundary

This is a staged prerequisite for MOR-2425, not the live RF migration and not RF completion. It intentionally does not modify `RfFrontEndSurface`, SRS, layout, focus, SDK, primitives, or production consumers. The required-handle Surface adoption and live integration remain a dependent delivery.

This is one unit because the persistent owner, required publication and handle types, and mounted authority/renderer/status proofs establish one indivisible RF/SQL lifetime boundary. The dependent migration will replace the existing Surface owner with these handles.

## Delivery metadata

- Final exact head: `241cd10711fde427ae7cf0bf24d42200a1645556`
- Four code paths, zero PNG files, `+935/-0 = 935 A+D`
- Prerequisite only; production remains on the existing RfFrontEndSurface owner until the dependent live migration lands

## Verification

- Host isolated suite: 25/25 passed
- Host plus control-feedback debt inventory: 36/36 passed
- `npm run check`: 0 errors, 0 warnings
- Changed-file ESLint: passed
- `git diff --check`: passed
- Required quick [34079219754](https://github.com/rigplane/rigplane-core/actions/runs/34079219754): SUCCESS
- Visual [34079219748](https://github.com/rigplane/rigplane-core/actions/runs/34079219748): SUCCESS
- Exact-head independent review [PASS 241cd1071](https://github.com/rigplane/rigplane-core/pull/3311#issuecomment-5564565283): no findings

## Preserved correction history

- Initial head `9ae302c00fa1d803e4766fae80cb3c76d9ab47ba`: required quick [34077970165](https://github.com/rigplane/rigplane-core/actions/runs/34077970165) found the missing accepted control-feedback marker; [BLOCKED](https://github.com/rigplane/rigplane-core/pull/3311#issuecomment-5564426256).
- Corrected head `4f7c9226e1d61d0290a70815031907f2d7b8c454`: quick [34078235898](https://github.com/rigplane/rigplane-core/actions/runs/34078235898) and visual [34078235765](https://github.com/rigplane/rigplane-core/actions/runs/34078235765) succeeded; [independent PASS](https://github.com/rigplane/rigplane-core/pull/3311#issuecomment-5564437435).
- Terminal reading of `4f7c9226e1d61d0290a70815031907f2d7b8c454` found that `same(null, null)` could re-enable retained reading or feedback input without current authority; [root BLOCKED](https://github.com/rigplane/rigplane-core/pull/3311#issuecomment-5564517580).
- Final successor `241cd10711fde427ae7cf0bf24d42200a1645556` adds the positive non-null authority guard and mounted combined/separate regressions, followed by fresh exact-head CI and review.
- Non-required v2 observation checks failed closed because the PR base was no longer the live `main` head. The required `Agent Review Gate` and `quick` contexts are green on the unchanged final head.

Linear: MOR-2425
