### PR TITLE
MOR-2425: integrate Filter Mode and Filter instruments

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -684,6 +684,15 @@
   .desktop-control-face :global([data-zone-id='meters']) { grid-area: 5 / 1 / 6 / -1; }
   .tx-aux-finite-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
   .dsp-finite-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+  .filter-finite-grid { display: flex; flex-direction: column; gap: 0.5rem; }
+  .filter-finite-seat { display: contents; }
+  .filter-finite-grid .filter-finite-seat[data-field='mode'] :global(.filter-choice-group) {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .filter-finite-grid .filter-finite-seat[data-field='filter'] :global(.filter-choice-group) {
+    display: flex;
+  }
   .vfo-operation-instrument-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
   .tx-aux-scalar-grid {
     display: grid;

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -31,6 +31,7 @@
   import VfoHeader from './VfoHeader.svelte';
   import type { InstrumentComposition } from '../wiring/instrument-composition';
   import type { DspFiniteHandles } from '../../semantic/dsp-instruments';
+  import type { FilterInstrumentHandles } from '../../semantic/filter-instruments';
   import { getManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
   import KeyboardHandler from './KeyboardHandler.svelte';
   import StatusBar from './StatusBar.svelte';
@@ -323,6 +324,13 @@
   </div>
 {/snippet}
 
+{#snippet filterFiniteLayout(filterInstruments: FilterInstrumentHandles)}
+  <div class="filter-finite-grid" data-testid="filter-finite-grid">
+    <div class="filter-finite-seat" data-field="mode">{@render filterInstruments.mode()}</div>
+    <div class="filter-finite-seat" data-field="filter">{@render filterInstruments.filter()}</div>
+  </div>
+{/snippet}
+
 {#snippet vfoOperationControls()}
   <div class="vfo-operation-instrument-grid" data-testid="vfo-operation-instrument-grid">
     {#if instruments.vfoOperations.split}<div class="vfo-operation-instrument-seat" data-field="split">{@render instruments.vfoOperations.split()}</div>{/if}
@@ -374,7 +382,11 @@
 
       <div class="desktop-controls-left">
         {@render instruments.rfFrontEnd()}
-        {@render instruments.filter()}
+        {#if skinId === 'desktop-v2'}
+          {@render instruments.filter(undefined, filterFiniteLayout)}
+        {:else}
+          {@render instruments.filter()}
+        {/if}
         {@render instruments.band()}
         {@render instruments.antenna()}
         {@render instruments.ritXitScan()}

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -59,6 +59,8 @@
   import DspInstrumentHost from '../../semantic/DspInstrumentHost.svelte';
   import type { DspFiniteHandles, DspFiniteLayout } from '../../semantic/dsp-instruments';
   import FilterSurface from '../../semantic/FilterSurface.svelte';
+  import FilterInstrumentHost from '../../semantic/FilterInstrumentHost.svelte';
+  import type { FilterFiniteLayout } from '../../semantic/filter-instruments';
   import MetersSurface from '../../semantic/MetersSurface.svelte';
   import type { MeterContinuitySession } from '../../primitives/meters/meter-ballistics.svelte';
   import {
@@ -544,6 +546,12 @@
     topologyId: string;
     activeReceiver: 'MAIN' | 'SUB' | 'unknown';
   }>;
+  type FilterFiniteAuthority = Readonly<{
+    sessionEpoch: number;
+    providerGeneration: number;
+    topologyId: string;
+    activeReceiver: 'MAIN' | 'SUB' | 'unknown';
+  }>;
   type VfoFiniteAuthority = Readonly<{
     sessionEpoch: number;
     providerGeneration: number;
@@ -634,6 +642,26 @@
       topologyId: model.topologyId,
     });
   }
+  function filterFiniteAuthority(
+    state: typeof runtime.state,
+    caps: typeof runtime.caps,
+    session: typeof runtime.controlSession,
+  ): FilterFiniteAuthority | null {
+    const stateGeneration = state?.providerGeneration;
+    const capsGeneration = caps?.providerGeneration;
+    if (session.state !== 'connected' || !Number.isSafeInteger(session.epoch) || session.epoch < 0
+      || !Number.isSafeInteger(stateGeneration) || stateGeneration! < 0
+      || stateGeneration !== capsGeneration) return null;
+    const model = toRadioViewModel(state, caps);
+    if (model?.modeFilter === undefined) return null;
+    return Object.freeze({
+      sessionEpoch: session.epoch,
+      providerGeneration: stateGeneration as number,
+      topologyId: model.topologyId,
+      activeReceiver: model.activeReceiver.status === 'known'
+        ? model.activeReceiver.receiver : 'unknown',
+    });
+  }
   const sameScopeFiniteAuthority = (
     left: ScopeFiniteAuthority | null | undefined,
     right: ScopeFiniteAuthority | null,
@@ -674,6 +702,16 @@
         && left.providerGeneration === right.providerGeneration
         && left.topologyId === right.topologyId
   );
+  const sameFilterFiniteAuthority = (
+    left: FilterFiniteAuthority | null | undefined,
+    right: FilterFiniteAuthority | null,
+  ): boolean => left !== undefined && (
+    left === null || right === null ? left === right
+      : left.sessionEpoch === right.sessionEpoch
+        && left.providerGeneration === right.providerGeneration
+        && left.topologyId === right.topologyId
+        && left.activeReceiver === right.activeReceiver
+  );
   const readSelectedFiniteAppearance = 'getSelectedFiniteControlAppearance' in componentKitActivation
     ? componentKitActivation.getSelectedFiniteControlAppearance : undefined;
   const selectedFiniteAppearance = readSelectedFiniteAppearance?.();
@@ -681,10 +719,12 @@
   let txAuxFiniteRendererContext = $state.raw<FiniteRendererContext | null>(null);
   let dspFiniteRendererContext = $state.raw<FiniteRendererContext | null>(null);
   let vfoFiniteRendererContext = $state.raw<FiniteRendererContext | null>(null);
+  let filterFiniteRendererContext = $state.raw<FiniteRendererContext | null>(null);
   let lastScopeFiniteAuthority: ScopeFiniteAuthority | null | undefined;
   let lastTxAuxFiniteAuthority: TxAuxFiniteAuthority | null | undefined;
   let lastDspFiniteAuthority: DspFiniteAuthority | null | undefined;
   let lastVfoFiniteAuthority: VfoFiniteAuthority | null | undefined;
+  let lastFilterFiniteAuthority: FilterFiniteAuthority | null | undefined;
   const unsubscribeScopeFiniteAuthority = selectedFiniteAppearance === undefined ? undefined
     : runtime.subscribeControlAuthority((publication) => {
       const next = scopeFiniteAuthority(publication.state, publication.caps, publication.session);
@@ -713,6 +753,13 @@
         lastVfoFiniteAuthority = nextVfo;
         vfoFiniteRendererContext = nextVfo === null ? null : createFiniteRendererContext();
       }
+      const nextFilter = filterFiniteAuthority(
+        publication.state, publication.caps, publication.session,
+      );
+      if (!sameFilterFiniteAuthority(lastFilterFiniteAuthority, nextFilter)) {
+        lastFilterFiniteAuthority = nextFilter;
+        filterFiniteRendererContext = nextFilter === null ? null : createFiniteRendererContext();
+      }
     });
   onDestroy(() => unsubscribeScopeFiniteAuthority?.());
   let scopeFiniteRendererSelection = $derived(selectedFiniteAppearance === undefined
@@ -728,6 +775,10 @@
   let vfoFiniteRendererSelection = $derived(selectedFiniteAppearance === undefined
     ? {} : {
       finiteAppearance: selectedFiniteAppearance, rendererContext: vfoFiniteRendererContext,
+    });
+  let filterFiniteRendererSelection = $derived(selectedFiniteAppearance === undefined
+    ? {} : {
+      finiteAppearance: selectedFiniteAppearance, rendererContext: filterFiniteRendererContext,
     });
 
   let scopeFrameSource = $derived(
@@ -1166,6 +1217,12 @@
   >
   {#snippet children(rfFrontEndInstruments)}
   {#snippet vfoInstrumentComposition(vfoOperations: VfoOperationHandles)}
+  <FilterInstrumentHost
+    {...filterFiniteRendererSelection} {view} {pendingFilter}
+    onModeChange={filterIntents.onModeChange}
+    onFilterChange={filterIntents.onFilterChange}
+  >
+  {#snippet children(filterInstruments)}
   <DspInstrumentHost
     {...dspFiniteRendererSelection} {view} {agcLabels} {pendingNb} {pendingNr}
     onToggle={(field, next) => DSP_TOGGLE_INTENT[field](next)}
@@ -1509,16 +1566,13 @@
     (`sdr-test`, `mobile` and the two `lcd-*` layouts declare no `filter` zone
     either), so it still renders nothing there.
   -->
-  {#snippet filterSurface()}
+  {#snippet filterSurface(finiteLayout?: FilterFiniteLayout)}
     {#if view?.modeFilter || view?.filterPassband}
       <FilterSurface
-        {view}
-        {pendingFilter}
+        {view} handles={filterInstruments} {finiteLayout}
         {pendingDataMode}
         {filterWidthFeedback}
         onDataModeChange={filterIntents.onDataModeChange}
-        onModeChange={filterIntents.onModeChange}
-        onFilterChange={filterIntents.onFilterChange}
         onFilterWidthChange={filterIntents.onFilterWidthChange}
         onFilterShapeChange={filterIntents.onFilterShapeChange}
         onIfShiftChange={filterIntents.onIfShiftChange}
@@ -1822,10 +1876,13 @@
   {#snippet hostedRfFrontEnd(allowBare = allowBareSurfaces)}
     {@render zoned('rfFrontEnd', view?.rfFrontEnd !== undefined, rfFrontEndSurface, allowBare)}
   {/snippet}
-  {#snippet hostedFilter(allowBare = allowBareSurfaces)}
+  {#snippet hostedFilter(
+    allowBare = allowBareSurfaces, finiteLayout?: FilterFiniteLayout,
+  )}
+    {#snippet body()}{@render filterSurface(finiteLayout)}{/snippet}
     {@render zoned(
       'filter', view?.modeFilter !== undefined || view?.filterPassband !== undefined,
-      filterSurface, allowBare,
+      body, allowBare,
     )}
   {/snippet}
   {#snippet hostedDsp(
@@ -2058,6 +2115,8 @@
   {/if}
   {/snippet}
   </DspInstrumentHost>
+  {/snippet}
+  </FilterInstrumentHost>
   {/snippet}
   <VfoOperationSeatHost
     {...vfoFiniteRendererSelection} input={vfoOperationInput} scheme={view?.vfoScheme ?? null}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -39,6 +39,8 @@ const h = vi.hoisted(() => ({
   voxDelay: vi.fn(),
   compLevel: vi.fn(),
   monLevel: vi.fn(),
+  modeChange: vi.fn(),
+  filterChange: vi.fn(),
   split: vi.fn(),
   dualWatch: vi.fn(),
   mainReceiver: vi.fn(),
@@ -178,10 +180,10 @@ vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
     // intent vocabulary; `makeModeHandlers` is composed at both call sites
     // (rxAudio's MOD-input remedy and filterIntents), so the stub carries both.
     makeModeHandlers: () => ({
-      onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop,
+      onModInputChange: h.noop, onModeChange: h.modeChange, onDataModeChange: h.noop,
     }),
     makeFilterHandlers: () => ({
-      onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
+      onFilterChange: h.filterChange, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
       onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
     }),
     // MOR-1305 — the wiring now also composes the dsp intent vocabulary. This
@@ -302,6 +304,32 @@ const vfoCaps = (): Capabilities => ({
   ],
 });
 
+function filterState(): ServerState {
+  const state = liveState(true);
+  const receiver = (value: typeof state.main) => ({
+    ...value, filterWidth: 2400, filterShape: 1, ifShift: 0,
+    pbtInner: 128, pbtOuter: 128, dataMode: 0,
+  });
+  const fields = ['filterWidth', 'filterShape', 'ifShift', 'pbtInner', 'pbtOuter', 'dataMode'];
+  return {
+    ...state, main: receiver(state.main), sub: receiver(state.sub!),
+    fieldStatus: {
+      ...state.fieldStatus,
+      ...Object.fromEntries(['main', 'sub'].flatMap(rx => fields.map(field => [`${rx}.${field}`, fresh]))),
+    },
+  } as ServerState;
+}
+
+const filterCaps = (): Capabilities => ({
+  ...liveCaps(true),
+  capabilities: [...liveCaps(true).capabilities, 'filter_shape', 'if_shift', 'pbt', 'data_mode'],
+  modes: ['USB', 'CW', 'FM'], filters: ['FIL1', 'FIL2', 'FIL3'],
+  dataModeCount: 2,
+  controls: {
+    pbt_inner: { raw_min: 0, raw_max: 255, raw_center: 128, display_min: -1200, display_max: 1200 },
+  },
+} as unknown as Capabilities);
+
 const finiteFixture = FiniteControlRendererFixture as FiniteControlAppearance['action'];
 const finiteAppearance = {
   action: finiteFixture,
@@ -333,14 +361,22 @@ function render(
 }
 
 function renderHostedDesktop(): void {
+  renderHostedLayout('desktop-v2');
+}
+
+function renderHostedLayout(skinId: 'desktop-v2' | 'sdr-test') {
   target = document.createElement('div');
   document.body.appendChild(target);
-  const plan = resolveSurfacePlan(desktopV2Layout, readWorkspace({ version: 1 }).workspace);
+  const props = proxy({ skinId });
   component = mount(HostedRadioLayoutFixture, {
-    target,
-    context: new Map<unknown, unknown>([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]),
+    target, props,
+    context: new Map<unknown, unknown>([[SURFACE_PLAN_CONTEXT_KEY, () => resolveSurfacePlan(
+      props.skinId === 'desktop-v2' ? desktopV2Layout : sdrTestLayout,
+      readWorkspace({ version: 1 }).workspace,
+    )]]),
   });
   flushSync();
+  return props;
 }
 
 function push(next: ManagedAppTxServerSnapshot): void {
@@ -688,6 +724,88 @@ describe('selected finite TX auxiliary authority lifetime', () => {
     expect(h.voxToggle).toHaveBeenCalledOnce();
     expect(h.split).toHaveBeenCalledOnce();
   });
+});
+
+describe('hosted Filter Mode and Filter ownership', () => {
+  const residual = [
+    'filter-width', 'filter-shape', 'filter-ifShift',
+    'filter-pbtInner', 'filter-pbtOuter', 'filter-data-mode',
+  ] as const;
+
+  it('places named Standard and grouped SDR seats once while residual owners stay single', () => {
+    h.state = filterState(); h.caps = filterCaps(); h.selectedFiniteAppearance = finiteAppearance;
+    const layout = renderHostedLayout('desktop-v2');
+    const subscribers = [...h.authoritySubscribers];
+    const grid = q('[data-testid="filter-finite-grid"]')!;
+    expect([...grid.children].map(node => node.getAttribute('data-field'))).toEqual(['mode', 'filter']);
+    expect(target.querySelectorAll('[data-testid="external-Mode"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-testid="external-Filter"]')).toHaveLength(1);
+    expect(q('[data-testid="external-Mode"]')?.getAttribute('data-reading')).toBe('USB');
+    for (const id of residual) expect(target.querySelectorAll(`[data-testid="${id}"]`)).toHaveLength(1);
+    retainedInvocations.get('Mode')?.('CW'); retainedInvocations.get('Filter')?.(2);
+    expect(h.modeChange).toHaveBeenCalledExactlyOnceWith('CW');
+    expect(h.filterChange).toHaveBeenCalledExactlyOnceWith(2);
+    const standardMode = retainedInvocations.get('Mode')!;
+
+    publishAuthority(); flushSync();
+    expect(retainedInvocations.get('Mode')).toBe(standardMode);
+    expect(q('[data-testid="external-Mode"]')?.getAttribute('data-reading')).toBe('USB');
+    layout.skinId = 'sdr-test'; flushSync();
+
+    expect(q('[data-testid="filter-finite-grid"]')).toBeNull();
+    expect(target.querySelectorAll('[data-testid="external-Mode"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-testid="external-Filter"]')).toHaveLength(1);
+    for (const id of residual) expect(target.querySelectorAll(`[data-testid="${id}"]`)).toHaveLength(1);
+    expect([...h.authoritySubscribers]).toEqual(subscribers);
+    const sdrMode = retainedInvocations.get('Mode')!;
+    expect(sdrMode).not.toBe(standardMode);
+    standardMode('FM'); expect(h.modeChange).toHaveBeenCalledTimes(1);
+    sdrMode('FM'); expect(h.modeChange).toHaveBeenLastCalledWith('FM');
+  });
+
+  it('keeps selected appearance inert at null Filter authority without hiding residual controls', () => {
+    h.state = filterState(); h.caps = filterCaps(); h.selectedFiniteAppearance = finiteAppearance;
+    h.session = { state: 'disconnected', epoch: 7 };
+    renderHostedDesktop();
+
+    expect(q('[data-testid="external-Mode"]')).toBeNull();
+    expect(q('[data-testid="external-Filter"]')).toBeNull();
+    expect(q('[data-testid="filter-mode"]')).toBeNull();
+    expect(q('[data-testid="filter-select"]')).toBeNull();
+    for (const id of residual) expect(target.querySelectorAll(`[data-testid="${id}"]`)).toHaveLength(1);
+    expect(h.authoritySubscribers.size).toBe(4);
+  });
+
+  it.each(['session', 'provider', 'topology', 'receiver', 'unknown'] as const)(
+    'fences retained A1 through synchronous %s A-B-A and admits only fresh A3',
+    (kind) => {
+      h.state = filterState(); h.caps = filterCaps(); h.selectedFiniteAppearance = finiteAppearance;
+      renderHostedDesktop();
+      const stateA = h.state as ServerState, capsA = h.caps as Capabilities, sessionA = h.session;
+      const retainedA1 = retainedInvocations.get('Mode')!;
+      if (kind === 'session') h.session = { state: 'connected', epoch: 8 };
+      if (kind === 'provider') {
+        h.state = { ...stateA, providerGeneration: 2 }; h.caps = { ...capsA, providerGeneration: 2 };
+      }
+      if (kind === 'topology') {
+        h.caps = { ...capsA, receivers: 1, vfoScheme: 'single',
+          capabilities: capsA.capabilities.filter(capability => capability !== 'dual_rx') };
+      }
+      if (kind === 'receiver') h.state = { ...stateA, active: 'SUB' };
+      if (kind === 'unknown') {
+        const fieldStatus = { ...stateA.fieldStatus }; delete fieldStatus.active;
+        h.state = { ...stateA, fieldStatus };
+      }
+      publishAuthority();
+      h.state = stateA; h.caps = capsA; h.session = sessionA; publishAuthority();
+      retainedA1('CW'); expect(h.modeChange).not.toHaveBeenCalled();
+      flushSync();
+      const retainedA3 = retainedInvocations.get('Mode')!;
+      expect(retainedA3).not.toBe(retainedA1);
+      retainedA3('CW'); expect(h.modeChange).toHaveBeenCalledExactlyOnceWith('CW');
+      retainedA1('FM'); expect(h.modeChange).toHaveBeenCalledTimes(1);
+    },
+  );
 });
 
 // ── 1. The structural gate: absent group ⇒ no surface, no element drift ────

--- a/frontend/src/components-v2/wiring/instrument-composition.ts
+++ b/frontend/src/components-v2/wiring/instrument-composition.ts
@@ -7,6 +7,7 @@ import type { RxAudioInstrumentHandles } from '../../semantic/rx-audio-instrumen
 import type { RfFrontEndLevelHandles } from '../../semantic/rf-front-end-instruments';
 import type { DspFiniteLayout } from '../../semantic/dsp-instruments';
 import type { VfoOperationHandles } from '../../semantic/VfoOperationSeatHost.svelte';
+import type { FilterFiniteLayout } from '../../semantic/filter-instruments';
 
 export type InstrumentVfoAppearance = 'semantic' | 'sdr' | 'standard';
 
@@ -27,7 +28,7 @@ export interface InstrumentComposition {
   readonly meters: Snippet<[allowBare?: boolean]>;
   readonly rxAudio: Snippet<[allowBare?: boolean]>;
   readonly rfFrontEnd: Snippet<[allowBare?: boolean]>;
-  readonly filter: Snippet<[allowBare?: boolean]>;
+  readonly filter: Snippet<[allowBare?: boolean, finiteLayout?: FilterFiniteLayout]>;
   readonly dsp: Snippet<[allowBare?: boolean, finiteLayout?: DspFiniteLayout]>;
   readonly band: Snippet<[allowBare?: boolean]>;
   readonly antenna: Snippet<[allowBare?: boolean]>;

--- a/frontend/src/lib/runtime/commands/__tests__/focus-target-resolution.component.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/focus-target-resolution.component.test.ts
@@ -81,7 +81,7 @@ import RxAudioInstrumentHostFixture from '../../../../semantic/__tests__/fixture
 import RfFrontEndInstrumentHostFixture, {
   rfTestAuthorityPublication,
 } from '../../../../semantic/__tests__/fixtures/RfFrontEndInstrumentHostFixture.svelte';
-import FilterSurface from '../../../../semantic/FilterSurface.svelte';
+import FilterInstrumentHostFixture from '../../../../semantic/__tests__/fixtures/FilterInstrumentHostFixture.svelte';
 import VfoSurface from '../../../../semantic/VfoSurface.svelte';
 import {
   topologyFixtures, withRxAudio, withModeFilter, withFilterPassband, withRfFrontEnd,
@@ -158,7 +158,9 @@ describe('focus_target dispatch resolves to a real, focusable anchor in the prod
   });
 
   it('"mode" focuses the first mode choice in FilterSurface (filter zone)', () => {
-    render(FilterSurface, { view: withFilterPassband(withModeFilter(topologyFixtures['1/single'])) });
+    render(FilterInstrumentHostFixture, {
+      view: withFilterPassband(withModeFilter(topologyFixtures['1/single'])), renderSurface: true,
+    });
     const button = document.querySelector('[data-testid="filter-mode"] button');
     expect(button).not.toBeNull();
 
@@ -168,7 +170,9 @@ describe('focus_target dispatch resolves to a real, focusable anchor in the prod
   });
 
   it('"filter" focuses the first filter choice in FilterSurface (filter zone)', () => {
-    render(FilterSurface, { view: withFilterPassband(withModeFilter(topologyFixtures['1/single'])) });
+    render(FilterInstrumentHostFixture, {
+      view: withFilterPassband(withModeFilter(topologyFixtures['1/single'])), renderSurface: true,
+    });
     const button = document.querySelector('[data-testid="filter-select"] button');
     expect(button).not.toBeNull();
 
@@ -178,7 +182,9 @@ describe('focus_target dispatch resolves to a real, focusable anchor in the prod
   });
 
   it('"pbt" focuses the PBT-inner slider in FilterSurface (filter zone)', () => {
-    render(FilterSurface, { view: withFilterPassband(withModeFilter(topologyFixtures['1/single'])) });
+    render(FilterInstrumentHostFixture, {
+      view: withFilterPassband(withModeFilter(topologyFixtures['1/single'])), renderSurface: true,
+    });
     const input = document.querySelector('[data-testid="filter-pbtInner"] input');
     expect(input).not.toBeNull();
 

--- a/frontend/src/primitives/control-instruments/__tests__/control-instrument-renderer.test.ts
+++ b/frontend/src/primitives/control-instruments/__tests__/control-instrument-renderer.test.ts
@@ -188,6 +188,35 @@ describe('finite renderer leases', () => {
     expect(lease.view?.reading).toEqual({ status: 'unknown' });
   });
 
+  it('keeps retained reading while availability-gated selection is an explicit opt-in', () => {
+    const context = createFiniteRendererContext();
+    let current: InstrumentField<string> = {
+      availability: { structural: true, operational: false },
+      reading: { status: 'known', value: 'USB' },
+    };
+    const invoke = vi.fn();
+    const readCurrent = () => ({
+      context, field: current, label: 'Mode',
+      options: [{ value: 'USB', label: 'USB' }], invoke,
+    });
+    const defaultLease = createChoiceRendererSeat(readCurrent).attachRenderer();
+    const gatedLease = createChoiceRendererSeat(readCurrent, {
+      selectionRequiresAvailability: true,
+    }).attachRenderer();
+
+    expect(defaultLease.view?.reading).toEqual({ status: 'known', value: 'USB' });
+    expect(defaultLease.view?.selected).toBe('USB');
+    expect(gatedLease.view?.reading).toEqual({ status: 'known', value: 'USB' });
+    expect(gatedLease.view?.selected).toBeUndefined();
+    defaultLease.invoke('USB'); gatedLease.invoke('USB');
+    expect(invoke).not.toHaveBeenCalled();
+
+    current = field('USB');
+    expect(gatedLease.view?.selected).toBe('USB');
+    gatedLease.invoke('USB');
+    expect(invoke).toHaveBeenCalledExactlyOnceWith('USB');
+  });
+
   it('passes current option reasons through without changing option admission', () => {
     const context = createFiniteRendererContext();
     let options: readonly ControlOption<string>[] = [

--- a/frontend/src/primitives/control-instruments/control-instrument-renderer.svelte.ts
+++ b/frontend/src/primitives/control-instruments/control-instrument-renderer.svelte.ts
@@ -244,6 +244,7 @@ function createChoiceLease<T, Feedback, Input extends RendererInput & {
   guard: LeaseGuard<Input>,
   behavior: ReturnType<typeof bindChoiceInstrument<T, Feedback>>,
   readingOf: (input: Input) => InstrumentReading<T>,
+  selectionRequiresAvailability = false,
 ): ChoiceRendererLease<T, Feedback> {
   return {
     get active() { return guard.current() !== undefined; },
@@ -251,7 +252,9 @@ function createChoiceLease<T, Feedback, Input extends RendererInput & {
       const input = guard.current();
       return input === undefined ? undefined : {
         ...labelView(input), available: behavior.available, reading: readingOf(input),
-        selected: behavior.selected, options: input.options,
+        selected: selectionRequiresAvailability && !behavior.available
+          ? undefined : behavior.selected,
+        options: input.options,
         ...(input.defaultValue === undefined ? {} : { defaultValue: input.defaultValue }),
         ...(input.requested === undefined ? {} : { requested: input.requested }),
         ...feedbackView(input.feedback),
@@ -268,6 +271,7 @@ function createChoiceLease<T, Feedback, Input extends RendererInput & {
 
 export function createChoiceRendererSeat<T, Feedback = never>(
   readCurrent: () => ChoiceRendererInput<T, Feedback>,
+  options: { readonly selectionRequiresAvailability?: boolean } = {},
 ): ChoiceRendererSeat<T, Feedback> {
   const behavior = bindChoiceInstrument<T, Feedback>(() => {
     const input = readCurrent();
@@ -279,6 +283,7 @@ export function createChoiceRendererSeat<T, Feedback = never>(
   });
   return createSeat(readCurrent, guard => createChoiceLease(
     guard, behavior, input => input.field?.reading ?? { status: 'unknown' },
+    options.selectionRequiresAvailability,
   ));
 }
 

--- a/frontend/src/semantic/FilterInstrumentHost.svelte
+++ b/frontend/src/semantic/FilterInstrumentHost.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import { onDestroy, type Snippet } from 'svelte';
+  import { t } from '$lib/i18n';
+  import { bindChoiceInstrument } from '../primitives/control-instruments/control-instrument-behavior';
+  import ControlInstrumentRendererHost from '../primitives/control-instruments/ControlInstrumentRendererHost.svelte';
+  import {
+    createChoiceRendererSeat, type FiniteControlAppearance, type FiniteRendererContext,
+  } from '../primitives/control-instruments/control-instrument-renderer.svelte';
+  import type { FilterFiniteChoiceValue, FilterInstrumentHandles } from './filter-instruments';
+  import type { RadioViewModel } from './radio-view-model';
+
+  interface ExistingProps {
+    view: RadioViewModel | null;
+    pendingFilter?: number | null;
+    onModeChange?: (mode: string) => void;
+    onFilterChange?: (filter: number) => void;
+    children: Snippet<[FilterInstrumentHandles]>;
+  }
+  type RendererSelection = { finiteAppearance?: undefined; rendererContext?: undefined } | {
+    finiteAppearance: FiniteControlAppearance<FilterFiniteChoiceValue>;
+    rendererContext: FiniteRendererContext | null;
+  };
+  type Props = ExistingProps & RendererSelection;
+
+  let {
+    view, pendingFilter = null, onModeChange, onFilterChange,
+    finiteAppearance, rendererContext, children,
+  }: Props = $props();
+
+  let modeFilter = $derived(view?.modeFilter);
+  const pendingId = $props.id();
+  const usable = (field: { availability: { structural: boolean; operational: boolean };
+    reading: { status: string } } | undefined): boolean => field !== undefined
+      && field.availability.structural && field.availability.operational
+      && field.reading.status === 'known';
+  const reason = (field: Parameters<typeof usable>[0]) =>
+    usable(field) ? undefined : 'field-not-observed';
+  const requested = <T,>(target: T | null) => target === null
+    ? undefined : { kind: 'requested-target' as const, target };
+
+  const modeBehavior = bindChoiceInstrument(() => ({
+    field: modeFilter?.currentMode, choices: modeFilter?.modeChoices ?? [],
+    invoke: (value) => onModeChange?.(value),
+  }));
+  const filterBehavior = bindChoiceInstrument(() => ({
+    field: modeFilter?.currentFilter,
+    choices: (modeFilter?.filterChoices ?? []).map((_choice, index) => index + 1),
+    invoke: (value) => onFilterChange?.(value),
+  }));
+
+  const modeSeat = createChoiceRendererSeat<FilterFiniteChoiceValue>(() => ({
+    context: rendererContext ?? null, field: modeFilter?.currentMode, label: 'Mode',
+    options: (modeFilter?.modeChoices ?? []).map(value => ({ value, label: value })),
+    invoke: value => onModeChange?.(value as string),
+  }), { selectionRequiresAvailability: true });
+  const filterSeat = createChoiceRendererSeat<FilterFiniteChoiceValue>(() => ({
+    context: rendererContext ?? null, field: modeFilter?.currentFilter, label: 'Filter',
+    options: (modeFilter?.filterChoices ?? []).map((label, index) => ({ value: index + 1, label })),
+    requested: requested(pendingFilter), invoke: value => onFilterChange?.(value as number),
+  }), { selectionRequiresAvailability: true });
+  onDestroy(() => { modeSeat.destroy(); filterSeat.destroy(); });
+</script>
+
+{#snippet external(seat: typeof modeSeat)}
+  {#if finiteAppearance}
+    {#key rendererContext}{#key finiteAppearance.choice}<ControlInstrumentRendererHost
+      {seat} renderer={finiteAppearance.choice}
+    />{/key}{/key}
+  {/if}
+{/snippet}
+{#snippet mode()}
+  {#if modeFilter?.currentMode.availability.structural}
+    {#if finiteAppearance}{@render external(modeSeat)}{:else}
+      <div class="filter-choice-group" data-testid="filter-mode" data-disabled-reason={reason(modeFilter.currentMode)}>
+        {#each modeFilter.modeChoices as choice (choice)}<button type="button" class="filter-choice"
+          data-testid={`filter-mode-${choice}`} aria-pressed={modeBehavior.available && modeBehavior.isSelected(choice)}
+          disabled={!modeBehavior.available} onclick={() => modeBehavior.invoke(choice)}>{choice}</button>{/each}
+      </div>
+    {/if}
+  {/if}
+{/snippet}
+{#snippet filter()}
+  {#if modeFilter?.currentFilter.availability.structural}
+    {#if finiteAppearance}{@render external(filterSeat)}{:else}
+      <div class="filter-choice-group" data-testid="filter-select" data-disabled-reason={reason(modeFilter.currentFilter)}
+        data-filter-status={pendingFilter !== null ? 'pending' : 'confirmed'} aria-describedby={pendingFilter !== null ? pendingId : undefined}>
+        {#each modeFilter.filterChoices as choice, index (choice)}<button type="button" class="filter-choice"
+          data-testid={`filter-select-${index + 1}`} aria-pressed={filterBehavior.available && filterBehavior.isSelected(index + 1)}
+          data-pending={pendingFilter === index + 1} disabled={!filterBehavior.available}
+          onclick={() => filterBehavior.invoke(index + 1)}>{choice}</button>{/each}
+        {#if pendingFilter !== null}<span id={pendingId} class="sr-only">{t('core.filter.select.pendingAnnouncement')}</span>{/if}
+      </div>
+    {/if}
+  {/if}
+{/snippet}
+
+{@render children({ mode, filter })}
+
+<style>
+  .filter-choice-group { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; }
+  .filter-choice[aria-pressed='true'] { font-weight: 700; }
+  .filter-choice:disabled { cursor: not-allowed; }
+  .filter-choice[data-pending='true'] { font-style: italic; opacity: 0.75; }
+  .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+</style>

--- a/frontend/src/semantic/FilterSurface.svelte
+++ b/frontend/src/semantic/FilterSurface.svelte
@@ -1,11 +1,11 @@
 <!--
   Semantic mode/filter surface (MOR-1304, vocabulary slice 4B).
 
-  Presentation only. Renders BOTH the MOR-1280 `modeFilter` group (mode,
-  filter selection, filter width) and the MOR-1284 `filterPassband` group
-  (filter shape, IF-shift, PBT inner/outer, DATA submode) — the same two
-  groups the v2 `FilterPanel` reads together (`panel-props.ts`'s
-  `deriveFilterProps`). A surface consuming only one half would be half-built.
+  Presentation only. Places the host-owned mode and filter handles beside
+  the MOR-1280 `modeFilter` width, then renders the MOR-1284
+  `filterPassband` group (filter shape, IF-shift, PBT inner/outer, DATA
+  submode) — the same two groups the v2 `FilterPanel` reads together
+  (`panel-props.ts`'s `deriveFilterProps`).
 
   Doctrine, same as `TxAuxSurface`/`MetersSurface`:
   (1) Facts only — every value and every min/max bound is READ from the
@@ -44,15 +44,9 @@
   answers whether the radio has a REAL `filter_shape` command; see
   `FilterPassbandViewModel.filterShapeControlStructural`'s doc comment.
 
-  PENDING AFFORDANCE (MOR-1441 leg 2). `pendingFilter` is a plain, command-
-  bus-blind display prop — same "read at the wiring seam, hand down a plain
-  value" precedent as `pendingFrequencyHz` (leg 1, `VfoSurface`). It marks
-  the targeted filter-select CHOICE distinctly (`data-pending`) and the
-  group `data-filter-status="pending"`, but `isSelected`/`aria-pressed`
-  keep reading `modeFilter.currentFilter`'s CONFIRMED reading exclusively —
-  the leg-1 lesson applied here: pending never becomes a selection source,
-  so a click while pending still dispatches the CLICKED (explicit) value,
-  never something computed off the pending display.
+  PENDING AFFORDANCE (MOR-1441 leg 2). The host-owned Filter handle carries
+  the pending target separately from confirmed truth. DATA remains local and
+  keeps the same separation below.
 -->
 <script module lang="ts">
   import type { DisplayObservedField, TxAuxField } from './radio-view-model';
@@ -101,19 +95,16 @@
     type CommandScalarFeedback, type ContinuousScalarInput,
     type ContinuousScalarRendererLease, type ContinuousScalarView,
   } from '../primitives/scalar/continuous-scalar.svelte';
+  import type { FilterFiniteLayout, FilterInstrumentHandles } from './filter-instruments';
   import type { RadioViewModel } from './radio-view-model';
 
   interface Props {
     view: RadioViewModel;
-    /** MOR-1441 leg 2 — the freshest in-flight `set_filter` target for the
-     *  active receiver, DISPLAY ONLY (see the file header). `null` when
-     *  nothing is pending. */
-    pendingFilter?: number | null;
+    handles: FilterInstrumentHandles;
+    finiteLayout?: FilterFiniteLayout;
     pendingDataMode?: number | null;
     filterWidthFeedback?: Readonly<CommandScalarFeedback>;
     onDataModeChange?: (mode: number) => void;
-    onModeChange?: (mode: string) => void;
-    onFilterChange?: (filter: number) => void;
     onFilterWidthChange?: (width: number) => void;
     onFilterShapeChange?: (shape: number) => void;
     onIfShiftChange?: (value: number) => void;
@@ -121,8 +112,8 @@
     onPbtOuterChange?: (value: number) => void;
   }
   let {
-    view, pendingFilter = null, pendingDataMode = null, filterWidthFeedback,
-    onDataModeChange, onModeChange, onFilterChange, onFilterWidthChange,
+    view, handles, finiteLayout, pendingDataMode = null, filterWidthFeedback,
+    onDataModeChange, onFilterWidthChange,
     onFilterShapeChange, onIfShiftChange, onPbtInnerChange, onPbtOuterChange,
   }: Props = $props();
 
@@ -213,19 +204,6 @@
     );
   });
   onDestroy(() => filterWidthScalar.destroy());
-  function modeInstrument() {
-    return bindChoiceInstrument(() => ({
-      field: modeFilter?.currentMode, choices: modeFilter?.modeChoices ?? [],
-      invoke: (value) => onModeChange?.(value),
-    }));
-  }
-  function filterInstrument() {
-    return bindChoiceInstrument(() => ({
-      field: modeFilter?.currentFilter,
-      choices: (modeFilter?.filterChoices ?? []).map((_choice, index) => index + 1),
-      invoke: (value) => onFilterChange?.(value),
-    }));
-  }
   function shapeInstrument() {
     return bindChoiceInstrument(() => ({
       field: filterPassband?.filterShape, choices: FILTER_SHAPES.map(([value]) => value),
@@ -255,43 +233,9 @@
 {#if modeFilter || filterPassband}
   <section class="filter-surface" data-testid="filter-surface" aria-label="Mode and filter controls">
     {#if modeFilter}
-      {#if modeFilter.currentMode.availability.structural}
-        {@const behavior = modeInstrument()}
-        <div
-          class="filter-choice-group" data-testid="filter-mode"
-          data-disabled-reason={reasonOf(modeFilter.currentMode)}
-        >
-          {#each modeFilter.modeChoices as choice (choice)}
-            <button
-              type="button" class="filter-choice" data-testid={`filter-mode-${choice}`}
-              aria-pressed={behavior.available && behavior.isSelected(choice)}
-              disabled={!behavior.available}
-              onclick={() => behavior.invoke(choice)}
-            >{choice}</button>
-          {/each}
-        </div>
-      {/if}
-      {#if modeFilter.currentFilter.availability.structural}
-        {@const behavior = filterInstrument()}
-        <div
-          class="filter-choice-group" data-testid="filter-select"
-          data-disabled-reason={reasonOf(modeFilter.currentFilter)}
-          data-filter-status={pendingFilter !== null ? 'pending' : 'confirmed'}
-          aria-describedby={pendingFilter !== null ? pendingFilterId : undefined}
-        >
-          {#each modeFilter.filterChoices as choice, index (choice)}
-            <button
-              type="button" class="filter-choice" data-testid={`filter-select-${index + 1}`}
-              aria-pressed={behavior.available && behavior.isSelected(index + 1)}
-              data-pending={pendingFilter === index + 1}
-              disabled={!behavior.available}
-              onclick={() => behavior.invoke(index + 1)}
-            >{choice}</button>
-          {/each}
-          {#if pendingFilter !== null}
-            <span id={pendingFilterId} class="sr-only">{t('core.filter.select.pendingAnnouncement')}</span>
-          {/if}
-        </div>
+      {#if finiteLayout}{@render finiteLayout(handles)}{:else}
+        {@render handles.mode()}
+        {@render handles.filter()}
       {/if}
       {#if modeFilter.filterWidth.availability.structural}
         <label class="filter-level" data-testid="filter-width" data-disabled-reason={reasonOf(modeFilter.filterWidth)}>

--- a/frontend/src/semantic/__tests__/FilterInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/FilterInstrumentHost.isolated.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
+import type { FiniteControlAppearance } from '../../primitives/control-instruments/control-instrument-renderer.svelte';
+import { createFiniteRendererContext } from '../../primitives/control-instruments/control-instrument-renderer.svelte';
+import FiniteControlRendererFixture, {
+  resetRetainedInvocations, retainedInvocations,
+} from '../../primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte';
+import type { FilterFiniteChoiceValue } from '../filter-instruments';
+import { topologyFixtures, withFilterPassband, withModeFilter } from '../fixtures/topologies';
+import type { ModeFilterViewModel, RadioViewModel } from '../radio-view-model';
+import FilterInstrumentHostFixture from './fixtures/FilterInstrumentHostFixture.svelte';
+
+const base = (): RadioViewModel => withFilterPassband(withModeFilter(topologyFixtures['1/single']));
+const appearance = {
+  action: FiniteControlRendererFixture as FiniteControlAppearance<FilterFiniteChoiceValue>['action'],
+  toggle: FiniteControlRendererFixture as FiniteControlAppearance<FilterFiniteChoiceValue>['toggle'],
+  choice: FiniteControlRendererFixture as FiniteControlAppearance<FilterFiniteChoiceValue>['choice'],
+} satisfies FiniteControlAppearance<FilterFiniteChoiceValue>;
+
+let target: HTMLDivElement;
+beforeEach(() => {
+  target = document.createElement('div'); document.body.appendChild(target); resetRetainedInvocations();
+});
+afterEach(() => target.remove());
+
+function modeReading(
+  view: RadioViewModel, name: 'currentMode' | 'currentFilter',
+  reading: { status: 'unknown' } | { status: 'known'; value: string | number },
+  operational = true,
+): RadioViewModel {
+  const modeFilter = view.modeFilter!;
+  return { ...view, modeFilter: { ...modeFilter, [name]: {
+    ...modeFilter[name], availability: { ...modeFilter[name].availability, operational }, reading,
+  } } as ModeFilterViewModel };
+}
+
+describe('FilterInstrumentHost Mode and Filter ownership', () => {
+  it('renders exact native choices in grouped and independent layouts with pending separate from truth', () => {
+    const onModeChange = vi.fn(), onFilterChange = vi.fn();
+    const props = proxy({ view: base(), presentation: 'grouped' as 'grouped' | 'independent',
+      pendingFilter: 2, onModeChange, onFilterChange });
+    const component = mount(FilterInstrumentHostFixture, { target, props }); flushSync();
+    const labels = (id: string) => [...target.querySelectorAll(`[data-testid="${id}"] button`)]
+      .map(button => button.textContent);
+    expect(target.querySelectorAll('[data-testid="grouped-filter-composition"] button')).toHaveLength(8);
+    expect(labels('filter-mode')).toEqual(['USB', 'LSB', 'CW', 'RTTY', 'FM']);
+    expect(labels('filter-select')).toEqual(['FIL1', 'FIL2', 'FIL3']);
+    expect(target.querySelector('[data-testid="filter-mode-USB"]')?.getAttribute('aria-pressed')).toBe('true');
+    expect(target.querySelector('[data-testid="filter-select-1"]')?.getAttribute('aria-pressed')).toBe('true');
+    expect((target.querySelector('[data-testid="filter-select-2"]') as HTMLElement).dataset.pending).toBe('true');
+    expect(target.querySelector('[data-testid="filter-select"]')?.getAttribute('aria-describedby')).not.toBeNull();
+    (target.querySelector('[data-testid="filter-mode-LSB"]') as HTMLButtonElement).click();
+    (target.querySelector('[data-testid="filter-select-2"]') as HTMLButtonElement).click();
+    expect(onModeChange).toHaveBeenCalledExactlyOnceWith('LSB');
+    expect(onFilterChange).toHaveBeenCalledExactlyOnceWith(2);
+    props.presentation = 'independent'; flushSync();
+    expect(target.querySelector('[data-testid="grouped-filter-composition"]')).toBeNull();
+    expect(target.querySelectorAll('[data-testid="independent-filter-composition"] button')).toHaveLength(8);
+    expect(target.querySelectorAll('[data-slot="mode"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-slot="filter"]')).toHaveLength(1);
+    unmount(component);
+  });
+
+  it('keeps external options, raw readings and callbacks current', () => {
+    const firstMode = vi.fn(), nextMode = vi.fn(), onFilterChange = vi.fn();
+    const props = proxy({
+      view: modeReading(base(), 'currentFilter', { status: 'known', value: 99 }),
+      presentation: 'independent' as const, finiteAppearance: appearance,
+      rendererContext: createFiniteRendererContext(), onModeChange: firstMode, onFilterChange,
+    });
+    const component = mount(FilterInstrumentHostFixture, { target, props }); flushSync();
+    const filter = target.querySelector('[data-testid="external-Filter"]')!;
+    expect(filter.getAttribute('data-reading')).toBe('99');
+    expect(filter.querySelector('[aria-checked="true"]')).toBeNull();
+    expect([...filter.querySelectorAll('button')].map(button => button.textContent)).toEqual(['FIL1', 'FIL2', 'FIL3']);
+    (filter.querySelector('[data-testid="external-Filter-2"]') as HTMLButtonElement).click();
+    expect(onFilterChange).toHaveBeenCalledExactlyOnceWith(2);
+
+    props.view = { ...props.view, modeFilter: { ...props.view.modeFilter!,
+      currentMode: { ...props.view.modeFilter!.currentMode, reading: { status: 'known', value: 'AM' } },
+      modeChoices: ['AM', 'FM'],
+    } as ModeFilterViewModel }; props.onModeChange = nextMode; flushSync();
+    const mode = target.querySelector('[data-testid="external-Mode"]')!;
+    expect([...mode.querySelectorAll('button')].map(button => button.textContent)).toEqual(['AM', 'FM']);
+    (mode.querySelector('[data-testid="external-Mode-AM"]') as HTMLButtonElement).click();
+    expect(firstMode).not.toHaveBeenCalled(); expect(nextMode).toHaveBeenCalledExactlyOnceWith('AM');
+    unmount(component);
+  });
+
+  it('revokes null, detached, A-B-A and host-teardown renderer callbacks', () => {
+    const onFilterChange = vi.fn(), a = createFiniteRendererContext(), b = createFiniteRendererContext();
+    const props = proxy({ view: base(), presentation: 'grouped' as 'grouped' | 'independent',
+      finiteAppearance: appearance, rendererContext: null as ReturnType<typeof createFiniteRendererContext> | null,
+      onFilterChange });
+    const component = mount(FilterInstrumentHostFixture, { target, props }); flushSync();
+    expect(target.querySelector('[data-testid="external-Filter"]')).toBeNull();
+    props.rendererContext = a; flushSync(); const groupedA = retainedInvocations.get('Filter')!;
+    props.presentation = 'independent'; flushSync(); const independentA = retainedInvocations.get('Filter')!;
+    groupedA(2); expect(onFilterChange).not.toHaveBeenCalled();
+    independentA(2); expect(onFilterChange).toHaveBeenCalledExactlyOnceWith(2);
+    props.rendererContext = b; flushSync(); const activeB = retainedInvocations.get('Filter')!;
+    independentA(3); expect(onFilterChange).toHaveBeenCalledTimes(1);
+    props.rendererContext = a; flushSync(); const activeA2 = retainedInvocations.get('Filter')!;
+    activeB(3); expect(onFilterChange).toHaveBeenCalledTimes(1);
+    unmount(component); activeA2(3); expect(onFilterChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses exact structural gates and retains unavailable readings without selected truth', () => {
+    const callbacks = { onModeChange: vi.fn(), onFilterChange: vi.fn() };
+    const absentBase = base();
+    const absent = { ...absentBase, modeFilter: { ...absentBase.modeFilter!,
+      currentMode: { ...absentBase.modeFilter!.currentMode,
+        availability: { structural: false, operational: true } },
+      currentFilter: { ...absentBase.modeFilter!.currentFilter,
+        availability: { structural: false, operational: true } },
+    } };
+    const props = proxy({ view: absent, presentation: 'independent' as const, ...callbacks });
+    let component = mount(FilterInstrumentHostFixture, { target, props }); flushSync();
+    expect(target.querySelectorAll('[data-testid^="filter-"]')).toHaveLength(0);
+    unmount(component);
+
+    let retained = modeReading(base(), 'currentMode', { status: 'known', value: 'USB' }, false);
+    retained = modeReading(retained, 'currentFilter', { status: 'known', value: 1 }, false);
+    props.view = retained;
+    component = mount(FilterInstrumentHostFixture, { target, props }); flushSync();
+    for (const id of ['filter-mode-USB', 'filter-select-1']) {
+      const button = target.querySelector(`[data-testid="${id}"]`) as HTMLButtonElement;
+      expect(button.disabled).toBe(true); expect(button.getAttribute('aria-pressed')).toBe('false'); button.click();
+    }
+    expect(callbacks.onModeChange).not.toHaveBeenCalled(); expect(callbacks.onFilterChange).not.toHaveBeenCalled();
+    unmount(component);
+
+    Object.assign(props, { finiteAppearance: appearance, rendererContext: createFiniteRendererContext() });
+    component = mount(FilterInstrumentHostFixture, { target, props }); flushSync();
+    for (const [label, exact] of [['Mode', 'USB'], ['Filter', '1']] as const) {
+      const group = target.querySelector(`[data-testid="external-${label}"]`)!;
+      expect(group.getAttribute('data-reading')).toBe(exact);
+      expect(group.querySelector('[aria-checked="true"]')).toBeNull();
+      expect(group.querySelectorAll('button:disabled')).toHaveLength(group.querySelectorAll('button').length);
+    }
+    retainedInvocations.get('Mode')?.('USB'); retainedInvocations.get('Filter')?.(1);
+    expect(callbacks.onModeChange).not.toHaveBeenCalled(); expect(callbacks.onFilterChange).not.toHaveBeenCalled();
+    unmount(component);
+  });
+});

--- a/frontend/src/semantic/__tests__/FilterSurface.test.ts
+++ b/frontend/src/semantic/__tests__/FilterSurface.test.ts
@@ -13,9 +13,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import { getLocale, setLocale } from '$lib/i18n';
-import FilterSurface, {
+import {
   FILTER_PASSBAND_LEVELS, FILTER_SHAPES, type FilterPassbandLevelField,
 } from '../FilterSurface.svelte';
+import FilterInstrumentHostFixture from './fixtures/FilterInstrumentHostFixture.svelte';
 import { topologyFixtures, withFilterPassband, withModeFilter } from '../fixtures/topologies';
 import type {
   Availability, FilterPassbandViewModel, ModeFilterViewModel, RadioViewModel,
@@ -111,10 +112,13 @@ type PendingProps = {
   pendingFilter?: number | null;
   pendingDataMode?: number | null;
   filterWidthFeedback?: Readonly<CommandScalarFeedback>;
+  presentation?: 'grouped' | 'independent';
 };
 function render(view: RadioViewModel, handlers: Handlers = {}, extra: PendingProps = {}) {
-  const component = mount(FilterSurface, { target, props: {
+  const component = mount(FilterInstrumentHostFixture, { target, props: {
     get view() { return view; },
+    renderSurface: true,
+    get presentation() { return extra.presentation; },
     get pendingFilter() { return extra.pendingFilter; },
     get pendingDataMode() { return extra.pendingDataMode; },
     get filterWidthFeedback() { return extra.filterWidthFeedback; },
@@ -140,6 +144,27 @@ function render(view: RadioViewModel, handlers: Handlers = {}, extra: PendingPro
     output: (testId: string) => q<HTMLElement>(`[data-testid="${testId}"] output`),
   };
 }
+
+describe('hosted Mode and Filter placement', () => {
+  it('renders grouped and independent Mode/Filter once and preserves every residual owner once', () => {
+    for (const presentation of ['grouped', 'independent'] as const) {
+      withSurface(base(), (s) => {
+        expect(target.querySelectorAll('[data-testid="filter-mode"]')).toHaveLength(1);
+        expect(target.querySelectorAll('[data-testid="filter-select"]')).toHaveLength(1);
+        expect(target.querySelectorAll('[data-testid="filter-width"]')).toHaveLength(1);
+        expect(target.querySelectorAll('[data-testid="filter-shape"]')).toHaveLength(1);
+        expect(target.querySelectorAll('[data-testid="filter-data-mode"]')).toHaveLength(1);
+        for (const field of ['ifShift', 'pbtInner', 'pbtOuter']) {
+          expect(target.querySelectorAll(`[data-testid="filter-${field}"]`)).toHaveLength(1);
+        }
+        expect(target.querySelectorAll('[data-slot="mode"], [data-slot="filter"]')).toHaveLength(
+          presentation === 'independent' ? 2 : 0,
+        );
+        expect(s.root()).not.toBeNull();
+      }, {}, { presentation });
+    }
+  });
+});
 
 function withSurface(
   view: RadioViewModel, fn: (s: ReturnType<typeof render>) => void, handlers: Handlers = {},

--- a/frontend/src/semantic/__tests__/fixtures/FilterInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/FilterInstrumentHostFixture.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import type { FiniteControlAppearance, FiniteRendererContext } from '../../../primitives/control-instruments/control-instrument-renderer.svelte';
+  import type { CommandScalarFeedback } from '../../../primitives/scalar/continuous-scalar.svelte';
+  import FilterInstrumentHost from '../../FilterInstrumentHost.svelte';
+  import FilterSurface from '../../FilterSurface.svelte';
+  import type { FilterFiniteChoiceValue, FilterInstrumentHandles } from '../../filter-instruments';
+  import type { RadioViewModel } from '../../radio-view-model';
+
+  interface Props {
+    view: RadioViewModel | null;
+    presentation?: 'grouped' | 'independent';
+    renderSurface?: boolean;
+    pendingFilter?: number | null;
+    pendingDataMode?: number | null;
+    filterWidthFeedback?: Readonly<CommandScalarFeedback>;
+    finiteAppearance?: FiniteControlAppearance<FilterFiniteChoiceValue>;
+    rendererContext?: FiniteRendererContext | null;
+    onModeChange?: (mode: string) => void;
+    onFilterChange?: (filter: number) => void;
+    onDataModeChange?: (mode: number) => void;
+    onFilterWidthChange?: (width: number) => void;
+    onFilterShapeChange?: (shape: number) => void;
+    onIfShiftChange?: (value: number) => void;
+    onPbtInnerChange?: (value: number) => void;
+    onPbtOuterChange?: (value: number) => void;
+  }
+  let {
+    view, presentation = 'grouped', renderSurface = false,
+    pendingFilter = null, pendingDataMode = null, filterWidthFeedback,
+    finiteAppearance, rendererContext = null, onModeChange, onFilterChange,
+    onDataModeChange, onFilterWidthChange, onFilterShapeChange,
+    onIfShiftChange, onPbtInnerChange, onPbtOuterChange,
+  }: Props = $props();
+  let selection = $derived(finiteAppearance === undefined ? {} : { finiteAppearance, rendererContext });
+</script>
+
+{#snippet independent(handles: FilterInstrumentHandles)}
+  <div data-slot="mode">{@render handles.mode()}</div>
+  <div data-slot="filter">{@render handles.filter()}</div>
+{/snippet}
+
+<FilterInstrumentHost {view} {pendingFilter} {onModeChange} {onFilterChange} {...selection}>
+  {#snippet children(handles: FilterInstrumentHandles)}
+    {#if renderSurface && view !== null}
+      <FilterSurface
+        {view} {handles} finiteLayout={presentation === 'independent' ? independent : undefined}
+        {pendingDataMode} {filterWidthFeedback} {onDataModeChange} {onFilterWidthChange}
+        {onFilterShapeChange} {onIfShiftChange} {onPbtInnerChange} {onPbtOuterChange}
+      />
+    {:else}
+      {#key presentation}
+        <section data-testid={`${presentation}-filter-composition`}>
+          {#if presentation === 'grouped'}
+            {@render handles.mode()}{@render handles.filter()}
+          {:else}
+            {@render independent(handles)}
+          {/if}
+        </section>
+      {/key}
+    {/if}
+  {/snippet}
+</FilterInstrumentHost>

--- a/frontend/src/semantic/filter-instruments.ts
+++ b/frontend/src/semantic/filter-instruments.ts
@@ -1,0 +1,10 @@
+import type { Snippet } from 'svelte';
+
+export type FilterFiniteChoiceValue = string | number;
+
+export interface FilterInstrumentHandles {
+  readonly mode: Snippet;
+  readonly filter: Snippet;
+}
+
+export type FilterFiniteLayout = Snippet<[FilterInstrumentHandles]>;


### PR DESCRIPTION
Root file-count waiver: 13 code + 0 regenerated baselines = 13 files.

Moves the Mode and Filter finite controls into one persistent semantic host, so selected component-kit renderers keep current readings and fenced callbacks across Standard and SDR layout changes. Standard places the two handles in named Mode/Filter seats; SDR keeps them grouped at the existing filter location. Filter width, Shape, IF shift, PBT, and DATA stay under their existing Surface owners, and the existing VFO/DSP/TX/RF host and subscription topology remains unchanged.

The selected finite appearance is opt-in for availability-gated choice selection only on Mode and Filter. Authority rotation covers control-session epoch, provider generation, topology, and active receiver, including unknown and synchronous A-B-A transitions; null authority remains inert.

Validation:
- `npm run check`
- scoped ESLint across all 13 changed paths
- 5 focused test files, 191 tests passed
- `git diff --check 80a5690b68bb2d0da14ffb2f76124cd14f51573a`

Linear: MOR-2425

Follow-up validation history:
- Initial head `f33866f3262a4d2494771ea2d9a928018c8b2a4b`: natural visual PASS; natural quick run `34090103569` failed only the four MOR-1400 production-root screenshots (83 other i18n tests passed). Independent exact-head code review PASS: https://github.com/rigplane/rigplane-core/pull/3329#issuecomment-5565956978.
- Diagnosis: the new named Filter seat made its choice group a first child, so the existing Mode-only two-column selector also applied to Filter; NARROW wrapped and shifted the left panel.
- Successor `627163b02a424b5dbc1fd35607ce104f1a85a05f`: `RadioLayout.svelte` now uses explicit named-seat rules (Mode two-column grid, Filter flex row) and restores the exact-base effective 8px (`0.5rem`) separation. No baseline was regenerated.
- Focused pixel classification: all four successor macOS actual PNGs are byte-identical to the corresponding exact-base actual PNGs. Both base and successor retain the same host-specific mismatch against the Linux baselines (`11636/12064/4015/5168` pixels), so natural Linux CI is the terminal pixel evidence.
- Successor local validation: build PASS; check PASS; scoped lint PASS; 5 focused Vitest files / 191 tests PASS; diff-check PASS.
- Successor terminal evidence at exact head: natural quick PASS (`34091398865`, 4m37s); natural visual PASS (`34091398767`, 1m14s); independent review PASS (https://github.com/rigplane/rigplane-core/pull/3329#issuecomment-5566130959); Agent Review Gate and Agent Review Gate v2 PASS.
