### PR TITLE
feat(MOR-2425): support availability-only actions

### DIFF
--- a/frontend/src/primitives/control-instruments/__tests__/control-instrument-behavior.test.ts
+++ b/frontend/src/primitives/control-instruments/__tests__/control-instrument-behavior.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   bindAbsoluteChoiceInstrument, bindActionInstrument, bindChoiceInstrument, bindToggleInstrument,
-  type InstrumentField,
+  type AvailabilityActionInput, type InstrumentAvailability, type InstrumentField,
 } from '../control-instrument-behavior';
 
 const usable = <T>(value: T): InstrumentField<T> => ({
@@ -15,6 +15,16 @@ const unknown = <T>(): InstrumentField<T> => ({
 });
 
 describe('control-instrument behavior bindings', () => {
+  it('keeps field and availability-only action inputs mutually exclusive', () => {
+    const invoke = vi.fn();
+    const mixed: AvailabilityActionInput = {
+      // @ts-expect-error Action evidence must come from exactly one input form.
+      availability: { structural: true, operational: true }, field: usable(1), invoke,
+    };
+
+    expect(mixed).toBeDefined();
+  });
+
   it('re-checks an action field and blocker at invocation time', () => {
     let field = usable(1);
     let blocked = false;
@@ -23,6 +33,8 @@ describe('control-instrument behavior bindings', () => {
 
     field = unavailable(1);
     behavior.invoke();
+    field = unknown<number>();
+    behavior.invoke();
     blocked = true;
     field = usable(1);
     behavior.invoke();
@@ -30,6 +42,45 @@ describe('control-instrument behavior bindings', () => {
     behavior.invoke();
 
     expect(invoke).toHaveBeenCalledOnce();
+  });
+
+  it('re-checks availability-only action admission and the current callback', () => {
+    let availability: InstrumentAvailability | undefined;
+    let blocked = false;
+    const first = vi.fn();
+    const replacement = vi.fn();
+    let invoke = first;
+    const behavior = bindActionInstrument(() => ({ availability, blocked, invoke }));
+
+    expect(behavior.available).toBe(false);
+    behavior.invoke();
+    availability = { structural: false, operational: true };
+    behavior.invoke();
+    availability = { structural: true, operational: false };
+    behavior.invoke();
+    availability = { structural: true, operational: true };
+    blocked = true;
+    behavior.invoke();
+    blocked = false;
+    invoke = replacement;
+
+    expect(behavior.available).toBe(true);
+    behavior.invoke();
+    expect(first).not.toHaveBeenCalled();
+    expect(replacement).toHaveBeenCalledOnce();
+  });
+
+  it('forwards optional availability-only action feedback without inventing it', () => {
+    const feedback = { phase: 'submitted' } as const;
+    const present = bindActionInstrument(() => ({
+      availability: { structural: true, operational: true }, feedback, invoke: vi.fn(),
+    }));
+    const absent = bindActionInstrument(() => ({
+      availability: { structural: true, operational: true }, invoke: vi.fn(),
+    }));
+
+    expect(present.feedback).toBe(feedback);
+    expect(absent.feedback).toBeUndefined();
   });
 
   it('derives a toggle target from the current confirmed boolean', () => {

--- a/frontend/src/primitives/control-instruments/__tests__/control-instrument-renderer.test.ts
+++ b/frontend/src/primitives/control-instruments/__tests__/control-instrument-renderer.test.ts
@@ -5,10 +5,11 @@ import {
   createChoiceRendererSeat,
   createFiniteRendererContext,
   createToggleRendererSeat,
+  type AvailabilityActionRendererInput,
   type ControlOption,
   type FiniteRendererContext,
 } from '../control-instrument-renderer.svelte';
-import type { InstrumentField } from '../control-instrument-behavior';
+import type { InstrumentAvailability, InstrumentField } from '../control-instrument-behavior';
 
 const field = <T>(value: T): InstrumentField<T> => ({
   availability: { structural: true, operational: true },
@@ -19,6 +20,17 @@ const unknown = <T>(): InstrumentField<T> => ({
 });
 
 describe('finite renderer leases', () => {
+  it('rejects mixed action evidence at the renderer boundary', () => {
+    const invoke = vi.fn();
+    const mixed: AvailabilityActionRendererInput = {
+      context: createFiniteRendererContext(), label: 'Run',
+      // @ts-expect-error Renderer action evidence must use exactly one input form.
+      availability: { structural: true, operational: true }, field: field(1), invoke,
+    };
+
+    expect(mixed).toBeDefined();
+  });
+
   it('permanently refuses a retained A1 callback after A-B-A without cleanup', () => {
     let context = createFiniteRendererContext();
     let current = field(1);
@@ -36,6 +48,77 @@ describe('finite renderer leases', () => {
     replacement.invoke();
     expect(replacement.active).toBe(true);
     expect(invoke).toHaveBeenCalledOnce();
+  });
+
+  it('renders availability-only actions without confirmed or status evidence', () => {
+    const context = createFiniteRendererContext();
+    const feedback = { phase: 'submitted' } as const;
+    const seat = createActionRendererSeat(() => ({
+      context, label: 'Equalize', title: 'Match VFOs',
+      availability: { structural: true, operational: true }, feedback, invoke: vi.fn(),
+    }));
+    const view = seat.attachRenderer().view;
+
+    expect(view).toEqual({
+      label: 'Equalize', title: 'Match VFOs', available: true, feedback,
+    });
+    expect('confirmed' in view!).toBe(false);
+    expect('reading' in view!).toBe(false);
+    expect('requested' in view!).toBe(false);
+  });
+
+  it('keeps availability-only leases independent and invokes the current callback once', () => {
+    const context = createFiniteRendererContext();
+    let availability: InstrumentAvailability | undefined = {
+      structural: true, operational: true,
+    };
+    const firstInvoke = vi.fn();
+    const replacementInvoke = vi.fn();
+    let invoke = firstInvoke;
+    const seat = createActionRendererSeat(() => ({
+      context, label: 'Swap', availability, invoke,
+    }));
+    const first = seat.attachRenderer();
+    const second = seat.attachRenderer();
+
+    first.dispose();
+    first.invoke();
+    invoke = replacementInvoke;
+    second.invoke();
+    availability = undefined;
+    second.invoke();
+    availability = { structural: true, operational: true };
+    seat.destroy();
+    second.invoke();
+
+    expect(first.active).toBe(false);
+    expect(second.active).toBe(false);
+    expect(firstInvoke).not.toHaveBeenCalled();
+    expect(replacementInvoke).toHaveBeenCalledOnce();
+  });
+
+  it('revokes availability-only A-B-A leases before reading action evidence', () => {
+    let context: FiniteRendererContext | null = null;
+    const readAvailability = vi.fn(() => ({ structural: true, operational: true }));
+    const invoke = vi.fn();
+    const seat = createActionRendererSeat(() => ({
+      context, label: 'Speak', get availability() { return readAvailability(); }, invoke,
+    }));
+    const absent = seat.attachRenderer();
+    expect(absent.view).toBeUndefined();
+    absent.invoke();
+
+    context = createFiniteRendererContext();
+    const stale = seat.attachRenderer();
+
+    context = createFiniteRendererContext();
+    context = createFiniteRendererContext();
+    expect(stale.view).toBeUndefined();
+    stale.invoke();
+
+    expect(stale.active).toBe(false);
+    expect(readAvailability).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
   });
 
   it('keeps simultaneous leases independent and destroys all only with the seat', () => {

--- a/frontend/src/primitives/control-instruments/control-instrument-behavior.ts
+++ b/frontend/src/primitives/control-instruments/control-instrument-behavior.ts
@@ -22,6 +22,15 @@ interface BindingInput<T, Feedback> {
 }
 
 interface ActionInput<T, Feedback> extends BindingInput<T, Feedback> {
+  readonly availability?: never;
+  readonly invoke: () => void;
+}
+
+export interface AvailabilityActionInput<Feedback = never> {
+  readonly availability: InstrumentAvailability | undefined;
+  readonly field?: never;
+  readonly blocked?: boolean;
+  readonly feedback?: Feedback;
   readonly invoke: () => void;
 }
 
@@ -51,6 +60,18 @@ const canInvoke = <T>(input: BindingInput<T, unknown>): input is BindingInput<T,
   && input.field.availability.operational
   && input.field.reading.status === 'known';
 
+const canInvokeAction = <T>(
+  input: ActionInput<T, unknown> | AvailabilityActionInput<unknown>,
+): boolean => {
+  if ('availability' in input) {
+    return input.blocked !== true
+      && input.availability !== undefined
+      && input.availability.structural
+      && input.availability.operational;
+  }
+  return canInvoke(input);
+};
+
 export interface ActionInstrumentBehavior<Feedback> {
   readonly available: boolean;
   readonly feedback: Feedback | undefined;
@@ -58,14 +79,14 @@ export interface ActionInstrumentBehavior<Feedback> {
 }
 
 export function bindActionInstrument<T, Feedback = never>(
-  current: () => ActionInput<T, Feedback>,
+  current: () => ActionInput<T, Feedback> | AvailabilityActionInput<Feedback>,
 ): ActionInstrumentBehavior<Feedback> {
   return {
-    get available() { return canInvoke(current()); },
+    get available() { return canInvokeAction(current()); },
     get feedback() { return current().feedback; },
     invoke() {
       const input = current();
-      if (canInvoke(input)) input.invoke();
+      if (canInvokeAction(input)) input.invoke();
     },
   };
 }

--- a/frontend/src/primitives/control-instruments/control-instrument-renderer.svelte.ts
+++ b/frontend/src/primitives/control-instruments/control-instrument-renderer.svelte.ts
@@ -4,6 +4,7 @@ import {
   bindActionInstrument,
   bindChoiceInstrument,
   bindToggleInstrument,
+  type InstrumentAvailability,
   type InstrumentField,
   type InstrumentReading,
 } from './control-instrument-behavior';
@@ -42,6 +43,15 @@ interface FieldRendererInput<T, Feedback> extends RendererInput {
 }
 
 export interface ActionRendererInput<T, Feedback = never> extends FieldRendererInput<T, Feedback> {
+  readonly availability?: never;
+  readonly invoke: () => void;
+}
+
+export interface AvailabilityActionRendererInput<Feedback = never> extends RendererInput {
+  readonly availability: InstrumentAvailability | undefined;
+  readonly field?: never;
+  readonly blocked?: boolean;
+  readonly feedback?: Feedback;
   readonly invoke: () => void;
 }
 
@@ -184,7 +194,7 @@ const feedbackView = <Feedback>(feedback: Feedback | undefined) =>
   feedback === undefined ? {} : { feedback };
 
 export function createActionRendererSeat<T, Feedback = never>(
-  readCurrent: () => ActionRendererInput<T, Feedback>,
+  readCurrent: () => ActionRendererInput<T, Feedback> | AvailabilityActionRendererInput<Feedback>,
 ): ActionRendererSeat<Feedback> {
   const behavior = bindActionInstrument<T, Feedback>(() => readCurrent());
   return createSeat(readCurrent, (guard) => ({


### PR DESCRIPTION
Linear owner: MOR-2425 (`d37d2dac-4dc3-4b64-a110-c8ca4b980196`)

## Problem and result

Action renderer seats currently require a known field reading even when an action has only structural and operational availability. This adds a mutually exclusive availability-only input to the existing action binding and renderer-seat factory while preserving the existing field-based input and its known-reading gate.

This is a staged primitive prerequisite only. It does not adopt live VFO operations, publish SDK or consumer changes, add action status, or change toggle and choice behavior.

## Scope

- Reuses `bindActionInstrument`, `createActionRendererSeat`, and the existing finite `createSeat` lifecycle.
- Re-reads availability, blocker, feedback, and callback at use time.
- Keeps undefined availability inert and preserves context revocation before action evidence reads.
- Rejects mixed field and availability inputs in the TypeScript contract.

Size: 4 code + 0 regenerated baselines = 4 files; 177 changed lines (171 additions, 6 deletions).

## Validation

- `npm test -- src/primitives/control-instruments/__tests__/control-instrument-behavior.test.ts` — 13 passed.
- `npm test -- src/primitives/control-instruments/__tests__/control-instrument-renderer.test.ts` — 13 passed.
- `npm run check` — 0 errors and 0 warnings.
- Scoped ESLint on the four changed files — passed.
- `git diff --check` — passed.

## Terminal verification

Exact head `ce41b848f25c568217f5939c067fd1ce5e3e85b4`: natural replacement quick34079255379 SUCCESS, visual34079255372 SUCCESS, and independent PASS5564578065. Initial draft/Ready-transition cancellations were superseded by these successful exact-head runs. Root read the full177-A+D diff, implementation report, independent report and final body before guarded merge. No live VFO or public SDK adoption is claimed.
