### PR TITLE
test(MOR-2425): isolate BarGauge hosted frame checks

### DIFF
--- a/frontend/src/components-v2/meters/__tests__/BarGauge.isolated.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/BarGauge.isolated.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import BarGauge from '../BarGauge.svelte';
+import type { BarMeterFrame } from '../bar-meter-motion.svelte';
+
+describe('BarGauge hosted frame input', () => {
+  it('renders a passive frame and delegates reset without creating schedules', () => {
+    const requestFrame = vi.spyOn(window, 'requestAnimationFrame');
+    const setInterval = vi.spyOn(window, 'setInterval');
+    const onResetPeak = vi.fn();
+    const frame: BarMeterFrame = { smoothedFraction: 0.45, peakFraction: 0.8 };
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    const component = mount(BarGauge, {
+      target,
+      props: { frame, label: 'Po', displayValue: '45W', onResetPeak },
+    });
+    flushSync();
+    try {
+      expect(target.querySelectorAll('[data-gauge-fill]')).toHaveLength(5);
+      expect(target.querySelector('[data-testid="bar-gauge-peak-marker"]')?.getAttribute('x'))
+        .toBe('211');
+      expect(requestFrame).not.toHaveBeenCalled();
+      expect(setInterval).not.toHaveBeenCalled();
+
+      target.querySelector('svg')!.dispatchEvent(new Event('dblclick', { bubbles: true }));
+      expect(onResetPeak).toHaveBeenCalledOnce();
+    } finally {
+      unmount(component);
+      target.remove();
+      requestFrame.mockRestore();
+      setInterval.mockRestore();
+    }
+  });
+
+  it('rejects mixed live-value and hosted-frame ownership', () => {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    let component: ReturnType<typeof mount> | undefined;
+    const frame: BarMeterFrame = { smoothedFraction: 0.4, peakFraction: null };
+    try {
+      expect(() => {
+        component = mount(BarGauge as never, {
+          target,
+          props: { value: 0.4, frame, label: 'Po', displayValue: '40W' },
+        });
+        flushSync();
+      }).toThrowError('BarGauge requires exactly one of frame or value');
+    } finally {
+      if (component !== undefined) unmount(component);
+      target.remove();
+    }
+  });
+});

--- a/frontend/src/components-v2/meters/__tests__/BarGauge.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/BarGauge.test.ts
@@ -1,7 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
-import { flushSync, mount, unmount } from 'svelte';
-import BarGauge from '../BarGauge.svelte';
-import type { BarMeterFrame } from '../bar-meter-motion.svelte';
+import { describe, it, expect } from 'vitest';
 import {
   DEFAULT_ZONES,
   valueToSegments,
@@ -221,55 +218,5 @@ describe('valueFontSize', () => {
     const base = valueFontSize('35W', 9);
     const stepped = valueFontSize('a much longer value', 9);
     expect(stepped).toBeLessThan(base);
-  });
-});
-
-describe('BarGauge hosted frame input', () => {
-  it('renders a passive frame and delegates reset without creating schedules', () => {
-    const requestFrame = vi.spyOn(window, 'requestAnimationFrame');
-    const setInterval = vi.spyOn(window, 'setInterval');
-    const onResetPeak = vi.fn();
-    const frame: BarMeterFrame = { smoothedFraction: 0.45, peakFraction: 0.8 };
-    const target = document.createElement('div');
-    document.body.appendChild(target);
-    const component = mount(BarGauge, {
-      target,
-      props: { frame, label: 'Po', displayValue: '45W', onResetPeak },
-    });
-    flushSync();
-    try {
-      expect(target.querySelectorAll('[data-gauge-fill]')).toHaveLength(5);
-      expect(target.querySelector('[data-testid="bar-gauge-peak-marker"]')?.getAttribute('x'))
-        .toBe('211');
-      expect(requestFrame).not.toHaveBeenCalled();
-      expect(setInterval).not.toHaveBeenCalled();
-
-      target.querySelector('svg')!.dispatchEvent(new Event('dblclick', { bubbles: true }));
-      expect(onResetPeak).toHaveBeenCalledOnce();
-    } finally {
-      unmount(component);
-      target.remove();
-      requestFrame.mockRestore();
-      setInterval.mockRestore();
-    }
-  });
-
-  it('rejects mixed live-value and hosted-frame ownership', () => {
-    const target = document.createElement('div');
-    document.body.appendChild(target);
-    let component: ReturnType<typeof mount> | undefined;
-    const frame: BarMeterFrame = { smoothedFraction: 0.4, peakFraction: null };
-    try {
-      expect(() => {
-        component = mount(BarGauge as never, {
-          target,
-          props: { value: 0.4, frame, label: 'Po', displayValue: '40W' },
-        });
-        flushSync();
-      }).toThrowError('BarGauge requires exactly one of frame or value');
-    } finally {
-      if (component !== undefined) unmount(component);
-      target.remove();
-    }
   });
 });


### PR DESCRIPTION
## Summary

- move the two mounted BarGauge hosted-frame ownership tests into the existing isolated Vitest project by filename
- retain the 33 pure gauge utility tests in the fast project
- preserve the zero-requestAnimationFrame and zero-setInterval assertions unchanged

## Root cause

Natural quick on N2 and the aggregate main quick failed the same hosted-frame assertion with 4 and 28 foreign rAF calls. The two heads diverge after e40bf1ed and neither range changes meter/scheduler/config code. The test added by PR #3322 mounts Svelte and installs global scheduler spies but remained in the shared fast/isolate:false project, contrary to the MOR-1272 routing rule already recorded in vite.config.ts. The production hosted-frame path was audited and creates no local motion owner. The exact foreign loop producer remains unresolved unless the isolated successor fails; this correction closes the demonstrated isolation-contract violation without overclaiming which unrelated test supplied the leaked callbacks.

## Scope

- accepted base: 5018d44506504c9c423827dff00185607f2e765d
- exact candidate: 6fbb779f9efe4b02dec75e44d44745e088bfaf8c
- 2 test paths, 55 additions + 54 deletions = 109 A+D
- no production, test-runner configuration, or N2 change

## Verification

- focused routing proof: BarGauge.test.ts 33/33 in fast; BarGauge.isolated.test.ts 2/2 in isolated
- combined with BarGauge.peakhold.svelte.test.ts: 52/52
- npm run check: 0 errors, 0 warnings
- scoped ESLint and git diff --check: passed
- no full-suite local rerun

## Published gates

- natural quick 34088696748: SUCCESS on attempt 1 (4m09)
- path-selected visual 34088696756: SUCCESS (1m08)
- independent exact-head review: PASS — https://github.com/rigplane/rigplane-core/pull/3328#issuecomment-5565754696
- review report: /Users/moroz/.codex/handoffs/rigplane-mini-20260905-01a07230/pr3328-independent-review-6fbb779f9.md
- canonical Agent Review Gate: PASS

No merge performed.

Linear: MOR-2425
