### PR TITLE
refactor(MOR-2425): persist RF front-end instrument ownership

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/SemanticControlPanelHarness.svelte
+++ b/frontend/src/components-v2/layout/__tests__/SemanticControlPanelHarness.svelte
@@ -2,7 +2,9 @@
   import type { SemanticSurfaceName } from '../../../presentation/layouts/contract';
   import type { RadioViewModel } from '../../../semantic/radio-view-model';
   import SemanticControlPanel from '../SemanticControlPanel.svelte';
-  import RfFrontEndSurface from '../../../semantic/RfFrontEndSurface.svelte';
+  import RfFrontEndFixture, {
+    rfTestAuthorityPublication,
+  } from '../../../semantic/__tests__/fixtures/RfFrontEndInstrumentHostFixture.svelte';
   import ScopeControlsSurface from '../../../semantic/ScopeControlsSurface.svelte';
   import ScopeDisplaySurface from '../../../semantic/ScopeDisplaySurface.svelte';
   import '../../../skins/desktop-v2/semantic-controls.css';
@@ -14,12 +16,17 @@
     onPreampChange?: (value: number) => void;
     onLevelChange?: (field: 'rfGain' | 'squelch', value: number) => void;
   } = $props();
+  const rfPublication = rfTestAuthorityPublication('separate');
 </script>
 
 <div class="desktop-control-face">
   <SemanticControlPanel {surface}>
     {#if surface === 'rfFrontEnd'}
-      <RfFrontEndSurface {view} {pendingPreamp} {onPreampChange} {onLevelChange} />
+      <RfFrontEndFixture
+        publication={rfPublication} {view} controlModel="separate" renderSurface={true}
+        subscribeControlAuthority={(handler) => { handler(rfPublication); return () => undefined; }}
+        {pendingPreamp} {onPreampChange} {onLevelChange}
+      />
     {:else if surface === 'scopeControls'}
       <ScopeControlsSurface {view} />
     {:else if surface === 'scopeDisplay'}

--- a/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
+++ b/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
@@ -30,6 +30,9 @@
   const txAuxInstruments = {
     atu: empty, vox: empty, compressor: empty, monitor: empty, atuTune: empty,
   } satisfies TxAuxFiniteHandles;
+  const rfFrontEndInstruments = {
+    kind: 'separate', rfGain: empty, squelch: empty,
+  } as const;
   const scalars = {
     rfPower: empty, micGain: empty, driveGain: empty, voxGain: empty,
     antiVoxGain: empty, voxDelay: empty, compressorLevel: empty, monitorLevel: empty,
@@ -38,7 +41,7 @@
   export const TEST_INSTRUMENTS = {
     vfo, rxTx: empty, txAuxControls: txAux, txAuxScalars: scalars, txAuxInstruments,
     receiverInstruments,
-    rxAudioInstruments,
+    rxAudioInstruments, rfFrontEndInstruments,
     meters: empty, rxAudio: empty, rfFrontEnd: empty, filter: empty, dsp: empty,
     band: empty, antenna: empty, ritXitScan: empty, cwKeyer: empty,
     scopeDisplay: empty, scopeControls: empty, txFaultRecovery: empty,
@@ -53,15 +56,27 @@
   import type { InstrumentComposition } from '../../../wiring/instrument-composition';
 
   let {
-    skinId = 'desktop-v2', rxAudioLayout = 'production',
+    skinId = 'desktop-v2', rxAudioLayout = 'production', rfFrontEndLayout = 'production',
   }: {
     skinId?: SkinId; rxAudioLayout?: 'production' | 'grouped' | 'independent';
+    rfFrontEndLayout?: 'production' | 'grouped' | 'independent';
   } = $props();
 </script>
 
 <SemanticRadioSurfaces>
   {#snippet children(instruments: InstrumentComposition)}
-    {#if rxAudioLayout === 'production'}
+    {#if rfFrontEndLayout === 'grouped'}
+      {@render instruments.rfFrontEnd()}
+    {:else if rfFrontEndLayout === 'independent'}
+      <div data-rf-layout="independent" data-handle-kind={instruments.rfFrontEndInstruments.kind}>
+        {#if instruments.rfFrontEndInstruments.kind === 'combined'}
+          {@render instruments.rfFrontEndInstruments.rfSql()}
+        {:else}
+          {@render instruments.rfFrontEndInstruments.rfGain()}
+          {@render instruments.rfFrontEndInstruments.squelch()}
+        {/if}
+      </div>
+    {:else if rxAudioLayout === 'production'}
       <RadioLayout {skinId} {instruments} />
     {:else if rxAudioLayout === 'grouped'}
       {@render instruments.rxAudio()}

--- a/frontend/src/components-v2/layout/__tests__/semantic-controls.component.svelte.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-controls.component.svelte.test.ts
@@ -14,6 +14,21 @@ function render(surface: SemanticSurfaceName, view = base(), handlers = {}) {
   return { target, dispose: async () => { await unmount(component); target.remove(); } };
 }
 
+function driveLevel(root: HTMLElement, value: number): HTMLElement {
+  const slider = root.querySelector<HTMLElement>('[role="slider"]')!;
+  const frame = slider.closest<HTMLElement>('.vc-hbar')!;
+  frame.getBoundingClientRect = () => ({ left: 0, width: 100 } as DOMRect);
+  Object.assign(slider, {
+    setPointerCapture: vi.fn(), hasPointerCapture: () => true, releasePointerCapture: vi.fn(),
+  });
+  slider.dispatchEvent(new PointerEvent('pointerdown', {
+    bubbles: true, clientX: value * 100, pointerId: 1,
+  }));
+  slider.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }));
+  flushSync();
+  return slider;
+}
+
 const TITLES = {
   rxTx: 'TX', txAux: 'TX CONTROLS', meters: 'STATION METERS', rxAudio: 'RX AUDIO',
   filter: 'MODE / FILTER', dsp: 'DSP', rfFrontEnd: 'RF FRONT END', band: 'BAND',
@@ -54,17 +69,19 @@ describe('desktop semantic control frames', () => {
     await r.dispose();
   });
 
-  it('preserves native inputs and emits the existing RF intent once', async () => {
+  it('preserves the rendered slider and emits the existing RF intent once', async () => {
     const onPreampChange = vi.fn();
     const onLevelChange = vi.fn();
     const r = render('rfFrontEnd', base(), { onPreampChange, onLevelChange });
     (r.target.querySelector('[data-testid="rf-front-end-preamp-1"]') as HTMLButtonElement).click();
     expect(onPreampChange).toHaveBeenCalledExactlyOnceWith(1);
-    const input = r.target.querySelector('[data-testid="rf-front-end-rfGain"] input') as HTMLInputElement;
-    expect(input.type).toBe('range');
-    input.value = '0.7';
-    input.dispatchEvent(new Event('input', { bubbles: true }));
-    expect(onLevelChange).toHaveBeenCalledExactlyOnceWith('rfGain', 0.7);
+    const level = r.target.querySelector('[data-testid="rf-front-end-rfGain"]') as HTMLElement;
+    const slider = driveLevel(level, 0.7);
+    expect(slider.closest<HTMLElement>('.vc-hbar')!.style
+      .getPropertyValue('--vc-fill-percent')).toBe('70%');
+    expect(onLevelChange).toHaveBeenCalledTimes(1);
+    expect(onLevelChange.mock.calls[0][0]).toBe('rfGain');
+    expect(onLevelChange.mock.calls[0][1]).toBeCloseTo(0.7, 12);
     expect(r.target.querySelectorAll('.rf-front-end-surface')).toHaveLength(1);
     await r.dispose();
   });
@@ -80,9 +97,9 @@ describe('desktop semantic control frames', () => {
     const button = r.target.querySelector('[data-testid="rf-front-end-preamp-1"]') as HTMLButtonElement;
     expect(button.disabled).toBe(true);
     button.click();
-    const input = r.target.querySelector('[data-testid="rf-front-end-rfGain"] input') as HTMLInputElement;
-    expect(input.disabled).toBe(true);
-    input.dispatchEvent(new Event('input', { bubbles: true }));
+    const level = r.target.querySelector('[data-testid="rf-front-end-rfGain"]') as HTMLElement;
+    const slider = driveLevel(level, 0.5);
+    expect(slider.getAttribute('aria-disabled')).toBe('true');
     expect(onPreampChange).not.toHaveBeenCalled();
     expect(onLevelChange).not.toHaveBeenCalled();
     expect(r.target.querySelector('[data-testid="rf-front-end-rfGain"] output')?.textContent).toBe('?');

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -67,6 +67,7 @@
   import RfFrontEndSurface, {
     type RfFrontEndLevelField, type RfFrontEndToggleField,
   } from '../../semantic/RfFrontEndSurface.svelte';
+  import RfFrontEndInstrumentHost from '../../semantic/RfFrontEndInstrumentHost.svelte';
   import RitXitScanSurface from '../../semantic/RitXitScanSurface.svelte';
   import RxAudioSurface from '../../semantic/RxAudioSurface.svelte';
   import RxAudioInstrumentHost from '../../semantic/RxAudioInstrumentHost.svelte';
@@ -894,6 +895,14 @@
     activeReceiverIndex === null ? null : getPendingPreampLevel(activeReceiverIndex),
   );
   let rfSqlFeedback = $derived(getRfSqlControlFeedback(controlSession));
+  let rfFrontEndInstrumentPresentation = $derived({
+    state: runtime.state,
+    caps: runtime.caps,
+    session: runtime.controlSession,
+    view: canonicalView,
+    controlModel: rfSqlControlModel,
+    rfSqlFeedback,
+  });
   let pendingNb = $derived(activeReceiverIndex === null ? null : getPendingNbOn(activeReceiverIndex));
   let pendingNr = $derived(activeReceiverIndex === null ? null : getPendingNrOn(activeReceiverIndex));
 
@@ -1029,6 +1038,12 @@
     onAfLevelChange={rxAudioIntents.onAfLevelChange}
   >
   {#snippet children(rxAudioInstruments)}
+  <RfFrontEndInstrumentHost
+    presentation={rfFrontEndInstrumentPresentation}
+    subscribeControlAuthority={(handler) => runtime.subscribeControlAuthority(handler)}
+    onLevelChange={(field, value) => RF_FRONT_END_LEVEL_INTENT[field](value)}
+  >
+  {#snippet children(rfFrontEndInstruments)}
   {#if readonlyDisplay}
     {#if view}{@render readonlyDisplay(view, selectedDisplayFrame)}{/if}
   {:else}
@@ -1479,12 +1494,10 @@
     {#if view?.rfFrontEnd}
       <RfFrontEndSurface
         {view}
-        controlModel={rfSqlControlModel}
-        {rfSqlFeedback}
+        levelHandles={rfFrontEndInstruments}
         {pendingPreamp}
         onPreampChange={(level) => rfFrontEndIntents.onPreChange(level)}
         onAttenuatorChange={(db) => rfFrontEndIntents.onAttChange(db)}
-        onLevelChange={(field, value) => RF_FRONT_END_LEVEL_INTENT[field](value)}
         onToggle={(field, next) => RF_FRONT_END_TOGGLE_INTENT[field](next)}
       />
     {/if}
@@ -1720,6 +1733,7 @@
       txAuxInstruments,
       receiverInstruments,
       rxAudioInstruments,
+      rfFrontEndInstruments,
       meters: hostedMeters,
       rxAudio: hostedRxAudio,
       rfFrontEnd: hostedRfFrontEnd,
@@ -1909,6 +1923,8 @@
   {/snippet}
   </TxAuxScalarHost>
   {/if}
+  {/snippet}
+  </RfFrontEndInstrumentHost>
   {/snippet}
   </RxAudioInstrumentHost>
   {/snippet}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-pbt-continuity.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-pbt-continuity.component.test.ts
@@ -53,7 +53,7 @@ describe('mounted PBT continuity is fenced by the live control session (MOR-1706
     render(); const initialInner = value('pbtInner'), initialOuter = value('pbtOuter'); expect(initialInner).not.toBeNull(); expect(initialOuter).not.toBeNull(); expect(h.commands).not.toHaveBeenCalled();
     const staleInput = target.querySelector<HTMLInputElement>('[data-testid="filter-pbtInner"] input'); expect(staleInput).not.toBeNull();
     accept(state(null, -200, 2)); flushSync(); expect(value('pbtInner')).toBe(initialInner); expect(value('pbtOuter')).toBe(initialOuter);
-    expect(h.listeners.size).toBe(3); transition('disconnected', 1, false); transition('connected', 1, false); flushSync(); expect(value('pbtInner')).toBeNull(); expect(value('pbtOuter')).toBeNull();
+    expect(h.listeners.size).toBe(4); transition('disconnected', 1, false); transition('connected', 1, false); flushSync(); expect(value('pbtInner')).toBeNull(); expect(value('pbtOuter')).toBeNull();
     staleInput!.value = '500'; staleInput!.dispatchEvent(new Event('input', { bubbles: true })); flushSync(); expect(h.commands).not.toHaveBeenCalled(); expect(txHarness.trace()).toEqual([]);
     transition('connected', 1); expect(value('pbtInner')).toBeNull(); accept(state(300, -400, 3)); flushSync(); expect(value('pbtInner')).not.toBeNull();
     transition('connected', 2); expect(value('pbtInner')).toBeNull(); accept(state(500, -600, 4)); flushSync(); expect(value('pbtOuter')).not.toBeNull();

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -31,6 +31,8 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
@@ -252,6 +254,7 @@ vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
 });
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+import HostedRadioLayoutFixture from '../../layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte';
 import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
 import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
 import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
@@ -328,8 +331,54 @@ function render(props: { strips?: 'single' | 'dual' } = {}, plan?: SurfacePlan):
   flushSync();
 }
 
+function renderHosted() {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  const props = proxy<{ rfFrontEndLayout: 'grouped' | 'independent' }>({
+    rfFrontEndLayout: 'grouped',
+  });
+  component = mount(HostedRadioLayoutFixture, { target, props });
+  flushSync();
+  return props;
+}
+
 const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
 const el = (id: string) => q<HTMLElement>(`[data-testid="rf-front-end-${id}"]`);
+interface LevelDriver {
+  readonly slider: HTMLElement;
+  readonly frame: HTMLElement;
+  readonly value: () => number;
+  readonly disabled: () => boolean;
+  readonly input: (value: number, pointerId?: number) => void;
+}
+
+function levelDriver(root: ParentNode): LevelDriver {
+  const slider = root.querySelector<HTMLElement>('[role="slider"]');
+  if (slider === null) throw new Error('Expected rendered RF level slider');
+  const frame = slider.closest<HTMLElement>('.vc-hbar, .vc-dual');
+  if (frame === null) throw new Error('Expected RF level renderer frame');
+  const dual = frame.classList.contains('vc-dual');
+  return {
+    slider,
+    frame,
+    value: () => Number.parseFloat(frame.style.getPropertyValue(
+      dual ? '--vc-thumb-pct' : '--vc-fill-percent',
+    )) / 100,
+    disabled: () => slider.getAttribute('aria-disabled') === 'true',
+    input: (value, pointerId = 1) => {
+      frame.getBoundingClientRect = () => ({ left: 0, width: 100 } as DOMRect);
+      Object.assign(slider, {
+        setPointerCapture: vi.fn(), hasPointerCapture: () => true, releasePointerCapture: vi.fn(),
+      });
+      slider.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true, clientX: value * 100, pointerId,
+      }));
+      slider.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId }));
+    },
+  };
+}
+
+const level = (id: string) => levelDriver(el(id)!);
 let acceptedState: ServerState;
 
 function publishAuthority(): void {
@@ -477,9 +526,7 @@ describe('every rfFrontEnd intent reaches its own command-bus handler, none cros
   // pinned as the literal 140.
   it('routes the RF-gain slider to onRfGainChange, converted to the raw 0-255 wire level', () => {
     render();
-    const input = el('rfGain')!.querySelector('input')!;
-    input.value = '0.55';
-    input.dispatchEvent(new Event('input', { bubbles: true }));
+    level('rfGain').input(0.55);
     flushSync();
     expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(140);
     for (const other of ALL.filter((s) => s !== h.rfGain)) expect(other).not.toHaveBeenCalled();
@@ -487,9 +534,7 @@ describe('every rfFrontEnd intent reaches its own command-bus handler, none cros
 
   it('routes the squelch slider to onSquelchChange, converted to the raw 0-255 wire level', () => {
     render();
-    const input = el('squelch')!.querySelector('input')!;
-    input.value = '0.2';
-    input.dispatchEvent(new Event('input', { bubbles: true }));
+    level('squelch').input(0.2);
     flushSync();
     expect(h.squelch).toHaveBeenCalledExactlyOnceWith(51);
     for (const other of ALL.filter((s) => s !== h.squelch)) expect(other).not.toHaveBeenCalled();
@@ -501,9 +546,7 @@ describe('every rfFrontEnd intent reaches its own command-bus handler, none cros
   // proves `Math.round` specifically, not merely "some" integer conversion.
   it('rounds a 0.5 drag to the raw wire level 128, not the truncated 127', () => {
     render();
-    const input = el('rfGain')!.querySelector('input')!;
-    input.value = '0.5';
-    input.dispatchEvent(new Event('input', { bubbles: true }));
+    level('rfGain').input(0.5);
     flushSync();
     expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(128);
   });
@@ -605,7 +648,7 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
     render();
     const group = el('rf-sql')!;
     expect(group.dataset.feedbackIntegration).toBe('authority-unresolved');
-    expect(group.querySelector('input')!.disabled).toBe(true);
+    expect(levelDriver(group).disabled()).toBe(true);
     expect(group.textContent).toContain('?');
   });
 
@@ -626,7 +669,7 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
     confirmCommand(rf.id, 7, 7); failCommand(sql.id, 7, 7, 'denied'); flushSync();
     expect(el('rf-sql')!.dataset.rfCommandPhase).toBe('confirmed');
     expect(el('rf-sql')!.dataset.sqlCommandPhase).toBe('failed');
-    expect(el('rf-sql')!.querySelectorAll('[data-control-feedback-status]')).toHaveLength(2);
+    expect(target.querySelectorAll('[data-control-feedback-status]')).toHaveLength(2);
   });
 
   it('keeps rendering the two separate sliders when the profile omits the declaration', () => {
@@ -641,15 +684,15 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
 
   it('fails both separate controls closed on disconnect and recovers from fresh connected authority', () => {
     render();
-    const rfInput = el('rfGain')!.querySelector('input')!;
-    const sqlInput = el('squelch')!.querySelector('input')!;
-    expect([rfInput.disabled, sqlInput.disabled]).toEqual([false, false]);
+    const rfInput = level('rfGain');
+    const sqlInput = level('squelch');
+    expect([rfInput.disabled(), sqlInput.disabled()]).toEqual([false, false]);
 
     h.session = { state: 'disconnected', epoch: 8 };
     for (const listener of h.sessionListeners) listener(h.session);
     publishAuthority();
     flushSync();
-    expect([rfInput.disabled, sqlInput.disabled]).toEqual([true, true]);
+    expect([level('rfGain').disabled(), level('squelch').disabled()]).toEqual([true, true]);
     expect(el('rfGain')!.textContent).toContain('?');
     expect(el('squelch')!.textContent).toContain('?');
 
@@ -657,9 +700,9 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
     for (const listener of h.sessionListeners) listener(h.session);
     publishAuthority();
     flushSync();
-    expect([rfInput.disabled, sqlInput.disabled]).toEqual([false, false]);
-    expect(rfInput.valueAsNumber).toBe(0.8);
-    expect(sqlInput.valueAsNumber).toBe(0.1);
+    expect([level('rfGain').disabled(), level('squelch').disabled()]).toEqual([false, false]);
+    expect(level('rfGain').value()).toBe(0.8);
+    expect(level('squelch').value()).toBe(0.1);
     expect(h.rfGain).not.toHaveBeenCalled();
     expect(h.squelch).not.toHaveBeenCalled();
   });
@@ -676,8 +719,10 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
     render();
     expect(el('rfGain')!.dataset.commandPhase).toBe('submitted');
     expect(el('squelch')!.dataset.commandPhase).toBe('submitted');
-    expect(el('rfGain')!.querySelector('input')!.valueAsNumber).toBe(128 / 255);
-    expect(el('squelch')!.querySelector('input')!.valueAsNumber).toBe(51 / 255);
+    expect(level('rfGain').value()).toBe(0.8);
+    expect(level('squelch').value()).toBe(0.1);
+    expect(el('rfGain')!.querySelector('output')!.textContent).toBe('50%');
+    expect(el('squelch')!.querySelector('output')!.textContent).toBe('20%');
     acknowledgeCommand(rf.id, 7, 7);
     acknowledgeCommand(sql.id, 7, 7);
     flushSync();
@@ -688,18 +733,17 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
     flushSync();
     expect(el('rfGain')!.dataset.commandPhase).toBe('confirmed');
     expect(el('squelch')!.dataset.commandPhase).toBe('failed');
-    expect(el('rfGain')!.querySelectorAll('[data-control-feedback-status]')).toHaveLength(1);
-    expect(el('squelch')!.querySelectorAll('[data-control-feedback-status]')).toHaveLength(1);
-    expect(el('squelch')!.textContent).toContain('denied');
+    expect(target.querySelectorAll('[data-feedback-lane="rf"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-feedback-lane="sql"]')).toHaveLength(1);
+    expect(target.textContent).toContain('denied');
   });
 
-  it('retires a native RF draft after real raw-command confirmation and follows later truth while SQL is pending', () => {
+  it('retires an RF draft after real raw-command confirmation and follows later truth while SQL is pending', () => {
     render();
-    const rfInput = el('rfGain')!.querySelector('input')!;
-    const sqlInput = el('squelch')!.querySelector('input')!;
+    const rfInput = level('rfGain');
+    const sqlInput = level('squelch');
 
-    rfInput.value = '0.7';
-    rfInput.dispatchEvent(new Event('input', { bubbles: true }));
+    rfInput.input(0.7);
     flushSync();
     expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(179);
     expect(h.sentCommands).toHaveLength(1);
@@ -716,8 +760,7 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
     flushSync();
     expect(el('rfGain')!.dataset.commandPhase).toBe('confirmed');
 
-    sqlInput.value = '0.6';
-    sqlInput.dispatchEvent(new Event('input', { bubbles: true }));
+    sqlInput.input(0.6);
     flushSync();
     expect(h.squelch).toHaveBeenCalledExactlyOnceWith(153);
     expect(h.sentCommands).toHaveLength(2);
@@ -729,10 +772,11 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
     state = observedMainLevels(state, { rfGain: 204 / 255 }, 7);
     acknowledgeSent(sqlCommand);
     flushSync();
-    expect(el('rfGain')!.querySelector('input')!.valueAsNumber).toBe(0.8);
+    expect(level('rfGain').value()).toBe(0.8);
     expect(el('rfGain')!.querySelector('output')!.textContent).toBe('80%');
     expect(el('squelch')!.dataset.commandPhase).toBe('awaiting-confirmation');
-    expect(el('squelch')!.querySelector('input')!.valueAsNumber).toBe(0.6);
+    expect(level('squelch').value()).toBe(0.1);
+    expect(el('squelch')!.querySelector('output')!.textContent).toBe('60%');
 
     observedMainLevels(state, { squelch: 153 / 255 }, 8);
     flushSync();
@@ -743,12 +787,8 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
 
   it('routes separate endpoint requests once through the unchanged raw conversion seam', () => {
     render();
-    const rfInput = el('rfGain')!.querySelector('input')!;
-    const sqlInput = el('squelch')!.querySelector('input')!;
-    rfInput.value = '0';
-    rfInput.dispatchEvent(new Event('input', { bubbles: true }));
-    sqlInput.value = '1';
-    sqlInput.dispatchEvent(new Event('input', { bubbles: true }));
+    level('rfGain').input(0);
+    level('squelch').input(1);
     flushSync();
     expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(0);
     expect(h.squelch).toHaveBeenCalledExactlyOnceWith(255);
@@ -758,9 +798,7 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
   it('routes a hard-left drag to RF min / SQL min, both raw wire integers', () => {
     h.caps = liveCaps(true, 'combined');
     render();
-    const input = el('rf-sql')!.querySelector('input')!;
-    input.value = '0';
-    input.dispatchEvent(new Event('input', { bubbles: true }));
+    level('rf-sql').input(0);
     flushSync();
     expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(0);
     expect(h.squelch).toHaveBeenCalledExactlyOnceWith(0);
@@ -774,9 +812,7 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
   it('routes the knob center to RF max / SQL min', () => {
     h.caps = liveCaps(true, 'combined');
     render();
-    const input = el('rf-sql')!.querySelector('input')!;
-    input.value = '0.5';
-    input.dispatchEvent(new Event('input', { bubbles: true }));
+    level('rf-sql').input(0.5);
     flushSync();
     expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(255);
     expect(h.squelch).toHaveBeenCalledExactlyOnceWith(0);
@@ -787,9 +823,7 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
   it('routes a hard-right drag to SQL max / RF max, both raw wire integers', () => {
     h.caps = liveCaps(true, 'combined');
     render();
-    const input = el('rf-sql')!.querySelector('input')!;
-    input.value = '1';
-    input.dispatchEvent(new Event('input', { bubbles: true }));
+    level('rf-sql').input(1);
     flushSync();
     expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(255);
     expect(h.squelch).toHaveBeenCalledExactlyOnceWith(255);
@@ -802,9 +836,7 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
   it('sweeps RF only on a left-of-center drag, leaving SQL pinned at min', () => {
     h.caps = liveCaps(true, 'combined');
     render();
-    const input = el('rf-sql')!.querySelector('input')!;
-    input.value = '0.23';
-    input.dispatchEvent(new Event('input', { bubbles: true }));
+    level('rf-sql').input(0.23);
     flushSync();
     expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(128);
     expect(h.squelch).toHaveBeenCalledExactlyOnceWith(0);
@@ -814,9 +846,7 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
   it('sweeps SQL only on a right-of-center drag, leaving RF pinned at max', () => {
     h.caps = liveCaps(true, 'combined');
     render();
-    const input = el('rf-sql')!.querySelector('input')!;
-    input.value = '0.77';
-    input.dispatchEvent(new Event('input', { bubbles: true }));
+    level('rf-sql').input(0.77);
     flushSync();
     expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(255);
     expect(h.squelch).toHaveBeenCalledExactlyOnceWith(128);
@@ -831,8 +861,7 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
     (h.state as unknown as { main: { rfGain: number; squelch: number } }).main.rfGain = 0.8196078431372549;
     (h.state as unknown as { main: { rfGain: number; squelch: number } }).main.squelch = 0.2;
     render();
-    const input = el('rf-sql')!.querySelector('input')!;
-    expect(input.valueAsNumber).toBeCloseTo(0.632, 3);
+    expect(level('rf-sql').value()).toBeCloseTo(0.632, 3);
   });
 
   // Verifier follow-up R1, pinned end-to-end through the real
@@ -847,9 +876,7 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
     (h.state as unknown as { main: { rfGain: number; squelch: number } }).main.rfGain = 1;
     (h.state as unknown as { main: { rfGain: number; squelch: number } }).main.squelch = 0;
     render();
-    const input = el('rf-sql')!.querySelector('input')!;
-    input.value = '0.5';
-    input.dispatchEvent(new Event('input', { bubbles: true }));
+    level('rf-sql').input(0.5);
     flushSync();
     expect(h.rfGain).not.toHaveBeenCalled();
     expect(h.squelch).not.toHaveBeenCalled();
@@ -861,12 +888,72 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
     (h.state as unknown as { main: { rfGain: number; squelch: number } }).main.rfGain = 1;
     (h.state as unknown as { main: { rfGain: number; squelch: number } }).main.squelch = 0;
     render();
-    const input = el('rf-sql')!.querySelector('input')!;
-    input.value = '0'; // hard left: RF -> 0 (changes), SQL stays 0 (unchanged)
-    input.dispatchEvent(new Event('input', { bubbles: true }));
+    level('rf-sql').input(0); // hard left: RF -> 0 (changes), SQL stays 0 (unchanged)
     flushSync();
     expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(0);
     expect(h.squelch).not.toHaveBeenCalled();
+  });
+});
+
+describe('the hosted RF owner survives replaceable presentation layouts', () => {
+  it('retains authority while replacing renderers, and cancels detached or revoked drafts', () => {
+    const props = renderHosted();
+    const originalSubscribers = [...h.authorityListeners];
+    const old = level('rfGain');
+    old.frame.getBoundingClientRect = () => ({ left: 0, width: 100 } as DOMRect);
+    Object.assign(old.slider, {
+      setPointerCapture: vi.fn(), hasPointerCapture: () => true, releasePointerCapture: vi.fn(),
+    });
+    old.slider.dispatchEvent(new PointerEvent('pointerdown', {
+      pointerId: 7, clientX: 70, bubbles: true,
+    }));
+    flushSync();
+    expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(179);
+    h.rfGain.mockClear();
+
+    props.rfFrontEndLayout = 'independent';
+    flushSync();
+    const replacement = level('rfGain');
+    expect(replacement.slider).not.toBe(old.slider);
+    expect(target.querySelector('[data-rf-layout="independent"]')).not.toBeNull();
+    expect(target.querySelectorAll('[data-testid="rf-front-end-rfGain"]')).toHaveLength(1);
+    expect([...h.authorityListeners]).toEqual(originalSubscribers);
+    expect(replacement.value()).toBe(0.8);
+
+    old.slider.dispatchEvent(new PointerEvent('pointermove', {
+      pointerId: 7, clientX: 90, bubbles: true,
+    }));
+    old.slider.dispatchEvent(new PointerEvent('pointerup', { pointerId: 7, bubbles: true }));
+    old.slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(h.rfGain).not.toHaveBeenCalled();
+
+    replacement.input(0.55, 8);
+    flushSync();
+    expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(140);
+    h.rfGain.mockClear();
+    h.session = { state: 'disconnected', epoch: 8 };
+    for (const listener of h.sessionListeners) listener(h.session);
+    publishAuthority();
+    flushSync();
+    const revoked = level('rfGain');
+    expect(revoked.disabled()).toBe(true);
+    expect(el('rfGain')!.textContent).toContain('?');
+    revoked.input(0.9, 9);
+    expect(h.rfGain).not.toHaveBeenCalled();
+    expect([...h.authorityListeners]).toEqual(originalSubscribers);
+
+    h.session = { state: 'connected', epoch: 9 };
+    for (const listener of h.sessionListeners) listener(h.session);
+    publishAuthority();
+    flushSync();
+    expect(level('rfGain').value()).toBe(0.8);
+    props.rfFrontEndLayout = 'grouped';
+    flushSync();
+    expect(level('rfGain').value()).toBe(0.8);
+    expect([...h.authorityListeners]).toEqual(originalSubscribers);
+    unmount(component!);
+    component = null;
+    expect(h.authorityListeners.size).toBe(0);
   });
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
@@ -371,7 +371,7 @@ describe('the hosted AF owner survives replaceable presentation layouts', () => 
     expect(target.querySelector('[data-af-layout="independent"]')).not.toBeNull();
     expect(target.querySelectorAll('[role="slider"][aria-label="AF"]')).toHaveLength(1);
     expect([...h.authoritySubscribers]).toEqual(originalSubscribers);
-    expect(h.authoritySubscribers.size).toBe(2);
+    expect(h.authoritySubscribers.size).toBe(3);
     expect(newSlider.closest<HTMLElement>('.vc-hbar')!.style
       .getPropertyValue('--vc-fill-percent')).toBe('42%');
     expect(newSlider.getAttribute('aria-valuenow')).toBe('0.42');

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
@@ -525,7 +525,7 @@ describe('selected finite Scope authority lifetime (MOR-2425)', () => {
     render();
     expect(el('scope-hold')).not.toBeNull();
     expect(el('external-HOLD')).toBeNull();
-    expect(h.authoritySubscribers.size).toBe(2);
+    expect(h.authoritySubscribers.size).toBe(3);
   });
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -442,7 +442,7 @@ describe('selected finite TX auxiliary authority lifetime', () => {
     expect(q('[data-testid="tx-aux-atu-tune"]')).toBeNull();
     expect(q('[data-testid="external-VOX"]')).toBeNull();
     expect(q('[data-testid="external-TUNE"]')).toBeNull();
-    expect(h.authoritySubscribers.size).toBe(3);
+    expect(h.authoritySubscribers.size).toBe(4);
   });
 
   it('revokes retained A1 synchronously on A-B-A before flush and admits only fresh A3', () => {

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -81,6 +81,7 @@ vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   getCwPitchControlFeedback: h.cwPitchFeedback,
   getKeySpeedControlFeedback: h.keySpeedFeedback,
   getTxAuxControlFeedback: h.txAuxFeedback,
+  getRfSqlControlFeedback: () => null,
   getPendingFrequencyHz: () => null,
   getPendingFilterSelection: () => null, getPendingNbOn: () => null,
   getPendingNrOn: () => null, getPendingPreampLevel: () => null,
@@ -305,7 +306,7 @@ describe('production receiver-indicator partitioning', () => {
   ) => {
     selectedFrequency.current = AlternateFrequencyReadoutHarness as FrequencyRenderer;
     render(caps('main_sub', 2), state(), {}, props);
-    expect(h.authoritySubscribers.size).toBe(2);
+    expect(h.authoritySubscribers.size).toBe(3);
     const digit = projectFrequencyReadout({ confirmedHz: 14_200_000 }).digits[0];
     const first = retainedInteractions().find((interaction) => !interaction.inert)!;
     first.handleDigitClick(digit, new MouseEvent('click'));

--- a/frontend/src/components-v2/wiring/instrument-composition.ts
+++ b/frontend/src/components-v2/wiring/instrument-composition.ts
@@ -4,6 +4,7 @@ import type { TxAuxScalarHandles } from '../../semantic/tx-aux-scalar';
 import type { TxAuxFiniteHandles } from '../../semantic/tx-aux-finite';
 import type { ReceiverInstrumentHandles } from '../../semantic/ReceiverInstrumentHost.svelte';
 import type { RxAudioInstrumentHandles } from '../../semantic/rx-audio-instruments';
+import type { RfFrontEndLevelHandles } from '../../semantic/rf-front-end-instruments';
 
 export type InstrumentVfoAppearance = 'semantic' | 'sdr' | 'standard';
 
@@ -15,6 +16,7 @@ export interface InstrumentComposition {
   readonly txAuxInstruments: TxAuxFiniteHandles;
   readonly receiverInstruments: ReceiverInstrumentHandles;
   readonly rxAudioInstruments: RxAudioInstrumentHandles;
+  readonly rfFrontEndInstruments: RfFrontEndLevelHandles;
   readonly meters: Snippet<[allowBare?: boolean]>;
   readonly rxAudio: Snippet<[allowBare?: boolean]>;
   readonly rfFrontEnd: Snippet<[allowBare?: boolean]>;

--- a/frontend/src/lib/runtime/commands/__tests__/focus-target-resolution.component.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/focus-target-resolution.component.test.ts
@@ -78,7 +78,9 @@ vi.mock('$lib/stores/tuning.svelte', () => ({
 
 import { makeKeyboardHandlers } from '../panel-commands';
 import RxAudioInstrumentHostFixture from '../../../../semantic/__tests__/fixtures/RxAudioInstrumentHostFixture.svelte';
-import RfFrontEndSurface from '../../../../semantic/RfFrontEndSurface.svelte';
+import RfFrontEndInstrumentHostFixture, {
+  rfTestAuthorityPublication,
+} from '../../../../semantic/__tests__/fixtures/RfFrontEndInstrumentHostFixture.svelte';
 import FilterSurface from '../../../../semantic/FilterSurface.svelte';
 import VfoSurface from '../../../../semantic/VfoSurface.svelte';
 import {
@@ -141,13 +143,18 @@ describe('focus_target dispatch resolves to a real, focusable anchor in the prod
   });
 
   it('"rf" focuses the RF-gain slider in RfFrontEndSurface (rfFrontEnd zone)', () => {
-    render(RfFrontEndSurface, { view: withRfFrontEnd(topologyFixtures['1/single']) });
-    const input = document.querySelector('[data-testid="rf-front-end-rfGain"] input');
-    expect(input).not.toBeNull();
+    const publication = rfTestAuthorityPublication('separate');
+    render(RfFrontEndInstrumentHostFixture, {
+      publication, view: withRfFrontEnd(topologyFixtures['1/single']),
+      controlModel: 'separate', renderSurface: true, onLevelChange: vi.fn(),
+      subscribeControlAuthority: (handler) => { handler(publication); return () => undefined; },
+    });
+    const slider = document.querySelector('[data-testid="rf-front-end-rfGain"] [role="slider"]');
+    expect(slider).not.toBeNull();
 
     dispatchFocusTarget('rf');
 
-    expect(document.activeElement).toBe(input);
+    expect(document.activeElement).toBe(slider);
   });
 
   it('"mode" focuses the first mode choice in FilterSurface (filter zone)', () => {

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -1727,8 +1727,8 @@ export function makeKeyboardHandlers() {
             // `data-panel`/`data-control` vocabulary no component emits.
             const selectors: Record<string, string> = {
               af: '[data-testid="rx-audio-af"] [role="slider"], [data-testid="rx-audio-af"] input[type="range"]',
-              rf: '[data-testid="rf-front-end-rf-sql"] input, [data-testid="rf-front-end-rfGain"] input',
-              squelch: '[data-testid="rf-front-end-rf-sql"] input, [data-testid="rf-front-end-squelch"] input',
+              rf: '[data-testid="rf-front-end-rf-sql"] [role="slider"], [data-testid="rf-front-end-rfGain"] [role="slider"], [data-testid="rf-front-end-rf-sql"] input, [data-testid="rf-front-end-rfGain"] input',
+              squelch: '[data-testid="rf-front-end-rf-sql"] [role="slider"], [data-testid="rf-front-end-squelch"] [role="slider"], [data-testid="rf-front-end-rf-sql"] input, [data-testid="rf-front-end-squelch"] input',
               filter: '[data-testid="filter-select"] button',
               mode: '[data-testid="filter-mode"] button',
               pbt: '[data-testid="filter-pbtInner"] input',

--- a/frontend/src/semantic/RfFrontEndSurface.svelte
+++ b/frontend/src/semantic/RfFrontEndSurface.svelte
@@ -3,10 +3,9 @@
 
   Presentation only. It renders the MOR-1262 decomposition family 11
   `rfFrontEnd` fact group (MOR-1292/MOR-1293) — preamp, attenuator, RF gain,
-  squelch, DIGI-SEL, IP+ — and emits control intents as callbacks. It holds
-  only primitive-owned local interaction state, consults no controller and
-  issues no command directly (v3 ADR invariant 11), same doctrine as
-  `TxAuxSurface`/`RxAudioSurface`.
+  squelch, DIGI-SEL, IP+ — and emits finite-control intents as callbacks.
+  Persistent RF/SQL behavior arrives through required host-owned handles;
+  this remainder consults no controller and issues no command directly.
 
   CARRY-FORWARDS (binding, from the MOR-1292/MOR-1293 review rulings — see
   `radio-view-model.ts`'s `RfFrontEndViewModel` doc comment for the fact-layer
@@ -16,11 +15,8 @@
       last-known value. This is inherited "for free" from `usable`/`textOf`
       gating on `reading.status === 'known'` — the same idiom
       `TxAuxSurface`/`RxAudioSurface` use — as long as nothing here adds a
-      fallback that reads `rf.<field>.reading.value` outside that gate. There
-      is deliberately no "show it anyway, marked stale" branch: the fact
-      layer already collapses a stale reading to `unknown` before this file
-      ever sees it (`radio-view-model-adapter.ts`'s `txAuxField`), so widening
-      here would silently reopen exactly the gate MOR-1292 closed.
+      fallback that reads `rf.<field>.reading.value` outside that gate. RF/SQL
+      level truth is rendered by the required instrument handles.
   (2)+(3) THE PREAMP MUTEX. PRE is genuinely disabled while DIGI-SEL is
       unobserved, by design (MOR-479 hardware mutex, IC-7610). Rendered as a
       disabled control WITH AN EXPLANATION, read from `view.disabledReasons`
@@ -50,7 +46,11 @@
 -->
 <script module lang="ts">
   import type { DisabledReasonCode, RfFrontEndField } from './radio-view-model';
-  import { formatKnownLevel } from './format-level';
+  export {
+    RF_FRONT_END_LEVELS,
+    type RfFrontEndLevelField,
+    type RfSqlControlModel,
+  } from './rf-front-end-instruments';
 
   /** The one rendering of "not read". Never 0, never the last value. */
   export const UNKNOWN_TEXT = '?';
@@ -61,31 +61,10 @@
   /** Honest text: an unread fact reads as unknown, never as a stale value. */
   export const textOf = (f: RfFrontEndField<unknown>): string =>
     f.reading.status === 'known' ? String(f.reading.value) : UNKNOWN_TEXT;
-  /** `[field, label, min, max, step]`. The radio's own normalized 0..1
-   *  reading (a wire-protocol FRACTION, not the raw 0-255 wire unit) — same
-   *  discipline as `TxAuxSurface.TX_AUX_LEVELS`. Rescaled to the raw 0-255
-   *  integer `set_rf_gain`/`set_squelch` require at the wiring seam
-   *  (`SemanticRadioSurfaces.svelte`'s `RF_FRONT_END_LEVEL_INTENT`, MOR-1447),
-   *  never inside this presentation-only file. */
-  export const RF_FRONT_END_LEVELS = [
-    ['rfGain', 'RF gain', 0, 1, 0.01],
-    ['squelch', 'Squelch', 0, 1, 0.01],
-  ] as const;
-  /** The combined-knob domain (MOR-1447 leg 2): both `rfGain` and `squelch`
-   *  share this [0,1] range, an invariant of the combined control model —
-   *  `dualParamValuesFromNormX`/`dualParamNormXFromValues` map ONE knob
-   *  position onto both fields over the SAME domain. */
-  const [, , RF_SQL_MIN, RF_SQL_MAX, RF_SQL_STEP] = RF_FRONT_END_LEVELS[0];
-  /** Profile-declared control model (MOR-1447 leg 2, data-driven from
-   *  `[capabilities].rf_sql_control_model` in the rig TOML — never a
-   *  vendor/model-name branch in code). `'separate'` is the default: two
-   *  independent sliders, unchanged from leg 1. */
-  export type RfSqlControlModel = 'separate' | 'combined';
   /** `[field, label]` on/off controls. */
   export const RF_FRONT_END_TOGGLES = [
     ['digiSel', 'DIGI-SEL'], ['ipPlus', 'IP+'],
   ] as const;
-  export type RfFrontEndLevelField = (typeof RF_FRONT_END_LEVELS)[number][0];
   export type RfFrontEndToggleField = (typeof RF_FRONT_END_TOGGLES)[number][0];
 
   /** Carry-forward 4: keyed by the generic CODE, never by a peer-control
@@ -97,19 +76,9 @@
 </script>
 
 <script lang="ts">
-  import { onDestroy, untrack } from 'svelte';
   import { t } from '$lib/i18n';
   import type { RadioViewModel } from './radio-view-model';
-  import {
-    createContinuousPair, nativeRangeContinuousPairPolicy,
-    type CommandFeedbackContinuousPairInput, type ContinuousPairInput,
-    type ContinuousPairRendererLease, type ContinuousPairView,
-  } from '../primitives/scalar/continuous-pair.svelte';
-  import {
-    createContinuousScalar, nativeRangeContinuousScalarPolicy,
-    type ContinuousScalarInput, type ContinuousScalarRendererLease,
-    type ContinuousScalarView,
-  } from '../primitives/scalar/continuous-scalar.svelte';
+  import type { RfFrontEndLevelHandles } from './rf-front-end-instruments';
   import {
     bindChoiceInstrument,
     bindToggleInstrument,
@@ -117,21 +86,13 @@
 
   interface Props {
     view: RadioViewModel;
-    /** Icom-style single-knob RF/SQL (MOR-1447 leg 2). Defaults to
-     *  `'separate'` — the two independent sliders leg 1 fixed. */
-    controlModel?: RfSqlControlModel;
-    /** Omitted only by compatibility mounts; null means integrated authority
-     *  is unresolved, while an object is the complete pair authority. */
-    rfSqlFeedback?: Readonly<
-      Pick<CommandFeedbackContinuousPairInput, 'rf' | 'sql'>
-    > | null;
+    levelHandles: RfFrontEndLevelHandles;
     /** MOR-1441 leg 2 — the freshest in-flight `set_preamp` target for the
      *  active receiver, DISPLAY ONLY (see the file header). `null` when
      *  nothing is pending. */
     pendingPreamp?: number | null;
     onPreampChange?: (level: number) => void;
     onAttenuatorChange?: (db: number) => void;
-    onLevelChange?: (field: RfFrontEndLevelField, value: number) => void;
     /** `next` is the FLIPPED value, computed here from the observed reading —
      *  `makeRfFrontEndHandlers().onDigiSelToggle`/`onIpPlusToggle` take an
      *  explicit `on: boolean`, unlike the argument-less vox/comp/mon toggles
@@ -140,8 +101,8 @@
     onToggle?: (field: RfFrontEndToggleField, next: boolean) => void;
   }
   let {
-    view, controlModel = 'separate', rfSqlFeedback, pendingPreamp = null,
-    onPreampChange, onAttenuatorChange, onLevelChange, onToggle,
+    view, levelHandles, pendingPreamp = null,
+    onPreampChange, onAttenuatorChange, onToggle,
   }: Props = $props();
 
   const pendingPreampId = $props.id();
@@ -174,197 +135,6 @@
     })),
   } satisfies Record<RfFrontEndToggleField, ReturnType<typeof bindToggleInstrument>>;
 
-  function changeLevel(field: RfFrontEndLevelField, value: number): void {
-    if (rf && usable(rf[field])) onLevelChange?.(field, value);
-  }
-  function requestPairLevel(field: RfFrontEndLevelField, value: number): void {
-    if (rfSqlFeedback === undefined) changeLevel(field, value);
-    else if (rfSqlFeedback !== null) onLevelChange?.(field, value);
-  }
-  /** MOR-1447 leg 2: both fields structurally present AND the profile
-   *  declares the combined knob — the gate for rendering ONE control instead
-   *  of two. A profile that declares `'combined'` but only observes one of
-   *  the pair structurally falls back to the two-slider rendering below
-   *  (the per-field `{#if rf[field].availability.structural}` gates still
-   *  apply), same "render what's actually there" discipline as every other
-   *  field in this file. */
-  let combinedUsable = $derived(
-    controlModel === 'combined'
-    && !!rf?.rfGain.availability.structural
-    && !!rf?.squelch.availability.structural,
-  );
-  const rfSqlDomain = {
-    min: RF_SQL_MIN, max: RF_SQL_MAX, step: RF_SQL_STEP,
-    defaultValue: null, fineStepDivisor: 10,
-  } as const;
-  function rfSqlInput(): Readonly<ContinuousPairInput> {
-    const common = {
-      domain: rfSqlDomain,
-      requestRf: (value: number) => requestPairLevel('rfGain', value),
-      requestSql: (value: number) => requestPairLevel('squelch', value),
-    };
-    if (rfSqlFeedback === null) return {
-      ...common,
-      evidence: 'reading', ownerKey: 'rf-sql:feedback-integrated:authority-unresolved',
-      enabled: false,
-      rf: { reading: { status: 'unknown' }, availability: 'unavailable' },
-      sql: { reading: { status: 'unknown' }, availability: 'unavailable' },
-    };
-    if (rfSqlFeedback !== undefined) return {
-      ...common,
-      evidence: 'command-feedback', enabled: controlModel === 'combined',
-      rf: rfSqlFeedback.rf, sql: rfSqlFeedback.sql,
-    };
-    const availability = (field: RfFrontEndField<number> | undefined) =>
-      field?.availability.structural && field.availability.operational
-        ? 'available' as const : 'unavailable' as const;
-    return {
-      ...common,
-      evidence: 'reading', ownerKey: JSON.stringify([
-        view.topologyId, view.activeReceiver.status,
-        view.activeReceiver.status === 'known' ? view.activeReceiver.receiver : null,
-      ]),
-      enabled: controlModel === 'combined',
-      rf: {
-        reading: rf?.rfGain.reading ?? { status: 'unknown' },
-        availability: availability(rf?.rfGain),
-      },
-      sql: {
-        reading: rf?.squelch.reading ?? { status: 'unknown' },
-        availability: availability(rf?.squelch),
-      },
-    };
-  }
-  type RfSqlLane = 'rf' | 'sql';
-  const laneForField = (field: RfFrontEndLevelField): RfSqlLane =>
-    field === 'rfGain' ? 'rf' : 'sql';
-  const separateLevelRendered = (field: RfFrontEndLevelField): boolean =>
-    !combinedUsable && !!rf?.[field].availability.structural;
-  function separateLevelInput(field: RfFrontEndLevelField): Readonly<ContinuousScalarInput> {
-    const common = {
-      domain: rfSqlDomain,
-      request: (value: number) => requestPairLevel(field, value),
-    };
-    if (rfSqlFeedback === null) return {
-      ...common,
-      evidence: 'reading',
-      ownerKey: `rf-sql:feedback-integrated:authority-unresolved:${field}`,
-      enabled: false,
-      reading: { status: 'unknown' },
-    };
-    if (rfSqlFeedback !== undefined) {
-      const lane = rfSqlFeedback[laneForField(field)];
-      return {
-        ...common,
-        evidence: 'command-feedback',
-        enabled: separateLevelRendered(field),
-        command: lane.command,
-        feedback: lane.feedback,
-      };
-    }
-    const fact = rf?.[field];
-    return {
-      ...common,
-      evidence: 'reading',
-      ownerKey: JSON.stringify([
-        'rf-sql:compatibility-reading', field, view.topologyId, view.activeReceiver.status,
-        view.activeReceiver.status === 'known' ? view.activeReceiver.receiver : null,
-      ]),
-      enabled: separateLevelRendered(field) && !!fact?.availability.operational,
-      reading: fact?.reading ?? { status: 'unknown' },
-    };
-  }
-  const rfSqlPair = createContinuousPair(rfSqlInput, nativeRangeContinuousPairPolicy);
-  const rfGainScalar = createContinuousScalar(
-    () => separateLevelInput('rfGain'), nativeRangeContinuousScalarPolicy,
-  );
-  const squelchScalar = createContinuousScalar(
-    () => separateLevelInput('squelch'), nativeRangeContinuousScalarPolicy,
-  );
-  let rfSqlLease: ContinuousPairRendererLease | null = $state(null);
-  let rfSqlView: Readonly<ContinuousPairView> = $state(untrack(() => rfSqlPair.view));
-  let rfGainLease: ContinuousScalarRendererLease | null = $state(null);
-  let rfGainView: Readonly<ContinuousScalarView> = $state(untrack(() => rfGainScalar.view));
-  let squelchLease: ContinuousScalarRendererLease | null = $state(null);
-  let squelchView: Readonly<ContinuousScalarView> = $state(untrack(() => squelchScalar.view));
-  $effect(() => {
-    const lease = rfSqlPair.attachRenderer();
-    rfSqlLease = lease;
-    return () => lease.dispose();
-  });
-  $effect(() => {
-    const lease = rfGainScalar.attachRenderer();
-    rfGainLease = lease;
-    return () => lease.dispose();
-  });
-  $effect(() => {
-    const lease = squelchScalar.attachRenderer();
-    squelchLease = lease;
-    return () => lease.dispose();
-  });
-  $effect(() => {
-    rfSqlView = rfSqlLease === null ? rfSqlPair.view : rfSqlLease.view;
-  });
-  $effect(() => {
-    rfGainView = rfGainLease === null ? rfGainScalar.view : rfGainLease.view;
-  });
-  $effect(() => {
-    squelchView = squelchLease === null ? squelchScalar.view : squelchLease.view;
-  });
-  let combinedNormX = $derived(rfSqlView.displayedPosition ?? RF_SQL_MIN);
-  const FEEDBACK_INTEGRATED_RANGE = { 'feedback-policy': 'feedback-integrated' } as const;
-  let feedbackIntegration = $derived(
-    rfSqlFeedback === undefined ? 'compatibility-reading'
-      : rfSqlFeedback === null ? 'authority-unresolved' : 'command-feedback',
-  );
-  const laneValue = (lane: 'rf' | 'sql'): number | null => {
-    const view = rfSqlView.lanes[lane];
-    return rfSqlView.draft?.[lane]
-      ?? (view.evidence === 'command-feedback' ? view.feedback.target : null)
-      ?? view.canonical;
-  };
-  const laneText = (lane: 'rf' | 'sql'): string => {
-    const value = laneValue(lane);
-    return value === null ? UNKNOWN_TEXT : formatKnownLevel(value, RF_SQL_MIN, RF_SQL_MAX);
-  };
-  const laneStatus = (lane: 'rf' | 'sql'): string => {
-    const view = rfSqlView.lanes[lane];
-    if (view.evidence !== 'command-feedback') return '';
-    const phase = view.phase.charAt(0).toUpperCase() + view.phase.slice(1).replaceAll('-', ' ');
-    const requested = view.feedback.target ?? view.feedback.requestedTarget;
-    const target = requested === null ? ''
-      : ` ${formatKnownLevel(requested, RF_SQL_MIN, RF_SQL_MAX)}`;
-    const confirmed = view.canonical === null ? UNKNOWN_TEXT
-      : formatKnownLevel(view.canonical, RF_SQL_MIN, RF_SQL_MAX);
-    return `${phase}${target}; confirmed ${confirmed}${view.error === null ? '' : `: ${view.error}`}`;
-  };
-  const separateLevelLease = (field: RfFrontEndLevelField): ContinuousScalarRendererLease | null =>
-    field === 'rfGain' ? rfGainLease : squelchLease;
-  const separateLevelView = (field: RfFrontEndLevelField): Readonly<ContinuousScalarView> =>
-    field === 'rfGain' ? rfGainView : squelchView;
-  const separateLevelValue = (view: Readonly<ContinuousScalarView>): number | null =>
-    view.draft
-      ?? (view.evidence === 'command-feedback' ? view.feedback.target : null)
-      ?? view.canonical;
-  const separateLevelText = (view: Readonly<ContinuousScalarView>): string => {
-    const value = separateLevelValue(view);
-    return value === null ? UNKNOWN_TEXT : formatKnownLevel(value, RF_SQL_MIN, RF_SQL_MAX);
-  };
-  const separateLevelStatus = (view: Readonly<ContinuousScalarView>): string => {
-    if (view.evidence !== 'command-feedback') return '';
-    const phase = view.phase.charAt(0).toUpperCase() + view.phase.slice(1).replaceAll('-', ' ');
-    const requested = view.feedback.target ?? view.feedback.requestedTarget;
-    const target = requested === null ? ''
-      : ` ${formatKnownLevel(requested, RF_SQL_MIN, RF_SQL_MAX)}`;
-    const confirmed = view.canonical === null ? UNKNOWN_TEXT
-      : formatKnownLevel(view.canonical, RF_SQL_MIN, RF_SQL_MAX);
-    return `${phase}${target}; confirmed ${confirmed}${view.error === null ? '' : `: ${view.error}`}`;
-  };
-  onDestroy(() => {
-    rfSqlPair.destroy();
-    rfGainScalar.destroy();
-    squelchScalar.destroy();
-  });
 </script>
 
 {#if rf}
@@ -416,80 +186,11 @@
       </div>
     {/if}
 
-    {#if combinedUsable}
-      <label
-        class="rf-front-end-level" data-testid="rf-front-end-rf-sql"
-        data-feedback-integration={feedbackIntegration}
-        data-observed={rfSqlView.lanes.rf.availability === 'available'
-          && rfSqlView.lanes.sql.availability === 'available'
-          && rfSqlView.canonical.rf !== null && rfSqlView.canonical.sql !== null}
-        data-rf-command-phase={rfSqlView.lanes.rf.phase ?? undefined}
-        data-sql-command-phase={rfSqlView.lanes.sql.phase ?? undefined}
-        aria-busy={rfSqlView.busy}
-      >
-        <span class="rf-front-end-name">RF/SQL</span>
-        <input
-          type="range" min={RF_SQL_MIN} max={RF_SQL_MAX} step={RF_SQL_STEP}
-          {...FEEDBACK_INTEGRATED_RANGE}
-          value={combinedNormX}
-          disabled={!rfSqlView.editable}
-          data-pair-evidence={rfSqlView.evidence}
-          oninput={(event) => rfSqlLease?.nativeInput(event.currentTarget.valueAsNumber)}
-        />
-        <output data-testid="rf-front-end-rf-sql-rf-value">{laneText('rf')}</output>
-        /
-        <output data-testid="rf-front-end-rf-sql-sql-value">{laneText('sql')}</output>
-        {#if rfSqlView.lanes.rf.evidence === 'command-feedback'}
-          <output data-testid="rf-front-end-rf-sql-rf-status">{laneStatus('rf')}</output>
-        {/if}
-        {#if rfSqlView.lanes.sql.evidence === 'command-feedback'}
-          <output data-testid="rf-front-end-rf-sql-sql-status">{laneStatus('sql')}</output>
-        {/if}
-        {#if rfSqlView.lanes.rf.announcement !== null}
-          <span class="sr-only" role="status" aria-live="polite" aria-atomic="true"
-            data-control-feedback-status data-feedback-lane="rf">{rfSqlView.lanes.rf.announcement}</span>
-        {/if}
-        {#if rfSqlView.lanes.sql.announcement !== null}
-          <span class="sr-only" role="status" aria-live="polite" aria-atomic="true"
-            data-control-feedback-status data-feedback-lane="sql">{rfSqlView.lanes.sql.announcement}</span>
-        {/if}
-      </label>
+    {#if levelHandles.kind === 'combined'}
+      {@render levelHandles.rfSql()}
     {:else}
-      {#each RF_FRONT_END_LEVELS as [field, label, min, max, step] (field)}
-        {#if rf[field].availability.structural}
-          {@const levelView = separateLevelView(field)}
-          {@const levelValue = separateLevelValue(levelView)}
-          <label
-            class="rf-front-end-level" data-testid={`rf-front-end-${field}`}
-            data-feedback-integration={feedbackIntegration}
-            data-observed={levelView.canonical !== null}
-            data-command-phase={levelView.phase ?? undefined}
-            aria-busy={levelView.busy}
-          >
-            <span class="rf-front-end-name">{label}</span>
-            <input
-              type="range" {min} {max} {step}
-              {...FEEDBACK_INTEGRATED_RANGE}
-              value={levelValue ?? min}
-              disabled={!levelView.editable}
-              data-scalar-evidence={levelView.evidence}
-              oninput={(event) => separateLevelLease(field)?.nativeInput(event.currentTarget.valueAsNumber)}
-            />
-            <output>{separateLevelText(levelView)}</output>
-            {#if levelView.evidence === 'command-feedback'}
-              <output data-testid={`rf-front-end-${field}-status`}>
-                {separateLevelStatus(levelView)}
-              </output>
-            {/if}
-            {#if levelView.announcement !== null}
-              <span class="sr-only" role="status" aria-live="polite" aria-atomic="true"
-                data-control-feedback-status data-feedback-lane={laneForField(field)}>
-                {levelView.announcement}
-              </span>
-            {/if}
-          </label>
-        {/if}
-      {/each}
+      {#if rf.rfGain.availability.structural}{@render levelHandles.rfGain()}{/if}
+      {#if rf.squelch.availability.structural}{@render levelHandles.squelch()}{/if}
     {/if}
 
     {#each RF_FRONT_END_TOGGLES as [field, label] (field)}
@@ -512,11 +213,9 @@
      sole state channel (MOR-977, forced-colors). */
   .rf-front-end-surface { display: flex; flex-direction: column; gap: 0.25rem; }
   .rf-front-end-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin: 0; }
-  .rf-front-end-level { display: flex; align-items: baseline; gap: 0.5rem; }
-  .rf-front-end-name { min-width: 6ch; }
   .rf-front-end-choice[aria-checked='true'] { font-weight: 700; }
   [data-observed='false'] { font-style: italic; }
-  button:disabled, input:disabled { cursor: not-allowed; }
+  button:disabled { cursor: not-allowed; }
   /* MOR-1441 leg 2 — same pending doctrine as `FilterSurface`'s
      `.filter-choice[data-pending='true']`: structural marker, never
      color-only. */

--- a/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
@@ -16,14 +16,25 @@ import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { flushSync, mount, unmount } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
-import RfFrontEndSurface, {
+import {
   DISABLED_REASON_LABEL, RF_FRONT_END_LEVELS, RF_FRONT_END_TOGGLES, UNKNOWN_TEXT,
 } from '../RfFrontEndSurface.svelte';
+import Fixture, {
+  rfTestAuthorityPublication,
+} from './fixtures/RfFrontEndInstrumentHostFixture.svelte';
 import { topologyFixtures, withRfFrontEnd } from '../fixtures/topologies';
 import type {
   Availability, DisabledReason, RadioViewModel, RfFrontEndField, RfFrontEndViewModel,
 } from '../radio-view-model';
-import type { CommandFeedbackContinuousPairInput } from '../../primitives/scalar/continuous-pair.svelte';
+import type {
+  RfFrontEndAuthorityPublication, RfFrontEndLevelFeedback,
+} from '../rf-front-end-instruments';
+
+const SOURCE = readFileSync('src/semantic/RfFrontEndSurface.svelte', 'utf8');
+const CODE = SOURCE
+  .replace(/<!--[\s\S]*?-->/g, '')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/^\s*\/\/.*$/gm, '');
 
 const ON: Availability = { structural: true, operational: true };
 const OFF: Availability = { structural: false, operational: false };
@@ -42,7 +53,7 @@ const unread = <T>(availability: Availability = ON): RfFrontEndField<T> =>
   ({ reading: { status: 'unknown' }, availability });
 const known = <T>(value: T, availability: Availability = ON): RfFrontEndField<T> =>
   ({ reading: { status: 'known', value }, availability });
-type PairFeedback = Readonly<Pick<CommandFeedbackContinuousPairInput, 'rf' | 'sql'>>;
+type PairFeedback = RfFrontEndLevelFeedback;
 const pairFeedback = (
   over: Partial<Record<'rf' | 'sql', Record<string, unknown>>> = {},
   providerGeneration = 3,
@@ -67,24 +78,30 @@ interface LevelDriver {
   readonly range: () => readonly [string, string];
   readonly value: () => number;
   readonly disabled: () => boolean;
-  readonly attribute: (name: string) => string | null;
-  readonly data: (name: string) => string | undefined;
   readonly input: (value: number) => void;
 }
 
-// This intermediate driver intentionally covers only the Surface's current native input.
 function levelDriver(root: ParentNode): LevelDriver {
-  const input = root.querySelector<HTMLInputElement>('input');
-  if (input === null) throw new Error('Expected current native RF level input');
+  const slider = root.querySelector<HTMLElement>('[role="slider"]');
+  if (slider === null) throw new Error('Expected rendered RF level slider');
+  const frame = slider.closest<HTMLElement>('.vc-hbar, .vc-dual');
+  if (frame === null) throw new Error('Expected RF level renderer frame');
+  const dual = frame.classList.contains('vc-dual');
   return {
-    range: () => [input.min, input.max],
-    value: () => input.valueAsNumber,
-    disabled: () => input.disabled,
-    attribute: (name) => input.getAttribute(name),
-    data: (name) => input.dataset[name],
+    range: () => [slider.getAttribute('aria-valuemin')!, slider.getAttribute('aria-valuemax')!],
+    value: () => Number.parseFloat(frame.style.getPropertyValue(
+      dual ? '--vc-thumb-pct' : '--vc-fill-percent',
+    )) / 100,
+    disabled: () => slider.getAttribute('aria-disabled') === 'true',
     input: (value) => {
-      input.value = String(value);
-      input.dispatchEvent(new Event('input', { bubbles: true }));
+      frame.getBoundingClientRect = () => ({ left: 0, width: 100 } as DOMRect);
+      Object.assign(slider, {
+        setPointerCapture: vi.fn(), hasPointerCapture: () => true, releasePointerCapture: vi.fn(),
+      });
+      slider.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true, clientX: value * 100, pointerId: 1,
+      }));
+      slider.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }));
     },
   };
 }
@@ -92,7 +109,14 @@ function levelDriver(root: ParentNode): LevelDriver {
 function render(view: RadioViewModel, handlers: Record<string, unknown> = {}) {
   target = document.createElement('div');
   document.body.appendChild(target);
-  const component = mount(RfFrontEndSurface, { target, props: { view, ...handlers } });
+  const controlModel = handlers.controlModel === 'combined' ? 'combined' : 'separate';
+  const publication = rfTestAuthorityPublication(controlModel);
+  const component = mount(Fixture, { target, props: {
+    publication, view, controlModel, renderSurface: true,
+    subscribeControlAuthority: (handler) => { handler(publication); return () => undefined; },
+    onLevelChange: () => undefined,
+    ...handlers,
+  } });
   flushSync();
   const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
   return {
@@ -115,7 +139,7 @@ describe('the surface self-gates on the rfFrontEnd group', () => {
     delete (view as { rfFrontEnd?: unknown }).rfFrontEnd;
     const r = render(view);
     expect(r.root()).toBeNull();
-    expect(target.textContent).toBe('');
+    expect(target.textContent?.trim()).toBe('');
     r.dispose();
   });
 
@@ -344,8 +368,6 @@ describe('RF gain and squelch render as 0..1 sliders, no rescale', () => {
   it('renders a known RF-gain reading as a rounded percent, not the raw wire float', () => {
     const r = render(withRf({ rfGain: known(0.8196078431372549) }));
     expect(r.el('rfGain')!.dataset.feedbackIntegration).toBe('compatibility-reading');
-    expect(r.level('rfGain')!.attribute('feedback-policy'))
-      .toBe('feedback-integrated');
     expect(r.text('rfGain')).toContain('82%');
     expect(r.text('rfGain')).not.toContain('0.8196078431372549');
     r.dispose();
@@ -396,7 +418,8 @@ describe('RF gain and squelch render as 0..1 sliders, no rescale', () => {
     expect(rfGroup.dataset.commandPhase).toBe('awaiting-confirmation');
     expect(rfGroup.getAttribute('aria-busy')).toBe('true');
     expect(rfGroup.dataset.observed).toBe('true');
-    expect(rfInput.value()).toBe(0.75);
+    expect(rfInput.value()).toBe(0.5);
+    expect(rfInput.range()).toEqual(['0', '1']);
     expect(rfGroup.querySelector('output')?.textContent).toBe('75%');
     expect(rfInput.disabled()).toBe(false);
     expect(sqlGroup.dataset.commandPhase).toBe('unavailable');
@@ -421,7 +444,7 @@ describe('RF gain and squelch render as 0..1 sliders, no rescale', () => {
     expect(r.el('squelch')).toBeNull();
     const rfInput = r.level('rfGain')!;
     expect(rfInput.disabled()).toBe(false);
-    expect(rfInput.value()).toBe(0.4);
+    expect(rfInput.value()).toBe(0.5);
     rfInput.input(0.3);
     flushSync();
     expect(onLevelChange).toHaveBeenCalledExactlyOnceWith('rfGain', 0.3);
@@ -431,10 +454,12 @@ describe('RF gain and squelch render as 0..1 sliders, no rescale', () => {
   it('invalidates separate drafts and announcements across provider and null authority replacement', () => {
     const feedback = new SvelteMap<string, PairFeedback>([['current', pairFeedback()]]);
     const onLevelChange = vi.fn();
+    const publication = rfTestAuthorityPublication('separate');
     target = document.createElement('div');
     document.body.appendChild(target);
-    const component = mount(RfFrontEndSurface, { target, props: {
-      view: base(), onLevelChange,
+    const component = mount(Fixture, { target, props: {
+      publication, view: base(), controlModel: 'separate', renderSurface: true, onLevelChange,
+      subscribeControlAuthority: (handler) => { handler(publication); return () => undefined; },
       get rfSqlFeedback() { return feedback.get('current') ?? null; },
     } });
     flushSync();
@@ -457,10 +482,12 @@ describe('RF gain and squelch render as 0..1 sliders, no rescale', () => {
   it('retires only the represented lane draft and follows later same-authority canonical truth', () => {
     const feedback = new SvelteMap<string, PairFeedback>([['current', pairFeedback()]]);
     const onLevelChange = vi.fn();
+    const publication = rfTestAuthorityPublication('separate');
     target = document.createElement('div');
     document.body.appendChild(target);
-    const component = mount(RfFrontEndSurface, { target, props: {
-      view: base(), onLevelChange,
+    const component = mount(Fixture, { target, props: {
+      publication, view: base(), controlModel: 'separate', renderSurface: true, onLevelChange,
+      subscribeControlAuthority: (handler) => { handler(publication); return () => undefined; },
       get rfSqlFeedback() { return feedback.get('current')!; },
     } });
     flushSync();
@@ -499,28 +526,25 @@ describe('RF gain and squelch render as 0..1 sliders, no rescale', () => {
     target.remove();
   });
 
-  it('owns and destroys two independent native scalar bindings', () => {
-    const source = readFileSync('src/semantic/RfFrontEndSurface.svelte', 'utf8');
-    expect(source).toMatch(
-      /const rfGainScalar = createContinuousScalar\([\s\S]*?'rfGain'[\s\S]*?nativeRangeContinuousScalarPolicy/,
-    );
-    expect(source).toMatch(
-      /const squelchScalar = createContinuousScalar\([\s\S]*?'squelch'[\s\S]*?nativeRangeContinuousScalarPolicy/,
-    );
-    expect(source).toMatch(/rfGainScalar\.destroy\(\)/);
-    expect(source).toMatch(/squelchScalar\.destroy\(\)/);
+  it('requires host handles and owns no continuous binding or renderer lifecycle', () => {
+    const props = CODE.slice(CODE.indexOf('interface Props'), CODE.indexOf('}: Props'));
+    expect(props).toContain('levelHandles: RfFrontEndLevelHandles');
+    for (const forbidden of ['controlModel', 'rfSqlFeedback', 'onLevelChange']) {
+      expect(props).not.toContain(forbidden);
+    }
+    for (const forbidden of [
+      'createContinuousPair', 'createContinuousScalar', 'attachRenderer', 'nativeRangeContinuous',
+      'onDestroy', '$effect', '.destroy()',
+    ]) expect(CODE).not.toContain(forbidden);
   });
 });
 
 /* ── MOR-1447 leg 2: the combined RF/SQL knob ────────────────────── */
 
 describe('the combined RF/SQL knob (controlModel="combined")', () => {
-  it('keeps its optional feedback prop primitive-shaped and free of runtime imports', () => {
-    const source = readFileSync('src/semantic/RfFrontEndSurface.svelte', 'utf8');
-    const props = source.slice(source.indexOf('interface Props'), source.indexOf('}: Props'));
-    expect(props).toContain("Pick<CommandFeedbackContinuousPairInput, 'rf' | 'sql'>");
-    expect(props).toMatch(/rfSqlFeedback\?:[\s\S]*\| null/);
-    expect(source).not.toMatch(/from ['"]\$lib\/runtime|from ['"][^'"]*runtime\/adapters/);
+  it('renders the required host handle and stays free of runtime imports', () => {
+    expect(CODE).toContain('{@render levelHandles.rfSql()}');
+    expect(CODE).not.toMatch(/from ['"]\$lib\/runtime|from ['"][^'"]*runtime\/adapters/);
   });
 
   it('renders one rf-sql control instead of the two separate sliders', () => {
@@ -547,11 +571,11 @@ describe('the combined RF/SQL knob (controlModel="combined")', () => {
     r.dispose();
   });
 
-  it('declares the combined slider on the 0..1 scale', () => {
+  it('exposes the combined renderer position on its actual 0..100 ARIA scale', () => {
     const r = render(base(), { controlModel: 'combined' });
     const input = r.level('rf-sql')!;
-    expect(input.range()).toEqual(['0', '1']);
-    expect(input.attribute('feedback-policy')).toBe('feedback-integrated');
+    expect(input.range()).toEqual(['0', '100']);
+    expect(r.el('rf-sql')!.dataset.feedbackIntegration).toBe('compatibility-reading');
     r.dispose();
   });
 
@@ -592,9 +616,11 @@ describe('the combined RF/SQL knob (controlModel="combined")', () => {
 
   it('renders independent lane phases, errors, busy state, and announcements', () => {
     const values = new SvelteMap<string, PairFeedback>([['feedback', pairFeedback()]]);
+    const publication = rfTestAuthorityPublication('combined');
     target = document.createElement('div'); document.body.appendChild(target);
-    const component = mount(RfFrontEndSurface, { target, props: {
-      view: base(), controlModel: 'combined',
+    const component = mount(Fixture, { target, props: {
+      publication, view: base(), controlModel: 'combined', renderSurface: true,
+      subscribeControlAuthority: (handler) => { handler(publication); return () => undefined; },
       get rfSqlFeedback() { return values.get('feedback')!; },
     } });
     flushSync();
@@ -613,9 +639,11 @@ describe('the combined RF/SQL knob (controlModel="combined")', () => {
     expect(group.dataset.rfCommandPhase).toBe('confirmed');
     expect(group.dataset.sqlCommandPhase).toBe('failed');
     expect(group.getAttribute('aria-busy')).toBe('false');
-    expect(group.querySelector('[data-testid="rf-front-end-rf-sql-rf-status"]')?.textContent).toContain('Confirmed');
-    expect(group.querySelector('[data-testid="rf-front-end-rf-sql-sql-status"]')?.textContent).toContain('Failed');
-    expect(group.querySelectorAll('[data-control-feedback-status]')).toHaveLength(2);
+    expect(group.querySelector('[data-testid="rf-front-end-rf-sql-rf-status"]')?.textContent)
+      .toContain('confirmed; requested 50%; confirmed 50%');
+    expect(group.querySelector('[data-testid="rf-front-end-rf-sql-sql-status"]')?.textContent)
+      .toContain('failed; requested 40%; confirmed 20%');
+    expect(target.querySelectorAll('[data-control-feedback-status]')).toHaveLength(2);
     expect(group.textContent).toContain('denied');
     unmount(component); target.remove();
   });
@@ -627,16 +655,19 @@ describe('the combined RF/SQL knob (controlModel="combined")', () => {
     } });
     const r = render(base(), { controlModel: 'combined', rfSqlFeedback: feedback });
     expect(r.text('rf-sql-rf-value')).toBe('75%');
-    expect(r.text('rf-sql-rf-status')).toContain('Awaiting confirmation 75%; confirmed 50%');
+    expect(r.text('rf-sql-rf-status'))
+      .toContain('awaiting confirmation; requested 75%; confirmed 50%');
     expect(r.el('rf-sql')!.getAttribute('aria-busy')).toBe('true');
     r.dispose();
   });
 
   it('invalidates a local draft when provider authority is replaced', () => {
     const values = new SvelteMap<string, PairFeedback>([['feedback', pairFeedback()]]);
+    const publication = rfTestAuthorityPublication('combined');
     target = document.createElement('div'); document.body.appendChild(target);
-    const component = mount(RfFrontEndSurface, { target, props: {
-      view: base(), controlModel: 'combined',
+    const component = mount(Fixture, { target, props: {
+      publication, view: base(), controlModel: 'combined', renderSurface: true,
+      subscribeControlAuthority: (handler) => { handler(publication); return () => undefined; },
       get rfSqlFeedback() { return values.get('feedback')!; },
       onLevelChange: vi.fn(),
     } });
@@ -681,7 +712,7 @@ describe('the combined RF/SQL knob (controlModel="combined")', () => {
     const onLevelChange = vi.fn();
     const r = render(base(), { controlModel: 'combined', onLevelChange });
     const input = r.level('rf-sql')!;
-    expect(input.data('pairEvidence')).toBe('reading');
+    expect(r.el('rf-sql')!.dataset.feedbackIntegration).toBe('compatibility-reading');
     input.input(1);
     input.input(0.5);
     flushSync();
@@ -692,16 +723,23 @@ describe('the combined RF/SQL knob (controlModel="combined")', () => {
     r.dispose();
   });
 
-  it('clears identical lane draft and request state when receiver topology is replaced', () => {
+  it('clears identical lane draft and request state when topology and authority are replaced', () => {
     const views = new SvelteMap([['current', base()]]);
+    const publications = new SvelteMap([['current', rfTestAuthorityPublication('combined')]]);
+    const subscribers = new Set<(next: RfFrontEndAuthorityPublication) => void>();
     const onLevelChange = vi.fn();
     target = document.createElement('div');
     document.body.appendChild(target);
-    const component = mount(RfFrontEndSurface, {
+    const component = mount(Fixture, {
       target,
       props: {
+        get publication() { return publications.get('current')!; },
         get view() { return views.get('current')!; },
-        controlModel: 'combined', onLevelChange,
+        controlModel: 'combined', renderSurface: true, onLevelChange,
+        subscribeControlAuthority: (handler) => {
+          subscribers.add(handler); handler(publications.get('current')!);
+          return () => subscribers.delete(handler);
+        },
       },
     });
     flushSync();
@@ -709,11 +747,20 @@ describe('the combined RF/SQL knob (controlModel="combined")', () => {
     input.input(1);
     flushSync();
     expect(input.value()).toBe(1);
+    expect(onLevelChange).toHaveBeenCalledExactlyOnceWith('squelch', 1);
 
     views.set('current', withRfFrontEnd(topologyFixtures['2/ab_shared']));
+    publications.set('current', rfTestAuthorityPublication('combined', 4));
+    subscribers.forEach((handler) => handler(publications.get('current')!));
     flushSync();
-    expect(input.value()).toBe(0.5);
+    const replacement = levelDriver(
+      target.querySelector('[data-testid="rf-front-end-rf-sql"]')!,
+    );
+    expect(replacement.value()).toBe(0.5);
     input.input(1);
+    flushSync();
+    expect(onLevelChange).toHaveBeenCalledTimes(1);
+    replacement.input(1);
     flushSync();
     expect(onLevelChange.mock.calls).toEqual([
       ['squelch', 1],

--- a/frontend/src/semantic/__tests__/fixtures/RfFrontEndInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/RfFrontEndInstrumentHostFixture.svelte
@@ -1,5 +1,60 @@
+<script module lang="ts">
+  import type { Capabilities } from '$lib/types/capabilities';
+  import type { ServerState } from '$lib/types/state';
+  import type {
+    RfFrontEndAuthorityPublication as ModulePublication,
+    RfSqlControlModel as ModuleControlModel,
+  } from '../../rf-front-end-instruments';
+
+  const observed = {
+    storePath: 'fixture', observed: true, freshness: 'fresh', availability: 'available',
+    lastObservedMonotonic: 1,
+  };
+  const authorityState = {
+    stateContractVersion: 1, providerGeneration: 3,
+    revision: 1, stateRevision: 1, freshnessRevision: 1, observationSeq: 1,
+    updatedAt: '2026-09-07T00:00:00Z', active: 'MAIN', ptt: false,
+    split: false, dualWatch: false, tunerStatus: 0,
+    txTarget: { status: 'unknown', reason: 'not-observed' },
+    main: {
+      freqHz: 14_250_000, mode: 'USB', filterNum: 1, filter: 1, dataMode: 0,
+      vfoA: { freqHz: 14_250_000, mode: 'USB', filterNum: 1, dataMode: 0 },
+      vfoB: { freqHz: 14_300_000, mode: 'USB', filterNum: 1, dataMode: 0 },
+      activeSlot: 'A', afLevel: 0.5, rfGain: 1, squelch: 0,
+      sMeter: 0, att: 0, preamp: 0, nb: false, nr: false,
+    },
+    connection: {},
+    fieldStatus: Object.fromEntries([
+      'active', 'split', 'dualWatch', 'txTarget', 'main.freqHz', 'main.mode', 'main.filter',
+      'main.activeSlot', 'main.rfGain', 'main.squelch',
+    ].map((path) => [path, { ...observed }])),
+  } as unknown as ServerState;
+
+  export function rfTestAuthorityPublication(
+    controlModel: ModuleControlModel, generation = 3,
+  ): ModulePublication {
+    const caps = {
+      stateContractVersion: 1, providerGeneration: generation, model: 'RF-SURFACE-TEST',
+      scope: false, audio: true, tx: false,
+      capabilities: ['audio', 'rf_gain', 'squelch', 'preamp', 'attenuator', 'digisel', 'ip_plus'],
+      receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+      preValues: [0, 1, 2], attValues: [0, 6, 12, 18],
+      audioConfig: { sampleRate: 48_000, channels: 1, codecs: [] },
+      webrtc: { available: false, enabled: false }, txBands: null,
+      rfSqlControlModel: controlModel,
+    } as Capabilities;
+    return {
+      state: { ...authorityState, providerGeneration: generation },
+      caps, session: { state: 'connected', epoch: 7 },
+    };
+  }
+</script>
+
 <script lang="ts">
   import RfFrontEndInstrumentHost from '../../RfFrontEndInstrumentHost.svelte';
+  import RfFrontEndSurface, {
+    type RfFrontEndToggleField,
+  } from '../../RfFrontEndSurface.svelte';
   import type { RadioViewModel } from '../../radio-view-model';
   import type {
     RfFrontEndAuthorityPublication,
@@ -17,12 +72,18 @@
     controlModel: RfSqlControlModel;
     rfSqlFeedback?: RfFrontEndLevelFeedback | null;
     layout?: 'grouped' | 'independent';
+    renderSurface?: boolean;
+    pendingPreamp?: number | null;
+    onPreampChange?: (level: number) => void;
+    onAttenuatorChange?: (db: number) => void;
     onLevelChange?: (field: RfFrontEndLevelField, value: number) => void;
+    onToggle?: (field: RfFrontEndToggleField, next: boolean) => void;
   }
 
   let {
     publication, view, subscribeControlAuthority, controlModel, rfSqlFeedback,
-    layout = 'grouped', onLevelChange,
+    layout = 'grouped', renderSurface = false, pendingPreamp = null,
+    onPreampChange, onAttenuatorChange, onLevelChange, onToggle,
   }: Props = $props();
   let presentation = $derived({
     ...publication, view, controlModel, rfSqlFeedback,
@@ -33,15 +94,22 @@
   {presentation} {subscribeControlAuthority} {onLevelChange}
 >
   {#snippet children(handles: RfFrontEndLevelHandles)}
-    {#key layout}
-      <section data-layout={layout} data-handle-kind={handles.kind}>
-        {#if handles.kind === 'combined'}
-          <div data-slot="rf-sql">{@render handles.rfSql()}</div>
-        {:else}
-          <div data-slot="rf-gain">{@render handles.rfGain()}</div>
-          <div data-slot="squelch">{@render handles.squelch()}</div>
-        {/if}
-      </section>
-    {/key}
+    {#if renderSurface && view !== null}
+      <RfFrontEndSurface
+        {view} levelHandles={handles} {pendingPreamp}
+        {onPreampChange} {onAttenuatorChange} {onToggle}
+      />
+    {:else}
+      {#key layout}
+        <section data-layout={layout} data-handle-kind={handles.kind}>
+          {#if handles.kind === 'combined'}
+            <div data-slot="rf-sql">{@render handles.rfSql()}</div>
+          {:else}
+            <div data-slot="rf-gain">{@render handles.rfGain()}</div>
+            <div data-slot="squelch">{@render handles.squelch()}</div>
+          {/if}
+        </section>
+      {/key}
+    {/if}
   {/snippet}
 </RfFrontEndInstrumentHost>


### PR DESCRIPTION
16 code + 0 regenerated baselines = 16 files; root-approved file-count exception.

## Summary
- move RF gain and squelch continuous ownership into the persistent RF front-end host
- expose combined or separate RF level handles to replaceable layouts while keeping finite controls surface-owned
- exercise the actual HBar/Dual renderers, authority replacement, detached DOM, command feedback, and normalized-to-raw routing
- qualify existing wiring consumers for the additional persistent RF authority owner while preserving subscriber identity and zero-teardown assertions
- keep RF and squelch focus commands compatible with the rendered slider role

## Control plane
- Linear owner: MOR-2425
- accepted replay base: `66334b952834af6677a15704f14252bf3ecfaa87`
- public/open-core scope only; no API, protocol, configuration, or wire compatibility break

## Verification
- five original quick-failure consumers: 192 tests passed
- RF matrix: 124 tests passed
- `npm run check` (0 errors, 0 warnings)
- scoped ESLint over all 16 changed paths
- `git diff --check`

## Scope evidence
- 16 changed files, 444 additions, 478 deletions, 922 A+D
- no regenerated baseline or PNG changes
- preserves accepted TX, RX, Scope, receiver, VFO, and radio-wide indicator composition changes

## Correction history
- natural quick `34083547528` exposed five stale fixture expectations / one incomplete full mock on the prior head
- original BLOCKED review history is preserved; the successor head contains only the root-approved five-consumer test qualification

## Terminal exact-head evidence
- exact head: `5f884beb2d84801118a1202817348363e8db4726`
- natural quick `34084248262`: SUCCESS (https://github.com/rigplane/rigplane-core/actions/runs/34084248262)
- natural visual `34084248231`: SUCCESS (https://github.com/rigplane/rigplane-core/actions/runs/34084248231)
- binding independent review: Agent Review PASS (https://github.com/rigplane/rigplane-core/pull/3323#issuecomment-5565185488)