### PR TITLE
fix(MOR-2425): revoke stale committed scalar renderers

### DIFF
--- a/frontend/src/primitives/scalar/__tests__/committed-scalar.test.ts
+++ b/frontend/src/primitives/scalar/__tests__/committed-scalar.test.ts
@@ -117,10 +117,11 @@ describe('createCommittedScalar', () => {
     ['editability', { editable: false }],
   ] as const)('invalidates a draft on %s change and rejects its stale release', (_name, change) => {
     const { scalar, request, update } = setup();
-    scalar.input(111);
+    const lease = scalar.attachRenderer();
+    lease.input(111);
     update(change);
-    expect(scalar.view.draft).toBeNull();
-    expect(scalar.commit(111)).not.toBeNull();
+    expect(lease.view.draft).toBeNull();
+    expect(lease.commit(111)).not.toBeNull();
     expect(request).not.toHaveBeenCalled();
   });
 
@@ -142,13 +143,14 @@ describe('createCommittedScalar', () => {
       outcome: { phase: 'failed' },
     });
     const { scalar, request, update } = setup(rejectPolicy, terminal);
-    expect(scalar.view.announcement).toBe('Failed: 111');
-    scalar.input(90);
-    expect(scalar.view.draft).toBe(90);
+    const lease = scalar.attachRenderer();
+    expect(lease.view.announcement).toBe('Failed: 111');
+    lease.input(90);
+    expect(lease.view.draft).toBe(90);
 
     update({ feedback: feedback('idle', { providerGeneration: 4 }) });
-    expect(scalar.view).toMatchObject({ draft: null, announcement: null });
-    expect(scalar.commit(90)).toBe(64);
+    expect(lease.view).toMatchObject({ draft: null, announcement: null });
+    expect(lease.commit(90)).toBe(64);
     expect(request).not.toHaveBeenCalled();
   });
 
@@ -173,5 +175,83 @@ describe('createCommittedScalar', () => {
     expect(second.view.draft).toBeNull();
     expect(first.view.announcement).not.toBeNull();
     expect(second.view.announcement).not.toBeNull();
+  });
+
+  it('revokes replaced renderers without letting stale calls consume the current draft', () => {
+    const { scalar, request } = setup();
+    const rendererA = scalar.attachRenderer();
+    rendererA.input(90);
+
+    const rendererB = scalar.attachRenderer();
+    expect(rendererB.view).toMatchObject({ draft: null, displayed: 64, editing: false });
+    rendererB.input(111);
+    rendererA.commit(77);
+    rendererA.input(88);
+    rendererA.cancel();
+    rendererA.dispose();
+
+    expect(request).not.toHaveBeenCalled();
+    expect(rendererB.view).toMatchObject({ draft: 111, displayed: 111, editing: true });
+    expect(rendererB.commit(77)).toBeNull();
+    expect(request).toHaveBeenCalledExactlyOnceWith(111);
+
+    const rendererAReplacement = scalar.attachRenderer();
+    rendererAReplacement.input(120);
+    rendererA.input(121);
+    rendererA.commit(121);
+    rendererA.cancel();
+    expect(rendererAReplacement.view.draft).toBe(120);
+    rendererAReplacement.commit(120);
+    expect(request.mock.calls).toEqual([[111], [120]]);
+  });
+
+  it('makes destroyed owners and their retained renderers permanently inert', () => {
+    const first = setup();
+    const retained = first.scalar.attachRenderer();
+    retained.input(90);
+    first.scalar.destroy();
+    first.scalar.destroy();
+
+    const replacement = setup();
+    const current = replacement.scalar.attachRenderer();
+    current.input(111);
+    retained.input(88);
+    retained.commit(88);
+    retained.cancel();
+    retained.dispose();
+    first.scalar.input(77);
+    expect(first.scalar.commit(77)).toBe(64);
+    expect(first.scalar.cancel()).toBe(64);
+    const afterDestroy = first.scalar.attachRenderer();
+    afterDestroy.input(99);
+    afterDestroy.commit(99);
+
+    expect(first.request).not.toHaveBeenCalled();
+    expect(first.scalar.view).toMatchObject({ draft: null, displayed: 64, editing: false });
+    expect(current.view.draft).toBe(111);
+    current.commit(0);
+    expect(replacement.request).toHaveBeenCalledExactlyOnceWith(111);
+  });
+
+  it('disposes idempotently and preserves feedback presentation across renderer detach', () => {
+    const terminal = feedback('failed', {
+      requestedTarget: 111, transitionId: 'failed-1', outcome: { phase: 'failed' },
+    });
+    const { scalar, request } = setup(rejectPolicy, terminal);
+    const rendererA = scalar.attachRenderer();
+    expect(rendererA.view.announcement).toBe('Failed: 111');
+    rendererA.input(90);
+    rendererA.dispose();
+    rendererA.dispose();
+    rendererA.cancel();
+    rendererA.commit(90);
+
+    const rendererB = scalar.attachRenderer();
+    expect(rendererB.view).toMatchObject({
+      draft: null, displayed: 64, editing: false, announcement: 'Failed: 111',
+    });
+    rendererB.input(99);
+    rendererB.commit(99);
+    expect(request).toHaveBeenCalledExactlyOnceWith(99);
   });
 });

