### PR TITLE
MOR-2425: adopt live VFO operation projection

### DIFF
--- a/frontend/src/semantic/VfoOperationGroup.svelte
+++ b/frontend/src/semantic/VfoOperationGroup.svelte
@@ -1,44 +1,18 @@
 <script module lang="ts">
   import type {
-    ActiveRx,
     BooleanFact,
-    DualActionBlockViewModel,
     RadioViewModel,
   } from './radio-view-model';
-
-  export type VfoOperationIntent =
-    | { kind: 'select-receiver'; receiver: 'MAIN' | 'SUB' }
-    | { kind: 'toggle-split' | 'toggle-dual-watch' }
-    | { kind: 'equalize' | 'swap' | 'quick-split' | 'quick-dual-watch' | 'speak' };
-
-  export interface OperationAvailability {
-    structural: boolean;
-    operational: boolean;
-    reason?: string;
-  }
-
-  export interface OperationReasons {
-    main?: string;
-    sub?: string;
-    equalize?: string;
-    swap?: string;
-    quickSplit?: string;
-    quickDualWatch?: string;
-    speak?: string;
-  }
+  import type {
+    VfoOperationIntent,
+    VfoOperationProjection,
+  } from './vfo-operation-projection';
 
   interface Props {
     appearance: 'semantic' | 'sdr' | 'standard';
     scheme: RadioViewModel['vfoScheme'];
-    activeReceiver: ActiveRx;
-    split: BooleanFact;
-    dualWatch: BooleanFact;
-    splitAvailability: OperationAvailability;
-    dualWatchAvailability: OperationAvailability;
-    actions: DualActionBlockViewModel;
-    actionReasons?: OperationReasons;
+    projection: VfoOperationProjection;
     digest?: { rx: string; tx: string; splitState: 'true' | 'false' | 'mixed' };
-    groupReason?: string;
     onIntent: (intent: VfoOperationIntent) => void;
   }
 
@@ -54,25 +28,26 @@
   let {
     appearance,
     scheme,
-    activeReceiver,
-    split,
-    dualWatch,
-    splitAvailability,
-    dualWatchAvailability,
-    actions,
-    actionReasons = {},
+    projection,
     digest,
-    groupReason,
     onIntent,
   }: Props = $props();
 
   const reasonIdPrefix = `vfo-operation-reason-${++sequence}`;
-  let active = $derived(activeReceiver.status === 'known' ? activeReceiver.receiver : null);
-  let hasReceiverSelector = $derived(actions.main.structural || actions.sub.structural);
-  let hasActions = $derived(Object.values(actions).some((action) => action.structural));
+  let active = $derived(projection.activeReceiver.reading.status === 'known'
+    ? projection.activeReceiver.reading.receiver : null);
+  let hasReceiverSelector = $derived(projection.activeReceiver.availability.structural);
+  let hasActions = $derived([
+    projection.activeReceiver.availability,
+    projection.equalize.availability,
+    projection.swap.availability,
+    projection.quickSplit.availability,
+    projection.quickDualWatch.availability,
+    projection.speak.availability,
+  ].some((operation) => operation.structural));
   let receiverAvailability = $derived({
-    MAIN: { ...actions.main, reason: actionReasons.main },
-    SUB: { ...actions.sub, reason: actionReasons.sub },
+    MAIN: projection.activeReceiver.options[0].availability,
+    SUB: projection.activeReceiver.options[1].availability,
   });
 
   function triState(fact: BooleanFact): 'true' | 'false' | 'mixed' {
@@ -88,53 +63,52 @@
     return reason ? `${reasonIdPrefix}-${name}` : undefined;
   }
 
