### PR TITLE
feat(MOR-2425): integrate VFO operation instruments

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -323,8 +323,21 @@
   </div>
 {/snippet}
 
+{#snippet vfoOperationControls()}
+  <div class="vfo-operation-instrument-grid" data-testid="vfo-operation-instrument-grid">
+    {#if instruments.vfoOperations.split}<div class="vfo-operation-instrument-seat" data-field="split">{@render instruments.vfoOperations.split()}</div>{/if}
+    {#if instruments.vfoOperations.dualWatch}<div class="vfo-operation-instrument-seat" data-field="dualWatch">{@render instruments.vfoOperations.dualWatch()}</div>{/if}
+    {#if instruments.vfoOperations.activeReceiver}<div class="vfo-operation-instrument-seat" data-field="activeReceiver">{@render instruments.vfoOperations.activeReceiver()}</div>{/if}
+    {#if instruments.vfoOperations.equalize}<div class="vfo-operation-instrument-seat" data-field="equalize">{@render instruments.vfoOperations.equalize()}</div>{/if}
+    {#if instruments.vfoOperations.swap}<div class="vfo-operation-instrument-seat" data-field="swap">{@render instruments.vfoOperations.swap()}</div>{/if}
+    {#if instruments.vfoOperations.quickSplit}<div class="vfo-operation-instrument-seat" data-field="quickSplit">{@render instruments.vfoOperations.quickSplit()}</div>{/if}
+    {#if instruments.vfoOperations.quickDualWatch}<div class="vfo-operation-instrument-seat" data-field="quickDualWatch">{@render instruments.vfoOperations.quickDualWatch()}</div>{/if}
+    {#if instruments.vfoOperations.speak}<div class="vfo-operation-instrument-seat" data-field="speak">{@render instruments.vfoOperations.speak()}</div>{/if}
+  </div>
+{/snippet}
+
 {#snippet semanticDeckContent(appearance: 'standard' | 'sdr' | 'semantic', allowBare = false)}
-  {@render instruments.vfo(appearance, allowBare)}
+  {@render instruments.vfo(appearance, allowBare, vfoOperationControls)}
   {@render instruments.rxTx(allowBare)}
   {@render instruments.txFaultRecovery()}
   {@render instruments.modInputTxWarning()}
@@ -355,7 +368,9 @@
     <KeyboardHandler config={keyboardConfig} onAction={keyboardHandlers.dispatch} />
 
     <section class="receiver-deck" bind:this={receiverDeckElement} style={receiverDeckStyle}>
-      {@render instruments.vfo(skinId === 'sdr-test' ? 'sdr' : 'standard')}
+      {@render instruments.vfo(
+        skinId === 'sdr-test' ? 'sdr' : 'standard', undefined, vfoOperationControls,
+      )}
 
       <div class="desktop-controls-left">
         {@render instruments.rfFrontEnd()}
@@ -657,6 +672,7 @@
   .desktop-control-face :global([data-zone-id='meters']) { grid-area: 5 / 1 / 6 / -1; }
   .tx-aux-finite-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
   .dsp-finite-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+  .vfo-operation-instrument-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
   .tx-aux-scalar-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
+++ b/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
@@ -9,9 +9,12 @@
     ReceiverVfoAppearance,
   } from '../../../../semantic/ReceiverInstrumentHost.svelte';
   import type { TxAuxFiniteHandles } from '../../../../semantic/tx-aux-finite';
+  import type { VfoOperationHandles } from '../../../../semantic/VfoOperationSeatHost.svelte';
 
   const empty = createRawSnippet(() => ({ render: () => '' }));
-  const vfo = createRawSnippet<[appearance: FixtureVfoAppearance, allowBare?: boolean]>(
+  const vfo = createRawSnippet<[
+    appearance: FixtureVfoAppearance, allowBare?: boolean, operationControls?: FixtureSnippet,
+  ]>(
     () => ({ render: () => '' }),
   );
   const txAux = createRawSnippet<[scalarLayout: FixtureSnippet, allowBare?: boolean]>(
@@ -30,6 +33,10 @@
   const txAuxInstruments = {
     atu: empty, vox: empty, compressor: empty, monitor: empty, atuTune: empty,
   } satisfies TxAuxFiniteHandles;
+  const vfoOperations = {
+    split: null, dualWatch: null, activeReceiver: null, equalize: null,
+    swap: null, quickSplit: null, quickDualWatch: null, speak: null,
+  } satisfies VfoOperationHandles;
   const rfFrontEndInstruments = {
     kind: 'separate', rfGain: empty, squelch: empty,
   } as const;
@@ -39,7 +46,8 @@
   };
 
   export const TEST_INSTRUMENTS = {
-    vfo, rxTx: empty, txAuxControls: txAux, txAuxScalars: scalars, txAuxInstruments,
+    vfo, vfoOperations, rxTx: empty, txAuxControls: txAux,
+    txAuxScalars: scalars, txAuxInstruments,
     receiverInstruments,
     rxAudioInstruments, rfFrontEndInstruments,
     meters: empty, rxAudio: empty, rfFrontEnd: empty, filter: empty, dsp: empty,

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -726,7 +726,7 @@
       finiteAppearance: selectedFiniteAppearance, rendererContext: dspFiniteRendererContext,
     });
   let vfoFiniteRendererSelection = $derived(selectedFiniteAppearance === undefined
-    ? null : {
+    ? {} : {
       finiteAppearance: selectedFiniteAppearance, rendererContext: vfoFiniteRendererContext,
     });
 
@@ -1130,10 +1130,6 @@
       splitUnknown: t('core.vfo.split.unknownReason'),
       dualWatchUnknown: t('core.vfo.dualWatch.unknownReason'),
     },
-  });
-  const EMPTY_VFO_OPERATION_HANDLES: VfoOperationHandles = Object.freeze({
-    split: null, dualWatch: null, activeReceiver: null, equalize: null,
-    swap: null, quickSplit: null, quickDualWatch: null, speak: null,
   });
 </script>
 
@@ -2063,17 +2059,13 @@
   {/snippet}
   </DspInstrumentHost>
   {/snippet}
-  {#if vfoFiniteRendererSelection !== null && vfoOperationInput !== null}
-    <VfoOperationSeatHost
-      {...vfoFiniteRendererSelection} input={vfoOperationInput} scheme={view!.vfoScheme}
-    >
-      {#snippet children(vfoOperations)}
-        {@render vfoInstrumentComposition(vfoOperations)}
-      {/snippet}
-    </VfoOperationSeatHost>
-  {:else}
-    {@render vfoInstrumentComposition(EMPTY_VFO_OPERATION_HANDLES)}
-  {/if}
+  <VfoOperationSeatHost
+    {...vfoFiniteRendererSelection} input={vfoOperationInput} scheme={view?.vfoScheme ?? null}
+  >
+    {#snippet children(vfoOperations)}
+      {@render vfoInstrumentComposition(vfoOperations)}
+    {/snippet}
+  </VfoOperationSeatHost>
   {/snippet}
   </RfFrontEndInstrumentHost>
   {/snippet}

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -86,6 +86,12 @@
   } from '../../semantic/TxAuxSurface.svelte';
   import type { TxAuxScalarHandles } from '../../semantic/tx-aux-scalar';
   import type { TxAuxFiniteHandles } from '../../semantic/tx-aux-finite';
+  import VfoOperationSeatHost, {
+    type VfoOperationHandles,
+  } from '../../semantic/VfoOperationSeatHost.svelte';
+  import type {
+    VfoOperationCallbacks, VfoOperationProjectionInput,
+  } from '../../semantic/vfo-operation-projection';
   import { keyBlockedReasons } from '../../semantic/rx-tx-surface';
   import VfoSurface, { type VfoSelection } from '../../semantic/VfoSurface.svelte';
   import SemanticControlPanel from '../layout/SemanticControlPanel.svelte';
@@ -538,6 +544,11 @@
     topologyId: string;
     activeReceiver: 'MAIN' | 'SUB' | 'unknown';
   }>;
+  type VfoFiniteAuthority = Readonly<{
+    sessionEpoch: number;
+    providerGeneration: number;
+    topologyId: string;
+  }>;
   const slotIdentity = (slot: VfoSlot): string => {
     if (slot.kind === 'slotted') return `slotted:${slot.id}`;
     if (slot.kind === 'relative') return `relative:${slot.role}`;
@@ -606,6 +617,23 @@
         ? model.activeReceiver.receiver : 'unknown',
     });
   }
+  function vfoFiniteAuthority(
+    state: typeof runtime.state,
+    caps: typeof runtime.caps,
+    session: typeof runtime.controlSession,
+  ): VfoFiniteAuthority | null {
+    const stateGeneration = state?.providerGeneration;
+    const capsGeneration = caps?.providerGeneration;
+    if (session.state !== 'connected' || !Number.isSafeInteger(session.epoch) || session.epoch < 0
+      || !Number.isSafeInteger(stateGeneration) || stateGeneration! < 0
+      || stateGeneration !== capsGeneration) return null;
+    const model = toRadioViewModel(state, caps);
+    return model === null ? null : Object.freeze({
+      sessionEpoch: session.epoch,
+      providerGeneration: stateGeneration as number,
+      topologyId: model.topologyId,
+    });
+  }
   const sameScopeFiniteAuthority = (
     left: ScopeFiniteAuthority | null | undefined,
     right: ScopeFiniteAuthority | null,
@@ -637,15 +665,26 @@
         && left.topologyId === right.topologyId
         && left.activeReceiver === right.activeReceiver
   );
+  const sameVfoFiniteAuthority = (
+    left: VfoFiniteAuthority | null | undefined,
+    right: VfoFiniteAuthority | null,
+  ): boolean => left !== undefined && (
+    left === null || right === null ? left === right
+      : left.sessionEpoch === right.sessionEpoch
+        && left.providerGeneration === right.providerGeneration
+        && left.topologyId === right.topologyId
+  );
   const readSelectedFiniteAppearance = 'getSelectedFiniteControlAppearance' in componentKitActivation
     ? componentKitActivation.getSelectedFiniteControlAppearance : undefined;
   const selectedFiniteAppearance = readSelectedFiniteAppearance?.();
   let finiteRendererContext = $state.raw<FiniteRendererContext | null>(null);
   let txAuxFiniteRendererContext = $state.raw<FiniteRendererContext | null>(null);
   let dspFiniteRendererContext = $state.raw<FiniteRendererContext | null>(null);
+  let vfoFiniteRendererContext = $state.raw<FiniteRendererContext | null>(null);
   let lastScopeFiniteAuthority: ScopeFiniteAuthority | null | undefined;
   let lastTxAuxFiniteAuthority: TxAuxFiniteAuthority | null | undefined;
   let lastDspFiniteAuthority: DspFiniteAuthority | null | undefined;
+  let lastVfoFiniteAuthority: VfoFiniteAuthority | null | undefined;
   const unsubscribeScopeFiniteAuthority = selectedFiniteAppearance === undefined ? undefined
     : runtime.subscribeControlAuthority((publication) => {
       const next = scopeFiniteAuthority(publication.state, publication.caps, publication.session);
@@ -667,6 +706,13 @@
         lastDspFiniteAuthority = nextDsp;
         dspFiniteRendererContext = nextDsp === null ? null : createFiniteRendererContext();
       }
+      const nextVfo = vfoFiniteAuthority(
+        publication.state, publication.caps, publication.session,
+      );
+      if (!sameVfoFiniteAuthority(lastVfoFiniteAuthority, nextVfo)) {
+        lastVfoFiniteAuthority = nextVfo;
+        vfoFiniteRendererContext = nextVfo === null ? null : createFiniteRendererContext();
+      }
     });
   onDestroy(() => unsubscribeScopeFiniteAuthority?.());
   let scopeFiniteRendererSelection = $derived(selectedFiniteAppearance === undefined
@@ -678,6 +724,10 @@
   let dspFiniteRendererSelection = $derived(selectedFiniteAppearance === undefined
     ? {} : {
       finiteAppearance: selectedFiniteAppearance, rendererContext: dspFiniteRendererContext,
+    });
+  let vfoFiniteRendererSelection = $derived(selectedFiniteAppearance === undefined
+    ? null : {
+      finiteAppearance: selectedFiniteAppearance, rendererContext: vfoFiniteRendererContext,
     });
 
   let scopeFrameSource = $derived(
@@ -1053,6 +1103,38 @@
   function toggleDualWatch(): void {
     if (view?.dualWatch.status === 'known') vfo.onDualWatchToggle(!view.dualWatch.value);
   }
+
+  const vfoOperationCallbacks = Object.freeze({
+    onToggleSplit: vfo.onSplitToggle,
+    onToggleDualWatch: toggleDualWatch,
+    onSelectMainReceiver: vfo.onMainVfoClick,
+    onSelectSubReceiver: vfo.onSubVfoClick,
+    onEqualizeVfos: vfo.onEqual,
+    onSwapVfos: vfo.onSwap,
+    onQuickSplit: vfo.onQuickSplit,
+    onQuickDualWatch: vfo.onQuickDw,
+    onSpeak: systemIntents.onSpeak,
+  }) satisfies VfoOperationCallbacks;
+  let vfoOperationInput: VfoOperationProjectionInput | null = $derived(view === null ? null : {
+    hasVfoPair: view.vfos.length > 1,
+    hasDualReceiver,
+    relativeIdentityUnknown: view.vfos.some((candidate) => candidate.slot.kind === 'relative'),
+    activeReceiver: view.activeReceiver,
+    split: view.split,
+    dualWatch: view.dualWatch,
+    actions: view.radioWideIndicators?.actions,
+    callbacks: vfoOperationCallbacks,
+    reasons: {
+      receiverUnavailable: t('core.vfo.select.receiverUnavailableReason'),
+      identityUnknown: t('core.vfo.ops.identityUnknownReason'),
+      splitUnknown: t('core.vfo.split.unknownReason'),
+      dualWatchUnknown: t('core.vfo.dualWatch.unknownReason'),
+    },
+  });
+  const EMPTY_VFO_OPERATION_HANDLES: VfoOperationHandles = Object.freeze({
+    split: null, dualWatch: null, activeReceiver: null, equalize: null,
+    swap: null, quickSplit: null, quickDualWatch: null, speak: null,
+  });
 </script>
 
 <div class="semantic-surfaces" class:hosted={hostedChildren !== undefined} data-testid="semantic-radio-surfaces">
@@ -1062,17 +1144,9 @@
         viewModel={view}
         {appearance}
         showVfoList={false}
+        operationInput={vfoOperationInput ?? undefined}
         groupLabel={t('core.vfo.radioWideGroupLabel')}
         {hasDualReceiver}
-        onToggleSplit={vfo.onSplitToggle}
-        onToggleDualWatch={toggleDualWatch}
-        onEqualizeVfos={vfo.onEqual}
-        onSwapVfos={vfo.onSwap}
-        onQuickSplit={vfo.onQuickSplit}
-        onQuickDualWatch={vfo.onQuickDw}
-        onSelectMainReceiver={vfo.onMainVfoClick}
-        onSelectSubReceiver={vfo.onSubVfoClick}
-        onSpeak={systemIntents.onSpeak}
       />
     {/if}
   {/snippet}
@@ -1095,6 +1169,7 @@
     onLevelChange={(field, value) => RF_FRONT_END_LEVEL_INTENT[field](value)}
   >
   {#snippet children(rfFrontEndInstruments)}
+  {#snippet vfoInstrumentComposition(vfoOperations: VfoOperationHandles)}
   <DspInstrumentHost
     {...dspFiniteRendererSelection} {view} {agcLabels} {pendingNb} {pendingNr}
     onToggle={(field, next) => DSP_TOGGLE_INTENT[field](next)}
@@ -1189,23 +1264,18 @@
     site below is where the default path's VFO already was, so an unresolved
     or default plan reproduces today's element sequence exactly.
   -->
-  {#snippet vfoSurface(appearance: InstrumentVfoAppearance = vfoAppearance)}
+  {#snippet vfoSurface(
+    appearance: InstrumentVfoAppearance = vfoAppearance, operationControls?: Snippet,
+  )}
     {#if view}
       <VfoSurface
         viewModel={view}
         {appearance}
+        operationInput={vfoOperationInput ?? undefined}
+        {operationControls}
         onSelectVfo={selectVfo}
         onTuneFrequency={tuneFrequency}
         {hasDualReceiver}
-        onToggleSplit={vfo.onSplitToggle}
-        onToggleDualWatch={toggleDualWatch}
-        onEqualizeVfos={vfo.onEqual}
-        onSwapVfos={vfo.onSwap}
-        onQuickSplit={vfo.onQuickSplit}
-        onQuickDualWatch={vfo.onQuickDw}
-        onSelectMainReceiver={vfo.onMainVfoClick}
-        onSelectSubReceiver={vfo.onSubVfoClick}
-        onSpeak={systemIntents.onSpeak}
         {receiverInstruments}
         continuitySession={meterContinuitySession}
         {pendingFrequencyHz}
@@ -1726,8 +1796,15 @@
   >
   {#snippet children(txAuxInstruments)}
   {#snippet txAuxBody()}{@render txAuxSurface(txAuxInstruments, txAuxScalars)}{/snippet}
-  {#snippet hostedVfo(appearance: InstrumentVfoAppearance, allowBare = allowBareSurfaces)}
-    {#snippet body()}{@render vfoSurface(appearance)}{/snippet}
+  {#snippet hostedVfo(
+    appearance: InstrumentVfoAppearance,
+    allowBare = allowBareSurfaces,
+    operationControls?: Snippet,
+  )}
+    {#snippet body()}{@render vfoSurface(
+      appearance,
+      selectedFiniteAppearance === undefined ? undefined : operationControls,
+    )}{/snippet}
     {@render zoned('vfo', view !== null && singleOrder.includes('vfo'), body, allowBare)}
   {/snippet}
   {#snippet hostedRxTx(allowBare = allowBareSurfaces)}
@@ -1786,6 +1863,7 @@
   {#if hostedChildren}
     {@render hostedChildren({
       vfo: hostedVfo,
+      vfoOperations,
       rxTx: hostedRxTx,
       txAuxControls: hostedTxAux,
       txAuxScalars,
@@ -1984,6 +2062,18 @@
   {/if}
   {/snippet}
   </DspInstrumentHost>
+  {/snippet}
+  {#if vfoFiniteRendererSelection !== null && vfoOperationInput !== null}
+    <VfoOperationSeatHost
+      {...vfoFiniteRendererSelection} input={vfoOperationInput} scheme={view!.vfoScheme}
+    >
+      {#snippet children(vfoOperations)}
+        {@render vfoInstrumentComposition(vfoOperations)}
+      {/snippet}
+    </VfoOperationSeatHost>
+  {:else}
+    {@render vfoInstrumentComposition(EMPTY_VFO_OPERATION_HANDLES)}
+  {/if}
   {/snippet}
   </RfFrontEndInstrumentHost>
   {/snippet}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -362,7 +362,7 @@ function pushSession(next: ControlSessionSnapshot): void {
   flushSync();
 }
 
-function pushRadioState(next: ServerState): void {
+function pushRadioState(next: ServerState | null): void {
   h.state = next;
   for (const listener of h.radioListeners) listener(next);
   publishAuthority();
@@ -602,6 +602,35 @@ describe('hosted Standard VFO operation instruments', () => {
     for (const spy of [
       h.split, h.dualWatch, h.subReceiver, h.equalize, h.swap, h.speak,
     ]) expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('keeps the accepted neighboring host subtree mounted through a temporary null view', () => {
+    h.caps = vfoCaps();
+    h.selectedFiniteAppearance = finiteAppearance;
+    renderHostedDesktop();
+    const layout = q('.radio-layout');
+    const retainedVox = retainedInvocations.get('VOX')!;
+    const subscribers = [...h.authoritySubscribers];
+
+    h.caps = null;
+    pushRadioState(null);
+    push({});
+    expect(q('[data-testid="vfo-surface"]')).toBeNull();
+    expect(q('[data-testid="external-VOX"]')).toBeNull();
+    expect(q('.radio-layout')).toBe(layout);
+    expect([...h.authoritySubscribers]).toEqual(subscribers);
+    retainedVox();
+    expect(h.voxToggle).not.toHaveBeenCalled();
+
+    h.caps = vfoCaps();
+    pushRadioState(liveState(true));
+    push({});
+    expect(q('.radio-layout')).toBe(layout);
+    expect(q('[data-testid="external-VOX"]')).not.toBeNull();
+    expect([...h.authoritySubscribers]).toEqual(subscribers);
+    expect(retainedInvocations.get('VOX')).not.toBe(retainedVox);
+    retainedInvocations.get('VOX')!();
+    expect(h.voxToggle).toHaveBeenCalledOnce();
   });
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -39,6 +39,15 @@ const h = vi.hoisted(() => ({
   voxDelay: vi.fn(),
   compLevel: vi.fn(),
   monLevel: vi.fn(),
+  split: vi.fn(),
+  dualWatch: vi.fn(),
+  mainReceiver: vi.fn(),
+  subReceiver: vi.fn(),
+  equalize: vi.fn(),
+  swap: vi.fn(),
+  quickSplit: vi.fn(),
+  quickDualWatch: vi.fn(),
+  speak: vi.fn(),
   noop: vi.fn(),
   session: { state: 'connected', epoch: 7 } as ControlSessionSnapshot,
   sessionSubscriber: null as ((next: ControlSessionSnapshot) => void) | null,
@@ -135,8 +144,17 @@ vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
   return {
     ...actual,
     makeVfoHandlers: () => ({
-      onVfoSelect: h.noop, onSplitToggle: h.noop, onDualWatchToggle: h.noop,
+      onVfoSelect: h.noop,
+      onSplitToggle: h.split,
+      onDualWatchToggle: h.dualWatch,
+      onMainVfoClick: h.mainReceiver,
+      onSubVfoClick: h.subReceiver,
+      onEqual: h.equalize,
+      onSwap: h.swap,
+      onQuickSplit: h.quickSplit,
+      onQuickDw: h.quickDualWatch,
     }),
+    makeSystemHandlers: () => ({ onSpeak: h.speak }),
     makeVoxHandlers: () => ({
       onVoxToggle: h.voxToggle, onVoxGainChange: h.voxGain,
       onAntiVoxGainChange: h.antiVoxGain, onVoxDelayChange: h.voxDelay,
@@ -275,6 +293,14 @@ const liveCaps = (withTxAux: boolean): Capabilities => ({
   txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
   scopeSource: null, audioFftAvailable: false,
 } as unknown as Capabilities);
+
+const vfoCaps = (): Capabilities => ({
+  ...liveCaps(true),
+  capabilities: [
+    ...liveCaps(true).capabilities,
+    'dual_watch', 'split', 'vfo_equalize', 'vfo_swap', 'speech',
+  ],
+});
 
 const finiteFixture = FiniteControlRendererFixture as FiniteControlAppearance['action'];
 const finiteAppearance = {
@@ -421,6 +447,164 @@ describe('L1 hosted desktop TX auxiliary composition', () => {
   });
 });
 
+describe('hosted Standard VFO operation instruments', () => {
+  it('keeps native absolute receiver options actionable when current identity is unknown', () => {
+    h.caps = vfoCaps();
+    const unknownActive = liveState(true);
+    delete unknownActive.fieldStatus?.active;
+    h.state = unknownActive;
+    renderHostedDesktop();
+
+    const main = q<HTMLButtonElement>('[data-active-receiver-segment="MAIN"]')!;
+    const sub = q<HTMLButtonElement>('[data-active-receiver-segment="SUB"]')!;
+    expect(main.ariaChecked).toBe('false');
+    expect(sub.ariaChecked).toBe('false');
+    expect(sub.disabled).toBe(false);
+    sub.click();
+    expect(h.subReceiver).toHaveBeenCalledOnce();
+  });
+
+  it('places every admitted named seat once, invokes current callbacks, and keeps one digest', () => {
+    h.caps = vfoCaps();
+    h.selectedFiniteAppearance = finiteAppearance;
+    renderHostedDesktop();
+
+    const grid = q('[data-testid="vfo-operation-instrument-grid"]')!;
+    expect([...grid.children].map((seat) => seat.getAttribute('data-field'))).toEqual([
+      'split', 'dualWatch', 'activeReceiver', 'equalize', 'swap', 'speak',
+    ]);
+    expect(q('[data-vfo-split]')).toBeNull();
+    expect(target.querySelectorAll('[data-testid="vfo-split-digest"]')).toHaveLength(1);
+    expect(q('[data-testid="external-Quick split"]')).toBeNull();
+    expect(q('[data-testid="external-Quick dual watch"]')).toBeNull();
+
+    q<HTMLButtonElement>('[data-testid="external-Split"]')!.click();
+    q<HTMLButtonElement>('[data-testid="external-Dual watch"]')!.click();
+    q<HTMLButtonElement>('[data-testid="external-Receiver-SUB"]')!.click();
+    q<HTMLButtonElement>('[data-testid="external-M=S"]')!.click();
+    q<HTMLButtonElement>('[data-testid="external-M↔S"]')!.click();
+    q<HTMLButtonElement>('[data-testid="external-SPEAK"]')!.click();
+    expect(h.split).toHaveBeenCalledOnce();
+    expect(h.dualWatch).toHaveBeenCalledExactlyOnceWith(true);
+    expect(h.subReceiver).toHaveBeenCalledOnce();
+    expect(h.equalize).toHaveBeenCalledOnce();
+    expect(h.swap).toHaveBeenCalledOnce();
+    expect(h.speak).toHaveBeenCalledOnce();
+    expect(h.quickSplit).not.toHaveBeenCalled();
+    expect(h.quickDualWatch).not.toHaveBeenCalled();
+  });
+
+  it('keeps unknown receiver unselected while admitted external MAIN and SUB establish identity', () => {
+    h.caps = vfoCaps();
+    const unknownActive = liveState(true);
+    delete unknownActive.fieldStatus?.active;
+    h.state = unknownActive;
+    h.selectedFiniteAppearance = finiteAppearance;
+    renderHostedDesktop();
+
+    const main = q<HTMLButtonElement>('[data-testid="external-Receiver-MAIN"]')!;
+    const sub = q<HTMLButtonElement>('[data-testid="external-Receiver-SUB"]')!;
+    expect(main.ariaChecked).toBe('false');
+    expect(sub.ariaChecked).toBe('false');
+    expect(main.disabled).toBe(false);
+    expect(sub.disabled).toBe(false);
+    main.click();
+    sub.click();
+    expect(h.mainReceiver).toHaveBeenCalledOnce();
+    expect(h.subReceiver).toHaveBeenCalledOnce();
+  });
+
+  it('retains asymmetric receiver reasons without disabling the offered MAIN option', () => {
+    h.caps = vfoCaps();
+    const degraded = liveState(true);
+    delete (degraded as Partial<ServerState>).sub;
+    h.state = degraded;
+    h.selectedFiniteAppearance = finiteAppearance;
+    renderHostedDesktop();
+
+    const main = q<HTMLButtonElement>('[data-testid="external-Receiver-MAIN"]')!;
+    const sub = q<HTMLButtonElement>('[data-testid="external-Receiver-SUB"]')!;
+    expect(main.disabled).toBe(false);
+    expect(main.title).toBe('');
+    expect(sub.disabled).toBe(true);
+    expect(sub.title.length).toBeGreaterThan(0);
+    expect(document.getElementById(sub.getAttribute('aria-describedby')!)?.textContent).toBe(sub.title);
+    main.click();
+    expect(h.mainReceiver).toHaveBeenCalledOnce();
+  });
+
+  it('does not rotate radio-wide authority when only selected receiver truth becomes unknown', () => {
+    h.caps = vfoCaps();
+    h.selectedFiniteAppearance = finiteAppearance;
+    renderHostedDesktop();
+    const receiver = q('[data-testid="external-Receiver"]');
+    const retained = retainedInvocations.get('Receiver')!;
+
+    const unknownActive = liveState(true);
+    delete unknownActive.fieldStatus?.active;
+    pushRadioState(unknownActive);
+    push({});
+
+    expect(q('[data-testid="external-Receiver"]')).toBe(receiver);
+    expect(retainedInvocations.get('Receiver')).toBe(retained);
+    expect(q<HTMLButtonElement>('[data-testid="external-Receiver-MAIN"]')!.ariaChecked).toBe('false');
+    expect(q<HTMLButtonElement>('[data-testid="external-Receiver-SUB"]')!.ariaChecked).toBe('false');
+    retained('SUB');
+    expect(h.subReceiver).toHaveBeenCalledOnce();
+  });
+
+  it('re-reads same-context admission and keeps unknown relative toggles inert', () => {
+    h.caps = vfoCaps();
+    h.selectedFiniteAppearance = finiteAppearance;
+    renderHostedDesktop();
+    const retained = retainedInvocations.get('Split')!;
+
+    const unknownSplit = liveState(true);
+    delete unknownSplit.fieldStatus?.split;
+    pushRadioState(unknownSplit);
+    push({});
+    expect(q<HTMLButtonElement>('[data-testid="external-Split"]')!.disabled).toBe(true);
+    h.split.mockClear();
+    retained();
+    expect(h.split).not.toHaveBeenCalled();
+
+    pushRadioState(liveState(true));
+    push({});
+    retained();
+    expect(h.split).toHaveBeenCalledOnce();
+  });
+
+  it('fails selected appearance closed at null authority without losing the digest', () => {
+    h.caps = vfoCaps();
+    h.selectedFiniteAppearance = finiteAppearance;
+    h.session = { state: 'disconnected', epoch: 7 };
+    renderHostedDesktop();
+
+    expect(q('[data-vfo-split]')).toBeNull();
+    expect(q('[data-testid="external-Split"]')).toBeNull();
+    expect(q('[data-testid="external-Receiver"]')).toBeNull();
+    expect(target.querySelectorAll('[data-testid="vfo-split-digest"]')).toHaveLength(1);
+  });
+
+  it('revokes every retained VFO renderer when the persistent host is destroyed', () => {
+    h.caps = vfoCaps();
+    h.selectedFiniteAppearance = finiteAppearance;
+    renderHostedDesktop();
+    const retained = ['Split', 'Dual watch', 'Receiver', 'M=S', 'M↔S', 'SPEAK']
+      .map((label) => retainedInvocations.get(label)!);
+    unmount(component!);
+    component = null;
+
+    retained[0]!();
+    retained[1]!();
+    retained[2]!('SUB');
+    for (const invoke of retained.slice(3)) invoke();
+    for (const spy of [
+      h.split, h.dualWatch, h.subReceiver, h.equalize, h.swap, h.speak,
+    ]) expect(spy).not.toHaveBeenCalled();
+  });
+});
+
 describe('selected finite TX auxiliary authority lifetime', () => {
   it('keeps one external Standard reason list after every scalar', () => {
     h.selectedFiniteAppearance = finiteAppearance;
@@ -446,24 +630,34 @@ describe('selected finite TX auxiliary authority lifetime', () => {
   });
 
   it('revokes retained A1 synchronously on A-B-A before flush and admits only fresh A3', () => {
+    h.caps = vfoCaps();
     h.selectedFiniteAppearance = finiteAppearance;
-    render();
+    renderHostedDesktop();
     const retainedA1 = retainedInvocations.get('VOX')!;
+    const retainedVfoA1 = retainedInvocations.get('Split')!;
 
     h.session = { state: 'connected', epoch: 8 };
     publishAuthority();
     h.session = { state: 'connected', epoch: 7 };
     publishAuthority();
     retainedA1();
+    retainedVfoA1();
     expect(h.voxToggle).not.toHaveBeenCalled();
+    expect(h.split).not.toHaveBeenCalled();
 
     flushSync();
     const retainedA3 = retainedInvocations.get('VOX')!;
+    const retainedVfoA3 = retainedInvocations.get('Split')!;
     expect(retainedA3).not.toBe(retainedA1);
+    expect(retainedVfoA3).not.toBe(retainedVfoA1);
     retainedA3();
+    retainedVfoA3();
     expect(h.voxToggle).toHaveBeenCalledOnce();
+    expect(h.split).toHaveBeenCalledOnce();
     retainedA1();
+    retainedVfoA1();
     expect(h.voxToggle).toHaveBeenCalledOnce();
+    expect(h.split).toHaveBeenCalledOnce();
   });
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/vfo-ops-command-bus.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/vfo-ops-command-bus.isolated.test.ts
@@ -73,7 +73,7 @@ const commandSource = readFileSync('src/lib/runtime/commands/panel-commands.ts',
   .replace(/\/\/.*$/gm, '');
 
 /**
- * The seven surface props and the exact frontend intent tuple each facade
+ * The nine surface props and the exact frontend intent tuple each facade
  * receives. Read as pairs so a cross-wiring fails on the command, not merely
  * on "something was called".
  */
@@ -141,7 +141,7 @@ describe('the wiring binds every VFO op to a handler the real command bus provid
     expect(command[0]).not.toMatch(/ptt|key|start_tx|stop_tx|tune/i);
   });
 
-  // R9. None of the seven may touch a key path: the transmitter is keyed only
+  // R9. None of the nine may touch a key path: the transmitter is keyed only
   // through the App TX controller, never from a VFO action.
   it('no VFO op emits a TX key/unkey command', () => {
     for (const { handler } of OPS) {

--- a/frontend/src/components-v2/wiring/__tests__/vfo-ops-command-bus.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/vfo-ops-command-bus.isolated.test.ts
@@ -1,8 +1,8 @@
 /**
- * MOR-2309 — the seven DUAL intents bind once to the real frontend facades.
+ * MOR-2309 — the nine radio-wide intents bind once to the real frontend facades.
  *
- * `SemanticRadioSurfaces` binds all seven `VfoSurface` props by name
- * (`onEqualizeVfos={vfo.onEqual}`, …). Its own component test mocks
+ * `SemanticRadioSurfaces` binds one canonical N1 callback record and supplies
+ * that input to both legitimate radio-wide `VfoSurface` mounts. Its component test mocks
  * `../command-bus`, so a renamed or deleted handler there would be invisible:
  * the mock would keep answering. This file closes that gap the same way
  * `tx-aux-command-bus.isolated.test.ts` does — load the real module, read the
@@ -78,13 +78,15 @@ const commandSource = readFileSync('src/lib/runtime/commands/panel-commands.ts',
  * on "something was called".
  */
 const OPS = [
-  { prop: 'onSelectMainReceiver', owner: 'vfo', handler: 'onMainVfoClick', command: ['set_vfo', { vfo: 'MAIN' }], focus: 'main' },
-  { prop: 'onSelectSubReceiver', owner: 'vfo', handler: 'onSubVfoClick', command: ['set_vfo', { vfo: 'SUB' }], focus: 'sub' },
-  { prop: 'onEqualizeVfos', owner: 'vfo', handler: 'onEqual', command: ['vfo_equalize', {}] },
-  { prop: 'onSwapVfos', owner: 'vfo', handler: 'onSwap', command: ['vfo_swap', {}] },
-  { prop: 'onQuickSplit', owner: 'vfo', handler: 'onQuickSplit', command: ['quick_split', {}] },
-  { prop: 'onQuickDualWatch', owner: 'vfo', handler: 'onQuickDw', command: ['quick_dualwatch', {}] },
-  { prop: 'onSpeak', owner: 'systemIntents', handler: 'onSpeak', command: ['speak', { mode: 0 }] },
+  { prop: 'onToggleSplit', binding: 'vfo.onSplitToggle', handler: 'onSplitToggle', command: ['set_split', { on: true }] },
+  { prop: 'onToggleDualWatch', binding: 'toggleDualWatch', handler: 'onDualWatchToggle', command: ['set_dual_watch', { on: true }] },
+  { prop: 'onSelectMainReceiver', binding: 'vfo.onMainVfoClick', handler: 'onMainVfoClick', command: ['set_vfo', { vfo: 'MAIN' }], focus: 'main' },
+  { prop: 'onSelectSubReceiver', binding: 'vfo.onSubVfoClick', handler: 'onSubVfoClick', command: ['set_vfo', { vfo: 'SUB' }], focus: 'sub' },
+  { prop: 'onEqualizeVfos', binding: 'vfo.onEqual', handler: 'onEqual', command: ['vfo_equalize', {}] },
+  { prop: 'onSwapVfos', binding: 'vfo.onSwap', handler: 'onSwap', command: ['vfo_swap', {}] },
+  { prop: 'onQuickSplit', binding: 'vfo.onQuickSplit', handler: 'onQuickSplit', command: ['quick_split', {}] },
+  { prop: 'onQuickDualWatch', binding: 'vfo.onQuickDw', handler: 'onQuickDw', command: ['quick_dualwatch', {}] },
+  { prop: 'onSpeak', binding: 'systemIntents.onSpeak', handler: 'onSpeak', command: ['speak', { mode: 0 }] },
 ] as const;
 
 type OpHandlerName = (typeof OPS)[number]['handler'];
@@ -92,6 +94,8 @@ type OpHandlerName = (typeof OPS)[number]['handler'];
 function handlerFor(handler: OpHandlerName): () => void {
   const vfo = makeVfoHandlers();
   switch (handler) {
+    case 'onSplitToggle': return vfo.onSplitToggle;
+    case 'onDualWatchToggle': return () => vfo.onDualWatchToggle(true);
     case 'onMainVfoClick': return vfo.onMainVfoClick;
     case 'onSubVfoClick': return vfo.onSubVfoClick;
     case 'onEqual': return vfo.onEqual;
@@ -111,16 +115,15 @@ beforeEach(() => {
 });
 
 describe('the wiring binds every VFO op to a handler the real command bus provides', () => {
-  // Kills: a prop bound to `vfo.onQuickDW` (or any other typo) — Svelte would
-  // pass `undefined` silently and the button would do nothing at runtime.
-  it.each(OPS)('$prop is bound to $owner.$handler in the real wiring source', ({ prop, owner, handler }) => {
-    expect(wiringSource).toContain(`${prop}={${owner}.${handler}}`);
+  // Kills: a callback duplicated or bound to a neighbouring facade.
+  it.each(OPS)('$prop has exactly one canonical $binding binding', ({ prop, binding }) => {
+    expect(wiringSource.split(`${prop}: ${binding}`).length - 1).toBe(1);
   });
 
   // Kills: a rename/removal in command-bus.ts that the mocked component test
   // cannot see.
-  it.each(OPS)('$owner.$handler exists and is callable', ({ owner, handler }) => {
-    expect(typeof handlerFor(handler), owner).toBe('function');
+  it.each(OPS)('$handler exists and is callable', ({ handler }) => {
+    expect(typeof handlerFor(handler)).toBe('function');
   });
 
   // Kills: cross-wiring. Each handler must emit ITS command and no other —
@@ -161,9 +164,8 @@ describe('placement — the ops ride with the radio-wide facts', () => {
   // render one equalize button PER RECEIVER in the dual-receiver cockpit. The
   // strip mount is the one that sets `showRadioWideFacts={false}`; the two
   // legitimate mounts are the cockpit's global row and the single composition.
-  it.each(OPS)('$prop is bound exactly twice — the global row and the single composition', ({ prop }) => {
-    const occurrences = wiringSource.split(`${prop}={`).length - 1;
-    expect(occurrences).toBe(2);
+  it('passes the one N1 input to exactly the global row and single composition', () => {
+    expect(wiringSource.split('operationInput={vfoOperationInput ?? undefined}').length - 1).toBe(2);
   });
 
   // The strip mount stays op-free — asserted on the strip's own markup block
@@ -173,6 +175,6 @@ describe('placement — the ops ride with the radio-wide facts', () => {
       wiringSource.indexOf('showRadioWideFacts={false}') - 400,
       wiringSource.indexOf('showRadioWideFacts={false}') + 400,
     );
-    for (const { prop } of OPS) expect(stripBlock, prop).not.toContain(prop);
+    expect(stripBlock).not.toContain('operationInput=');
   });
 });

--- a/frontend/src/components-v2/wiring/instrument-composition.ts
+++ b/frontend/src/components-v2/wiring/instrument-composition.ts
@@ -6,11 +6,17 @@ import type { ReceiverInstrumentHandles } from '../../semantic/ReceiverInstrumen
 import type { RxAudioInstrumentHandles } from '../../semantic/rx-audio-instruments';
 import type { RfFrontEndLevelHandles } from '../../semantic/rf-front-end-instruments';
 import type { DspFiniteLayout } from '../../semantic/dsp-instruments';
+import type { VfoOperationHandles } from '../../semantic/VfoOperationSeatHost.svelte';
 
 export type InstrumentVfoAppearance = 'semantic' | 'sdr' | 'standard';
 
 export interface InstrumentComposition {
-  readonly vfo: Snippet<[appearance: InstrumentVfoAppearance, allowBare?: boolean]>;
+  readonly vfo: Snippet<[
+    appearance: InstrumentVfoAppearance,
+    allowBare?: boolean,
+    operationControls?: Snippet,
+  ]>;
+  readonly vfoOperations: VfoOperationHandles;
   readonly rxTx: Snippet<[allowBare?: boolean]>;
   readonly txAuxControls: Snippet<[scalarLayout: Snippet, allowBare?: boolean]>;
   readonly txAuxScalars: TxAuxScalarHandles;

--- a/frontend/src/semantic/VfoOperationGroup.svelte
+++ b/frontend/src/semantic/VfoOperationGroup.svelte
@@ -1,4 +1,5 @@
 <script module lang="ts">
+  import type { Snippet } from 'svelte';
   import type {
     BooleanFact,
     RadioViewModel,
@@ -14,6 +15,7 @@
     projection: VfoOperationProjection;
     digest?: { rx: string; tx: string; splitState: 'true' | 'false' | 'mixed' };
     onIntent: (intent: VfoOperationIntent) => void;
+    controls?: Snippet;
   }
 
   let sequence = 0;
@@ -31,6 +33,7 @@
     projection,
     digest,
     onIntent,
+    controls,
   }: Props = $props();
 
   const reasonIdPrefix = `vfo-operation-reason-${++sequence}`;
@@ -68,6 +71,9 @@
   }
 </script>
 
+  {#if controls}
+    {@render controls()}
+  {:else}
   <div class="fact-toggles" data-vfo-operation-appearance={appearance}>
     {#if projection.split.availability.structural}
       {@const splitReasonId = reasonId('split', projection.split.availability.reason)}
@@ -179,6 +185,7 @@
         {#if id}<span {id} class="sr-only">{projection.speak.availability.reason}</span>{/if}
       {/if}
     </div>
+  {/if}
   {/if}
 
   {#if digest}

--- a/frontend/src/semantic/VfoOperationSeatHost.svelte
+++ b/frontend/src/semantic/VfoOperationSeatHost.svelte
@@ -1,0 +1,191 @@
+<script module lang="ts">
+  import type { Snippet } from 'svelte';
+  import type {
+    FiniteControlAppearance, FiniteRendererContext,
+  } from '../primitives/control-instruments/control-instrument-renderer.svelte';
+  import type { RadioViewModel } from './radio-view-model';
+  import type {
+    VfoOperationProjectionInput, VfoOperationReceiver,
+  } from './vfo-operation-projection';
+
+  export type VfoOperationHandle = Snippet<[]>;
+
+  export type VfoOperationHandles = Readonly<{
+    split: VfoOperationHandle | null;
+    dualWatch: VfoOperationHandle | null;
+    activeReceiver: VfoOperationHandle | null;
+    equalize: VfoOperationHandle | null;
+    swap: VfoOperationHandle | null;
+    quickSplit: VfoOperationHandle | null;
+    quickDualWatch: VfoOperationHandle | null;
+    speak: VfoOperationHandle | null;
+  }>;
+
+  interface Props {
+    input: VfoOperationProjectionInput;
+    finiteAppearance: FiniteControlAppearance<VfoOperationReceiver>;
+    rendererContext: FiniteRendererContext | null;
+    scheme: RadioViewModel['vfoScheme'];
+    children: Snippet<[VfoOperationHandles]>;
+  }
+</script>
+
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { t } from '$lib/i18n';
+  import { vfoEqualLabel, vfoSwapLabel } from '../components-v2/vfo/vfo-ops-utils';
+  import ControlInstrumentRendererHost from '../primitives/control-instruments/ControlInstrumentRendererHost.svelte';
+  import {
+    createAbsoluteChoiceRendererSeat, createActionRendererSeat, createToggleRendererSeat,
+    type AbsoluteChoiceRendererInput, type AvailabilityActionRendererInput,
+    type ToggleRendererInput,
+  } from '../primitives/control-instruments/control-instrument-renderer.svelte';
+  import {
+    invokeVfoOperation, projectVfoOperations, type VfoActionOperation,
+    type VfoOperationIntent, type VfoOperationProjection, type VfoToggleOperation,
+  } from './vfo-operation-projection';
+
+  let { input, finiteAppearance, rendererContext, scheme, children }: Props = $props();
+
+  const projection = (): VfoOperationProjection => projectVfoOperations(input);
+  const invoke = (intent: VfoOperationIntent): void => invokeVfoOperation(() => input, intent);
+
+  function toggleInput(
+    operation: VfoToggleOperation,
+    label: string,
+    intent: VfoOperationIntent,
+  ): ToggleRendererInput {
+    return {
+      context: rendererContext,
+      field: { availability: operation.availability, reading: operation.reading },
+      label,
+      title: operation.availability.reason,
+      invoke: () => invoke(intent),
+    };
+  }
+
+  function actionInput(
+    operation: VfoActionOperation,
+    label: string,
+    intent: VfoOperationIntent,
+  ): AvailabilityActionRendererInput {
+    return {
+      context: rendererContext,
+      availability: operation.availability,
+      label,
+      title: operation.availability.reason,
+      invoke: () => invoke(intent),
+    };
+  }
+
+  function receiverInput(): AbsoluteChoiceRendererInput<VfoOperationReceiver> {
+    const operation = projection().activeReceiver;
+    return {
+      context: rendererContext,
+      reading: operation.reading.status === 'known'
+        ? { status: 'known', value: operation.reading.receiver }
+        : { status: 'unknown' },
+      available: operation.availability.operational,
+      label: 'Receiver',
+      accessibleLabel: 'Active receiver',
+      options: operation.options
+        .filter((option) => option.availability.structural)
+        .map((option) => ({
+          value: option.value,
+          label: option.value,
+          disabled: !option.availability.operational,
+          ...(option.availability.reason === undefined
+            ? {} : { disabledReason: option.availability.reason }),
+        })),
+      invoke: (receiver) => invoke({ kind: 'select-receiver', receiver }),
+    };
+  }
+
+  const splitSeat = createToggleRendererSeat(() => toggleInput(
+    projection().split, t('core.vfo.split.label'), { kind: 'toggle-split' },
+  ));
+  const dualWatchSeat = createToggleRendererSeat(() => toggleInput(
+    projection().dualWatch, t('core.vfo.dualWatch.label'), { kind: 'toggle-dual-watch' },
+  ));
+  const receiverSeat = createAbsoluteChoiceRendererSeat(receiverInput);
+  const equalizeSeat = createActionRendererSeat(() => actionInput(
+    projection().equalize, vfoEqualLabel(scheme), { kind: 'equalize' },
+  ));
+  const swapSeat = createActionRendererSeat(() => actionInput(
+    projection().swap, vfoSwapLabel(scheme), { kind: 'swap' },
+  ));
+  const quickSplitSeat = createActionRendererSeat(() => actionInput(
+    projection().quickSplit, t('core.vfo.ops.quickSplit'), { kind: 'quick-split' },
+  ));
+  const quickDualWatchSeat = createActionRendererSeat(() => actionInput(
+    projection().quickDualWatch, t('core.vfo.ops.quickDualWatch'), { kind: 'quick-dual-watch' },
+  ));
+  const speakSeat = createActionRendererSeat(() => actionInput(
+    projection().speak, 'SPEAK', { kind: 'speak' },
+  ));
+
+  const seats = [
+    splitSeat, dualWatchSeat, receiverSeat, equalizeSeat, swapSeat,
+    quickSplitSeat, quickDualWatchSeat, speakSeat,
+  ] as const;
+  onDestroy(() => {
+    for (const seat of seats) seat.destroy();
+  });
+
+  function handles(): VfoOperationHandles {
+    const current = projection();
+    return {
+      split: current.split.availability.structural ? split : null,
+      dualWatch: current.dualWatch.availability.structural ? dualWatch : null,
+      activeReceiver: current.activeReceiver.availability.structural ? activeReceiver : null,
+      equalize: current.equalize.availability.structural ? equalize : null,
+      swap: current.swap.availability.structural ? swap : null,
+      quickSplit: current.quickSplit.availability.structural ? quickSplit : null,
+      quickDualWatch: current.quickDualWatch.availability.structural ? quickDualWatch : null,
+      speak: current.speak.availability.structural ? speak : null,
+    };
+  }
+</script>
+
+{#snippet split()}
+  {#key rendererContext}{#key finiteAppearance.toggle}<ControlInstrumentRendererHost
+    seat={splitSeat} renderer={finiteAppearance.toggle}
+  />{/key}{/key}
+{/snippet}
+{#snippet dualWatch()}
+  {#key rendererContext}{#key finiteAppearance.toggle}<ControlInstrumentRendererHost
+    seat={dualWatchSeat} renderer={finiteAppearance.toggle}
+  />{/key}{/key}
+{/snippet}
+{#snippet activeReceiver()}
+  {#key rendererContext}{#key finiteAppearance.choice}<ControlInstrumentRendererHost
+    seat={receiverSeat} renderer={finiteAppearance.choice}
+  />{/key}{/key}
+{/snippet}
+{#snippet equalize()}
+  {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
+    seat={equalizeSeat} renderer={finiteAppearance.action}
+  />{/key}{/key}
+{/snippet}
+{#snippet swap()}
+  {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
+    seat={swapSeat} renderer={finiteAppearance.action}
+  />{/key}{/key}
+{/snippet}
+{#snippet quickSplit()}
+  {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
+    seat={quickSplitSeat} renderer={finiteAppearance.action}
+  />{/key}{/key}
+{/snippet}
+{#snippet quickDualWatch()}
+  {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
+    seat={quickDualWatchSeat} renderer={finiteAppearance.action}
+  />{/key}{/key}
+{/snippet}
+{#snippet speak()}
+  {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
+    seat={speakSeat} renderer={finiteAppearance.action}
+  />{/key}{/key}
+{/snippet}
+
+{@render children(handles())}

--- a/frontend/src/semantic/VfoOperationSeatHost.svelte
+++ b/frontend/src/semantic/VfoOperationSeatHost.svelte
@@ -23,7 +23,7 @@
 
   interface Props {
     input: VfoOperationProjectionInput;
-    finiteAppearance: FiniteControlAppearance<VfoOperationReceiver>;
+    finiteAppearance: FiniteControlAppearance<string | number>;
     rendererContext: FiniteRendererContext | null;
     scheme: RadioViewModel['vfoScheme'];
     children: Snippet<[VfoOperationHandles]>;

--- a/frontend/src/semantic/VfoOperationSeatHost.svelte
+++ b/frontend/src/semantic/VfoOperationSeatHost.svelte
@@ -21,13 +21,18 @@
     speak: VfoOperationHandle | null;
   }>;
 
-  interface Props {
-    input: VfoOperationProjectionInput;
-    finiteAppearance: FiniteControlAppearance<string | number>;
-    rendererContext: FiniteRendererContext | null;
-    scheme: RadioViewModel['vfoScheme'];
+  interface ExistingProps {
+    input: VfoOperationProjectionInput | null;
+    scheme: RadioViewModel['vfoScheme'] | null;
     children: Snippet<[VfoOperationHandles]>;
   }
+  type RendererSelection =
+    | { finiteAppearance?: undefined; rendererContext?: undefined }
+    | {
+        finiteAppearance: FiniteControlAppearance<string | number>;
+        rendererContext: FiniteRendererContext | null;
+      };
+  type Props = ExistingProps & RendererSelection;
 </script>
 
 <script lang="ts">
@@ -47,48 +52,54 @@
 
   let { input, finiteAppearance, rendererContext, scheme, children }: Props = $props();
 
-  const projection = (): VfoOperationProjection => projectVfoOperations(input);
-  const invoke = (intent: VfoOperationIntent): void => invokeVfoOperation(() => input, intent);
+  const projection = (): VfoOperationProjection | null =>
+    input === null ? null : projectVfoOperations(input);
+  const invoke = (intent: VfoOperationIntent): void => {
+    const current = input;
+    if (current !== null) invokeVfoOperation(() => current, intent);
+  };
 
   function toggleInput(
-    operation: VfoToggleOperation,
+    operation: VfoToggleOperation | undefined,
     label: string,
     intent: VfoOperationIntent,
   ): ToggleRendererInput {
     return {
-      context: rendererContext,
-      field: { availability: operation.availability, reading: operation.reading },
+      context: rendererContext ?? null,
+      field: operation === undefined
+        ? undefined
+        : { availability: operation.availability, reading: operation.reading },
       label,
-      title: operation.availability.reason,
+      title: operation?.availability.reason,
       invoke: () => invoke(intent),
     };
   }
 
   function actionInput(
-    operation: VfoActionOperation,
+    operation: VfoActionOperation | undefined,
     label: string,
     intent: VfoOperationIntent,
   ): AvailabilityActionRendererInput {
     return {
-      context: rendererContext,
-      availability: operation.availability,
+      context: rendererContext ?? null,
+      availability: operation?.availability,
       label,
-      title: operation.availability.reason,
+      title: operation?.availability.reason,
       invoke: () => invoke(intent),
     };
   }
 
   function receiverInput(): AbsoluteChoiceRendererInput<VfoOperationReceiver> {
-    const operation = projection().activeReceiver;
+    const operation = projection()?.activeReceiver;
     return {
-      context: rendererContext,
-      reading: operation.reading.status === 'known'
+      context: rendererContext ?? null,
+      reading: operation?.reading.status === 'known'
         ? { status: 'known', value: operation.reading.receiver }
         : { status: 'unknown' },
-      available: operation.availability.operational,
+      available: operation?.availability.operational ?? false,
       label: 'Receiver',
       accessibleLabel: 'Active receiver',
-      options: operation.options
+      options: (operation?.options ?? [])
         .filter((option) => option.availability.structural)
         .map((option) => ({
           value: option.value,
@@ -102,26 +113,30 @@
   }
 
   const splitSeat = createToggleRendererSeat(() => toggleInput(
-    projection().split, t('core.vfo.split.label'), { kind: 'toggle-split' },
+    projection()?.split, t('core.vfo.split.label'), { kind: 'toggle-split' },
   ));
   const dualWatchSeat = createToggleRendererSeat(() => toggleInput(
-    projection().dualWatch, t('core.vfo.dualWatch.label'), { kind: 'toggle-dual-watch' },
+    projection()?.dualWatch, t('core.vfo.dualWatch.label'), { kind: 'toggle-dual-watch' },
   ));
   const receiverSeat = createAbsoluteChoiceRendererSeat(receiverInput);
   const equalizeSeat = createActionRendererSeat(() => actionInput(
-    projection().equalize, vfoEqualLabel(scheme), { kind: 'equalize' },
+    projection()?.equalize,
+    scheme === null ? t('core.vfo.ops.equalize') : vfoEqualLabel(scheme),
+    { kind: 'equalize' },
   ));
   const swapSeat = createActionRendererSeat(() => actionInput(
-    projection().swap, vfoSwapLabel(scheme), { kind: 'swap' },
+    projection()?.swap,
+    scheme === null ? t('core.vfo.ops.swap') : vfoSwapLabel(scheme),
+    { kind: 'swap' },
   ));
   const quickSplitSeat = createActionRendererSeat(() => actionInput(
-    projection().quickSplit, t('core.vfo.ops.quickSplit'), { kind: 'quick-split' },
+    projection()?.quickSplit, t('core.vfo.ops.quickSplit'), { kind: 'quick-split' },
   ));
   const quickDualWatchSeat = createActionRendererSeat(() => actionInput(
-    projection().quickDualWatch, t('core.vfo.ops.quickDualWatch'), { kind: 'quick-dual-watch' },
+    projection()?.quickDualWatch, t('core.vfo.ops.quickDualWatch'), { kind: 'quick-dual-watch' },
   ));
   const speakSeat = createActionRendererSeat(() => actionInput(
-    projection().speak, 'SPEAK', { kind: 'speak' },
+    projection()?.speak, 'SPEAK', { kind: 'speak' },
   ));
 
   const seats = [
@@ -134,6 +149,12 @@
 
   function handles(): VfoOperationHandles {
     const current = projection();
+    if (current === null || finiteAppearance === undefined) {
+      return {
+        split: null, dualWatch: null, activeReceiver: null, equalize: null,
+        swap: null, quickSplit: null, quickDualWatch: null, speak: null,
+      };
+    }
     return {
       split: current.split.availability.structural ? split : null,
       dualWatch: current.dualWatch.availability.structural ? dualWatch : null,
@@ -148,44 +169,44 @@
 </script>
 
 {#snippet split()}
-  {#key rendererContext}{#key finiteAppearance.toggle}<ControlInstrumentRendererHost
+  {#if finiteAppearance}{#key rendererContext}{#key finiteAppearance.toggle}<ControlInstrumentRendererHost
     seat={splitSeat} renderer={finiteAppearance.toggle}
-  />{/key}{/key}
+  />{/key}{/key}{/if}
 {/snippet}
 {#snippet dualWatch()}
-  {#key rendererContext}{#key finiteAppearance.toggle}<ControlInstrumentRendererHost
+  {#if finiteAppearance}{#key rendererContext}{#key finiteAppearance.toggle}<ControlInstrumentRendererHost
     seat={dualWatchSeat} renderer={finiteAppearance.toggle}
-  />{/key}{/key}
+  />{/key}{/key}{/if}
 {/snippet}
 {#snippet activeReceiver()}
-  {#key rendererContext}{#key finiteAppearance.choice}<ControlInstrumentRendererHost
+  {#if finiteAppearance}{#key rendererContext}{#key finiteAppearance.choice}<ControlInstrumentRendererHost
     seat={receiverSeat} renderer={finiteAppearance.choice}
-  />{/key}{/key}
+  />{/key}{/key}{/if}
 {/snippet}
 {#snippet equalize()}
-  {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
+  {#if finiteAppearance}{#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
     seat={equalizeSeat} renderer={finiteAppearance.action}
-  />{/key}{/key}
+  />{/key}{/key}{/if}
 {/snippet}
 {#snippet swap()}
-  {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
+  {#if finiteAppearance}{#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
     seat={swapSeat} renderer={finiteAppearance.action}
-  />{/key}{/key}
+  />{/key}{/key}{/if}
 {/snippet}
 {#snippet quickSplit()}
-  {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
+  {#if finiteAppearance}{#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
     seat={quickSplitSeat} renderer={finiteAppearance.action}
-  />{/key}{/key}
+  />{/key}{/key}{/if}
 {/snippet}
 {#snippet quickDualWatch()}
-  {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
+  {#if finiteAppearance}{#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
     seat={quickDualWatchSeat} renderer={finiteAppearance.action}
-  />{/key}{/key}
+  />{/key}{/key}{/if}
 {/snippet}
 {#snippet speak()}
-  {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
+  {#if finiteAppearance}{#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
     seat={speakSeat} renderer={finiteAppearance.action}
-  />{/key}{/key}
+  />{/key}{/key}{/if}
 {/snippet}
 
 {@render children(handles())}

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -36,6 +36,7 @@
 </script>
 
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { t } from '$lib/i18n';
   import FrequencyDisplayInteractive from '../primitives/frequency/FrequencyDisplayInteractive.svelte';
   import LinearSMeter from '../components-v2/meters/LinearSMeter.svelte';
@@ -174,6 +175,8 @@
     onSelectMainReceiver?: () => void;
     onSelectSubReceiver?: () => void;
     onSpeak?: () => void;
+    operationInput?: VfoOperationProjectionInput;
+    operationControls?: Snippet;
   }
 
   let {
@@ -200,6 +203,8 @@
     onSelectMainReceiver,
     onSelectSubReceiver,
     onSpeak,
+    operationInput,
+    operationControls,
   }: Props = $props();
 
   /**
@@ -255,7 +260,7 @@
     return relativeIdentityUnknown ? t('core.vfo.ops.identityUnknownReason') : undefined;
   }
 
-  function vfoOperationInput(): VfoOperationProjectionInput {
+  function localVfoOperationInput(): VfoOperationProjectionInput {
     return {
       hasVfoPair,
       hasDualReceiver,
@@ -284,7 +289,9 @@
     };
   }
 
-  let vfoOperations = $derived(projectVfoOperations(vfoOperationInput()));
+  const currentVfoOperationInput = (): VfoOperationProjectionInput =>
+    operationInput ?? localVfoOperationInput();
+  let vfoOperations = $derived(projectVfoOperations(currentVfoOperationInput()));
 
   function slotKey(slot: VfoSlot): string {
     if (slot.kind === 'slotted') return slot.id;
@@ -390,7 +397,7 @@
   }
 
   function handleOperationIntent(intent: VfoOperationIntent): void {
-    invokeVfoOperation(vfoOperationInput, intent);
+    invokeVfoOperation(currentVfoOperationInput, intent);
   }
 
   /**
@@ -677,6 +684,7 @@
       {appearance}
       scheme={viewModel.vfoScheme}
       projection={vfoOperations}
+      controls={operationControls}
       digest={hasVfoPair ? {
         rx: formatFrequency(rxFrequencyHz),
         tx: formatFrequency(txFrequencyHz),


### PR DESCRIPTION
## Summary

- map the accepted N1 VFO operation projection onto eight nullable zero-argument finite instrument handles
- keep one canonical current N1 input for the native radio-wide surfaces and the persistent external host
- make the shipped Standard layout the first live named-handle consumer while preserving the native fallback and the existing sole RX/TX digest
- rotate VFO renderer authority inside the existing finite subscription, excluding active-receiver truth from identity

## Mechanics audit

The final design was run through the full mechanics-audit method before implementation. The audit rejected a standalone unused host and selected this complete live nine-file cut. It reuses the existing finite seat/context/lease mechanism and the accepted N1 projector/invoker; it adds no callback policy, manager, subscription, PTT/TUNE path, raw fact, or public SDK surface.

The first candidate exposed a rejected conditional-parent lifecycle: temporary `view -> null -> view` destroyed and recreated the accepted DSP/TX host subtree. The successor keeps `VfoOperationSeatHost` as the constant parent, makes only its input and renderer selection nullable, and fails closed with empty VFO handles. A permanent real hosted witness now proves the layout node and all neighboring authority subscription leases retain identity, stale VOX invocation is revoked while null, and fresh invocation recovers after restoration.

Unknown split and dual-watch remain structurally mounted but inert. Unknown active receiver selects neither option; an explicitly offered operational MAIN or SUB remains actionable and may establish identity through the existing absolute-choice seat.

## Scope

- exact accepted base: `e40bf1ed4b4e86f4eda6f4b237273cc8ec700f5e`
- exact successor head: `d2d6107e01bf00e6191810fbbb5641c8dd06c637`
- 9 paths, 618 additions + 54 deletions = 672 A+D
- no public component-kit API or Instrument Line change

## Verification

- lifecycle RED reproduced on the first candidate; permanent successor witness passes
- focused Vitest: 6 files, 347 tests passed on the successor
- `npm run check`: 0 errors, 0 warnings
- scoped ESLint: passed
- production frontend build: passed
- `git diff --check`: passed
- real hosted Standard witnesses cover named placement, native fallback, one digest, null authority, current-input admission, unknown active receiver, asymmetric option reasons, A-B-A revocation, host teardown, and null-view topology persistence
- command-bus witness covers all 9 exact intents and rejects TX key/unkey paths

## Published gates

- first exact head `424da1af0a5cc795137152bdf3eac345b222a3f6`: independent BLOCKED after reproducing the conditional-parent lifecycle defect
- successor exact head `d2d6107e01bf00e6191810fbbb5641c8dd06c637`: independent PASS ([comment](https://github.com/rigplane/rigplane-core/pull/3327#issuecomment-5565568472))
- canonical Agent Review Gate: PASS on the successor
- visual run `34087290646`: SUCCESS
- natural quick run `34087290653`, attempt 1: FAILED only in the unchanged BarGauge passive-frame test after 11,073 other tests passed; the exact failing test then passed alone locally (1/1)
- same exact-head failed-job retry, attempt 2: SUCCESS in 4m06s

No merge performed.

Linear: MOR-2425
