### PR TITLE
MOR-2425: host external receiver meter appearances

### DIFF
--- a/frontend/src/component-kits/MeterRendererSeat.svelte
+++ b/frontend/src/component-kits/MeterRendererSeat.svelte
@@ -3,7 +3,7 @@
   import type { SignalMeterFrame } from '../components-v2/meters/signal-meter-motion.svelte';
   import type { MeterReading, MeterValueDomain } from '../semantic/radio-view-model';
   import { toSignalMeterRendererView } from '../semantic/meter-renderer-view';
-  import * as activation from './activation';
+  import { getSelectedMeterAppearance } from './activation';
 
   interface Props {
     frame: SignalMeterFrame;
@@ -13,11 +13,7 @@
   }
 
   let { frame, reading, domain, fallback }: Props = $props();
-  const selectedRenderer = untrack(() =>
-    'getSelectedMeterAppearance' in activation
-      ? activation.getSelectedMeterAppearance()?.signal
-      : undefined,
-  );
+  const selectedRenderer = untrack(() => getSelectedMeterAppearance()?.signal);
   const view = $derived(toSignalMeterRendererView(frame, reading, domain));
 </script>
 

--- a/frontend/src/component-kits/MeterRendererSeat.svelte
+++ b/frontend/src/component-kits/MeterRendererSeat.svelte
@@ -3,7 +3,7 @@
   import type { SignalMeterFrame } from '../components-v2/meters/signal-meter-motion.svelte';
   import type { MeterReading, MeterValueDomain } from '../semantic/radio-view-model';
   import { toSignalMeterRendererView } from '../semantic/meter-renderer-view';
-  import { getSelectedMeterAppearance } from './activation';
+  import * as activation from './activation';
 
   interface Props {
     frame: SignalMeterFrame;
@@ -13,7 +13,11 @@
   }
 
   let { frame, reading, domain, fallback }: Props = $props();
-  const selectedRenderer = untrack(() => getSelectedMeterAppearance()?.signal);
+  const selectedRenderer = untrack(() =>
+    'getSelectedMeterAppearance' in activation
+      ? activation.getSelectedMeterAppearance()?.signal
+      : undefined,
+  );
   const view = $derived(toSignalMeterRendererView(frame, reading, domain));
 </script>
 

