### PR TITLE
feat(MOR-2425): publish meter appearance contract

### DIFF
--- a/.github/scripts/quick-path-filters.test.py
+++ b/.github/scripts/quick-path-filters.test.py
@@ -208,7 +208,14 @@ new AsyncFunction('github', 'context', 'core', script)(github, context, core)
 
         self.assertEqual(quick.count(command), 1)
         self.assertEqual(worker.count(command), 1)
-        self.assertLess(quick.index("npm ci"), quick.index(command))
+        npm_install = quick.index("npm ci")
+        browser_install = quick.index("npx playwright install chromium")
+        system_dependencies = quick.index("npx playwright install-deps chromium")
+        portable_verifier = quick.index(command)
+        self.assertLess(npm_install, browser_install)
+        self.assertLess(browser_install, system_dependencies)
+        self.assertLess(system_dependencies, portable_verifier)
+        self.assertLess(portable_verifier, quick.index("Frontend i18n visual smoke"))
         self.assertLess(worker.index("npm ci"), worker.index(command))
 
     def test_docs_only_routes_match_predicate_and_are_base_controlled(self) -> None:

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -208,7 +208,6 @@ jobs:
         run: |
           cd frontend
           npm ci
-          npm run verify:component-kit-api
           npm run lint
           npm run i18n:check
           npm run check
@@ -231,6 +230,11 @@ jobs:
         if: needs.classify.outputs.frontend == 'true'
         working-directory: frontend
         run: sudo -E env "PATH=$PATH" npx playwright install-deps chromium
+
+      - name: Verify portable component-kit package
+        if: needs.classify.outputs.frontend == 'true'
+        working-directory: frontend
+        run: npm run verify:component-kit-api
 
       - name: Frontend i18n visual smoke (RP-ML-006)
         id: i18n-visual

--- a/frontend/component-kit-api/build.mjs
+++ b/frontend/component-kit-api/build.mjs
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { build } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 const packageRoot = path.dirname(fileURLToPath(import.meta.url));
 const frontendRoot = path.dirname(packageRoot);
@@ -11,6 +12,7 @@ const apiDist = path.join(packageRoot, 'dist');
 const fixtureRoot = path.join(packageRoot, 'fixtures', 'external-kit');
 const fixtureDist = path.join(fixtureRoot, 'dist');
 const tsc = path.join(frontendRoot, 'node_modules', 'typescript', 'bin', 'tsc');
