### PR TITLE
feat(MOR-2425): host station meter instruments

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -1244,6 +1244,8 @@
 </script>
 
 <div class="semantic-surfaces" class:hosted={hostedChildren !== undefined} data-testid="semantic-radio-surfaces">
+  <StationMeterInstrumentHost {subscribeStationMeterAuthority}>
+  {#snippet children(stationMeters: StationMeterInstrumentHandles)}
   {#snippet receiverVfoOperations(appearance: ReceiverVfoAppearance)}
     {#if view}
       <VfoSurface
@@ -1289,8 +1291,6 @@
     onAgcModeChange={agcIntents.onAgcModeChange}
   >
   {#snippet children(dspInstruments)}
-  <StationMeterInstrumentHost {subscribeStationMeterAuthority}>
-  {#snippet children(stationMeters: StationMeterInstrumentHandles)}
   {#if readonlyDisplay}
     {#if view}{@render readonlyDisplay(view, selectedDisplayFrame)}{/if}
   {:else}
@@ -2175,8 +2175,6 @@
   </TxAuxScalarHost>
   {/if}
   {/snippet}
-  </StationMeterInstrumentHost>
-  {/snippet}
   </DspInstrumentHost>
   {/snippet}
   </FilterInstrumentHost>
@@ -2194,6 +2192,8 @@
   </RxAudioInstrumentHost>
   {/snippet}
   </ReceiverInstrumentHost>
+  {/snippet}
+  </StationMeterInstrumentHost>
 </div>
 
 <style>

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -62,7 +62,13 @@
   import FilterInstrumentHost from '../../semantic/FilterInstrumentHost.svelte';
   import type { FilterFiniteLayout } from '../../semantic/filter-instruments';
   import MetersSurface from '../../semantic/MetersSurface.svelte';
+  import StationMeterInstrumentHost, {
+    type StationMeterAuthorityPublication,
+    type StationMeterInstrumentHandles,
+    type SubscribeStationMeterAuthority,
+  } from '../../semantic/StationMeterInstrumentHost.svelte';
   import type { MeterContinuitySession } from '../../primitives/meters/meter-ballistics.svelte';
+  import type { ControlAuthorityPublication } from '$lib/runtime/frontend-runtime';
   import {
     createFiniteRendererContext,
     type FiniteRendererContext,
@@ -462,7 +468,60 @@
   const tx = getManagedAppTxController();
 
   let txState = $state.raw(tx.snapshot());
-  const stopWatchingTx = tx.subscribe((next) => { txState = next; });
+  let stationSubscriber: Parameters<SubscribeStationMeterAuthority>[0] | null = null;
+  let stationControl: ControlAuthorityPublication | null = null;
+
+  const stationSession = (
+    publication: ControlAuthorityPublication,
+  ): MeterContinuitySession | null => publication.session.state === 'connected'
+    && Number.isSafeInteger(publication.session.epoch)
+    && publication.session.epoch >= 0
+    ? { controlSessionEpoch: publication.session.epoch }
+    : null;
+
+  function publishStationMeters(): void {
+    if (stationSubscriber === null || stationControl === null) return;
+    const publication: StationMeterAuthorityPublication = {
+      view: guardRadioViewModel(
+        toRadioViewModel(stationControl.state, stationControl.caps, txState),
+      ),
+      session: stationSession(stationControl),
+    };
+    stationSubscriber(publication);
+  }
+
+  const subscribeStationMeterAuthority: SubscribeStationMeterAuthority = (subscriber) => {
+    if (stationSubscriber !== null) throw new Error('Station meter authority already subscribed');
+    stationSubscriber = subscriber;
+    try {
+      const stop = runtime.subscribeControlAuthority((publication) => {
+        if (stationSubscriber !== subscriber) return;
+        stationControl = publication;
+        publishStationMeters();
+      });
+      let active = true;
+      return () => {
+        if (!active) return;
+        active = false;
+        if (stationSubscriber === subscriber) {
+          stationSubscriber = null;
+          stationControl = null;
+        }
+        stop();
+      };
+    } catch (error) {
+      if (stationSubscriber === subscriber) {
+        stationSubscriber = null;
+        stationControl = null;
+      }
+      throw error;
+    }
+  };
+
+  const stopWatchingTx = tx.subscribe((next) => {
+    txState = next;
+    publishStationMeters();
+  });
 
   onDestroy(() => {
     stopWatchingTx();
@@ -1230,6 +1289,8 @@
     onAgcModeChange={agcIntents.onAgcModeChange}
   >
   {#snippet children(dspInstruments)}
+  <StationMeterInstrumentHost {subscribeStationMeterAuthority}>
+  {#snippet children(stationMeters: StationMeterInstrumentHandles)}
   {#if readonlyDisplay}
     {#if view}{@render readonlyDisplay(view, selectedDisplayFrame)}{/if}
   {:else}
@@ -1480,14 +1541,14 @@
     (`dual-receiver-cockpit.ts`) declares no `meters` zone. The zone schema
     stays config-free (risk R3) either way.
 
-    It takes NO authority snapshot and no intent callbacks. That is the R9
-    boundary made structural: the meters are a readout, their TX truth is
-    already decided inside `view.meters` by the App-owned authority the
-    adapter was handed, and this component has nothing else to give them.
+    It takes no intent callbacks. The persistent station host above every
+    replaceable body owns the authority subscription and motion; this slot only
+    places its passive handles. TX truth is still decided by the adapter from
+    the App-owned authority, and the surface remains a readout.
   -->
   {#snippet metersSurface()}
     {#if view?.meters}
-      <MetersSurface {view} continuitySession={meterContinuitySession} />
+      <MetersSurface handles={stationMeters} />
     {/if}
   {/snippet}
 
@@ -2113,6 +2174,8 @@
   {/snippet}
   </TxAuxScalarHost>
   {/if}
+  {/snippet}
+  </StationMeterInstrumentHost>
   {/snippet}
   </DspInstrumentHost>
   {/snippet}

--- a/frontend/src/components-v2/wiring/__tests__/design-language-selector-reachability.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/design-language-selector-reachability.component.test.ts
@@ -16,8 +16,8 @@
  * declarations barrel, `presentation/languages/declarations`, registers
  * them — imported here transitively through `VfoSurface.svelte` and
  * explicitly below so the registration is not left to that transitive
- * chain), this file mounts the REAL semantic surfaces — `VfoSurface`,
- * `RxTxSurface`, `MetersSurface` directly, plus `SemanticRadioSurfaces`
+ * chain), this file exercises the REAL semantic surfaces — `VfoSurface`,
+ * `RxTxSurface`, `MetersSurface` through its real station-host fixture, plus `SemanticRadioSurfaces`
  * (the only component that emits `.semantic-surfaces`/`.channel-strip`) —
  * across a battery of real states, and asks the REAL DOM whether each
  * selector in that language's own `<id>.css` matches at least one element,
@@ -98,7 +98,7 @@ import type { MeterField, RadioViewModel } from '../../../semantic/radio-view-mo
 import { topologyFixtures, withMeters } from '../../../semantic/fixtures/topologies';
 import VfoSurface from '../../../semantic/VfoSurface.svelte';
 import RxTxSurface from '../../../semantic/RxTxSurface.svelte';
-import MetersSurface from '../../../semantic/MetersSurface.svelte';
+import MetersSurface from '../../../semantic/__tests__/fixtures/StationMeterInstrumentHostFixture.svelte';
 
 const h = vi.hoisted(() => ({
   state: null as ServerState | null,
@@ -342,7 +342,7 @@ const SCENES: readonly Scene[] = [
   {
     // The only scene that reaches `.semantic-surfaces`/`.channel-strip` —
     // the two selectors both studioline.css and fieldline.css declare that
-    // no directly-mounted VfoSurface/RxTxSurface/MetersSurface ever emits.
+    // no directly-mounted VfoSurface/RxTxSurface or hosted meter fixture emits.
     name: 'semantic-radio-surfaces (dual strips)',
     render() {
       const txHarness = new ManagedAppTxHarness();

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -580,7 +580,7 @@ describe('persistent finite DSP composition and authority (MOR-2425)', () => {
     for (const label of external) expect(q(`[data-testid="external-${label}"]`)).toBeNull();
     expect(ranges()).toHaveLength(7);
     // Receiver + AF + accepted RF level host + the single finite-renderer fan-in.
-    expect(h.authoritySubscribers.size).toBe(4);
+    expect(h.authoritySubscribers.size).toBe(5);
   });
 
   it.each([

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -579,7 +579,7 @@ describe('persistent finite DSP composition and authority (MOR-2425)', () => {
     expect(target.querySelectorAll('.dsp-toggle, .dsp-choice')).toHaveLength(0);
     for (const label of external) expect(q(`[data-testid="external-${label}"]`)).toBeNull();
     expect(ranges()).toHaveLength(7);
-    // Receiver + AF + accepted RF level host + the single finite-renderer fan-in.
+    // Receiver + AF + RF level + station meter hosts + the single finite-renderer fan-in.
     expect(h.authoritySubscribers.size).toBe(5);
   });
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -489,6 +489,19 @@ describe('the meters surface mounts only when the view model carries the group',
     };
 
     armRetainedPeak(1, 1);
+    const sameTurnPower = barSvg('power');
+    const subscribers = h.authoritySubscribers.size;
+    txHarness.emitServerSnapshot({ intent: 'transmit', observedPtt: 'on' });
+    txHarness.emitServerSnapshot({ intent: 'rx', observedPtt: 'off' });
+    txHarness.emitServerSnapshot({ intent: 'transmit', observedPtt: 'on' });
+    vi.advanceTimersByTime(100);
+    flushSync();
+    expect(h.authoritySubscribers.size).toBe(subscribers);
+    expect(barSvg('power')).toBe(sameTurnPower);
+    expect(barFillCount('power')).toBe(1);
+    expect(barPeakX('power')).toBe(64);
+
+    armRetainedPeak(1, 1);
     pushSession({ state: 'connected', epoch: 2 });
     expect(barFillCount('power')).toBe(1);
     expect(barPeakX('power')).toBe(64);
@@ -517,7 +530,7 @@ describe('the meters surface mounts only when the view model carries the group',
       },
     };
     push({ intent: 'transmit', observedPtt: 'on' });
-    expect(barSvg('power')).toBe(mountedPower);
+    expect(barSvg('power')).not.toBe(mountedPower);
     expect(q('[data-testid="meter-power"]')!.dataset.observed).toBe('false');
     expect(barFillCount('power')).toBe(0);
     expect(barPeakX('power')).toBeNull();

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -32,6 +32,7 @@ const h = vi.hoisted(() => ({
   txController: null as ManagedAppTxController | null,
   session: { state: 'connected', epoch: 1 } as ControlSessionSnapshot,
   sessionSubscriber: null as ((next: ControlSessionSnapshot) => void) | null,
+  deferAuthority: false,
   authoritySubscribers: new Set<(next: {
     state: unknown; caps: unknown; session: ControlSessionSnapshot;
     rxAudioTarget: RxAudioTargetSnapshot;
@@ -52,7 +53,7 @@ vi.mock('$lib/runtime', () => ({
     },
     subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
       h.authoritySubscribers.add(handler);
-      handler({
+      if (!h.deferAuthority) handler({
         state: h.state, caps: h.caps, session: h.session,
         rxAudioTarget: Object.freeze({ muted: h.audio.muted, rxEnabled: h.audio.rxEnabled }),
       });
@@ -284,6 +285,7 @@ beforeEach(() => {
   expect(setCapabilities(h.caps as Capabilities)).toBe(true);
   h.session = { state: 'connected', epoch: 1 };
   h.sessionSubscriber = null;
+  h.deferAuthority = false;
   h.noop.mockReset();
 });
 
@@ -363,6 +365,16 @@ describe('the meters surface mounts only when the view model carries the group',
     expect(Object.keys(relevance())).toContain('power');
     expect(q('[data-testid="meter-signal"]')!.dataset.observed).toBe('true');
     expect(q('[data-testid="meter-drainVoltage"]')!.dataset.observed).toBe('true');
+  });
+
+  it('keeps one station host across delayed dual-receiver authority', () => {
+    h.deferAuthority = true;
+    render({ strips: 'dual' });
+    expect(h.authoritySubscribers.size).toBe(4);
+    expect(() => push({})).not.toThrow();
+    expect(target.querySelectorAll('[data-testid="semantic-radio-surfaces"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-testid="meters-surface"]')).toHaveLength(1);
+    expect(h.authoritySubscribers.size).toBe(4);
   });
 
   it('keeps mounted meter shells but clears readings across a provider generation mismatch', () => {

--- a/frontend/src/components-v2/wiring/__tests__/semantic-pbt-continuity.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-pbt-continuity.component.test.ts
@@ -53,7 +53,7 @@ describe('mounted PBT continuity is fenced by the live control session (MOR-1706
     render(); const initialInner = value('pbtInner'), initialOuter = value('pbtOuter'); expect(initialInner).not.toBeNull(); expect(initialOuter).not.toBeNull(); expect(h.commands).not.toHaveBeenCalled();
     const staleInput = target.querySelector<HTMLInputElement>('[data-testid="filter-pbtInner"] input'); expect(staleInput).not.toBeNull();
     accept(state(null, -200, 2)); flushSync(); expect(value('pbtInner')).toBe(initialInner); expect(value('pbtOuter')).toBe(initialOuter);
-    expect(h.listeners.size).toBe(4); transition('disconnected', 1, false); transition('connected', 1, false); flushSync(); expect(value('pbtInner')).toBeNull(); expect(value('pbtOuter')).toBeNull();
+    expect(h.listeners.size).toBe(5); transition('disconnected', 1, false); transition('connected', 1, false); flushSync(); expect(value('pbtInner')).toBeNull(); expect(value('pbtOuter')).toBeNull();
     staleInput!.value = '500'; staleInput!.dispatchEvent(new Event('input', { bubbles: true })); flushSync(); expect(h.commands).not.toHaveBeenCalled(); expect(txHarness.trace()).toEqual([]);
     transition('connected', 1); expect(value('pbtInner')).toBeNull(); accept(state(300, -400, 3)); flushSync(); expect(value('pbtInner')).not.toBeNull();
     transition('connected', 2); expect(value('pbtInner')).toBeNull(); accept(state(500, -600, 4)); flushSync(); expect(value('pbtOuter')).not.toBeNull();

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
@@ -371,7 +371,7 @@ describe('the hosted AF owner survives replaceable presentation layouts', () => 
     expect(target.querySelector('[data-af-layout="independent"]')).not.toBeNull();
     expect(target.querySelectorAll('[role="slider"][aria-label="AF"]')).toHaveLength(1);
     expect([...h.authoritySubscribers]).toEqual(originalSubscribers);
-    expect(h.authoritySubscribers.size).toBe(3);
+    expect(h.authoritySubscribers.size).toBe(4);
     expect(newSlider.closest<HTMLElement>('.vc-hbar')!.style
       .getPropertyValue('--vc-fill-percent')).toBe('42%');
     expect(newSlider.getAttribute('aria-valuenow')).toBe('0.42');

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
@@ -525,7 +525,7 @@ describe('selected finite Scope authority lifetime (MOR-2425)', () => {
     render();
     expect(el('scope-hold')).not.toBeNull();
     expect(el('external-HOLD')).toBeNull();
-    expect(h.authoritySubscribers.size).toBe(3);
+    expect(h.authoritySubscribers.size).toBe(4);
   });
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -691,7 +691,7 @@ describe('selected finite TX auxiliary authority lifetime', () => {
     expect(q('[data-testid="tx-aux-atu-tune"]')).toBeNull();
     expect(q('[data-testid="external-VOX"]')).toBeNull();
     expect(q('[data-testid="external-TUNE"]')).toBeNull();
-    expect(h.authoritySubscribers.size).toBe(4);
+    expect(h.authoritySubscribers.size).toBe(5);
   });
 
   it('revokes retained A1 synchronously on A-B-A before flush and admits only fresh A3', () => {
@@ -773,7 +773,7 @@ describe('hosted Filter Mode and Filter ownership', () => {
     expect(q('[data-testid="filter-mode"]')).toBeNull();
     expect(q('[data-testid="filter-select"]')).toBeNull();
     for (const id of residual) expect(target.querySelectorAll(`[data-testid="${id}"]`)).toHaveLength(1);
-    expect(h.authoritySubscribers.size).toBe(4);
+    expect(h.authoritySubscribers.size).toBe(5);
   });
 
   it.each(['session', 'provider', 'topology', 'receiver', 'unknown'] as const)(

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -306,7 +306,7 @@ describe('production receiver-indicator partitioning', () => {
   ) => {
     selectedFrequency.current = AlternateFrequencyReadoutHarness as FrequencyRenderer;
     render(caps('main_sub', 2), state(), {}, props);
-    expect(h.authoritySubscribers.size).toBe(3);
+    expect(h.authoritySubscribers.size).toBe(4);
     const digit = projectFrequencyReadout({ confirmedHz: 14_200_000 }).digits[0];
     const first = retainedInteractions().find((interaction) => !interaction.inert)!;
     first.handleDigitClick(digit, new MouseEvent('click'));

--- a/frontend/src/semantic/MetersSurface.svelte
+++ b/frontend/src/semantic/MetersSurface.svelte
@@ -1,20 +1,15 @@
 <script module lang="ts">
   import type { MeterField } from './radio-view-model';
-  import {
-    projectSignalMeter,
-    type SignalMeterProjection,
-  } from '../components-v2/meters/smeter-scale';
+  import type { SignalMeterProjection } from '../components-v2/meters/smeter-scale';
   import { renderSlot } from './design-language-renderers';
   import type { LowerScaleDescriptor } from '../components-v2/meters/LinearSMeter.svelte';
-  import type { SwrMeterProjection } from './bar-meter-projector';
+  import type { StationLevelMeterFrame } from './StationMeterInstrumentHost.svelte';
 
   /** Level 1 — does this radio HAVE the meter at all. */
   const present = (f: MeterField): boolean => f.availability.structural;
   /** Level 2 — is it readable now AND actually read. */
   const observed = (f: MeterField): boolean =>
     f.availability.operational && f.reading.status === 'known';
-  const rawOf = (f: MeterField): number => (f.reading.status === 'known' ? f.reading.value : 0);
-
   /**
    * MOR-2250 (PR 2 of 2): the bottom scale row of the shared S-meter bar —
    * the real IC-7300's second, radio-selected TX-meter scale, fixed to SWR
@@ -33,11 +28,12 @@
     { value: 1, label: '∞' },
   ] as const;
 
-  function swrLowerScale(projection: SwrMeterProjection): LowerScaleDescriptor {
+  function swrLowerScale(frame: StationLevelMeterFrame<'swr'>): LowerScaleDescriptor {
+    const projection = frame.projection;
     return {
       label: 'SWR',
       ticks: projection.ratioScale ? SWR_LOWER_SCALE_TICKS : [],
-      valueFraction: projection.motionFraction ?? 0,
+      valueFraction: frame.motion.smoothedFraction,
       fault: projection.fault,
       relevant: projection.relevant,
       stateText: projection.state === 'current' && !projection.ratioScale
@@ -71,112 +67,88 @@
 </script>
 
 <script lang="ts">
-  import BarGauge from '../components-v2/meters/BarGauge.svelte';
   import LinearSMeter from '../components-v2/meters/LinearSMeter.svelte';
-  import type { RadioViewModel } from './radio-view-model';
-  import type { MeterContinuitySession } from '../primitives/meters/meter-ballistics.svelte';
   import { RF_LABEL, RF_MARK } from './rx-tx-surface';
-  import { projectBarMeters, projectSwrMeter } from './bar-meter-projector';
+  import StationMeterBarPlacement from './StationMeterBarPlacement.svelte';
+  import type {
+    StationMeterInstrumentHandles, StationSignalMeterFrame,
+  } from './StationMeterInstrumentHost.svelte';
+  import type { ActionRendererSeat } from '../primitives/control-instruments/control-instrument-renderer.svelte';
+  import type { MeterRfState } from './radio-view-model';
 
   interface Props {
-    view: RadioViewModel;
-    continuitySession?: MeterContinuitySession | null;
+    handles: StationMeterInstrumentHandles;
   }
-  let { view, continuitySession }: Props = $props();
-
-  /** Absent group ⇒ this surface renders nothing (S0 optional-group doctrine,
-   *  risk R3): a radio that reports no meters gets no empty dock, and no zone
-   *  schema had to learn about it. */
-  let meters = $derived(view.meters);
-
-  let signalProjection = $derived(projectSignalMeter(
-    meters && observed(meters.signal) ? rawOf(meters.signal) : null,
-    meters?.signal.domain,
-  ));
-  let barMeters = $derived(projectBarMeters(view));
-  let swrProjection = $derived(projectSwrMeter(view));
-
-  /**
-   * The active design language's `meters` descriptor for this render, or
-   * `null` when no language is active, the language declares no `meters`
-   * renderer, or its descriptor is missing the `MeterDisplay` quintet.
-   *
-   * MOR-2255: hoisted out of the S-meter branch so the S-meter tile
-   * (`attributes` + `display`) and every `BarGauge` tile (`display.zones`)
-   * read the SAME descriptor from ONE `renderSlot` call. Each consumer falls
-   * back to its own component default when this is `null`.
-   */
-  let display = $derived(meters ? meterDisplay(signalProjection) : null);
-  /** Explicit raw/unknown domains keep the shared bar palette but receive no
-   * S-specific language geometry or annotations. A non-null crossover also
-   * preserves the pre-MOR-2425 omitted-domain compatibility path. */
-  let signalDisplay = $derived(
-    signalProjection.crossoverFraction === null ? null : display,
-  );
-
+  let { handles }: Props = $props();
 </script>
 
-{#if meters}
+{#snippet station(
+  signalFrame: StationSignalMeterFrame | null, signalProjection: SignalMeterProjection | null,
+  swrFrame: StationLevelMeterFrame<'swr'> | null,
+  rfState: MeterRfState,
+  presentGroup: boolean,
+)}
+{#if presentGroup}
+  {@const display = signalProjection ? meterDisplay(signalProjection) : null}
+  {@const signalDisplay = signalProjection?.crossoverFraction == null ? null : display}
+  {#snippet level(frame: StationLevelMeterFrame, resetPeakSeat?: ActionRendererSeat)}
+    {@const bar = frame.projection}
+    <div class="meter-tile" data-meter-tile data-meter={bar.key} data-testid={`meter-${bar.key}`}
+      data-relevant={bar.relevant} data-observed={bar.observed} data-fault={bar.fault}
+      role="group" aria-label={`${bar.label} meter`}>
+      {#if bar.gauge}
+        {#key resetPeakSeat}<StationMeterBarPlacement {frame} label={bar.label}
+          displayValue={bar.displayText} accessibleDescription={bar.accessibleDescription}
+          compact fault={bar.fault} zones={display?.display?.zones} {resetPeakSeat} />{/key}
+      {:else}<span class="meter-unknown">{bar.displayText}</span>{/if}
+    </div>
+  {/snippet}
+  {#snippet power(frame: StationLevelMeterFrame<'power'>, seat?: ActionRendererSeat)}{@render level(frame, seat)}{/snippet}
+  {#snippet alc(frame: StationLevelMeterFrame<'alc'>, seat?: ActionRendererSeat)}{@render level(frame, seat)}{/snippet}
+  {#snippet drainCurrent(frame: StationLevelMeterFrame<'drainCurrent'>, seat?: ActionRendererSeat)}{@render level(frame, seat)}{/snippet}
+  {#snippet drainVoltage(frame: StationLevelMeterFrame<'drainVoltage'>)}{@render level(frame)}{/snippet}
+  {#snippet compression(frame: StationLevelMeterFrame<'compression'>)}{@render level(frame)}{/snippet}
   <section
     class="meters-surface" data-testid="meters-surface"
-    data-rf-state={meters.rfState} aria-label="Station meters"
+    data-rf-state={rfState} aria-label="Station meters"
   >
     <p class="meters-rf" data-testid="meters-rf">
-      <span data-testid="meters-rf-mark">{RF_MARK[meters.rfState]}</span>
-      <span data-testid="meters-rf-label">{RF_LABEL[meters.rfState]}</span>
+      <span data-testid="meters-rf-mark">{RF_MARK[rfState]}</span>
+      <span data-testid="meters-rf-label">{RF_LABEL[rfState]}</span>
     </p>
 
-    {#if present(meters.signal) || present(meters.swr)}
+    {#if signalFrame !== null}
+      {@const field = signalFrame.field}
       <div
-        class="meter-tile" data-meter-tile data-meter={present(meters.signal) ? "signal" : "swr"} data-testid={present(meters.signal) ? "meter-signal" : "meter-swr"}
-        data-relevant={meters.signal.relevant} data-observed={observed(meters.signal)}
-        role="group" aria-label={present(meters.signal) ? "S meter" : "SWR meter"}
+        class="meter-tile" data-meter-tile data-meter={present(field) ? "signal" : "swr"} data-testid={present(field) ? "meter-signal" : "meter-swr"}
+        data-relevant={field.relevant} data-observed={observed(field)}
+        role="group" aria-label={present(field) ? "S meter" : "SWR meter"}
         {...signalDisplay?.attributes ?? {}}
       >
         <LinearSMeter
-          projection={signalProjection} label="S" compact
-          mainPresent={present(meters.signal)}
+          frame={signalFrame.motion} label="S" compact
+          mainPresent={present(field)}
           display={signalDisplay?.display ?? undefined}
-          lowerScale={swrProjection ? swrLowerScale(swrProjection) : undefined}
-          relevant={meters.signal.relevant}
-          source={meters.signal.source}
-          session={continuitySession}
+          lowerScale={swrFrame ? swrLowerScale(swrFrame) : undefined}
+          relevant={field.relevant}
         />
       </div>
     {/if}
-
-    {#each barMeters as bar (bar.key)}
-        <div
-          class="meter-tile" data-meter-tile data-meter={bar.key} data-testid={`meter-${bar.key}`}
-          data-relevant={bar.relevant} data-observed={bar.observed} data-fault={bar.fault}
-          role="group" aria-label={`${bar.label} meter`}
-        >
-          {#if bar.gauge}
-            <!-- MOR-2255: `zones` comes from the SAME `display` descriptor
-                 the S-meter above reads, so every gauge on this surface is
-                 painted by one language. `undefined` (no language, or a
-                 descriptor without the quintet) falls back to `BarGauge`'s
-                 own `DEFAULT_ZONES`. -->
-            <BarGauge
-              value={bar.motionFraction} label={bar.label}
-              displayValue={bar.displayText}
-              accessibleDescription={bar.accessibleDescription}
-              compact showPeak={bar.showPeak} fault={bar.fault}
-              zones={display?.display?.zones}
-              source={bar.source} session={continuitySession}
-            />
-          {:else}
-            <span class="meter-unknown">{bar.displayText}</span>
-          {/if}
-        </div>
-    {/each}
+    {@render handles.power(power)}
+    {@render handles.alc(alc)}
+    {@render handles.drainCurrent(drainCurrent)}
+    {@render handles.drainVoltage(drainVoltage)}
+    {@render handles.compression(compression)}
   </section>
 {/if}
+{/snippet}
+
+{@render handles.signal(station)}
 
 <style>
   /* Structure only — a design language owns the palette and must never become
-     the sole state channel (MOR-977). Nothing here moves: the gauges own their
-     own ballistics and honour reduced motion themselves. */
+     the sole state channel (MOR-977). The persistent station host owns motion;
+     these gauges only draw its passive frames. */
   .meters-surface { display: flex; flex-direction: column; gap: 0.25rem; }
   .meters-rf { display: flex; align-items: baseline; gap: 0.4ch; margin: 0; font-weight: 700; }
   .meter-tile { display: block; }

--- a/frontend/src/semantic/StationMeterBarPlacement.svelte
+++ b/frontend/src/semantic/StationMeterBarPlacement.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import { onDestroy, untrack } from 'svelte';
+  import BarGauge from '../components-v2/meters/BarGauge.svelte';
+  import type { Zone } from '../components-v2/meters/bar-gauge-utils';
+  import type { ActionRendererLease, ActionRendererSeat } from '../primitives/control-instruments/control-instrument-renderer.svelte';
+  import type { StationLevelMeterFrame } from './StationMeterInstrumentHost.svelte';
+  interface Props {
+    frame: StationLevelMeterFrame;
+    label: string;
+    displayValue: string;
+    accessibleDescription?: string;
+    zones?: readonly Zone[];
+    compact?: boolean;
+    fault?: boolean;
+    resetPeakSeat?: ActionRendererSeat;
+  }
+  let {
+    frame, label, displayValue, accessibleDescription, zones,
+    compact = false, fault = false, resetPeakSeat,
+  }: Props = $props();
+  const lease: ActionRendererLease | null = untrack(() => resetPeakSeat?.attachRenderer() ?? null);
+  onDestroy(() => lease?.dispose());
+</script>
+<BarGauge frame={frame.motion} {label} {displayValue} {accessibleDescription}
+  {zones} {compact} {fault} onResetPeak={lease === null ? undefined : () => lease.invoke()} />

--- a/frontend/src/semantic/StationMeterInstrumentHost.svelte
+++ b/frontend/src/semantic/StationMeterInstrumentHost.svelte
@@ -1,0 +1,332 @@
+<script module lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { BarMeterFrame } from '../components-v2/meters/bar-meter-motion.svelte';
+  import type { SignalMeterFrame } from '../components-v2/meters/signal-meter-motion.svelte';
+  import type {
+    MeterContinuitySession,
+    MeterSourceIdentity,
+  } from '../primitives/meters/meter-ballistics.svelte';
+  import type { ActionRendererSeat } from '../primitives/control-instruments/control-instrument-renderer.svelte';
+  import type {
+    LevelMeterKey,
+    LevelMeterProjection,
+    SwrMeterProjection,
+  } from './bar-meter-projector';
+  import type { MeterField, MeterRfState, RadioViewModel } from './radio-view-model';
+
+  export type StationSignalFacts = Readonly<
+    Pick<MeterField, 'reading' | 'availability' | 'relevant' | 'domain'>
+  >;
+  export interface StationSignalMeterFrame {
+    readonly field: StationSignalFacts;
+    readonly motion: SignalMeterFrame;
+  }
+  export type RenderLevelProjection<K extends LevelMeterKey> = Readonly<
+    Omit<K extends 'swr' ? SwrMeterProjection : LevelMeterProjection<K>, 'source'>
+  >;
+  export interface StationLevelMeterFrame<K extends LevelMeterKey = LevelMeterKey> {
+    readonly projection: RenderLevelProjection<K>;
+    readonly motion: BarMeterFrame;
+  }
+  export type StationLevelMeterRenderer<K extends LevelMeterKey> = Snippet<[
+    frame: StationLevelMeterFrame<K>,
+    resetPeakSeat?: ActionRendererSeat,
+  ]>;
+  export type StationSignalMeterRenderer = Snippet<[
+    frame: StationSignalMeterFrame | null,
+    projection: SignalMeterFrame['projection'] | null,
+    swr: StationLevelMeterFrame<'swr'> | null,
+    rfState: MeterRfState,
+    present: boolean,
+  ]>;
+  export interface StationMeterInstrumentHandles {
+    readonly signal: Snippet<[renderer: StationSignalMeterRenderer]>;
+    readonly power: Snippet<[renderer: StationLevelMeterRenderer<'power'>]>;
+    readonly swr: Snippet<[renderer: StationLevelMeterRenderer<'swr'>]>;
+    readonly alc: Snippet<[renderer: StationLevelMeterRenderer<'alc'>]>;
+    readonly drainCurrent: Snippet<[renderer: StationLevelMeterRenderer<'drainCurrent'>]>;
+    readonly drainVoltage: Snippet<[renderer: StationLevelMeterRenderer<'drainVoltage'>]>;
+    readonly compression: Snippet<[renderer: StationLevelMeterRenderer<'compression'>]>;
+  }
+  export interface StationMeterAuthorityPublication {
+    readonly view: RadioViewModel | null;
+    readonly session?: MeterContinuitySession | null;
+  }
+  export type SubscribeStationMeterAuthority = (
+    handler: (publication: StationMeterAuthorityPublication) => void,
+  ) => () => void;
+</script>
+<script lang="ts">
+  import { onDestroy, onMount, untrack } from 'svelte';
+  import {
+    createBarMeterMotion,
+    type BarMeterMotionBinding,
+  } from '../components-v2/meters/bar-meter-motion.svelte';
+  import {
+    createSignalMeterMotion,
+    type SignalMeterMotionBinding,
+  } from '../components-v2/meters/signal-meter-motion.svelte';
+  import {
+    createActionRendererSeat,
+    createFiniteRendererContext,
+    type FiniteRendererContext,
+  } from '../primitives/control-instruments/control-instrument-renderer.svelte';
+  import { projectBarMeters, projectSwrMeter } from './bar-meter-projector';
+  import { projectSignalMeter } from '../components-v2/meters/smeter-scale';
+  interface Props {
+    subscribeStationMeterAuthority: SubscribeStationMeterAuthority;
+    children: Snippet<[StationMeterInstrumentHandles]>;
+  }
+  interface SignalOwner {
+    readonly binding: SignalMeterMotionBinding;
+    readonly frame: StationSignalMeterFrame;
+    field: StationSignalFacts;
+  }
+  interface LevelOwner<K extends LevelMeterKey = LevelMeterKey> {
+    readonly key: K;
+    readonly binding: BarMeterMotionBinding;
+    readonly frame: StationLevelMeterFrame<K>;
+    projection: RenderLevelProjection<K>;
+    source: MeterSourceIdentity | null | undefined;
+    session: MeterContinuitySession | null | undefined;
+    resetContext: FiniteRendererContext | null;
+    resetSeat: ActionRendererSeat | undefined;
+    disposeRoot: () => void;
+  }
+  let { subscribeStationMeterAuthority, children }: Props = $props();
+  let signalOwner = $state.raw<SignalOwner | null>(null);
+  let signalProjection = $state.raw<SignalMeterFrame['projection'] | null>(null);
+  let signalRoot: (() => void) | null = null;
+  let owners = $state.raw(new Map<LevelMeterKey, LevelOwner>());
+  let rfState = $state<MeterRfState>('unknown');
+  let groupPresent = $state(false);
+  let mounted = false;
+  let destroyed = false;
+  const factsOf = (field: MeterField): StationSignalFacts => ({
+    reading: field.reading,
+    availability: field.availability,
+    relevant: field.relevant,
+    domain: field.domain,
+  });
+  const observed = (field: MeterField): boolean =>
+    field.availability.operational && field.reading.status === 'known';
+  const renderProjection = <K extends LevelMeterKey>(
+    projection: LevelMeterProjection<K>,
+  ): RenderLevelProjection<K> => {
+    const { source: _source, ...render } = projection;
+    return render as unknown as RenderLevelProjection<K>;
+  };
+  const sameSource = (a: MeterSourceIdentity, b: MeterSourceIdentity): boolean =>
+    a.providerGeneration === b.providerGeneration
+    && a.scope === b.scope
+    && a.receiver === b.receiver
+    && a.path === b.path;
+  const sameAuthority = (
+    aSource: MeterSourceIdentity | null | undefined,
+    aSession: MeterContinuitySession | null | undefined,
+    bSource: MeterSourceIdentity | null | undefined,
+    bSession: MeterContinuitySession | null | undefined,
+  ): boolean => {
+    const mode = (source: typeof aSource, session: typeof aSession) => {
+      if (source === null || session === null) return 'null';
+      return source === undefined || session === undefined ? 'unqualified' : 'qualified';
+    };
+    const aMode = mode(aSource, aSession);
+    const bMode = mode(bSource, bSession);
+    if (aMode !== bMode) return false;
+    if (aMode !== 'qualified') return true;
+    return sameSource(aSource!, bSource!)
+      && aSession!.controlSessionEpoch === bSession!.controlSessionEpoch;
+  };
+  const currentOwner = <K extends LevelMeterKey>(owner: LevelOwner<K>): boolean =>
+    owners.get(owner.key) === owner;
+  function clean(cleanups: readonly (() => void)[]): void {
+    let failed = false;
+    let failure: unknown;
+    for (const cleanup of cleanups) {
+      try {
+        cleanup();
+      } catch (error) {
+        if (!failed) {
+          failed = true;
+          failure = error;
+        }
+      }
+    }
+    if (failed) throw failure;
+  }
+  function installResetSeat<K extends LevelMeterKey>(owner: LevelOwner<K>): void {
+    if (!['power', 'alc', 'drainCurrent'].includes(owner.key)) return;
+    owner.resetContext = createFiniteRendererContext();
+    owner.resetSeat = createActionRendererSeat(() => ({
+      context: owner.resetContext,
+      availability: {
+        structural: currentOwner(owner),
+        operational: currentOwner(owner) && owner.projection.showPeak,
+      },
+      label: 'Reset peak',
+      invoke: () => {
+        if (currentOwner(owner)) owner.binding.resetPeak();
+      },
+    }));
+  }
+  function installLevel<K extends LevelMeterKey>(
+    projection: LevelMeterProjection<K>,
+    session: MeterContinuitySession | null | undefined,
+  ): LevelOwner<K> {
+    let created!: LevelOwner<K>;
+    const disposeRoot = $effect.root(() => {
+      let render = $state.raw(renderProjection(projection));
+      let resetSeat = $state.raw<ActionRendererSeat | undefined>();
+      const binding = createBarMeterMotion({
+        value: projection.motionFraction,
+        peakEnabled: projection.showPeak,
+        source: projection.source,
+        session,
+      });
+      created = {
+        key: projection.key,
+        binding,
+        frame: {
+          get projection() { return created.projection; },
+          motion: binding.frame,
+        },
+        get projection() { return render; },
+        set projection(value) { render = value; },
+        source: projection.source,
+        session,
+        resetContext: null,
+        get resetSeat() { return resetSeat; },
+        set resetSeat(value) { resetSeat = value; },
+        disposeRoot: () => undefined,
+      };
+    });
+    created.disposeRoot = disposeRoot;
+    owners.set(projection.key, created);
+    installResetSeat(created);
+    if (mounted) created.binding.start();
+    return created;
+  }
+  function removeLevel(key: LevelMeterKey): void {
+    const owner = owners.get(key);
+    if (!owner) return;
+    const seat = owner.resetSeat;
+    const root = owner.disposeRoot;
+    owners.delete(key);
+    owner.resetContext = null;
+    owner.resetSeat = undefined;
+    owner.disposeRoot = () => undefined;
+    clean([() => seat?.destroy(), () => owner.binding.stop(), root]);
+  }
+  function removeSignal(): void {
+    const signal = signalOwner;
+    const root = signalRoot;
+    signalOwner = null;
+    signalRoot = null;
+    clean([() => signal?.binding.stop(), () => root?.()]);
+  }
+  function syncLevel<K extends LevelMeterKey>(
+    owner: LevelOwner<K>,
+    projection: LevelMeterProjection<K>,
+    session: MeterContinuitySession | null | undefined,
+  ): void {
+    if (!sameAuthority(owner.source, owner.session, projection.source, session)) {
+      owner.resetSeat?.destroy();
+      owner.resetContext = null;
+      owner.resetSeat = undefined;
+      owner.source = projection.source;
+      owner.session = session;
+      installResetSeat(owner);
+    }
+    owner.projection = renderProjection(projection);
+    owner.binding.sync({
+      value: projection.motionFraction,
+      peakEnabled: projection.showPeak,
+      source: projection.source,
+      session,
+    });
+  }
+  function applyPublication({ view, session }: StationMeterAuthorityPublication): void {
+    if (destroyed) return;
+    const meters = view?.meters;
+    groupPresent = meters !== undefined;
+    rfState = meters?.rfState ?? 'unknown';
+    const projection = meters ? projectSignalMeter(
+      observed(meters.signal) && meters.signal.reading.status === 'known'
+        ? meters.signal.reading.value : null,
+      meters.signal.domain,
+    ) : null;
+    signalProjection = projection;
+    const composite = !!meters
+      && (meters.signal.availability.structural || meters.swr.availability.structural);
+    if (!composite && signalOwner) removeSignal();
+    else if (composite && meters && projection) {
+      const field = factsOf(meters.signal);
+      if (!signalOwner) {
+        let created!: SignalOwner;
+        signalRoot = $effect.root(() => {
+          let currentField = $state.raw(field);
+          const binding = createSignalMeterMotion({
+            projection, present: meters.signal.availability.structural,
+            source: meters.signal.source, session,
+          });
+          created = { binding,
+            get field() { return currentField; },
+            set field(value) { currentField = value; },
+            frame: { get field() { return created.field; }, motion: binding.frame } };
+        });
+        signalOwner = created;
+        if (mounted) created.binding.start();
+      } else {
+        signalOwner.field = field;
+        signalOwner.binding.sync({
+          projection, present: meters.signal.availability.structural,
+          source: meters.signal.source, session,
+        });
+      }
+    }
+    const swr = view ? projectSwrMeter(view) : null;
+    const projected: LevelMeterProjection[] = view
+      ? [...projectBarMeters(view), ...(swr === null ? [] : [swr])]
+      : [];
+    const admitted = new Set(projected.map(({ key }) => key));
+    for (const key of [...owners.keys()]) if (!admitted.has(key)) removeLevel(key);
+    for (const projection of projected) {
+      const owner = owners.get(projection.key);
+      if (owner) syncLevel(owner, projection, session);
+      else installLevel(projection, session);
+    }
+    owners = new Map(owners);
+  }
+  function disposeOwned(): void {
+    clean([removeSignal, ...[...owners.keys()].map((key) => () => removeLevel(key))]);
+  }
+  const subscribe = untrack(() => subscribeStationMeterAuthority);
+  let unsubscribe: () => void = () => undefined;
+  try {
+    unsubscribe = subscribe(applyPublication);
+  } catch (error) {
+    destroyed = true;
+    try { disposeOwned(); } catch {}
+    throw error;
+  }
+  onMount(() => {
+    mounted = true;
+    signalOwner?.binding.start();
+    for (const owner of owners.values()) owner.binding.start();
+  });
+  onDestroy(() => {
+    destroyed = true;
+    clean([unsubscribe, disposeOwned]);
+  });
+</script>
+{#snippet signal(renderer: StationSignalMeterRenderer)}
+  {@render renderer(signalOwner?.frame ?? null, signalProjection, owners.get('swr')?.frame as StationLevelMeterFrame<'swr'> ?? null, rfState, groupPresent)}
+{/snippet}
+{#snippet power(renderer: StationLevelMeterRenderer<'power'>)}{@const owner = owners.get('power')}{#if owner}{@render renderer(owner.frame as StationLevelMeterFrame<'power'>, owner.resetSeat)}{/if}{/snippet}
+{#snippet swr(renderer: StationLevelMeterRenderer<'swr'>)}{@const owner = owners.get('swr')}{#if owner}{@render renderer(owner.frame as StationLevelMeterFrame<'swr'>)}{/if}{/snippet}
+{#snippet alc(renderer: StationLevelMeterRenderer<'alc'>)}{@const owner = owners.get('alc')}{#if owner}{@render renderer(owner.frame as StationLevelMeterFrame<'alc'>, owner.resetSeat)}{/if}{/snippet}
+{#snippet drainCurrent(renderer: StationLevelMeterRenderer<'drainCurrent'>)}{@const owner = owners.get('drainCurrent')}{#if owner}{@render renderer(owner.frame as StationLevelMeterFrame<'drainCurrent'>, owner.resetSeat)}{/if}{/snippet}
+{#snippet drainVoltage(renderer: StationLevelMeterRenderer<'drainVoltage'>)}{@const owner = owners.get('drainVoltage')}{#if owner}{@render renderer(owner.frame as StationLevelMeterFrame<'drainVoltage'>)}{/if}{/snippet}
+{#snippet compression(renderer: StationLevelMeterRenderer<'compression'>)}{@const owner = owners.get('compression')}{#if owner}{@render renderer(owner.frame as StationLevelMeterFrame<'compression'>)}{/if}{/snippet}
+{@render children({ signal, power, swr, alc, drainCurrent, drainVoltage, compression })}

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -28,14 +28,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 // @ts-expect-error -- Svelte does not publish types for its reactive test harness.
 import { proxy } from 'svelte/internal/client';
-import MetersSurface from '../MetersSurface.svelte';
+import MetersSurface from './fixtures/StationMeterInstrumentHostFixture.svelte';
 import { projectBarMeters, type BarMeterKey } from '../bar-meter-projector';
 import { topologyFixtures, withMeters, withTxAux } from '../fixtures/topologies';
 import type {
   Availability, MeterField, MeterRfState, MetersViewModel, MeterValueDomain, RadioViewModel,
 } from '../radio-view-model';
 import { RF_LABEL, RF_MARK } from '../rx-tx-surface';
-import { isAlcFault, isSwrFault } from '../../components-v2/panels/meter-utils';
 import { dimColor } from '../../components-v2/meters/bar-gauge-utils';
 import type { Capabilities } from '$lib/types/capabilities';
 import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
@@ -83,6 +82,8 @@ const SOURCE = readFileSync('src/semantic/MetersSurface.svelte', 'utf8')
   .replace(/\/\*[\s\S]*?\*\//g, '')
   .replace(/^\s*\/\/.*$/gm, '');
 const PROJECTOR_SOURCE = readFileSync('src/semantic/bar-meter-projector.ts', 'utf8');
+const HOST_SOURCE = readFileSync('src/semantic/StationMeterInstrumentHost.svelte', 'utf8');
+const PLACEMENT_SOURCE = readFileSync('src/semantic/StationMeterBarPlacement.svelte', 'utf8');
 
 const AVAIL: Availability = { structural: true, operational: true };
 const RF_STATES: readonly MeterRfState[] = ['receiving', 'transmitting', 'uncertain', 'unknown'];
@@ -176,8 +177,10 @@ function compressor(view: RadioViewModel, value: boolean | 'unknown' | 'no-group
 }
 
 let target: HTMLDivElement;
-beforeEach(() => { target = document.createElement('div'); document.body.appendChild(target); });
-afterEach(() => { target.remove(); });
+let originalMatchMedia: typeof window.matchMedia;
+beforeEach(() => { target = document.createElement('div'); document.body.appendChild(target);
+  originalMatchMedia = window.matchMedia; window.matchMedia = vi.fn().mockReturnValue({ matches: true }); });
+afterEach(() => { target.remove(); window.matchMedia = originalMatchMedia; });
 
 function render(view: RadioViewModel) {
   const component = mount(MetersSurface, { target, props: { view } });
@@ -423,11 +426,9 @@ describe('TX truth reaches this surface only through the fact layer (R9)', () =>
     expect(SOURCE).not.toMatch(/\bptt\b/i);
     expect(SOURCE).not.toMatch(/TxAuthoritySnapshot/);
     expect(SOURCE).not.toMatch(/radioState/);
-    // Exactly one fact input plus the generic continuity boundary. Neither is
-    // a second TX authority or a raw runtime/state input.
-    expect(SOURCE).toMatch(
-      /interface Props\s*\{\s*view:\s*RadioViewModel;\s*continuitySession\?:\s*MeterContinuitySession\s*\|\s*null;\s*\}/,
-    );
+    // Only owner-hosted handles cross this presentation boundary: no raw
+    // authority, runtime, view model, source, or session input is accepted.
+    expect(SOURCE).toMatch(/interface Props\s*\{\s*handles:\s*StationMeterInstrumentHandles;\s*\}/);
   });
 
   // MUTATION KILLED: computing an RF state locally (e.g. from txPermit, or
@@ -491,18 +492,16 @@ describe('the cold-start unknown window renders fail-closed', () => {
 // ── 7. Motion / forced-colors carry-overs (MOR-1249 / 1252 / 1250) ────────
 
 describe('motion and forced-colors mechanisms are reused, not forked', () => {
-  // MUTATION KILLED: a local rAF/interval ballistics loop. Smoothing and
-  // peak-hold — including their `prefers-reduced-motion` behaviour — belong to
-  // the reused SVG meter components (LinearSMeter / BarGauge, both driving
-  // `$lib/utils/smoothing.svelte`'s `createSmoother`, which snaps instead of
-  // animating under reduce). A copy here would be a second, unaudited loop.
+  // MUTATION KILLED: a local rAF/interval ballistics loop. The persistent host
+  // owns canonical signal/bar motion; the SVG meters draw passive hosted frames.
   it('schedules no animation loop of its own', () => {
     expect(SOURCE).not.toMatch(/requestAnimationFrame|setInterval|setTimeout/);
     expect(SOURCE).not.toMatch(/createSmoother|updatePeakHold|peakHoldDisplay/);
   });
 
   it('delegates every gauge to the shipped SVG meter components', () => {
-    expect(SOURCE).toMatch(/import BarGauge from '\.\.\/components-v2\/meters\/BarGauge\.svelte'/);
+    expect(SOURCE).toMatch(/import StationMeterBarPlacement from '\.\/StationMeterBarPlacement\.svelte'/);
+    expect(PLACEMENT_SOURCE).toMatch(/import BarGauge from '\.\.\/components-v2\/meters\/BarGauge\.svelte'/);
     expect(SOURCE).toMatch(/import LinearSMeter from '\.\.\/components-v2\/meters\/LinearSMeter\.svelte'/);
   });
 
@@ -559,7 +558,7 @@ describe('the meter table matches the shipped dock', () => {
 
   it('reads its levels and formatters from the shipped meter-utils', () => {
     expect(PROJECTOR_SOURCE).toMatch(/from '\.\.\/components-v2\/panels\/meter-utils'/);
-    expect(SOURCE).toMatch(/from '\.\/bar-meter-projector'/);
+    expect(HOST_SOURCE).toMatch(/from '\.\/bar-meter-projector'/);
   });
 
   // MOR-2250 (PR 2 of 2): 'SWR' dropped from the expected list — it left
@@ -573,11 +572,10 @@ describe('the meter table matches the shipped dock', () => {
 // ── 9. Peak-hold channel (MOR-1282) — the surface passes it through ────────
 
 describe('BarGauge peak channel (MOR-1282)', () => {
-  it('forwards each keyed bar field source and the existing surface session', () => {
-    const calls = [...SOURCE.matchAll(/<BarGauge([\s\S]*?)\/>/g)];
-    expect(calls).toHaveLength(1);
-    expect(calls[0][1]).toMatch(/source=\{bar\.source\}/);
-    expect(calls[0][1]).toMatch(/session=\{continuitySession\}/);
+  it('keeps source/session private and supplies only hosted frames', () => {
+    expect(SOURCE).not.toMatch(/source=|session=|showPeak=|value=\{bar\.|projection=\{/);
+    expect(SOURCE).toMatch(/<LinearSMeter\s+[\s\S]*?frame=\{signalFrame\.motion\}/);
+    expect(PLACEMENT_SOURCE).toMatch(/<BarGauge frame=\{frame\.motion\}/);
     expect(projectBarMeters(base('transmitting')).map(({ key }) => key)).toEqual([
       'power', 'alc', 'drainCurrent', 'drainVoltage', 'compression',
     ]);
@@ -862,6 +860,7 @@ describe('the host descriptor and LinearSMeter share one signal projection', () 
       const replacementCaps = makeFaultCaps();
       replacementCaps.meterCalibrations!.s_meter = REPLACEMENT_S_METER_CAL;
       setCapabilities(replacementCaps);
+      props.view = { ...props.view };
       flushSync();
 
       const replacementTicks = tickXs();
@@ -888,12 +887,12 @@ describe('the host descriptor and LinearSMeter share one signal projection', () 
   });
 
   it('creates one shared descriptor while permissioning its S-specific consumers separately', () => {
-    expect(SOURCE.match(/\bprojectSignalMeter\(/g)).toHaveLength(1);
+    expect(HOST_SOURCE.match(/\bprojectSignalMeter\(/g)).toHaveLength(1);
     expect(SOURCE.match(/\brenderSlot\(/g)).toHaveLength(1);
     expect(SOURCE).toMatch(/value:\s*signalProjection\.motionFraction/);
     expect(SOURCE).toMatch(/s9:\s*signalProjection\.crossoverFraction/);
-    expect(SOURCE).toMatch(/projectSignalMeter\([\s\S]*?meters\?\.signal\.domain/);
-    expect(SOURCE).toMatch(/<LinearSMeter[\s\S]*?projection=\{signalProjection\}/);
+    expect(HOST_SOURCE).toMatch(/projectSignalMeter\([\s\S]*?meters\.signal\.domain/);
+    expect(SOURCE).toMatch(/<LinearSMeter[\s\S]*?frame=\{signalFrame\.motion\}/);
     expect(SOURCE).toMatch(/zones=\{display\?\.display\?\.zones\}/);
     expect(SOURCE).toMatch(/display=\{signalDisplay\?\.display\s*\?\?\s*undefined\}/);
     expect(SOURCE).not.toMatch(/\bsLevel\(/);
@@ -1011,21 +1010,11 @@ describe('SWR/ALC fault highlighting reuses the dock\'s own threshold', () => {
     });
   });
 
-  // MUTATION KILLED (verifier mutant M6a, verify-MOR-1345): changing `rawOf`'s
-  // unknown-fallback to a value either predicate would fault on. Today the
-  // whole meters suite stays GREEN through such a change, because the
-  // `isObserved` conjunct above absorbs it — so the fallback is the silent
-  // assumption the "unknown never faults" property actually rests on, and
-  // nothing else in the repo pins it. Source-scanned rather than behavioural
-  // because `rawOf` is module-private to the component: a behavioural test
-  // cannot observe a fallback the render path never reaches.
-  it('pins rawOf\'s unknown-fallback to a value neither fault predicate fires on', () => {
-    const fallback = /reading\.status === 'known' \? f\.reading\.value : (-?\d+(?:\.\d+)?)/.exec(SOURCE);
-    expect(fallback, 'rawOf no longer has a numeric literal fallback').not.toBeNull();
-    const raw = Number(fallback![1]);
-    expect(raw).toBe(0);
-    expect(isSwrFault(raw)).toBe(false);
-    expect(isAlcFault(raw)).toBe(false);
+  // Projection occurs in the host, so this presentation surface has no raw
+  // value fallback or local fault predicate.
+  it('has no surface-local raw fallback that can feed fault predicates', () => {
+    expect(SOURCE).not.toMatch(/rawOf|isSwrFault|isAlcFault/);
+    expect(HOST_SOURCE).not.toMatch(/isSwrFault|isAlcFault/);
   });
 
   // Threads the boolean through to the REAL LinearSMeter (no stub) — mirrors
@@ -1047,7 +1036,7 @@ describe('SWR/ALC fault highlighting reuses the dock\'s own threshold', () => {
   // PEAK_DECAY_MS parity test above (block 10).
   it('the shared projector and MetersDockPanel import their fault predicates from shared meter-utils', () => {
     const dockSource = readFileSync('src/components-v2/panels/MetersDockPanel.svelte', 'utf8');
-    expect(SOURCE).toMatch(/projectSwrMeter/);
+    expect(HOST_SOURCE).toMatch(/projectSwrMeter/);
     expect(PROJECTOR_SOURCE).toMatch(/import\s*\{[^}]*isAlcFault[^}]*isSwrFault[^}]*\}\s*from\s*'\.\.\/components-v2\/panels\/meter-utils'/);
     expect(dockSource).toMatch(/import\s*\{[^}]*isSwrFault[^}]*\}\s*from\s*'\.\/meter-utils'/);
     expect(dockSource).toMatch(/import\s*\{[^}]*isAlcFault[^}]*\}\s*from\s*'\.\/meter-utils'/);

--- a/frontend/src/semantic/__tests__/StationMeterInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/StationMeterInstrumentHost.isolated.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
+const motion = vi.hoisted(() => ({ bars: [] as any[], signals: [] as any[] }));
+vi.mock('../../components-v2/meters/bar-meter-motion.svelte', async (original) => {
+  const actual = await original<typeof import('../../components-v2/meters/bar-meter-motion.svelte')>();
+  return { ...actual, createBarMeterMotion(input: Parameters<typeof actual.createBarMeterMotion>[0]) {
+    const binding = actual.createBarMeterMotion(input);
+    const wrapped = { initial: input, frame: binding.frame, sync: vi.fn(binding.sync), start: vi.fn(binding.start),
+      stop: vi.fn(binding.stop), resetPeak: vi.fn(binding.resetPeak) };
+    motion.bars.push(wrapped); return wrapped;
+  } };
+});
+vi.mock('../../components-v2/meters/signal-meter-motion.svelte', async (original) => {
+  const actual = await original<typeof import('../../components-v2/meters/signal-meter-motion.svelte')>();
+  return { ...actual, createSignalMeterMotion(input: Parameters<typeof actual.createSignalMeterMotion>[0]) {
+    const binding = actual.createSignalMeterMotion(input);
+    const wrapped = { frame: binding.frame, sync: vi.fn(binding.sync), start: vi.fn(binding.start),
+      stop: vi.fn(binding.stop) };
+    motion.signals.push(wrapped); return wrapped;
+  } };
+});
+import Fixture, { StationMeterTestPublisher, stationMeterProbe } from './fixtures/StationMeterInstrumentHostFixture.svelte';
+import { topologyFixtures, withMeters, withTxAux } from '../fixtures/topologies';
+import type { MeterSourceIdentity, MeterValueDomain, RadioViewModel } from '../radio-view-model';
+import type { StationMeterAuthorityPublication, SubscribeStationMeterAuthority } from '../StationMeterInstrumentHost.svelte';
+import { getDesignLanguage, registerDesignLanguage } from '../../presentation/languages/contract';
+import { dimColor } from '../../components-v2/meters/bar-gauge-utils';
+const paths = { signal: 'main.sMeter', power: 'powerMeter', swr: 'swrMeter', alc: 'alcMeter',
+  compression: 'compMeter', drainVoltage: 'vdMeter', drainCurrent: 'idMeter' } as const;
+type Key = keyof typeof paths;
+const source = (path: MeterSourceIdentity['path']): MeterSourceIdentity =>
+  ({ providerGeneration: 1, scope: 'radio', receiver: null, path });
+function view(rfState: 'receiving' | 'transmitting' = 'transmitting'): RadioViewModel {
+  const base = withMeters(withTxAux(topologyFixtures['1/single']), rfState);
+  const meters = { ...base.meters! };
+  for (const key of Object.keys(paths) as Key[]) meters[key] = { ...meters[key], source: source(paths[key]) };
+  return { ...base, meters, txAux: { ...base.txAux!, compressor: {
+    reading: { status: 'known', value: true }, availability: { structural: true, operational: true },
+  } } };
+}
+function field(base: RadioViewModel, key: Key, over: Record<string, unknown>): RadioViewModel {
+  return { ...base, meters: { ...base.meters!, [key]: { ...base.meters![key], ...over } } };
+}
+const domain = (base: RadioViewModel, value: MeterValueDomain | undefined): RadioViewModel =>
+  field(base, 'swr', { domain: value });
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null;
+beforeEach(() => {
+  target = document.createElement('div'); document.body.appendChild(target);
+  component = null; motion.bars = []; motion.signals = []; stationMeterProbe.clear();
+  window.matchMedia = vi.fn().mockReturnValue({ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() });
+});
+afterEach(() => { if (component) unmount(component); target.remove(); vi.restoreAllMocks(); });
+function render(initial: StationMeterAuthorityPublication = { view: view(), session: { controlSessionEpoch: 1 } }) {
+  const publisher = new StationMeterTestPublisher(initial);
+  const props = proxy({ subscribeStationMeterAuthority: publisher.subscribe, presentation: 'native', probe: true });
+  component = mount(Fixture, { target, props }); flushSync();
+  return { publisher, props };
+}
+const expectStopped = () => { expect(motion.signals[0].stop).toHaveBeenCalledOnce(); for (const binding of motion.bars) expect(binding.stop).toHaveBeenCalledOnce(); };
+describe('StationMeterInstrumentHost', () => {
+  it('owns seven live bindings, stable passive frames, and tears them down once', () => {
+    let id = 0; const add = vi.fn(); const remove = vi.fn();
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false, addEventListener: add, removeEventListener: remove });
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => ++id);
+    const cancel = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+    const interval = vi.spyOn(window, 'setInterval').mockImplementation(() => ++id as any);
+    const clear = vi.spyOn(window, 'clearInterval').mockImplementation(() => {});
+    const { publisher, props } = render();
+    expect([motion.signals.length, motion.bars.length]).toEqual([1, 6]);
+    expect(raf).toHaveBeenCalledTimes(8); expect(interval).toHaveBeenCalledTimes(3); expect(add.mock.calls.length).toBeGreaterThanOrEqual(7);
+    expect([...stationMeterProbe.frames.keys()].sort()).toEqual(Object.keys(paths).sort());
+    const initial = new Map(stationMeterProbe.frames);
+    for (const [key, frame] of initial) {
+      expect(Object.keys(frame).sort()).toEqual(key === 'signal' ? ['field', 'motion'] : ['motion', 'projection']);
+      expect('source' in frame || 'session' in frame || 'resetPeak' in frame || 'binding' in frame).toBe(false);
+      if (key === 'signal') expect(Object.hasOwn((frame as any).field, 'source')).toBe(false);
+      if (key !== 'signal') expect(Object.hasOwn((frame as any).projection, 'source')).toBe(false);
+    }
+    const detached = target.querySelector<SVGSVGElement>('[data-meter="power"] svg')!;
+    props.presentation = 'alternate'; flushSync(); detached.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+    expect(motion.bars[0].resetPeak).not.toHaveBeenCalled();
+    for (const [key, frame] of initial) expect(stationMeterProbe.frames.get(key)).toBe(frame);
+    const stale = (stationMeterProbe.seats.get('power') as any).attachRenderer();
+    expect(publisher.handlers.size).toBe(1); unmount(component!); component = null; stale.invoke();
+    expect(publisher.handlers.size).toBe(0);
+    expect(motion.bars[0].resetPeak).not.toHaveBeenCalled();
+    expectStopped();
+    expect(cancel.mock.calls.length).toBeGreaterThanOrEqual(8); expect(clear).toHaveBeenCalledTimes(3); expect(remove).toHaveBeenCalled();
+  });
+  it('cleans mounted owners while preserving subscription and unsubscribe failures', async () => {
+    const initial = { view: view(), session: { controlSessionEpoch: 1 } };
+    const setupFailure = new Error('setup failed');
+    const cleanupFailure = new Error('cleanup failed');
+    const setup: SubscribeStationMeterAuthority = (handler) => {
+      handler(initial);
+      motion.bars[0].stop.mockImplementationOnce(() => { throw cleanupFailure; });
+      throw setupFailure;
+    };
+    let caught: unknown;
+    try {
+      mount(Fixture, { target, props: { subscribeStationMeterAuthority: setup, probe: true } });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBe(setupFailure);
+    expectStopped();
+    motion.bars = [];
+    motion.signals = [];
+    const stopFailure = new Error('stop failed');
+    let publish!: (next: StationMeterAuthorityPublication) => void;
+    const subscribe: SubscribeStationMeterAuthority = (handler) => {
+      publish = handler;
+      handler(initial);
+      return () => { throw stopFailure; };
+    };
+    component = mount(Fixture, { target, props: { subscribeStationMeterAuthority: subscribe, probe: true } }); flushSync();
+    const frame = stationMeterProbe.frames.get('power');
+    const lease = (stationMeterProbe.seats.get('power') as any).attachRenderer();
+    motion.bars[0].stop.mockImplementationOnce(() => { throw cleanupFailure; });
+    let removal: unknown;
+    try {
+      publish({ view: field(view(), 'power', { availability: { structural: false, operational: false } }), session: initial.session });
+    } catch (error) {
+      removal = error;
+    }
+    expect(removal).toBe(cleanupFailure); publish(initial); flushSync();
+    expect(stationMeterProbe.frames.get('power')).not.toBe(frame);
+    expect(lease.active).toBe(false);
+    motion.bars.at(-1).stop.mockImplementationOnce(() => { throw cleanupFailure; });
+    const mounted = component; component = null;
+    await expect(unmount(mounted)).rejects.toBe(stopFailure);
+    lease.invoke();
+    expectStopped();
+    expect(lease.active).toBe(false);
+    expect(motion.bars[0].resetPeak).not.toHaveBeenCalled();
+  });
+  it('preserves both SWR ratio-scale projections without exposing source', () => {
+    const { publisher } = render({ view: domain(view(), undefined), session: { controlSessionEpoch: 1 } });
+    const frame = () => stationMeterProbe.frames.get('swr') as any;
+    expect(frame().projection.ratioScale).toBe(true);
+    publisher.emit({ view: domain(view(), { kind: 'raw' }), session: { controlSessionEpoch: 1 } }); flushSync();
+    expect(frame().projection.ratioScale).toBe(false); expect(Object.hasOwn(frame().projection, 'source')).toBe(false);
+  });
+  it('keeps custom level palettes without admitting a signal owner or gauge', () => {
+    const original = getDesignLanguage('fieldline')!; const zones = [{ end: 1, color: '#123456' }] as const;
+    registerDesignLanguage({ ...original, renderers: { ...original.renderers, meters: () => ({ kind: 'host-projection', segmentCount: 10, segmentGapPx: 2, toneBelowS9: '#111', toneAboveS9: '#222', zones, unknown: false }) } });
+    document.documentElement.dataset.designLanguage = 'fieldline';
+    try {
+      const absent = field(field(view(), 'signal', { availability: { structural: false, operational: false } }), 'swr', { availability: { structural: false, operational: false } });
+      render({ view: absent, session: { controlSessionEpoch: 1 } });
+      expect(motion.signals).toHaveLength(0); expect(target.querySelector('[data-testid="meter-signal"]')).toBeNull();
+      const fills = [...target.querySelectorAll('[data-testid="meter-power"] rect')].map((node) => node.getAttribute('fill'));
+      expect(fills).toContain(dimColor(zones[0].color));
+    } finally { registerDesignLanguage(original); delete document.documentElement.dataset.designLanguage; }
+  });
+  it('rotates reset authority for every qualified source/session field across pre-flush A-B-A', () => {
+    const { publisher } = render();
+    const mutate = [
+      (s: MeterSourceIdentity) => ({ ...s, providerGeneration: 2 }),
+      (s: MeterSourceIdentity) => ({ ...s, scope: 'receiver' as const }),
+      (s: MeterSourceIdentity) => ({ ...s, receiver: 'MAIN' as const }),
+      (s: MeterSourceIdentity) => ({ ...s, path: 'alcMeter' as const }),
+    ];
+    for (const change of mutate) {
+      const oldSeat = stationMeterProbe.seats.get('power') as any; const stale = oldSeat.attachRenderer();
+      publisher.emit({ view: field(view(), 'power', { source: change(source('powerMeter')) }), session: { controlSessionEpoch: 1 } });
+      publisher.emit({ view: view(), session: { controlSessionEpoch: 1 } }); flushSync();
+      stale.invoke(); expect(motion.bars[0].resetPeak).not.toHaveBeenCalled();
+    }
+    const oldSeat = stationMeterProbe.seats.get('power') as any; const stale = oldSeat.attachRenderer();
+    publisher.emit({ view: view(), session: { controlSessionEpoch: 2 } });
+    publisher.emit({ view: view(), session: { controlSessionEpoch: 1 } }); flushSync();
+    stale.invoke(); expect(motion.bars[0].resetPeak).not.toHaveBeenCalled();
+    target.querySelector<SVGSVGElement>('[data-meter="power"] svg')!
+      .dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+    expect(motion.bars[0].resetPeak).toHaveBeenCalledOnce();
+    const unqualified = field(view(), 'power', { source: undefined });
+    publisher.emit({ view: unqualified, session: { controlSessionEpoch: 1 } }); flushSync();
+    const legacy = (stationMeterProbe.seats.get('power') as any).attachRenderer();
+    publisher.emit({ view: unqualified, session: { controlSessionEpoch: 1 } }); flushSync(); expect(legacy.active).toBe(true);
+    publisher.emit({ view: field(unqualified, 'power', { source: null }), session: null });
+    publisher.emit({ view: unqualified, session: { controlSessionEpoch: 1 } }); flushSync(); legacy.invoke();
+    expect(motion.bars[0].resetPeak).toHaveBeenCalledOnce();
+  });
+  it('keeps same-source reset authority through null samples, then re-admits a fresh owner', () => {
+    const { publisher } = render();
+    const seat = stationMeterProbe.seats.get('power') as any; const lease = seat.attachRenderer();
+    const idle = view('receiving');
+    publisher.emit({ view: idle, session: { controlSessionEpoch: 1 } }); flushSync();
+    expect(stationMeterProbe.seats.get('power')).toBe(seat); expect(lease.view.available).toBe(false);
+    expect(motion.bars[0].sync.mock.lastCall[0].value).toBeNull();
+    expect(motion.bars[0].sync.mock.lastCall[0].source).toEqual(source('powerMeter'));
+    lease.invoke(); expect(motion.bars[0].resetPeak).not.toHaveBeenCalled();
+    publisher.emit({ view: view(), session: { controlSessionEpoch: 1 } }); flushSync();
+    expect(stationMeterProbe.seats.get('power')).toBe(seat); lease.invoke();
+    expect(motion.bars[0].resetPeak).toHaveBeenCalledOnce();
+    publisher.emit({ view: field(idle, 'power', { source: null }), session: { controlSessionEpoch: 1 } }); flushSync();
+    expect(stationMeterProbe.seats.get('power')).not.toBe(seat);
+    expect(lease.active).toBe(false);
+    const oldFrame = stationMeterProbe.frames.get('compression');
+    const comp = motion.bars[4];
+    const off = { ...view(), txAux: { ...view().txAux!, compressor: { reading: { status: 'known' as const, value: false }, availability: { structural: true, operational: true } } } };
+    publisher.emit({ view: off, session: { controlSessionEpoch: 1 } }); flushSync(); expect(comp.stop).toHaveBeenCalledOnce();
+    publisher.emit({ view: { ...off, txAux: { ...off.txAux!, compressor: { ...off.txAux!.compressor, reading: { status: 'unknown' } } } }, session: { controlSessionEpoch: 1 } }); flushSync(); expect(motion.bars).toHaveLength(6);
+    publisher.emit({ view: view(), session: { controlSessionEpoch: 1 } }); flushSync();
+    expect(stationMeterProbe.frames.get('compression')).not.toBe(oldFrame);
+  });
+});

--- a/frontend/src/semantic/__tests__/design-language-wiring.component.test.ts
+++ b/frontend/src/semantic/__tests__/design-language-wiring.component.test.ts
@@ -34,7 +34,7 @@ import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
-import MetersSurface from '../MetersSurface.svelte';
+import MetersSurface from './fixtures/StationMeterInstrumentHostFixture.svelte';
 import RxTxSurface from '../RxTxSurface.svelte';
 import VfoSurface from '../VfoSurface.svelte';
 import { topologyFixtures, withMeters, withTxAux } from '../fixtures/topologies';

--- a/frontend/src/semantic/__tests__/fixtures/StationMeterInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/StationMeterInstrumentHostFixture.svelte
@@ -1,0 +1,69 @@
+<script module lang="ts">
+  import type { StationMeterAuthorityPublication,
+    SubscribeStationMeterAuthority } from '../../StationMeterInstrumentHost.svelte';
+  export class StationMeterTestPublisher {
+    readonly handlers = new Set<(publication: StationMeterAuthorityPublication) => void>();
+    current: StationMeterAuthorityPublication;
+    constructor(current: StationMeterAuthorityPublication) { this.current = current; }
+    readonly subscribe: SubscribeStationMeterAuthority = (handler) => {
+      this.handlers.add(handler); handler(this.current);
+      return () => { this.handlers.delete(handler); };
+    };
+    emit(publication: StationMeterAuthorityPublication): void {
+      this.current = publication;
+      for (const handler of this.handlers) handler(publication);
+    }
+  }
+  export const stationMeterProbe = {
+    frames: new Map<string, object>(),
+    seats: new Map<string, object | undefined>(),
+    clear() { this.frames.clear(); this.seats.clear(); },
+  };
+</script>
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import StationMeterInstrumentHost, { type StationLevelMeterFrame, type StationMeterInstrumentHandles, type StationSignalMeterFrame } from '../../StationMeterInstrumentHost.svelte';
+  import MetersSurface from '../../MetersSurface.svelte';
+  import type { MeterContinuitySession } from '../../../primitives/meters/meter-ballistics.svelte';
+  import type { RadioViewModel } from '../../radio-view-model';
+  interface Props { subscribeStationMeterAuthority?: SubscribeStationMeterAuthority;
+    view?: RadioViewModel; session?: MeterContinuitySession | null; presentation?: string;
+    renderSurface?: boolean; probe?: boolean }
+  let {
+    subscribeStationMeterAuthority: externalSubscribe, view, session,
+    presentation = 'native', renderSurface = true, probe = false,
+  }: Props = $props();
+  const local = new StationMeterTestPublisher(untrack(() => ({ view: view ?? null, session })));
+  let last = untrack(() => view);
+  $effect.pre(() => {
+    const next = view;
+    const nextSession = session;
+    if (!Object.is(next, last)) {
+      last = next;
+      local.emit({ view: next ?? null, session: nextSession });
+    }
+  });
+  const subscribeStationMeterAuthority: SubscribeStationMeterAuthority =
+    untrack(() => externalSubscribe) ?? local.subscribe;
+</script>
+<StationMeterInstrumentHost {subscribeStationMeterAuthority}>
+  {#snippet children(handles: StationMeterInstrumentHandles)}
+    {#key presentation}
+      <div data-presentation={presentation}>
+        {#if renderSurface}<MetersSurface {handles} />{/if}
+        {#if probe}
+          {#snippet signal(frame: StationSignalMeterFrame | null)}{@const _ = stationMeterProbe.frames.set('signal', frame ?? {})}<i hidden>{_.size}</i>{/snippet}
+          {#snippet power(frame: StationLevelMeterFrame<'power'>, seat?: object)}{@const _ = stationMeterProbe.frames.set('power', frame)}{@const s = stationMeterProbe.seats.set('power', seat)}<i hidden>{_.size + s.size}</i>{/snippet}
+          {#snippet swr(frame: StationLevelMeterFrame<'swr'>)}{@const _ = stationMeterProbe.frames.set('swr', frame)}<i hidden>{_.size}</i>{/snippet}
+          {#snippet alc(frame: StationLevelMeterFrame<'alc'>, seat?: object)}{@const _ = stationMeterProbe.frames.set('alc', frame)}{@const s = stationMeterProbe.seats.set('alc', seat)}<i hidden>{_.size + s.size}</i>{/snippet}
+          {#snippet drainCurrent(frame: StationLevelMeterFrame<'drainCurrent'>, seat?: object)}{@const _ = stationMeterProbe.frames.set('drainCurrent', frame)}{@const s = stationMeterProbe.seats.set('drainCurrent', seat)}<i hidden>{_.size + s.size}</i>{/snippet}
+          {#snippet drainVoltage(frame: StationLevelMeterFrame<'drainVoltage'>)}{@const _ = stationMeterProbe.frames.set('drainVoltage', frame)}<i hidden>{_.size}</i>{/snippet}
+          {#snippet compression(frame: StationLevelMeterFrame<'compression'>)}{@const _ = stationMeterProbe.frames.set('compression', frame)}<i hidden>{_.size}</i>{/snippet}
+          {@render handles.signal(signal)}{@render handles.power(power)}{@render handles.swr(swr)}
+          {@render handles.alc(alc)}{@render handles.drainCurrent(drainCurrent)}
+          {@render handles.drainVoltage(drainVoltage)}{@render handles.compression(compression)}
+        {/if}
+      </div>
+    {/key}
+  {/snippet}
+</StationMeterInstrumentHost>

--- a/frontend/src/semantic/__tests__/state-vocabulary.component.test.ts
+++ b/frontend/src/semantic/__tests__/state-vocabulary.component.test.ts
@@ -26,7 +26,7 @@
  */
 import { describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
-import MetersSurface from '../MetersSurface.svelte';
+import MetersSurface from './fixtures/StationMeterInstrumentHostFixture.svelte';
 import RxTxSurface from '../RxTxSurface.svelte';
 import { topologyFixtures, withMeters } from '../fixtures/topologies';
 import { BLOCKED_LABEL, RF_LABEL, SESSION_LABEL, type TxAuthoritySnapshot } from '../rx-tx-surface';


### PR DESCRIPTION
Root file-count waiver: 17 code + 0 regenerated baselines = 17 files.

Linear: https://linear.app/morozsm/issue/MOR-2425/expose-a-supported-v3-host-boundary-for-independently-installed

## Summary

- add one persistent StationMeterInstrumentHost around the complete replaceable Receiver/RxAudio/RF/Filter/DSP stack and migrate the single meters slot to its passive seven-instrument handles
- publish station authority synchronously from one station control-authority subscriber and the existing managed-TX callback, with no second TX subscriber or meter scheduler
- preserve qualified source/session reset-seat rotation, pre-flush A-B-A revocation, same-source TX-RX-TX null motion, physical source stripping, custom design-language zones, and best-effort lifecycle cleanup
- retain SWR as the shared S-meter lower row using the intentional peak-disabled bar-motion policy with 0.08s attack and 0.2s release
- migrate the three direct meter-surface test consumers to the real station-host fixture and update exact neighboring subscriber-count assertions without weakening teardown, identity, or lifetime checks
- keep the station host stable while a delayed first authority publication replaces the receiver host's single/dual children branch

## Scope and compatibility

Exactly 17 frontend code/test paths, 837 additions + 151 deletions = 988 A+D. No public API, SDK, activation, skin, calibration, backend, config, or wire change. Existing VFO, Filter, DSP, RX audio, RF front-end, and finite fan-in stacks remain intact.

## Verification

- focused meter/host/wiring matrix on the initial product head: 17 files, 389 tests passed
- coordinator independent changed-suite verification on the initial product head: 3 files, 170 tests passed
- test-consumer correction matrix covering all 9 initially failed suites plus the station trio: 12 files, 469 tests passed
- delayed-first-publication regression RED: `Station meter authority already subscribed`; GREEN after moving the host boundary
- final 12-file correction matrix including the regression: 470 tests passed
- cold production build and Chromium desktop-geometry run: 40 tests passed, including all previously blank dual/standard/SDR scenes
- npm run check: 0 errors, 0 warnings
- scoped ESLint on all 17 changed paths: passed
- git diff --check: passed
- synchronous TX publication mutant: removing publication from the existing managed-TX callback left the retained high fill at 7 instead of reseeding to 1
- source comparator mutant: substituting a historical source for an explicit noncurrent source:null retained the old reset seat instead of permanently revoking it

Accepted base 335019309dfe8deed88dffbd371481f097f90c58 had aggregate main quick run 34092383464 succeed.

## Natural CI history

Initial head d64cba111ecbdc21578714a298f9009a8253f944: visual 34094852601 SUCCESS; quick 34094852798 FAILED 27 tests in 9 files. The failures were a genuine test-consumer migration and exact subscription-census lease underestimate, not runner failure.

Test-migration successor dec041c8addbdfebb864c8e4983de2434ee16760: visual 34095793089 SUCCESS; quick 34095793166 FAILED in the i18n geometry smoke after 9 passed, 10 missing-element failures, and 68 tests did not run.

Comment-only successor 04698f21b416d50e47dd7c2aa3e8bbf642a104ab: visual 34096138776 SUCCESS; quick 34096138542 FAILED in the same blank-page geometry family after 29 passed, 10 failures, and 48 tests did not run. Trace diagnosis identified the nested-host singleton exception.

Corrected head 1bc06643b0695f92a87a631813b81bac6e2344a5: natural quick 34097393300 SUCCESS; natural visual 34097393404 SUCCESS. No workflow was manually dispatched or rerun.

## Independent review history

- Historical exact-head BLOCKED for 04698f21b416d50e47dd7c2aa3e8bbf642a104ab: https://github.com/rigplane/rigplane-core/pull/3331#issuecomment-5567049516
- Final exact-head PASS for 1bc06643b0695f92a87a631813b81bac6e2344a5: https://github.com/rigplane/rigplane-core/pull/3331#issuecomment-5567311581

This author will not review or merge the PR.
