### PR TITLE
refactor: extract bar meter motion frame (MOR-2425)

### DIFF
--- a/frontend/src/components-v2/meters/BarGauge.svelte
+++ b/frontend/src/components-v2/meters/BarGauge.svelte
@@ -1,22 +1,17 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
-  import {
-    createSmoother,
-    prefersReducedMotion,
-    onReducedMotionChange,
-  } from '$lib/utils/smoothing.svelte';
-  import {
-    createElapsedEnvelopePeakStrategy,
-    createMeterBallistics,
-    type MeterContinuitySession,
-    type MeterSourceIdentity,
+  import type {
+    MeterContinuitySession,
+    MeterSourceIdentity,
   } from '../../primitives/meters/meter-ballistics.svelte';
-  import { DEFAULT_ZONES, valueToSegments, getSegmentZone, dimColor, valueFontSize } from './bar-gauge-utils';
+  import { DEFAULT_ZONES, getSegmentZone, dimColor, valueFontSize } from './bar-gauge-utils';
   import type { Zone } from './bar-gauge-utils';
-  import { updatePeakHold, peakHoldDisplay, PEAK_DECAY_MS, type PeakHoldState } from '../panels/meter-utils';
+  import {
+    createBarMeterMotion,
+    type BarMeterFrame,
+  } from './bar-meter-motion.svelte';
 
-  interface Props {
-    value: number | null;         // 0–1 normalized
+  interface CommonProps {
     label: string;         // 'Po' | 'SWR' | 'ALC' | 'COMP'
     displayValue: string;  // '35W' | '1.2' | '-8'
     accessibleDescription?: string;
@@ -30,16 +25,67 @@
      */
     zones?: readonly Zone[];
     compact?: boolean;
-    showPeak?: boolean;    // MOR-1282: optional peak-hold marker
     fault?: boolean;       // MOR-1345: SWR/ALC over-threshold fault highlight
-    source?: MeterSourceIdentity | null;
-    session?: MeterContinuitySession | null;
   }
 
-  let {
-    value, label, displayValue, zones = DEFAULT_ZONES, compact = false, showPeak = false,
-    fault = false, accessibleDescription, source, session,
-  }: Props = $props();
+  type LiveValueInput = {
+    value: number | null;         // 0–1 normalized
+    frame?: never;
+    showPeak?: boolean;    // MOR-1282: optional peak-hold marker
+    source?: MeterSourceIdentity | null;
+    session?: MeterContinuitySession | null;
+    onResetPeak?: never;
+  };
+  type HostedFrameInput = {
+    frame: BarMeterFrame;
+    value?: never;
+    showPeak?: never;
+    source?: never;
+    session?: never;
+    onResetPeak?: () => void;
+  };
+  type Props = CommonProps & (LiveValueInput | HostedFrameInput);
+
+  type InputMode = 'value' | 'frame';
+
+  function hasOwn(value: object, key: string): boolean {
+    return Object.prototype.hasOwnProperty.call(value, key);
+  }
+
+  function resolveInputMode(current: Props): InputMode {
+    const hasFrame = hasOwn(current, 'frame');
+    const hasValue = hasOwn(current, 'value');
+    if (Number(hasFrame) + Number(hasValue) !== 1) {
+      throw new TypeError('BarGauge requires exactly one of frame or value');
+    }
+    if (hasFrame && current.frame === undefined) {
+      throw new TypeError('BarGauge frame must be defined when supplied');
+    }
+    if (hasValue && current.value === undefined) {
+      throw new TypeError('BarGauge value must be a number or null when supplied');
+    }
+    if (hasFrame && (hasOwn(current, 'source') || hasOwn(current, 'session') || hasOwn(current, 'showPeak'))) {
+      throw new TypeError('BarGauge frame owns peak and continuity state');
+    }
+    return hasFrame ? 'frame' : 'value';
+  }
+
+  let props: Props = $props();
+  const initialInputMode = untrack(() => resolveInputMode(props));
+  const inputMode = $derived.by(() => {
+    const current = resolveInputMode(props);
+    if (current !== initialInputMode) {
+      throw new TypeError('BarGauge input mode cannot change after mount');
+    }
+    return current;
+  });
+  const label = $derived(props.label);
+  const displayValue = $derived(props.displayValue);
+  const zones = $derived(props.zones ?? DEFAULT_ZONES);
+  const compact = $derived(props.compact ?? false);
+  const fault = $derived(props.fault ?? false);
+  const accessibleDescription = $derived(props.accessibleDescription);
+  const liveValue = $derived(inputMode === 'value' ? (props as LiveValueInput).value : null);
 
   // ── Segment geometry ────────────────────────────────────────────────────────
   const SEG_COUNT = 10;
@@ -65,58 +111,59 @@
   const VALUE_FS    = $derived(valueFontSize(displayValue, compact ? 9 : 11));
   const TEXT_Y      = $derived(TRACK_Y + TRACK_H / 2);
 
-  // ── Smoother ────────────────────────────────────────────────────────────────
-  const smoother = createSmoother(0.08, 0.2);
-  const ballistics = createMeterBallistics(smoother, {
-    now: () => Date.now(),
-    requestFrame: (callback) => requestAnimationFrame(callback),
-    cancelFrame: (id) => cancelAnimationFrame(id),
-    setInterval: (callback, milliseconds) => setInterval(callback, milliseconds),
-    clearInterval: (id) => clearInterval(id),
-    prefersReducedMotion,
-    onReducedMotionChange,
-  }, {
-    peakSource: 'sample',
-    ticker: { kind: 'interval', milliseconds: 100 },
-    peak: createElapsedEnvelopePeakStrategy<PeakHoldState>({
-      decayMilliseconds: PEAK_DECAY_MS,
-      updatePeakHold,
-      peakHoldDisplay,
-    }),
-  });
+  const localMotion = initialInputMode === 'value'
+    ? untrack(() => createBarMeterMotion({
+        value: (props as LiveValueInput).value,
+        peakEnabled: (props as LiveValueInput).showPeak ?? false,
+        source: (props as LiveValueInput).source,
+        session: (props as LiveValueInput).session,
+      }))
+    : null;
+  const meterFrame = $derived(
+    inputMode === 'frame' ? (props as HostedFrameInput).frame : localMotion!.frame,
+  );
 
   $effect(() => {
-    const continuitySource = source;
-    const continuitySession = session;
-    const smoothTarget = value === null ? null : valueToSegments(value, SEG_COUNT) / SEG_COUNT;
-    untrack(() => ballistics.sync({
-      sample: value, smoothTarget, peakEnabled: showPeak,
-      source: continuitySource, session: continuitySession,
+    if (localMotion === null) return;
+    const currentValue = (props as LiveValueInput).value;
+    const peakEnabled = (props as LiveValueInput).showPeak ?? false;
+    const source = (props as LiveValueInput).source;
+    const session = (props as LiveValueInput).session;
+    untrack(() => localMotion.sync({
+      value: currentValue,
+      peakEnabled,
+      source,
+      session,
     }));
   });
 
   onMount(() => {
-    ballistics.start();
-    return () => ballistics.stop();
+    if (localMotion === null) return;
+    localMotion.start();
+    return () => localMotion.stop();
   });
 
   // ── Peak-hold marker (MOR-1282) ─────────────────────────────────────────────
   let peakPct = $derived.by(() => {
-    const level = ballistics.view.peakValue;
+    const level = meterFrame.peakFraction;
     if (level === null) return undefined;
     return Math.max(0, Math.min(100, level * 100));
   });
 
   function resetPeak() {
-    if (showPeak) ballistics.resetPeak();
+    if (inputMode === 'frame') {
+      (props as HostedFrameInput).onResetPeak?.();
+    } else if ((props as LiveValueInput).showPeak) {
+      localMotion!.resetPeak();
+    }
   }
 
   // ── Reactive display values ─────────────────────────────────────────────────
-  const measuredFault = $derived(value !== null && fault);
-  let smoothedSegs = $derived(ballistics.view.smoothedValue * SEG_COUNT);
-  let fullSegs = $derived(value === null ? 0 : Math.floor(smoothedSegs));
+  const measuredFault = $derived((inputMode === 'frame' || liveValue !== null) && fault);
+  let smoothedSegs = $derived(meterFrame.smoothedFraction * SEG_COUNT);
+  let fullSegs = $derived(liveValue === null && inputMode === 'value' ? 0 : Math.floor(smoothedSegs));
   let fracSeg  = $derived(
-    value === null
+    liveValue === null && inputMode === 'value'
       ? 0
       : smoothedSegs - Math.floor(smoothedSegs),
   );
@@ -199,7 +246,7 @@
   {/each}
 
   <!-- Peak-hold marker (MOR-1282) -->
-  {#if showPeak && peakPct !== undefined}
+  {#if peakPct !== undefined}
     <rect
       x={BAR_X + (peakPct / 100) * BAR_WIDTH - 1}
       y={TRACK_Y}

--- a/frontend/src/components-v2/meters/__tests__/BarGauge.peakhold.svelte.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/BarGauge.peakhold.svelte.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
 import BarGauge from '../BarGauge.svelte';
+import type { BarMeterFrame } from '../bar-meter-motion.svelte';
 import type {
   MeterContinuitySession,
   MeterSourceIdentity,
@@ -117,6 +118,27 @@ describe('BarGauge peak-hold marker (MOR-1282)', () => {
 
     t.querySelector('svg')!.dispatchEvent(new Event('dblclick', { bubbles: true }));
     flushSync();
+    expect(markerCount(t)).toBe(0);
+  });
+
+  it('renders hosted frame updates and keeps the reset action revocable', () => {
+    const onResetPeak = vi.fn();
+    const { t, state } = mountReactive({
+      frame: { smoothedFraction: 0.4, peakFraction: 0.8 } satisfies BarMeterFrame,
+      label: 'Po', displayValue: '40W', onResetPeak,
+    });
+    expect(fillCount(t)).toBe(4);
+    expect(markerX(t)).toBe(211);
+
+    t.querySelector('svg')!.dispatchEvent(new Event('dblclick', { bubbles: true }));
+    expect(onResetPeak).toHaveBeenCalledOnce();
+    state.onResetPeak = undefined;
+    t.querySelector('svg')!.dispatchEvent(new Event('dblclick', { bubbles: true }));
+    expect(onResetPeak).toHaveBeenCalledOnce();
+
+    state.frame = { smoothedFraction: 0.2, peakFraction: null } satisfies BarMeterFrame;
+    flushSync();
+    expect(fillCount(t)).toBe(2);
     expect(markerCount(t)).toBe(0);
   });
 

--- a/frontend/src/components-v2/meters/__tests__/BarGauge.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/BarGauge.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import BarGauge from '../BarGauge.svelte';
+import type { BarMeterFrame } from '../bar-meter-motion.svelte';
 import {
   DEFAULT_ZONES,
   valueToSegments,
@@ -218,5 +221,55 @@ describe('valueFontSize', () => {
     const base = valueFontSize('35W', 9);
     const stepped = valueFontSize('a much longer value', 9);
     expect(stepped).toBeLessThan(base);
+  });
+});
+
+describe('BarGauge hosted frame input', () => {
+  it('renders a passive frame and delegates reset without creating schedules', () => {
+    const requestFrame = vi.spyOn(window, 'requestAnimationFrame');
+    const setInterval = vi.spyOn(window, 'setInterval');
+    const onResetPeak = vi.fn();
+    const frame: BarMeterFrame = { smoothedFraction: 0.45, peakFraction: 0.8 };
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    const component = mount(BarGauge, {
+      target,
+      props: { frame, label: 'Po', displayValue: '45W', onResetPeak },
+    });
+    flushSync();
+    try {
+      expect(target.querySelectorAll('[data-gauge-fill]')).toHaveLength(5);
+      expect(target.querySelector('[data-testid="bar-gauge-peak-marker"]')?.getAttribute('x'))
+        .toBe('211');
+      expect(requestFrame).not.toHaveBeenCalled();
+      expect(setInterval).not.toHaveBeenCalled();
+
+      target.querySelector('svg')!.dispatchEvent(new Event('dblclick', { bubbles: true }));
+      expect(onResetPeak).toHaveBeenCalledOnce();
+    } finally {
+      unmount(component);
+      target.remove();
+      requestFrame.mockRestore();
+      setInterval.mockRestore();
+    }
+  });
+
+  it('rejects mixed live-value and hosted-frame ownership', () => {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    let component: ReturnType<typeof mount> | undefined;
+    const frame: BarMeterFrame = { smoothedFraction: 0.4, peakFraction: null };
+    try {
+      expect(() => {
+        component = mount(BarGauge as never, {
+          target,
+          props: { value: 0.4, frame, label: 'Po', displayValue: '40W' },
+        });
+        flushSync();
+      }).toThrowError('BarGauge requires exactly one of frame or value');
+    } finally {
+      if (component !== undefined) unmount(component);
+      target.remove();
+    }
   });
 });

--- a/frontend/src/components-v2/meters/__tests__/bar-meter-motion.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/bar-meter-motion.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  MeterContinuitySession,
+  MeterSourceIdentity,
+} from '../../../primitives/meters/meter-ballistics.svelte';
+import { createBarMeterMotion } from '../bar-meter-motion.svelte';
+
+const MAIN_SOURCE = {
+  providerGeneration: 1,
+  scope: 'receiver',
+  receiver: 'MAIN',
+  path: 'main.rfPower',
+} as const satisfies MeterSourceIdentity;
+const SUB_SOURCE = {
+  providerGeneration: 1,
+  scope: 'receiver',
+  receiver: 'SUB',
+  path: 'sub.rfPower',
+} as const satisfies MeterSourceIdentity;
+const SESSION_1 = { controlSessionEpoch: 1 } as const satisfies MeterContinuitySession;
+const SESSION_2 = { controlSessionEpoch: 2 } as const satisfies MeterContinuitySession;
+
+interface MotionHarness {
+  readonly activeFrames: number;
+  readonly activeIntervals: number;
+  readonly listenerCount: number;
+  readonly intervalDelays: readonly number[];
+  flushFrame(elapsedMilliseconds: number): void;
+  setReduced(reduced: boolean): void;
+  restore(): void;
+}
+
+function installMotionHarness(initialReduced = false): MotionHarness {
+  let reduced = initialReduced;
+  let nextFrameId = 1;
+  let nextIntervalId = 1;
+  const frames = new Map<number, FrameRequestCallback>();
+  const intervals = new Map<number, () => void>();
+  const intervalDelays: number[] = [];
+  const listeners = new Set<() => void>();
+  const mql = {
+    get matches() { return reduced; },
+    addEventListener: (_type: string, callback: () => void) => { listeners.add(callback); },
+    removeEventListener: (_type: string, callback: () => void) => { listeners.delete(callback); },
+  } as unknown as MediaQueryList;
+  const originalMatchMedia = window.matchMedia;
+  const originalSetInterval = window.setInterval;
+  const originalClearInterval = window.clearInterval;
+  window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia;
+  window.setInterval = ((callback: TimerHandler, delay?: number) => {
+    const id = nextIntervalId++;
+    intervals.set(id, callback as () => void);
+    intervalDelays.push(delay ?? 0);
+    return id;
+  }) as typeof window.setInterval;
+  window.clearInterval = ((id: number) => { intervals.delete(id); }) as typeof window.clearInterval;
+  const requestFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+    const id = nextFrameId++;
+    frames.set(id, callback);
+    return id;
+  });
+  const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id) => {
+    frames.delete(id);
+  });
+  return {
+    get activeFrames() { return frames.size; },
+    get activeIntervals() { return intervals.size; },
+    get listenerCount() { return listeners.size; },
+    get intervalDelays() { return intervalDelays; },
+    flushFrame(elapsedMilliseconds) {
+      const next = frames.entries().next().value as [number, FrameRequestCallback] | undefined;
+      if (next === undefined) throw new Error('No animation frame is scheduled');
+      frames.delete(next[0]);
+      next[1](performance.now() + elapsedMilliseconds);
+    },
+    setReduced(next) {
+      reduced = next;
+      listeners.forEach((callback) => callback());
+    },
+    restore() {
+      window.matchMedia = originalMatchMedia;
+      window.setInterval = originalSetInterval;
+      window.clearInterval = originalClearInterval;
+      requestFrame.mockRestore();
+      cancelFrame.mockRestore();
+    },
+  };
+}
+
+let harness: MotionHarness | undefined;
+
+beforeEach(() => {
+  harness = installMotionHarness();
+});
+
+afterEach(() => {
+  harness?.restore();
+  harness = undefined;
+});
+
+describe('createBarMeterMotion', () => {
+  it('exposes one stable passive fractions-only frame', () => {
+    const binding = createBarMeterMotion({
+      value: 0.257,
+      peakEnabled: true,
+      source: MAIN_SOURCE,
+      session: SESSION_1,
+    });
+    const frame = binding.frame;
+    expect(Object.keys(frame)).toEqual(['smoothedFraction', 'peakFraction']);
+    expect(frame.smoothedFraction).toBe(0.257);
+    expect(frame.peakFraction).toBe(0.257);
+
+    binding.sync({
+      value: 0.1234,
+      peakEnabled: true,
+      source: SUB_SOURCE,
+      session: SESSION_1,
+    });
+    expect(binding.frame).toBe(frame);
+    expect(frame.smoothedFraction).toBe(0.1234);
+  });
+
+  it('clamps only the smoothing fraction while retaining a finite over-range peak sample', () => {
+    const binding = createBarMeterMotion({
+      value: 1.6,
+      peakEnabled: true,
+      source: MAIN_SOURCE,
+      session: SESSION_1,
+    });
+    expect(binding.frame.smoothedFraction).toBe(1);
+    expect(binding.frame.peakFraction).toBe(1.6);
+
+    binding.sync({
+      value: -0.5,
+      peakEnabled: true,
+      source: SUB_SOURCE,
+      session: SESSION_1,
+    });
+    expect(binding.frame.smoothedFraction).toBe(0);
+    expect(binding.frame.peakFraction).toBe(-0.5);
+  });
+
+  it('clears both channels for null samples and explicit null continuity', () => {
+    const binding = createBarMeterMotion({
+      value: 0.8,
+      peakEnabled: true,
+      source: MAIN_SOURCE,
+      session: SESSION_1,
+    });
+    binding.sync({ value: null, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1 });
+    expect(binding.frame.smoothedFraction).toBe(0);
+    expect(binding.frame.peakFraction).toBeNull();
+
+    binding.sync({ value: 0.6, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1 });
+    binding.sync({ value: 0.9, peakEnabled: true, source: null, session: SESSION_1 });
+    expect(binding.frame.smoothedFraction).toBe(0);
+    expect(binding.frame.peakFraction).toBeNull();
+  });
+
+  it('preserves the existing non-finite arithmetic instead of inventing absence', () => {
+    const nan = createBarMeterMotion({
+      value: Number.NaN,
+      peakEnabled: true,
+      source: MAIN_SOURCE,
+      session: SESSION_1,
+    });
+    expect(Number.isNaN(nan.frame.smoothedFraction)).toBe(true);
+    expect(Number.isNaN(nan.frame.peakFraction)).toBe(true);
+
+    const infinity = createBarMeterMotion({
+      value: Number.POSITIVE_INFINITY,
+      peakEnabled: true,
+      source: MAIN_SOURCE,
+      session: SESSION_1,
+    });
+    expect(infinity.frame.smoothedFraction).toBe(1);
+    expect(infinity.frame.peakFraction).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('observes source and session boundaries synchronously', () => {
+    const binding = createBarMeterMotion({
+      value: 0.8,
+      peakEnabled: true,
+      source: MAIN_SOURCE,
+      session: SESSION_1,
+    });
+    binding.sync({ value: 0.2, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_1 });
+    expect(binding.frame.smoothedFraction).toBe(0.8);
+    expect(binding.frame.peakFraction).toBe(0.8);
+
+    binding.sync({ value: 0.3, peakEnabled: true, source: SUB_SOURCE, session: SESSION_1 });
+    expect(binding.frame.smoothedFraction).toBe(0.3);
+    expect(binding.frame.peakFraction).toBe(0.3);
+    binding.sync({ value: 0.4, peakEnabled: true, source: MAIN_SOURCE, session: SESSION_2 });
+    expect(binding.frame.smoothedFraction).toBe(0.4);
+    expect(binding.frame.peakFraction).toBe(0.4);
+  });
+
+  it('owns the existing schedules and tears them down idempotently', () => {
+    const binding = createBarMeterMotion({ value: 0.8, peakEnabled: true });
+    binding.start();
+    binding.start();
+    expect(harness!.activeFrames).toBe(1);
+    expect(harness!.activeIntervals).toBe(1);
+    expect(harness!.intervalDelays).toEqual([100]);
+    expect(harness!.listenerCount).toBe(2);
+
+    binding.stop();
+    binding.stop();
+    expect(harness!.activeFrames).toBe(0);
+    expect(harness!.activeIntervals).toBe(0);
+    expect(harness!.listenerCount).toBe(0);
+  });
+
+  it('retains the 0.08 attack and 0.2 release response', () => {
+    const attack = createBarMeterMotion({
+      value: 0,
+      peakEnabled: false,
+      source: MAIN_SOURCE,
+      session: SESSION_1,
+    });
+    attack.sync({ value: 1, peakEnabled: false, source: MAIN_SOURCE, session: SESSION_1 });
+    attack.start();
+    harness!.flushFrame(50);
+    expect(attack.frame.smoothedFraction).toBeCloseTo(1 - Math.exp(-0.05 / 0.08), 2);
+    attack.stop();
+
+    const release = createBarMeterMotion({
+      value: 1,
+      peakEnabled: false,
+      source: MAIN_SOURCE,
+      session: SESSION_1,
+    });
+    release.sync({ value: 0, peakEnabled: false, source: MAIN_SOURCE, session: SESSION_1 });
+    release.start();
+    harness!.flushFrame(50);
+    expect(release.frame.smoothedFraction).toBeCloseTo(Math.exp(-0.05 / 0.2), 2);
+    release.stop();
+  });
+
+  it('keeps the peak schedule disabled when peak is disabled', () => {
+    const binding = createBarMeterMotion({ value: 0.8, peakEnabled: false });
+    binding.start();
+    expect(harness!.activeFrames).toBe(1);
+    expect(harness!.activeIntervals).toBe(0);
+    expect(binding.frame.peakFraction).toBeNull();
+    binding.stop();
+  });
+
+  it('resets the peak independently of its passive frame', () => {
+    const binding = createBarMeterMotion({
+      value: 0.8,
+      peakEnabled: true,
+      source: MAIN_SOURCE,
+      session: SESSION_1,
+    });
+    const frame = binding.frame;
+    binding.resetPeak();
+    expect(binding.frame).toBe(frame);
+    expect(frame.smoothedFraction).toBe(0.8);
+    expect(frame.peakFraction).toBeNull();
+  });
+
+  it('stops both schedules for reduced motion and restores them afterwards', () => {
+    const binding = createBarMeterMotion({ value: 0.5, peakEnabled: true });
+    binding.start();
+    expect(harness!.activeFrames).toBe(1);
+    expect(harness!.activeIntervals).toBe(1);
+
+    harness!.setReduced(true);
+    expect(harness!.activeFrames).toBe(0);
+    expect(harness!.activeIntervals).toBe(0);
+    harness!.setReduced(false);
+    expect(harness!.activeFrames).toBe(1);
+    expect(harness!.activeIntervals).toBe(1);
+    binding.stop();
+  });
+});

--- a/frontend/src/components-v2/meters/bar-meter-motion.svelte.ts
+++ b/frontend/src/components-v2/meters/bar-meter-motion.svelte.ts
@@ -1,0 +1,90 @@
+import {
+  createSmoother,
+  onReducedMotionChange,
+  prefersReducedMotion,
+} from '$lib/utils/smoothing.svelte';
+import {
+  createElapsedEnvelopePeakStrategy,
+  createMeterBallistics,
+  type MeterContinuitySession,
+  type MeterMotionHost,
+  type MeterSourceIdentity,
+} from '../../primitives/meters/meter-ballistics.svelte';
+import {
+  PEAK_DECAY_MS,
+  peakHoldDisplay,
+  updatePeakHold,
+  type PeakHoldState,
+} from '../panels/meter-utils';
+
+export interface BarMeterFrame {
+  readonly smoothedFraction: number;
+  readonly peakFraction: number | null;
+}
+
+export type BarMeterMotionInput = Readonly<{
+  value: number | null;
+  peakEnabled: boolean;
+  source?: MeterSourceIdentity | null;
+  session?: MeterContinuitySession | null;
+}>;
+
+export interface BarMeterMotionBinding {
+  readonly frame: BarMeterFrame;
+  sync(input: BarMeterMotionInput): void;
+  start(): void;
+  stop(): void;
+  resetPeak(): void;
+}
+
+const ATTACK_SECONDS = 0.08;
+const RELEASE_SECONDS = 0.2;
+const PEAK_TICK_MILLISECONDS = 100;
+
+const browserMotionHost: MeterMotionHost = {
+  now: () => Date.now(),
+  requestFrame: (callback) => requestAnimationFrame(callback),
+  cancelFrame: (id) => cancelAnimationFrame(id),
+  setInterval: (callback, milliseconds) => setInterval(callback, milliseconds),
+  clearInterval: (id) => clearInterval(id),
+  prefersReducedMotion,
+  onReducedMotionChange,
+};
+
+function clampFraction(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+export function createBarMeterMotion(initial: BarMeterMotionInput): BarMeterMotionBinding {
+  const smoother = createSmoother(ATTACK_SECONDS, RELEASE_SECONDS);
+  const ballistics = createMeterBallistics(smoother, browserMotionHost, {
+    peakSource: 'sample',
+    ticker: { kind: 'interval', milliseconds: PEAK_TICK_MILLISECONDS },
+    peak: createElapsedEnvelopePeakStrategy<PeakHoldState>({
+      decayMilliseconds: PEAK_DECAY_MS,
+      updatePeakHold,
+      peakHoldDisplay,
+    }),
+  });
+  const frame: BarMeterFrame = {
+    get smoothedFraction() { return ballistics.view.smoothedValue; },
+    get peakFraction() { return ballistics.view.peakValue; },
+  };
+  const binding: BarMeterMotionBinding = {
+    frame,
+    sync(input) {
+      ballistics.sync({
+        sample: input.value,
+        smoothTarget: input.value === null ? null : clampFraction(input.value),
+        peakEnabled: input.peakEnabled,
+        source: input.source,
+        session: input.session,
+      });
+    },
+    start: () => ballistics.start(),
+    stop: () => ballistics.stop(),
+    resetPeak: () => ballistics.resetPeak(),
+  };
+  binding.sync(initial);
+  return binding;
+}

--- a/frontend/src/primitives/meters/__tests__/meter-ballistics.test.ts
+++ b/frontend/src/primitives/meters/__tests__/meter-ballistics.test.ts
@@ -184,9 +184,16 @@ describe('createMeterBallistics frame-step strategy', () => {
     expect(linear).not.toMatch(/createMeterBallistics\(|createSmoother\(/);
     expect(linear.match(/createSignalMeterMotion\(/g)).toHaveLength(1);
 
+    const barBinding = readFileSync(
+      'src/components-v2/meters/bar-meter-motion.svelte.ts',
+      'utf8',
+    );
+    expect(barBinding.match(/createMeterBallistics\(/g)).toHaveLength(1);
+    expect(barBinding.match(/createSmoother\(/g)).toHaveLength(1);
+
     const bar = readFileSync('src/components-v2/meters/BarGauge.svelte', 'utf8');
-    expect(bar.match(/createMeterBallistics\(/g)).toHaveLength(1);
-    expect(bar.match(/createSmoother\(/g)).toHaveLength(1);
+    expect(bar).not.toMatch(/createMeterBallistics\(|createSmoother\(/);
+    expect(bar.match(/createBarMeterMotion\(/g)).toHaveLength(1);
   });
 
   it('delegates smoothing and clears both outputs when either coordinate is absent', () => {

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -604,16 +604,16 @@ describe('BarGauge peak channel (MOR-1282)', () => {
 describe('MetersSurface and MetersDockPanel are on the same peak-hold channel', () => {
   // MUTATION KILLED: either side reimplementing the hold/decay math instead
   // of calling the shared `meter-utils` functions. `MetersSurface` itself may
-  // never import them (block 7 above); `BarGauge` (which it delegates every
-  // gauge to) and `MetersDockPanel` must both import the SAME functions from
+  // never import them (block 7 above); the bar-motion binding used by every
+  // `BarGauge` and `MetersDockPanel` must both import the SAME functions from
   // the SAME module, so a raw sample can never decay differently depending on
   // which surface is rendering it.
-  it('both BarGauge and MetersDockPanel import updatePeakHold/peakHoldDisplay from the shared meter-utils module', () => {
-    const barGaugeSource = readFileSync('src/components-v2/meters/BarGauge.svelte', 'utf8');
+  it('both bar meter motion and MetersDockPanel import updatePeakHold/peakHoldDisplay from the shared meter-utils module', () => {
+    const barMotionSource = readFileSync('src/components-v2/meters/bar-meter-motion.svelte.ts', 'utf8');
     const dockSource = readFileSync('src/components-v2/panels/MetersDockPanel.svelte', 'utf8');
-    expect(barGaugeSource).toMatch(/updatePeakHold/);
-    expect(barGaugeSource).toMatch(/peakHoldDisplay/);
-    expect(barGaugeSource).toMatch(/from '\.\.\/panels\/meter-utils'/);
+    expect(barMotionSource).toMatch(/updatePeakHold/);
+    expect(barMotionSource).toMatch(/peakHoldDisplay/);
+    expect(barMotionSource).toMatch(/from '\.\.\/panels\/meter-utils'/);
     expect(dockSource).toMatch(/updatePeakHold/);
     expect(dockSource).toMatch(/peakHoldDisplay/);
     expect(dockSource).toMatch(/from '\.\/meter-utils'/);
@@ -623,12 +623,12 @@ describe('MetersSurface and MetersDockPanel are on the same peak-hold channel', 
   // literal instead of importing the shared one from `meter-utils` — the
   // exact duplicated-window drift the verifier proved was previously pinned
   // by NOTHING. Both must import the SAME binding; neither may shadow it.
-  it('both BarGauge and MetersDockPanel import the shared PEAK_DECAY_MS instead of declaring their own', () => {
-    const barGaugeSource = readFileSync('src/components-v2/meters/BarGauge.svelte', 'utf8');
+  it('both bar meter motion and MetersDockPanel import the shared PEAK_DECAY_MS instead of declaring their own', () => {
+    const barMotionSource = readFileSync('src/components-v2/meters/bar-meter-motion.svelte.ts', 'utf8');
     const dockSource = readFileSync('src/components-v2/panels/MetersDockPanel.svelte', 'utf8');
-    expect(barGaugeSource).toMatch(/import\s*\{[^}]*PEAK_DECAY_MS[^}]*\}\s*from\s*'\.\.\/panels\/meter-utils'/);
+    expect(barMotionSource).toMatch(/import\s*\{[^}]*PEAK_DECAY_MS[^}]*\}\s*from\s*'\.\.\/panels\/meter-utils'/);
     expect(dockSource).toMatch(/import\s*\{[^}]*PEAK_DECAY_MS[^}]*\}\s*from\s*'\.\/meter-utils'/);
-    expect(barGaugeSource).not.toMatch(/const\s+PEAK_DECAY_MS\s*=/);
+    expect(barMotionSource).not.toMatch(/const\s+PEAK_DECAY_MS\s*=/);
     expect(dockSource).not.toMatch(/const\s+PEAK_DECAY_MS\s*=/);
   });
 });


### PR DESCRIPTION
Linear: MOR-2425

BarGauge now uses the existing smoother and peak policy through one private motion binding. Its stable readonly frame carries smoothed and peak fractions; hosted-frame rendering creates no local motion owner or scheduler, and peak reset is a separate current callback. Live-value callers keep their existing behavior.

The extraction preserves attack/release, sample peak, interval/envelope timing, over-range, null/non-finite values, continuity reset, reduced motion, DOM and palette behavior. Static ownership tests now inspect the actual extracted owner. No new public meter API, SDK export, activation or alternate-skin change.

Scope: 7 code/test files,565 additions+67 deletions=632 A+D,0baselines. One coherent extraction includes live renderer adoption and its ownership tests; splitting would leave unused host code or stale assertions. The candidate is a patch-identical replay of private8ec173895+fb48c767d onto accepted66334b952. M2-1 was not imported; its later merged MetersSurface test edits are separate from these static ownership assertions.

Validation at e6dcb2f804fcc50a40cfe84970312032b9a84779:

- Focused7files/120tests passed; targeted ownership2passed/143skipped; Svelte/TypeScript0errors0warnings; scoped lint/diff-check passed.
- Genuine two-test ownership RED preceded correction. Independent clamp, hosted-owner and cached-reset mutations were detected; equivalent benign clamp remained green. Independent mounted before/after comparison covered40scenarios across peak/reduced-motion/null/nonfinite values.
- Natural quick34083530151 SUCCESS:449files/11,044tests and87visual-smoke. Natural visual34083530234 SUCCESS:36tests.
- Independent exact-head PASS: https://github.com/rigplane/rigplane-core/pull/3322#issuecomment-5565129329. No findings or mandatory PR/squash corrections.
- Root read full632AD, exact replay range-diff, implementation/final independent reports and body. Canonical required gates and current-main start guard are rechecked immediately before merge. Non-required v2 observations are not acceptance evidence.

Station host ownership, external drawing frames and public meter API remain later scope; this extraction does not claim their completion.
