### PR TITLE
fix(MOR-2425): honor station meter value domains

### DIFF
--- a/frontend/src/components-v2/panels/meter-utils.test.ts
+++ b/frontend/src/components-v2/panels/meter-utils.test.ts
@@ -255,6 +255,63 @@ describe('formatAlc / alcLevel / isAlcFault (calibrated: input is normalized 0-1
   });
 });
 
+describe('explicit meter domains override capability metadata (MOR-2425)', () => {
+  const raw = { kind: 'raw' } as const;
+  const unknown = { kind: 'unknown' } as const;
+
+  it('keeps an explicit raw sample raw even when calibrated tables exist', () => {
+    expect(formatPowerWatts(50, raw)).toBe('50 raw');
+    expect(normalizePower(50, raw)).toBeCloseTo(50 / 255);
+    expect(formatSwr(3, raw)).toBe('3 raw');
+    expect(swrLevel(120, raw)).toBeCloseTo(120 / 255);
+    expect(isSwrFault(3, raw)).toBe(false);
+    expect(formatAlc(0.95, raw)).toBe('1 raw');
+    expect(alcLevel(120, raw)).toBeCloseTo(120 / 255);
+    expect(isAlcFault(255, raw)).toBe(false);
+    expect(formatVolts(13.8, raw)).toBe('14 raw');
+    expect(vdLevel(13.8, raw)).toBeCloseTo(13.8 / 255);
+    expect(formatAmps(10, raw)).toBe('10 raw');
+    expect(idLevel(10, raw)).toBeCloseTo(10 / 255);
+    expect(formatCompDb(15, raw)).toBe('15 raw');
+    expect(compLevel(15, raw)).toBeCloseTo(15 / 255);
+  });
+
+  it('retains known numeric evidence for an unknown unit without geometry or faults', () => {
+    expect(formatPowerWatts(50, unknown)).toBe('50 unit unknown');
+    expect(normalizePower(50, unknown)).toBeNull();
+    expect(formatSwr(3, unknown)).toBe('3 unit unknown');
+    expect(swrLevel(3, unknown)).toBeNull();
+    expect(isSwrFault(3, unknown)).toBe(false);
+    expect(formatAlc(0.95, unknown)).toBe('0.95 unit unknown');
+    expect(alcLevel(0.95, unknown)).toBeNull();
+    expect(isAlcFault(0.95, unknown)).toBe(false);
+    expect(formatVolts(13.8, unknown)).toBe('13.8 unit unknown');
+    expect(vdLevel(13.8, unknown)).toBeNull();
+    expect(formatAmps(10, unknown)).toBe('10 unit unknown');
+    expect(idLevel(10, unknown)).toBeNull();
+    expect(formatCompDb(15, unknown)).toBe('15 unit unknown');
+    expect(compLevel(15, unknown)).toBeNull();
+  });
+
+  it('keeps declared engineering units when a physical scale is unavailable', () => {
+    clearCapabilities();
+    expect(formatPowerWatts(50, { kind: 'engineering', unit: 'w' })).toBe('50W');
+    expect(normalizePower(50, { kind: 'engineering', unit: 'w' })).toBeNull();
+    expect(formatVolts(13.8, { kind: 'engineering', unit: 'v' })).toBe('13.8 V');
+    expect(vdLevel(13.8, { kind: 'engineering', unit: 'v' })).toBeNull();
+    expect(formatSwr(2.25, { kind: 'engineering', unit: 'ratio' })).toBe('2.3');
+    expect(swrLevel(2.25, { kind: 'engineering', unit: 'ratio' })).toBeNull();
+    expect(isSwrFault(2.25, { kind: 'engineering', unit: 'ratio' })).toBe(true);
+    expect(formatAlc(0.95, { kind: 'engineering', unit: 'normalized' })).toBe('95%');
+    expect(alcLevel(0.95, { kind: 'engineering', unit: 'normalized' })).toBe(0.95);
+    expect(isAlcFault(0.95, { kind: 'engineering', unit: 'normalized' })).toBe(true);
+    expect(formatAmps(10, { kind: 'engineering', unit: 'a' })).toBe('10.0 A');
+    expect(idLevel(10, { kind: 'engineering', unit: 'a' })).toBeNull();
+    expect(formatCompDb(15, { kind: 'engineering', unit: 'db' })).toBe('15 dB');
+    expect(compLevel(15, { kind: 'engineering', unit: 'db' })).toBeNull();
+  });
+});
+
 describe('formatVolts / vdLevel (calibrated: input is volts)', () => {
   it('renders the bench supply voltage as-is', () => {
     expect(formatVolts(13.8)).toBe('13.8 V');

--- a/frontend/src/components-v2/panels/meter-utils.test.ts
+++ b/frontend/src/components-v2/panels/meter-utils.test.ts
@@ -113,6 +113,7 @@ import {
   compLevel,
   sLevel,
   isSwrFault,
+  hasSwrRatioScale,
   isAlcFault,
   updatePeakHold,
   peakHoldDisplay,
@@ -260,6 +261,7 @@ describe('explicit meter domains override capability metadata (MOR-2425)', () =>
   const unknown = { kind: 'unknown' } as const;
 
   it('keeps an explicit raw sample raw even when calibrated tables exist', () => {
+    expect(hasSwrRatioScale(raw)).toBe(false);
     expect(formatPowerWatts(50, raw)).toBe('50 raw');
     expect(normalizePower(50, raw)).toBeCloseTo(50 / 255);
     expect(formatSwr(3, raw)).toBe('3 raw');
@@ -277,6 +279,7 @@ describe('explicit meter domains override capability metadata (MOR-2425)', () =>
   });
 
   it('retains known numeric evidence for an unknown unit without geometry or faults', () => {
+    expect(hasSwrRatioScale(unknown)).toBe(false);
     expect(formatPowerWatts(50, unknown)).toBe('50 unit unknown');
     expect(normalizePower(50, unknown)).toBeNull();
     expect(formatSwr(3, unknown)).toBe('3 unit unknown');
@@ -295,6 +298,7 @@ describe('explicit meter domains override capability metadata (MOR-2425)', () =>
 
   it('keeps declared engineering units when a physical scale is unavailable', () => {
     clearCapabilities();
+    expect(hasSwrRatioScale({ kind: 'engineering', unit: 'ratio' })).toBe(false);
     expect(formatPowerWatts(50, { kind: 'engineering', unit: 'w' })).toBe('50W');
     expect(normalizePower(50, { kind: 'engineering', unit: 'w' })).toBeNull();
     expect(formatVolts(13.8, { kind: 'engineering', unit: 'v' })).toBe('13.8 V');
@@ -309,6 +313,10 @@ describe('explicit meter domains override capability metadata (MOR-2425)', () =>
     expect(idLevel(10, { kind: 'engineering', unit: 'a' })).toBeNull();
     expect(formatCompDb(15, { kind: 'engineering', unit: 'db' })).toBe('15 dB');
     expect(compLevel(15, { kind: 'engineering', unit: 'db' })).toBeNull();
+  });
+
+  it('keeps ratio-scale availability independent of the current sample', () => {
+    expect(hasSwrRatioScale({ kind: 'engineering', unit: 'ratio' })).toBe(true);
   });
 });
 

--- a/frontend/src/components-v2/panels/meter-utils.ts
+++ b/frontend/src/components-v2/panels/meter-utils.ts
@@ -3,15 +3,16 @@
 // Domain contract (MOR-1470, finishing ADR level-meter-calibrated-domain
 // Phase 3; mirrors the s_meter cutover from MOR-1451):
 //
-// - A meter whose active radio profile declares a
+// - A meter whose explicit domain is engineering and whose active radio
+//   profile declares a
 //   `[[meters.<key>.calibration]]` table arrives here ALREADY in
 //   engineering units — the backend interpolates raw→actual at the
 //   observation boundary (MOR-469): power=W, swr=ratio, alc=normalized
 //   0–1, comp=dB, vd=V, id=A. Formatters render that value directly and
 //   level fns normalize it against the table's top knot. Re-running the
 //   value through the curve would be a double conversion.
-// - A meter with NO declared table arrives as the raw device byte,
-//   flagged uncalibrated server-side. Every function here degrades to an
+// - An explicit raw domain is authoritative even if local capability metadata
+//   also has a table. Every function here degrades to an
 //   honest raw-scale reading tagged "raw" (e.g. "158 raw"; MOR-1527 — a
 //   naked number here was previously indistinguishable from a real
 //   engineering-unit reading), a neutral raw/255 bar, and no fault claims
@@ -32,6 +33,10 @@ import {
   getCalibratedScaleMaxRaw,
   isSmeterCalibrated,
 } from '../../primitives/meters/s-meter-scale';
+import type {
+  MeterEngineeringUnit,
+  MeterValueDomain,
+} from '../../semantic/radio-view-model';
 
 export type MeterSource = 'S' | 'SWR' | 'POWER' | 'po';
 
@@ -51,8 +56,7 @@ function clamp01(value: number): number {
   return Math.max(0, Math.min(1, value));
 }
 
-/** The declared calibration table for a meter, or null when the radio's
- *  profile does not declare one (the honest-raw domain). */
+/** The active profile's calibration table for a meter, when usable. */
 function getCal(meterType: string): MeterCalPoint[] | null {
   const cal = getMeterCalibration(meterType);
   return cal && cal.length >= 2 ? cal : null;
@@ -70,18 +74,51 @@ function formatRaw(value: number): string {
   return `${Math.round(Math.max(0, Math.min(RAW_SCALE_MAX, value)))} raw`;
 }
 
+const ENGINEERING_UNIT_LABEL = {
+  db: 'dB',
+  normalized: 'normalized',
+  w: 'W',
+  ratio: 'ratio',
+  v: 'V',
+  a: 'A',
+} as const satisfies Readonly<Record<MeterEngineeringUnit, string>>;
+
+function formatUnknownUnit(value: number): string {
+  return `${value} unit unknown`;
+}
+
+function formatDeclaredEngineering(value: number, unit: MeterEngineeringUnit): string {
+  return `${value} ${ENGINEERING_UNIT_LABEL[unit]}`;
+}
+
+function matchesEngineering(
+  domain: MeterValueDomain | undefined,
+  unit: MeterEngineeringUnit,
+): boolean {
+  return domain?.kind === 'engineering' && domain.unit === unit;
+}
+
 // ---- RF power (W when calibrated) ----
 
-export function formatPowerWatts(value: number): string {
+export function formatPowerWatts(value: number, domain?: MeterValueDomain): string {
+  if (domain?.kind === 'raw') return formatRaw(value);
+  if (domain?.kind === 'unknown') return formatUnknownUnit(value);
+  if (domain?.kind === 'engineering' && domain.unit !== 'w') {
+    return formatDeclaredEngineering(value, domain.unit);
+  }
   const cal = getCal('power');
-  if (!cal) return formatRaw(value);
-  const watts = Math.max(0, Math.min(topActual(cal), value));
+  if (!cal && domain === undefined) return formatRaw(value);
+  const watts = Math.max(0, cal ? Math.min(topActual(cal), value) : value);
   return `${Math.round(watts)}W`;
 }
 
-export function normalizePower(value: number): number {
+export function normalizePower(value: number): number;
+export function normalizePower(value: number, domain: MeterValueDomain): number | null;
+export function normalizePower(value: number, domain?: MeterValueDomain): number | null {
+  if (domain?.kind === 'raw') return normalize(value);
+  if (domain !== undefined && !matchesEngineering(domain, 'w')) return null;
   const cal = getCal('power');
-  if (!cal) return normalize(value);
+  if (!cal) return domain === undefined ? normalize(value) : null;
   const max = topActual(cal);
   return max > 0 ? clamp01(value / max) : 0;
 }
@@ -89,16 +126,24 @@ export function normalizePower(value: number): number {
 // ---- SWR (ratio when calibrated) ----
 
 /**
- * The SWR ratio, or NaN when the radio declares no swr table — an
- * uncalibrated raw byte has no honest ratio interpretation.
+ * The SWR ratio, or NaN when the domain cannot support a ratio claim.
+ * Omitted-domain compatibility still uses the active profile table.
  */
-export function swrRatio(value: number): number {
+export function swrRatio(value: number, domain?: MeterValueDomain): number {
+  if (domain !== undefined) return matchesEngineering(domain, 'ratio') ? value : NaN;
   return getCal('swr') ? value : NaN;
 }
 
-export function formatSwr(value: number): string {
+export function formatSwr(value: number, domain?: MeterValueDomain): string {
+  if (domain?.kind === 'raw') return formatRaw(value);
+  if (domain?.kind === 'unknown') return formatUnknownUnit(value);
+  if (domain?.kind === 'engineering' && domain.unit !== 'ratio') {
+    return formatDeclaredEngineering(value, domain.unit);
+  }
   const cal = getCal('swr');
-  if (!cal) return formatRaw(value);
+  if (!cal) {
+    return domain === undefined ? formatRaw(value) : Math.max(1, value).toFixed(1);
+  }
   const top = topActual(cal);
   // At/beyond the table top the true ratio is off-scale — render the
   // profile's own top label (e.g. "6.0+") instead of a fake exact value.
@@ -106,27 +151,34 @@ export function formatSwr(value: number): string {
   return Math.max(cal[0].actual, value).toFixed(1);
 }
 
-/** Bar level for SWR: ratio relative to the table's top knot. */
-export function swrLevel(value: number): number {
+/** SWR level in its explicit raw domain or against a declared ratio scale. */
+export function swrLevel(value: number): number;
+export function swrLevel(value: number, domain: MeterValueDomain): number | null;
+export function swrLevel(value: number, domain?: MeterValueDomain): number | null {
+  if (domain?.kind === 'raw') return normalize(value);
+  if (domain !== undefined && !matchesEngineering(domain, 'ratio')) return null;
   const cal = getCal('swr');
-  if (!cal) return normalize(value);
+  if (!cal) return domain === undefined ? normalize(value) : null;
   const max = topActual(cal);
   return max > 0 ? clamp01(value / max) : 0;
 }
 
-/** True when SWR exceeds 2.0 — only claimable in the calibrated ratio
- *  domain; an uncalibrated radio never asserts a fault it cannot
- *  measure. */
-export function isSwrFault(value: number): boolean {
-  const ratio = swrRatio(value);
+/** True when SWR exceeds 2.0 in an explicit or legacy-qualified ratio domain. */
+export function isSwrFault(value: number, domain?: MeterValueDomain): boolean {
+  const ratio = swrRatio(value, domain);
   return Number.isFinite(ratio) && ratio > 2.0;
 }
 
 // ---- ALC (normalized 0-1 when calibrated; redline-relative raw
 //      otherwise; plain raw with no data at all) ----
 
-export function formatAlc(value: number): string {
-  if (getCal('alc')) {
+export function formatAlc(value: number, domain?: MeterValueDomain): string {
+  if (domain?.kind === 'raw') return formatRaw(value);
+  if (domain?.kind === 'unknown') return formatUnknownUnit(value);
+  if (domain?.kind === 'engineering' && domain.unit !== 'normalized') {
+    return formatDeclaredEngineering(value, domain.unit);
+  }
+  if (getCal('alc') || matchesEngineering(domain, 'normalized')) {
     return `${Math.round(clamp01(value) * 100)}%`;
   }
   const redline = getMeterRedline('alc');
@@ -136,10 +188,13 @@ export function formatAlc(value: number): string {
   return formatRaw(value);
 }
 
-/** Redline-relative ALC level (0-1). The calibrated domain is already
- *  redline-relative (the table's top knot is the redline). */
-export function alcLevel(value: number): number {
-  if (getCal('alc')) return clamp01(value);
+/** Redline-relative ALC level, neutral raw geometry, or no supported motion. */
+export function alcLevel(value: number): number;
+export function alcLevel(value: number, domain: MeterValueDomain): number | null;
+export function alcLevel(value: number, domain?: MeterValueDomain): number | null {
+  if (domain?.kind === 'raw') return normalize(value);
+  if (domain !== undefined && !matchesEngineering(domain, 'normalized')) return null;
+  if (getCal('alc') || matchesEngineering(domain, 'normalized')) return clamp01(value);
   const redline = getMeterRedline('alc');
   if (redline !== null && redline > 0) {
     return Math.max(0, Math.min(redline, value)) / redline;
@@ -147,50 +202,78 @@ export function alcLevel(value: number): number {
   return normalize(value);
 }
 
-/** True when ALC is driven past 90% of the redline — only claimable when
- *  the profile declared a table or a redline. */
-export function isAlcFault(value: number): boolean {
+/** True when ALC is past 90% in an explicit normalized or legacy-qualified domain. */
+export function isAlcFault(value: number, domain?: MeterValueDomain): boolean {
+  if (domain !== undefined && !matchesEngineering(domain, 'normalized')) return false;
+  if (matchesEngineering(domain, 'normalized')) return clamp01(value) > 0.9;
   if (!getCal('alc') && getMeterRedline('alc') === null) return false;
   return alcLevel(value) > 0.9;
 }
 
 // ---- Vd / Id / COMP (V / A / dB when calibrated) ----
 
-export function formatVolts(value: number): string {
+export function formatVolts(value: number, domain?: MeterValueDomain): string {
+  if (domain?.kind === 'raw') return formatRaw(value);
+  if (domain?.kind === 'unknown') return formatUnknownUnit(value);
+  if (domain?.kind === 'engineering' && domain.unit !== 'v') {
+    return formatDeclaredEngineering(value, domain.unit);
+  }
   const cal = getCal('vd');
-  if (!cal) return formatRaw(value);
-  return `${Math.max(0, Math.min(topActual(cal), value)).toFixed(1)} V`;
+  if (!cal && domain === undefined) return formatRaw(value);
+  return `${Math.max(0, cal ? Math.min(topActual(cal), value) : value).toFixed(1)} V`;
 }
 
-export function vdLevel(value: number): number {
+export function vdLevel(value: number): number;
+export function vdLevel(value: number, domain: MeterValueDomain): number | null;
+export function vdLevel(value: number, domain?: MeterValueDomain): number | null {
+  if (domain?.kind === 'raw') return normalize(value);
+  if (domain !== undefined && !matchesEngineering(domain, 'v')) return null;
   const cal = getCal('vd');
-  if (!cal) return normalize(value);
+  if (!cal) return domain === undefined ? normalize(value) : null;
   const max = topActual(cal);
   return max > 0 ? clamp01(value / max) : 0;
 }
 
-export function formatAmps(value: number): string {
+export function formatAmps(value: number, domain?: MeterValueDomain): string {
+  if (domain?.kind === 'raw') return formatRaw(value);
+  if (domain?.kind === 'unknown') return formatUnknownUnit(value);
+  if (domain?.kind === 'engineering' && domain.unit !== 'a') {
+    return formatDeclaredEngineering(value, domain.unit);
+  }
   const cal = getCal('id');
-  if (!cal) return formatRaw(value);
-  return `${Math.max(0, Math.min(topActual(cal), value)).toFixed(1)} A`;
+  if (!cal && domain === undefined) return formatRaw(value);
+  return `${Math.max(0, cal ? Math.min(topActual(cal), value) : value).toFixed(1)} A`;
 }
 
-export function idLevel(value: number): number {
+export function idLevel(value: number): number;
+export function idLevel(value: number, domain: MeterValueDomain): number | null;
+export function idLevel(value: number, domain?: MeterValueDomain): number | null {
+  if (domain?.kind === 'raw') return normalize(value);
+  if (domain !== undefined && !matchesEngineering(domain, 'a')) return null;
   const cal = getCal('id');
-  if (!cal) return normalize(value);
+  if (!cal) return domain === undefined ? normalize(value) : null;
   const max = topActual(cal);
   return max > 0 ? clamp01(value / max) : 0;
 }
 
-export function formatCompDb(value: number): string {
+export function formatCompDb(value: number, domain?: MeterValueDomain): string {
+  if (domain?.kind === 'raw') return formatRaw(value);
+  if (domain?.kind === 'unknown') return formatUnknownUnit(value);
+  if (domain?.kind === 'engineering' && domain.unit !== 'db') {
+    return formatDeclaredEngineering(value, domain.unit);
+  }
   const cal = getCal('comp');
-  if (!cal) return formatRaw(value);
-  return `${Math.round(Math.max(0, Math.min(topActual(cal), value)))} dB`;
+  if (!cal && domain === undefined) return formatRaw(value);
+  return `${Math.round(Math.max(0, cal ? Math.min(topActual(cal), value) : value))} dB`;
 }
 
-export function compLevel(value: number): number {
+export function compLevel(value: number): number;
+export function compLevel(value: number, domain: MeterValueDomain): number | null;
+export function compLevel(value: number, domain?: MeterValueDomain): number | null {
+  if (domain?.kind === 'raw') return normalize(value);
+  if (domain !== undefined && !matchesEngineering(domain, 'db')) return null;
   const cal = getCal('comp');
-  if (!cal) return normalize(value);
+  if (!cal) return domain === undefined ? normalize(value) : null;
   const max = topActual(cal);
   return max > 0 ? clamp01(value / max) : 0;
 }

--- a/frontend/src/components-v2/panels/meter-utils.ts
+++ b/frontend/src/components-v2/panels/meter-utils.ts
@@ -134,6 +134,12 @@ export function swrRatio(value: number, domain?: MeterValueDomain): number {
   return getCal('swr') ? value : NaN;
 }
 
+/** Whether the lower SWR row has a physical ratio scale, independent of sample state. */
+export function hasSwrRatioScale(domain?: MeterValueDomain): boolean {
+  if (domain === undefined) return true;
+  return matchesEngineering(domain, 'ratio') && getCal('swr') !== null;
+}
+
 export function formatSwr(value: number, domain?: MeterValueDomain): string {
   if (domain?.kind === 'raw') return formatRaw(value);
   if (domain?.kind === 'unknown') return formatUnknownUnit(value);

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -446,7 +446,28 @@ describe('the meters surface mounts only when the view model carries the group',
       addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(() => false),
     }));
     h.session = { state: 'disconnected', epoch: 0 };
-    h.state = liveState(true, { powerMeter: 255 });
+    const initial = liveState(true, { powerMeter: 255 });
+    h.state = {
+      ...initial,
+      fieldStatus: {
+        ...initial.fieldStatus,
+        powerMeter: { ...fresh, quality: ['calibrated'] },
+      },
+    };
+    // This lifecycle test needs known physics to witness a retained peak:
+    // state values are already watts and this synthetic scale supplies only
+    // the display-axis maximum. Raw and unknown domains intentionally do not peak.
+    h.caps = {
+      ...(h.caps as Capabilities),
+      meterCalibrations: {
+        ...(h.caps as Capabilities).meterCalibrations,
+        power: [
+          { raw: 0, actual: 0, label: '0' },
+          { raw: 255, actual: 255, label: '255' },
+        ],
+      },
+    };
+    expect(setCapabilities(h.caps as Capabilities)).toBe(true);
     render();
     push({ intent: 'transmit', observedPtt: 'on' });
 

--- a/frontend/src/semantic/MetersSurface.svelte
+++ b/frontend/src/semantic/MetersSurface.svelte
@@ -34,19 +34,13 @@
   ] as const;
 
   function swrLowerScale(projection: SwrMeterProjection): LowerScaleDescriptor {
-    const hasRatioScale = projection.domain === undefined
-      || (
-        projection.domain.kind === 'engineering'
-        && projection.domain.unit === 'ratio'
-        && projection.motionFraction !== null
-      );
     return {
       label: 'SWR',
-      ticks: hasRatioScale ? SWR_LOWER_SCALE_TICKS : [],
+      ticks: projection.ratioScale ? SWR_LOWER_SCALE_TICKS : [],
       valueFraction: projection.motionFraction ?? 0,
       fault: projection.fault,
       relevant: projection.relevant,
-      stateText: projection.state === 'current' && !hasRatioScale
+      stateText: projection.state === 'current' && !projection.ratioScale
         ? projection.displayText : projection.stateText,
       accessibleDescription: projection.accessibleDescription ?? 'SWR: Not observed',
     };

--- a/frontend/src/semantic/MetersSurface.svelte
+++ b/frontend/src/semantic/MetersSurface.svelte
@@ -1,13 +1,12 @@
 <script module lang="ts">
-  import type { DisplayObservedMeterField, MeterRfState, MeterField } from './radio-view-model';
-  import { isSwrFault, swrLevel } from '../components-v2/panels/meter-utils';
+  import type { MeterField } from './radio-view-model';
   import {
     projectSignalMeter,
     type SignalMeterProjection,
   } from '../components-v2/meters/smeter-scale';
   import { renderSlot } from './design-language-renderers';
   import type { LowerScaleDescriptor } from '../components-v2/meters/LinearSMeter.svelte';
-  import { projectTxMeterPresentation } from './bar-meter-projector';
+  import type { SwrMeterProjection } from './bar-meter-projector';
 
   /** Level 1 — does this radio HAVE the meter at all. */
   const present = (f: MeterField): boolean => f.availability.structural;
@@ -34,14 +33,22 @@
     { value: 1, label: '∞' },
   ] as const;
 
-  function swrLowerScale(f: DisplayObservedMeterField, rfState: MeterRfState): LowerScaleDescriptor {
-    const state = projectTxMeterPresentation(f, rfState);
+  function swrLowerScale(projection: SwrMeterProjection): LowerScaleDescriptor {
+    const hasRatioScale = projection.domain === undefined
+      || (
+        projection.domain.kind === 'engineering'
+        && projection.domain.unit === 'ratio'
+        && projection.motionFraction !== null
+      );
     return {
-      label: 'SWR', ticks: SWR_LOWER_SCALE_TICKS,
-      valueFraction: state.value === null ? 0 : swrLevel(state.value),
-      fault: state.value !== null && f.relevant && isSwrFault(state.value),
-      relevant: f.relevant, stateText: state.text,
-      accessibleDescription: `SWR: ${state.description}`,
+      label: 'SWR',
+      ticks: hasRatioScale ? SWR_LOWER_SCALE_TICKS : [],
+      valueFraction: projection.motionFraction ?? 0,
+      fault: projection.fault,
+      relevant: projection.relevant,
+      stateText: projection.state === 'current' && !hasRatioScale
+        ? projection.displayText : projection.stateText,
+      accessibleDescription: projection.accessibleDescription ?? 'SWR: Not observed',
     };
   }
 
@@ -75,7 +82,7 @@
   import type { RadioViewModel } from './radio-view-model';
   import type { MeterContinuitySession } from '../primitives/meters/meter-ballistics.svelte';
   import { RF_LABEL, RF_MARK } from './rx-tx-surface';
-  import { projectBarMeters } from './bar-meter-projector';
+  import { projectBarMeters, projectSwrMeter } from './bar-meter-projector';
 
   interface Props {
     view: RadioViewModel;
@@ -93,6 +100,7 @@
     meters?.signal.domain,
   ));
   let barMeters = $derived(projectBarMeters(view));
+  let swrProjection = $derived(projectSwrMeter(view));
 
   /**
    * The active design language's `meters` descriptor for this render, or
@@ -135,7 +143,7 @@
           projection={signalProjection} label="S" compact
           mainPresent={present(meters.signal)}
           display={signalDisplay?.display ?? undefined}
-          lowerScale={present(meters.swr) ? swrLowerScale(meters.swr, meters.rfState) : undefined}
+          lowerScale={swrProjection ? swrLowerScale(swrProjection) : undefined}
           relevant={meters.signal.relevant}
           source={meters.signal.source}
           session={continuitySession}

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -145,6 +145,18 @@ function withSignalDomain(view: RadioViewModel, domain: MeterValueDomain): Radio
   };
 }
 
+function withMeterDomain(
+  view: RadioViewModel, field: MeterKey | 'swr', domain: MeterValueDomain,
+): RadioViewModel {
+  return {
+    ...view,
+    meters: {
+      ...view.meters!,
+      [field]: { ...view.meters![field], domain },
+    },
+  };
+}
+
 /** Sets the MOR-1244 `txAux.compressor` fact, or drops the whole group. */
 function compressor(view: RadioViewModel, value: boolean | 'unknown' | 'no-group'): RadioViewModel {
   if (value === 'no-group') {
@@ -1033,10 +1045,10 @@ describe('SWR/ALC fault highlighting reuses the dock\'s own threshold', () => {
   // MUTATION KILLED: either surface/projector reimplementing the threshold
   // instead of importing the shared predicates — the same instrument as the
   // PEAK_DECAY_MS parity test above (block 10).
-  it('the surface, projector, and MetersDockPanel import their fault predicates from shared meter-utils', () => {
+  it('the shared projector and MetersDockPanel import their fault predicates from shared meter-utils', () => {
     const dockSource = readFileSync('src/components-v2/panels/MetersDockPanel.svelte', 'utf8');
-    expect(SOURCE).toMatch(/import\s*\{[^}]*isSwrFault[^}]*\}\s*from\s*'\.\.\/components-v2\/panels\/meter-utils'/);
-    expect(PROJECTOR_SOURCE).toMatch(/import\s*\{[^}]*isAlcFault[^}]*\}\s*from\s*'\.\.\/components-v2\/panels\/meter-utils'/);
+    expect(SOURCE).toMatch(/projectSwrMeter/);
+    expect(PROJECTOR_SOURCE).toMatch(/import\s*\{[^}]*isAlcFault[^}]*isSwrFault[^}]*\}\s*from\s*'\.\.\/components-v2\/panels\/meter-utils'/);
     expect(dockSource).toMatch(/import\s*\{[^}]*isSwrFault[^}]*\}\s*from\s*'\.\/meter-utils'/);
     expect(dockSource).toMatch(/import\s*\{[^}]*isAlcFault[^}]*\}\s*from\s*'\.\/meter-utils'/);
     expect(SOURCE).not.toMatch(/function\s+isSwrFault|function\s+isAlcFault/);
@@ -1049,6 +1061,49 @@ describe('SWR/ALC fault highlighting reuses the dock\'s own threshold', () => {
   it('carries the fault as a boolean/attribute only — its own stylesheet stays colour-free', () => {
     const styles = SOURCE.slice(SOURCE.indexOf('<style>'));
     expect(styles).not.toMatch(/#[0-9a-f]{3,8}\b|\brgb\(|\bhsl\(/i);
+  });
+});
+
+describe('station level meters honor explicit sample domains (MOR-2425)', () => {
+  it('keeps calibrated metadata from turning explicit raw ALC/SWR into physical claims', () => {
+    setCapabilities(makeFaultCaps());
+    try {
+      let view = withRaw(base('transmitting'), 'alc', 255);
+      view = withMeterDomain(view, 'alc', { kind: 'raw' });
+      view = withRaw(view, 'swr', 120);
+      view = withMeterDomain(view, 'swr', { kind: 'raw' });
+      withSurface(view, (s) => {
+        expect(s.tile('alc')!.textContent).toContain('255 raw');
+        expect(s.tile('alc')!.dataset.fault).toBe('false');
+        expect(s.tile('alc')!.querySelector('[data-testid="bar-gauge-peak-marker"]')).toBeNull();
+        expect(s.signalSvg()!.getAttribute('data-lower-fault')).toBe('false');
+        expect(s.signalSvg()!.textContent).toContain('120 raw');
+        expect(s.signalSvg()!.querySelectorAll('[data-lower-tick-mark]')).toHaveLength(0);
+        expect(s.lowerFillCount()).toBeGreaterThan(0);
+      });
+    } finally {
+      clearCapabilities();
+    }
+  });
+
+  it('keeps a known unknown-domain value visible but suppresses motion, fault, and peak', () => {
+    setCapabilities(makeFaultCaps());
+    try {
+      let view = withRaw(base('transmitting'), 'power', 50);
+      view = withMeterDomain(view, 'power', { kind: 'unknown' });
+      view = withRaw(view, 'swr', 3);
+      view = withMeterDomain(view, 'swr', { kind: 'unknown' });
+      withSurface(view, (s) => {
+        expect(s.tile('power')!.textContent).toContain('50 unit unknown');
+        expect(s.tile('power')!.querySelectorAll('[data-gauge-fill]')).toHaveLength(0);
+        expect(s.tile('power')!.querySelector('[data-testid="bar-gauge-peak-marker"]')).toBeNull();
+        expect(s.signalSvg()!.textContent).toContain('3 unit unknown');
+        expect(s.signalSvg()!.querySelectorAll('[data-lower-fill]')).toHaveLength(0);
+        expect(s.signalSvg()!.getAttribute('data-lower-fault')).toBe('false');
+      });
+    } finally {
+      clearCapabilities();
+    }
   });
 });
 

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -1105,6 +1105,64 @@ describe('station level meters honor explicit sample domains (MOR-2425)', () => 
       clearCapabilities();
     }
   });
+
+  it('keeps a usable engineering SWR scale mounted across current, stale, unknown, and idle', () => {
+    setCapabilities(makeFaultCaps());
+    try {
+      const view = base('transmitting');
+      view.meters!.swr = {
+        ...view.meters!.swr,
+        domain: { kind: 'engineering', unit: 'ratio' },
+        display: { state: 'current', value: 2.25 },
+      };
+      const props: { view: RadioViewModel } = proxy({ view });
+      const component = mount(MetersSurface, { target, props });
+      flushSync();
+      const ticks = () => target.querySelectorAll('[data-lower-tick-mark]').length;
+      const fills = () => target.querySelectorAll('[data-lower-fill]').length;
+      const fault = () => target.querySelector('[data-lower-fault]')?.getAttribute('data-lower-fault');
+      expect(ticks()).toBe(6);
+      expect(fills()).toBeGreaterThan(0);
+      expect(fault()).toBe('true');
+
+      for (const display of [
+        { state: 'stale', value: 2.25 } as const,
+        { state: 'unknown', reason: 'not-observed' } as const,
+      ]) {
+        props.view = {
+          ...props.view,
+          meters: {
+            ...props.view.meters!,
+            swr: { ...props.view.meters!.swr, display },
+          },
+        };
+        flushSync();
+        expect(ticks()).toBe(6);
+        expect(fills()).toBe(0);
+        expect(fault()).toBe('false');
+      }
+
+      props.view = {
+        ...props.view,
+        meters: {
+          ...props.view.meters!,
+          rfState: 'receiving',
+          swr: {
+            ...props.view.meters!.swr,
+            relevant: false,
+            display: { state: 'current', value: 2.25 },
+          },
+        },
+      };
+      flushSync();
+      expect(ticks()).toBe(6);
+      expect(fills()).toBe(0);
+      expect(fault()).toBe('false');
+      unmount(component);
+    } finally {
+      clearCapabilities();
+    }
+  });
 });
 
 // ── 12. MOR-2250 (PR 2 of 2) — the shared lower-scale bar ──────────────────

--- a/frontend/src/semantic/__tests__/bar-meter-projector.test.ts
+++ b/frontend/src/semantic/__tests__/bar-meter-projector.test.ts
@@ -297,6 +297,7 @@ describe('projectBarMeters', () => {
       domain: { kind: 'raw' },
       motionFraction: 120 / 255,
       displayText: '120 raw',
+      ratioScale: false,
       fault: false,
       showPeak: false,
     });
@@ -310,7 +311,21 @@ describe('projectBarMeters', () => {
       domain: { kind: 'unknown' },
       motionFraction: null,
       displayText: '120 unit unknown',
+      ratioScale: false,
       fault: false,
+    });
+
+    view.meters!.swr = {
+      ...view.meters!.swr,
+      domain: { kind: 'engineering', unit: 'ratio' },
+      display: { state: 'current', value: 2.25 },
+    };
+    expect(projectSwrMeter(view)).toMatchObject({
+      state: 'current',
+      motionFraction: null,
+      displayText: '2.3',
+      ratioScale: false,
+      fault: true,
     });
   });
 });

--- a/frontend/src/semantic/__tests__/bar-meter-projector.test.ts
+++ b/frontend/src/semantic/__tests__/bar-meter-projector.test.ts
@@ -9,7 +9,11 @@ import type {
   MetersViewModel,
   RadioViewModel,
 } from '../radio-view-model';
-import { projectBarMeters, type BarMeterKey } from '../bar-meter-projector';
+import {
+  projectBarMeters,
+  projectSwrMeter,
+  type BarMeterKey,
+} from '../bar-meter-projector';
 
 function base(rfState: MeterRfState = 'transmitting'): RadioViewModel {
   const view = withMeters(withTxAux(topologyFixtures['1/single']), rfState);
@@ -89,8 +93,9 @@ describe('projectBarMeters', () => {
       { key: 'compression', label: 'COMP' },
     ]);
     expect(Object.keys(projected[0]).sort()).toEqual([
-      'accessibleDescription', 'displayText', 'fault', 'gauge', 'key', 'label',
-      'motionFraction', 'observed', 'relevant', 'showPeak', 'source',
+      'accessibleDescription', 'displayText', 'domain', 'fault', 'gauge', 'key',
+      'label', 'motionFraction', 'observed', 'relevant', 'showPeak', 'source',
+      'state', 'stateText',
     ]);
     expect(projected[0]).toMatchObject({
       motionFraction: 128 / 255,
@@ -137,7 +142,10 @@ describe('projectBarMeters', () => {
   it('keeps stale, unknown, idle, and indeterminate TX observations distinct', () => {
     const view = base();
     setDisplay(view, 'power', { state: 'stale', value: 170 });
+    setMeter(view, 'power', { domain: { kind: 'raw' } });
     expect(projectBarMeters(view)[0]).toMatchObject({
+      state: 'stale',
+      domain: { kind: 'raw' },
       motionFraction: null,
       displayText: 'STALE',
       accessibleDescription: 'Po: Stale observation',
@@ -148,6 +156,7 @@ describe('projectBarMeters', () => {
 
     setDisplay(view, 'power', { state: 'unknown', reason: 'not-observed' });
     expect(projectBarMeters(view)[0]).toMatchObject({
+      state: 'unknown',
       motionFraction: null,
       displayText: '?',
       accessibleDescription: 'Po: Not observed',
@@ -159,6 +168,7 @@ describe('projectBarMeters', () => {
     setMeter(view, 'power', { relevant: false });
     setDisplay(view, 'power', { state: 'current', value: 170 });
     expect(projectBarMeters(view)[0]).toMatchObject({
+      state: 'idle',
       motionFraction: null,
       displayText: 'IDLE',
       accessibleDescription: 'Po: Not measuring in RX',
@@ -169,6 +179,7 @@ describe('projectBarMeters', () => {
     view.meters!.rfState = 'unknown';
     setMeter(view, 'power', { relevant: true });
     expect(projectBarMeters(view)[0]).toMatchObject({
+      state: 'current',
       motionFraction: 170 / 255,
       displayText: '170 raw ?',
       accessibleDescription: 'Po: RF relevance indeterminate. Current observation. 170 raw',
@@ -232,5 +243,74 @@ describe('projectBarMeters', () => {
     setMeter(view, 'alc', { relevant: true });
     setDisplay(view, 'alc', { state: 'stale', value: 0.95 });
     expect(projectBarMeters(view).find(({ key }) => key === 'alc')?.fault).toBe(false);
+  });
+
+  it('arbitrates identical current values by each field\'s explicit domain', () => {
+    setCapabilities(calibratedCaps());
+    const raw = base();
+    setDisplay(raw, 'power', { state: 'current', value: 50 });
+    setMeter(raw, 'power', { domain: { kind: 'raw' } });
+    expect(projectBarMeters(raw)[0]).toMatchObject({
+      state: 'current',
+      domain: { kind: 'raw' },
+      motionFraction: 50 / 255,
+      displayText: '50 raw',
+      fault: false,
+      showPeak: false,
+    });
+
+    const engineering = base();
+    setDisplay(engineering, 'power', { state: 'current', value: 50 });
+    setMeter(engineering, 'power', { domain: { kind: 'engineering', unit: 'w' } });
+    expect(projectBarMeters(engineering)[0]).toMatchObject({
+      state: 'current',
+      domain: { kind: 'engineering', unit: 'w' },
+      motionFraction: 0.25,
+      displayText: '50W',
+      showPeak: true,
+    });
+
+    const unknown = base();
+    setDisplay(unknown, 'power', { state: 'current', value: 50 });
+    setMeter(unknown, 'power', { domain: { kind: 'unknown' } });
+    expect(projectBarMeters(unknown)[0]).toMatchObject({
+      state: 'current',
+      domain: { kind: 'unknown' },
+      motionFraction: null,
+      displayText: '50 unit unknown',
+      fault: false,
+      showPeak: false,
+    });
+  });
+
+  it('projects SWR once with explicit state/domain and no raw-derived fault', () => {
+    setCapabilities(calibratedCaps());
+    const view = base();
+    view.meters!.swr = {
+      ...view.meters!.swr,
+      domain: { kind: 'raw' },
+      display: { state: 'current', value: 120 },
+    };
+    expect(projectSwrMeter(view)).toMatchObject({
+      key: 'swr',
+      state: 'current',
+      domain: { kind: 'raw' },
+      motionFraction: 120 / 255,
+      displayText: '120 raw',
+      fault: false,
+      showPeak: false,
+    });
+
+    view.meters!.swr = {
+      ...view.meters!.swr,
+      domain: { kind: 'unknown' },
+    };
+    expect(projectSwrMeter(view)).toMatchObject({
+      state: 'current',
+      domain: { kind: 'unknown' },
+      motionFraction: null,
+      displayText: '120 unit unknown',
+      fault: false,
+    });
   });
 });

--- a/frontend/src/semantic/bar-meter-projector.ts
+++ b/frontend/src/semantic/bar-meter-projector.ts
@@ -5,10 +5,13 @@ import {
   formatAmps,
   formatCompDb,
   formatPowerWatts,
+  formatSwr,
   formatVolts,
   idLevel,
   isAlcFault,
+  isSwrFault,
   normalizePower,
+  swrLevel,
   vdLevel,
 } from '../components-v2/panels/meter-utils';
 import { projectTxMeterDisplay } from './tx-meter-display';
@@ -16,19 +19,25 @@ import type {
   DisplayObservedMeterField,
   MeterRfState,
   MeterSourceIdentity,
+  MeterValueDomain,
   MetersViewModel,
   RadioViewModel,
 } from './radio-view-model';
 
 export type BarMeterKey = Exclude<keyof MetersViewModel, 'rfState' | 'signal' | 'swr'>;
+export type LevelMeterKey = Exclude<keyof MetersViewModel, 'rfState' | 'signal'>;
+export type LevelMeterState = 'unsupported' | 'idle' | 'current' | 'stale' | 'unknown';
 
-export interface BarMeterProjection {
-  readonly key: BarMeterKey;
+export interface LevelMeterProjection<Key extends LevelMeterKey = LevelMeterKey> {
+  readonly key: Key;
   readonly label: string;
   readonly relevant: boolean;
   readonly observed: boolean;
+  readonly state: LevelMeterState;
+  readonly domain: MeterValueDomain | undefined;
   readonly motionFraction: number | null;
   readonly displayText: string;
+  readonly stateText: string;
   readonly accessibleDescription: string | undefined;
   readonly fault: boolean;
   readonly showPeak: boolean;
@@ -36,11 +45,14 @@ export interface BarMeterProjection {
   readonly gauge: boolean;
 }
 
-type BarDefinition = readonly [
-  BarMeterKey,
+export type BarMeterProjection = LevelMeterProjection<BarMeterKey>;
+export type SwrMeterProjection = LevelMeterProjection<'swr'>;
+
+type MeterDefinition<Key extends LevelMeterKey> = readonly [
+  Key,
   string,
-  (value: number) => number,
-  (value: number) => string,
+  (value: number, domain?: MeterValueDomain) => number | null,
+  (value: number, domain?: MeterValueDomain) => string,
   boolean,
 ];
 
@@ -50,10 +62,17 @@ const BAR_DEFINITIONS = [
   ['drainCurrent', 'Id', idLevel, formatAmps, true],
   ['drainVoltage', 'Vd', vdLevel, formatVolts, false],
   ['compression', 'COMP', compLevel, formatCompDb, false],
-] as const satisfies readonly BarDefinition[];
+] as const satisfies readonly MeterDefinition<BarMeterKey>[];
 
-const FAULT_CHECKS: Partial<Record<BarMeterKey, (value: number) => boolean>> = {
+const SWR_DEFINITION = [
+  'swr', 'SWR', swrLevel, formatSwr, false,
+] as const satisfies MeterDefinition<'swr'>;
+
+const FAULT_CHECKS: Partial<
+  Record<LevelMeterKey, (value: number, domain?: MeterValueDomain) => boolean>
+> = {
   alc: isAlcFault,
+  swr: isSwrFault,
 };
 
 const observed = (field: DisplayObservedMeterField): boolean =>
@@ -65,20 +84,69 @@ const reading = (field: DisplayObservedMeterField): number =>
 export function projectTxMeterPresentation(
   field: DisplayObservedMeterField,
   rfState: MeterRfState,
-) {
+): {
+  readonly state: LevelMeterState;
+  readonly value: number | null;
+  readonly text: string;
+  readonly description: string;
+} {
   const projected = projectTxMeterDisplay(field, rfState);
-  if (!projected.supported) return { value: null, text: '?', description: 'Not observed' };
+  if (!projected.supported) {
+    return { state: 'unsupported', value: null, text: '?', description: 'Not observed' };
+  }
   const { relevance, observation } = projected;
   if (relevance === 'idle') {
-    return { value: null, text: 'IDLE', description: 'Not measuring in RX' };
+    return { state: 'idle', value: null, text: 'IDLE', description: 'Not measuring in RX' };
   }
   const cue = relevance === 'indeterminate' ? 'RF relevance indeterminate. ' : '';
   return {
+    state: observation.state,
     value: observation.state === 'current' ? observation.value : null,
     text: observation.state === 'stale' ? 'STALE' : observation.state === 'current'
       ? (relevance === 'indeterminate' ? ' ?' : '') : '?',
     description: cue + (observation.state === 'stale' ? 'Stale observation'
       : observation.state === 'current' ? 'Current observation' : 'Not observed'),
+  };
+}
+
+function projectLevelMeter<Key extends LevelMeterKey>(
+  definition: MeterDefinition<Key>,
+  field: DisplayObservedMeterField,
+  rfState: MeterRfState,
+  txObserved: boolean,
+): LevelMeterProjection<Key> {
+  const [key, label, level, format, peakEligible] = definition;
+  const tx = txObserved ? projectTxMeterPresentation(field, rfState) : null;
+  const isObserved = tx ? tx.value !== null : observed(field);
+  const value = tx ? tx.value ?? 0 : reading(field);
+  const gauge = isObserved || tx !== null;
+  const formatted = format(value, field.domain);
+  const stateText = tx?.text ?? '';
+  const displayText = gauge
+    ? tx ? (isObserved ? formatted + stateText : stateText) : formatted
+    : `${label} ?`;
+  const motionFraction = isObserved ? level(value, field.domain) : null;
+  const state: LevelMeterState = tx?.state ?? (isObserved ? 'current' : 'unknown');
+
+  return {
+    key,
+    label,
+    relevant: field.relevant,
+    observed: isObserved,
+    state,
+    domain: field.domain,
+    motionFraction,
+    displayText,
+    stateText,
+    accessibleDescription: tx
+      ? `${label}: ${tx.description}${isObserved ? `. ${formatted}` : ''}`
+      : undefined,
+    fault: isObserved && field.relevant
+      && (FAULT_CHECKS[key]?.(value, field.domain) ?? false),
+    showPeak: peakEligible && isObserved && motionFraction !== null
+      && (field.domain === undefined || field.domain.kind === 'engineering'),
+    source: field.source,
+    gauge,
   };
 }
 
@@ -88,34 +156,19 @@ export function projectBarMeters(view: RadioViewModel): readonly BarMeterProject
   const compressorOn = view.txAux?.compressor.reading.status === 'known'
     && view.txAux.compressor.reading.value === true;
 
-  return BAR_DEFINITIONS.flatMap(([key, label, level, format, peakEligible]) => {
+  return BAR_DEFINITIONS.flatMap((definition) => {
+    const [key] = definition;
     const field = meters[key];
     if (!field.availability.structural || (key === 'compression' && !compressorOn)) return [];
 
-    const tx = key === 'power' || key === 'alc'
-      ? projectTxMeterPresentation(field, meters.rfState)
-      : null;
-    const isObserved = tx ? tx.value !== null : observed(field);
-    const value = tx ? tx.value ?? 0 : reading(field);
-    const gauge = isObserved || tx !== null;
-    const displayText = gauge
-      ? tx ? (isObserved ? format(value) + tx.text : tx.text) : format(value)
-      : `${label} ?`;
-
-    return [{
-      key,
-      label,
-      relevant: field.relevant,
-      observed: isObserved,
-      motionFraction: isObserved ? level(value) : null,
-      displayText,
-      accessibleDescription: tx
-        ? `${label}: ${tx.description}${isObserved ? `. ${format(value)}` : ''}`
-        : undefined,
-      fault: isObserved && field.relevant && (FAULT_CHECKS[key]?.(value) ?? false),
-      showPeak: peakEligible && isObserved,
-      source: field.source,
-      gauge,
-    }];
+    return [projectLevelMeter(
+      definition, field, meters.rfState, key === 'power' || key === 'alc',
+    )];
   });
+}
+
+export function projectSwrMeter(view: RadioViewModel): SwrMeterProjection | null {
+  const meters = view.meters;
+  if (!meters || !meters.swr.availability.structural) return null;
+  return projectLevelMeter(SWR_DEFINITION, meters.swr, meters.rfState, true);
 }

--- a/frontend/src/semantic/bar-meter-projector.ts
+++ b/frontend/src/semantic/bar-meter-projector.ts
@@ -7,6 +7,7 @@ import {
   formatPowerWatts,
   formatSwr,
   formatVolts,
+  hasSwrRatioScale,
   idLevel,
   isAlcFault,
   isSwrFault,
@@ -46,7 +47,9 @@ export interface LevelMeterProjection<Key extends LevelMeterKey = LevelMeterKey>
 }
 
 export type BarMeterProjection = LevelMeterProjection<BarMeterKey>;
-export type SwrMeterProjection = LevelMeterProjection<'swr'>;
+export type SwrMeterProjection = LevelMeterProjection<'swr'> & {
+  readonly ratioScale: boolean;
+};
 
 type MeterDefinition<Key extends LevelMeterKey> = readonly [
   Key,
@@ -170,5 +173,8 @@ export function projectBarMeters(view: RadioViewModel): readonly BarMeterProject
 export function projectSwrMeter(view: RadioViewModel): SwrMeterProjection | null {
   const meters = view.meters;
   if (!meters || !meters.swr.availability.structural) return null;
-  return projectLevelMeter(SWR_DEFINITION, meters.swr, meters.rfState, true);
+  return {
+    ...projectLevelMeter(SWR_DEFINITION, meters.swr, meters.rfState, true),
+    ratioScale: hasSwrRatioScale(meters.swr.domain),
+  };
 }


### PR DESCRIPTION
Linear owner: [MOR-2425](https://linear.app/morozsm/issue/MOR-2425)

Station level-meter presentation now follows explicit engineering/raw/unknown sample domains for text, motion, faults and peaks. Engineering samples are never interpolated again. Raw samples retain neutral raw geometry without physical faults or peak claims; unknown units retain numeric evidence without physical motion, faults or peaks. Engineering values without a usable scale retain their unit text without invented geometry. Omitted-domain internal compatibility remains unchanged.

SWR uses the shared meter projector and existing S+SWR lower row. Qualified ratio-scale ticks remain present across current/stale/unknown/idle sample states; fill and fault follow actual sample relevance. The power continuity fixture now qualifies only its peak witness as engineering watts with a matching synthetic scale.

## Verification and history

- Initial RED: 7 expected failures against metadata-driven behavior and the missing shared SWR projection, 229 passed. Initial focused GREEN: 236 passed.
- First head f8c9460f53a19cd1981294c16095926e38cd7d81 received independent BLOCKED for sample-dependent SWR tick loss and the unqualified power continuity fixture. Natural quick34082520405 failed one test / 11,004 passed; visual passed. This history is retained.
- Successor2f403b8bd66b5cb9622575db4fb68618c970a654: four focused files /254 passed, Svelte/TypeScript0 errors0 warnings, changed-path ESLint and diff-check passed.
- Independent mutation checks detect motion-dependent ticks, unqualified power, missing session forwarding, fabricated ratio-scale availability and raw peak enabling. Restored candidate remains clean.
- Natural quick34082946767 SUCCESS (446 files /11,007 tests and87visual-smoke); visual34082946769 SUCCESS (36tests).
- Fresh independent exact-head PASS: https://github.com/rigplane/rigplane-core/pull/3319#issuecomment-5565046115. No findings or mandatory body/squash corrections. Root read the full final diff, final report and body. Canonical required gate and quick are green; current main start guard is checked immediately before merge. Optional v2 observation statuses are not acceptance evidence.

## Scope

7 files,547 additions+103 deletions=650 A+D. This is one coherent helper/projector/live-consumer/continuity-witness change; splitting would leave either unused projection or a current consumer still deciding domains independently. No new public SDK/activation, host lifetime, alternate skin, legacy renderer, calibration table or scheduler change. No baseline regeneration.
