### PR TITLE
MOR-2425: honor station signal sample domain

### DIFF
--- a/frontend/fixtures/catalog.ts
+++ b/frontend/fixtures/catalog.ts
@@ -193,7 +193,11 @@ function withMeters(state: ServerState): ServerState {
     ...s,
     powerMeter: 120, swrMeter: 30, alcMeter: 40, compMeter: 20, vdMeter: 200, idMeter: 90,
     main: rx(s.main, -12), sub: rx(s.sub, -30),
-    fieldStatus: { ...(s.fieldStatus as FieldStatusMap), ...statuses(METER_PATHS) },
+    fieldStatus: {
+      ...(s.fieldStatus as FieldStatusMap), ...statuses(METER_PATHS),
+      'main.sMeter': { ...fresh, quality: ['calibrated'] },
+      'sub.sMeter': { ...fresh, quality: ['calibrated'] },
+    },
   } as unknown as ServerState;
 }
 

--- a/frontend/src/components-v2/meters/LinearSMeter.svelte
+++ b/frontend/src/components-v2/meters/LinearSMeter.svelte
@@ -220,7 +220,7 @@
   // still reports strong/over-range readings in the ramp's hot colors
   // rather than collapsing every reading to one fixed color.
   function activeColor(i: number): string {
-    if (signalProjection.scaleMode === 's' && hasTone && crossoverSegmentIndex !== null) {
+    if (hasTone && crossoverSegmentIndex !== null) {
       return i < crossoverSegmentIndex ? display.toneBelowS9 : display.toneAboveS9;
     }
     const denom = SEG_COUNT - 1;
@@ -238,7 +238,7 @@
   // this PR doesn't already have a caller for). So this stays the same two
   // hex literals it was before, language active or not.
   function dimColor(i: number): string {
-    return signalProjection.scaleMode === 's' && crossoverSegmentIndex !== null
+    return crossoverSegmentIndex !== null
       ? (i < crossoverSegmentIndex ? '#0A2415' : '#1A1008') : '#0A2415';
   }
 
@@ -374,7 +374,7 @@
   const peakZoneOrange = $derived(Math.round((18 / RAW_SEGMENT_DOMAIN) * SEG_COUNT));
 
   // Color of peak line based on zone
-  let peakColor = $derived(signalProjection.scaleMode !== 's' || crossoverSegmentIndex === null
+  let peakColor = $derived(crossoverSegmentIndex === null
     ? 'var(--v2-accent-cyan-bright)'
     : peakSegs <= crossoverSegmentIndex ? 'var(--v2-accent-cyan-bright)'
       : peakSegs <= peakZoneYellow ? 'var(--v2-accent-yellow)'
@@ -399,7 +399,7 @@
   const sdrCrossover = $derived(signalProjection.crossoverFraction === null
     ? null : signalProjection.crossoverFraction * SDR_CELLS * 2);
   function sdrColor(index: number): string {
-    if (signalProjection.scaleMode !== 's' || sdrCrossover === null) {
+    if (sdrCrossover === null) {
       return index < sdrFill ? '#4FB9EC' : '#1a2230';
     }
     const aboveS9 = index >= sdrCrossover;

--- a/frontend/src/components-v2/meters/LinearSMeter.svelte
+++ b/frontend/src/components-v2/meters/LinearSMeter.svelte
@@ -187,9 +187,8 @@
 
   // Index of the first visual segment at or above the projected S9 anchor,
   // rescaled by SEG_COUNT so it follows non-20 display geometry.
-  const s9SegmentIndex = $derived(
-    Math.round(signalProjection.s9Fraction * SEG_COUNT),
-  );
+  const crossoverSegmentIndex = $derived(signalProjection.crossoverFraction === null
+    ? null : Math.round(signalProjection.crossoverFraction * SEG_COUNT));
 
   // ── Colors ──────────────────────────────────────────────────────────────────
   const ACTIVE_COLORS: ReadonlyArray<string> = [
@@ -221,8 +220,8 @@
   // still reports strong/over-range readings in the ramp's hot colors
   // rather than collapsing every reading to one fixed color.
   function activeColor(i: number): string {
-    if (hasTone) {
-      return i < s9SegmentIndex ? display.toneBelowS9 : display.toneAboveS9;
+    if (signalProjection.scaleMode === 's' && hasTone && crossoverSegmentIndex !== null) {
+      return i < crossoverSegmentIndex ? display.toneBelowS9 : display.toneAboveS9;
     }
     const denom = SEG_COUNT - 1;
     const fraction = denom === 0 ? Math.min(1, Math.max(0, smoothedSegs / SEG_COUNT)) : i / denom;
@@ -239,7 +238,8 @@
   // this PR doesn't already have a caller for). So this stays the same two
   // hex literals it was before, language active or not.
   function dimColor(i: number): string {
-    return i < s9SegmentIndex ? '#0A2415' : '#1A1008';
+    return signalProjection.scaleMode === 's' && crossoverSegmentIndex !== null
+      ? (i < crossoverSegmentIndex ? '#0A2415' : '#1A1008') : '#0A2415';
   }
 
   // ── Lower scale row (MOR-2250, PR 2 of 2) ───────────────────────────────────
@@ -363,17 +363,22 @@
   let peakX = $derived(BAR_X + peakSegs * (SEG_W + SEG_GAP));
   // Only show peak line if it's meaningfully ahead of current bar
   let showPeak = $derived(
-    signalProjection.motionFraction !== null && mainPresent && peakSegs - smoothedSegs > 0.3,
+    signalProjection.scaleMode !== 'none' && signalProjection.motionFraction !== null
+      && mainPresent && peakSegs - smoothedSegs > 0.3,
   );
 
   // Peak-line color zones as fractions of the raw 20-segment domain — 15/20
   // and 18/20 are visual gradient stops with no calibration anchor (unlike
-  // s9SegmentIndex above), rescaled the same way so they track SEG_COUNT.
+  // projected crossover above), rescaled the same way so they track SEG_COUNT.
   const peakZoneYellow = $derived(Math.round((15 / RAW_SEGMENT_DOMAIN) * SEG_COUNT));
   const peakZoneOrange = $derived(Math.round((18 / RAW_SEGMENT_DOMAIN) * SEG_COUNT));
 
   // Color of peak line based on zone
-  let peakColor = $derived(peakSegs <= s9SegmentIndex ? 'var(--v2-accent-cyan-bright)' : peakSegs <= peakZoneYellow ? 'var(--v2-accent-yellow)' : peakSegs <= peakZoneOrange ? 'var(--v2-accent-orange-alt)' : 'var(--v2-accent-red-alt)');
+  let peakColor = $derived(signalProjection.scaleMode !== 's' || crossoverSegmentIndex === null
+    ? 'var(--v2-accent-cyan-bright)'
+    : peakSegs <= crossoverSegmentIndex ? 'var(--v2-accent-cyan-bright)'
+      : peakSegs <= peakZoneYellow ? 'var(--v2-accent-yellow)'
+        : peakSegs <= peakZoneOrange ? 'var(--v2-accent-orange-alt)' : 'var(--v2-accent-red-alt)');
 
   // ── Reactive display values ─────────────────────────────────────────────────
   let fullSegs = $derived(signalProjection.motionFraction === null ? 0 : Math.floor(smoothedSegs));
@@ -391,9 +396,13 @@
   const sdrFill = $derived(
     (signalProjection.motionFraction === null ? 0 : meterFrame.smoothedFraction) * SDR_CELLS * 2,
   );
-  const sdrS9 = $derived(signalProjection.s9Fraction * SDR_CELLS * 2);
+  const sdrCrossover = $derived(signalProjection.crossoverFraction === null
+    ? null : signalProjection.crossoverFraction * SDR_CELLS * 2);
   function sdrColor(index: number): string {
-    const aboveS9 = index >= sdrS9;
+    if (signalProjection.scaleMode !== 's' || sdrCrossover === null) {
+      return index < sdrFill ? '#4FB9EC' : '#1a2230';
+    }
+    const aboveS9 = index >= sdrCrossover;
     return index < sdrFill ? (aboveS9 ? '#FF3030' : '#4FB9EC')
       : (aboveS9 ? '#2a1618' : '#1a2230');
   }
@@ -401,11 +410,11 @@
 
 {#if variant === 'sdr-screen'}
   <svg class="sdr-meter" viewBox="0 0 420 50" preserveAspectRatio="none"
-    data-variant={variant} role="img" aria-label={`S meter ${displaySUnit} ${displayDbm}`}>
+    data-variant={variant} role="img" aria-label={signalProjection.accessibleDescription}>
     {#if mainPresent}
     <g data-main-relevant={relevant ? 'true' : 'false'} opacity={relevant ? 1 : DIM_OPACITY}>
       <g font-family="Roboto Mono, monospace" font-size="11" fill="var(--v2-text-primary, #C8D4E0)" font-weight="700">
-        <text x="4" y="14">{displayDbm === 'uncalibrated' ? 'raw' : 'S'}</text>
+        <text x="4" y="14">{signalProjection.scaleMode === 's' ? 'S' : signalProjection.scaleMode === 'raw' ? 'raw' : 'level'}</text>
         {#each labelMarks as mark}
           <text x={14 + mark.fraction * 328} y="14"
             text-anchor="middle" fill={mark.actual > 0 ? 'var(--v2-accent-red, #FF4040)' : 'var(--v2-text-primary, #C8D4E0)'}>
@@ -420,7 +429,7 @@
       {/each}
       <text x="412" y="31" text-anchor="end" fill="var(--v2-text-primary, #DFFCF5)"
         font-family="Roboto Mono, monospace" font-size="12" font-weight="700">{displaySUnit}</text>
-      {#if displayDbm === 'uncalibrated'}
+      {#if signalProjection.scaleMode === 'raw'}
         <text x="412" y="46" text-anchor="end" fill="var(--v2-text-secondary, #A0B4C8)" font-size="10">uncalibrated</text>
       {/if}
     </g>
@@ -433,6 +442,8 @@
   height="auto"
   preserveAspectRatio="xMidYMid meet"
   data-variant={variant}
+  role="img"
+  aria-label={signalProjection.accessibleDescription}
   data-lower-fault={lowerScale ? (lowerScale.fault ? 'true' : 'false') : undefined}
 >
   <!-- Main-bar content (MOR-2250 fix cycle 2): everything that is NOT the

--- a/frontend/src/components-v2/meters/__tests__/LinearSMeter.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/LinearSMeter.test.ts
@@ -336,6 +336,50 @@ describe('LinearSMeter calibrated S-meter domain', () => {
     expect(sdr.querySelector('[data-sdr-segment="40"]')?.getAttribute('fill')).toBe('#1a2230');
   });
 
+  it('renders explicit raw domain without S marks, dBm, or an S9 color crossover', () => {
+    const projection = projectSignalMeter(53, { kind: 'raw' });
+    const frame = {
+      projection,
+      smoothedFraction: projection.motionFraction!,
+      peakFraction: 0.9,
+    } satisfies SignalMeterFrame;
+    const normal = mountMeter({ frame });
+    const sdr = mountMeter({ frame, variant: 'sdr-screen' });
+
+    for (const target of [normal, sdr]) {
+      expect(target.textContent).toContain('53');
+      expect(target.textContent).toContain('uncalibrated');
+      expect(target.textContent).not.toMatch(/S[0-9]|dBm/);
+      expect(target.querySelector('svg')?.getAttribute('aria-label')).toBe(
+        projection.accessibleDescription,
+      );
+    }
+    expect(normal.querySelectorAll('line')).toHaveLength(1);
+    expect(sdr.textContent).toContain('raw');
+    expect(sdr.querySelector('[data-sdr-segment="40"]')?.getAttribute('fill')).toBe('#1a2230');
+    expect(sdr.querySelector('[data-sdr-segment="79"]')?.getAttribute('fill')).toBe('#1a2230');
+  });
+
+  it.each([
+    [{ kind: 'engineering', unit: 'db' } as const, '\u221212 dB rel S9', 'scale unavailable'],
+    [{ kind: 'unknown' } as const, '-12', 'unit unknown'],
+  ])('suppresses motion, peak, and geometry for unprojectable domain %j', (domain, primary, secondary) => {
+    if (domain.kind === 'engineering') setCapabilities(makeCaps());
+    const projection = projectSignalMeter(-12, domain);
+    const target = mountMeter({
+      frame: { projection, smoothedFraction: 0.8, peakFraction: 0.95 },
+    });
+
+    expect(target.textContent).toContain(primary);
+    expect(target.textContent).toContain(secondary);
+    expect(target.querySelectorAll('[data-meter-fill]')).toHaveLength(0);
+    expect(target.querySelector('[data-meter-peak]')).toBeNull();
+    expect(target.querySelectorAll('line')).toHaveLength(0);
+    expect(target.querySelector('svg')?.getAttribute('aria-label')).toBe(
+      projection.accessibleDescription,
+    );
+  });
+
   it('starts no local motion owner for a host frame while compatibility callers start one', () => {
     const originalMatchMedia = window.matchMedia;
     window.matchMedia = vi.fn().mockReturnValue({

--- a/frontend/src/components-v2/meters/__tests__/signal-meter-motion.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/signal-meter-motion.test.ts
@@ -24,12 +24,15 @@ const SESSION_2 = { controlSessionEpoch: 2 } as const satisfies MeterContinuityS
 function projection(
   motionFraction: number | null,
   primaryText = motionFraction === null ? 'S ?' : 'S5',
+  scaleMode: SignalMeterProjection['scaleMode'] = motionFraction === null ? 'none' : 's',
 ): SignalMeterProjection {
   return {
+    scaleMode,
     motionFraction,
     primaryText,
     secondaryText: motionFraction === null ? '' : '\u2212121 dBm',
-    s9Fraction: 0.55,
+    accessibleDescription: primaryText,
+    crossoverFraction: scaleMode === 's' ? 0.55 : null,
     marks: [],
     ticks: [],
   };
@@ -164,11 +167,11 @@ describe('createSignalMeterMotion', () => {
   });
 
   it('keeps known raw projection text but resets motion for unknown or absent samples', () => {
-    const raw = projection(0.4, 'raw 103');
+    const raw = projection(0.4, 'raw 103', 'raw');
     const binding = createSignalMeterMotion({ projection: raw, present: true });
     expect(binding.frame.projection.primaryText).toBe('raw 103');
 
-    const unknown = projection(null);
+    const unknown = projection(null, '103, unit unknown', 'none');
     binding.sync({ projection: unknown, present: true });
     expect(binding.frame.projection).toBe(unknown);
     expect(binding.frame.smoothedFraction).toBe(0);

--- a/frontend/src/components-v2/meters/__tests__/smeter-scale.projection.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/smeter-scale.projection.test.ts
@@ -41,15 +41,17 @@ afterEach(() => clearCapabilities());
 
 describe('projectSignalMeter', () => {
   it('projects one calibrated reading into motion, text, crossover, and labeled marks', () => {
-    const projection = projectSignalMeter(-48);
+    const projection = projectSignalMeter(-48, { kind: 'engineering', unit: 'db' });
 
     expect(Object.keys(projection).sort()).toEqual([
-      'marks', 'motionFraction', 'primaryText', 's9Fraction', 'secondaryText', 'ticks',
+      'accessibleDescription', 'crossoverFraction', 'marks', 'motionFraction', 'primaryText',
+      'scaleMode', 'secondaryText', 'ticks',
     ]);
+    expect(projection.scaleMode).toBe('s');
     expect(projection.motionFraction).toBeCloseTo(11 / 9 / 20);
     expect(projection.primaryText).toBe('S1');
     expect(projection.secondaryText).toBe('\u2212121 dBm');
-    expect(projection.s9Fraction).toBe(11 / 20);
+    expect(projection.crossoverFraction).toBe(11 / 20);
     expect(projection.marks.map(({ actual, text }) => ({ actual, text }))).toEqual([
       { actual: -48, text: 'S1' },
       { actual: -36, text: 'S3' },
@@ -78,7 +80,8 @@ describe('projectSignalMeter', () => {
       motionFraction: null,
       primaryText: 'S ?',
       secondaryText: '',
-      s9Fraction: 11 / 20,
+      crossoverFraction: 11 / 20,
+      scaleMode: 's',
     });
     expect(unknown.marks).toEqual(zero.marks);
     expect(unknown.ticks).toEqual(zero.ticks);
@@ -161,12 +164,67 @@ describe('projectSignalMeter', () => {
 
     const projection = projectSignalMeter(53);
     expect(projection.motionFraction).toBeCloseTo((53 / 127.5) * 11 / 20);
+    expect(projection.scaleMode).toBe('raw');
     expect(projection.primaryText).toBe('53');
     expect(projection.secondaryText).toBe('uncalibrated');
-    expect(projection.s9Fraction).toBe(11 / 20);
+    expect(projection.crossoverFraction).toBeNull();
     expect(projection.marks).toEqual([]);
-    expect(projection.ticks).toEqual([
-      { fraction: 0, kind: 'major', color: 'var(--v2-text-bright)' },
-    ]);
+    expect(projection.ticks).toEqual([]);
+  });
+
+  it('honors an explicit raw domain even when a calibration table is available', () => {
+    const projection = projectSignalMeter(53, { kind: 'raw' });
+
+    expect(projection).toMatchObject({
+      scaleMode: 'raw',
+      primaryText: '53',
+      secondaryText: 'uncalibrated',
+      crossoverFraction: null,
+      marks: [],
+      ticks: [],
+    });
+    expect(projection.motionFraction).toBeCloseTo((53 / 127.5) * 11 / 20);
+    expect(projection.accessibleDescription).not.toMatch(/S[0-9]|dBm/);
+  });
+
+  it('keeps engineering text but suppresses unsupported geometry without calibration', () => {
+    setCapabilities(capabilities(false));
+
+    const projection = projectSignalMeter(-12, { kind: 'engineering', unit: 'db' });
+    expect(projection).toMatchObject({
+      scaleMode: 'none',
+      motionFraction: null,
+      primaryText: '\u221212 dB rel S9',
+      secondaryText: 'scale unavailable',
+      crossoverFraction: null,
+      marks: [],
+      ticks: [],
+    });
+    expect(projection.accessibleDescription).toContain('\u221212 decibels relative to S9');
+  });
+
+  it('never infers units or S geometry for an explicit unknown domain', () => {
+    const projection = projectSignalMeter(53, { kind: 'unknown' });
+
+    expect(projection).toMatchObject({
+      scaleMode: 'none',
+      motionFraction: null,
+      primaryText: '53',
+      secondaryText: 'unit unknown',
+      crossoverFraction: null,
+      marks: [],
+      ticks: [],
+    });
+    expect(projection.accessibleDescription).not.toMatch(/S[0-9]|dBm|raw/);
+  });
+
+  it('does not emit an S-unit placeholder for an unknown sample with explicit unknown domain', () => {
+    const projection = projectSignalMeter(null, { kind: 'unknown' });
+
+    expect(projection).toMatchObject({
+      scaleMode: 'none', motionFraction: null, primaryText: '?',
+      secondaryText: 'unit unknown', crossoverFraction: null, marks: [], ticks: [],
+    });
+    expect(projection.primaryText).not.toContain('S');
   });
 });

--- a/frontend/src/components-v2/meters/__tests__/smeter-scale.projection.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/smeter-scale.projection.test.ts
@@ -167,7 +167,7 @@ describe('projectSignalMeter', () => {
     expect(projection.scaleMode).toBe('raw');
     expect(projection.primaryText).toBe('53');
     expect(projection.secondaryText).toBe('uncalibrated');
-    expect(projection.crossoverFraction).toBeNull();
+    expect(projection.crossoverFraction).toBe(11 / 20);
     expect(projection.marks).toEqual([]);
     expect(projection.ticks).toEqual([]);
   });

--- a/frontend/src/components-v2/meters/smeter-scale.ts
+++ b/frontend/src/components-v2/meters/smeter-scale.ts
@@ -57,7 +57,7 @@ export interface SignalMeterProjection {
   readonly primaryText: string;
   readonly secondaryText: string;
   readonly accessibleDescription: string;
-  /** S9 crossover in `s` mode; absent for raw/unprojectable geometry. */
+  /** S9 crossover for calibrated S or omitted-domain compatibility only. */
   readonly crossoverFraction: number | null;
   readonly marks: readonly SignalMeterProjectionMark[];
   readonly ticks: readonly SignalMeterProjectionTick[];
@@ -248,7 +248,7 @@ export function projectSignalMeter(
     color: mark.color,
   }));
   const ticks = scaleMode === 's' ? scaleTicks(scale, projectionCalibration) : [];
-  const crossoverFraction = scaleMode === 's'
+  const crossoverFraction = scaleMode === 's' || domain === undefined
     ? rawToSegmentsForCalibration(
         getS9RawForCalibration(projectionCalibration), projectionCalibration,
       ) / SEGMENT_DOMAIN

--- a/frontend/src/components-v2/meters/smeter-scale.ts
+++ b/frontend/src/components-v2/meters/smeter-scale.ts
@@ -29,6 +29,7 @@ import {
   rawToSUnit as rawToSUnitForCalibration,
   type SmeterCalibrationPoint,
 } from '../../primitives/meters/s-meter-scale';
+import type { MeterValueDomain } from '../../semantic/radio-view-model';
 
 export interface SmeterMark {
   raw: number;
@@ -51,10 +52,13 @@ export interface SignalMeterProjectionTick {
 }
 
 export interface SignalMeterProjection {
+  readonly scaleMode: 's' | 'raw' | 'none';
   readonly motionFraction: number | null;
   readonly primaryText: string;
   readonly secondaryText: string;
-  readonly s9Fraction: number;
+  readonly accessibleDescription: string;
+  /** S9 crossover in `s` mode; absent for raw/unprojectable geometry. */
+  readonly crossoverFraction: number | null;
   readonly marks: readonly SignalMeterProjectionMark[];
   readonly ticks: readonly SignalMeterProjectionTick[];
 }
@@ -224,39 +228,97 @@ export function getScaleMarks(): SmeterMark[] {
  * The facade remains the only store reader; the pure primitives above own all
  * calibration, interpolation, labeling, and raw fallback behavior.
  */
-export function projectSignalMeter(value: number | null): SignalMeterProjection {
+export function projectSignalMeter(
+  value: number | null, domain?: MeterValueDomain,
+): SignalMeterProjection {
   const calibration = getCal();
-  const scale = scaleMarks(calibration);
+  // Omission is a compatibility path for pre-MOR-2425 internal callers. Live
+  // adapter-produced facts always pass an explicit domain, including unknown.
+  const calibrated = isSmeterCalibratedForCalibration(calibration);
+  const scaleMode: SignalMeterProjection['scaleMode'] = domain === undefined
+    ? (calibrated ? 's' : 'raw')
+    : domain.kind === 'raw' ? 'raw'
+      : domain.kind === 'engineering' && domain.unit === 'db' && calibrated ? 's' : 'none';
+  const projectionCalibration = scaleMode === 's' ? calibration : [];
+  const scale = scaleMode === 's' ? scaleMarks(calibration) : [];
   const marks = scale.map((mark) => ({
     actual: mark.actual,
-    fraction: rawToSegmentsForCalibration(mark.raw, calibration) / SEGMENT_DOMAIN,
+    fraction: rawToSegmentsForCalibration(mark.raw, projectionCalibration) / SEGMENT_DOMAIN,
     text: mark.text,
     color: mark.color,
   }));
-  const ticks = scaleTicks(scale, calibration);
-  const s9Fraction = rawToSegmentsForCalibration(
-    getS9RawForCalibration(calibration),
-    calibration,
-  ) / SEGMENT_DOMAIN;
+  const ticks = scaleMode === 's' ? scaleTicks(scale, projectionCalibration) : [];
+  const crossoverFraction = scaleMode === 's'
+    ? rawToSegmentsForCalibration(
+        getS9RawForCalibration(projectionCalibration), projectionCalibration,
+      ) / SEGMENT_DOMAIN
+    : null;
 
   if (value === null) {
+    const legacy = domain === undefined;
+    const primaryText = legacy || scaleMode === 's' ? 'S ?' : '?';
+    const secondaryText = legacy ? ''
+      : scaleMode === 'raw' ? 'uncalibrated'
+        : scaleMode === 'none' && domain?.kind === 'engineering' ? 'scale unavailable'
+          : scaleMode === 'none' ? 'unit unknown' : '';
     return {
+      scaleMode,
       motionFraction: null,
-      primaryText: 'S ?',
-      secondaryText: '',
-      s9Fraction,
+      primaryText,
+      secondaryText,
+      accessibleDescription: `S meter reading unknown${secondaryText ? `, ${secondaryText}` : ''}`,
+      crossoverFraction,
       marks,
       ticks,
     };
   }
 
+  if (scaleMode === 'raw') {
+    const primaryText = calibratedToSUnitForCalibration(value, projectionCalibration);
+    return {
+      scaleMode,
+      motionFraction: calibratedToSegmentsForCalibration(value, projectionCalibration) / SEGMENT_DOMAIN,
+      primaryText,
+      secondaryText: 'uncalibrated',
+      accessibleDescription: `S meter ${primaryText} raw, uncalibrated`,
+      crossoverFraction,
+      marks,
+      ticks,
+    };
+  }
+
+  if (scaleMode === 'none') {
+    const engineeringDb = domain?.kind === 'engineering' && domain.unit === 'db';
+    const signedValue = `${value < 0 ? '\u2212' : value > 0 ? '+' : ''}${Math.abs(value)}`;
+    const valueText = engineeringDb
+      ? `${signedValue} dB rel S9`
+      : String(value);
+    const stateText = engineeringDb ? 'scale unavailable' : 'unit unknown';
+    return {
+      scaleMode,
+      motionFraction: null,
+      primaryText: valueText,
+      secondaryText: stateText,
+      accessibleDescription: engineeringDb
+        ? `S meter ${signedValue} decibels relative to S9, ${stateText}`
+        : `S meter ${valueText}, ${stateText}`,
+      crossoverFraction,
+      marks,
+      ticks,
+    };
+  }
+
+  const primaryText = calibratedToSUnitForCalibration(value, projectionCalibration);
+  const secondaryText = formatDbmForCalibration(
+    calibratedToDbmForCalibration(value, projectionCalibration),
+  );
   return {
-    motionFraction: calibratedToSegmentsForCalibration(value, calibration) / SEGMENT_DOMAIN,
-    primaryText: calibratedToSUnitForCalibration(value, calibration),
-    secondaryText: formatDbmForCalibration(
-      calibratedToDbmForCalibration(value, calibration),
-    ),
-    s9Fraction,
+    scaleMode,
+    motionFraction: calibratedToSegmentsForCalibration(value, projectionCalibration) / SEGMENT_DOMAIN,
+    primaryText,
+    secondaryText,
+    accessibleDescription: `S meter ${primaryText}, ${secondaryText}`,
+    crossoverFraction,
     marks,
     ticks,
   };

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -23,6 +23,7 @@ import type { ServerState } from '$lib/types/state';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
 import type { ControlSessionSnapshot } from '$lib/runtime/frontend-runtime';
 import type { RxAudioTargetSnapshot } from '$lib/stores/audio.svelte';
+import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
 
 
 const h = vi.hoisted(() => ({
@@ -176,6 +177,11 @@ const METER_PATHS = [
   'powerMeter', 'swrMeter', 'alcMeter', 'compMeter', 'vdMeter', 'idMeter',
   'main.sMeter', 'sub.sMeter', 'compressorOn', 'compressorLevel',
 ];
+const S_METER_CAL = [
+  { raw: 0, actual: -54, label: 'S0' },
+  { raw: 120, actual: 0, label: 'S9' },
+  { raw: 241, actual: 60, label: 'S9+60' },
+];
 
 function liveState(withMeters: boolean, over: Partial<ServerState> = {}): ServerState {
   const paths = ['active', 'split', 'dualWatch', 'txTarget'];
@@ -197,7 +203,10 @@ function liveState(withMeters: boolean, over: Partial<ServerState> = {}): Server
     main: receiver(14250000), sub: receiver(14300000),
     ...(withMeters ? METER_STATE : {}),
     ...over,
-    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+    fieldStatus: Object.fromEntries(paths.map((p) => [
+      p, p === 'main.sMeter' || p === 'sub.sMeter'
+        ? { ...fresh, quality: ['calibrated'] } : fresh,
+    ])),
   } as unknown as ServerState;
 }
 
@@ -211,6 +220,7 @@ const liveCaps = (withMeters: boolean): Capabilities => ({
   audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
   webrtc: { available: false, enabled: false },
   txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+  meterCalibrations: withMeters ? { s_meter: S_METER_CAL } : undefined,
   scopeSource: null, audioFftAvailable: false,
 } as unknown as Capabilities);
 
@@ -271,6 +281,7 @@ beforeEach(() => {
   h.txController = txHarness.controller;
   h.state = liveState(true);
   h.caps = liveCaps(true);
+  expect(setCapabilities(h.caps as Capabilities)).toBe(true);
   h.session = { state: 'connected', epoch: 1 };
   h.sessionSubscriber = null;
   h.noop.mockReset();
@@ -284,6 +295,7 @@ afterEach(() => {
   expect(txHarness.trace()).toEqual([]);
   expect(h.sessionSubscriber).toBeNull();
   document.body.innerHTML = '';
+  clearCapabilities();
   vi.unstubAllGlobals();
   vi.useRealTimers();
 });
@@ -382,22 +394,23 @@ describe('the meters surface mounts only when the view model carries the group',
     ): void => {
       h.state = signalState(active, sMeter, providerGeneration);
       h.caps = { ...liveCaps(true), providerGeneration };
+      expect(setCapabilities(h.caps as Capabilities)).toBe(true);
       push({});
     };
     const signalObserved = (): string | undefined =>
       q('[data-testid="meter-signal"]')!.dataset.observed;
     const armPeak = (active: 'MAIN' | 'SUB', providerGeneration = 1): number => {
-      setSignal(active, 240, providerGeneration);
-      setSignal(active, 60, providerGeneration);
+      setSignal(active, 40, providerGeneration);
+      setSignal(active, -30, providerGeneration);
       expect(signalObserved()).toBe('true');
       expect(signalHasPeak()).toBe(true);
       return signalFillCount();
     };
 
-    h.state = signalState('MAIN', 240);
+    h.state = signalState('MAIN', 40);
     render();
     const receiverFill = armPeak('MAIN');
-    setSignal('SUB', 60);
+    setSignal('SUB', -30);
     expect(signalObserved()).toBe('true');
     expect(signalFillCount()).toBe(receiverFill);
     expect(signalHasPeak()).toBe(false);
@@ -409,7 +422,7 @@ describe('the meters surface mounts only when the view model carries the group',
     expect(signalHasPeak()).toBe(false);
 
     const providerFill = armPeak('SUB');
-    setSignal('SUB', 60, 2);
+    setSignal('SUB', -30, 2);
     expect(signalObserved()).toBe('true');
     expect(signalFillCount()).toBe(providerFill);
     expect(signalHasPeak()).toBe(false);

--- a/frontend/src/lib/runtime/adapters/__tests__/meters-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/meters-adapter.test.ts
@@ -162,6 +162,46 @@ describe('canonical meter source identity (MOR-2400)', () => {
       meters.drainVoltage, meters.drainCurrent,
     ]) expect(field.source).toBeNull();
   });
+
+  it.each([
+    [['calibrated'], { kind: 'engineering', unit: 'db' }],
+    [['uncalibrated'], { kind: 'raw' }],
+    [[], { kind: 'unknown' }],
+    [['calibrated', 'calibrated'], { kind: 'unknown' }],
+    [['calibrated', 'uncalibrated'], { kind: 'unknown' }],
+    [['driver-note', 'calibrated'], { kind: 'engineering', unit: 'db' }],
+    [[3], { kind: 'unknown' }],
+  ] as const)('derives the station signal domain from strict quality evidence %#', (quality, domain) => {
+    const state = meterState();
+    state.fieldStatus!['main.sMeter'] = {
+      ...fresh, quality: quality as unknown as string[],
+    };
+    expect(model(state, caps(), RX).meters!.signal.domain).toEqual(domain);
+  });
+
+  it('emits unknown domain when a calibrated marker is not current', () => {
+    const state = meterState();
+    state.fieldStatus!['main.sMeter'] = { ...stale, quality: ['calibrated'] };
+    expect(model(state, caps(), RX).meters!.signal.domain).toEqual({ kind: 'unknown' });
+  });
+
+  it('maps calibrated quality to each meter field\'s canonical engineering unit', () => {
+    const state = meterState();
+    state.fieldStatus = Object.fromEntries(Object.entries(state.fieldStatus!).map(([path, status]) => [
+      path, METER_PATHS.includes(path as typeof METER_PATHS[number])
+        ? { ...status, quality: ['calibrated'] } : status,
+    ]));
+    const meters = model(state, caps(), TX).meters!;
+    const keys = [
+      'signal', 'power', 'swr', 'alc', 'compression', 'drainVoltage', 'drainCurrent',
+    ] as const;
+    expect(Object.fromEntries(keys.map((key) => [key, meters[key].domain]))).toEqual({
+      signal: { kind: 'engineering', unit: 'db' }, power: { kind: 'engineering', unit: 'w' },
+      swr: { kind: 'engineering', unit: 'ratio' }, alc: { kind: 'engineering', unit: 'normalized' },
+      compression: { kind: 'engineering', unit: 'db' }, drainVoltage: { kind: 'engineering', unit: 'v' },
+      drainCurrent: { kind: 'engineering', unit: 'a' },
+    });
+  });
 });
 
 describe('target meter display provenance (MOR-2359)', () => {
@@ -225,6 +265,7 @@ describe('target meter display provenance (MOR-2359)', () => {
           expect(strict).toEqual({
             reading: operational ? { status: 'known', value: state[path] } : { status: 'unknown' },
             availability: { structural: true, operational }, relevant,
+            domain: { kind: 'unknown' },
             source: operational
               ? { providerGeneration: 1, scope: 'radio', receiver: null, path }
               : null,
@@ -287,7 +328,7 @@ describe('meters evidence gate and per-meter derivation (MOR-1262 slice 2A)', ()
     const meters = model(meterState({ alcMeter: undefined }), caps(), TX).meters!;
     expect(meters.alc).toEqual({
       reading: { status: 'unknown' }, availability: { structural: false, operational: false }, relevant: true,
-      display: { state: 'unsupported' }, source: null,
+      display: { state: 'unsupported' }, domain: { kind: 'unknown' }, source: null,
     });
   });
 
@@ -297,7 +338,7 @@ describe('meters evidence gate and per-meter derivation (MOR-1262 slice 2A)', ()
     }), caps(), TX).meters!;
     expect(meters.swr).toEqual({
       reading: { status: 'unknown' }, availability: { structural: true, operational: false }, relevant: true,
-      display: { state: 'stale', value: 20 }, source: null,
+      display: { state: 'stale', value: 20 }, domain: { kind: 'unknown' }, source: null,
     });
   });
 
@@ -406,6 +447,7 @@ describe('meters evidence gate and per-meter derivation (MOR-1262 slice 2A)', ()
       reading: { status: 'unknown' },
       availability: { structural: true, operational: false },
       relevant: true,
+      domain: { kind: 'unknown' },
       source: null,
     });
   });
@@ -420,6 +462,7 @@ describe('meters evidence gate and per-meter derivation (MOR-1262 slice 2A)', ()
       reading: { status: 'unknown' },
       availability: { structural: true, operational: false },
       relevant: true,
+      domain: { kind: 'unknown' },
       source: null,
     });
   });

--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -339,6 +339,7 @@ describe('receiver indicators are structural-receiver addressed (MOR-2299 slice 
     const signature = (view: RadioViewModel) => view.receiverIndicators?.map((indicator) => ({
       receiver: indicator.receiver,
       s: indicator.sMeter.reading,
+      domain: indicator.sMeter.domain,
       source: indicator.sMeter.source,
       bw: indicator.bandwidthHz.reading,
       agc: indicator.agcMode.reading,
@@ -353,6 +354,7 @@ describe('receiver indicators are structural-receiver addressed (MOR-2299 slice 
     expect(signature(before)).toEqual([
       {
         receiver: 'MAIN', s: { status: 'known', value: 0 },
+        domain: { kind: 'unknown' },
         source: { providerGeneration: 1, scope: 'receiver', receiver: 'MAIN', path: 'main.sMeter' },
         bw: { status: 'known', value: 2400 }, agc: { status: 'known', value: 0 },
         nb: { status: 'known', value: false }, att: { status: 'known', value: 0 },
@@ -361,12 +363,29 @@ describe('receiver indicators are structural-receiver addressed (MOR-2299 slice 
       },
       {
         receiver: 'SUB', s: { status: 'known', value: -37 },
+        domain: { kind: 'unknown' },
         source: { providerGeneration: 1, scope: 'receiver', receiver: 'SUB', path: 'sub.sMeter' },
         bw: { status: 'known', value: 500 }, agc: { status: 'known', value: 'SLOW' },
         nb: { status: 'known', value: true }, att: { status: 'known', value: 12 },
         pre: { status: 'known', value: 2 }, rfg: { status: 'known', value: 0.75 },
         digi: { status: 'known', value: true }, ip: { status: 'known', value: false },
       },
+    ]);
+  });
+
+  it('keeps MAIN and SUB S-meter domains receiver-addressed', () => {
+    const state = indicatorState();
+    state.fieldStatus!['main.sMeter'] = {
+      ...state.fieldStatus!['main.sMeter'], quality: ['calibrated'],
+    };
+    state.fieldStatus!['sub.sMeter'] = {
+      ...state.fieldStatus!['sub.sMeter'], quality: ['uncalibrated'],
+    };
+
+    const indicators = model(state, INDICATOR_CAPS, RECEIVING).receiverIndicators!;
+    expect(indicators.map(({ receiver, sMeter }) => ({ receiver, domain: sMeter.domain }))).toEqual([
+      { receiver: 'MAIN', domain: { kind: 'engineering', unit: 'db' } },
+      { receiver: 'SUB', domain: { kind: 'raw' } },
     ]);
   });
 
@@ -389,6 +408,7 @@ describe('receiver indicators are structural-receiver addressed (MOR-2299 slice 
       .receiverIndicators?.find((indicator) => indicator.receiver === 'MAIN');
     expect(main?.sMeter.reading).toEqual({ status: 'unknown' });
     expect(main?.sMeter.availability.operational).toBe(false);
+    expect(main?.sMeter.domain).toEqual({ kind: 'unknown' });
     expect(main?.sMeter.source).toBeNull();
   });
 
@@ -404,6 +424,7 @@ describe('receiver indicators are structural-receiver addressed (MOR-2299 slice 
       .receiverIndicators?.find((indicator) => indicator.receiver === 'MAIN')!;
     expect(main.sMeter.reading).toEqual({ status: 'unknown' });
     expect(main.sMeter.availability.operational).toBe(false);
+    expect(main.sMeter.domain).toEqual({ kind: 'unknown' });
     expect(main.sMeter.source).toBeNull();
     expect(main.nbActive.reading).toEqual({ status: 'known', value: false });
   });
@@ -1074,8 +1095,14 @@ describe('RF gain additive display observation', () => {
     const legacyView = structuredClone(view);
     for (const field of [
       'signal', 'power', 'swr', 'alc', 'compression', 'drainVoltage', 'drainCurrent',
-    ] as const) delete legacyView.meters?.[field].source;
-    for (const indicator of legacyView.receiverIndicators ?? []) delete indicator.sMeter.source;
+    ] as const) {
+      delete legacyView.meters?.[field].source;
+      delete legacyView.meters?.[field].domain;
+    }
+    for (const indicator of legacyView.receiverIndicators ?? []) {
+      delete indicator.sMeter.source;
+      delete indicator.sMeter.domain;
+    }
     const strictJson = JSON.stringify(legacyView, (key, value) => ['display', 'activeFilterConfiguration', 'dataModeChoices'].includes(key) ? undefined : value);
     const digest = createHash('sha256').update(strictJson).digest('hex');
     expect(digest).toBe(stale ? 'b4b5cff2b85557e39baa48e4d73c756e12ff026488ffa05a1ef558ca0b3f0507' : '379a5f00e3bebae780e4215af4e014351df2a07fc067d412f97df6aeadca840f');

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -27,7 +27,8 @@ import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import type {
   RadioViewModel, TxAuxField, TxAuxViewModel, AtuStatus,
-  MeterField, MeterRfState, MeterSourceIdentity, MeterSourcePath, MetersViewModel,
+  MeterEngineeringUnit, MeterField, MeterRfState, MeterSourceIdentity, MeterSourcePath,
+  MeterValueDomain, MetersViewModel,
   AudioFocus, MonitorMode, RxAudioViewModel, ModeFilterViewModel,
   ActiveFilterConfiguration, FilterPassbandViewModel, DspViewModel, RfFrontEndViewModel,
   BandChoice, BandViewModel, RitXitViewModel, AntennaViewModel, ScanViewModel,
@@ -273,6 +274,34 @@ function meterRfState(tx: MetersTxAuthority): MeterRfState {
   return tx.radioTx === 'off' && tx.txRisk === 'none' ? 'receiving' : 'unknown';
 }
 
+const METER_UNIT_BY_PATH = {
+  'main.sMeter': 'db', 'sub.sMeter': 'db', powerMeter: 'w', swrMeter: 'ratio',
+  alcMeter: 'normalized', compMeter: 'db', vdMeter: 'v', idMeter: 'a',
+} as const satisfies Readonly<Record<MeterSourcePath, MeterEngineeringUnit>>;
+
+/**
+ * Observation quality says what the backend published; capability calibration
+ * only says which projection geometry is available. Exactly one decisive token
+ * in an otherwise all-string array establishes the domain. Live fields always
+ * receive an explicit result, including `unknown`.
+ */
+function meterValueDomain(
+  state: ServerState | null, path: MeterSourcePath, qualified: boolean,
+): MeterValueDomain {
+  if (!qualified) return { kind: 'unknown' };
+  const quality: readonly unknown[] | undefined = state?.fieldStatus?.[path]?.quality;
+  if (!Array.isArray(quality) || quality.some((value) => typeof value !== 'string')) {
+    return { kind: 'unknown' };
+  }
+  const decisive = quality.filter(
+    (value) => value === 'calibrated' || value === 'uncalibrated',
+  );
+  if (decisive.length !== 1) return { kind: 'unknown' };
+  return decisive[0] === 'calibrated'
+    ? { kind: 'engineering', unit: METER_UNIT_BY_PATH[path] }
+    : { kind: 'raw' };
+}
+
 function meterField(
   structural: boolean, observation: DisplayObservation<number>, relevant: boolean,
   state: ServerState,
@@ -285,6 +314,9 @@ function meterField(
     reading: operational ? { status: 'known', value: observation.value } : { status: 'unknown' },
     availability: { structural, operational },
     relevant,
+    domain: source === null
+      ? { kind: 'unknown' }
+      : meterValueDomain(state, source.path, operational),
     source: operational && source !== null
       && typeof providerGeneration === 'number'
       && Number.isSafeInteger(providerGeneration) && providerGeneration >= 0
@@ -909,6 +941,9 @@ function deriveReceiverIndicators(
         ...txAuxField(
           true, sMeterOperational,
           sMeterObservation.state === 'current' ? sMeterObservation.value : undefined,
+        ),
+        domain: meterValueDomain(
+          state, receiver === 'MAIN' ? 'main.sMeter' : 'sub.sMeter', sMeterOperational,
         ),
         source: sMeterOperational
           && typeof providerGeneration === 'number'

--- a/frontend/src/semantic/MetersSurface.svelte
+++ b/frontend/src/semantic/MetersSurface.svelte
@@ -58,12 +58,14 @@
    * the slot is called ONCE per render (see `display` below) and read twice,
    * never once per gauge.
    */
-  const signalDisplay = (signalProjection: SignalMeterProjection): ReturnType<typeof renderSlot> =>
-    signalProjection.scaleMode !== 's' || signalProjection.crossoverFraction === null ? null
-      : renderSlot('meters', {
+  const meterDisplay = (signalProjection: SignalMeterProjection): ReturnType<typeof renderSlot> =>
+    renderSlot('meters', {
       value: signalProjection.motionFraction,
       max: 1,
-      s9: signalProjection.crossoverFraction,
+      // Explicit raw/unknown domains cannot expose this fallback to the
+      // S-meter: `signalDisplay` below withholds their S-specific descriptor.
+      // The shared descriptor still owns the unrelated BarGauge palettes.
+      s9: signalProjection.crossoverFraction ?? 0,
     });
 </script>
 
@@ -102,7 +104,13 @@
    * read the SAME descriptor from ONE `renderSlot` call. Each consumer falls
    * back to its own component default when this is `null`.
    */
-  let display = $derived(meters ? signalDisplay(signalProjection) : null);
+  let display = $derived(meters ? meterDisplay(signalProjection) : null);
+  /** Explicit raw/unknown domains keep the shared bar palette but receive no
+   * S-specific language geometry or annotations. A non-null crossover also
+   * preserves the pre-MOR-2425 omitted-domain compatibility path. */
+  let signalDisplay = $derived(
+    signalProjection.crossoverFraction === null ? null : display,
+  );
 
 </script>
 
@@ -121,12 +129,12 @@
         class="meter-tile" data-meter-tile data-meter={present(meters.signal) ? "signal" : "swr"} data-testid={present(meters.signal) ? "meter-signal" : "meter-swr"}
         data-relevant={meters.signal.relevant} data-observed={observed(meters.signal)}
         role="group" aria-label={present(meters.signal) ? "S meter" : "SWR meter"}
-        {...display?.attributes ?? {}}
+        {...signalDisplay?.attributes ?? {}}
       >
         <LinearSMeter
           projection={signalProjection} label="S" compact
           mainPresent={present(meters.signal)}
-          display={display?.display ?? undefined}
+          display={signalDisplay?.display ?? undefined}
           lowerScale={present(meters.swr) ? swrLowerScale(meters.swr, meters.rfState) : undefined}
           relevant={meters.signal.relevant}
           source={meters.signal.source}

--- a/frontend/src/semantic/MetersSurface.svelte
+++ b/frontend/src/semantic/MetersSurface.svelte
@@ -59,10 +59,11 @@
    * never once per gauge.
    */
   const signalDisplay = (signalProjection: SignalMeterProjection): ReturnType<typeof renderSlot> =>
-    renderSlot('meters', {
+    signalProjection.scaleMode !== 's' || signalProjection.crossoverFraction === null ? null
+      : renderSlot('meters', {
       value: signalProjection.motionFraction,
       max: 1,
-      s9: signalProjection.s9Fraction,
+      s9: signalProjection.crossoverFraction,
     });
 </script>
 
@@ -87,6 +88,7 @@
 
   let signalProjection = $derived(projectSignalMeter(
     meters && observed(meters.signal) ? rawOf(meters.signal) : null,
+    meters?.signal.domain,
   ));
   let barMeters = $derived(projectBarMeters(view));
 

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -36,8 +36,10 @@ import type {
 } from '../radio-view-model';
 import { RF_LABEL, RF_MARK } from '../rx-tx-surface';
 import { isAlcFault, isSwrFault } from '../../components-v2/panels/meter-utils';
+import { dimColor } from '../../components-v2/meters/bar-gauge-utils';
 import type { Capabilities } from '$lib/types/capabilities';
 import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
+import { getDesignLanguage, registerDesignLanguage } from '../../presentation/languages/contract';
 
 // MOR-1470: swr/alc tables for the fault-highlighting suite — fault
 // predicates only fire in the calibrated engineering domain.
@@ -667,19 +669,61 @@ describe('station signal rendering honors the explicit sample domain (MOR-2425)'
     { raw: 240, actual: 40, label: 'S9+40' },
   ];
 
-  it('ignores a profile table for explicit raw samples and emits no S claims', () => {
+  const PROBE_ZONES = [
+    { end: 0.5, color: '#102030' },
+    { end: 1, color: '#D0E0F0' },
+  ] as const;
+  const BAR_FIELDS = ['power', 'alc', 'drainCurrent', 'drainVoltage', 'compression'] as const;
+
+  function withProbeMeterLanguage(fn: () => void): void {
+    const original = getDesignLanguage('fieldline')!;
+    registerDesignLanguage({
+      ...original,
+      renderers: {
+        ...original.renderers,
+        meters: () => ({
+          kind: 'domain-probe-meter', segmentCount: 12, segmentGapPx: 3,
+          toneBelowS9: '#112233', toneAboveS9: '#AABBCC', zones: PROBE_ZONES,
+          unknown: false,
+        }),
+      },
+    });
+    document.documentElement.dataset.designLanguage = 'fieldline';
+    try {
+      fn();
+    } finally {
+      registerDesignLanguage(original);
+      delete document.documentElement.dataset.designLanguage;
+    }
+  }
+
+  it.each([
+    [{ kind: 'raw' } as const, 53, 'uncalibrated'],
+    [{ kind: 'unknown' } as const, 53, 'unit unknown'],
+  ])('keeps selected bar palettes but withholds S semantics for explicit %j', (domain, value, stateText) => {
     const caps = makeFaultCaps();
     caps.meterCalibrations!.s_meter = S_METER_CAL;
     setCapabilities(caps);
     try {
-      const view = withSignalDomain(withRaw(base(), 'signal', 53), { kind: 'raw' });
-      withSurface(view, (s) => {
-        const tile = s.tile('signal')!;
-        expect(tile.textContent).toContain('53');
-        expect(tile.textContent).toContain('uncalibrated');
-        expect(tile.textContent).not.toMatch(/S[0-9]|dBm/);
-        expect(tile.querySelectorAll('[data-main-relevant] line')).toHaveLength(0);
-        expect(tile.hasAttribute('data-dl-lit-count')).toBe(false);
+      withProbeMeterLanguage(() => {
+        const view = withSignalDomain(withRaw(base(), 'signal', value), domain);
+        withSurface(view, (s) => {
+          const signal = s.tile('signal')!;
+          expect(signal.textContent).toContain(String(value));
+          expect(signal.textContent).toContain(stateText);
+          expect(signal.textContent).not.toMatch(/S[0-9]|dBm/);
+          expect(signal.querySelectorAll('[data-main-relevant] line')).toHaveLength(0);
+          expect(signal.querySelectorAll('[data-segment]')).toHaveLength(20);
+          expect([...signal.attributes].some((attribute) => attribute.name.startsWith('data-dl-')))
+            .toBe(false);
+
+          for (const field of BAR_FIELDS) {
+            const fills = [...s.tile(field)!.querySelectorAll('rect')]
+              .map((rect) => rect.getAttribute('fill'));
+            expect(fills).toContain(dimColor(PROBE_ZONES[0].color));
+            expect(fills).toContain(dimColor(PROBE_ZONES[1].color));
+          }
+        });
       });
     } finally {
       clearCapabilities();
@@ -704,24 +748,6 @@ describe('station signal rendering honors the explicit sample domain (MOR-2425)'
     }
   });
 
-  it('renders known numeric text but no inferred unit or geometry for explicit unknown', () => {
-    const caps = makeFaultCaps();
-    caps.meterCalibrations!.s_meter = S_METER_CAL;
-    setCapabilities(caps);
-    try {
-      const view = withSignalDomain(withRaw(base(), 'signal', 53), { kind: 'unknown' });
-      withSurface(view, (s) => {
-        const tile = s.tile('signal')!;
-        expect(tile.textContent).toContain('53');
-        expect(tile.textContent).toContain('unit unknown');
-        expect(tile.textContent).not.toMatch(/S[0-9]|dBm|uncalibrated/);
-        expect(tile.querySelectorAll('[data-meter-fill], [data-meter-peak]')).toHaveLength(0);
-        expect(tile.querySelectorAll('[data-main-relevant] line')).toHaveLength(0);
-      });
-    } finally {
-      clearCapabilities();
-    }
-  });
 });
 
 describe('the host descriptor and LinearSMeter share one signal projection', () => {
@@ -849,12 +875,15 @@ describe('the host descriptor and LinearSMeter share one signal projection', () 
     }
   });
 
-  it('creates one projection and reuses its motion and S9 fractions for the descriptor and the exact object for LinearSMeter', () => {
+  it('creates one shared descriptor while permissioning its S-specific consumers separately', () => {
     expect(SOURCE.match(/\bprojectSignalMeter\(/g)).toHaveLength(1);
+    expect(SOURCE.match(/\brenderSlot\(/g)).toHaveLength(1);
     expect(SOURCE).toMatch(/value:\s*signalProjection\.motionFraction/);
     expect(SOURCE).toMatch(/s9:\s*signalProjection\.crossoverFraction/);
     expect(SOURCE).toMatch(/projectSignalMeter\([\s\S]*?meters\?\.signal\.domain/);
     expect(SOURCE).toMatch(/<LinearSMeter[\s\S]*?projection=\{signalProjection\}/);
+    expect(SOURCE).toMatch(/zones=\{display\?\.display\?\.zones\}/);
+    expect(SOURCE).toMatch(/display=\{signalDisplay\?\.display\s*\?\?\s*undefined\}/);
     expect(SOURCE).not.toMatch(/\bsLevel\(/);
   });
 });

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -32,7 +32,7 @@ import MetersSurface from '../MetersSurface.svelte';
 import { projectBarMeters, type BarMeterKey } from '../bar-meter-projector';
 import { topologyFixtures, withMeters, withTxAux } from '../fixtures/topologies';
 import type {
-  Availability, MeterField, MeterRfState, MetersViewModel, RadioViewModel,
+  Availability, MeterField, MeterRfState, MetersViewModel, MeterValueDomain, RadioViewModel,
 } from '../radio-view-model';
 import { RF_LABEL, RF_MARK } from '../rx-tx-surface';
 import { isAlcFault, isSwrFault } from '../../components-v2/panels/meter-utils';
@@ -130,6 +130,16 @@ function withRaw(view: RadioViewModel, field: MeterKey, value: number): RadioVie
       ...meters,
       [field]: { ...current, reading: { status: 'known', value } } satisfies MeterField,
     } as MetersViewModel,
+  };
+}
+
+function withSignalDomain(view: RadioViewModel, domain: MeterValueDomain): RadioViewModel {
+  return {
+    ...view,
+    meters: {
+      ...view.meters!,
+      signal: { ...view.meters!.signal, domain },
+    },
   };
 }
 
@@ -650,6 +660,70 @@ describe('raw sMeter renders honestly, never a fabricated S-unit (MOR-1451)', ()
   });
 });
 
+describe('station signal rendering honors the explicit sample domain (MOR-2425)', () => {
+  const S_METER_CAL = [
+    { raw: 0, actual: -54, label: 'S0' },
+    { raw: 130, actual: 0, label: 'S9' },
+    { raw: 240, actual: 40, label: 'S9+40' },
+  ];
+
+  it('ignores a profile table for explicit raw samples and emits no S claims', () => {
+    const caps = makeFaultCaps();
+    caps.meterCalibrations!.s_meter = S_METER_CAL;
+    setCapabilities(caps);
+    try {
+      const view = withSignalDomain(withRaw(base(), 'signal', 53), { kind: 'raw' });
+      withSurface(view, (s) => {
+        const tile = s.tile('signal')!;
+        expect(tile.textContent).toContain('53');
+        expect(tile.textContent).toContain('uncalibrated');
+        expect(tile.textContent).not.toMatch(/S[0-9]|dBm/);
+        expect(tile.querySelectorAll('[data-main-relevant] line')).toHaveLength(0);
+        expect(tile.hasAttribute('data-dl-lit-count')).toBe(false);
+      });
+    } finally {
+      clearCapabilities();
+    }
+  });
+
+  it('retains engineering text but suppresses unsupported motion without a table', () => {
+    setCapabilities(makeFaultCaps());
+    try {
+      const view = withSignalDomain(withRaw(base(), 'signal', -12), {
+        kind: 'engineering', unit: 'db',
+      });
+      withSurface(view, (s) => {
+        const tile = s.tile('signal')!;
+        expect(tile.textContent).toContain('\u221212 dB rel S9');
+        expect(tile.textContent).toContain('scale unavailable');
+        expect(tile.querySelectorAll('[data-meter-fill], [data-meter-peak]')).toHaveLength(0);
+        expect(tile.querySelectorAll('[data-main-relevant] line')).toHaveLength(0);
+      });
+    } finally {
+      clearCapabilities();
+    }
+  });
+
+  it('renders known numeric text but no inferred unit or geometry for explicit unknown', () => {
+    const caps = makeFaultCaps();
+    caps.meterCalibrations!.s_meter = S_METER_CAL;
+    setCapabilities(caps);
+    try {
+      const view = withSignalDomain(withRaw(base(), 'signal', 53), { kind: 'unknown' });
+      withSurface(view, (s) => {
+        const tile = s.tile('signal')!;
+        expect(tile.textContent).toContain('53');
+        expect(tile.textContent).toContain('unit unknown');
+        expect(tile.textContent).not.toMatch(/S[0-9]|dBm|uncalibrated/);
+        expect(tile.querySelectorAll('[data-meter-fill], [data-meter-peak]')).toHaveLength(0);
+        expect(tile.querySelectorAll('[data-main-relevant] line')).toHaveLength(0);
+      });
+    } finally {
+      clearCapabilities();
+    }
+  });
+});
+
 describe('the host descriptor and LinearSMeter share one signal projection', () => {
   const NONUNIFORM_S_METER_CAL = [
     { raw: 0, actual: -54, label: 'S0' },
@@ -689,7 +763,9 @@ describe('the host descriptor and LinearSMeter share one signal projection', () 
     }) as unknown as typeof window.matchMedia;
 
     try {
-      withSurface(withRaw(base(), 'signal', -48), (s) => {
+      withSurface(withSignalDomain(withRaw(base(), 'signal', -48), {
+        kind: 'engineering', unit: 'db',
+      }), (s) => {
         const tile = s.tile('signal')!;
         expect(tile.dataset.dlUnknown).toBe('false');
         expect(tile.dataset.dlLitCount).toBe('1');
@@ -723,7 +799,11 @@ describe('the host descriptor and LinearSMeter share one signal projection', () 
       removeEventListener: () => {},
     }) as unknown as typeof window.matchMedia;
 
-    const props: { view: RadioViewModel } = proxy({ view: withRaw(base(), 'signal', -48) });
+    const props: { view: RadioViewModel } = proxy({
+      view: withSignalDomain(withRaw(base(), 'signal', -48), {
+        kind: 'engineering', unit: 'db',
+      }),
+    });
     const component = mount(MetersSurface, { target, props });
     flushSync();
     const tickXs = () => [...target.querySelectorAll<SVGLineElement>('[data-main-relevant] line')]
@@ -772,7 +852,8 @@ describe('the host descriptor and LinearSMeter share one signal projection', () 
   it('creates one projection and reuses its motion and S9 fractions for the descriptor and the exact object for LinearSMeter', () => {
     expect(SOURCE.match(/\bprojectSignalMeter\(/g)).toHaveLength(1);
     expect(SOURCE).toMatch(/value:\s*signalProjection\.motionFraction/);
-    expect(SOURCE).toMatch(/s9:\s*signalProjection\.s9Fraction/);
+    expect(SOURCE).toMatch(/s9:\s*signalProjection\.crossoverFraction/);
+    expect(SOURCE).toMatch(/projectSignalMeter\([\s\S]*?meters\?\.signal\.domain/);
     expect(SOURCE).toMatch(/<LinearSMeter[\s\S]*?projection=\{signalProjection\}/);
     expect(SOURCE).not.toMatch(/\bsLevel\(/);
   });

--- a/frontend/src/semantic/__tests__/radio-view-model.test.ts
+++ b/frontend/src/semantic/__tests__/radio-view-model.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { validateRadioViewModel, type RadioViewModel } from '../radio-view-model';
-import { withModeFilter, withFilterPassband } from '../fixtures/topologies';
+import { topologyFixtures, withMeters, withModeFilter, withFilterPassband } from '../fixtures/topologies';
 
 function valid(): RadioViewModel {
   return {
@@ -105,6 +105,55 @@ describe('validateRadioViewModel', () => {
       .receiverIndicators![0].sMeter.source).toEqual(MAIN_S_SOURCE);
     expect(validateRadioViewModel(withReceiverSource('SUB', SUB_S_SOURCE))
       .receiverIndicators![0].sMeter.source).toEqual(SUB_S_SOURCE);
+  });
+
+  it.each([
+    { kind: 'engineering', unit: 'db' }, { kind: 'raw' }, { kind: 'unknown' },
+  ] as const)('round-trips receiver S-meter domain %j', (domain) => {
+    const indicator = receiverIndicator();
+    const model = validateRadioViewModel({
+      ...valid(), receiverIndicators: [{
+        ...indicator, sMeter: { ...indicator.sMeter, domain },
+      }],
+    });
+    expect(model.receiverIndicators![0].sMeter.domain).toEqual(domain);
+  });
+
+  it.each([
+    { kind: 'engineering', unit: 'ratio' },
+    { kind: 'engineering' },
+    { kind: 'raw', unit: 'db' },
+    { kind: 'unknown', source: 'guess' },
+    { kind: 'mystery' },
+  ])('rejects malformed receiver S-meter domain %j', (domain) => {
+    const indicator = receiverIndicator();
+    expect(() => validateRadioViewModel({
+      ...valid(), receiverIndicators: [{
+        ...indicator, sMeter: { ...indicator.sMeter, domain },
+      }],
+    })).toThrow(TypeError);
+  });
+
+  it('preserves omitted legacy station domain and validates explicit station signal domain', () => {
+    const legacy = withMeters(topologyFixtures['1/single']);
+    expect(validateRadioViewModel(legacy).meters!.signal).not.toHaveProperty('domain');
+
+    const explicit = {
+      ...legacy,
+      meters: {
+        ...legacy.meters!,
+        signal: { ...legacy.meters!.signal, domain: { kind: 'engineering', unit: 'db' } },
+      },
+    } as const;
+    expect(validateRadioViewModel(explicit).meters!.signal.domain)
+      .toEqual({ kind: 'engineering', unit: 'db' });
+    expect(() => validateRadioViewModel({
+      ...legacy,
+      meters: {
+        ...legacy.meters!,
+        signal: { ...legacy.meters!.signal, domain: { kind: 'engineering', unit: 'w' } },
+      },
+    })).toThrow(TypeError);
   });
 
   it.each([

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -187,6 +187,11 @@ export interface TxAuxViewModel {
  * authority's conclusion, it never computes one.
  */
 export type MeterReading = { status: 'known'; value: number } | { status: 'unknown' };
+export type MeterEngineeringUnit = 'db' | 'normalized' | 'w' | 'ratio' | 'v' | 'a';
+export type MeterValueDomain =
+  | { readonly kind: 'engineering'; readonly unit: MeterEngineeringUnit }
+  | { readonly kind: 'raw' }
+  | { readonly kind: 'unknown' };
 export type MeterSourcePath =
   | 'main.sMeter' | 'sub.sMeter'
   | 'powerMeter' | 'swrMeter' | 'alcMeter' | 'compMeter' | 'vdMeter' | 'idMeter';
@@ -197,6 +202,12 @@ export interface MeterField {
   reading: MeterReading;
   availability: Availability;
   relevant: boolean;
+  /**
+   * Omitted only by pre-MOR-2425 internal fixtures/callers. Live adapters emit
+   * an explicit domain, including `unknown`; consumers must not infer an
+   * explicit unknown domain from profile calibration metadata.
+   */
+  domain?: MeterValueDomain;
   source?: MeterSourceIdentity | null;
 }
 
@@ -1033,6 +1044,8 @@ export interface ScopeDisplayViewModel {
  */
 export type ReceiverIndicatorField<T> = TxAuxField<T>;
 export interface ReceiverSMeterField extends ReceiverIndicatorField<number> {
+  /** Same compatibility rule as `MeterField.domain`. */
+  domain?: MeterValueDomain;
   source?: MeterSourceIdentity | null;
 }
 export interface ReceiverIndicatorViewModel {
@@ -1381,6 +1394,30 @@ const METER_SOURCE_PATHS: readonly MeterSourcePath[] = [
   'main.sMeter', 'sub.sMeter', 'powerMeter', 'swrMeter', 'alcMeter', 'compMeter', 'vdMeter', 'idMeter',
 ];
 type MeterSourceExpectation = 'signal' | Exclude<MeterSourcePath, 'main.sMeter' | 'sub.sMeter'>;
+const METER_UNIT_BY_SOURCE = {
+  'main.sMeter': 'db', 'sub.sMeter': 'db', powerMeter: 'w', swrMeter: 'ratio',
+  alcMeter: 'normalized', compMeter: 'db', vdMeter: 'v', idMeter: 'a',
+} as const satisfies Readonly<Record<MeterSourcePath, MeterEngineeringUnit>>;
+
+function validateMeterValueDomain(
+  value: unknown, path: string, expectedSource: MeterSourceExpectation,
+): MeterValueDomain {
+  const v = record(value, path);
+  if (v.kind === 'engineering') {
+    exactKeys(v, ['kind', 'unit'], path);
+    const unit = oneOf(
+      v.unit, ['db', 'normalized', 'w', 'ratio', 'v', 'a'] as const, `${path}.unit`,
+    );
+    const expectedUnit = expectedSource === 'signal' ? 'db' : METER_UNIT_BY_SOURCE[expectedSource];
+    if (unit !== expectedUnit) invalid(`${path}.unit`, expectedUnit);
+    return { kind: 'engineering', unit };
+  }
+  if (v.kind === 'raw' || v.kind === 'unknown') {
+    exactKeys(v, ['kind'], path);
+    return { kind: v.kind };
+  }
+  return invalid(`${path}.kind`, "'engineering' | 'raw' | 'unknown'");
+}
 
 function validateMeterSource(
   value: unknown, path: string, expected: MeterSourceExpectation,
@@ -1413,7 +1450,7 @@ function validateMeterField(
   value: unknown, path: string, expectedSource: MeterSourceExpectation,
 ): MeterField {
   const v = record(value, path);
-  exactKeys(v, ['reading', 'availability', 'relevant', 'source'], path);
+  exactKeys(v, ['reading', 'availability', 'relevant', 'domain', 'source'], path);
   const r = record(v.reading, `${path}.reading`);
   let reading: MeterReading;
   if (r.status === 'known') {
@@ -1429,6 +1466,9 @@ function validateMeterField(
     reading,
     availability: validateAvailability(v.availability, `${path}.availability`),
     relevant: bool(v.relevant, `${path}.relevant`),
+    ...(v.domain !== undefined
+      ? { domain: validateMeterValueDomain(v.domain, `${path}.domain`, expectedSource) }
+      : {}),
     ...(v.source !== undefined
       ? { source: v.source === null ? null : validateMeterSource(v.source, `${path}.source`, expectedSource) }
       : {}),
@@ -1439,9 +1479,10 @@ function validateDisplayObservedMeterField(
   value: unknown, path: string, expectedSource: MeterSourceExpectation,
 ): DisplayObservedMeterField {
   const v = record(value, path);
-  exactKeys(v, ['reading', 'availability', 'relevant', 'display', 'source'], path);
+  exactKeys(v, ['reading', 'availability', 'relevant', 'display', 'domain', 'source'], path);
   const strict = validateMeterField({
     reading: v.reading, availability: v.availability, relevant: v.relevant,
+    ...(v.domain !== undefined ? { domain: v.domain } : {}),
     ...(v.source !== undefined ? { source: v.source } : {}),
   }, path, expectedSource);
   return {
@@ -1552,17 +1593,19 @@ function validateReceiverSMeterField(
   value: unknown, path: string, receiver: ReceiverId,
 ): ReceiverSMeterField {
   const v = record(value, path);
-  exactKeys(v, ['reading', 'availability', 'source'], path);
+  exactKeys(v, ['reading', 'availability', 'domain', 'source'], path);
   const strict = validateTxAuxField(
     { reading: v.reading, availability: v.availability }, path, num,
   );
-  if (v.source === undefined) return strict;
-  if (v.source === null) return { ...strict, source: null };
+  const domain = v.domain === undefined
+    ? {} : { domain: validateMeterValueDomain(v.domain, `${path}.domain`, 'signal') };
+  if (v.source === undefined) return { ...strict, ...domain };
+  if (v.source === null) return { ...strict, ...domain, source: null };
   const source = validateMeterSource(v.source, `${path}.source`, 'signal');
   if (source.receiver !== receiver) {
     invalid(`${path}.source`, `the canonical ${receiver} receiver source`);
   }
-  return { ...strict, source };
+  return { ...strict, ...domain, source };
 }
 
 function validateReceiverIndicator(value: unknown, path: string): ReceiverIndicatorViewModel {


### PR DESCRIPTION
File-count exception: 14 code + 0 regenerated baselines = 14 files; root approved the file-count exception.

## Scope

- Linked issue / task: MOR-2425
- Compatibility impact: additive internal UI fact contract; no API / CLI / config / wire behavior change
- Adds a closed meter value-domain fact derived strictly from current fieldStatus quality evidence and carries it on station and receiver S-meter facts.
- Makes the canonical station signal projection honor explicit engineering, raw, and unknown domains.
- Gates S-unit geometry, crossover colors, S-specific design-language annotations, motion, peak, labels, and accessibility text on the projection permission.
- Keeps the single existing meter-language descriptor as the shared source for all five BarGauge palettes.
- Preserves the pre-MOR-2425 omitted-domain projection, language geometry, and annotation behavior for internal fixtures and callers only.

The 14 paths form one unit: qualified domain evidence is produced and validated once, consumed by the canonical station projection and renderer, and exercised through their direct component, language, and live-fixture consumers. No baseline was regenerated.

## BLOCKED correction

- Supersedes blocked head c044c2d7077657e915b93da66df5353d01bf5ce6.
- B1 fixed: explicit raw/unknown withhold only the S-specific descriptor; power, ALC, drain-current, drain-voltage, and compression still consume the selected shared palette.
- B2 fixed: intended-calibrated catalog and semantic-wiring S-meter fixtures now carry exactly one calibrated all-string quality marker per receiver and matching calibration evidence. Other meter fixture paths were not relabeled as engineering.
- The producer and validator canonical-unit maps remain duplicated declarative data because the enforced adapter-to-semantic seam permits type-only imports and rejects the requested value import; no reverse heavy adapter dependency or new module was introduced.
- Revised authorized scope is exactly 14 code files and 0 regenerated baselines; authored-base diff is 584 additions + 72 deletions = 656 A+D.

## Prior blocked-head CI evidence

- Quick run 34078600787: FAILED, 444 files with 441 passed / 3 failed; 10,935 tests passed / 10 failed.
- Visual run 34078600779: FAILED, 35 passed / 1 failed; topology-1-single--desktop differed by 5,554 pixels (1%).
- Those failures belong to stale head c044c2d7077657e915b93da66df5353d01bf5ce6 and are preserved here rather than overwritten.

## Acceptance boundary

- This proves the canonical station signal projection honors the sample domain.
- Receiver-domain fact plumbing is prepared, but ReceiverInstrumentHost consumption remains deferred to RH-M.
- Bars/SWR live semantics, Segmentline/direct-needle paths, legacy surfaces, SDK/activation, backend/profile work, and radio-side conversion are unchanged.

## Verification

- [x] Focused corrected plus affected legacy consumers: 10 Vitest files, 599 tests passed
- [x] npm run check: Svelte/TypeScript passed with 0 errors and 0 warnings
- [x] Scoped ESLint passed on applicable authorized paths; the fixture catalog is outside the src ESLint match and passed the harness TypeScript check
- [x] git diff --check passed
- [x] Natural successor quick 34079536103 passed in 4m20s
- [x] Natural successor visual 34079536128 passed in 1m37s; 36/36 comparisons, no regenerated baseline
- [x] Public/open-core boundary checked
- [x] Release or migration impact documented: none; optional domain preserves old internal fixture shape

## Agent Review

- [x] Fresh independent exact-head review comment posted for c1dbbcd2847b208195d399fff74209f147726289
- Reviewer: independent verifier report pr3313-independent-review-c1dbbcd28.md
- Result: Agent Review PASS, https://github.com/rigplane/rigplane-core/pull/3313#issuecomment-5564610245; canonical Agent Review Gate commit status is green

## Notes

- The coordinator read the full final diff, correction reports and independent reviews, and verified the actual main protection: canonical Agent Review Gate and quick are required and green. Separate v2 observation statuses are not required; affected visual is also green. The corrected squash body preserves this domain boundary and terminal result.
- Out of scope / follow-ups: RH-M receiver-host consumption and the explicitly deferred rendering families above.