--- a/frontend/src/primitives/scalar/__tests__/committed-scalar.test.ts
+++ b/frontend/src/primitives/scalar/__tests__/committed-scalar.test.ts
@@ -247,9 +247,11 @@ describe('createCommittedScalar', () => {
     rendererA.commit(90);
 
     const rendererB = scalar.attachRenderer();
-    expect(rendererB.view).toMatchObject({
+    const rendererBView = rendererB.view;
+    expect(rendererBView).toMatchObject({
       draft: null, displayed: 64, editing: false, announcement: 'Failed: 111',
     });
+    expect(rendererBView.presentation.politeAnnouncement).toBeNull();
     rendererB.input(99);
     rendererB.commit(99);
     expect(request).toHaveBeenCalledExactlyOnceWith(99);

--- a/frontend/src/primitives/scalar/committed-scalar.svelte.ts
+++ b/frontend/src/primitives/scalar/committed-scalar.svelte.ts
@@ -29,11 +29,20 @@ export interface CommittedScalarView {
   readonly presentation: Readonly<ControlFeedbackPresentation>;
   readonly announcement: string | null;
 }
+export interface CommittedScalarRendererLease {
+  readonly view: Readonly<CommittedScalarView>;
+  input(value: number): void;
+  commit(value: number): number | null;
+  cancel(): number | null;
+  dispose(): void;
+}
 export interface CommittedScalar {
   readonly view: Readonly<CommittedScalarView>;
   input(value: number): void;
   commit(value: number): number | null;
   cancel(): number | null;
+  attachRenderer(): CommittedScalarRendererLease;
+  destroy(): void;
 }
 
 type DraftIdentity = {
@@ -93,6 +102,9 @@ export function createCommittedScalar(
   let announcement: string | null = null;
   let providerAuthorityInitialized = false;
   let lastProviderGeneration: number | null = null;
+  let activeRenderer: number | null = null;
+  let rendererSequence = 0;
+  let destroyed = false;
 
   function isEditable(input: Readonly<CommittedScalarInput>): boolean {
     return input.editable && input.feedback.phase !== 'unavailable';
@@ -166,47 +178,115 @@ export function createCommittedScalar(
       announcement,
     });
   }
+  function passiveViewOf(input: Readonly<CommittedScalarInput>): Readonly<CommittedScalarView> {
+    const presentation = projectControlFeedbackPresentation(
+      input.feedback, presentationState, policy.describeTarget,
+    );
+    const confirmed = input.feedback.phase === 'unavailable' ? null : input.feedback.confirmed;
+    return Object.freeze({
+      feedback: input.feedback,
+      confirmed,
+      draft: null,
+      displayed: authoritativeDisplayed(input, presentation),
+      editable: isEditable(input),
+      editing: false,
+      presentation,
+      announcement: presentation.politeAnnouncement?.message ?? announcement,
+    });
+  }
   function restore(input: Readonly<CommittedScalarInput>): number | null {
     return authoritativeDisplayed(input,
       projectControlFeedbackPresentation(input.feedback, presentationState, policy.describeTarget));
   }
 
-  return {
-    get view() { return viewOf(read()); },
-    input(value: number): void {
-      const current = read();
-      reconcile(current);
+  function clearRendererDraft(): void {
+    draft = null;
+    draftIdentity = null;
+    suppressCommit = false;
+  }
+
+  function input(value: number): void {
+    const current = read();
+    reconcile(current);
+    suppressCommit = false;
+    if (!isEditable(current)) return;
+    const candidate = policy.draftPolicy === 'normalize'
+      ? normalize(value)
+      : Number.isFinite(value) && policy.accepts(value) ? value : null;
+    if (candidate === null) return;
+    draft = candidate;
+    draftIdentity = identityOf(current);
+  }
+
+  function commit(value: number): number | null {
+    const current = read();
+    reconcile(current);
+    if (suppressCommit) {
       suppressCommit = false;
-      if (!isEditable(current)) return;
-      const candidate = policy.draftPolicy === 'normalize'
-        ? normalize(value)
-        : Number.isFinite(value) && policy.accepts(value) ? value : null;
-      if (candidate === null) return;
-      draft = candidate;
-      draftIdentity = identityOf(current);
+      return restore(current);
+    }
+    if (!isEditable(current)) return restore(current);
+    const candidate = normalize(activeDraft(current) ?? value);
+    draft = null;
+    draftIdentity = null;
+    if (candidate === null) return restore(current);
+    request(candidate);
+    return null;
+  }
+
+  function cancel(): number | null {
+    const current = read();
+    reconcile(current);
+    draft = null;
+    draftIdentity = null;
+    suppressCommit = true;
+    return restore(current);
+  }
+
+  function makeLease(renderer: number): CommittedScalarRendererLease {
+    const isActive = (): boolean => !destroyed && renderer === activeRenderer;
+    return {
+      get view() { return isActive() ? viewOf(read()) : passiveViewOf(read()); },
+      input(value: number): void {
+        if (isActive()) input(value);
+      },
+      commit(value: number): number | null {
+        return isActive() ? commit(value) : restore(read());
+      },
+      cancel(): number | null {
+        return isActive() ? cancel() : restore(read());
+      },
+      dispose(): void {
+        if (!isActive()) return;
+        clearRendererDraft();
+        activeRenderer = null;
+      },
+    };
+  }
+
+  return {
+    get view() { return destroyed ? passiveViewOf(read()) : viewOf(read()); },
+    input(value: number): void {
+      if (!destroyed) input(value);
     },
     commit(value: number): number | null {
-      const current = read();
-      reconcile(current);
-      if (suppressCommit) {
-        suppressCommit = false;
-        return restore(current);
-      }
-      if (!isEditable(current)) return restore(current);
-      const candidate = normalize(activeDraft(current) ?? value);
-      draft = null;
-      draftIdentity = null;
-      if (candidate === null) return restore(current);
-      request(candidate);
-      return null;
+      return destroyed ? restore(read()) : commit(value);
     },
     cancel(): number | null {
-      const current = read();
-      reconcile(current);
-      draft = null;
-      draftIdentity = null;
-      suppressCommit = true;
-      return restore(current);
+      return destroyed ? restore(read()) : cancel();
+    },
+    attachRenderer(): CommittedScalarRendererLease {
+      if (destroyed) return makeLease(-1);
+      clearRendererDraft();
+      const renderer = ++rendererSequence;
+      activeRenderer = renderer;
+      return makeLease(renderer);
+    },
+    destroy(): void {
+      if (destroyed) return;
+      destroyed = true;
+      clearRendererDraft();
+      activeRenderer = null;
     },
   };
 }

--- a/frontend/src/semantic/CwKeyerSurface.svelte
+++ b/frontend/src/semantic/CwKeyerSurface.svelte
@@ -319,6 +319,7 @@
   onDestroy(() => {
     keySpeedScalar.destroy();
     cwPitchScalar.destroy();
+    breakInDelayScalar.destroy();
   });
   function feedbackLevelValueText(
     label: string, current: Readonly<ContinuousScalarView>, displayed: number | null, unit: string,
@@ -409,7 +410,8 @@
     },
     (value) => setLevel('breakInDelay', value),
   );
-  let breakInDelayView = $derived(breakInDelayScalar.view);
+  const breakInDelayLease = breakInDelayScalar.attachRenderer();
+  let breakInDelayView = $derived(breakInDelayLease.view);
   let breakInDelayBusy = $derived(
     breakInDelayView.presentation.attributes['aria-busy'] === 'true',
   );
@@ -437,14 +439,14 @@
     return `Confirmed ${confirmed}`;
   });
   function noteBreakInDelayInput(target: HTMLInputElement): void {
-    breakInDelayScalar.input(target.valueAsNumber);
+    breakInDelayLease.input(target.valueAsNumber);
   }
   function commitBreakInDelay(target: HTMLInputElement): void {
-    const restored = breakInDelayScalar.commit(target.valueAsNumber);
+    const restored = breakInDelayLease.commit(target.valueAsNumber);
     if (restored !== null) target.value = String(restored);
   }
   function cancelBreakInDelay(target: HTMLInputElement): void {
-    const restored = breakInDelayScalar.cancel();
+    const restored = breakInDelayLease.cancel();
     if (restored !== null) target.value = String(restored);
   }
   function keyBreakInDelay(event: KeyboardEvent & { currentTarget: HTMLInputElement }): void {

--- a/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
@@ -634,7 +634,23 @@ describe('Break-in Delay separates draft, submitted target and confirmed truth',
     r.dispose();
   });
 
-  it('emits nothing when unmounted after intermediate drag input', () => {
+  it('adopts one committed renderer lease and destroys its owner on unmount', () => {
+    const committedBlock = CODE.slice(
+      CODE.indexOf('const breakInDelayScalar'),
+      CODE.indexOf('function requestRxFrequencyCorrection'),
+    );
+    expect(committedBlock).toContain(
+      'const breakInDelayLease = breakInDelayScalar.attachRenderer()',
+    );
+    expect(committedBlock).toContain('$derived(breakInDelayLease.view)');
+    expect(committedBlock).not.toMatch(/breakInDelayScalar\.(?:input|commit|cancel)\(/);
+    for (const method of ['input', 'commit', 'cancel']) {
+      expect(committedBlock).toContain(`breakInDelayLease.${method}(`);
+    }
+    expect(CODE).toMatch(/onpointercancel=.*cancelBreakInDelay/);
+    expect(CODE).toMatch(/function keyBreakInDelay[\s\S]*?cancelBreakInDelay\(event\.currentTarget\)/);
+    expect(CODE).toMatch(/onDestroy\(\(\) => \{[\s\S]*?breakInDelayScalar\.destroy\(\)/);
+
     const onLevelChange = vi.fn();
     const r = render(base(), { onLevelChange });
     const input = r.input('breakInDelay')!;


### PR DESCRIPTION
## Problem

The live v3 `CwKeyerSurface` retained unrestricted committed-scalar callbacks after renderer replacement or unmount. A stale renderer could therefore consume, overwrite, or cancel the current renderer's draft, including committing the current renderer's `111` draft through an old callback.

## Change

- Add a renderer lease and idempotent destruction to the existing committed-scalar owner.
- Revoke superseded, disposed, and destroyed callers before they can reconcile state or issue a request, while preserving provider/context invalidation and feedback presentation behavior.
- Route the current v3 break-in-delay view, input, commit, cancel, pointer-cancel, and Escape paths through one lease, and destroy the owner on surface unmount.
- Keep the legacy `CwPanel` source and direct committed-scalar methods compatible.

Linear owner: MOR-2425

Base: `e40bf1ed4b4e86f4eda6f4b237273cc8ec700f5e`

Candidate: `cbdbe7c15d3c8a16472c3d6f9f370256fcfdd984`

## Review correction

The initial `8fffa5231299274bf695d59703a2f64f72bbc41e` head had green natural quick and visual CI, then received an exact-head BLOCKED review because its detach test did not prove announcement dedup memory survived. The successor test now requires the replacement renderer to retain the announcement text without reissuing `failed-1`. The exact reviewer mutation that cleared `presentationState` and `announcement` in `clearRendererDraft()` fails this assertion; restored product source passes it.

The corrected head received `Agent Review: PASS cbdbe7c15d3c8a16472c3d6f9f370256fcfdd984` in [the binding independent review comment](https://github.com/rigplane/rigplane-core/pull/3326#issuecomment-5565540496). Natural exact-head [quick run 34087007497](https://github.com/rigplane/rigplane-core/actions/runs/34087007497) and [visual run 34087007519](https://github.com/rigplane/rigplane-core/actions/runs/34087007519) both completed successfully.

## Validation

- `npx vitest run` on the two changed files plus the three unchanged `CwPanel` files — 196 passed.
- Mutant probe against reset presentation memory — 1 targeted failure; restored source — 19 passed.
- `npm run check` — 0 errors and 0 warnings.
- `npx eslint src/primitives/scalar/committed-scalar.svelte.ts src/primitives/scalar/__tests__/committed-scalar.test.ts src/semantic/CwKeyerSurface.svelte src/semantic/__tests__/CwKeyerSurface.test.ts` — passed.
- `git diff --check` — passed.
