### PR TITLE
feat(MOR-2425): expose finite option disabled reasons

### DIFF
--- a/frontend/component-kit-api/verify-package.mjs
+++ b/frontend/component-kit-api/verify-package.mjs
@@ -208,6 +208,7 @@ try {
   defineComponentKit,
   type ComponentKitDeclaration,
   type ChoiceRendererProps,
+  type ControlOption,
   type FiniteChoiceValue,
   type FiniteControlAppearance,
   type FiniteControlReading,
@@ -225,15 +226,21 @@ const layout: LayoutManifest | undefined = declaration.layouts?.[0];
 const presentation: PresentationDeclaration | undefined = declaration.presentations?.[0];
 const finite: FiniteControlAppearance | undefined = declaration.finiteControlAppearances?.fixture;
 const numericChoiceRenderer: Component<ChoiceRendererProps<number>> | undefined = finite?.choice;
+const oldChoiceOption: ControlOption<'OFF'> = { value: 'OFF', label: 'Off' };
+const reasonedChoiceOption: ControlOption<'DATA1'> = {
+  value: 'DATA1', label: 'Data 1', disabled: true, disabledReason: 'Not available',
+};
 function inspectChoice(props: ChoiceRendererProps<'OFF' | 'DATA1'>):
   FiniteControlReading<'OFF' | 'DATA1'> | undefined {
   const view = props.lease.view;
   if (view === undefined) return undefined;
   const option = view.options[0]?.value;
+  const disabledReason: string | undefined = view.options[0]?.disabledReason;
   const supported: FiniteChoiceValue | undefined = option;
   const optionalEvidence = [view.defaultValue, view.requested, view.feedback] as const;
   const request = option === undefined ? undefined : () => props.lease.invoke(option);
   void supported;
+  void disabledReason;
   void optionalEvidence;
   void request;
   return view.reading;
@@ -244,6 +251,8 @@ void scalar;
 void layout;
 void presentation;
 void numericChoiceRenderer;
+void oldChoiceOption;
+void reasonedChoiceOption;
 void inspectChoice;
 export const installedKit = defineComponentKit(declaration);
 export const apiVersion = COMPONENT_KIT_API_VERSION;

--- a/frontend/src/primitives/control-instruments/__tests__/control-instrument-renderer.test.ts
+++ b/frontend/src/primitives/control-instruments/__tests__/control-instrument-renderer.test.ts
@@ -188,6 +188,35 @@ describe('finite renderer leases', () => {
     expect(lease.view?.reading).toEqual({ status: 'unknown' });
   });
 
+  it('passes current option reasons through without changing option admission', () => {
+    const context = createFiniteRendererContext();
+    let options: readonly ControlOption<string>[] = [
+      { value: 'MAIN', label: 'MAIN', disabled: true, disabledReason: 'MAIN unavailable' },
+      { value: 'SUB', label: 'SUB', disabledReason: 'SUB description only' },
+    ];
+    const invoke = vi.fn();
+    const seat = createAbsoluteChoiceRendererSeat(() => ({
+      context, reading: { status: 'unknown' }, available: true,
+      label: 'Active receiver', options, invoke,
+    }));
+    const lease = seat.attachRenderer();
+
+    expect(lease.view?.options).toEqual(options);
+    lease.invoke('MAIN');
+    lease.invoke('SUB');
+    expect(invoke).toHaveBeenCalledExactlyOnceWith('SUB');
+
+    options = [
+      { value: 'MAIN', label: 'MAIN', disabled: true, disabledReason: 'Replacement reason' },
+      { value: 'SUB', label: 'SUB' },
+    ];
+    expect(lease.view?.options[0]?.disabledReason).toBe('Replacement reason');
+    expect(lease.view?.options[1]?.disabledReason).toBeUndefined();
+    lease.invoke('MAIN');
+    lease.invoke('SUB');
+    expect(invoke).toHaveBeenCalledTimes(2);
+  });
+
   it('keeps an unknown absolute choice actionable through the existing binding', () => {
     const context = createFiniteRendererContext();
     const invoke = vi.fn();

--- a/frontend/src/primitives/control-instruments/__tests__/control-instrument-renderers.component.test.ts
+++ b/frontend/src/primitives/control-instruments/__tests__/control-instrument-renderers.component.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import ControlInstrumentRenderHarness from './ControlInstrumentRenderHarness.svelte';
+import FiniteControlRendererFixture from './support/FiniteControlRendererFixture.svelte';
 import type { InstrumentField } from '../control-instrument-behavior';
+import {
+  createAbsoluteChoiceRendererSeat, createFiniteRendererContext,
+} from '../control-instrument-renderer.svelte';
 
 const usable = <T>(value: T): InstrumentField<T> => ({
   availability: { structural: true, operational: true }, reading: { status: 'known', value },
@@ -39,6 +43,52 @@ describe('control-instrument renderer independence', () => {
     expect(r.radio('A').closest('[role="radiogroup"]')).toBe(r.choiceGroup());
     expect(r.radio('B').closest('[role="radiogroup"]')).toBe(r.choiceGroup());
     r.dispose();
+  });
+
+  it('renders per-option reasons as unique non-live descriptions without changing admission', () => {
+    const invoke = vi.fn();
+    const context = createFiniteRendererContext();
+    const seat = createAbsoluteChoiceRendererSeat(() => ({
+      context,
+      reading: { status: 'unknown' as const },
+      available: true,
+      label: 'Active receiver',
+      options: [
+        { value: 'MAIN', label: 'MAIN', disabled: true, disabledReason: 'MAIN unavailable' },
+        { value: 'SUB', label: 'SUB', disabledReason: 'SUB remains available' },
+      ],
+      invoke,
+    }));
+    const firstLease = seat.attachRenderer();
+    const secondLease = seat.attachRenderer();
+    const first = mount(FiniteControlRendererFixture, { target, props: { lease: firstLease } });
+    const secondTarget = document.createElement('div');
+    target.appendChild(secondTarget);
+    const second = mount(FiniteControlRendererFixture, {
+      target: secondTarget, props: { lease: secondLease },
+    });
+    flushSync();
+
+    const main = target.querySelector<HTMLButtonElement>('[data-testid="external-Active receiver-MAIN"]')!;
+    const sub = target.querySelector<HTMLButtonElement>('[data-testid="external-Active receiver-SUB"]')!;
+    const reasonId = main.getAttribute('aria-describedby');
+    const describedIds = [...target.querySelectorAll<HTMLButtonElement>('[aria-describedby]')]
+      .map(button => button.getAttribute('aria-describedby'));
+    expect(main.disabled).toBe(true);
+    expect(main.title).toBe('MAIN unavailable');
+    expect(reasonId).not.toBeNull();
+    expect(target.querySelector(`#${reasonId}`)?.textContent).toBe('MAIN unavailable');
+    expect(new Set(describedIds).size).toBe(describedIds.length);
+    expect(target.querySelector('[role="status"], [aria-live]')).toBeNull();
+
+    main.click();
+    sub.click();
+    expect(invoke).toHaveBeenCalledExactlyOnceWith('SUB');
+
+    unmount(first);
+    unmount(second);
+    firstLease.dispose();
+    secondLease.dispose();
   });
 
   it('renders unknown checkbox as mixed and leaves an out-of-list observed choice unselected', () => {

--- a/frontend/src/primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte
+++ b/frontend/src/primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte
@@ -1,6 +1,7 @@
 <script module lang="ts">
   export const retainedInvocations = new Map<string, (value?: unknown) => void>();
   export const resetRetainedInvocations = () => retainedInvocations.clear();
+  let optionReasonSequence = 0;
 </script>
 
 <script lang="ts">
@@ -12,6 +13,7 @@
   type Lease = ActionRendererLease | ToggleRendererLease | ChoiceRendererLease<unknown>;
   let { lease }: { lease: Lease } = $props();
   let view = $derived(lease.view);
+  const optionReasonPrefix = `finite-option-reason-${++optionReasonSequence}`;
 
   function invoke(value?: unknown): void {
     const current = lease.view;
@@ -35,13 +37,18 @@
       data-reading={view.reading.status === 'known' ? String(view.reading.value) : 'unknown'}
       data-testid={`external-${view.label}`}
     >
-      {#each view.options as option (option.value)}
+      {#each view.options as option, index (option.value)}
+        {@const reasonId = option.disabledReason
+          ? `${optionReasonPrefix}-${index}`
+          : undefined}
         <button
           type="button" role="radio" aria-checked={Object.is(view.selected, option.value)}
+          aria-describedby={reasonId} title={option.disabledReason}
           disabled={!view.available || option.disabled === true}
           data-testid={`external-${view.label}-${option.value}`}
           onclick={() => invoke(option.value)}
         >{option.label}</button>
+        {#if reasonId}<span id={reasonId} class="sr-only">{option.disabledReason}</span>{/if}
       {/each}
     </div>
   {:else if 'confirmed' in view}
@@ -57,3 +64,17 @@
     >{view.label}</button>
   {/if}
 {/if}
+
+<style>
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/frontend/src/primitives/control-instruments/control-instrument-renderer.svelte.ts
+++ b/frontend/src/primitives/control-instruments/control-instrument-renderer.svelte.ts
@@ -25,6 +25,7 @@ export interface ControlOption<T> {
   readonly value: T;
   readonly label: string;
   readonly disabled?: boolean;
+  readonly disabledReason?: string;
 }
 
 export interface RequestedTarget<T> {


### PR DESCRIPTION
Add optional `disabledReason` metadata to finite choice options so an external renderer can explain why one alternative is unavailable. `disabled` remains the per-option admission bit; changing a reason does not change invocation. The existing public alias carries the field without a new runtime export.

MOR-2425 packet R. Five files, 111 additions + 1 deletion = 112 A+D. No version, host lifecycle, VFO or activation change; actual Instrument Line consumption is a separate dependent task.

Validation at `352e5282a71b9425410486a67e7f4d38d159baa3`:

- Two focused files / 18 tests passed, covering current metadata, reason replacement/removal, unchanged admission and non-live accessible descriptions on the real radio fixture.
- Type/Svelte check: zero errors and warnings; scoped lint and diff check passed.
- `verify:component-kit-api` packed and installed API/fixture tarballs into a clean consumer; old and new option shapes compiled, Vite built, runtime exports stayed unchanged and exactly one physical Svelte installation was found.
- Natural [quick 34081915589](https://github.com/rigplane/rigplane-core/actions/runs/34081915589) SUCCESS and [visual 34081915623](https://github.com/rigplane/rigplane-core/actions/runs/34081915623) SUCCESS.
- Independent exact-head [PASS](https://github.com/rigplane/rigplane-core/pull/3318#issuecomment-5564888074). Root read the full diff, implementation report, review and body before guarded integration.