-  function emit(intent: VfoOperationIntent, availability: OperationAvailability): void {
-    if (!availability.structural || !availability.operational) return;
+  function emit(intent: VfoOperationIntent): void {
     onIntent(intent);
   }
 </script>
 
   <div class="fact-toggles" data-vfo-operation-appearance={appearance}>
-    {#if splitAvailability.structural}
-      {@const splitReasonId = reasonId('split', splitAvailability.reason)}
+    {#if projection.split.availability.structural}
+      {@const splitReasonId = reasonId('split', projection.split.availability.reason)}
       <button
         type="button"
         class="fact-toggle"
         class:v2-control-button={appearance !== 'semantic'}
         data-vfo-split
         data-op="split"
-        data-active={triState(split)}
+        data-active={triState(projection.split.reading)}
         data-color="cyan"
         role="switch"
-        aria-checked={triState(split)}
-        aria-label={`${t('core.vfo.split.label')}: ${stateWord(split)}`}
+        aria-checked={triState(projection.split.reading)}
+        aria-label={`${t('core.vfo.split.label')}: ${stateWord(projection.split.reading)}`}
         aria-describedby={splitReasonId}
-        title={splitAvailability.reason}
-        disabled={!splitAvailability.operational}
-        onclick={() => emit({ kind: 'toggle-split' }, splitAvailability)}
+        title={projection.split.availability.reason}
+        disabled={!projection.split.availability.operational}
+        onclick={() => emit({ kind: 'toggle-split' })}
       >SPLIT</button>
-      {#if splitReasonId}<span id={splitReasonId} class="sr-only">{splitAvailability.reason}</span>{/if}
+      {#if splitReasonId}<span id={splitReasonId} class="sr-only">{projection.split.availability.reason}</span>{/if}
     {/if}
 
-    {#if dualWatchAvailability.structural}
-      {@const dualWatchReasonId = reasonId('dual-watch', dualWatchAvailability.reason)}
+    {#if projection.dualWatch.availability.structural}
+      {@const dualWatchReasonId = reasonId('dual-watch', projection.dualWatch.availability.reason)}
       <button
         type="button"
         class="fact-toggle"
         class:v2-control-button={appearance !== 'semantic'}
         data-vfo-dual-watch
         data-op="dw"
-        data-active={triState(dualWatch)}
+        data-active={triState(projection.dualWatch.reading)}
         data-color="green"
         role="switch"
-        aria-checked={triState(dualWatch)}
-        aria-label={`${t('core.vfo.dualWatch.label')}: ${stateWord(dualWatch)}`}
+        aria-checked={triState(projection.dualWatch.reading)}
+        aria-label={`${t('core.vfo.dualWatch.label')}: ${stateWord(projection.dualWatch.reading)}`}
         aria-describedby={dualWatchReasonId}
-        title={dualWatchAvailability.reason}
-        disabled={!dualWatchAvailability.operational}
-        onclick={() => emit({ kind: 'toggle-dual-watch' }, dualWatchAvailability)}
+        title={projection.dualWatch.availability.reason}
+        disabled={!projection.dualWatch.availability.operational}
+        onclick={() => emit({ kind: 'toggle-dual-watch' })}
       >DW</button>
-      {#if dualWatchReasonId}<span id={dualWatchReasonId} class="sr-only">{dualWatchAvailability.reason}</span>{/if}
+      {#if dualWatchReasonId}<span id={dualWatchReasonId} class="sr-only">{projection.dualWatch.availability.reason}</span>{/if}
     {/if}
   </div>
 
@@ -145,8 +119,8 @@
       data-vfo-operation-appearance={appearance}
       data-testid="vfo-ops"
       data-dual-action-block
-      data-disabled-reason={groupReason ? 'vfo-identity-unknown' : undefined}
-      title={groupReason}
+      data-disabled-reason={projection.groupReason ? 'vfo-identity-unknown' : undefined}
+      title={projection.groupReason}
     >
       {#if hasReceiverSelector}
         <ActiveReceiverToggle
@@ -155,57 +129,54 @@
           segmentLabels={{ MAIN: 'MAIN', SUB: 'SUB' }}
           allowReselect
           embedded
-          onChange={(receiver) => emit(
-            { kind: 'select-receiver', receiver },
-            receiver === 'MAIN' ? actions.main : actions.sub,
-          )}
+          onChange={(receiver) => emit({ kind: 'select-receiver', receiver })}
         />
       {/if}
 
-      {#if actions.equalize.structural}
-        {@const id = reasonId('equalize', actionReasons.equalize)}
+      {#if projection.equalize.availability.structural}
+        {@const id = reasonId('equalize', projection.equalize.availability.reason)}
         <button type="button" class="vfo-op" class:v2-control-button={appearance !== 'semantic'}
           data-op="copy" data-color="muted" data-active="false"
           data-vfo-equalize data-dual-action="equalize" aria-label={vfoEqualLabel(scheme)}
-          aria-describedby={id} title={actionReasons.equalize} disabled={!actions.equalize.operational}
-          onclick={() => emit({ kind: 'equalize' }, actions.equalize)}>{vfoEqualLabel(scheme)}</button>
-        {#if id}<span {id} class="sr-only">{actionReasons.equalize}</span>{/if}
+          aria-describedby={id} title={projection.equalize.availability.reason} disabled={!projection.equalize.availability.operational}
+          onclick={() => emit({ kind: 'equalize' })}>{vfoEqualLabel(scheme)}</button>
+        {#if id}<span {id} class="sr-only">{projection.equalize.availability.reason}</span>{/if}
       {/if}
 
-      {#if actions.swap.structural}
-        {@const id = reasonId('swap', actionReasons.swap)}
+      {#if projection.swap.availability.structural}
+        {@const id = reasonId('swap', projection.swap.availability.reason)}
         <button type="button" class="vfo-op" class:v2-control-button={appearance !== 'semantic'}
           data-op="swap" data-color="muted" data-active="false"
           data-vfo-swap data-dual-action="swap" aria-label={vfoSwapLabel(scheme)}
-          aria-describedby={id} title={actionReasons.swap} disabled={!actions.swap.operational}
-          onclick={() => emit({ kind: 'swap' }, actions.swap)}>{vfoSwapLabel(scheme)}</button>
-        {#if id}<span {id} class="sr-only">{actionReasons.swap}</span>{/if}
+          aria-describedby={id} title={projection.swap.availability.reason} disabled={!projection.swap.availability.operational}
+          onclick={() => emit({ kind: 'swap' })}>{vfoSwapLabel(scheme)}</button>
+        {#if id}<span {id} class="sr-only">{projection.swap.availability.reason}</span>{/if}
       {/if}
 
-      {#if actions.quickSplit.structural}
-        {@const id = reasonId('quick-split', actionReasons.quickSplit)}
+      {#if projection.quickSplit.availability.structural}
+        {@const id = reasonId('quick-split', projection.quickSplit.availability.reason)}
         <button type="button" class="vfo-op" class:v2-control-button={appearance !== 'semantic'}
           data-vfo-quick-split data-dual-action="quick-split" aria-label={t('core.vfo.ops.quickSplit')}
-          aria-describedby={id} title={actionReasons.quickSplit} disabled={!actions.quickSplit.operational}
-          onclick={() => emit({ kind: 'quick-split' }, actions.quickSplit)}>{t('core.vfo.ops.quickSplit')}</button>
-        {#if id}<span {id} class="sr-only">{actionReasons.quickSplit}</span>{/if}
+          aria-describedby={id} title={projection.quickSplit.availability.reason} disabled={!projection.quickSplit.availability.operational}
+          onclick={() => emit({ kind: 'quick-split' })}>{t('core.vfo.ops.quickSplit')}</button>
+        {#if id}<span {id} class="sr-only">{projection.quickSplit.availability.reason}</span>{/if}
       {/if}
 
-      {#if actions.quickDualWatch.structural}
-        {@const id = reasonId('quick-dual-watch', actionReasons.quickDualWatch)}
+      {#if projection.quickDualWatch.availability.structural}
+        {@const id = reasonId('quick-dual-watch', projection.quickDualWatch.availability.reason)}
         <button type="button" class="vfo-op" class:v2-control-button={appearance !== 'semantic'}
           data-vfo-quick-dual-watch data-dual-action="quick-dual-watch" aria-label={t('core.vfo.ops.quickDualWatch')}
-          aria-describedby={id} title={actionReasons.quickDualWatch} disabled={!actions.quickDualWatch.operational}
-          onclick={() => emit({ kind: 'quick-dual-watch' }, actions.quickDualWatch)}>{t('core.vfo.ops.quickDualWatch')}</button>
-        {#if id}<span {id} class="sr-only">{actionReasons.quickDualWatch}</span>{/if}
+          aria-describedby={id} title={projection.quickDualWatch.availability.reason} disabled={!projection.quickDualWatch.availability.operational}
+          onclick={() => emit({ kind: 'quick-dual-watch' })}>{t('core.vfo.ops.quickDualWatch')}</button>
+        {#if id}<span {id} class="sr-only">{projection.quickDualWatch.availability.reason}</span>{/if}
       {/if}
 
-      {#if actions.speak.structural}
-        {@const id = reasonId('speak', actionReasons.speak)}
+      {#if projection.speak.availability.structural}
+        {@const id = reasonId('speak', projection.speak.availability.reason)}
         <button type="button" class="vfo-op" class:v2-control-button={appearance !== 'semantic'}
-          data-dual-action="speak" aria-describedby={id} title={actionReasons.speak ?? 'Speak current frequency aloud'}
-          disabled={!actions.speak.operational} onclick={() => emit({ kind: 'speak' }, actions.speak)}>SPEAK</button>
-        {#if id}<span {id} class="sr-only">{actionReasons.speak}</span>{/if}
+          data-dual-action="speak" aria-describedby={id} title={projection.speak.availability.reason ?? 'Speak current frequency aloud'}
+          disabled={!projection.speak.availability.operational} onclick={() => emit({ kind: 'speak' })}>SPEAK</button>
+        {#if id}<span {id} class="sr-only">{projection.speak.availability.reason}</span>{/if}
       {/if}
     </div>
   {/if}

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -42,7 +42,13 @@
   import type { SignalMeterFrame } from '../components-v2/meters/signal-meter-motion.svelte';
   import VfoPanel from '../components-v2/vfo/VfoPanel.svelte';
   import VfoIndicatorRow from './VfoIndicatorRow.svelte';
-  import VfoOperationGroup, { type VfoOperationIntent } from './VfoOperationGroup.svelte';
+  import VfoOperationGroup from './VfoOperationGroup.svelte';
+  import {
+    invokeVfoOperation,
+    projectVfoOperations,
+    type VfoOperationIntent,
+    type VfoOperationProjectionInput,
+  } from './vfo-operation-projection';
   import type { ReceiverInstrumentHandles } from './ReceiverInstrumentHost.svelte';
   import { splitFrequencyToDigits, groupDigitsForDisplay } from '../primitives/frequency/frequency-tuning';
   import { renderSlot } from './design-language-renderers';
@@ -206,15 +212,6 @@
    */
   let vfoPool = $derived(selectionPoolSize ?? viewModel.vfos.length);
   let hasVfoPair = $derived(vfoPool > 1);
-  let dualActions = $derived(viewModel.radioWideIndicators?.actions ?? {
-    main: { structural: false, operational: false },
-    sub: { structural: false, operational: false },
-    equalize: { structural: hasVfoPair, operational: Boolean(onEqualizeVfos) },
-    swap: { structural: hasVfoPair, operational: Boolean(onSwapVfos) },
-    quickSplit: { structural: false, operational: false },
-    quickDualWatch: { structural: false, operational: false },
-    speak: { structural: false, operational: false },
-  });
   let relativeIdentityUnknown = $derived(viewModel.vfos.some((vfo) => vfo.slot.kind === 'relative'));
   let relativeReceiver = $derived(
     viewModel.vfos.find((vfo) => vfo.slot.kind === 'relative')?.receiver ?? null,
@@ -257,21 +254,37 @@
   function identityOnlyReasonText(): string | undefined {
     return relativeIdentityUnknown ? t('core.vfo.ops.identityUnknownReason') : undefined;
   }
-  /** MOR-1481: quick-split's own operational gate
-   *  (`viewModel.split.status === 'unknown'`) is the SAME condition
-   *  `toggleSplit`'s fact-toggle carries below, so the two share one
-   *  catalog key rather than a parallel vocabulary. Identity wins when both
-   *  apply — it is the more actionable claim (the A/B resolver exists for
-   *  it), while nothing on this surface resolves an unread split state. */
-  function quickSplitReasonText(): string | undefined {
-    if (relativeIdentityUnknown) return t('core.vfo.ops.identityUnknownReason');
-    return viewModel.split.status === 'unknown' ? t('core.vfo.split.unknownReason') : undefined;
+
+  function vfoOperationInput(): VfoOperationProjectionInput {
+    return {
+      hasVfoPair,
+      hasDualReceiver,
+      relativeIdentityUnknown,
+      activeReceiver: viewModel.activeReceiver,
+      split: viewModel.split,
+      dualWatch: viewModel.dualWatch,
+      actions: viewModel.radioWideIndicators?.actions,
+      callbacks: {
+        onToggleSplit,
+        onToggleDualWatch,
+        onSelectMainReceiver,
+        onSelectSubReceiver,
+        onEqualizeVfos,
+        onSwapVfos,
+        onQuickSplit,
+        onQuickDualWatch,
+        onSpeak,
+      },
+      reasons: {
+        receiverUnavailable: t('core.vfo.select.receiverUnavailableReason'),
+        identityUnknown: t('core.vfo.ops.identityUnknownReason'),
+        splitUnknown: t('core.vfo.split.unknownReason'),
+        dualWatchUnknown: t('core.vfo.dualWatch.unknownReason'),
+      },
+    };
   }
-  /** Mirrors `quickSplitReasonText` for dual watch. */
-  function quickDualWatchReasonText(): string | undefined {
-    if (relativeIdentityUnknown) return t('core.vfo.ops.identityUnknownReason');
-    return viewModel.dualWatch.status === 'unknown' ? t('core.vfo.dualWatch.unknownReason') : undefined;
-  }
+
+  let vfoOperations = $derived(projectVfoOperations(vfoOperationInput()));
 
   function slotKey(slot: VfoSlot): string {
     if (slot.kind === 'slotted') return slot.id;
@@ -376,84 +389,8 @@
     window.setTimeout(() => { relativeSelectionPending = false; }, 2500);
   }
 
-  function toggleSplit(): void {
-    if (viewModel.split.status !== 'known') return;
-    onToggleSplit?.();
-  }
-
-  function toggleDualWatch(): void {
-    if (viewModel.dualWatch.status !== 'known') return;
-    onToggleDualWatch?.();
-  }
-
-  /**
-   * MOR-1652 — equalize and swap are caller-admitted primitive intents. They
-   * do not need an observed A/B identity because this surface neither chooses
-   * a direction nor derives source/target; an omitted callback remains inert.
-   */
-  function equalizeVfos(): void {
-    if (!dualActions.equalize.operational) return;
-    onEqualizeVfos?.();
-  }
-
-  function swapVfos(): void {
-    if (!dualActions.swap.operational) return;
-    onSwapVfos?.();
-  }
-
-  function selectMainReceiver(): void {
-    if (!dualActions.main.operational) return;
-    onSelectMainReceiver?.();
-  }
-
-  function selectSubReceiver(): void {
-    if (!dualActions.sub.operational) return;
-    onSelectSubReceiver?.();
-  }
-
-  function speak(): void {
-    if (!dualActions.speak.operational) return;
-    onSpeak?.();
-  }
-
-  /**
-   * MOR-1321 — the OPERATIONAL half of the gate, and it applies to the quick
-   * triggers only. `quick_split` / `quick_dualwatch` end with the corresponding
-   * fact turned ON, so firing one while that fact is unobserved would ask the
-   * radio to reach a state this surface cannot see it reach — the same reason
-   * `toggleSplit`/`toggleDualWatch` above refuse, and the same `disabled`
-   * attribute, not a parallel mechanism.
-   *
-   * Equalize and swap deliberately have NO such guard: neither reads a fact,
-   * both are meaningful whatever split/dual-watch report, and gating them on an
-   * unrelated unknown would invent a dependency the radio does not have.
-   */
-  function quickSplit(): void {
-    if (relativeIdentityUnknown || !dualActions.quickSplit.operational
-      || viewModel.split.status !== 'known') return;
-    onQuickSplit?.();
-  }
-
-  function quickDualWatch(): void {
-    if (relativeIdentityUnknown || !dualActions.quickDualWatch.operational
-      || viewModel.dualWatch.status !== 'known') return;
-    onQuickDualWatch?.();
-  }
-
   function handleOperationIntent(intent: VfoOperationIntent): void {
-    switch (intent.kind) {
-      case 'select-receiver':
-        if (intent.receiver === 'MAIN') selectMainReceiver();
-        else selectSubReceiver();
-        break;
-      case 'toggle-split': toggleSplit(); break;
-      case 'toggle-dual-watch': toggleDualWatch(); break;
-      case 'equalize': equalizeVfos(); break;
-      case 'swap': swapVfos(); break;
-      case 'quick-split': quickSplit(); break;
-      case 'quick-dual-watch': quickDualWatch(); break;
-      case 'speak': speak(); break;
-    }
+    invokeVfoOperation(vfoOperationInput, intent);
   }
 
   /**
@@ -482,23 +419,6 @@
   let txFrequencyHz = $derived(
     viewModel.txTarget.status === 'known' ? viewModel.txTarget.frequencyHz : null,
   );
-  let operationActions = $derived({
-    main: { ...dualActions.main, operational: dualActions.main.operational && onSelectMainReceiver !== undefined },
-    sub: { ...dualActions.sub, operational: dualActions.sub.operational && onSelectSubReceiver !== undefined },
-    equalize: { ...dualActions.equalize, operational: dualActions.equalize.operational && onEqualizeVfos !== undefined },
-    swap: { ...dualActions.swap, operational: dualActions.swap.operational && onSwapVfos !== undefined },
-    quickSplit: {
-      ...dualActions.quickSplit,
-      operational: !relativeIdentityUnknown && viewModel.split.status === 'known'
-        && dualActions.quickSplit.operational && onQuickSplit !== undefined,
-    },
-    quickDualWatch: {
-      ...dualActions.quickDualWatch,
-      operational: !relativeIdentityUnknown && viewModel.dualWatch.status === 'known'
-        && dualActions.quickDualWatch.operational && onQuickDualWatch !== undefined,
-    },
-    speak: { ...dualActions.speak, operational: dualActions.speak.operational && onSpeak !== undefined },
-  });
   function instrumentSlot(receiver: ReceiverId): string {
     const slot = viewModel.vfos.find((vfo) => vfo.receiver === receiver && vfo.isActiveSlot)?.slot;
     return slot?.kind === 'slotted' ? slot.id : '—';
@@ -753,29 +673,15 @@
         {continuitySession}
       />
     {/if}
-    {@const splitReason = viewModel.split.status === 'unknown' ? t('core.vfo.split.unknownReason') : undefined}
-    {@const dualWatchReason = viewModel.dualWatch.status === 'unknown' ? t('core.vfo.dualWatch.unknownReason') : undefined}
     <VfoOperationGroup
       {appearance}
       scheme={viewModel.vfoScheme}
-      activeReceiver={viewModel.activeReceiver}
-      split={viewModel.split}
-      dualWatch={viewModel.dualWatch}
-      splitAvailability={{ structural: true, operational: viewModel.split.status === 'known', reason: splitReason }}
-      dualWatchAvailability={{ structural: hasDualReceiver, operational: viewModel.dualWatch.status === 'known', reason: dualWatchReason }}
-      actions={operationActions}
-      actionReasons={{
-        main: dualActions.main.structural && !dualActions.main.operational ? t('core.vfo.select.receiverUnavailableReason') : undefined,
-        sub: dualActions.sub.structural && !dualActions.sub.operational ? t('core.vfo.select.receiverUnavailableReason') : undefined,
-        quickSplit: quickSplitReasonText(),
-        quickDualWatch: quickDualWatchReasonText(),
-      }}
+      projection={vfoOperations}
       digest={hasVfoPair ? {
         rx: formatFrequency(rxFrequencyHz),
         tx: formatFrequency(txFrequencyHz),
         splitState: viewModel.split.status === 'known' ? String(viewModel.split.value) as 'true' | 'false' : 'mixed',
       } : undefined}
-      groupReason={identityOnlyReasonText()}
       onIntent={handleOperationIntent}
     />
   {/if}

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -458,6 +458,21 @@ describe('radio-wide singleton row and complete DUAL action block (MOR-2309)', (
       expect(callbacks[handler]).not.toHaveBeenCalled();
     }
   });
+
+  it('rechecks current facts before a stale enabled operation can invoke', () => {
+    const state = writable(withRadioWide());
+    const live = fromStore(state);
+    const onQuickSplit = vi.fn();
+    const target = mountSurface({ get viewModel() { return live.current; }, onQuickSplit });
+    const button = target.querySelector<HTMLButtonElement>('[data-vfo-quick-split]')!;
+    expect(button.disabled).toBe(false);
+    state.set(validateRadioViewModel({ ...withRadioWide(), split: { status: 'unknown' } }));
+    expect(button.disabled).toBe(false);
+    button.click();
+    expect(onQuickSplit).not.toHaveBeenCalled();
+    flushSync();
+    expect(button.disabled).toBe(true);
+  });
 });
 
 /** Normalized rendered-DOM summary — only VFO-surface-owned facts. */
@@ -2373,7 +2388,8 @@ describe('MOR-2342 historical instrument presentations', () => {
   it('delegates operations to a pure v3 fact-and-intent component', () => {
     const surface = readFileSync('src/semantic/VfoSurface.svelte', 'utf8');
     const group = readFileSync('src/semantic/VfoOperationGroup.svelte', 'utf8');
-    expect(surface).toMatch(/import VfoOperationGroup, \{ type VfoOperationIntent \} from '\.\/VfoOperationGroup\.svelte'/);
+    expect(surface).toContain("import VfoOperationGroup from './VfoOperationGroup.svelte'");
+    expect(surface).toContain("from './vfo-operation-projection'");
     expect(surface).toContain('<VfoOperationGroup');
     expect(group).toContain('ActiveReceiverToggle');
     expect(group).not.toMatch(/\$lib\/(?:runtime|stores|transport)|capabilities\.svelte|withDoubleClick/);

--- a/frontend/src/semantic/__tests__/vfo-operation-projection.test.ts
+++ b/frontend/src/semantic/__tests__/vfo-operation-projection.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { DualActionBlockViewModel } from '../radio-view-model';
+import {
+  invokeVfoOperation,
+  projectVfoOperations,
+  type VfoOperationCallbacks,
+  type VfoOperationIntent,
+  type VfoOperationProjectionInput,
+} from '../vfo-operation-projection';
+
+const REASONS = {
+  receiverUnavailable: 'receiver unavailable',
+  identityUnknown: 'identity unknown',
+  splitUnknown: 'split unknown',
+  dualWatchUnknown: 'dual watch unknown',
+} as const;
+
+const noCallbacks = (): VfoOperationCallbacks => ({
+  onToggleSplit: undefined,
+  onToggleDualWatch: undefined,
+  onSelectMainReceiver: undefined,
+  onSelectSubReceiver: undefined,
+  onEqualizeVfos: undefined,
+  onSwapVfos: undefined,
+  onQuickSplit: undefined,
+  onQuickDualWatch: undefined,
+  onSpeak: undefined,
+});
+
+const spyCallbacks = () => ({
+  onToggleSplit: vi.fn(), onToggleDualWatch: vi.fn(),
+  onSelectMainReceiver: vi.fn(), onSelectSubReceiver: vi.fn(),
+  onEqualizeVfos: vi.fn(), onSwapVfos: vi.fn(),
+  onQuickSplit: vi.fn(), onQuickDualWatch: vi.fn(), onSpeak: vi.fn(),
+}) satisfies VfoOperationCallbacks;
+
+const availableActions = (): DualActionBlockViewModel => ({
+  main: { structural: true, operational: true },
+  sub: { structural: true, operational: true },
+  equalize: { structural: true, operational: true },
+  swap: { structural: true, operational: true },
+  quickSplit: { structural: true, operational: true },
+  quickDualWatch: { structural: true, operational: true },
+  speak: { structural: true, operational: true },
+});
+
+function input(
+  changes: Partial<Omit<VfoOperationProjectionInput, 'callbacks'>> & {
+    callbacks?: Partial<VfoOperationCallbacks>;
+  } = {},
+): VfoOperationProjectionInput {
+  return {
+    hasVfoPair: true,
+    hasDualReceiver: true,
+    relativeIdentityUnknown: false,
+    activeReceiver: { status: 'known', receiver: 'MAIN' },
+    split: { status: 'known', value: false },
+    dualWatch: { status: 'known', value: false },
+    actions: availableActions(),
+    reasons: REASONS,
+    ...changes,
+    callbacks: { ...noCallbacks(), ...changes.callbacks },
+  };
+}
+
+describe('projectVfoOperations', () => {
+  it('keeps the exact eight named operations and excludes unrelated mechanisms', () => {
+    const projected = projectVfoOperations(input());
+    expect(Object.keys(projected)).toEqual([
+      'split', 'dualWatch', 'activeReceiver', 'equalize', 'swap',
+      'quickSplit', 'quickDualWatch', 'speak', 'groupReason',
+    ]);
+    for (const key of ['digest', 'frequency', 'slot', 'ptt', 'tune', 'context', 'lease', 'feedback']) {
+      expect(projected).not.toHaveProperty(key);
+    }
+    expect(projected.activeReceiver.options.map(({ value }) => value)).toEqual(['MAIN', 'SUB']);
+  });
+
+  it('preserves the no-action-block fallback without making quick or receiver actions live', () => {
+    const projected = projectVfoOperations(input({
+      actions: undefined,
+      callbacks: { onEqualizeVfos: vi.fn(), onSwapVfos: vi.fn(), onQuickSplit: vi.fn() },
+    }));
+    expect(projected.equalize.availability).toMatchObject({ structural: true, operational: true });
+    expect(projected.swap.availability).toMatchObject({ structural: true, operational: true });
+    expect(projected.quickSplit.availability).toMatchObject({ structural: false, operational: false });
+    expect(projected.activeReceiver.availability).toMatchObject({ structural: false, operational: false });
+  });
+
+  it('keeps unknown facts honest and gives identity priority only to quick actions', () => {
+    const callbacks = spyCallbacks();
+    const projected = projectVfoOperations(input({
+      relativeIdentityUnknown: true,
+      activeReceiver: { status: 'unknown' },
+      split: { status: 'unknown' },
+      dualWatch: { status: 'unknown' },
+      callbacks,
+    }));
+    expect(projected.split).toMatchObject({
+      reading: { status: 'unknown' },
+      availability: { structural: true, operational: false, reason: REASONS.splitUnknown },
+    });
+    expect(projected.dualWatch.availability).toMatchObject({ operational: false, reason: REASONS.dualWatchUnknown });
+    expect(projected.quickSplit.availability).toMatchObject({ operational: false, reason: REASONS.identityUnknown });
+    expect(projected.quickDualWatch.availability).toMatchObject({ operational: false, reason: REASONS.identityUnknown });
+    expect(projected.equalize.availability.operational).toBe(true);
+    expect(projected.swap.availability.operational).toBe(true);
+    expect(projected.groupReason).toBe(REASONS.identityUnknown);
+    expect(projected.activeReceiver.reading).toEqual({ status: 'unknown' });
+    expect(projected.activeReceiver.availability.operational).toBe(true);
+  });
+
+  it('keeps option reasons source-owned and callback absence reasonless', () => {
+    const actions = availableActions();
+    actions.main = { structural: true, operational: false };
+    const projected = projectVfoOperations(input({
+      actions,
+      callbacks: { onSelectMainReceiver: vi.fn() },
+    }));
+    expect(projected.activeReceiver.options[0].availability).toEqual({
+      structural: true, operational: false, reason: REASONS.receiverUnavailable,
+    });
+    expect(projected.activeReceiver.options[1].availability).toEqual({
+      structural: true, operational: false, reason: undefined,
+    });
+  });
+
+  it('preserves accepted toggle DOM admission when callbacks are absent', () => {
+    const projected = projectVfoOperations(input({ callbacks: {} }));
+    expect(projected.split.availability.operational).toBe(true);
+    expect(projected.dualWatch.availability.operational).toBe(true);
+  });
+});
+
+describe('invokeVfoOperation', () => {
+  it('maps all nine intents one-to-one', () => {
+    const callbacks = spyCallbacks();
+    const cases: readonly [VfoOperationIntent, keyof VfoOperationCallbacks][] = [
+      [{ kind: 'toggle-split' }, 'onToggleSplit'],
+      [{ kind: 'toggle-dual-watch' }, 'onToggleDualWatch'],
+      [{ kind: 'select-receiver', receiver: 'MAIN' }, 'onSelectMainReceiver'],
+      [{ kind: 'select-receiver', receiver: 'SUB' }, 'onSelectSubReceiver'],
+      [{ kind: 'equalize' }, 'onEqualizeVfos'],
+      [{ kind: 'swap' }, 'onSwapVfos'],
+      [{ kind: 'quick-split' }, 'onQuickSplit'],
+      [{ kind: 'quick-dual-watch' }, 'onQuickDualWatch'],
+      [{ kind: 'speak' }, 'onSpeak'],
+    ];
+    const current = input({ callbacks });
+
+    for (const [intent, expected] of cases) {
+      Object.values(callbacks).forEach((callback) => callback.mockClear());
+      invokeVfoOperation(() => current, intent);
+      for (const [name, callback] of Object.entries(callbacks)) {
+        expect(callback, `${intent.kind} -> ${name}`).toHaveBeenCalledTimes(name === expected ? 1 : 0);
+      }
+    }
+  });
+
+  type GateChange = Partial<Pick<VfoOperationProjectionInput,
+    'split' | 'dualWatch' | 'hasDualReceiver' | 'relativeIdentityUnknown'>> & {
+      action?: keyof DualActionBlockViewModel; structural?: boolean; operational?: boolean;
+    };
+  const rejected: readonly [string, VfoOperationIntent, keyof VfoOperationCallbacks, GateChange][] = [
+    ['split unknown', { kind: 'toggle-split' }, 'onToggleSplit', { split: { status: 'unknown' } }],
+    ['dual absent', { kind: 'toggle-dual-watch' }, 'onToggleDualWatch', { hasDualReceiver: false }],
+    ['MAIN absent', { kind: 'select-receiver', receiver: 'MAIN' }, 'onSelectMainReceiver', { action: 'main', structural: false }],
+    ['SUB disabled', { kind: 'select-receiver', receiver: 'SUB' }, 'onSelectSubReceiver', { action: 'sub', operational: false }],
+    ['equalize absent', { kind: 'equalize' }, 'onEqualizeVfos', { action: 'equalize', structural: false }],
+    ['swap disabled', { kind: 'swap' }, 'onSwapVfos', { action: 'swap', operational: false }],
+    ['quick split identity unknown', { kind: 'quick-split' }, 'onQuickSplit', { relativeIdentityUnknown: true }],
+    ['quick DW fact unknown', { kind: 'quick-dual-watch' }, 'onQuickDualWatch', { dualWatch: { status: 'unknown' } }],
+    ['speak disabled', { kind: 'speak' }, 'onSpeak', { action: 'speak', operational: false }],
+  ];
+  it.each(rejected)('rejects %s even when invocation is forced', (_name, intent, callbackName, change) => {
+    const callback = vi.fn();
+    const actions = availableActions();
+    if (change.action !== undefined) actions[change.action] = {
+      structural: change.structural ?? true,
+      operational: change.operational ?? true,
+    };
+    const current = input({
+      actions,
+      ...('split' in change ? { split: change.split } : {}),
+      ...('dualWatch' in change ? { dualWatch: change.dualWatch } : {}),
+      ...('hasDualReceiver' in change ? { hasDualReceiver: change.hasDualReceiver } : {}),
+      ...('relativeIdentityUnknown' in change
+        ? { relativeIdentityUnknown: change.relativeIdentityUnknown } : {}),
+      callbacks: { [callbackName]: callback },
+    });
+    invokeVfoOperation(() => current, intent);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('reads current input exactly once and uses only the replacement callback', () => {
+    const stale = vi.fn();
+    const replacement = vi.fn();
+    let current = input({ callbacks: { onEqualizeVfos: stale } });
+    expect(projectVfoOperations(current).equalize.availability.operational).toBe(true);
+    current = input({ callbacks: { onEqualizeVfos: replacement } });
+    let reads = 0;
+    invokeVfoOperation(() => { reads += 1; return current; }, { kind: 'equalize' });
+    expect(reads).toBe(1);
+    expect(stale).not.toHaveBeenCalled();
+    expect(replacement).toHaveBeenCalledOnce();
+
+    const actions = availableActions();
+    actions.equalize = { structural: true, operational: false };
+    current = input({ actions, callbacks: { onEqualizeVfos: replacement } });
+    invokeVfoOperation(() => current, { kind: 'equalize' });
+    expect(replacement).toHaveBeenCalledOnce();
+    current = input({ callbacks: { onEqualizeVfos: undefined } });
+    invokeVfoOperation(() => current, { kind: 'equalize' });
+    expect(replacement).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/semantic/vfo-operation-projection.ts
+++ b/frontend/src/semantic/vfo-operation-projection.ts
@@ -1,0 +1,214 @@
+import type { ActiveRx, BooleanFact, DualActionBlockViewModel, ReceiverId } from './radio-view-model';
+export type VfoOperationReceiver = Extract<ReceiverId, 'MAIN' | 'SUB'>;
+export type VfoOperationIntent =
+  | Readonly<{ kind: 'select-receiver'; receiver: VfoOperationReceiver }>
+  | Readonly<{ kind: 'toggle-split' | 'toggle-dual-watch' }>
+  | Readonly<{
+      kind: 'equalize' | 'swap' | 'quick-split' | 'quick-dual-watch' | 'speak';
+    }>;
+
+export type VfoOperationAvailability = Readonly<{
+  structural: boolean;
+  operational: boolean;
+  reason: string | undefined;
+}>;
+
+export type VfoOperationCallbacks = Readonly<{
+  onToggleSplit: (() => void) | undefined; onToggleDualWatch: (() => void) | undefined;
+  onSelectMainReceiver: (() => void) | undefined; onSelectSubReceiver: (() => void) | undefined;
+  onEqualizeVfos: (() => void) | undefined; onSwapVfos: (() => void) | undefined;
+  onQuickSplit: (() => void) | undefined; onQuickDualWatch: (() => void) | undefined;
+  onSpeak: (() => void) | undefined;
+}>;
+
+export type VfoOperationReasonText = Readonly<{
+  receiverUnavailable: string; identityUnknown: string;
+  splitUnknown: string; dualWatchUnknown: string;
+}>;
+
+export type VfoOperationProjectionInput = Readonly<{
+  hasVfoPair: boolean; hasDualReceiver: boolean; relativeIdentityUnknown: boolean;
+  activeReceiver: ActiveRx;
+  split: BooleanFact; dualWatch: BooleanFact;
+  actions: DualActionBlockViewModel | undefined;
+  callbacks: VfoOperationCallbacks;
+  reasons: VfoOperationReasonText;
+}>;
+
+export type VfoToggleOperation = Readonly<{
+  kind: 'toggle';
+  reading: BooleanFact;
+  availability: VfoOperationAvailability;
+}>;
+
+export type VfoActionOperation = Readonly<{
+  kind: 'action';
+  availability: VfoOperationAvailability;
+}>;
+
+export type VfoReceiverOption = Readonly<{
+  value: VfoOperationReceiver;
+  availability: VfoOperationAvailability;
+}>;
+
+export type VfoReceiverChoiceOperation = Readonly<{
+  kind: 'choice';
+  reading: ActiveRx;
+  availability: VfoOperationAvailability;
+  options: readonly [VfoReceiverOption, VfoReceiverOption];
+}>;
+
+export type VfoOperationProjection = Readonly<{
+  split: VfoToggleOperation; dualWatch: VfoToggleOperation;
+  activeReceiver: VfoReceiverChoiceOperation;
+  equalize: VfoActionOperation; swap: VfoActionOperation;
+  quickSplit: VfoActionOperation; quickDualWatch: VfoActionOperation;
+  speak: VfoActionOperation;
+  groupReason: string | undefined;
+}>;
+
+const availability = (
+  structural: boolean,
+  operational: boolean,
+  reason: string | undefined,
+): VfoOperationAvailability => ({ structural, operational, reason });
+
+function fallbackActions(input: VfoOperationProjectionInput): DualActionBlockViewModel {
+  const absent = { structural: false, operational: false };
+  return {
+    main: absent, sub: absent,
+    equalize: { structural: input.hasVfoPair, operational: input.callbacks.onEqualizeVfos !== undefined },
+    swap: { structural: input.hasVfoPair, operational: input.callbacks.onSwapVfos !== undefined },
+    quickSplit: absent, quickDualWatch: absent, speak: absent,
+  };
+}
+
+export function projectVfoOperations(
+  input: VfoOperationProjectionInput,
+): VfoOperationProjection {
+  const actions = input.actions ?? fallbackActions(input);
+  const admitted = (
+    action: keyof DualActionBlockViewModel,
+    callback: (() => void) | undefined,
+    reason?: string,
+  ): VfoActionOperation => ({ kind: 'action', availability: availability(
+    actions[action].structural, actions[action].operational && callback !== undefined, reason,
+  ) });
+  const receiverOption = (
+    value: VfoOperationReceiver,
+    action: 'main' | 'sub',
+    callback: (() => void) | undefined,
+  ): VfoReceiverOption => ({
+    value,
+    availability: availability(
+      actions[action].structural,
+      actions[action].operational && callback !== undefined,
+      actions[action].structural && !actions[action].operational
+        ? input.reasons.receiverUnavailable
+        : undefined,
+    ),
+  });
+  const main = receiverOption('MAIN', 'main', input.callbacks.onSelectMainReceiver);
+  const sub = receiverOption('SUB', 'sub', input.callbacks.onSelectSubReceiver);
+  const splitUnknown = input.split.status === 'unknown';
+  const dualWatchUnknown = input.dualWatch.status === 'unknown';
+  const quickSplitReason = input.relativeIdentityUnknown
+    ? input.reasons.identityUnknown
+    : splitUnknown ? input.reasons.splitUnknown : undefined;
+  const quickDualWatchReason = input.relativeIdentityUnknown
+    ? input.reasons.identityUnknown
+    : dualWatchUnknown ? input.reasons.dualWatchUnknown : undefined;
+
+  return {
+    split: {
+      kind: 'toggle',
+      reading: input.split,
+      availability: availability(true, !splitUnknown, splitUnknown ? input.reasons.splitUnknown : undefined),
+    },
+    dualWatch: {
+      kind: 'toggle',
+      reading: input.dualWatch,
+      availability: availability(
+        input.hasDualReceiver,
+        !dualWatchUnknown,
+        dualWatchUnknown ? input.reasons.dualWatchUnknown : undefined,
+      ),
+    },
+    activeReceiver: {
+      kind: 'choice',
+      reading: input.activeReceiver,
+      availability: availability(
+        main.availability.structural || sub.availability.structural,
+        (main.availability.structural && main.availability.operational)
+          || (sub.availability.structural && sub.availability.operational),
+        undefined,
+      ),
+      options: [main, sub],
+    },
+    equalize: admitted('equalize', input.callbacks.onEqualizeVfos),
+    swap: admitted('swap', input.callbacks.onSwapVfos),
+    quickSplit: admitted(
+      'quickSplit',
+      input.relativeIdentityUnknown || splitUnknown ? undefined : input.callbacks.onQuickSplit,
+      quickSplitReason,
+    ),
+    quickDualWatch: admitted(
+      'quickDualWatch',
+      input.relativeIdentityUnknown || dualWatchUnknown ? undefined : input.callbacks.onQuickDualWatch,
+      quickDualWatchReason,
+    ),
+    speak: admitted('speak', input.callbacks.onSpeak),
+    groupReason: input.relativeIdentityUnknown ? input.reasons.identityUnknown : undefined,
+  };
+}
+
+export function invokeVfoOperation(
+  readCurrent: () => VfoOperationProjectionInput,
+  intent: VfoOperationIntent,
+): void {
+  const input = readCurrent();
+  const projected = projectVfoOperations(input);
+  let current: VfoOperationAvailability;
+  let callback: (() => void) | undefined;
+
+  switch (intent.kind) {
+    case 'select-receiver': {
+      const index = intent.receiver === 'MAIN' ? 0 : 1;
+      current = projected.activeReceiver.options[index].availability;
+      callback = intent.receiver === 'MAIN'
+        ? input.callbacks.onSelectMainReceiver
+        : input.callbacks.onSelectSubReceiver;
+      break;
+    }
+    case 'toggle-split':
+      current = projected.split.availability;
+      callback = input.callbacks.onToggleSplit;
+      break;
+    case 'toggle-dual-watch':
+      current = projected.dualWatch.availability;
+      callback = input.callbacks.onToggleDualWatch;
+      break;
+    case 'equalize':
+      current = projected.equalize.availability;
+      callback = input.callbacks.onEqualizeVfos;
+      break;
+    case 'swap':
+      current = projected.swap.availability;
+      callback = input.callbacks.onSwapVfos;
+      break;
+    case 'quick-split':
+      current = projected.quickSplit.availability;
+      callback = input.callbacks.onQuickSplit;
+      break;
+    case 'quick-dual-watch':
+      current = projected.quickDualWatch.availability;
+      callback = input.callbacks.onQuickDualWatch;
+      break;
+    case 'speak':
+      current = projected.speak.availability;
+      callback = input.callbacks.onSpeak;
+      break;
+  }
+
+  if (current.structural && current.operational) callback?.();
+}


### PR DESCRIPTION
Linear: MOR-2425

The live VFO surface now uses one operation projection for admission and reasons, and the current-input invoker rechecks each of the nine intents before dispatch. The presentation group renders the supplied eight-control projection while retaining existing DOM, roles, reasons, digest, relative A/B resolver and hosted frequency/S-meter paths.

The exact prepared N1 projector and test blobs from 0baeb09742b83113ae8ef2ac3ea59691e914faa9 are retained. This is one unit: projector, its live renderer/invoker consumption and mounted proof replace one duplicated VFO admission contract. No SRS, SDK, activation, frequency host, renderer primitive or other-family changes. Internal frontend compatibility only; no public API or wire change.

Scope: 5 files, 552 additions + 229 deletions = 781 A+D; no regenerated baselines.

Validation at 24e12878833c8a410917def31ba57b31511431c5:

- 2 focused files / 192 tests passed, including current-fact mutation before Svelte flush and all nine invocation/refusal mappings.
- Svelte/TypeScript: 0 errors, 0 warnings; scoped ESLint and diff check passed; real npm ci.
- Natural quick 34082677537 SUCCESS; natural visual 34082686484 SUCCESS.
- Independent exact-head Agent Review PASS, comment https://github.com/rigplane/rigplane-core/pull/3320#issuecomment-5565001895. No findings or mandatory body corrections.
- Root read the full final diff, implementation result and independent report. Canonical Agent Review Gate is green; required statuses and the current main start guard are checked again immediately before merge. Optional observations are not acceptance evidence.

No full local suite or visual baseline regeneration was run. Packet B external operation seats and SDK layout activation remain separate work; this PR does not claim their completion.