+const svelteCheck = path.join(frontendRoot, 'node_modules', 'svelte-check', 'bin', 'svelte-check');
 
 function runTypeScript(config) {
   const result = spawnSync(process.execPath, [tsc, '-p', config], {
@@ -22,10 +24,20 @@ function runTypeScript(config) {
   }
 }
 
-async function bundle(entry, outDir, external) {
+function runSvelteCheck(config) {
+  const result = spawnSync(process.execPath, [
+    svelteCheck, '--workspace', fixtureRoot, '--tsconfig', config, '--threshold', 'error',
+  ], { cwd: frontendRoot, encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`Svelte fixture check failed.\n${result.stdout}${result.stderr}`);
+  }
+}
+
+async function bundle(entry, outDir, external, plugins = []) {
   await build({
     configFile: false,
     logLevel: 'warn',
+    plugins,
     publicDir: false,
     build: {
       emptyOutDir: false,
@@ -76,9 +88,11 @@ async function buildFixture() {
   await bundle(
     path.join(fixtureRoot, 'src', 'index.ts'),
     fixtureDist,
-    ['@rigplane/component-kit-api', 'svelte'],
+    (id) => id === '@rigplane/component-kit-api' || id === 'svelte' || id.startsWith('svelte/'),
+    [svelte()],
   );
   const temporaryConfig = path.join(fixtureDist, 'tsconfig.build.json');
+  const checkConfig = path.join(fixtureDist, 'tsconfig.check.json');
   await writeFile(temporaryConfig, JSON.stringify({
     extends: '../../../../tsconfig.app.json',
     compilerOptions: {
@@ -102,10 +116,26 @@ async function buildFixture() {
     },
     include: ['../src/index.ts'],
   }, null, 2));
+  await writeFile(checkConfig, JSON.stringify({
+    extends: '../../../../tsconfig.app.json',
+    compilerOptions: {
+      allowJs: false,
+      baseUrl: '../../../..',
+      checkJs: false,
+      paths: {
+        '@rigplane/component-kit-api': [
+          'component-kit-api/dist/types/component-kit-api/src/index.d.ts',
+        ],
+      },
+    },
+    include: ['../src/**/*.ts', '../src/**/*.svelte'],
+  }, null, 2));
   try {
+    runSvelteCheck(checkConfig);
     runTypeScript(temporaryConfig);
   } finally {
     await unlink(temporaryConfig).catch(() => {});
+    await unlink(checkConfig).catch(() => {});
   }
 }
 

--- a/frontend/component-kit-api/fixtures/external-kit/package.json
+++ b/frontend/component-kit-api/fixtures/external-kit/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "sideEffects": false,
   "peerDependencies": {
-    "@rigplane/component-kit-api": "0.2.0",
+    "@rigplane/component-kit-api": "0.3.0",
     "svelte": ">=5.45.2 <6"
   },
   "files": [

--- a/frontend/component-kit-api/fixtures/external-kit/src/FixtureLevelMeter.svelte
+++ b/frontend/component-kit-api/fixtures/external-kit/src/FixtureLevelMeter.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import type { LevelMeterRendererProps } from '@rigplane/component-kit-api';
+
+  let { view, resetPeak }: LevelMeterRendererProps = $props();
+  const domain = $derived(
+    view.evidence.domain.kind === 'engineering'
+      ? `engineering:${view.evidence.domain.unit}`
+      : view.evidence.domain.kind,
+  );
+</script>
+
+<div
+  data-fixture-level={view.key}
+  data-state={view.evidence.state}
+  data-domain={domain}
+  data-value={view.evidence.state === 'current' || view.evidence.state === 'stale'
+    ? view.evidence.value
+    : undefined}
+  data-ratio-scale={view.key === 'swr' ? view.ratioScale : undefined}
+  aria-label={view.accessibleDescription}
+>
+  <span>{view.displayText}</span>
+  {#if resetPeak?.view?.available}
+    <button type="button" onclick={() => resetPeak?.invoke()}>Reset peak</button>
+  {/if}
+</div>

--- a/frontend/component-kit-api/fixtures/external-kit/src/FixtureSignalMeter.svelte
+++ b/frontend/component-kit-api/fixtures/external-kit/src/FixtureSignalMeter.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import type { SignalMeterRendererProps } from '@rigplane/component-kit-api';
+
+  let { view }: SignalMeterRendererProps = $props();
+  const domain = $derived(
+    view.evidence.domain.kind === 'engineering'
+      ? `engineering:${view.evidence.domain.unit}`
+      : view.evidence.domain.kind,
+  );
+</script>
+
+<div
+  data-fixture-signal
+  data-state={view.evidence.state}
+  data-domain={domain}
+  data-value={view.evidence.state === 'current' ? view.evidence.value : undefined}
+  data-scale={view.scaleMode}
+  data-tick-kinds={view.ticks.map(({ kind }) => kind).join(',')}
+  aria-label={view.accessibleDescription}
+>
+  <span>{view.primaryText}</span>
+  <span>{view.secondaryText}</span>
+</div>

--- a/frontend/component-kit-api/fixtures/external-kit/src/index.ts
+++ b/frontend/component-kit-api/fixtures/external-kit/src/index.ts
@@ -7,10 +7,13 @@ import {
   type FrequencyRenderer,
   type InstrumentGroup,
   type LayoutManifest,
+  type MeterAppearance,
   type PresentationComponent,
   type PresentationDeclaration,
   type ScalarAppearance,
 } from '@rigplane/component-kit-api';
+import FixtureLevelMeter from './FixtureLevelMeter.svelte';
+import FixtureSignalMeter from './FixtureSignalMeter.svelte';
 
 const component = (() => ({})) as unknown as PresentationComponent;
 const scalarRenderer = (() => ({})) as unknown as NonNullable<ScalarAppearance['hbar']>;
@@ -29,6 +32,10 @@ const choiceRenderer = ((_internals, { lease }) => {
   void request;
   return {};
 }) satisfies FiniteControlAppearance['choice'];
+const meterAppearance = {
+  signal: FixtureSignalMeter,
+  level: FixtureLevelMeter,
+} satisfies MeterAppearance;
 
 const language: DesignLanguageManifest = {
   id: 'fixture-line',
@@ -82,6 +89,7 @@ export const fixtureKit: ComponentKitDeclaration = defineComponentKit({
   finiteControlAppearances: {
     fixture: { action: actionRenderer, toggle: toggleRenderer, choice: choiceRenderer },
   },
+  meterAppearances: { fixture: meterAppearance },
   designLanguages: [language],
   layouts: [layout],
   instrumentGroups: [group],

--- a/frontend/component-kit-api/package.json
+++ b/frontend/component-kit-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rigplane/component-kit-api",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "sideEffects": false,

--- a/frontend/component-kit-api/src/index.ts
+++ b/frontend/component-kit-api/src/index.ts
@@ -59,6 +59,80 @@ export type ChoiceRendererProps<T extends FiniteChoiceValue = FiniteChoiceValue>
   HostChoiceRendererProps<T>;
 export type FiniteControlAppearance = HostFiniteControlAppearance<FiniteChoiceValue>;
 
+export type MeterDisplayDomain =
+  | Readonly<{ kind: 'engineering'; unit: 'db' | 'normalized' | 'w' | 'ratio' | 'v' | 'a' }>
+  | Readonly<{ kind: 'raw' }>
+  | Readonly<{ kind: 'unknown' }>;
+
+export type MeterNumericEvidence =
+  | Readonly<{
+    state: 'current' | 'stale';
+    value: number;
+    domain: MeterDisplayDomain;
+  }>
+  | Readonly<{
+    state: 'idle' | 'unknown' | 'unsupported';
+    domain: MeterDisplayDomain;
+  }>;
+export type SignalMeterEvidence =
+  | Readonly<{ state: 'current'; value: number; domain: MeterDisplayDomain }>
+  | Readonly<{ state: 'unknown'; domain: MeterDisplayDomain }>;
+export type SignalMeterScaleMode = 's' | 'raw' | 'none';
+export type SignalMeterTickKind = 'major' | 'mid' | 'minor';
+export interface SignalMeterMark {
+  readonly actual: number;
+  readonly fraction: number;
+  readonly text: string;
+}
+export interface SignalMeterTick {
+  readonly fraction: number;
+  readonly kind: SignalMeterTickKind;
+}
+export interface SignalMeterRendererView {
+  readonly kind: 'signal';
+  readonly evidence: SignalMeterEvidence;
+  readonly relevant?: boolean;
+  readonly scaleMode: SignalMeterScaleMode;
+  readonly displayedFraction: number | null;
+  readonly peakFraction: number | null;
+  readonly primaryText: string;
+  readonly secondaryText: string;
+  readonly accessibleDescription: string;
+  readonly crossoverFraction: number | null;
+  readonly marks: readonly SignalMeterMark[];
+  readonly ticks: readonly SignalMeterTick[];
+}
+export type LevelMeterKey =
+  | 'power' | 'swr' | 'alc' | 'drainCurrent' | 'drainVoltage' | 'compression';
+interface LevelMeterRendererViewBase<Key extends LevelMeterKey> {
+  readonly kind: 'level';
+  readonly key: Key;
+  readonly label: string;
+  readonly evidence: MeterNumericEvidence;
+  readonly relevant: boolean;
+  readonly observed: boolean;
+  readonly displayedFraction: number | null;
+  readonly peakFraction: number | null;
+  readonly displayText: string;
+  readonly stateText: string;
+  readonly accessibleDescription?: string;
+  readonly gauge: boolean;
+  readonly fault: boolean;
+  readonly peakEnabled: boolean;
+}
+export type LevelMeterRendererView =
+  | Readonly<LevelMeterRendererViewBase<Exclude<LevelMeterKey, 'swr'>>>
+  | Readonly<LevelMeterRendererViewBase<'swr'> & { readonly ratioScale: boolean }>;
+export interface SignalMeterRendererProps { readonly view: Readonly<SignalMeterRendererView> }
+export interface LevelMeterRendererProps {
+  readonly view: Readonly<LevelMeterRendererView>;
+  readonly resetPeak?: ActionRendererLease;
+}
+export interface MeterAppearance {
+  readonly signal: Component<SignalMeterRendererProps>;
+  readonly level: Component<LevelMeterRendererProps>;
+}
+
 export interface FrequencyRendererProps {
   readonly model: Readonly<FrequencyReadoutModel>;
   readonly interaction: FrequencyInteraction;
@@ -83,6 +157,7 @@ export interface ComponentKitDeclaration {
   readonly scalarAppearances?: Readonly<Record<string, ScalarAppearance>>;
   readonly frequencyReadouts?: Readonly<Record<string, FrequencyRenderer>>;
   readonly finiteControlAppearances?: Readonly<Record<string, FiniteControlAppearance>>;
+  readonly meterAppearances?: Readonly<Record<string, MeterAppearance>>;
   readonly designLanguages?: readonly DesignLanguageManifest[];
   readonly layouts?: readonly LayoutManifest[];
   readonly instrumentGroups?: readonly InstrumentGroup[];

--- a/frontend/component-kit-api/src/index.ts
+++ b/frontend/component-kit-api/src/index.ts
@@ -59,11 +59,16 @@ export type ChoiceRendererProps<T extends FiniteChoiceValue = FiniteChoiceValue>
   HostChoiceRendererProps<T>;
 export type FiniteControlAppearance = HostFiniteControlAppearance<FiniteChoiceValue>;
 
+/**
+ * Signal `engineering/db` values are dB relative to S9, never dBm.
+ * `raw` and `unknown` do not authorize an engineering unit label.
+ */
 export type MeterDisplayDomain =
   | Readonly<{ kind: 'engineering'; unit: 'db' | 'normalized' | 'w' | 'ratio' | 'v' | 'a' }>
   | Readonly<{ kind: 'raw' }>
   | Readonly<{ kind: 'unknown' }>;
 
+/** Stale evidence may retain its numeric value while live projected geometry is unavailable. */
 export type MeterNumericEvidence =
   | Readonly<{
     state: 'current' | 'stale';

--- a/frontend/component-kit-api/verify-package.mjs
+++ b/frontend/component-kit-api/verify-package.mjs
@@ -424,15 +424,30 @@ mount(App, { target: document.querySelector('#app')! });
       displayText: '1.5', stateText: '', accessibleDescription: 'SWR: Current observation. 1.5',
       gauge: true, fault: false, peakEnabled: false, ratioScale: true,
     },
+    {
+      kind: 'level', key: 'swr', label: 'SWR',
+      evidence: { state: 'current', value: 120, domain: { kind: 'raw' } },
+      relevant: true, observed: true, displayedFraction: 0.47, peakFraction: null,
+      displayText: '120 raw', stateText: '', accessibleDescription: 'SWR: 120 raw',
+      gauge: true, fault: false, peakEnabled: false, ratioScale: false,
+    },
   ];
-  const counter = globalThis as typeof globalThis & { __resetCount: number };
+  const counter = globalThis as typeof globalThis & {
+    __resetCount: number;
+    __disposeReset: () => void;
+    __invokeReset: () => void;
+  };
+  let resetActive = $state(true);
   counter.__resetCount = 0;
   const resetPeak: ActionRendererLease = {
-    get active() { return true; },
-    get view() { return { label: 'Reset peak', available: true }; },
-    invoke() { counter.__resetCount += 1; },
-    dispose() {},
+    get active() { return resetActive; },
+    get view() { return resetActive ? { label: 'Reset peak', available: true } : undefined; },
+    invoke() { if (resetActive) counter.__resetCount += 1; },
+    dispose() { resetActive = false; },
   };
+  const retainedResetInvoke = resetPeak.invoke.bind(resetPeak);
+  counter.__disposeReset = () => resetPeak.dispose();
+  counter.__invokeReset = retainedResetInvoke;
 </script>
 
 {#each signals as view}<Signal {view} />{/each}
@@ -455,11 +470,21 @@ mount(App, { target: document.querySelector('#app')! });
       const page = await browser.newPage();
       const pageErrors = [];
       page.on('pageerror', (error) => pageErrors.push(error));
+      await page.addInitScript(() => {
+        globalThis.__fixtureTimerCalls = [];
+        for (const name of ['setTimeout', 'setInterval', 'requestAnimationFrame']) {
+          const original = globalThis[name];
+          globalThis[name] = (...args) => {
+            globalThis.__fixtureTimerCalls.push(name);
+            return Reflect.apply(original, globalThis, args);
+          };
+        }
+      });
       await page.goto(origin, { waitUntil: 'networkidle' });
       const signals = page.locator('[data-fixture-signal]');
       const levels = page.locator('[data-fixture-level]');
       assert.equal(await signals.count(), 5);
-      assert.equal(await levels.count(), 6);
+      assert.equal(await levels.count(), 7);
       assert.equal(await signals.nth(0).getAttribute('data-domain'), 'engineering:db');
       assert.equal(await signals.nth(0).getAttribute('data-tick-kinds'), 'major,mid,minor');
       assert.equal(await signals.nth(1).getAttribute('data-scale'), 'none');
@@ -471,9 +496,19 @@ mount(App, { target: document.querySelector('#app')! });
       assert.equal(await page.locator('[data-fixture-level="alc"]').getAttribute('data-state'), 'stale');
       assert.equal(await page.locator('[data-fixture-level="alc"]').getAttribute('data-value'), '0.2');
       assert.equal(await page.locator('[data-fixture-level="drainCurrent"]').getAttribute('data-value'), null);
-      assert.equal(await page.locator('[data-fixture-level="swr"]').getAttribute('data-ratio-scale'), 'true');
+      assert.deepEqual(
+        await page.locator('[data-fixture-level="swr"]').evaluateAll((nodes) =>
+          nodes.map((node) => node.getAttribute('data-ratio-scale'))),
+        ['true', 'false'],
+      );
+      assert.equal(await page.getByRole('button', { name: 'Reset peak' }).count(), 1);
       await page.getByRole('button', { name: 'Reset peak' }).click();
       assert.equal(await page.evaluate(() => globalThis.__resetCount), 1);
+      await page.evaluate(() => globalThis.__disposeReset());
+      await page.evaluate(() => globalThis.__invokeReset());
+      assert.equal(await page.evaluate(() => globalThis.__resetCount), 1);
+      assert.equal(await page.getByRole('button', { name: 'Reset peak' }).count(), 0);
+      assert.deepEqual(await page.evaluate(() => globalThis.__fixtureTimerCalls), []);
       assert.deepEqual(pageErrors, []);
     } finally {
       await browser.close();

--- a/frontend/component-kit-api/verify-package.mjs
+++ b/frontend/component-kit-api/verify-package.mjs
@@ -1,13 +1,16 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import {
   mkdtemp, mkdir, readFile, readdir, realpath, rm, writeFile,
 } from 'node:fs/promises';
+import { createServer } from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import ts from 'typescript';
+import { chromium } from 'playwright';
 
 const packageRoot = path.dirname(fileURLToPath(import.meta.url));
 const frontendRoot = path.dirname(packageRoot);
@@ -32,6 +35,38 @@ async function filesUnder(directory) {
 
 function packageFiles(pack) {
   return pack.files.map(({ path: file }) => file).sort();
+}
+
+async function sha256(file) {
+  return createHash('sha256').update(await readFile(file)).digest('hex');
+}
+
+async function withStaticServer(directory, visit) {
+  const server = createServer(async (request, response) => {
+    try {
+      const pathname = new URL(request.url ?? '/', 'http://127.0.0.1').pathname;
+      const relative = pathname === '/' ? 'index.html' : pathname.slice(1);
+      const file = path.resolve(directory, relative);
+      if (!file.startsWith(`${path.resolve(directory)}${path.sep}`)) throw new Error('bad path');
+      const body = await readFile(file);
+      response.setHeader('content-type', file.endsWith('.js') ? 'text/javascript' : 'text/html');
+      response.end(body);
+    } catch {
+      response.statusCode = 404;
+      response.end('not found');
+    }
+  });
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  try {
+    const address = server.address();
+    assert(address && typeof address === 'object');
+    await visit(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
 }
 
 async function assertPackedShape(pack, directory, requiredTypes) {
@@ -139,6 +174,8 @@ try {
 
   const apiPack = pack(packageRoot, tarballs);
   const fixturePack = pack(fixtureRoot, tarballs);
+  const apiTarballSha256 = await sha256(apiPack.tarball);
+  const fixtureTarballSha256 = await sha256(fixturePack.tarball);
   await assertPackedShape(apiPack, packageRoot, [
     'dist/types/component-kit-api/src/index.d.ts',
     'dist/types/src/primitives/control-instruments/control-instrument-behavior.d.ts',
@@ -180,6 +217,7 @@ try {
       svelte: '5.55.8',
     },
     devDependencies: {
+      '@sveltejs/vite-plugin-svelte': '6.2.1',
       typescript: '5.9.3',
       vite: '7.3.3',
     },
@@ -194,13 +232,12 @@ try {
       target: 'ES2022',
       types: ['svelte'],
     },
-    include: ['src/**/*.ts'],
+    include: ['src/**/*.ts', 'src/**/*.svelte'],
   }, null, 2));
-  await writeFile(path.join(consumer, 'vite.config.js'), `export default {
+  await writeFile(path.join(consumer, 'vite.config.js'), `import { svelte } from '@sveltejs/vite-plugin-svelte';
+export default {
+  plugins: [svelte()],
   publicDir: false,
-  build: {
-    lib: { entry: 'src/index.ts', formats: ['es'], fileName: () => 'consumer.js' },
-  },
 };
 `);
   await writeFile(path.join(consumer, 'src', 'index.ts'), `import {
@@ -214,8 +251,13 @@ try {
   type FiniteControlReading,
   type FrequencyRendererProps,
   type LayoutManifest,
+  type LevelMeterRendererProps,
+  type MeterAppearance,
+  type MeterNumericEvidence,
   type PresentationDeclaration,
   type ScalarAppearance,
+  type SignalMeterRendererProps,
+  type SignalMeterEvidence,
 } from '@rigplane/component-kit-api';
 import type { Component } from 'svelte';
 import fixtureKit from '@rigplane/external-component-kit-fixture';
@@ -226,6 +268,14 @@ const layout: LayoutManifest | undefined = declaration.layouts?.[0];
 const presentation: PresentationDeclaration | undefined = declaration.presentations?.[0];
 const finite: FiniteControlAppearance | undefined = declaration.finiteControlAppearances?.fixture;
 const numericChoiceRenderer: Component<ChoiceRendererProps<number>> | undefined = finite?.choice;
+const meter: MeterAppearance | undefined = declaration.meterAppearances?.fixture;
+const signalMeterRenderer: Component<SignalMeterRendererProps> | undefined = meter?.signal;
+const levelMeterRenderer: Component<LevelMeterRendererProps> | undefined = meter?.level;
+const oldShape: ComponentKitDeclaration = { apiVersion: 1, id: 'old-shape' };
+// @ts-expect-error a current numeric observation always carries its value
+const invalidCurrentEvidence: MeterNumericEvidence = { state: 'current', domain: { kind: 'engineering', unit: 'w' } };
+// @ts-expect-error unknown signal evidence cannot smuggle a numeric value
+const invalidUnknownSignal: SignalMeterEvidence = { state: 'unknown', value: 0, domain: { kind: 'unknown' } };
 const oldChoiceOption: ControlOption<'OFF'> = { value: 'OFF', label: 'Off' };
 const reasonedChoiceOption: ControlOption<'DATA1'> = {
   value: 'DATA1', label: 'Data 1', disabled: true, disabledReason: 'Not available',
@@ -251,6 +301,11 @@ void scalar;
 void layout;
 void presentation;
 void numericChoiceRenderer;
+void signalMeterRenderer;
+void levelMeterRenderer;
+void oldShape;
+void invalidCurrentEvidence;
+void invalidUnknownSignal;
 void oldChoiceOption;
 void reasonedChoiceOption;
 void inspectChoice;
@@ -271,6 +326,118 @@ export type PrivateRootMustStayUnavailable = [
   ChoiceRendererInput<string>,
 ];
 `);
+  await writeFile(path.join(consumer, 'index.html'), `<main id="app"></main><script type="module" src="/src/mount.ts"></script>`);
+  await writeFile(path.join(consumer, 'src', 'mount.ts'), `import { mount } from 'svelte';
+import App from './App.svelte';
+mount(App, { target: document.querySelector('#app')! });
+`);
+  await writeFile(path.join(consumer, 'src', 'App.svelte'), `<script lang="ts">
+  import fixtureKit from '@rigplane/external-component-kit-fixture';
+  import type {
+    ActionRendererLease,
+    LevelMeterRendererView,
+    SignalMeterRendererView,
+  } from '@rigplane/component-kit-api';
+
+  const appearance = fixtureKit.meterAppearances?.fixture;
+  if (appearance === undefined) throw new Error('packed meter appearance missing');
+  const Signal = appearance.signal;
+  const Level = appearance.level;
+  const engineering = { kind: 'engineering', unit: 'db' } as const;
+  const signals: readonly SignalMeterRendererView[] = [
+    {
+      kind: 'signal', evidence: { state: 'current', value: -12, domain: engineering },
+      scaleMode: 's', displayedFraction: 0.4, peakFraction: 0.6,
+      primaryText: 'S7', secondaryText: '−85 dBm', accessibleDescription: 'S meter S7',
+      crossoverFraction: 0.55, marks: [{ actual: 0, fraction: 0.55, text: '9' }],
+      ticks: [
+        { fraction: 0, kind: 'major' }, { fraction: 0.1, kind: 'mid' },
+        { fraction: 0.2, kind: 'minor' },
+      ],
+    },
+    {
+      kind: 'signal', evidence: { state: 'current', value: -12, domain: engineering },
+      scaleMode: 'none', displayedFraction: null, peakFraction: null,
+      primaryText: '−12 dB rel S9', secondaryText: 'scale unavailable',
+      accessibleDescription: 'S meter minus 12 decibels relative to S9, scale unavailable',
+      crossoverFraction: null, marks: [], ticks: [],
+    },
+    {
+      kind: 'signal', evidence: { state: 'current', value: 112, domain: { kind: 'raw' } },
+      scaleMode: 'raw', displayedFraction: 0.44, peakFraction: 0.5,
+      primaryText: '112', secondaryText: 'uncalibrated',
+      accessibleDescription: 'S meter 112 raw, uncalibrated', crossoverFraction: null,
+      marks: [], ticks: [],
+    },
+    {
+      kind: 'signal', evidence: { state: 'current', value: 41, domain: { kind: 'unknown' } },
+      scaleMode: 'none', displayedFraction: null, peakFraction: null,
+      primaryText: '41', secondaryText: 'unit unknown',
+      accessibleDescription: 'S meter 41, unit unknown', crossoverFraction: null,
+      marks: [], ticks: [],
+    },
+    {
+      kind: 'signal', evidence: { state: 'unknown', domain: { kind: 'unknown' } },
+      scaleMode: 'none', displayedFraction: null, peakFraction: null,
+      primaryText: '?', secondaryText: 'unit unknown',
+      accessibleDescription: 'S meter reading unknown, unit unknown', crossoverFraction: null,
+      marks: [], ticks: [],
+    },
+  ];
+  const levels: readonly LevelMeterRendererView[] = [
+    {
+      kind: 'level', key: 'power', label: 'Po',
+      evidence: { state: 'current', value: 50, domain: { kind: 'engineering', unit: 'w' } },
+      relevant: true, observed: true, displayedFraction: 0.5, peakFraction: 0.7,
+      displayText: '50 W', stateText: '', accessibleDescription: 'Po: Current observation. 50 W',
+      gauge: true, fault: false, peakEnabled: true,
+    },
+    {
+      kind: 'level', key: 'alc', label: 'ALC',
+      evidence: { state: 'stale', value: 0.2, domain: { kind: 'engineering', unit: 'normalized' } },
+      relevant: true, observed: false, displayedFraction: null, peakFraction: null,
+      displayText: 'STALE', stateText: 'STALE', accessibleDescription: 'ALC: Stale observation',
+      gauge: true, fault: false, peakEnabled: false,
+    },
+    {
+      kind: 'level', key: 'drainCurrent', label: 'Id',
+      evidence: { state: 'idle', domain: { kind: 'engineering', unit: 'a' } },
+      relevant: false, observed: false, displayedFraction: null, peakFraction: null,
+      displayText: 'IDLE', stateText: 'IDLE', gauge: true, fault: false, peakEnabled: false,
+    },
+    {
+      kind: 'level', key: 'drainVoltage', label: 'Vd',
+      evidence: { state: 'unknown', domain: { kind: 'unknown' } },
+      relevant: true, observed: false, displayedFraction: null, peakFraction: null,
+      displayText: 'Vd ?', stateText: '', gauge: false, fault: false, peakEnabled: false,
+    },
+    {
+      kind: 'level', key: 'compression', label: 'COMP',
+      evidence: { state: 'unsupported', domain: { kind: 'engineering', unit: 'db' } },
+      relevant: true, observed: false, displayedFraction: null, peakFraction: null,
+      displayText: '?', stateText: '?', gauge: false, fault: false, peakEnabled: false,
+    },
+    {
+      kind: 'level', key: 'swr', label: 'SWR',
+      evidence: { state: 'current', value: 1.5, domain: { kind: 'engineering', unit: 'ratio' } },
+      relevant: true, observed: true, displayedFraction: 0.2, peakFraction: null,
+      displayText: '1.5', stateText: '', accessibleDescription: 'SWR: Current observation. 1.5',
+      gauge: true, fault: false, peakEnabled: false, ratioScale: true,
+    },
+  ];
+  const counter = globalThis as typeof globalThis & { __resetCount: number };
+  counter.__resetCount = 0;
+  const resetPeak: ActionRendererLease = {
+    get active() { return true; },
+    get view() { return { label: 'Reset peak', available: true }; },
+    invoke() { counter.__resetCount += 1; },
+    dispose() {},
+  };
+</script>
+
+{#each signals as view}<Signal {view} />{/each}
+{#each levels as view, index}<Level {view} resetPeak={index === 0 ? resetPeak : undefined} />{/each}
+`);
 
   execute('npm', [
     'install', '--ignore-scripts', '--no-audit', '--no-fund', '--package-lock=false',
@@ -281,6 +448,37 @@ export type PrivateRootMustStayUnavailable = [
   execute(process.execPath, [
     path.join(consumer, 'node_modules', 'vite', 'bin', 'vite.js'), 'build', '--config', 'vite.config.js',
   ], consumer);
+
+  await withStaticServer(path.join(consumer, 'dist'), async (origin) => {
+    const browser = await chromium.launch({ headless: true });
+    try {
+      const page = await browser.newPage();
+      const pageErrors = [];
+      page.on('pageerror', (error) => pageErrors.push(error));
+      await page.goto(origin, { waitUntil: 'networkidle' });
+      const signals = page.locator('[data-fixture-signal]');
+      const levels = page.locator('[data-fixture-level]');
+      assert.equal(await signals.count(), 5);
+      assert.equal(await levels.count(), 6);
+      assert.equal(await signals.nth(0).getAttribute('data-domain'), 'engineering:db');
+      assert.equal(await signals.nth(0).getAttribute('data-tick-kinds'), 'major,mid,minor');
+      assert.equal(await signals.nth(1).getAttribute('data-scale'), 'none');
+      assert.equal(await signals.nth(1).getAttribute('data-value'), '-12');
+      assert.equal(await signals.nth(2).getAttribute('data-domain'), 'raw');
+      assert.equal(await signals.nth(3).getAttribute('data-domain'), 'unknown');
+      assert.equal(await signals.nth(3).getAttribute('data-value'), '41');
+      assert.equal(await signals.nth(4).getAttribute('data-value'), null);
+      assert.equal(await page.locator('[data-fixture-level="alc"]').getAttribute('data-state'), 'stale');
+      assert.equal(await page.locator('[data-fixture-level="alc"]').getAttribute('data-value'), '0.2');
+      assert.equal(await page.locator('[data-fixture-level="drainCurrent"]').getAttribute('data-value'), null);
+      assert.equal(await page.locator('[data-fixture-level="swr"]').getAttribute('data-ratio-scale'), 'true');
+      await page.getByRole('button', { name: 'Reset peak' }).click();
+      assert.equal(await page.evaluate(() => globalThis.__resetCount), 1);
+      assert.deepEqual(pageErrors, []);
+    } finally {
+      await browser.close();
+    }
+  });
 
   await writeFile(path.join(consumer, 'inspect.mjs'), `import assert from 'node:assert/strict';
 import * as api from '@rigplane/component-kit-api';
@@ -308,12 +506,17 @@ assert.equal(api.defineComponentKit(fixtureKit), fixtureKit);
     path.join(consumer, 'node_modules', '@rigplane', 'component-kit-api', 'package.json'),
     'utf8',
   ));
+  const installedFixture = JSON.parse(await readFile(
+    path.join(consumer, 'node_modules', '@rigplane', 'external-component-kit-fixture', 'package.json'),
+    'utf8',
+  ));
   const installedSvelte = JSON.parse(await readFile(
     path.join(consumer, 'node_modules', 'svelte', 'package.json'),
     'utf8',
   ));
-  assert.equal(installedApi.version, '0.2.0');
+  assert.equal(installedApi.version, '0.3.0');
   assert.equal(installedApi.peerDependencies.svelte, '>=5.45.2 <6');
+  assert.equal(installedFixture.peerDependencies['@rigplane/component-kit-api'], '0.3.0');
 
   console.log('component-kit-api portable package verification: OK');
   console.log(`runtime exports: COMPONENT_KIT_API_VERSION, defineComponentKit`);
@@ -322,6 +525,8 @@ assert.equal(api.defineComponentKit(fixtureKit), fixtureKit);
   console.log(`fixture declarations: ${fixtureDeclarations.length}`);
   console.log(`API tarball files (${apiPack.files.length}): ${packageFiles(apiPack).join(', ')}`);
   console.log(`fixture tarball files (${fixturePack.files.length}): ${packageFiles(fixturePack).join(', ')}`);
+  console.log(`API tarball SHA-256: ${apiTarballSha256}`);
+  console.log(`fixture tarball SHA-256 (browser mounted): ${fixtureTarballSha256}`);
 } finally {
   await rm(temporaryRoot, { recursive: true, force: true });
 }

--- a/frontend/src/component-kits/__tests__/activation.test.ts
+++ b/frontend/src/component-kits/__tests__/activation.test.ts
@@ -138,7 +138,7 @@ describe('component-kit activation transaction', () => {
     await activation.activateComponentKits(config([
       kit('copy-meter-kit', { meterAppearances: meters }),
     ], { meterAppearance: 'selected' }));
-    selectedAppearance.level = signalMeterRenderer as MeterAppearance['level'];
+    selectedAppearance.level = (() => ({})) as unknown as MeterAppearance['level'];
     delete meters.selected;
 
     expect(activation.getSelectedMeterAppearance()?.level).toBe(levelMeterRenderer);

--- a/frontend/src/component-kits/__tests__/activation.test.ts
+++ b/frontend/src/component-kits/__tests__/activation.test.ts
@@ -3,6 +3,7 @@ import type {
   ComponentKitDeclaration,
   FiniteControlAppearance,
   FrequencyRenderer,
+  MeterAppearance,
   ScalarAppearance,
 } from '../../../component-kit-api/src/index';
 
@@ -11,6 +12,8 @@ const scalarRenderer = (() => ({})) as unknown as NonNullable<ScalarAppearance['
 const actionRenderer = (() => ({})) as unknown as FiniteControlAppearance['action'];
 const toggleRenderer = (() => ({})) as unknown as FiniteControlAppearance['toggle'];
 const choiceRenderer = (() => ({})) as unknown as FiniteControlAppearance['choice'];
+const signalMeterRenderer = (() => ({})) as unknown as MeterAppearance['signal'];
+const levelMeterRenderer = (() => ({})) as unknown as MeterAppearance['level'];
 
 function appearance(name: string): ScalarAppearance {
   return { name, knob: scalarRenderer };
@@ -18,6 +21,10 @@ function appearance(name: string): ScalarAppearance {
 
 function finiteAppearance(): FiniteControlAppearance {
   return { action: actionRenderer, toggle: toggleRenderer, choice: choiceRenderer };
+}
+
+function meterAppearance(): MeterAppearance {
+  return { signal: signalMeterRenderer, level: levelMeterRenderer };
 }
 
 function kit(
@@ -64,23 +71,31 @@ describe('component-kit activation transaction', () => {
     expect(activation.getSelectedScalarAppearance()).toBeUndefined();
     expect(activation.getSelectedFrequencyReadout()).toBeUndefined();
     expect(activation.getSelectedFiniteControlAppearance()).toBeUndefined();
+    expect(activation.getSelectedMeterAppearance()).toBeUndefined();
   });
 
-  it('loads every kit, then commits selected scalar, frequency, and finite renderers', async () => {
+  it('loads every kit, then commits every selected appearance in one snapshot', async () => {
     const activation = await subject();
     const finite = finiteAppearance();
-    const declaration = kit('field-kit', { finiteControlAppearances: { 'field-kit-finite': finite } });
+    const meter = meterAppearance();
+    const declaration = kit('field-kit', {
+      finiteControlAppearances: { 'field-kit-finite': finite },
+      meterAppearances: { 'field-kit-meter': meter },
+    });
 
     await activation.activateComponentKits(config([declaration], {
       scalarAppearance: 'field-kit-scalar',
       frequencyReadout: 'field-kit-frequency',
       finiteControlAppearance: 'field-kit-finite',
+      meterAppearance: 'field-kit-meter',
     }));
 
     expect(activation.getSelectedScalarAppearance()).toEqual(appearance('field-kit scalar'));
     expect(activation.getSelectedFrequencyReadout()).toBe(renderer);
     expect(activation.getSelectedFiniteControlAppearance()).toEqual(finite);
     expect(Object.isFrozen(activation.getSelectedFiniteControlAppearance())).toBe(true);
+    expect(activation.getSelectedMeterAppearance()).toEqual(meter);
+    expect(Object.isFrozen(activation.getSelectedMeterAppearance())).toBe(true);
   });
 
   it('keeps scalar/frequency-only API 1 declarations compatible', async () => {
@@ -88,6 +103,7 @@ describe('component-kit activation transaction', () => {
     await activation.activateComponentKits(config([kit('legacy-api-one')]));
 
     expect(activation.getSelectedFiniteControlAppearance()).toBeUndefined();
+    expect(activation.getSelectedMeterAppearance()).toBeUndefined();
   });
 
   it('copies declarations and selection before the single commit', async () => {
@@ -114,6 +130,20 @@ describe('component-kit activation transaction', () => {
     expect(activation.getSelectedFrequencyReadout()).toBe(renderer);
   });
 
+  it('copies a meter appearance before committing it', async () => {
+    const activation = await subject();
+    const selectedAppearance = { signal: signalMeterRenderer, level: levelMeterRenderer };
+    const meters: Record<string, MeterAppearance> = { selected: selectedAppearance };
+
+    await activation.activateComponentKits(config([
+      kit('copy-meter-kit', { meterAppearances: meters }),
+    ], { meterAppearance: 'selected' }));
+    selectedAppearance.level = signalMeterRenderer as MeterAppearance['level'];
+    delete meters.selected;
+
+    expect(activation.getSelectedMeterAppearance()?.level).toBe(levelMeterRenderer);
+  });
+
   it.each([
     ['wrong API version', { ...kit('bad-version'), apiVersion: 2 }],
     ['missing kit id', { ...kit('missing-id'), id: '' }],
@@ -128,6 +158,11 @@ describe('component-kit activation transaction', () => {
     ['finite appearance with an extra member', { ...kit('bad-finite-extra'), finiteControlAppearances: { bad: { ...finiteAppearance(), extra: true } } }],
     ['finite appearance with a non-component member', { ...kit('bad-finite-component'), finiteControlAppearances: { bad: { ...finiteAppearance(), choice: 'nope' } } }],
     ['empty finite appearance id', { ...kit('bad-finite-id'), finiteControlAppearances: { '': finiteAppearance() } }],
+    ['non-record meter declarations', { ...kit('bad-meter-map'), meterAppearances: [] }],
+    ['meter appearance missing a member', { ...kit('bad-meter-missing'), meterAppearances: { bad: { signal: signalMeterRenderer } } }],
+    ['meter appearance with an extra member', { ...kit('bad-meter-extra'), meterAppearances: { bad: { ...meterAppearance(), extra: true } } }],
+    ['meter appearance with a non-component member', { ...kit('bad-meter-component'), meterAppearances: { bad: { ...meterAppearance(), level: 'nope' } } }],
+    ['empty meter appearance id', { ...kit('bad-meter-id'), meterAppearances: { '': meterAppearance() } }],
   ])('rejects %s without committing', async (_name, declaration) => {
     const activation = await subject();
 
@@ -179,6 +214,13 @@ describe('component-kit activation transaction', () => {
         target: selectedAppearance,
       };
     }],
+    ['meter appearance', () => {
+      const selectedAppearance = meterAppearance();
+      return {
+        configured: config([kit('exact-meter-kit', { meterAppearances: { exact: selectedAppearance } })]),
+        target: selectedAppearance,
+      };
+    }],
   ] as const)('rejects symbol and non-enumerable unknown properties on %s', async (_name, makeCase) => {
     const activation = await subject();
     for (const kind of ['symbol', 'non-enumerable'] as const) {
@@ -224,6 +266,11 @@ describe('component-kit activation transaction', () => {
       Reflect.defineProperty(selectedAppearance, 'choice', { value: choiceRenderer, enumerable: false });
       return config([kit('descriptor-finite-kit', { finiteControlAppearances: { descriptor: selectedAppearance } })]);
     }],
+    ['meter appearance', () => {
+      const selectedAppearance = meterAppearance();
+      Reflect.defineProperty(selectedAppearance, 'level', { value: levelMeterRenderer, enumerable: false });
+      return config([kit('descriptor-meter-kit', { meterAppearances: { descriptor: selectedAppearance } })]);
+    }],
   ] as const)('rejects a non-enumerable allowed property on %s', async (_name, makeConfig) => {
     const activation = await subject();
 
@@ -254,6 +301,18 @@ describe('component-kit activation transaction', () => {
     expect(getter).not.toHaveBeenCalled();
   });
 
+  it('rejects a meter appearance accessor without invoking it', async () => {
+    const activation = await subject();
+    const meter = meterAppearance();
+    const getter = vi.fn(() => levelMeterRenderer);
+    Reflect.defineProperty(meter, 'level', { get: getter, enumerable: true });
+
+    await expect(activation.activateComponentKits(config([
+      kit('accessor-meter-kit', { meterAppearances: { accessor: meter } }),
+    ]))).rejects.toThrow(/enumerable data property/i);
+    expect(getter).not.toHaveBeenCalled();
+  });
+
   it('allows additional exports on the loader module namespace', async () => {
     const activation = await subject();
 
@@ -269,6 +328,8 @@ describe('component-kit activation transaction', () => {
     ['frequencyReadouts', 'non-enumerable'],
     ['finiteControlAppearances', 'symbol'],
     ['finiteControlAppearances', 'non-enumerable'],
+    ['meterAppearances', 'symbol'],
+    ['meterAppearances', 'non-enumerable'],
   ] as const)('rejects a %s map with a %s entry', async (mapName, kind) => {
     const activation = await subject();
     const declarations: Record<PropertyKey, unknown> = {};
@@ -276,7 +337,8 @@ describe('component-kit activation transaction', () => {
     Reflect.defineProperty(declarations, key, {
       value: mapName === 'scalarAppearances'
         ? appearance('Hidden')
-        : mapName === 'frequencyReadouts' ? renderer : finiteAppearance(),
+        : mapName === 'frequencyReadouts' ? renderer
+          : mapName === 'finiteControlAppearances' ? finiteAppearance() : meterAppearance(),
       enumerable: kind === 'symbol',
     });
 
@@ -301,6 +363,7 @@ describe('component-kit activation transaction', () => {
     ['duplicate scalar id', [kit('scalar-a', { scalarAppearances: { shared: appearance('A') } }), kit('scalar-b', { scalarAppearances: { shared: appearance('B') } })]],
     ['duplicate frequency id', [kit('frequency-a', { frequencyReadouts: { shared: renderer } }), kit('frequency-b', { frequencyReadouts: { shared: renderer } })]],
     ['duplicate finite id', [kit('finite-a', { finiteControlAppearances: { shared: finiteAppearance() } }), kit('finite-b', { finiteControlAppearances: { shared: finiteAppearance() } })]],
+    ['duplicate meter id', [kit('meter-a', { meterAppearances: { shared: meterAppearance() } }), kit('meter-b', { meterAppearances: { shared: meterAppearance() } })]],
   ])('rejects %s across the complete loaded set', async (_name, declarations) => {
     const activation = await subject();
 
@@ -322,6 +385,7 @@ describe('component-kit activation transaction', () => {
     ['scalarAppearance', 'missing-scalar'],
     ['frequencyReadout', 'missing-frequency'],
     ['finiteControlAppearance', 'missing-finite'],
+    ['meterAppearance', 'missing-meter'],
   ])('rejects an unresolved %s selection', async (property, value) => {
     const activation = await subject();
 

--- a/frontend/src/component-kits/activation.ts
+++ b/frontend/src/component-kits/activation.ts
@@ -2,6 +2,7 @@ import {
   COMPONENT_KIT_API_VERSION,
   type FiniteControlAppearance,
   type FrequencyRenderer,
+  type MeterAppearance,
   type ScalarAppearance,
 } from '../../component-kit-api/src/index';
 import { skins as builtInScalarAppearances } from '../components-v2/controls/value-control/skins';
@@ -10,6 +11,7 @@ export interface ComponentKitSelection {
   readonly scalarAppearance?: string;
   readonly frequencyReadout?: string;
   readonly finiteControlAppearance?: string;
+  readonly meterAppearance?: string;
 }
 
 export interface ComponentKitHostConfig {
@@ -21,26 +23,30 @@ interface ActiveSnapshot {
   readonly scalarAppearances: ReadonlyMap<string, ScalarAppearance>;
   readonly frequencyReadouts: ReadonlyMap<string, FrequencyRenderer>;
   readonly finiteControlAppearances: ReadonlyMap<string, FiniteControlAppearance>;
+  readonly meterAppearances: ReadonlyMap<string, MeterAppearance>;
   readonly selectedScalarAppearance?: string;
   readonly selectedFrequencyReadout?: string;
   readonly selectedFiniteControlAppearance?: string;
+  readonly selectedMeterAppearance?: string;
 }
 
 const EMPTY_SNAPSHOT: ActiveSnapshot = Object.freeze({
   scalarAppearances: new Map(),
   frequencyReadouts: new Map(),
   finiteControlAppearances: new Map(),
+  meterAppearances: new Map(),
 });
 const CONFIG_KEYS = ['kits', 'selection'] as const;
 const SELECTION_KEYS = [
-  'scalarAppearance', 'frequencyReadout', 'finiteControlAppearance',
+  'scalarAppearance', 'frequencyReadout', 'finiteControlAppearance', 'meterAppearance',
 ] as const;
 const KIT_KEYS = [
   'apiVersion', 'id', 'scalarAppearances', 'frequencyReadouts', 'finiteControlAppearances',
-  'designLanguages', 'layouts', 'instrumentGroups', 'presentations',
+  'meterAppearances', 'designLanguages', 'layouts', 'instrumentGroups', 'presentations',
 ] as const;
 const APPEARANCE_KEYS = ['name', 'knob', 'hbar', 'bipolar', 'discrete'] as const;
 const FINITE_APPEARANCE_KEYS = ['action', 'toggle', 'choice'] as const;
+const METER_APPEARANCE_KEYS = ['signal', 'level'] as const;
 const UNSUPPORTED_SECTIONS = [
   'designLanguages', 'layouts', 'instrumentGroups', 'presentations',
 ] as const;
@@ -117,6 +123,21 @@ function copyFiniteAppearance(value: unknown, id: string): FiniteControlAppearan
   return Object.freeze({ ...value }) as unknown as FiniteControlAppearance;
 }
 
+function copyMeterAppearance(value: unknown, id: string): MeterAppearance {
+  if (!isPlainRecord(value)) {
+    throw new ComponentKitActivationError(`Meter appearance "${id}" must be an object.`);
+  }
+  ownDataEntries(value, `Meter appearance "${id}"`, METER_APPEARANCE_KEYS);
+  for (const slot of METER_APPEARANCE_KEYS) {
+    if (typeof value[slot] !== 'function') {
+      throw new ComponentKitActivationError(
+        `Meter appearance "${id}" member "${slot}" must be a component.`,
+      );
+    }
+  }
+  return Object.freeze({ ...value }) as unknown as MeterAppearance;
+}
+
 function readSelection(value: unknown): ComponentKitSelection {
   if (value === undefined) return {};
   if (!isPlainRecord(value)) {
@@ -142,6 +163,8 @@ function prepareSnapshot(declarations: readonly unknown[], selectionValue: unkno
   const frequencyOwners = new Map<string, string>();
   const finiteControlAppearances = new Map<string, FiniteControlAppearance>();
   const finiteAppearanceOwners = new Map<string, string>();
+  const meterAppearances = new Map<string, MeterAppearance>();
+  const meterAppearanceOwners = new Map<string, string>();
   const kitIds = new Set<string>();
 
   for (const value of declarations) {
@@ -223,6 +246,27 @@ function prepareSnapshot(declarations: readonly unknown[], selectionValue: unkno
         finiteAppearanceOwners.set(appearanceId, `component kit "${id}"`);
       }
     }
+
+    if (value.meterAppearances !== undefined) {
+      if (!isPlainRecord(value.meterAppearances)) {
+        throw new ComponentKitActivationError(
+          `Component kit "${id}" meterAppearances must be a record.`,
+        );
+      }
+      for (const [appearanceId, appearance] of ownDataEntries(
+        value.meterAppearances,
+        `Component kit "${id}" meterAppearances`,
+      )) {
+        requireId(appearanceId, `Component kit "${id}" meter appearance`);
+        if (meterAppearanceOwners.has(appearanceId)) {
+          throw new ComponentKitActivationError(
+            `Duplicate meter appearance "${appearanceId}" conflicts with ${meterAppearanceOwners.get(appearanceId)}.`,
+          );
+        }
+        meterAppearances.set(appearanceId, copyMeterAppearance(appearance, appearanceId));
+        meterAppearanceOwners.set(appearanceId, `component kit "${id}"`);
+      }
+    }
   }
 
   const selection = readSelection(selectionValue);
@@ -238,13 +282,21 @@ function prepareSnapshot(declarations: readonly unknown[], selectionValue: unkno
       `Selected finite control appearance "${selection.finiteControlAppearance}" is not registered.`,
     );
   }
+  if (selection.meterAppearance !== undefined
+    && !meterAppearances.has(selection.meterAppearance)) {
+    throw new ComponentKitActivationError(
+      `Selected meter appearance "${selection.meterAppearance}" is not registered.`,
+    );
+  }
   return Object.freeze({
     scalarAppearances,
     frequencyReadouts,
     finiteControlAppearances,
+    meterAppearances,
     selectedScalarAppearance: selection.scalarAppearance,
     selectedFrequencyReadout: selection.frequencyReadout,
     selectedFiniteControlAppearance: selection.finiteControlAppearance,
+    selectedMeterAppearance: selection.meterAppearance,
   });
 }
 
@@ -291,4 +343,10 @@ export function getSelectedFiniteControlAppearance(): FiniteControlAppearance | 
   return snapshot.selectedFiniteControlAppearance === undefined
     ? undefined
     : snapshot.finiteControlAppearances.get(snapshot.selectedFiniteControlAppearance);
+}
+
+export function getSelectedMeterAppearance(): MeterAppearance | undefined {
+  return snapshot.selectedMeterAppearance === undefined
+    ? undefined
+    : snapshot.meterAppearances.get(snapshot.selectedMeterAppearance);
 }


### PR DESCRIPTION
Root file-count waiver: 12 code + 0 regenerated baselines = 12 files.

Linear: MOR-2425

## Scope

Publishes the component-kit meter appearance contract and adds it to the existing atomic activation transaction. The external fixture contains real Svelte signal and level renderers, and the portable-package verifier mounts the physically installed tarballs in Chromium. This PR does not claim Core meter-host integration; that begins in the held M2-4B follow-up.

The 12-file waived lease is one semantic package/activation unit: public types, the real external fixture and its build/pack verifier, the single activation snapshot and tests, and the minimal quick-workflow ordering correction required to run that browser verifier after the existing Chromium provisioning. The frozen change is 574 A+D (557 additions, 17 deletions), below the 600-line soft threshold and 1000-line hard ceiling.

## Contract

- immutable discriminated numeric evidence paired with explicit engineering, raw, or unknown domain
- signal engineering/db values explicitly mean dB relative to S9, never dBm; raw/unknown do not authorize engineering labels
- stale numeric evidence may remain while live projected geometry is unavailable
- Core-projected signal and level/SWR drawing aids, including both ratioScale states
- optional existing ActionRendererLease for peak reset, with absent and disposed-inert behavior proven
- one meter appearance with required signal and level renderers
- SDK package 0.3.0 with runtime API constant 1

No universal valueDbRelS9, calibration table, source/session identity, motion owner, meter normalizer, parallel registry, or pending observation state is exported.

## Verification

- RED: activation focused test initially had 7 expected failures
- independent-review corrections: timerful renderer mutation rejected on five setTimeout calls; missing ratioScale:false mutation rejected (null versus false); disposed retained reset callback mutation rejected (2 versus 1)
- npx vitest run src/component-kits/__tests__/activation.test.ts: 72 passed
- node component-kit-api/verify-package.mjs: PASS, including installed-tarball browser mount, both SWR ratioScale states, reset absence/disposal/retained callback, and zero renderer-created timers
- installed API tarball SHA-256: 29e5fb3ad34d295c36c80ddf5c1d768e2a864c58fe20628df9acb8c211e3cb41
- installed and browser-mounted fixture tarball SHA-256: 726a85423500204a0ef03c0d84987a54322664560185fd9ebd2c304ec50ddb13
- npm run check: 0 errors, 0 warnings
- npm run lint: clean
- uv run python .github/scripts/quick-path-filters.test.py: 9 Python tests plus 11 nested immutable-control tests passed
- uv run python -m py_compile .github/scripts/quick-path-filters.test.py: PASS
- git diff --check: clean

The JSDoc clarification is present in the public API source and PR diff, but the current declaration builder strips comments. Distributed packed declaration documentation remains a follow-up; this PR does not claim that tarball docs were repaired.

The earlier local check=0 statement described the tree before the later test-only snapshot mutation introduced the cross-family cast; it was not a passing check of exact failing head 44b5946. The final correction uses a fresh genuinely level-typed fake and preserves the original-component identity assertion.

## Natural CI history

Original head 77099c6040593ddf35903a999aa799c896642e07: visual run 34092804282 succeeded. Natural quick run 34092804331 failed because verify-package launched Playwright before quick.yml installed Chromium revision 1208.

Successor head 44b59460199858468355287fef2505b5a174119b: visual run 34093181020 succeeded. Natural quick run 34093181057 reached frontend check and failed on the test-only cross-family component cast. Independent exact-head review posted BLOCKED feedback in comment 5566446083; every required item is addressed in final head 7215ed2d79773d3d95786cda5f3efbfa5ad9d26c.

Final head 7215ed2d79773d3d95786cda5f3efbfa5ad9d26c: natural quick 34094391569 SUCCESS, natural visual 34094391532 SUCCESS, fresh independent exact-head PASS comment 5566657128, and canonical Agent Review Gate SUCCESS.

The workflow correction keeps one portable verifier invocation after the existing Chromium and system-dependency provisioning steps. It adds no installer, skip, fallback, or second verifier path. The existing quick-v2 worker remains unchanged because current quick-v2 is metadata-only and the worker is an immutable separately pinned control.

## Mechanism audit

PASS on the frozen production/package design. The change reuses the existing component-kit activation transaction and ActionRendererLease; it creates no motion, calibration, command, selector, registry, or session owner. Public meter types are consumed by the packed fixture and installed browser consumer. The selected-meter getter is intentionally first consumed by Core in M2-4B and is not described here as host integration. The workflow correction reuses the one existing browser provisioning authority and keeps exactly one portable verifier invocation. Timer checking is browser conformance evidence, not a runtime sandbox or new timer owner. No deletion is in scope.
