### PR TITLE
fix(face): format scalar readings on semantic surfaces

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
@@ -289,7 +289,8 @@ describe('AF level: 0..100 becomes 0..1 exactly once, at the adapter seam', () =
     render();
     expect(Number(afSlider()!.getAttribute('aria-valuenow')))
       .toBeCloseTo(0.42, 10);
-    expect(text('af-value')).toBe('0.42');
+    // The fact stays 0.42 (the slider above); only the READOUT is formatted.
+    expect(text('af-value')).toBe('42%');
   });
 
   it.each([0, 7, 50, 100])('renders a browser volume of %i on the 0..1 scale', (volume) => {

--- a/frontend/src/semantic/RxAudioSurface.svelte
+++ b/frontend/src/semantic/RxAudioSurface.svelte
@@ -49,6 +49,7 @@
 -->
 <script module lang="ts">
   import { MOD_INPUT_SOURCES, modInputSourceLabel } from '$lib/radio/mod-input';
+  import { formatKnownLevel } from './format-level';
   import type {
     AudioFocus, ModInputReadiness, MonitorMode, RxAudioField,
   } from './radio-view-model';
@@ -78,6 +79,17 @@
   /** Honest text: an unread fact reads as unknown, never as a default. */
   export const textOf = (f: RxAudioField<unknown>): string =>
     f.reading.status === 'known' ? String(f.reading.value) : UNKNOWN_TEXT;
+  /** `afLevel`'s declared domain (rule 4 above, and `RxAudioViewModel.afLevel`
+   *  in the contract). `formatKnownLevel` reads that domain — not the value —
+   *  to decide the readout, so a 0..1 fraction shows as a percent instead of
+   *  the wire float `String()` printed. */
+  const AF_LEVEL_MIN = 0;
+  const AF_LEVEL_MAX = 1;
+  /** The AF readout. The fact stays 0..1 (rule 4); only the STRING changes. */
+  const afText = (f: RxAudioField<number>): string =>
+    f.reading.status === 'known'
+      ? formatKnownLevel(f.reading.value, AF_LEVEL_MIN, AF_LEVEL_MAX)
+      : UNKNOWN_TEXT;
 </script>
 
 <script lang="ts">
@@ -200,7 +212,7 @@
         <!-- 0..1 — the contract's OWN unit (rule 4). No rescale in either
              direction: the value in is the fact, the value out is the intent. -->
         {@render handles.afLevel()}
-        <output data-testid="rx-audio-af-value">{textOf(rx.afLevel)}</output>
+        <output data-testid="rx-audio-af-value">{afText(rx.afLevel)}</output>
       </label>
     {/if}
 

--- a/frontend/src/semantic/TxAuxFiniteHost.svelte
+++ b/frontend/src/semantic/TxAuxFiniteHost.svelte
@@ -15,8 +15,13 @@
       ? disabledReasonText(field.availability)
       : usable(field) ? undefined : disabledReasonText({ structural: true, operational: false });
 
+  /** An unobserved reading renders as the em dash, not '?': a question mark
+   *  reads as a prompt rather than as "the radio never reported this". Only
+   *  `TX_AUX_TOGGLES` reaches this — ATU's three-state enum and three
+   *  booleans — so no numeric domain is formatted here; the TX-aux levels
+   *  are rendered by `TxAuxScalarHost`. */
   const textOf = (field: TxAuxField<unknown>): string =>
-    field.reading.status !== 'known' ? '?'
+    field.reading.status !== 'known' ? '—'
       : typeof field.reading.value === 'boolean' ? (field.reading.value ? 'on' : 'off')
         : String(field.reading.value);
 

--- a/frontend/src/semantic/VfoIndicatorRow.svelte
+++ b/frontend/src/semantic/VfoIndicatorRow.svelte
@@ -7,6 +7,8 @@
   import type { Snippet } from 'svelte';
   import LinearSMeter from '../components-v2/meters/LinearSMeter.svelte';
   import type { MeterContinuitySession } from '../primitives/meters/meter-ballistics.svelte';
+  import { formatKnownLevel } from './format-level';
+  import { RF_FRONT_END_LEVELS } from './rf-front-end-instruments';
   import type {
     DisplayObservedField, RadioWideIndicatorsViewModel, ReceiverIndicatorField,
     ReceiverIndicatorViewModel, TxAuxField,
@@ -36,10 +38,17 @@
     return field.reading.status === 'known' ? String(field.reading.value) : '—';
   }
 
-  function rfGainNumber(field: DisplayObservedField<number>): string {
-    if (!field.display) return numeric(field);
-    return field.display.state === 'current' || field.display.state === 'stale'
-      ? String(field.display.value) : '—';
+  /** RF gain's declared domain — the same `RF_FRONT_END_LEVELS[0]` tuple
+   *  `RfFrontEndInstrumentHost` reads for the RF-gain scalar's own domain.
+   *  The declared domain decides the readout, never the value itself. */
+  const [, , RF_GAIN_MIN, RF_GAIN_MAX] = RF_FRONT_END_LEVELS[0];
+
+  function rfGainText(field: DisplayObservedField<number>): string {
+    const level = field.display
+      ? (field.display.state === 'current' || field.display.state === 'stale'
+        ? field.display.value : undefined)
+      : (field.reading.status === 'known' ? field.reading.value : undefined);
+    return level === undefined ? '—' : formatKnownLevel(level, RF_GAIN_MIN, RF_GAIN_MAX);
   }
 
   function agc(field: ReceiverIndicatorViewModel['agcMode']): string {
@@ -162,8 +171,8 @@
         role="img"
         data-state={indicator.rfGain.reading.status}
         data-display-state={indicator.rfGain.display?.state ?? (indicator.rfGain.reading.status === 'known' ? 'current' : 'unknown')}
-        aria-label={`RF gain ${rfGainNumber(indicator.rfGain)}${indicator.rfGain.display?.state === 'stale' ? ' (stale, last observed)' : ''}`}
-      >RFG {rfGainNumber(indicator.rfGain)}<span
+        aria-label={`RF gain ${rfGainText(indicator.rfGain)}${indicator.rfGain.display?.state === 'stale' ? ' (stale, last observed)' : ''}`}
+      >RFG {rfGainText(indicator.rfGain)}<span
           class="stale-cue"
           style:display="inline-block"
           style:width="1ch"

--- a/frontend/src/semantic/__tests__/RxAudioSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RxAudioSurface.test.ts
@@ -113,14 +113,18 @@ describe('the RX-audio surface owns no audio lifetime (MOR-972 P0 / MOR-1058)', 
   /** The whole static import closure of the file, allow-listed. Kills: adding
    *  ANY import that could reach transport or the audio manager — including
    *  through a relative specifier, which a `$lib/...` regex would miss. */
-  it('imports only facts, MOD-input vocabulary, localization and control behavior', () => {
+  it('imports only facts, MOD-input vocabulary, localization, formatting and control behavior', () => {
     const specifiers = [...CODE.matchAll(/from\s+'([^']+)'/g)].map((m) => m[1]);
     expect(specifiers.length).toBeGreaterThan(0);
+    // `./format-level` is the shared readout formatter (MOR-1447). It is on
+    // this list because it declares no imports of its own — asserted below,
+    // so the closure this allow-list guards stays closed.
     expect([...new Set(specifiers)].sort()).toEqual([
       '$lib/i18n', '$lib/radio/mod-input',
-      '../primitives/control-instruments/control-instrument-behavior', './radio-view-model',
-      './rx-audio-instruments',
+      '../primitives/control-instruments/control-instrument-behavior', './format-level',
+      './radio-view-model', './rx-audio-instruments',
     ]);
+    expect(readFileSync('src/semantic/format-level.ts', 'utf8')).not.toMatch(/from\s+'/);
     expect(CODE).toContain('bindAbsoluteChoiceInstrument');
     expect(CODE).toContain('bindChoiceInstrument');
   });
@@ -375,7 +379,24 @@ describe('AF level is 0..1 end to end — converted exactly once, in the adapter
   it('renders the fact verbatim, with no second scaling', () => {
     const r = render(base());
     expect(Number(r.slider()!.getAttribute('aria-valuenow'))).toBeCloseTo(0.42, 10);
-    expect(r.text('af-value')).toBe('0.42');
+    // The slider above carries the unrescaled fact; the readout is formatted.
+    expect(r.text('af-value')).toBe('42%');
+    r.dispose();
+  });
+
+  // Kills: `String(value)` on the readout — the live IC-7300 "AF
+  // 0.2196078431372549" (56/255).
+  it('renders a known level as a percent of the declared 0..1 domain', () => {
+    const r = render(withRx({ afLevel: known(0.2196078431372549) }));
+    expect(r.text('af-value')).toBe('22%');
+    expect(r.text('af-value')).not.toContain('0.21');
+    r.dispose();
+  });
+
+  it('renders an unread level as the em dash, not as a percent', () => {
+    const r = render(withRx({ afLevel: unread<number>() }));
+    expect(r.text('af-value')).toBe(UNKNOWN_TEXT);
+    expect(r.text('af-value')).not.toContain('%');
     r.dispose();
   });
 

--- a/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
+++ b/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
@@ -217,6 +217,22 @@ describe('operational availability decides whether a control is USABLE', () => {
       }
     });
   });
+
+  // MUTATION KILLED: rendering an unobserved toggle as "COMP ?" — the live
+  // IC-7300 reading. '?' is a question, not a claim about the radio.
+  it.each(TX_AUX_TOGGLES)('renders an unobserved "%s" toggle as the em dash', (field, label) => {
+    const view = withField(base(), field, { unknown: true });
+    withSurface(view, snap(), (s) => {
+      expect(s.control(field)!.textContent).toBe(`${label}: —`);
+      expect(s.control(field)!.textContent).not.toContain('?');
+    });
+  });
+
+  it.each(TX_AUX_TOGGLES)('keeps an observed "%s" toggle reading its own word', (field, label) => {
+    withSurface(base(), snap(), (s) => {
+      expect(s.control(field)!.textContent).toBe(`${label}: off`);
+    });
+  });
 });
 
 // ── 2b. MOR-1422: the disabled reason is legible, not just a data hook ─────

--- a/frontend/src/semantic/__tests__/VfoIndicatorRow.test.ts
+++ b/frontend/src/semantic/__tests__/VfoIndicatorRow.test.ts
@@ -233,8 +233,8 @@ describe('RF gain display observation', () => {
     const node = target.querySelector('[data-indicator-fact="rf-gain"]')!;
     const marker = node.querySelector('.stale-cue')!;
     const text = node.textContent;
-    expect(text).toContain('RFG 0.75');
-    expect(target.querySelector('[role="img"][aria-label="RF gain 0.75"]')).toBe(node);
+    expect(text).toContain('RFG 75%');
+    expect(target.querySelector('[role="img"][aria-label="RF gain 75%"]')).toBe(node);
     expect(node.hasAttribute('tabindex')).toBe(false);
     expect(getComputedStyle(marker).visibility).toBe('hidden');
     expect(getComputedStyle(marker).width).toBe('1ch');
@@ -246,14 +246,14 @@ describe('RF gain display observation', () => {
     expect(node.textContent).toBe(text);
     expect(node.getAttribute('data-state')).toBe('unknown');
     expect(node.getAttribute('data-display-state')).toBe('stale');
-    expect(target.querySelector('[role="img"][aria-label="RF gain 0.75 (stale, last observed)"]')).toBe(node);
+    expect(target.querySelector('[role="img"][aria-label="RF gain 75% (stale, last observed)"]')).toBe(node);
     expect(getComputedStyle(marker).visibility).toBe('visible');
     expect(marker.textContent?.trim()).not.toBe('');
     expect(target.querySelector('[aria-live], button, input')).toBeNull();
     flushSync(() => state.set('indicator', current));
     expect(node.textContent).toBe(text);
     expect(node.getAttribute('data-display-state')).toBe('current');
-    expect(target.querySelector('[role="img"][aria-label="RF gain 0.75"]')).toBe(node);
+    expect(target.querySelector('[role="img"][aria-label="RF gain 75%"]')).toBe(node);
     expect(target.querySelector('[role="img"][aria-label*="stale"]')).toBeNull();
     expect(getComputedStyle(marker).visibility).toBe('hidden');
   });
@@ -268,5 +268,26 @@ describe('RF gain display observation', () => {
   it('keeps a display-unsupported RFgain absent', () => {
     render({ indicator: indicator({ rfGain: { ...known(0), display: { state: 'unsupported' } } }) });
     expect(target.querySelector('[data-indicator-fact="rf-gain"]')).toBeNull();
+  });
+
+  // Kills: `String(value)` on the readout — the live IC-7300 "RFG
+  // 0.8196078431372549" (209/255, the value captured verbatim in
+  // `lib/runtime/adapters/__tests__/fixtures/ic7300-state.json`'s `main.rfGain`).
+  it('renders a known RF gain as a percent of its declared 0..1 domain', () => {
+    const value = 0.8196078431372549;
+    render({ indicator: indicator({
+      rfGain: { ...known(value), display: { state: 'current', value } },
+    }) });
+    const node = target.querySelector('[data-indicator-fact="rf-gain"]')!;
+    expect(node.textContent).toContain('RFG 82%');
+    expect(node.textContent).not.toContain('0.81');
+    expect(target.querySelector('[role="img"][aria-label="RF gain 82%"]')).toBe(node);
+  });
+
+  it('renders an unread RF gain carrying no display observation as the em dash', () => {
+    render({ indicator: indicator({ rfGain: unknown<number>() }) });
+    const node = target.querySelector('[data-indicator-fact="rf-gain"]')!;
+    expect(node.textContent).toContain('RFG —');
+    expect(node.textContent).not.toContain('%');
   });
 });


### PR DESCRIPTION
## Problem

On the `sdr-test` face, a scalar reading whose declared domain is the 0..1
wire fraction was printed with `String(value)`. Observed on a live IC-7300 on
2026-09-06:

- `RFG 0.8196078431372549` on `VfoIndicatorRow` — 209/255. The same value is
  recorded in `frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-state.json`
  at `main.rfGain`.
- `AF 0.2196078431372549` on `RxAudioSurface` — 56/255.
- `COMP ?` on `TxAuxSurface` for a toggle the radio never reported.

## Fix

Presentation only — no fact is rescaled. Which formatter applies is decided by
the field's **declared** domain, never by the value:

- RF gain and AF level text now go through `formatKnownLevel` in
  `frontend/src/semantic/format-level.ts`, the existing shared readout
  formatter (MOR-1447), which already takes the declared `[min, max]` tuple
  and only converts when that tuple is exactly `0..1`.
- `TxAuxSurface`'s unknown token `?` becomes the em dash `—`, matching the
  other semantic surfaces. `?` reads as a prompt, not as "the radio never
  reported this".

The AF slider still receives the unrescaled 0..1 fact; only the `<output>`
string changed.

| Field | Formatter | Metadata consulted | Renders |
|---|---|---|---|
| `rfGain` (`VfoIndicatorRow`) | `formatKnownLevel` | `RF_FRONT_END_LEVELS[0]` = `['rfGain', 'RF gain', 0, 1, 0.01]` — the same tuple `RfFrontEndInstrumentHost` reads for the RF-gain scalar; indices `[2]`,`[3]` give the 0..1 domain | `82%` |
| `afLevel` (`RxAudioSurface`) | `formatKnownLevel` | the 0..1 domain `RxAudioViewModel.afLevel` and the file's own rule (4) declare | `22%` |
| TX-aux toggles (`TxAuxSurface`) | none (no numeric domain) | `TX_AUX_TOGGLES` — ATU's enum plus three booleans | `on` / `off` / `—` |

Bandwidth (Hz), attenuator (dB), preamp ordinal, antenna index and RIT/XIT
offsets are left as plain numbers: their declared domains are not fractions.

## Tests

- `VfoIndicatorRow.test.ts` — the three existing current/stale/current cases
  now assert `RFG 75%` and the matching `aria-label`; two new cases pin a known
  0.8196078431372549 rendering as `82%` (and *not* containing `0.81`), and an
  unread RF gain with no display observation rendering as the em dash.
- `RxAudioSurface.test.ts` — the verbatim-fact case now asserts `42%` on the
  readout while the slider still reads 0.42; two new cases pin 0.2196078431372549
  as `22%` and an unread level as the em dash with no `%`. The file's
  import-allow-list test gains `./format-level`, and now also asserts that
  `format-level.ts` declares no imports of its own, so the closure that test
  guards stays closed.
- `TxAuxSurface.test.ts` — two new parametrised cases over `TX_AUX_TOGGLES`:
  an unobserved toggle reads `<label>: —` and contains no `?`; an observed one
  keeps its own word.
- `semantic-rx-audio-wiring.component.test.ts` — the adapter-seam case keeps
  its `aria-valuenow` 0.42 assertion and updates the readout to `42%`.

## Mutation evidence

Both mutations were applied to this head, run, and reverted; `git diff HEAD`
was empty before the final run.

- **Revert the formatters** (`rfGainText` → `String(level)`, `afText` →
  `String(f.reading.value)`, TxAux `'—'` → `'?'`): **11 failed / 299 passed**
  — 4 in `VfoIndicatorRow.test.ts`, 2 in `RxAudioSurface.test.ts`, 4 in
  `TxAuxSurface.test.ts`, 1 in `semantic-rx-audio-wiring.component.test.ts`.
- **Wrong declared domain** (`RF_GAIN_MAX` and `AF_LEVEL_MAX` set to 255, so
  `formatKnownLevel` falls through to `String`): **7 failed / 303 passed** —
  the same set minus the four `TxAuxSurface` cases, which that mutation does
  not touch.

The two new "unread → em dash" cases survive both mutations, as expected:
neither mutation changes the unknown branch. They pin that branch against a
future formatter that would render `NaN%` or `0%` for an unread field.

## Soft threshold

7 files / 120 changed lines (`git diff --numstat origin/main..HEAD`, measured
at this head) — over the 6-file soft threshold, under the hard ceiling.

This is one unit of work: a single defect class — a 0..1 declared domain
printed with `String` — on the three semantic surfaces that carry such a
reading, plus the four pinned test files that hold those surfaces' rendered
text. Splitting it per surface would leave the face inconsistent between
merges, and the wiring test asserts one of the same strings, so it cannot be
separated from `RxAudioSurface` anyway.

## Left unfixed, same class

Enumerated with `grep -rn "'?'" frontend/src --include='*.svelte' --include='*.ts'`
at this head, excluding test files.

**Same defect (0..1 fraction via `String`), deliberately not touched here:**

- `frontend/src/semantic/VfoSurface.svelte`, the `RFG` badge in the
  indicator-badge builder (lines 541–543 at this head) — the same `rfGain`
  fraction, still via `displayValue`. That file is owned by the in-flight
  receiver-deck PR; editing it here would conflict.

**Unknown token `'?'` — needs a ruling on whether `?` is a deliberate
convention before any sweep:**

- `frontend/src/semantic/RfFrontEndSurface.svelte` — `export const UNKNOWN_TEXT = '?'`
- `frontend/src/semantic/FilterSurface.svelte`
- `frontend/src/semantic/ScopeControlsSurface.svelte` (two sites)
- `frontend/src/semantic/DspSurface.svelte` (three sites)
- `frontend/src/semantic/RfFrontEndInstrumentHost.svelte`
- `frontend/src/semantic/TxAuxScalarHost.svelte`
- `frontend/src/semantic/bar-meter-projector.ts` (two sites)
- `frontend/src/components-v2/meters/smeter-scale.ts` — `'S ?'` / `'?'`
- `frontend/src/components-v2/panels/ModInputTxWarning.svelte` — `sourceLabel ?? '?'`
- `frontend/src/skins/segmentline/lcd-display-helpers.ts` (five sites) — this
  one looks like a deliberate convention rather than an oversight: it uses
  `'?'` for *unknown* and `'—'` for *unsupported* in the same expression, so a
  blanket sweep would erase a distinction. Flagging rather than changing.

Not in the class, listed so the enumeration is checkable:
`components-v2/layout/vfo-layout-tokens.ts:207` (query-string parsing),
`components-v2/layout/keyboard-map.ts:66` (a keybinding), and
`lib/runtime/commands/radio-intents.ts:92` (an optional-field name suffix).

## Gates

Run in `frontend/` at this head:

- `npm run test -- VfoIndicatorRow RxAudioSurface TxAuxSurface semantic-rx-audio-wiring` — 4 files, **310 passed, 0 failed**
- `npm run lint` — clean, no output
- `npm run check` — `4775 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`

The full Python suite is not run locally; `quick.yml` on this PR is the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
