### PR TITLE
feat(MOR-2425): persist RX AF instrument ownership

### DIFF
--- a/frontend/fixtures/assertions.ts
+++ b/frontend/fixtures/assertions.ts
@@ -609,11 +609,14 @@ export function runAssertions(
   if (expected.rxAudio !== undefined) {
     const monitor = q<HTMLElement>('[data-testid="rx-audio-monitor"]');
     const liveChoice = q<HTMLElement>('[data-testid="rx-audio-monitor-live"]');
-    const af = q<HTMLInputElement>('[data-testid="rx-audio-af"] input[type="range"]');
+    const af = q<HTMLElement>('[data-testid="rx-audio-af"] [role="slider"]');
+    const afNow = af?.getAttribute('aria-valuenow') ?? null;
+    const normalizedAf = afNow !== null && afNow.trim() !== '' ? Number(afNow) : Number.NaN;
     const actualMode = monitor?.dataset.monitorMode ?? null;
     const actualConnection = liveChoice?.dataset.liveLink === undefined
       ? null : liveChoice.dataset.liveLink === 'true';
-    const actualVolume = actualMode === 'live' && af ? af.valueAsNumber * 100 : null;
+    const actualVolume = actualMode === 'live' && Number.isFinite(normalizedAf)
+      ? normalizedAf * 100 : null;
     check('rx-audio-runtime-axis',
       actualMode === expected.rxAudio.monitorMode
       && actualConnection === expected.rxAudio.connectionAudio

--- a/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
+++ b/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
@@ -22,6 +22,7 @@
     frequencyTunable: () => true,
     vfoOperations: operations,
   } satisfies ReceiverInstrumentHandles;
+  const rxAudioInstruments = { afLevel: empty };
   const scalars = {
     rfPower: empty, micGain: empty, driveGain: empty, voxGain: empty,
     antiVoxGain: empty, voxDelay: empty, compressorLevel: empty, monitorLevel: empty,
@@ -29,6 +30,7 @@
 
   export const TEST_INSTRUMENTS = {
     vfo, rxTx: empty, txAuxControls: txAux, txAuxScalars: scalars, receiverInstruments,
+    rxAudioInstruments,
     meters: empty, rxAudio: empty, rfFrontEnd: empty, filter: empty, dsp: empty,
     band: empty, antenna: empty, ritXitScan: empty, cwKeyer: empty,
     scopeDisplay: empty, scopeControls: empty, txFaultRecovery: empty,
@@ -42,11 +44,21 @@
   import SemanticRadioSurfaces from '../../../wiring/SemanticRadioSurfaces.svelte';
   import type { InstrumentComposition } from '../../../wiring/instrument-composition';
 
-  let { skinId = 'desktop-v2' }: { skinId?: SkinId } = $props();
+  let {
+    skinId = 'desktop-v2', rxAudioLayout = 'production',
+  }: {
+    skinId?: SkinId; rxAudioLayout?: 'production' | 'grouped' | 'independent';
+  } = $props();
 </script>
 
 <SemanticRadioSurfaces>
   {#snippet children(instruments: InstrumentComposition)}
-    <RadioLayout {skinId} {instruments} />
+    {#if rxAudioLayout === 'production'}
+      <RadioLayout {skinId} {instruments} />
+    {:else if rxAudioLayout === 'grouped'}
+      {@render instruments.rxAudio()}
+    {:else}
+      <div data-af-layout="independent">{@render instruments.rxAudioInstruments.afLevel()}</div>
+    {/if}
   {/snippet}
 </SemanticRadioSurfaces>

--- a/frontend/src/components-v2/layout/__tests__/tab-traversal.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/tab-traversal.isolated.test.ts
@@ -58,16 +58,21 @@ vi.mock('../../../lib/media/media-session', () => ({
   destroyMediaSession: vi.fn(),
 }));
 
-const rt = vi.hoisted(() => ({ state: null as unknown, caps: null as unknown }));
+const rt = vi.hoisted(() => ({
+  state: null as unknown,
+  caps: null as unknown,
+  session: { state: 'connected' as const, epoch: 1 },
+}));
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
     onTxAudioDied: () => () => {},
     get state() { return rt.state; },
     get caps() { return rt.caps; },
+    get controlSession() { return rt.session; },
     subscribeControlAuthority(handler: (publication: unknown) => void) {
       handler({
-        state: rt.state, caps: rt.caps, session: { state: 'connected', epoch: 1 },
+        state: rt.state, caps: rt.caps, session: rt.session,
         rxAudioTarget: Object.freeze({ muted: false, rxEnabled: false }),
       });
       return () => {};

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -69,6 +69,7 @@
   } from '../../semantic/RfFrontEndSurface.svelte';
   import RitXitScanSurface from '../../semantic/RitXitScanSurface.svelte';
   import RxAudioSurface from '../../semantic/RxAudioSurface.svelte';
+  import RxAudioInstrumentHost from '../../semantic/RxAudioInstrumentHost.svelte';
   import RxTxSurface from '../../semantic/RxTxSurface.svelte';
   import ScopeDisplaySurface from '../../semantic/ScopeDisplaySurface.svelte';
   import ReceiverInstrumentHost, {
@@ -506,6 +507,13 @@
       toRadioViewModel(runtime.state, runtime.caps, txState, rxAudioSnapshot, scopeDisplaySnapshot),
     ),
   );
+  let rxAudioInstrumentPresentation = $derived({
+    state: runtime.state,
+    caps: runtime.caps,
+    session: runtime.controlSession,
+    rxAudioTarget: { muted: runtime.audio.muted, rxEnabled: runtime.audio.rxEnabled },
+    rxAudio: canonicalView?.rxAudio,
+  });
 
   type ScopeFiniteAuthority = Readonly<{
     sessionEpoch: number;
@@ -968,6 +976,12 @@
     vfoOperations={receiverVfoOperations}
   >
   {#snippet children(receiverInstruments)}
+  <RxAudioInstrumentHost
+    presentation={rxAudioInstrumentPresentation}
+    subscribeControlAuthority={runtime.subscribeControlAuthority}
+    onAfLevelChange={rxAudioIntents.onAfLevelChange}
+  >
+  {#snippet children(rxAudioInstruments)}
   {#if readonlyDisplay}
     {#if view}{@render readonlyDisplay(view, selectedDisplayFrame)}{/if}
   {:else}
@@ -1260,15 +1274,16 @@
     under `sdr-test`/`mobile`/`lcd-*`, which declare no such zone. The cockpit
     has made no such decision either, so it still renders nothing there.
 
-    It takes NO authority snapshot: nothing here is TX truth. The intents are
-    the shipped command bus, wired above.
+    The surface takes no authority snapshot. Its persistent Host above this
+    replaceable body consumes the synchronous control publication only to
+    fence AF target changes; the grouped surface receives the named handle.
+    The remaining intents are the shipped command bus, wired above.
   -->
   {#snippet rxAudioSurface()}
     {#if view?.rxAudio}
       <RxAudioSurface
-        {view}
+        {view} handles={rxAudioInstruments}
         onMonitorMode={(mode) => rxAudioIntents.onMonitorModeChange(mode)}
-        onAfLevel={(level) => rxAudioIntents.onAfLevelChange(level)}
         onRoutingFocus={(focus) => routingIntents.onFocusChange(focus)}
         onRoutingSplit={(split) => routingIntents.onSplitStereoChange(split)}
         onSetModInputLan={setModInputLan}
@@ -1656,6 +1671,7 @@
       txAuxControls: hostedTxAux,
       txAuxScalars,
       receiverInstruments,
+      rxAudioInstruments,
       meters: hostedMeters,
       rxAudio: hostedRxAudio,
       rfFrontEnd: hostedRfFrontEnd,
@@ -1836,6 +1852,8 @@
   {/snippet}
   </TxAuxScalarHost>
   {/if}
+  {/snippet}
+  </RxAudioInstrumentHost>
   {/snippet}
   </ReceiverInstrumentHost>
 </div>

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -978,7 +978,7 @@
   {#snippet children(receiverInstruments)}
   <RxAudioInstrumentHost
     presentation={rxAudioInstrumentPresentation}
-    subscribeControlAuthority={runtime.subscribeControlAuthority}
+    subscribeControlAuthority={(handler) => runtime.subscribeControlAuthority(handler)}
     onAfLevelChange={rxAudioIntents.onAfLevelChange}
   >
   {#snippet children(rxAudioInstruments)}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -35,6 +35,7 @@ import type { RxAudioTargetSnapshot } from '$lib/stores/audio.svelte';
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
+  controlSession: { state: 'connected' as const, epoch: 1 as const },
   authoritySubscribers: new Set<(next: {
     state: unknown; caps: unknown; session: { state: 'connected'; epoch: 1 };
     rxAudioTarget: RxAudioTargetSnapshot;
@@ -79,10 +80,11 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    get controlSession() { return h.controlSession; },
     subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
       h.authoritySubscribers.add(handler);
       handler({
-        state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 },
+        state: h.state, caps: h.caps, session: h.controlSession,
         rxAudioTarget: Object.freeze({ muted: h.audio.muted, rxEnabled: h.audio.rxEnabled }),
       });
       return () => { h.authoritySubscribers.delete(handler); };
@@ -176,7 +178,7 @@ let txHarness: ManagedAppTxHarness;
 function publishAuthority(): void {
   for (const subscriber of h.authoritySubscribers) {
     subscriber({
-      state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 },
+      state: h.state, caps: h.caps, session: h.controlSession,
       rxAudioTarget: Object.freeze({ muted: h.audio.muted, rxEnabled: h.audio.rxEnabled }),
     });
   }

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -22,6 +22,7 @@ import type { RxAudioTargetSnapshot } from '$lib/stores/audio.svelte';
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
+  controlSession: { state: 'connected' as const, epoch: 1 as const },
   authoritySubscribers: new Set<(next: {
     state: unknown; caps: unknown; session: { state: 'connected'; epoch: 1 };
     rxAudioTarget: RxAudioTargetSnapshot;
@@ -47,10 +48,11 @@ vi.mock('$lib/runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    get controlSession() { return h.controlSession; },
     subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
       h.authoritySubscribers.add(handler);
       handler({
-        state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 },
+        state: h.state, caps: h.caps, session: h.controlSession,
         rxAudioTarget: Object.freeze({ muted: h.audio.muted, rxEnabled: h.audio.rxEnabled }),
       });
       return () => { h.authoritySubscribers.delete(handler); };

--- a/frontend/src/components-v2/wiring/__tests__/semantic-pbt-continuity.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-pbt-continuity.component.test.ts
@@ -53,7 +53,7 @@ describe('mounted PBT continuity is fenced by the live control session (MOR-1706
     render(); const initialInner = value('pbtInner'), initialOuter = value('pbtOuter'); expect(initialInner).not.toBeNull(); expect(initialOuter).not.toBeNull(); expect(h.commands).not.toHaveBeenCalled();
     const staleInput = target.querySelector<HTMLInputElement>('[data-testid="filter-pbtInner"] input'); expect(staleInput).not.toBeNull();
     accept(state(null, -200, 2)); flushSync(); expect(value('pbtInner')).toBe(initialInner); expect(value('pbtOuter')).toBe(initialOuter);
-    expect(h.listeners.size).toBe(2); transition('disconnected', 1, false); transition('connected', 1, false); flushSync(); expect(value('pbtInner')).toBeNull(); expect(value('pbtOuter')).toBeNull();
+    expect(h.listeners.size).toBe(3); transition('disconnected', 1, false); transition('connected', 1, false); flushSync(); expect(value('pbtInner')).toBeNull(); expect(value('pbtOuter')).toBeNull();
     staleInput!.value = '500'; staleInput!.dispatchEvent(new Event('input', { bubbles: true })); flushSync(); expect(h.commands).not.toHaveBeenCalled(); expect(txHarness.trace()).toEqual([]);
     transition('connected', 1); expect(value('pbtInner')).toBeNull(); accept(state(300, -400, 3)); flushSync(); expect(value('pbtInner')).not.toBeNull();
     transition('connected', 2); expect(value('pbtInner')).toBeNull(); accept(state(500, -600, 4)); flushSync(); expect(value('pbtOuter')).not.toBeNull();

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
@@ -28,6 +28,8 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
@@ -87,6 +89,7 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    get controlSession() { return { state: 'connected' as const, epoch: 1 }; },
     subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
       h.authoritySubscribers.add(handler);
       handler({
@@ -128,6 +131,7 @@ import { audioManager } from '$lib/audio/audio-manager';
 import { sendCommand } from '$lib/transport/ws-client';
 import { MOD_INPUT_SOURCES, modInputCommand, modInputStateKey } from '$lib/radio/mod-input';
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+import HostedRadioLayoutFixture from '../../layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte';
 import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
 import { makeAudioRoutingHandlers, makeModeHandlers, makeRxAudioHandlers } from '$lib/runtime/commands/panel-commands';
 import { desktopV2Layout } from '../../../presentation/layouts/declarations';
@@ -161,6 +165,7 @@ function liveState(over: Partial<ServerState> = {}): ServerState {
     ...slot(hz), vfoA: slot(hz), vfoB: slot(hz + 50000), activeSlot: 'A', filter: 1, afLevel: 0.31,
   });
   return {
+    providerGeneration: 1,
     active: 'MAIN', split: false, dualWatch: false, ptt: false, dataOffModInput: 5,
     txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
     main: receiver(14250000), sub: receiver(14300000),
@@ -177,6 +182,7 @@ const liveCaps = (tags: readonly string[]): Capabilities => ({
   webrtc: { available: false, enabled: false },
   txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
   scopeSource: null, audioFftAvailable: false,
+  providerGeneration: 1,
 } as unknown as Capabilities);
 
 const AUDIO_TAGS = ['audio', 'tx', 'dual_rx', 'af_level', 'mod_input_routing'] as const;
@@ -207,9 +213,21 @@ function render(props: { strips?: 'single' | 'dual' } = {}, plan?: SurfacePlan):
   flushSync();
 }
 
+function renderHosted() {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  const props = proxy<{ rxAudioLayout: 'grouped' | 'independent' }>({
+    rxAudioLayout: 'grouped',
+  });
+  component = mount(HostedRadioLayoutFixture, { target, props });
+  flushSync();
+  return props;
+}
+
 const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
 const el = (id: string) => q<HTMLElement>(`[data-testid="rx-audio-${id}"]`);
 const text = (id: string) => el(id)?.textContent?.trim();
+const afSlider = () => q<HTMLElement>('[data-testid="rx-audio-af"] [role="slider"]');
 
 const SEAM_SPIES = () => [
   audioManager.startRx, audioManager.stopRx, audioManager.setRxVolume,
@@ -269,7 +287,7 @@ describe('AF level: 0..100 becomes 0..1 exactly once, at the adapter seam', () =
   // (renders 42, clamped by the range to 1).
   it('renders a browser volume of 42 as an AF level of 0.42', () => {
     render();
-    expect(q<HTMLInputElement>('[data-testid="rx-audio-af"] input')!.valueAsNumber)
+    expect(Number(afSlider()!.getAttribute('aria-valuenow')))
       .toBeCloseTo(0.42, 10);
     expect(text('af-value')).toBe('0.42');
   });
@@ -277,21 +295,21 @@ describe('AF level: 0..100 becomes 0..1 exactly once, at the adapter seam', () =
   it.each([0, 7, 50, 100])('renders a browser volume of %i on the 0..1 scale', (volume) => {
     h.audio = { muted: false, rxEnabled: true, volume };
     render();
-    expect(q<HTMLInputElement>('[data-testid="rx-audio-af"] input')!.valueAsNumber)
+    expect(Number(afSlider()!.getAttribute('aria-valuenow')))
       .toBeCloseTo(volume / 100, 10);
   });
 
   // MUTATION KILLED: a rescale on the way OUT. Driven through the REAL
   // `makeRxAudioHandlers` the wiring composes, so the round trip 42 → 0.42 →
-  // 42 is proven end to end rather than asserted about a stub.
-  it('returns the same level to the runtime as a 0..100 volume, through the real bus', () => {
+  // 43 is proven end to end rather than asserted about a stub.
+  it('returns one 0.01 step to the runtime as a 0..100 volume, through the real bus', () => {
     render();
-    const input = q<HTMLInputElement>('[data-testid="rx-audio-af"] input')!;
-    input.value = '0.42';
-    input.dispatchEvent(new Event('input', { bubbles: true }));
+    afSlider()!.dispatchEvent(new KeyboardEvent(
+      'keydown', { key: 'ArrowRight', bubbles: true, cancelable: true },
+    ));
     flushSync();
-    expect(h.setRxVolume).toHaveBeenCalledExactlyOnceWith(0.42);
-    expect(h.setVolume).toHaveBeenCalledExactlyOnceWith(42);
+    expect(h.setRxVolume).toHaveBeenCalledExactlyOnceWith(0.43);
+    expect(h.setVolume).toHaveBeenCalledExactlyOnceWith(43);
   });
 
   // The command bus this wiring composes IS the shipped one — a fork would
@@ -305,6 +323,78 @@ describe('AF level: 0..100 becomes 0..1 exactly once, at the adapter seam', () =
       const handlers = factory() as Record<string, unknown>;
       for (const name of names) expect(typeof handlers[name]).toBe('function');
     }
+  });
+});
+
+describe('the hosted AF owner survives replaceable presentation layouts', () => {
+  it('cancels route A-B-A and detached drafts while retaining canonical readback', () => {
+    h.audio = proxy({ muted: false, rxEnabled: true, volume: 42 });
+    const props = renderHosted();
+    const originalSubscribers = [...h.authoritySubscribers];
+    const oldSlider = afSlider()!;
+    const frame = oldSlider.closest<HTMLElement>('.vc-hbar')!;
+    frame.getBoundingClientRect = () => ({
+      left: 0, right: 100, top: 0, bottom: 10, width: 100, height: 10, x: 0, y: 0,
+      toJSON: () => ({}),
+    });
+    Object.assign(oldSlider, {
+      setPointerCapture: vi.fn(), releasePointerCapture: vi.fn(), hasPointerCapture: () => true,
+    });
+    oldSlider.dispatchEvent(new PointerEvent(
+      'pointerdown', { pointerId: 7, clientX: 42, bubbles: true },
+    ));
+    h.audio.rxEnabled = false;
+    publishAuthority();
+    h.audio.rxEnabled = true;
+    publishAuthority();
+    h.setRxVolume.mockClear();
+    h.setVolume.mockClear();
+    oldSlider.dispatchEvent(new PointerEvent(
+      'pointermove', { pointerId: 7, clientX: 90, bubbles: true },
+    ));
+    oldSlider.dispatchEvent(new PointerEvent('pointerup', { pointerId: 7, bubbles: true }));
+    expect(h.setVolume).not.toHaveBeenCalled();
+
+    oldSlider.dispatchEvent(new PointerEvent(
+      'pointerdown', { pointerId: 8, clientX: 70, bubbles: true },
+    ));
+    flushSync();
+    expect(frame.style.getPropertyValue('--vc-fill-percent')).toBe('70%');
+    expect(h.setVolume).toHaveBeenCalledExactlyOnceWith(70);
+    h.setRxVolume.mockClear();
+    h.setVolume.mockClear();
+
+    props.rxAudioLayout = 'independent';
+    flushSync();
+    const newSlider = q<HTMLElement>('[role="slider"][aria-label="AF"]')!;
+    expect(newSlider).not.toBe(oldSlider);
+    expect(target.querySelector('[data-af-layout="independent"]')).not.toBeNull();
+    expect(target.querySelectorAll('[role="slider"][aria-label="AF"]')).toHaveLength(1);
+    expect([...h.authoritySubscribers]).toEqual(originalSubscribers);
+    expect(h.authoritySubscribers.size).toBe(2);
+    expect(newSlider.closest<HTMLElement>('.vc-hbar')!.style
+      .getPropertyValue('--vc-fill-percent')).toBe('42%');
+    expect(newSlider.getAttribute('aria-valuenow')).toBe('0.42');
+    oldSlider.dispatchEvent(new PointerEvent('pointerup', { pointerId: 8, bubbles: true }));
+    oldSlider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(h.setVolume).not.toHaveBeenCalled();
+
+    newSlider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    flushSync();
+    expect(h.setRxVolume).toHaveBeenCalledExactlyOnceWith(0.43);
+    expect(h.setVolume).toHaveBeenCalledExactlyOnceWith(43);
+
+    h.audio.volume = 43;
+    flushSync();
+    expect(newSlider.getAttribute('aria-valuenow')).toBe('0.43');
+    props.rxAudioLayout = 'grouped';
+    flushSync();
+    expect(afSlider()!.getAttribute('aria-valuenow')).toBe('0.43');
+    expect(target.querySelectorAll('[role="slider"][aria-label="AF"]')).toHaveLength(1);
+    expect([...h.authoritySubscribers]).toEqual(originalSubscribers);
+    unmount(component!);
+    component = null;
+    expect(h.authoritySubscribers.size).toBe(0);
   });
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -15,6 +15,7 @@ type Snapshot = {
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
+  controlSession: { state: 'connected' as const, epoch: 1 as const },
   authoritySubscribers: new Set<(next: {
     state: unknown; caps: unknown; session: { state: 'connected'; epoch: 1 };
     rxAudioTarget: RxAudioTargetSnapshot;
@@ -45,10 +46,11 @@ vi.mock('$lib/runtime', () => ({
   runtime: {
     get state() { return h.state; },
     get caps() { return h.caps; },
+    get controlSession() { return h.controlSession; },
     subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
       h.authoritySubscribers.add(handler);
       handler({
-        state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 },
+        state: h.state, caps: h.caps, session: h.controlSession,
         rxAudioTarget: Object.freeze({ muted: h.audio.muted, rxEnabled: h.audio.rxEnabled }),
       });
       return () => { h.authoritySubscribers.delete(handler); };

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
@@ -525,7 +525,7 @@ describe('selected finite Scope authority lifetime (MOR-2425)', () => {
     render();
     expect(el('scope-hold')).not.toBeNull();
     expect(el('external-HOLD')).toBeNull();
-    expect(h.authoritySubscribers.size).toBe(1);
+    expect(h.authoritySubscribers.size).toBe(2);
   });
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
@@ -52,6 +52,7 @@ const LIVE_SCOPE_STATUS: ScopeStatus = {
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
+  controlSession: { state: 'connected' as const, epoch: 1 as const },
   authoritySubscribers: new Set<(next: {
     state: unknown; caps: unknown; session: { state: 'connected'; epoch: 1 };
     rxAudioTarget: RxAudioTargetSnapshot;
@@ -72,10 +73,11 @@ vi.mock('$lib/runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    get controlSession() { return h.controlSession; },
     subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
       h.authoritySubscribers.add(handler);
       handler({
-        state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 },
+        state: h.state, caps: h.caps, session: h.controlSession,
         rxAudioTarget: Object.freeze({ muted: h.audio.muted, rxEnabled: h.audio.rxEnabled }),
       });
       return () => { h.authoritySubscribers.delete(handler); };

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -458,7 +458,7 @@ describe('the txAux surface mounts only when the view model carries the group', 
     + 'div span span span span span span button div section header strong div div div '
     + 'section header strong div div div section div span '
     + 'div button button div div button button p span span section p span span span p div button button '
-    + 'ul section div button button button label span input output div button button button output '
+    + 'ul section div button button button label span div div div div div div output div button button button output '
     + 'div button button output';
 
   it.each(['single', 'dual'] as const)('renders no txAux surface at all without the group (%s)', (strips) => {

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -290,7 +290,7 @@ describe('production receiver-indicator partitioning', () => {
   ) => {
     selectedFrequency.current = AlternateFrequencyReadoutHarness as FrequencyRenderer;
     render(caps('main_sub', 2), state(), {}, props);
-    expect(h.authoritySubscribers.size).toBe(1);
+    expect(h.authoritySubscribers.size).toBe(2);
     const digit = projectFrequencyReadout({ confirmedHz: 14_200_000 }).digits[0];
     const first = retainedInteractions().find((interaction) => !interaction.inert)!;
     first.handleDigitClick(digit, new MouseEvent('click'));

--- a/frontend/src/components-v2/wiring/__tests__/single-receiver-active-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/single-receiver-active-wiring.component.test.ts
@@ -33,6 +33,7 @@ import type { RxAudioTargetSnapshot } from '$lib/stores/audio.svelte';
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
+  controlSession: { state: 'connected' as const, epoch: 1 as const },
   authoritySubscribers: new Set<(next: {
     state: unknown; caps: unknown; session: { state: 'connected'; epoch: 1 };
     rxAudioTarget: RxAudioTargetSnapshot;
@@ -75,10 +76,11 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    get controlSession() { return h.controlSession; },
     subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
       h.authoritySubscribers.add(handler);
       handler({
-        state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 },
+        state: h.state, caps: h.caps, session: h.controlSession,
         rxAudioTarget: Object.freeze({ muted: h.audio.muted, rxEnabled: h.audio.rxEnabled }),
       });
       return () => { h.authoritySubscribers.delete(handler); };

--- a/frontend/src/components-v2/wiring/instrument-composition.ts
+++ b/frontend/src/components-v2/wiring/instrument-composition.ts
@@ -2,6 +2,7 @@ import type { Snippet } from 'svelte';
 import type { ManagedScopeRegion } from '$lib/runtime/adapters/scope-display-projection';
 import type { TxAuxScalarHandles } from '../../semantic/tx-aux-scalar';
 import type { ReceiverInstrumentHandles } from '../../semantic/ReceiverInstrumentHost.svelte';
+import type { RxAudioInstrumentHandles } from '../../semantic/rx-audio-instruments';
 
 export type InstrumentVfoAppearance = 'semantic' | 'sdr' | 'standard';
 
@@ -11,6 +12,7 @@ export interface InstrumentComposition {
   readonly txAuxControls: Snippet<[scalarLayout: Snippet, allowBare?: boolean]>;
   readonly txAuxScalars: TxAuxScalarHandles;
   readonly receiverInstruments: ReceiverInstrumentHandles;
+  readonly rxAudioInstruments: RxAudioInstrumentHandles;
   readonly meters: Snippet<[allowBare?: boolean]>;
   readonly rxAudio: Snippet<[allowBare?: boolean]>;
   readonly rfFrontEnd: Snippet<[allowBare?: boolean]>;

--- a/frontend/src/lib/runtime/commands/__tests__/focus-target-resolution.component.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/focus-target-resolution.component.test.ts
@@ -77,13 +77,16 @@ vi.mock('$lib/stores/tuning.svelte', () => ({
 }));
 
 import { makeKeyboardHandlers } from '../panel-commands';
-import RxAudioSurface from '../../../../semantic/RxAudioSurface.svelte';
+import RxAudioInstrumentHostFixture from '../../../../semantic/__tests__/fixtures/RxAudioInstrumentHostFixture.svelte';
 import RfFrontEndSurface from '../../../../semantic/RfFrontEndSurface.svelte';
 import FilterSurface from '../../../../semantic/FilterSurface.svelte';
 import VfoSurface from '../../../../semantic/VfoSurface.svelte';
 import {
   topologyFixtures, withRxAudio, withModeFilter, withFilterPassband, withRfFrontEnd,
 } from '../../../../semantic/fixtures/topologies';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import type { RxAudioAuthorityPublication } from '../../../../semantic/rx-audio-instruments';
 
 let mounted: ReturnType<typeof mount>[] = [];
 
@@ -111,13 +114,30 @@ afterEach(() => {
 
 describe('focus_target dispatch resolves to a real, focusable anchor in the production DOM (MOR-1456)', () => {
   it('"af" focuses the AF-gain slider in RxAudioSurface (rx-audio zone)', () => {
-    render(RxAudioSurface, { view: withRxAudio(topologyFixtures['1/single']) });
-    const input = document.querySelector('[data-testid="rx-audio-af"] input');
-    expect(input).not.toBeNull();
+    const publication: RxAudioAuthorityPublication = {
+      state: { providerGeneration: 1 } as ServerState,
+      caps: {
+        model: 'TEST', receivers: 1, vfoScheme: 'single', providerGeneration: 1,
+        capabilities: ['audio', 'af_level'], scope: false, audio: true, tx: false,
+        freqRanges: [], modes: [], filters: [],
+        audioConfig: { sampleRate: 48_000, channels: 1, codecs: [] },
+        webrtc: { available: false, enabled: false }, txBands: null,
+        stateContractVersion: 1,
+      } as Capabilities,
+      session: { state: 'connected', epoch: 1 },
+      rxAudioTarget: { muted: false, rxEnabled: true },
+    };
+    render(RxAudioInstrumentHostFixture, {
+      view: withRxAudio(topologyFixtures['1/single']), publication,
+      subscribeControlAuthority: (handler) => { handler(publication); return () => undefined; },
+      onAfLevelChange: vi.fn(),
+    });
+    const slider = document.querySelector('[data-testid="rx-audio-af"] [role="slider"]');
+    expect(slider).not.toBeNull();
 
     dispatchFocusTarget('af');
 
-    expect(document.activeElement).toBe(input);
+    expect(document.activeElement).toBe(slider);
   });
 
   it('"rf" focuses the RF-gain slider in RfFrontEndSurface (rfFrontEnd zone)', () => {

--- a/frontend/src/lib/runtime/commands/__tests__/focus-target-resolution.component.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/focus-target-resolution.component.test.ts
@@ -90,7 +90,7 @@ import type { RxAudioAuthorityPublication } from '../../../../semantic/rx-audio-
 
 let mounted: ReturnType<typeof mount>[] = [];
 
-function render<P extends Record<string, unknown>>(component: Component<P>, props: P): void {
+function render<P extends object>(component: Component<P>, props: P): void {
   const target = document.createElement('div');
   document.body.appendChild(target);
   mounted.push(mount(component, { target, props }));

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -1726,7 +1726,7 @@ export function makeKeyboardHandlers() {
             // `data-testid` hooks rather than inventing a parallel
             // `data-panel`/`data-control` vocabulary no component emits.
             const selectors: Record<string, string> = {
-              af: '[data-testid="rx-audio-af"] input',
+              af: '[data-testid="rx-audio-af"] [role="slider"], [data-testid="rx-audio-af"] input[type="range"]',
               rf: '[data-testid="rf-front-end-rf-sql"] input, [data-testid="rf-front-end-rfGain"] input',
               squelch: '[data-testid="rf-front-end-rf-sql"] input, [data-testid="rf-front-end-squelch"] input',
               filter: '[data-testid="filter-select"] button',

--- a/frontend/src/semantic/RxAudioInstrumentHost.svelte
+++ b/frontend/src/semantic/RxAudioInstrumentHost.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  import { onDestroy, onMount, type Snippet } from 'svelte';
+  import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
+  import { ValueControl } from '../components-v2/controls/value-control';
+  import {
+    createContinuousScalar,
+    createHBarContinuousScalarPolicy,
+    type ContinuousScalarInput,
+    type ContinuousScalarPolicy,
+    type ScalarDomain,
+  } from '../primitives/scalar/continuous-scalar.svelte';
+  import type {
+    RxAudioAuthorityPublication,
+    RxAudioInstrumentHandles,
+    RxAudioInstrumentPresentation,
+    SubscribeRxAudioAuthority,
+  } from './rx-audio-instruments';
+
+  interface Props {
+    presentation: RxAudioInstrumentPresentation;
+    subscribeControlAuthority: SubscribeRxAudioAuthority;
+    onAfLevelChange?: (value: number) => void;
+    children: Snippet<[RxAudioInstrumentHandles]>;
+  }
+
+  type Receiver = 'MAIN' | 'SUB' | 'unknown';
+  type AfTarget = 'browser-volume' | `radio-af:${Receiver}`;
+  interface AfAuthority {
+    readonly epoch: number;
+    readonly generation: number;
+    readonly topologyId: string;
+    readonly receiver: Receiver;
+    readonly muted: boolean;
+    readonly target: AfTarget;
+  }
+
+  let {
+    presentation, subscribeControlAuthority, onAfLevelChange, children,
+  }: Props = $props();
+  let published = $state.raw<RxAudioAuthorityPublication | null>(null);
+  let lastAuthority: AfAuthority | null | undefined;
+  let stop: (() => void) | null = null;
+
+  const safeGeneration = (value: unknown): value is number =>
+    typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+  function authority(source: RxAudioAuthorityPublication): AfAuthority | null {
+    const stateGeneration = source.state?.providerGeneration;
+    const capsGeneration = source.caps?.providerGeneration;
+    if (source.session.state !== 'connected'
+      || !safeGeneration(source.session.epoch)
+      || !safeGeneration(stateGeneration)
+      || !safeGeneration(capsGeneration)
+      || stateGeneration !== capsGeneration) return null;
+    const model = toRadioViewModel(source.state, source.caps);
+    if (model === null) return null;
+    const receiver = model.activeReceiver.status === 'known'
+      ? model.activeReceiver.receiver : 'unknown';
+    return {
+      epoch: source.session.epoch,
+      generation: stateGeneration,
+      topologyId: model.topologyId,
+      receiver,
+      muted: source.rxAudioTarget.muted,
+      target: source.rxAudioTarget.rxEnabled ? 'browser-volume' : `radio-af:${receiver}`,
+    };
+  }
+  function same(left: AfAuthority | null, right: AfAuthority | null): boolean {
+    if (left === null || right === null) return left === right;
+    return left.epoch === right.epoch
+      && left.generation === right.generation
+      && left.topologyId === right.topologyId
+      && left.receiver === right.receiver
+      && left.muted === right.muted
+      && left.target === right.target;
+  }
+  const key = (value: AfAuthority | null): string => value === null
+    ? 'rx-af:inactive'
+    : JSON.stringify([
+      'rx-af', value.epoch, value.generation, value.topologyId, value.receiver,
+      value.muted, value.target,
+    ]);
+
+  function input(): Readonly<ContinuousScalarInput> {
+    const field = presentation.rxAudio?.afLevel;
+    const currentAuthority = published === null ? null : authority(published);
+    const presentedAuthority = authority(presentation);
+    const reading = field?.reading.status === 'known'
+      ? { status: 'known' as const, value: field.reading.value }
+      : { status: 'unknown' as const };
+    const targetKnown = currentAuthority?.target === 'browser-volume'
+      || currentAuthority?.target === 'radio-af:MAIN'
+      || currentAuthority?.target === 'radio-af:SUB';
+    const readingMatchesTarget = currentAuthority?.target === 'browser-volume'
+      ? presentation.rxAudio?.monitorMode === 'live'
+      : presentation.rxAudio?.monitorMode !== 'live';
+    return {
+      evidence: 'reading',
+      domain: { min: 0, max: 1, step: 0.01, defaultValue: null, fineStepDivisor: 1 },
+      enabled: same(currentAuthority, presentedAuthority)
+        && targetKnown
+        && readingMatchesTarget
+        && field?.availability.structural === true
+        && field.availability.operational
+        && reading.status === 'known'
+        && Number.isFinite(reading.value)
+        && onAfLevelChange !== undefined,
+      request: (value) => onAfLevelChange?.(value),
+      reading,
+      ownerKey: key(currentAuthority),
+    };
+  }
+
+  const basePolicy = createHBarContinuousScalarPolicy({ preview: 'optimistic', debounceMs: 0 });
+  const policy: Readonly<ContinuousScalarPolicy> = Object.freeze({
+    ...basePolicy,
+    reset: (domain: ScalarDomain) => domain.defaultValue,
+  });
+  const afLevelBinding = createContinuousScalar(input, policy);
+
+  onMount(() => {
+    stop = subscribeControlAuthority((next) => {
+      const nextAuthority = authority(next);
+      if (lastAuthority !== undefined && !same(lastAuthority, nextAuthority)) {
+        afLevelBinding.cancel('authority');
+      }
+      lastAuthority = nextAuthority;
+      published = next;
+    });
+  });
+  onDestroy(() => {
+    try { stop?.(); } finally { afLevelBinding.destroy(); }
+  });
+</script>
+
+{#snippet afLevel()}
+  <ValueControl
+    binding={afLevelBinding} label="AF" renderer="hbar"
+    showLabel={false} showValue={false} compact={true}
+  />
+{/snippet}
+
+{@render children({ afLevel })}

--- a/frontend/src/semantic/RxAudioInstrumentHost.svelte
+++ b/frontend/src/semantic/RxAudioInstrumentHost.svelte
@@ -115,6 +115,7 @@
     ...basePolicy,
     reset: (domain: ScalarDomain) => domain.defaultValue,
   });
+  const feedbackIntegratedControl = { 'feedback-policy': 'feedback-integrated' } as const;
   const afLevelBinding = createContinuousScalar(input, policy);
 
   onMount(() => {
@@ -134,6 +135,7 @@
 
 {#snippet afLevel()}
   <ValueControl
+    {...feedbackIntegratedControl}
     binding={afLevelBinding} label="AF" renderer="hbar"
     showLabel={false} showValue={false} compact={true}
   />

--- a/frontend/src/semantic/RxAudioSurface.svelte
+++ b/frontend/src/semantic/RxAudioSurface.svelte
@@ -83,21 +83,22 @@
 <script lang="ts">
   import { t } from '$lib/i18n';
   import type { RadioViewModel } from './radio-view-model';
+  import type { RxAudioInstrumentHandles } from './rx-audio-instruments';
   import {
     bindAbsoluteChoiceInstrument, bindChoiceInstrument,
   } from '../primitives/control-instruments/control-instrument-behavior';
 
   interface Props {
     view: RadioViewModel;
+    handles: RxAudioInstrumentHandles;
     onMonitorMode?: (mode: MonitorMode) => void;
-    onAfLevel?: (level: number) => void;
     onRoutingFocus?: (focus: AudioFocus) => void;
     onRoutingSplit?: (split: boolean) => void;
     onSetModInputLan?: () => void;
     onModInputChange?: (source: number) => void;
   }
   let {
-    view, onMonitorMode, onAfLevel, onRoutingFocus, onRoutingSplit, onSetModInputLan,
+    view, handles, onMonitorMode, onRoutingFocus, onRoutingSplit, onSetModInputLan,
     onModInputChange,
   }: Props = $props();
 
@@ -161,12 +162,6 @@
   let linkLost = $derived(
     liveOffered && rx?.monitorMode === 'live' && rx.liveAudio.operational === false,
   );
-  /** The slider position while AF is unread is a guess, so the control is
-   *  inert then — the same "never act on an unknown reading" gate slice 1B
-   *  applies, enforced on the widget AND in the handler. */
-  function changeAf(level: number): void {
-    if (rx && usable(rx.afLevel)) onAfLevel?.(level);
-  }
 </script>
 
 {#if rx}
@@ -204,12 +199,7 @@
         <span class="rx-audio-name">AF</span>
         <!-- 0..1 — the contract's OWN unit (rule 4). No rescale in either
              direction: the value in is the fact, the value out is the intent. -->
-        <input
-          type="range" min="0" max="1" step="0.01"
-          value={rx.afLevel.reading.status === 'known' ? rx.afLevel.reading.value : 0}
-          disabled={!usable(rx.afLevel)}
-          oninput={(event) => changeAf(event.currentTarget.valueAsNumber)}
-        />
+        {@render handles.afLevel()}
         <output data-testid="rx-audio-af-value">{textOf(rx.afLevel)}</output>
       </label>
     {/if}
@@ -303,5 +293,5 @@
   /* Second channel beside `data-observed`, never the only one: the unknown
      text itself is the primary one and survives forced-colors. */
   [data-observed='false'] { font-style: italic; }
-  button:disabled, input:disabled, select:disabled { cursor: not-allowed; }
+  button:disabled, select:disabled { cursor: not-allowed; }
 </style>

--- a/frontend/src/semantic/__tests__/RxAudioInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/RxAudioInstrumentHost.isolated.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
+import type { Capabilities, VfoScheme } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+const activation = vi.hoisted(() => ({ selected: undefined as unknown }));
+const scalarCapture = vi.hoisted(() => ({ bindings: [] as unknown[] }));
+vi.mock('../../component-kits/activation', () => ({
+  getSelectedScalarAppearance: () => activation.selected,
+}));
+vi.mock('../../primitives/scalar/continuous-scalar.svelte', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../primitives/scalar/continuous-scalar.svelte')>();
+  return {
+    ...actual,
+    createContinuousScalar: (...args: Parameters<typeof actual.createContinuousScalar>) => {
+      const binding = actual.createContinuousScalar(...args);
+      scalarCapture.bindings.push(binding);
+      return binding;
+    },
+  };
+});
+
+import ExternalScalarRenderer from '../../components-v2/controls/value-control/__tests__/ExternalScalarRendererFixture.svelte';
+import type { Skin } from '../../components-v2/controls/value-control/skin';
+import type {
+  ContinuousScalarBinding,
+  ContinuousScalarRendererLease,
+} from '../../primitives/scalar/continuous-scalar.svelte';
+import Fixture from './fixtures/RxAudioInstrumentHostFixture.svelte';
+import type { RxAudioViewModel } from '../radio-view-model';
+import type {
+  RxAudioAuthorityPublication as Publication,
+  SubscribeRxAudioAuthority,
+} from '../rx-audio-instruments';
+
+type RendererNode = HTMLButtonElement & { readonly rendererLease: ContinuousScalarRendererLease };
+type Props = {
+  publication: Publication;
+  rxAudio: RxAudioViewModel | undefined;
+  subscribeControlAuthority: SubscribeRxAudioAuthority;
+  layout: 'grouped' | 'independent';
+  onAfLevelChange?: (value: number) => void;
+};
+
+function capabilities(receivers = 2, generation = 1, scheme?: VfoScheme): Capabilities {
+  return {
+    model: 'TEST', scope: false, audio: true, tx: false,
+    capabilities: receivers === 2 ? ['dual_rx', 'audio', 'af_level'] : ['audio', 'af_level'],
+    receivers, vfoScheme: scheme ?? (receivers === 2 ? 'main_sub' : 'single'),
+    freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48_000, channels: 1, codecs: [] },
+    webrtc: { available: false, enabled: false }, txBands: null,
+    stateContractVersion: 1, providerGeneration: generation,
+  } as Capabilities;
+}
+
+const observed = () => ({
+  observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 1,
+});
+function state(options: {
+  receivers?: number; generation?: number; active?: 'MAIN' | 'SUB'; activeKnown?: boolean;
+} = {}): ServerState {
+  const { receivers = 2, generation = 1, active = 'MAIN', activeKnown = true } = options;
+  const receiver = (afLevel: number) => ({
+    freqHz: 14_250_000, mode: 'USB', filter: 1, dataMode: 0, afLevel,
+    sMeter: 0, att: 0, preamp: 0, nb: false, nr: false, rfGain: 255, squelch: 0,
+  });
+  const paths = ['main', 'main.afLevel'];
+  if (activeKnown) paths.push('active');
+  if (receivers === 2) paths.push('sub', 'sub.afLevel');
+  return {
+    stateContractVersion: 1, providerGeneration: generation, revision: 1, stateRevision: 1,
+    freshnessRevision: 1, observationSeq: 1, updatedAt: '2026-09-06T00:00:00Z',
+    active, ptt: false, split: false, dualWatch: false, tunerStatus: 0,
+    txTarget: { status: 'unknown', reason: 'not-observed' },
+    main: receiver(0.2), ...(receivers === 2 ? { sub: receiver(0.6) } : {}),
+    connection: {} as ServerState['connection'],
+    fieldStatus: Object.fromEntries(paths.map((path) => [path, observed()])),
+  } as ServerState;
+}
+
+function publication(options: {
+  receivers?: number; generation?: number; capsGeneration?: number;
+  active?: 'MAIN' | 'SUB'; activeKnown?: boolean; scheme?: VfoScheme;
+  session?: Publication['session']['state']; epoch?: number; muted?: boolean; rxEnabled?: boolean;
+  nullState?: boolean;
+} = {}): Publication {
+  const receivers = options.receivers ?? 2;
+  const generation = options.generation ?? 1;
+  return {
+    state: options.nullState ? null : state({
+      receivers, generation, active: options.active, activeKnown: options.activeKnown,
+    }),
+    caps: capabilities(receivers, options.capsGeneration ?? generation, options.scheme),
+    session: { state: options.session ?? 'connected', epoch: options.epoch ?? 1 },
+    rxAudioTarget: { muted: options.muted ?? false, rxEnabled: options.rxEnabled ?? false },
+  };
+}
+
+const unknownField = {
+  reading: { status: 'unknown' as const },
+  availability: { structural: false, operational: false },
+};
+function audio(
+  value: number | null,
+  operational = true,
+  monitorMode: RxAudioViewModel['monitorMode'] = 'local',
+): RxAudioViewModel {
+  return {
+    monitorMode, liveAudio: { structural: true, operational: true },
+    afLevel: {
+      reading: value === null ? { status: 'unknown' } : { status: 'known', value },
+      availability: { structural: true, operational },
+    },
+    routingFocus: unknownField, routingSplit: unknownField,
+    modInputSource: unknownField, modInputReadiness: { status: 'not-applicable' },
+  } as RxAudioViewModel;
+}
+
+class Publisher {
+  handlers = new Set<(next: Publication) => void>();
+  constructor(public current: Publication) {}
+  subscribe: SubscribeRxAudioAuthority = (handler) => {
+    this.handlers.add(handler); handler(this.current);
+    return () => { this.handlers.delete(handler); };
+  };
+  emit(next: Publication): void {
+    this.current = next;
+    this.handlers.forEach((handler) => handler(next));
+  }
+}
+
+let target: HTMLDivElement;
+let components: ReturnType<typeof mount>[] = [];
+beforeEach(() => {
+  target = document.createElement('div'); document.body.appendChild(target);
+  activation.selected = { name: 'RX AF test', hbar: ExternalScalarRenderer } satisfies Skin;
+  scalarCapture.bindings = [];
+});
+afterEach(() => {
+  components.forEach((component) => unmount(component)); components = [];
+  activation.selected = undefined; target.remove();
+});
+
+function render(initial = publication(), initialAudio = audio(0.2)) {
+  const publisher = new Publisher(initial);
+  const onAfLevelChange = vi.fn<(value: number) => void>();
+  const props = proxy<Props>({
+    publication: initial, rxAudio: initialAudio,
+    subscribeControlAuthority: publisher.subscribe,
+    layout: 'grouped', onAfLevelChange,
+  });
+  const component = mount(Fixture, { target, props }); components.push(component); flushSync();
+  const slider = () => target.querySelector<RendererNode>('[data-external-scalar-renderer]')!;
+  const transition = (next: Publication, nextAudio: RxAudioViewModel) => {
+    props.publication = next; props.rxAudio = nextAudio; publisher.emit(next);
+  };
+  return { publisher, props, onAfLevelChange, slider, transition, component };
+}
+
+describe('RxAudioInstrumentHost', () => {
+  const changes = [
+    ['session', () => publication({ epoch: 2 })],
+    ['provider', () => publication({ generation: 2 })],
+    ['topology', () => publication({ scheme: 'ab_shared' })],
+    ['receiver', () => publication({ active: 'SUB' })],
+    ['receiver knowledge', () => publication({ activeKnown: false })],
+    ['mute', () => publication({ muted: true })],
+    ['live route', () => publication({ rxEnabled: true })],
+  ] as const;
+
+  it.each(changes)('cancels an old pointer across same-task %s A-B-A', (_name, middle) => {
+    const r = render(); const lease = r.slider().rendererLease;
+    const token = lease.beginPointer(); expect(token).not.toBeNull();
+    r.transition(middle(), audio(0.7));
+    r.transition(publication(), audio(0.35));
+    lease.pointer(token!, 0.9); lease.endPointer(token!);
+    expect(r.onAfLevelChange).not.toHaveBeenCalled();
+    expect(lease.view.canonical).toBe(0.35);
+    expect(lease.key({ key: 'ArrowRight', fine: false })).toBe(true);
+    expect(r.onAfLevelChange).toHaveBeenCalledExactlyOnceWith(0.36);
+  });
+
+  it.each([
+    ['pointer', 0.73, (lease: ContinuousScalarRendererLease) => {
+      const token = lease.beginPointer()!; lease.pointer(token, 0.73); lease.endPointer(token);
+    }],
+    ['native', 0.73, (lease: ContinuousScalarRendererLease) => lease.nativeInput(0.73)],
+    ['key', 0.71, (lease: ContinuousScalarRendererLease) => lease.key({ key: 'ArrowRight', fine: false })],
+    ['wheel', 0.76, (lease: ContinuousScalarRendererLease) => lease.wheel({ direction: 1, fine: false })],
+  ] as const)('uses the fresh same-task presentation for %s input', (_name, expected, act) => {
+    const r = render(); const lease = r.slider().rendererLease;
+    r.transition(publication({ rxEnabled: true }), audio(0.7, true, 'live'));
+    act(lease);
+    expect(r.onAfLevelChange).toHaveBeenCalledExactlyOnceWith(expected);
+  });
+
+  it('keeps a known reading but rejects it when its presentation source disagrees with the raw route', () => {
+    const r = render(); const lease = r.slider().rendererLease;
+    r.transition(publication({ rxEnabled: true }), audio(0.7));
+    expect(lease.view.canonical).toBe(0.7); expect(lease.view.editable).toBe(false);
+    r.props.rxAudio = audio(0.7, true, 'live');
+    lease.nativeInput(0.72);
+    expect(r.onAfLevelChange).toHaveBeenCalledExactlyOnceWith(0.72);
+  });
+
+  it('preserves readings while authority or availability makes the control inert, then recovers', () => {
+    const r = render(publication({ nullState: true }), audio(0.41));
+    const lease = r.slider().rendererLease;
+    expect(lease.view.canonical).toBe(0.41); expect(lease.view.editable).toBe(false);
+    r.transition(publication({ generation: 1, capsGeneration: 2 }), audio(0.42));
+    expect(lease.view.canonical).toBe(0.42); expect(lease.view.editable).toBe(false);
+    r.transition(publication({ session: 'disconnected', epoch: -1 }), audio(0.43));
+    expect(lease.view.canonical).toBe(0.43); expect(lease.view.editable).toBe(false);
+    r.transition(publication(), audio(0.44, false));
+    expect(lease.view.canonical).toBe(0.44); expect(lease.view.editable).toBe(false);
+    r.transition(publication(), audio(null));
+    expect(lease.view.canonical).toBeNull(); expect(lease.view.editable).toBe(false);
+    r.transition(publication({ generation: 2 }), audio(0.5));
+    expect(lease.key({ key: 'ArrowRight', fine: false })).toBe(true);
+    expect(r.onAfLevelChange).toHaveBeenCalledExactlyOnceWith(0.51);
+  });
+
+  it('updates value evidence without canceling an unchanged command target', () => {
+    const r = render(); const lease = r.slider().rendererLease;
+    const token = lease.beginPointer()!;
+    r.props.rxAudio = audio(0.3);
+    expect(lease.view.canonical).toBe(0.3);
+    r.transition(publication(), audio(0.31));
+    lease.pointer(token, 0.4); lease.endPointer(token);
+    expect(r.onAfLevelChange).toHaveBeenCalledExactlyOnceWith(0.4);
+  });
+
+  it('uses the adapter single-receiver MAIN fact and rejects unknown dual-RX routing', () => {
+    const single = publication({ receivers: 1, activeKnown: false });
+    const r = render(single);
+    expect(r.slider().rendererLease.key({ key: 'ArrowRight', fine: false })).toBe(true);
+    r.transition(publication({ activeKnown: false }), audio(0.3));
+    expect(r.slider().rendererLease.view.canonical).toBe(0.3);
+    expect(r.slider().rendererLease.view.editable).toBe(false);
+  });
+
+  it('retains one binding across layout replacement and retires the detached renderer lease', () => {
+    const r = render(); const binding = scalarCapture.bindings[0] as ContinuousScalarBinding;
+    const oldLease = r.slider().rendererLease;
+    r.props.layout = 'independent'; flushSync();
+    expect(scalarCapture.bindings).toEqual([binding]);
+    expect(oldLease.key({ key: 'ArrowRight', fine: false })).toBe(false);
+    expect(r.slider().rendererLease.key({ key: 'ArrowRight', fine: false })).toBe(true);
+    expect(r.onAfLevelChange).toHaveBeenCalledExactlyOnceWith(0.21);
+  });
+
+  it('has no reset default and tears down the subscriber, binding, and active gesture', () => {
+    const r = render(); const lease = r.slider().rendererLease;
+    lease.reset(); expect(r.onAfLevelChange).not.toHaveBeenCalled();
+    const token = lease.beginPointer()!;
+    unmount(r.component); components = components.filter((item) => item !== r.component);
+    expect(r.publisher.handlers.size).toBe(0);
+    lease.pointer(token, 0.8); lease.endPointer(token);
+    expect(r.onAfLevelChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/semantic/__tests__/RxAudioSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RxAudioSurface.test.ts
@@ -27,13 +27,17 @@ import { flushSync, mount, unmount } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import { MOD_INPUT_SOURCES } from '$lib/radio/mod-input';
 import { t } from '$lib/i18n';
-import RxAudioSurface, {
+import {
   FOCUS_CHOICES, LINK_LOST_TEXT, MONITOR_MODES, READINESS_LABEL, SPLIT_CHOICES, UNKNOWN_TEXT,
 } from '../RxAudioSurface.svelte';
+import Fixture from './fixtures/RxAudioInstrumentHostFixture.svelte';
 import { topologyFixtures, withRxAudio } from '../fixtures/topologies';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
 import type {
   AudioFocus, Availability, MonitorMode, RadioViewModel, RxAudioField, RxAudioViewModel,
 } from '../radio-view-model';
+import type { RxAudioAuthorityPublication } from '../rx-audio-instruments';
 
 const SOURCE = readFileSync('src/semantic/RxAudioSurface.svelte', 'utf8');
 /** Comments stripped, so the file's own doctrine prose can never be what a
@@ -71,15 +75,34 @@ type Handlers = {
   onModInputChange?: (source: number) => void;
 };
 
+const AUTHORITY_STATE = { providerGeneration: 1 } as ServerState;
+const AUTHORITY_CAPS = {
+  model: 'TEST', receivers: 1, vfoScheme: 'single', providerGeneration: 1,
+  capabilities: ['audio', 'af_level'], scope: false, audio: true, tx: false,
+  freqRanges: [], modes: [], filters: [],
+  audioConfig: { sampleRate: 48_000, channels: 1, codecs: [] },
+  webrtc: { available: false, enabled: false }, txBands: null, stateContractVersion: 1,
+} as Capabilities;
+
 function render(view: RadioViewModel, handlers: Handlers = {}) {
-  const component = mount(RxAudioSurface, { target, props: { view, ...handlers } });
+  const mode = view.rxAudio?.monitorMode;
+  const publication: RxAudioAuthorityPublication = {
+    state: AUTHORITY_STATE, caps: AUTHORITY_CAPS,
+    session: { state: 'connected', epoch: 1 },
+    rxAudioTarget: { muted: mode === 'mute', rxEnabled: mode === 'live' },
+  };
+  const component = mount(Fixture, { target, props: {
+    view, publication, ...handlers,
+    onAfLevelChange: handlers.onAfLevel,
+    subscribeControlAuthority: (handler) => { handler(publication); return () => undefined; },
+  } });
   flushSync();
   const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
   return {
     dispose: () => unmount(component),
     root: () => q('[data-testid="rx-audio-surface"]'),
     el: (id: string) => q<HTMLElement>(`[data-testid="rx-audio-${id}"]`),
-    input: () => q<HTMLInputElement>('[data-testid="rx-audio-af"] input'),
+    slider: () => q<HTMLElement>('[data-testid="rx-audio-af"] [role="slider"]'),
     text: (id: string) => q<HTMLElement>(`[data-testid="rx-audio-${id}"]`)?.textContent?.trim(),
   };
 }
@@ -96,6 +119,7 @@ describe('the RX-audio surface owns no audio lifetime (MOR-972 P0 / MOR-1058)', 
     expect([...new Set(specifiers)].sort()).toEqual([
       '$lib/i18n', '$lib/radio/mod-input',
       '../primitives/control-instruments/control-instrument-behavior', './radio-view-model',
+      './rx-audio-instruments',
     ]);
     expect(CODE).toContain('bindAbsoluteChoiceInstrument');
     expect(CODE).toContain('bindChoiceInstrument');
@@ -118,11 +142,11 @@ describe('the RX-audio surface owns no audio lifetime (MOR-972 P0 / MOR-1058)', 
     }
   });
 
-  // Kills: the surface growing a second props member and reading live state.
-  it('takes exactly one state prop — the view model — plus intent callbacks', () => {
+  // Kills: the surface reading live state or restoring a private AF owner.
+  it('takes one state prop, the required instrument handles, and finite intent callbacks', () => {
     const props = CODE.slice(CODE.indexOf('interface Props'), CODE.indexOf('}: Props'));
     expect([...props.matchAll(/^\s{4}(\w+)[?]?:/gm)].map((m) => m[1])).toEqual([
-      'view', 'onMonitorMode', 'onAfLevel', 'onRoutingFocus', 'onRoutingSplit',
+      'view', 'handles', 'onMonitorMode', 'onRoutingFocus', 'onRoutingSplit',
       'onSetModInputLan', 'onModInputChange',
     ]);
   });
@@ -280,11 +304,10 @@ describe('every unread fact renders honestly, never as the v2 default', () => {
   it('makes the AF slider inert while the level is unread, and emits nothing', () => {
     const onAfLevel = vi.fn();
     const r = render(withRx({ afLevel: unread<number>() }), { onAfLevel });
-    const input = r.input()!;
-    expect(input.disabled).toBe(true);
-    expect(input.valueAsNumber).toBe(0);
-    input.value = '0.7';
-    input.dispatchEvent(new Event('input', { bubbles: true }));
+    const slider = r.slider()!;
+    expect(slider.getAttribute('aria-disabled')).toBe('true');
+    expect(slider.hasAttribute('aria-valuenow')).toBe(false);
+    slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
     flushSync();
     expect(onAfLevel).not.toHaveBeenCalled();
     r.dispose();
@@ -351,35 +374,37 @@ describe('AF level is 0..1 end to end — converted exactly once, in the adapter
   // level, i.e. an RxAudioSnapshot volume of 42 already divided by the adapter.
   it('renders the fact verbatim, with no second scaling', () => {
     const r = render(base());
-    expect(r.input()!.valueAsNumber).toBeCloseTo(0.42, 10);
+    expect(Number(r.slider()!.getAttribute('aria-valuenow'))).toBeCloseTo(0.42, 10);
     expect(r.text('af-value')).toBe('0.42');
     r.dispose();
   });
 
   it.each([0, 0.01, 0.5, 1])('renders the level %s verbatim', (value) => {
     const r = render(withRx({ afLevel: known(value) }));
-    expect(r.input()!.valueAsNumber).toBe(value);
+    expect(Number(r.slider()!.getAttribute('aria-valuenow'))).toBe(value);
     r.dispose();
   });
 
   // Kills: `level / 100` or `level * 100` on the way OUT. The command handler
   // (`makeRxAudioHandlers().onAfLevelChange`) takes 0..1, so the round trip
   // must be the identity.
-  it.each([0, 0.25, 0.7, 1])('emits the slider level %s verbatim', (value) => {
+  it('emits one 0.01 AF step with no rescaling', () => {
     const onAfLevel = vi.fn();
     const r = render(base(), { onAfLevel });
-    const input = r.input()!;
-    input.value = String(value);
-    input.dispatchEvent(new Event('input', { bubbles: true }));
+    r.slider()!.dispatchEvent(new KeyboardEvent(
+      'keydown', { key: 'ArrowRight', bubbles: true, cancelable: true },
+    ));
     flushSync();
-    expect(onAfLevel).toHaveBeenCalledExactlyOnceWith(value);
+    expect(onAfLevel).toHaveBeenCalledExactlyOnceWith(0.43);
     r.dispose();
   });
 
   // Kills: a range whose bounds silently rescale the fact.
   it('declares the slider on the contract`s own 0..1 scale', () => {
     const r = render(base());
-    expect([r.input()!.min, r.input()!.max]).toEqual(['0', '1']);
+    expect([
+      r.slider()!.getAttribute('aria-valuemin'), r.slider()!.getAttribute('aria-valuemax'),
+    ]).toEqual(['0', '1']);
     r.dispose();
   });
 });
@@ -495,9 +520,16 @@ describe('MOD-input selection uses observed facts and absolute intents (MOR-2366
   it('follows unknown, readback and unavailable transitions without emitting', () => {
     const facts = new SvelteMap([['view', withRx({ modInputSource: unread<number>() })]]);
     const onModInputChange = vi.fn();
-    const component = mount(RxAudioSurface, {
-      target, props: { get view() { return facts.get('view')!; }, onModInputChange },
-    });
+    const publication: RxAudioAuthorityPublication = {
+      state: AUTHORITY_STATE, caps: AUTHORITY_CAPS,
+      session: { state: 'connected', epoch: 1 },
+      rxAudioTarget: { muted: false, rxEnabled: false },
+    };
+    const component = mount(Fixture, { target, props: {
+      get view() { return facts.get('view')!; },
+      publication, onModInputChange,
+      subscribeControlAuthority: (handler) => { handler(publication); return () => undefined; },
+    } });
     flushSync();
     const select = target.querySelector<HTMLSelectElement>('[data-testid="rx-audio-mod-select"]');
     expect(select).not.toBeNull();
@@ -517,9 +549,16 @@ describe('MOD-input selection uses observed facts and absolute intents (MOR-2366
   it('refuses a stale DOM selection and restores the latest observed source', () => {
     const facts = new SvelteMap([['view', base()]]);
     const onModInputChange = vi.fn();
-    const component = mount(RxAudioSurface, {
-      target, props: { get view() { return facts.get('view')!; }, onModInputChange },
-    });
+    const publication: RxAudioAuthorityPublication = {
+      state: AUTHORITY_STATE, caps: AUTHORITY_CAPS,
+      session: { state: 'connected', epoch: 1 },
+      rxAudioTarget: { muted: false, rxEnabled: false },
+    };
+    const component = mount(Fixture, { target, props: {
+      get view() { return facts.get('view')!; },
+      publication, onModInputChange,
+      subscribeControlAuthority: (handler) => { handler(publication); return () => undefined; },
+    } });
     flushSync();
     const select = target.querySelector<HTMLSelectElement>('[data-testid="rx-audio-mod-select"]')!;
     facts.set('view', withRx({ modInputSource: known(1, DEGRADED) }));

--- a/frontend/src/semantic/__tests__/fixtures/RxAudioInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/RxAudioInstrumentHostFixture.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import RxAudioInstrumentHost from '../../RxAudioInstrumentHost.svelte';
+  import type { RxAudioViewModel } from '../../radio-view-model';
+  import type {
+    RxAudioAuthorityPublication,
+    RxAudioInstrumentHandles,
+    SubscribeRxAudioAuthority,
+  } from '../../rx-audio-instruments';
+
+  interface Props {
+    publication: RxAudioAuthorityPublication;
+    rxAudio: RxAudioViewModel | undefined;
+    subscribeControlAuthority: SubscribeRxAudioAuthority;
+    layout: 'grouped' | 'independent';
+    onAfLevelChange?: (value: number) => void;
+  }
+
+  let {
+    publication, rxAudio, subscribeControlAuthority, layout, onAfLevelChange,
+  }: Props = $props();
+  let presentation = $derived({ ...publication, rxAudio });
+</script>
+
+<RxAudioInstrumentHost {presentation} {subscribeControlAuthority} {onAfLevelChange}>
+  {#snippet children(handles: RxAudioInstrumentHandles)}
+    {#key layout}
+      <section data-layout={layout}>
+        <div data-af-slot={layout}>{@render handles.afLevel()}</div>
+      </section>
+    {/key}
+  {/snippet}
+</RxAudioInstrumentHost>

--- a/frontend/src/semantic/__tests__/fixtures/RxAudioInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/RxAudioInstrumentHostFixture.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import RxAudioInstrumentHost from '../../RxAudioInstrumentHost.svelte';
-  import type { RxAudioViewModel } from '../../radio-view-model';
+  import RxAudioSurface from '../../RxAudioSurface.svelte';
+  import type {
+    AudioFocus, MonitorMode, RadioViewModel, RxAudioViewModel,
+  } from '../../radio-view-model';
   import type {
     RxAudioAuthorityPublication,
     RxAudioInstrumentHandles,
@@ -9,24 +12,38 @@
 
   interface Props {
     publication: RxAudioAuthorityPublication;
-    rxAudio: RxAudioViewModel | undefined;
+    rxAudio?: RxAudioViewModel;
+    view?: RadioViewModel;
     subscribeControlAuthority: SubscribeRxAudioAuthority;
-    layout: 'grouped' | 'independent';
+    layout?: 'grouped' | 'independent';
     onAfLevelChange?: (value: number) => void;
+    onMonitorMode?: (mode: MonitorMode) => void;
+    onRoutingFocus?: (focus: AudioFocus) => void;
+    onRoutingSplit?: (split: boolean) => void;
+    onSetModInputLan?: () => void;
+    onModInputChange?: (source: number) => void;
   }
 
   let {
-    publication, rxAudio, subscribeControlAuthority, layout, onAfLevelChange,
+    publication, rxAudio, view, subscribeControlAuthority, layout = 'grouped', onAfLevelChange,
+    onMonitorMode, onRoutingFocus, onRoutingSplit, onSetModInputLan, onModInputChange,
   }: Props = $props();
-  let presentation = $derived({ ...publication, rxAudio });
+  let presentation = $derived({ ...publication, rxAudio: rxAudio ?? view?.rxAudio });
 </script>
 
 <RxAudioInstrumentHost {presentation} {subscribeControlAuthority} {onAfLevelChange}>
   {#snippet children(handles: RxAudioInstrumentHandles)}
-    {#key layout}
-      <section data-layout={layout}>
-        <div data-af-slot={layout}>{@render handles.afLevel()}</div>
-      </section>
-    {/key}
+    {#if view}
+      <RxAudioSurface
+        {view} {handles} {onMonitorMode} {onRoutingFocus} {onRoutingSplit}
+        {onSetModInputLan} {onModInputChange}
+      />
+    {:else}
+      {#key layout}
+        <section data-layout={layout}>
+          <div data-af-slot={layout}>{@render handles.afLevel()}</div>
+        </section>
+      {/key}
+    {/if}
   {/snippet}
 </RxAudioInstrumentHost>

--- a/frontend/src/semantic/rx-audio-instruments.ts
+++ b/frontend/src/semantic/rx-audio-instruments.ts
@@ -1,0 +1,33 @@
+import type { Snippet } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import type { RxAudioViewModel } from './radio-view-model';
+
+export interface RxAudioTargetAuthority {
+  readonly muted: boolean;
+  readonly rxEnabled: boolean;
+}
+
+export interface RxAudioControlSession {
+  readonly state: 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
+  readonly epoch: number;
+}
+
+export interface RxAudioAuthorityPublication {
+  readonly state: ServerState | null;
+  readonly caps: Capabilities | null;
+  readonly session: RxAudioControlSession;
+  readonly rxAudioTarget: RxAudioTargetAuthority;
+}
+
+export type SubscribeRxAudioAuthority = (
+  handler: (publication: RxAudioAuthorityPublication) => void,
+) => () => void;
+
+export type RxAudioInstrumentPresentation = Readonly<RxAudioAuthorityPublication & {
+  readonly rxAudio: RxAudioViewModel | undefined;
+}>;
+
+export interface RxAudioInstrumentHandles {
+  readonly afLevel: Snippet;
+}

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -23,6 +23,7 @@ let txHarness: ManagedAppTxHarness;
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
+  session: { state: 'disconnected' as const, epoch: 0 },
   selectVfo: vi.fn(),
   splitToggle: vi.fn(),
   dualWatchToggle: vi.fn(),
@@ -40,9 +41,10 @@ vi.mock('$lib/runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    get controlSession() { return h.session; },
     subscribeControlAuthority(handler: (publication: unknown) => void) {
       handler({
-        state: h.state, caps: h.caps, session: { state: 'disconnected', epoch: 0 },
+        state: h.state, caps: h.caps, session: h.session,
         rxAudioTarget: Object.freeze({ muted: true, rxEnabled: false }),
       });
       return () => {};


### PR DESCRIPTION
Guardrail exception: 24 code + 0 regenerated baselines = 24 files; root approved the file-count exception.

The RX AF control previously lived inside the replaceable surface, so radio/session/provider/topology/receiver and browser-audio route changes could leave a physical gesture or delayed callback attached to stale authority. This change adds one persistent RX AF instrument host above replaceable presentation, binds the surface through its named handle, and keeps the canonical runtime handler as the sole command route.

The host owns one normalized `0..1`, step `0.01` reading-backed scalar. It subscribes to the existing synchronous control-authority publisher, cancels on null or meaningful authority changes (including A→B→A), and keeps input inert until the reactive presentation matches the latest publication. Browser volume is selected from raw `rxEnabled`; radio AF remains receiver-specific; mute is retained as a separate authority fact. Because the control is reading-backed, it does not invent a pending phase. Unknown and disabled readings, teardown, and renderer replacement remain truthful and inert.

This is one unit because the host, required surface handle, live SRS composition, focus route, authority-bound callback, static feedback classification, and consumer fixture/guard alignments implement and prove one persistent AF ownership contract. The 24 paths are the six production paths, six original AF tests/fixtures, eleven direct consumer fixture alignments, and the existing production fixture assertion that observes the hosted AF renderer. The exact corrected delta is +758/-77 = 835 A+D with no regenerated baselines.

Linear: MOR-2425 (In Progress)

Accepted prerequisite: receiver-host merge `f5663b8fd29ea8d28845d2487a0e68e1972a16ae`, reviewed source `0a59c4f95eec0fedd3462034c67cf49207f7c0fb` (PR #3303). Its exact-head quick run `34077088825`, visual run `34077088826`, and independent PASS comment `5564343290` were supplied by the coordinator. This branch starts from `bff9350195eab5006ee48e26f74d621f8b66410d`, which contains that merge plus the disjoint accepted presentation-registry change.

The first Ready head `2ed2348496f8cd7676a1c2f8380bf610b6b5cd9c` received natural quick `34077989240`, which failed after 10,909 passing tests with three focused failures: the missing AF feedback classification and two composition runtime doubles lacking the required current `controlSession` getter. Natural visual `34077989216` passed. Independent BLOCKED comment `5564443875` and `pr3312-independent-review-2ed234849.md` identified those exact three sites. The corrected head adds the established static `feedback-integrated` classification and makes each double expose the same current session object through both its getter and synchronous publication; it adds no production fallback, optional getter, scanner change, allowlist, or behavior expansion.

The second Ready head `9c758103e98ee8175489d7e08b93a3be41bb932e` resolved those findings. Its natural quick `34078901625` then passed the unit/type/build stages and failed only the production fixture guard: 63/65 captures passed, while the two live AF cells still queried the removed native range and reported `null` instead of 37/73. Natural visual `34078901479` passed. Independent BLOCKED comment `5564553493` and `pr3312-independent-review-9c758103e.md` identified that exact assertion. The successor reads the hosted role=slider's non-empty finite `aria-valuenow`, preserves missing/invalid values as null, and applies the existing normalized-AF × 100 comparison only in live mode. The assertion remains mandatory; no fake input, skip, or baseline change was added.

Validation retained for successor `3dea1a06a917103edfcf6a2601796bf69546725d` (the final correction changes only the production browser assertion; the prior 23 file blobs are unchanged):

- production browser fixture harness: both previously failing live cells and the existing mute/null negative cell passed, 30/30 assertions each, 3 captures / 0 invalid
- correction matrix covering both real composition consumers, the debt gate, and focused AF host/surface/live/focus: 7 files, 202 tests passed
- direct current SRS-importing consumer class: 24 files, 512 tests passed
- `npm run check`: 0 errors, 0 warnings
- ESLint over the 23 source/test paths: passed; the fixture assertion is outside the ESLint match and passed the harness TypeScript check
- component-kit API build and portable-package verification: passed (16 API declarations, 1 fixture declaration, one physical Svelte install)
- `git diff --check`: passed
- accepted receiver-host aggregate main quick `34077614083`: 444 files / 10,891 tests passed, 87 i18n browser cases, 65 fixture captures / 0 invalid, 0 type errors

Terminal exact-head result for `3dea1a06a917103edfcf6a2601796bf69546725d`:

- natural quick `34079439730`: SUCCESS
- natural visual `34079439727`: SUCCESS
- fresh independent code review: PASS, https://github.com/rigplane/rigplane-core/pull/3312#issuecomment-5564597839; report `pr3312-independent-review-3dea1a06a.md`
- canonical `Agent Review Gate`: SUCCESS

The coordinator read the full final 24-path diff, the final independent review, all correction reports, and the current required-status policy. The separate v2 observation statuses are not required by main protection; the required canonical gate and quick are green. The corrected squash body records reading-backed AF semantics and the terminal result, preserving the earlier BLOCKED/failed-head history above.