--- a/frontend/src/component-kits/MeterRendererSeat.svelte
+++ b/frontend/src/component-kits/MeterRendererSeat.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import { untrack, type Snippet } from 'svelte';
+  import type { SignalMeterFrame } from '../components-v2/meters/signal-meter-motion.svelte';
+  import type { MeterReading, MeterValueDomain } from '../semantic/radio-view-model';
+  import { toSignalMeterRendererView } from '../semantic/meter-renderer-view';
+  import { getSelectedMeterAppearance } from './activation';
+
+  interface Props {
+    frame: SignalMeterFrame;
+    reading: MeterReading;
+    domain?: MeterValueDomain;
+    fallback: Snippet<[frame: SignalMeterFrame]>;
+  }
+
+  let { frame, reading, domain, fallback }: Props = $props();
+  const selectedRenderer = untrack(() => getSelectedMeterAppearance()?.signal);
+  const view = $derived(toSignalMeterRendererView(frame, reading, domain));
+</script>
+
+{#if selectedRenderer}
+  {@const Renderer = selectedRenderer}
+  <Renderer {view} />
+{:else}
+  {@render fallback(frame)}
+{/if}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
@@ -54,6 +54,7 @@ vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
 vi.mock('../../../component-kits/activation', () => ({
   getSelectedFiniteControlAppearance: () => h.selectedFiniteAppearance,
   getSelectedFrequencyReadout: () => undefined,
+  getSelectedMeterAppearance: () => undefined,
   getSelectedScalarAppearance: () => undefined,
 }));
 vi.mock('$lib/runtime/commands/radio-intents', async () => {

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -30,6 +30,7 @@ const group = new Proxy({}, { get: () => h.noop });
 
 vi.mock('../../../component-kits/activation', () => ({
   getSelectedFrequencyReadout: () => selectedFrequency.current,
+  getSelectedMeterAppearance: () => undefined,
 }));
 
 vi.mock('$lib/runtime', () => ({

--- a/frontend/src/semantic/ReceiverInstrumentHost.svelte
+++ b/frontend/src/semantic/ReceiverInstrumentHost.svelte
@@ -23,6 +23,7 @@
   import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
   import { t } from '$lib/i18n';
   import FrequencyRendererSeat from '../primitives/frequency/FrequencyRendererSeat.svelte';
+  import MeterRendererSeat from '../component-kits/MeterRendererSeat.svelte';
   import {
     createFrequencyInstrumentBinding,
     type FrequencyInstrumentBinding,
@@ -33,7 +34,9 @@
     type SignalMeterMotionInput,
   } from '../components-v2/meters/signal-meter-motion.svelte';
   import { projectSignalMeter } from '../components-v2/meters/smeter-scale';
-  import type { RadioViewModel, ReceiverId, VfoViewModel } from './radio-view-model';
+  import type {
+    MeterReading, RadioViewModel, ReceiverId, ReceiverSMeterField, VfoViewModel,
+  } from './radio-view-model';
 
   type ReceiverAuthorityPublication = Readonly<{
     state: ServerState | null; caps: Capabilities | null;
@@ -88,6 +91,13 @@
 
   const safeGeneration = (value: unknown): value is number =>
     typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+  const UNKNOWN_METER_READING = Object.freeze({ status: 'unknown' }) satisfies MeterReading;
+
+  function receiverMeter(
+    model: RadioViewModel | null, receiver: ReceiverId,
+  ): ReceiverSMeterField | undefined {
+    return model?.receiverIndicators?.find((item) => item.receiver === receiver)?.sMeter;
+  }
 
   function activeRecord(model: RadioViewModel | null, receiver: ReceiverId): VfoViewModel | null {
     const records = model?.vfos.filter((record) => record.receiver === receiver && record.isActiveSlot) ?? [];
@@ -322,13 +332,17 @@
 
 {#snippet mainSMeter(renderer: ReceiverSMeterRenderer)}
   {#if mainOwner !== null}
-    {@render renderer(mainOwner.motion.frame)}
+    {@const meter = receiverMeter(mainOwner.model, 'MAIN')}
+    <MeterRendererSeat frame={mainOwner.motion.frame}
+      reading={meter?.reading ?? UNKNOWN_METER_READING} domain={meter?.domain} fallback={renderer} />
   {/if}
 {/snippet}
 
 {#snippet subSMeter(renderer: ReceiverSMeterRenderer)}
   {#if subOwner !== null}
-    {@render renderer(subOwner.motion.frame)}
+    {@const meter = receiverMeter(subOwner.model, 'SUB')}
+    <MeterRendererSeat frame={subOwner.motion.frame}
+      reading={meter?.reading ?? UNKNOWN_METER_READING} domain={meter?.domain} fallback={renderer} />
   {/if}
 {/snippet}
 

--- a/frontend/src/semantic/__tests__/ReceiverInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/ReceiverInstrumentHost.isolated.test.ts
@@ -2,15 +2,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import { fromStore, writable } from 'svelte/store';
 import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import type { Capabilities, VfoScheme } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
-import type { FrequencyRenderer } from '../../../component-kit-api/src/index';
+import type { FrequencyRenderer, MeterAppearance } from '../../../component-kit-api/src/index';
 const selectedFrequency = vi.hoisted(() => ({ current: undefined as unknown }));
+const selectedMeter = vi.hoisted(() => ({ current: undefined as MeterAppearance | undefined }));
 vi.mock('../../component-kits/activation', () => ({
   getSelectedFrequencyReadout: () => selectedFrequency.current,
+  getSelectedMeterAppearance: () => selectedMeter.current,
 }));
-import Fixture from './fixtures/ReceiverInstrumentHostFixture.svelte';
+import Fixture, {
+  FIXTURE_LEVEL_SOURCE_SHA256, FIXTURE_SIGNAL_SOURCE_SHA256,
+  FIXTURE_TARBALL_SHA256, fixtureMeterAppearance,
+} from './fixtures/ReceiverInstrumentHostFixture.svelte';
 import AlternateFrequencyReadoutHarness, {
   clearRetainedInteractions, retainedInteractions,
 } from '../../primitives/frequency/__tests__/AlternateFrequencyReadoutHarness.svelte';
@@ -132,12 +138,14 @@ let components: ReturnType<typeof mount>[] = [];
 let motion: MotionHarness;
 beforeEach(() => {
   selectedFrequency.current = AlternateFrequencyReadoutHarness as FrequencyRenderer;
+  selectedMeter.current = undefined;
   clearRetainedInteractions(); motion = installMotionHarness();
   expect(setCapabilities(capabilities())).toBe(true);
 });
 afterEach(() => {
   components.forEach((component) => unmount(component)); components = [];
   document.body.replaceChildren(); selectedFrequency.current = undefined; motion.restore();
+  selectedMeter.current = undefined;
   clearCapabilities();
 });
 function mountFixture(publisher: Publisher, props: Record<string, unknown> = {}): HTMLElement {
@@ -328,6 +336,65 @@ describe('ReceiverInstrumentHost', () => {
     motion.reduced(false); expect(motion.frames).toBe(4);
   });
 
+  it('mounts the real external fixture renderer for MAIN and SUB with honest domains', () => {
+    expect(createHash('sha256').update(readFileSync(
+      'component-kit-api/fixtures/external-kit/src/FixtureSignalMeter.svelte',
+    )).digest('hex')).toBe(FIXTURE_SIGNAL_SOURCE_SHA256);
+    expect(createHash('sha256').update(readFileSync(
+      'component-kit-api/fixtures/external-kit/src/FixtureLevelMeter.svelte',
+    )).digest('hex')).toBe(FIXTURE_LEVEL_SOURCE_SHA256);
+    expect(FIXTURE_TARBALL_SHA256)
+      .toBe('726a85423500204a0ef03c0d84987a54322664560185fd9ebd2c304ec50ddb13');
+    selectedMeter.current = fixtureMeterAppearance;
+    const publisher = new Publisher(publication()); const root = mountFixture(publisher);
+    const meters = () => Array.from(root.querySelectorAll<HTMLElement>('[data-fixture-signal]'));
+    expect(meters()).toHaveLength(2);
+    expect(meters().map((meter) => [meter.dataset.domain, meter.dataset.value]))
+      .toEqual([['engineering:db', '20'], ['engineering:db', '-24']]);
+
+    publisher.emit(publication({ mainS: 53, subS: 54, meterQuality: ['uncalibrated'] })); flushSync();
+    expect(meters().map((meter) => [meter.dataset.domain, meter.dataset.value]))
+      .toEqual([['raw', '53'], ['raw', '54']]);
+    expect(meters().every((meter) => !/dBm|\bS[0-9]/.test(meter.textContent ?? ''))).toBe(true);
+    publisher.emit(publication({ mainS: 41, subS: 42, meterQuality: [] })); flushSync();
+    expect(meters().map((meter) => [meter.dataset.domain, meter.dataset.value, meter.dataset.scale]))
+      .toEqual([['unknown', '41', 'none'], ['unknown', '42', 'none']]);
+    publisher.emit(publication({ meterKnown: false, meterQuality: [] })); flushSync();
+    expect(meters().every((meter) => meter.dataset.value === undefined)).toBe(true);
+  });
+
+  it('preserves dB-relative-to-S9 evidence without inventing geometry or dBm', () => {
+    selectedMeter.current = fixtureMeterAppearance;
+    const noCalibration = { ...capabilities(), meterCalibrations: {} };
+    expect(setCapabilities(noCalibration)).toBe(true);
+    const initial = publication({ mainS: -12 });
+    const publisher = new Publisher({ ...initial, caps: noCalibration });
+    const root = mountFixture(publisher);
+    const meter = root.querySelector<HTMLElement>('[data-fixture-signal]')!;
+    expect([meter.dataset.domain, meter.dataset.value, meter.dataset.scale])
+      .toEqual(['engineering:db', '-12', 'none']);
+    expect(meter.textContent).toContain('−12 dB rel S9');
+    expect(meter.textContent).not.toContain('dBm');
+  });
+
+  it('keeps one motion owner across external-native-external component replacement', () => {
+    selectedMeter.current = fixtureMeterAppearance;
+    const publisher = new Publisher(publication()); const layout = writable('external-a');
+    const live = fromStore(layout);
+    const root = mountFixture(publisher, { get layoutKey() { return live.current; } });
+    expect(root.querySelectorAll('[data-fixture-signal]')).toHaveLength(2);
+    expect(motion.frames).toBe(4);
+
+    selectedMeter.current = undefined; layout.set('native-b'); flushSync();
+    expect(root.querySelectorAll('[data-fixture-signal]')).toHaveLength(0);
+    expect(root.querySelectorAll('[data-meter-frame]')).toHaveLength(2);
+    expect(motion.frames).toBe(4);
+
+    selectedMeter.current = fixtureMeterAppearance; layout.set('external-a-again'); flushSync();
+    expect(root.querySelectorAll('[data-fixture-signal]')).toHaveLength(2);
+    expect(motion.frames).toBe(4);
+  });
+
   it('resets retained MAIN meter history at a real topology boundary', () => {
     const publisher = new Publisher(publication({ mainS: 20, scheme: 'main_sub' }));
     const root = mountFixture(publisher);
@@ -382,6 +449,10 @@ describe('ReceiverInstrumentHost', () => {
   });
 
   it('requires the synchronous publisher and owns no fallback clocks or continuity comparison', () => {
+    const addedSources = [
+      'src/semantic/meter-renderer-view.ts',
+      'src/component-kits/MeterRendererSeat.svelte',
+    ].map((file) => readFileSync(file, 'utf8')).join('\n');
     const source = readFileSync('src/semantic/ReceiverInstrumentHost.svelte', 'utf8');
     expect(source).toMatch(/subscribeControlAuthority: SubscribeReceiverAuthority/);
     expect(source).not.toMatch(/subscribeControlAuthority\?|requestAnimationFrame|setInterval|setTimeout|Date\.now/);
@@ -389,5 +460,10 @@ describe('ReceiverInstrumentHost', () => {
     expect(source).toContain('projectSignalMeter(value, meter?.domain)');
     expect(source).not.toMatch(/LinearSMeter/);
     expect(source).not.toMatch(/providerGeneration === .*source|controlSessionEpoch ===/);
+    expect(`${source}\n${addedSources}`)
+      .not.toMatch(/requestAnimationFrame|setInterval|setTimeout|Date\.now/);
+    expect(addedSources).not.toMatch(
+      /calibrat|normaliz|MeterSourceIdentity|MeterContinuitySession|FrequencyInstrumentBinding/i,
+    );
   });
 });

--- a/frontend/src/semantic/__tests__/fixtures/ReceiverInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/ReceiverInstrumentHostFixture.svelte
@@ -1,3 +1,21 @@
+<script module lang="ts">
+  import type { MeterAppearance } from '../../../../component-kit-api/src/index';
+  import FixtureLevelMeter from '../../../../component-kit-api/fixtures/external-kit/src/FixtureLevelMeter.svelte';
+  import FixtureSignalMeter from '../../../../component-kit-api/fixtures/external-kit/src/FixtureSignalMeter.svelte';
+
+  export const FIXTURE_SIGNAL_SOURCE_SHA256 =
+    '6a1ce5577294415d033d6c45edf88a2e2c30f1ab5f81baf2678614616dcffca8';
+  export const FIXTURE_LEVEL_SOURCE_SHA256 =
+    'e6f909e12cb8b0bcb1adccde853ce47d8fbb4813805bd6cf73490a367f569ecc';
+  export const FIXTURE_TARBALL_SHA256 =
+    '726a85423500204a0ef03c0d84987a54322664560185fd9ebd2c304ec50ddb13';
+
+  export const fixtureMeterAppearance = {
+    signal: FixtureSignalMeter,
+    level: FixtureLevelMeter,
+  } satisfies MeterAppearance;
+</script>
+
 <script lang="ts">
   import ReceiverInstrumentHost, {
     type ReceiverInstrumentHandles,

--- a/frontend/src/semantic/__tests__/meter-renderer-view.test.ts
+++ b/frontend/src/semantic/__tests__/meter-renderer-view.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
+import type { SignalMeterFrame } from '../../components-v2/meters/signal-meter-motion.svelte';
+import type { SignalMeterProjection } from '../../components-v2/meters/smeter-scale';
+import { toSignalMeterRendererView } from '../meter-renderer-view';
+
+function capabilities(): Capabilities {
+  return {
+    model: 'public-meter-test', scope: false, audio: false, tx: false,
+    capabilities: [], receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48_000, channels: 1, codecs: [] },
+    webrtc: { available: false, enabled: false }, txBands: null,
+    stateContractVersion: 1, providerGeneration: 0,
+    meterCalibrations: { s_meter: [
+      { raw: 0, actual: -54, label: 'S0' },
+      { raw: 130, actual: 0, label: 'S9' },
+      { raw: 240, actual: 40, label: 'S9+40' },
+    ] },
+  };
+}
+
+beforeEach(() => setCapabilities(capabilities()));
+afterEach(() => clearCapabilities());
+
+function frame(overrides: Partial<SignalMeterProjection> = {}): SignalMeterFrame {
+  return {
+    projection: {
+      scaleMode: 's', motionFraction: 0.4,
+      primaryText: 'S7', secondaryText: '−85 dBm',
+      accessibleDescription: 'S meter S7, −85 dBm', crossoverFraction: 0.55,
+      marks: [{ actual: 0, fraction: 0.55, text: '9', color: 'red' }],
+      ticks: [{ fraction: 0.1, kind: 'mid', color: 'white' }],
+      ...overrides,
+    },
+    smoothedFraction: 0.35,
+    peakFraction: 0.6,
+  };
+}
+
+describe('toSignalMeterRendererView', () => {
+  it('copies only the public graph and freezes it recursively', () => {
+    const source = frame();
+    const view = toSignalMeterRendererView(
+      source, { status: 'known', value: -12 }, { kind: 'engineering', unit: 'db' },
+    );
+
+    expect(Reflect.ownKeys(view)).toEqual([
+      'kind', 'evidence', 'scaleMode', 'displayedFraction', 'peakFraction',
+      'primaryText', 'secondaryText', 'accessibleDescription', 'crossoverFraction',
+      'marks', 'ticks',
+    ]);
+    expect(view).toMatchObject({
+      evidence: { state: 'current', value: -12, domain: { kind: 'engineering', unit: 'db' } },
+      displayedFraction: 0.35, peakFraction: 0.6,
+    });
+    expect(view.marks).toEqual([{ actual: 0, fraction: 0.55, text: '9' }]);
+    expect(view.ticks).toEqual([{ fraction: 0.1, kind: 'mid' }]);
+    expect(view.marks).not.toBe(source.projection.marks);
+    expect(view.ticks).not.toBe(source.projection.ticks);
+    expect(JSON.stringify(view)).not.toMatch(/color|source|session|binding/);
+    expect([
+      view, view.evidence, view.evidence.domain, view.marks, view.marks[0],
+      view.ticks, view.ticks[0],
+    ].every(Object.isFrozen)).toBe(true);
+    expect([view, view.evidence, view.evidence.domain, view.marks[0], view.ticks[0]]
+      .flatMap((item) => Object.values(Object.getOwnPropertyDescriptors(item)))
+      .every((descriptor) => 'value' in descriptor)).toBe(true);
+    expect(() => (view.marks as unknown as Array<SignalMeterProjection['marks'][number]>).push({
+      actual: 20, fraction: 0.7, text: '+20', color: 'orange',
+    })).toThrow();
+    expect(source.projection.marks).toEqual([
+      { actual: 0, fraction: 0.55, text: '9', color: 'red' },
+    ]);
+  });
+
+  it.each([
+    ['raw', { kind: 'raw' } as const, 'raw'],
+    ['unknown', { kind: 'unknown' } as const, 'unknown'],
+  ])('preserves an explicit %s domain without engineering relabeling', (_name, domain, kind) => {
+    const view = toSignalMeterRendererView(
+      frame({ scaleMode: kind === 'raw' ? 'raw' : 'none' }),
+      { status: 'known', value: 53 }, domain,
+    );
+    expect(view.evidence).toEqual({ state: 'current', value: 53, domain });
+  });
+
+  it.each(['s', 'raw'] as const)('downgrades the omitted legacy %s domain without inference',
+    (scaleMode) => {
+      const view = toSignalMeterRendererView(
+        frame({ scaleMode }), { status: 'known', value: 12 }, undefined,
+      );
+      expect(view.evidence).toEqual({ state: 'current', value: 12, domain: { kind: 'unknown' } });
+      expect(view).toMatchObject({
+        scaleMode: 'none', displayedFraction: null, peakFraction: null,
+        crossoverFraction: null, marks: [], ticks: [], primaryText: '12',
+        secondaryText: 'unit unknown',
+      });
+      expect(`${view.primaryText} ${view.secondaryText}`).not.toMatch(/dBm|rel S9|uncalibrated/);
+    });
+
+  it('keeps qualified dB-relative-to-S9 evidence when calibrated geometry is unavailable', () => {
+    const view = toSignalMeterRendererView(frame({
+      scaleMode: 'none', motionFraction: null, primaryText: '−12 dB rel S9',
+      secondaryText: 'scale unavailable', accessibleDescription: 'minus 12 dB relative to S9',
+      crossoverFraction: null, marks: [], ticks: [],
+    }), { status: 'known', value: -12 }, { kind: 'engineering', unit: 'db' });
+
+    expect(view.evidence).toEqual({
+      state: 'current', value: -12, domain: { kind: 'engineering', unit: 'db' },
+    });
+    expect(view).toMatchObject({ displayedFraction: null, peakFraction: null });
+    expect(`${view.primaryText} ${view.secondaryText}`).not.toContain('dBm');
+  });
+
+  it('uses canonical unknown text and no live geometry for a stale valid frame', () => {
+    const view = toSignalMeterRendererView(frame(),
+      { status: 'unknown' }, { kind: 'engineering', unit: 'db' });
+    expect(view.evidence).toEqual({
+      state: 'unknown', domain: { kind: 'engineering', unit: 'db' },
+    });
+    expect(view.scaleMode).toBe('s');
+    expect(view.marks.length).toBeGreaterThan(0);
+    expect(view.ticks.length).toBeGreaterThan(0);
+    expect(view.displayedFraction).toBeNull();
+    expect(view.peakFraction).toBeNull();
+    expect(`${view.primaryText} ${view.secondaryText}`).not.toContain('dBm');
+  });
+
+  it('turns a non-finite internal reading into unknown evidence', () => {
+    const view = toSignalMeterRendererView(
+      frame(),
+      { status: 'known', value: Number.NaN },
+      { kind: 'engineering', unit: 'db' },
+    );
+    expect(view.evidence).toEqual({
+      state: 'unknown', domain: { kind: 'engineering', unit: 'db' },
+    });
+    expect(view.displayedFraction).toBeNull();
+  });
+
+  it.each([
+    ['motion', () => frame({ motionFraction: 1.1 })],
+    ['displayed', () => ({ ...frame(), smoothedFraction: Number.NaN })],
+    ['peak', () => ({ ...frame(), peakFraction: Infinity })],
+  ])('drops invalid %s live geometry without erasing the valid static scale', (_name, makeFrame) => {
+    expect(toSignalMeterRendererView(
+      makeFrame(), { status: 'known', value: 0 }, { kind: 'engineering', unit: 'db' },
+    )).toMatchObject({
+      scaleMode: 's', displayedFraction: null, peakFraction: null,
+    });
+  });
+
+  it.each([
+    ['crossover', () => frame({ crossoverFraction: Number.NaN })],
+    ['mark', () => frame({ marks: [{ actual: 0, fraction: -0.1, text: '9', color: '' }] })],
+    ['mark actual', () => frame({ marks: [{ actual: Number.NaN, fraction: 0.1, text: '9', color: '' }] })],
+    ['tick', () => frame({ ticks: [{ fraction: Infinity, kind: 'minor', color: '' }] })],
+  ])('drops invalid %s static geometry instead of clamping or normalizing', (_name, makeFrame) => {
+    expect(toSignalMeterRendererView(
+      makeFrame(), { status: 'known', value: 0 }, { kind: 'engineering', unit: 'db' },
+    )).toMatchObject({
+      scaleMode: 'none', displayedFraction: null, peakFraction: null,
+      crossoverFraction: null, marks: [], ticks: [],
+    });
+  });
+});

--- a/frontend/src/semantic/meter-renderer-view.ts
+++ b/frontend/src/semantic/meter-renderer-view.ts
@@ -1,0 +1,82 @@
+import type {
+  MeterDisplayDomain,
+  SignalMeterEvidence,
+  SignalMeterMark,
+  SignalMeterRendererView,
+  SignalMeterTick,
+} from '../../component-kit-api/src/index';
+import type { SignalMeterFrame } from '../components-v2/meters/signal-meter-motion.svelte';
+import { projectSignalMeter } from '../components-v2/meters/smeter-scale';
+import type { MeterReading, MeterValueDomain } from './radio-view-model';
+
+function validFraction(value: number | null): boolean {
+  return value === null || (Number.isFinite(value) && value >= 0 && value <= 1);
+}
+
+function displayDomain(domain: MeterValueDomain | undefined): MeterDisplayDomain {
+  if (domain?.kind === 'engineering') {
+    return Object.freeze({ kind: 'engineering', unit: domain.unit });
+  }
+  if (domain?.kind === 'raw') return Object.freeze({ kind: 'raw' });
+  if (domain?.kind === 'unknown') return Object.freeze({ kind: 'unknown' });
+  return Object.freeze({ kind: 'unknown' });
+}
+
+function evidence(
+  reading: MeterReading,
+  domain: MeterDisplayDomain,
+): SignalMeterEvidence {
+  return reading.status === 'known' && Number.isFinite(reading.value)
+    ? Object.freeze({ state: 'current', value: reading.value, domain })
+    : Object.freeze({ state: 'unknown', domain });
+}
+
+function marks(source: SignalMeterFrame['projection']['marks']): readonly SignalMeterMark[] {
+  return Object.freeze(source.map((mark) => Object.freeze({
+    actual: mark.actual,
+    fraction: mark.fraction,
+    text: mark.text,
+  })));
+}
+
+function ticks(source: SignalMeterFrame['projection']['ticks']): readonly SignalMeterTick[] {
+  return Object.freeze(source.map((tick) => Object.freeze({
+    fraction: tick.fraction,
+    kind: tick.kind,
+  })));
+}
+
+/** Copy one Core-owned receiver frame into the smaller public, immutable renderer graph. */
+export function toSignalMeterRendererView(
+  frame: SignalMeterFrame,
+  reading: MeterReading,
+  domain: MeterValueDomain | undefined,
+): SignalMeterRendererView {
+  const current = reading.status === 'known' && Number.isFinite(reading.value);
+  const projection = domain === undefined
+    ? projectSignalMeter(current ? reading.value : null, { kind: 'unknown' })
+    : current ? frame.projection : projectSignalMeter(null, domain);
+  const publicDomain = displayDomain(domain);
+  const validStaticGeometry = validFraction(projection.crossoverFraction)
+    && projection.marks.every((mark) => Number.isFinite(mark.actual) && validFraction(mark.fraction))
+    && projection.ticks.every((tick) => validFraction(tick.fraction));
+  const live = validStaticGeometry
+    && current
+    && projection.motionFraction !== null
+    && validFraction(projection.motionFraction)
+    && validFraction(frame.smoothedFraction)
+    && validFraction(frame.peakFraction);
+  return Object.freeze({
+    kind: 'signal',
+    evidence: evidence(reading, publicDomain),
+    scaleMode: validStaticGeometry ? projection.scaleMode : 'none',
+    displayedFraction: live ? frame.smoothedFraction : null,
+    peakFraction: live ? frame.peakFraction : null,
+    primaryText: projection.primaryText,
+    secondaryText: projection.secondaryText,
+    accessibleDescription: projection.accessibleDescription,
+    crossoverFraction: validStaticGeometry ? projection.crossoverFraction : null,
+    marks: validStaticGeometry ? marks(projection.marks) : Object.freeze([]),
+    ticks: validStaticGeometry ? ticks(projection.ticks) : Object.freeze([]),
+  });
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -18,6 +18,7 @@
     "moduleDetection": "force",
     "baseUrl": ".",
     "paths": {
+      "@rigplane/component-kit-api": ["component-kit-api/src/index.ts"],
       "$lib": ["src/lib"],
       "$lib/*": ["src/lib/*"]
     }


### PR DESCRIPTION
Root file-count waiver: 9 code + 0 regenerated baselines = 9 files.

Linear: MOR-2425
Depends on merged M2-4A / PR #3330 (`df8cee747982f14cb46caed05f20915c17914299`).

## Scope

Connects the public meter appearance selected by the existing component-kit activation transaction to the existing persistent MAIN/SUB receiver instrument owner. The new seat chooses the selected external signal component or invokes the unchanged native renderer snippet. All existing `VfoSurface` placements remain the real Standard/SDR fallback consumers.

Exact head: `8cce8365b4dec90e3d2a6d8ca6b0b26e92b5c1af`. Nine approved paths, 390 additions + 5 deletions = 395 A+D, below the 700 target and 800 hard ceiling. Seven product/test-fixture/config paths contain the 393 A+D receiver-host design; two root-approved wiring-test paths add one truthful missing activation-mock export each.

## Boundary and ownership

- `ReceiverInstrumentHost` continues to own exactly one signal motion/frame per receiver.
- `projectSignalMeter` remains the canonical calibration, text and static-scale projector.
- current finite qualified evidence may receive live smoothed fill/peak from the existing frame
- unknown/non-finite evidence uses canonical unknown projection and cannot inherit stale live fill/peak
- omitted legacy domain becomes explicit public `unknown`, retaining finite numeric evidence without S/dBm inference
- invalid live fractions null fill/peak without erasing a valid static scale; invalid static fractions suppress the invalid scale graph
- public output is an explicit recursively frozen copy with no color, source, session, binding, getter, symbol, callback, frame or owner escape

No motion, calibration, normalization, clock, registry, selection, session or layout owner was added. Station topology lifetime and M2-4C remain out of scope.

## Real external artifact proof

The Core host test imports the actual M2-4A `FixtureSignalMeter.svelte` and `FixtureLevelMeter.svelte` sources. The approved `tsconfig.app.json` mapping resolves only their type-only public-root imports for root `svelte-check`; there is no Vite alias or runtime/package resolution change.

- signal source SHA-256: `6a1ce5577294415d033d6c45edf88a2e2c30f1ab5f81baf2678614616dcffca8`
- level source SHA-256: `e6f909e12cb8b0bcb1adccde853ce47d8fbb4813805bd6cf73490a367f569ecc`
- retained M2-4A installed/browser-mounted fixture tarball SHA-256: `726a85423500204a0ef03c0d84987a54322664560185fd9ebd2c304ec50ddb13`

MAIN and SUB both mount the real signal component through the current host for engineering, raw, unknown-domain numeric and unknown-reading cases. External-native-external replacement retains the same four receiver motion schedules.

## Verification

- RED before implementation: missing helper suite plus 3 external-host failures
- mutation RED: ignored selection produced 3 host failures
- mutation RED: copied private `color` produced exact-key failure
- mutation RED: legacy inference to engineering/db produced 2 failures
- `npx vitest run` for meter view, ReceiverInstrumentHost and VfoSurface: 220/220 passed
- `npm run check`: 0 errors, 0 warnings
- scoped ESLint: clean
- `git diff --check`: clean
- merged M2-4A aggregate main quick 34095231630: SUCCESS
- first natural quick 34098688291 on superseded `d86b0a0e…`: FAILED in the VFO wiring suite (27/30) because its complete activation mock omitted `getSelectedMeterAppearance`; the Scope wiring mock was the same reachable contract class and was repaired in the final test-only correction
- diagnostic production guard was intentionally removed after the full frontend suite passed 453 files / 11,121 tests; it is not final-head evidence
- final exact-head focused correction proof: five suites, 297/297 passed; strict production selector unchanged
- exact-head natural quick 34099278375: SUCCESS
- exact-head natural visual 34099278250: SUCCESS
- independent exact-head review: PASS in comment https://github.com/rigplane/rigplane-core/pull/3333#issuecomment-5567503838; required Agent Review Gate green

## Mechanics audit

PASS on the frozen design. Definition/liveness, prior ruling, in-flight work, dynamic/public/open-core guards, steelman and scoped dead-code sweep were completed. The audit enumerates the new helpers, constants, component contract/derived values and snippet lookups across all three production paths; each has a concrete consumer. The two test-only mock members are exercised by their full semantic mounts. No deletion, consolidation or competing mechanism was found. The independent projection adjudication required reuse of canonical `projectSignalMeter` and separate static-scale versus live-geometry eligibility; the frozen head implements that ruling.

Audit report: `/Users/moroz/.codex/handoffs/rigplane-mini-20260905-01a07230/public-meter-api-m2-4b-mechanics-audit.md` (SHA-256 `af29b46ed0e8ba168c14a3180d905a2d218478eb18b54b1e0683c9881bb694b1`). Independent review report: `/Users/moroz/.codex/handoffs/rigplane-mini-20260905-01a07230/public-meter-api-m2-4b-final-independent-review.md` (SHA-256 `be026871938696ce08c643333f2206dc54e9d48efbe68a915b6b8ca8743f03d6`).
