### PR TITLE
docs: quick runs only on ready PRs

### DIFF
--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -69,22 +69,23 @@ Rules:
 
 The suite result is CI's, so the PR opens here — before REVIEW, not after it.
 
-1. Commit (`refactor: <area description>`), push, then `gh pr create --draft`:
-   `quick.yml` triggers on push/PR to `main`, so the branch has no run of its
-   own until the PR exists (CLAUDE.md §Agent working rules)
+1. Commit (`refactor: <area description>`), push, then `gh pr create` —
+   ready, not `--draft`: `quick.yml` triggers on push/PR to `main` and its
+   `quick` job's `if:` skips a draft PR, so the branch has no run of its own
+   until a ready PR exists (CLAUDE.md §Agent working rules)
 2. Read the gates off that PR's `quick` run at this head: it runs the pytest
    suite, `ruff check` and `ruff format --check` under its `core` path filter,
    and `mypy --strict src/rigplane/web` under its `frontend` one
 3. Compare pass/fail counts against Phase 2 baseline
 4. Any new failure = behavior change → rollback all, mark FAILED
-5. With `quick` green at this head, `gh pr ready`: the verifier reviews a ready
-   PR, never a draft (AGENTS.md, "Draft PRs must not merge ... run `gh pr
-   ready`, then complete checks and review")
+5. Proceed to REVIEW only with `quick` green at this head; the PR opened
+   ready, so the verifier reviews a ready PR, never a draft (AGENTS.md,
+   "Draft PRs must not merge")
 
 ### Phase 6: REVIEW
 
 Dispatch the `verifier` role (`.claude/agents/verifier.md`) on the PR Phase 5
-took out of draft — the implementation agent never reviews its own work
+opened — the implementation agent never reviews its own work
 (CLAUDE.md §Language & Git).
 Have it confirm:
 - Improved readability or reduced duplication

--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -71,8 +71,8 @@ The suite result is CI's, so the PR opens here — before REVIEW, not after it.
 
 1. Commit (`refactor: <area description>`), push, then `gh pr create` —
    ready, not `--draft`: `quick.yml` triggers on push/PR to `main` and its
-   `quick` job's `if:` skips a draft PR, so the branch has no run of its own
-   until a ready PR exists (CLAUDE.md §Agent working rules)
+   `quick` job's `if:` skips a draft PR, so the branch has no `quick` job to
+   read until a ready PR exists (CLAUDE.md §Agent working rules)
 2. Read the gates off that PR's `quick` run at this head: it runs the pytest
    suite, `ruff check` and `ruff format --check` under its `core` path filter,
    and `mypy --strict src/rigplane/web` under its `frontend` one

--- a/.claude/commands/regression-check.md
+++ b/.claude/commands/regression-check.md
@@ -10,8 +10,9 @@ Detect test regressions after code changes.
 ## Steps
 
 1. Read the test results off the `quick` run for the head under review — the
-   run on its draft PR, per CLAUDE.md §Agent working rules. The suite is not
-   re-run locally for a head CI has run
+   run on its ready PR, per CLAUDE.md §Agent working rules; a draft PR's
+   `quick` job is skipped by its `if:` in `.github/workflows/quick.yml`. The
+   suite is not re-run locally for a head CI has run
 2. Capture: total passed, failed, errors, warnings, runtime
 3. Read `.claude/workflow/regression.md` for previous baseline (if exists)
 4. Compare against baseline:

--- a/.claude/commands/solve-issue.md
+++ b/.claude/commands/solve-issue.md
@@ -39,22 +39,23 @@ Dispatch the `builder` role (`.claude/agents/builder.md`) with the plan as its s
 ### Phase 4: REGCHECK (mandatory)
 The post-change result is CI's, so the PR opens here — before REVIEW, not after it.
 - Commit with a conventional message: `fix(#$ARGUMENTS): ...` or `feat(#$ARGUMENTS): ...`
-- Push, then `gh pr create --draft` with `Closes #$ARGUMENTS` in the body:
-  `quick.yml` triggers on push/PR to `main`, so the branch has no run of its
-  own until the PR exists (CLAUDE.md §Agent working rules)
+- Push, then `gh pr create` — ready, not `--draft` — with `Closes #$ARGUMENTS`
+  in the body: `quick.yml` triggers on push/PR to `main` and its `quick`
+  job's `if:` skips a draft PR, so the branch has no run of its own until a
+  ready PR exists (CLAUDE.md §Agent working rules)
 - Run `/regression-check` (see `.claude/commands/regression-check.md`), which
   takes its numbers from that PR's `quick` run at this head
 - Compare test results against baseline
 - If regression detected → back to EXECUTE (counts toward retry limit); push
   the fix and read the `quick` run on the new head
 - Do NOT proceed to REVIEW with regressions
-- With `quick` green at this head, `gh pr ready`: the verifier reviews a ready
-  PR, never a draft (AGENTS.md, "Draft PRs must not merge ... run `gh pr
-  ready`, then complete checks and review")
+- Proceed to REVIEW only with `quick` green at this head; the PR opened
+  ready, so the verifier reviews a ready PR, never a draft (AGENTS.md,
+  "Draft PRs must not merge")
 
 ### Phase 5: REVIEW
 Dispatch the `verifier` role (`.claude/agents/verifier.md`) — on the PR Phase 4
-took out of draft.
+opened.
 - The verifier did not write the change and must not be the builder
 - Review all changes against the plan; check safety, correctness, layering
 - Have the verifier report its verdict back as text; you relay it
@@ -73,8 +74,8 @@ pytest suite, `ruff check`, `ruff format`, and `mypy`.
   run on the new head
 
 ### Phase 7: PR (merge readiness)
-The PR is already open and out of draft since Phase 4; this phase is what makes
-it mergeable.
+The PR has been open and ready since Phase 4; this phase is what makes it
+mergeable.
 - PR body references the issue: `Closes #$ARGUMENTS`, and says why the change
   is one unit of work if it crosses the soft threshold in CLAUDE.md §Guardrails
 - Re-derive the size at the head you pushed — `git diff --stat

--- a/.claude/commands/solve-issue.md
+++ b/.claude/commands/solve-issue.md
@@ -41,8 +41,8 @@ The post-change result is CI's, so the PR opens here — before REVIEW, not afte
 - Commit with a conventional message: `fix(#$ARGUMENTS): ...` or `feat(#$ARGUMENTS): ...`
 - Push, then `gh pr create` — ready, not `--draft` — with `Closes #$ARGUMENTS`
   in the body: `quick.yml` triggers on push/PR to `main` and its `quick`
-  job's `if:` skips a draft PR, so the branch has no run of its own until a
-  ready PR exists (CLAUDE.md §Agent working rules)
+  job's `if:` skips a draft PR, so the branch has no `quick` job to read
+  until a ready PR exists (CLAUDE.md §Agent working rules)
 - Run `/regression-check` (see `.claude/commands/regression-check.md`), which
   takes its numbers from that PR's `quick` run at this head
 - Compare test results against baseline

--- a/.claude/skills/coordinate-sessions/SKILL.md
+++ b/.claude/skills/coordinate-sessions/SKILL.md
@@ -96,13 +96,15 @@ whose commit changed the tree being compared, valid only while `git diff
 --name-only <that sha>..<your base> -- <those paths>` is empty (CLAUDE.md
 §Agent working rules). One tree state, one instrument.
 
-Then: push → `gh pr create --draft` → `quick` runs on the PR → `gh pr ready` →
+Then: push → `gh pr create` (ready, not draft) → `quick` runs on the PR →
 the implementation or integration owner directly dispatches a fresh independent
 review on the final candidate → receive its immutable packet → confirm required
 checks green at the exact head → merge → remove the worktree.
 
 - There is no window before the PR: `quick.yml` triggers only on push/PR to
-  `main`, so a pushed branch has no run of its own until a PR exists.
+  `main`, and its `quick` job's `if:` skips a draft PR
+  (`.github/workflows/quick.yml`), so a pushed branch has no run of its own
+  until a ready PR exists.
 - Read the gate's verdict from the commit status — `gh pr checks <n>`, the
   `Agent Review Gate` row — never from a run list. The publisher job is green
   when it has successfully published a *refusal*, and `issue_comment` runs

--- a/.claude/skills/coordinate-sessions/SKILL.md
+++ b/.claude/skills/coordinate-sessions/SKILL.md
@@ -103,8 +103,8 @@ checks green at the exact head → merge → remove the worktree.
 
 - There is no window before the PR: `quick.yml` triggers only on push/PR to
   `main`, and its `quick` job's `if:` skips a draft PR
-  (`.github/workflows/quick.yml`), so a pushed branch has no run of its own
-  until a ready PR exists.
+  (`.github/workflows/quick.yml`), so a pushed branch has no `quick` job to
+  read until a ready PR exists.
 - Read the gate's verdict from the commit status — `gh pr checks <n>`, the
   `Agent Review Gate` row — never from a run list. The publisher job is green
   when it has successfully published a *refusal*, and `issue_comment` runs

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -138,7 +138,7 @@ uv build && rm -rf dist/
 
 ```bash
 # 2j. Optional regression check (.claude/commands/regression-check.md).
-# Its step 1 reads "the run on its draft PR", which a release cut from
+# Its step 1 reads "the run on its ready PR", which a release cut from
 # `main` does not have; 2h above is the record in that case.
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,11 +276,16 @@ nothing prompts for them; each drop has a cost paid later:
   coordinator takes all four from the head's `quick.yml` run, which runs
   pytest and ruff under its `core` path filter and `mypy --strict
   src/rigplane/web` under its `frontend` one. `quick.yml` triggers only on
-  push/PR to `main`, so a pushed branch gets no run until a PR exists:
-  push, open the PR as a draft, let `quick` run, `gh pr ready`, then
-  dispatch the review — the verifier reviews a ready PR, never a draft
-  (AGENTS.md, "Draft PRs must not merge"). Single test files may run
-  locally; the full suite may not.
+  push/PR to `main`, and its `quick` job's `if:` skips a draft PR
+  (`github.event.pull_request.draft == false`,
+  `.github/workflows/quick.yml`), so a pushed branch gets no `quick` run
+  until it has a ready PR: push, open the PR ready — or `gh pr ready` an
+  existing draft; `ready_for_review` is in the workflow's `pull_request`
+  `types:` — let that head's `quick` run go green, then dispatch the
+  review — the verifier reviews a ready PR, never a draft (AGENTS.md,
+  "Draft PRs must not merge"). The same `if:` skips the job for a
+  docs-only head (`needs.classify.outputs.docs`), which is green without
+  numbers. Single test files may run locally; the full suite may not.
 
 Dropping a phase is the owner's call, not the coordinator's. Announce the drop
 and why, before the work, rather than reporting it afterwards.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,14 +278,16 @@ nothing prompts for them; each drop has a cost paid later:
   src/rigplane/web` under its `frontend` one. `quick.yml` triggers only on
   push/PR to `main`, and its `quick` job's `if:` skips a draft PR
   (`github.event.pull_request.draft == false`,
-  `.github/workflows/quick.yml`), so a pushed branch gets no `quick` run
-  until it has a ready PR: push, open the PR ready — or `gh pr ready` an
-  existing draft; `ready_for_review` is in the workflow's `pull_request`
-  `types:` — let that head's `quick` run go green, then dispatch the
-  review — the verifier reviews a ready PR, never a draft (AGENTS.md,
-  "Draft PRs must not merge"). The same `if:` skips the job for a
-  docs-only head (`needs.classify.outputs.docs`), which is green without
-  numbers. Single test files may run locally; the full suite may not.
+  `.github/workflows/quick.yml`), so a draft head's `Tests (quick)` run
+  has no `quick` job to read: push, open the PR ready — or `gh pr ready`
+  an existing draft; `ready_for_review` is in the workflow's
+  `pull_request` `types:` — let that head's `quick` run go green, then
+  dispatch the review — the verifier reviews a ready PR, never a draft
+  (AGENTS.md, "Draft PRs must not merge"). A docs-only head gets no
+  `quick.yml` run at all (its `paths-ignore`); its required `quick`
+  context is published green, without numbers, by
+  `.github/workflows/docs-only-quick.yml`. Single test files may run
+  locally; the full suite may not.
 
 Dropping a phase is the owner's call, not the coordinator's. Announce the drop
 and why, before the work, rather than reporting it afterwards.


### PR DESCRIPTION
## Summary

CLAUDE.md §Agent working rules → The pipeline → TEST said: push, open the PR as a draft, let `quick` run, `gh pr ready`, then dispatch the review. That is stale. The `quick` job in `.github/workflows/quick.yml` now carries

```yaml
if: >-
  always() &&
  needs.classify.outputs.docs != 'true' &&
  (github.event_name == 'push' ||
  github.event.pull_request.draft == false)
```

so a draft PR's head gets a `Tests (quick)` run whose `quick` job is server-side skipped, with nothing to read. Observed on PR #3321, run 34083195166 (`gh run view 34083195166 --json jobs`): `classify` succeeded, `quick` completed as skipped while the PR was a draft. On #3321 the `quick` job ran on the next push after the PR was marked ready (head 3e76ed9, run 34084717847, synchronize); the ready_for_review event itself started no run there (cause unknown), though it does on other PRs (reviewer's sweep of 7 recent PRs, comment on this PR).

## Changes

- `CLAUDE.md`: the TEST bullet now says the `quick` job's `if:` skips a draft PR, that the PR must be ready (opened ready, or `gh pr ready` — `ready_for_review` is in the workflow's `pull_request` `types:`), that the verifier is dispatched after the ready PR's run is green, and that a docs-only head gets no `quick.yml` run at all (`paths-ignore`) with its `quick` context published by `.github/workflows/docs-only-quick.yml`.
- `.claude/commands/solve-issue.md`, `.claude/commands/refactor.md`, `.claude/commands/regression-check.md`, `.claude/skills/coordinate-sessions/SKILL.md`, `.claude/skills/release/SKILL.md`: the five files that quote the draft-then-ready sequence or regression-check's wording, rewritten to open the PR ready. They were not named in the request; they carry the identical stale sequence and cite the CLAUDE.md bullet, so leaving them would have made the documented workflows contradict the rule they cite.

Checked and unchanged: `AGENTS.md` ("Draft PRs must not merge and do not run the expensive self-hosted `quick` or `visual` jobs ... the `ready_for_review` event starts its required CI") and `docs/internals/github-project-workflow.md` step 5 already state the ready-first order.

## Verification

- Every added claim names the file or condition that makes it true: the `if:` block, `paths-ignore` and `types:` list in `.github/workflows/quick.yml`, the publisher job in `.github/workflows/docs-only-quick.yml`, and AGENTS.md "Draft PRs must not merge".
- `git grep -n "run on its draft PR"` returns nothing at the head.
- No `file:line` citations or relative `.md` links added, so the doc-citation and doc-link gates have nothing new to check. They could not be run locally (the script needs bash 4 `declare -A`; macOS ships bash 3).
- Docs-only diff: `quick.yml`'s `paths-ignore` excludes `**/*.md` and `.claude/**`, so this PR gets no `Tests (quick)` run by design; its `quick` context comes from `docs-only-quick.yml`.

Follow-up outside this PR's class (reviewer finding 4): `CLAUDE.md` CI workflows table still says `quick.yml` runs "unconditionally — the workflow always runs, then skips its own steps".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
