### PR TITLE
feat(MOR-2425): activate external face presentations

### DIFF
--- a/frontend/src/component-kits/__tests__/activation.test.ts
+++ b/frontend/src/component-kits/__tests__/activation.test.ts
@@ -689,6 +689,43 @@ describe('component-kit activation transaction', () => {
     expect(toJSON).not.toHaveBeenCalled();
   });
 
+  it.each(['apiVersion', 'resource'] as const)(
+    'rejects a non-primitive %s without coercion or registry side effects',
+    async (target) => {
+      const activation = await subject();
+      const registry = await import('../../skins/registry');
+      const layouts = await import('../../presentation/layouts/contract');
+      const idSuffix = target === 'apiVersion' ? 'api-version' : target;
+      const declaration = hostedKit(`coercion-${idSuffix}`);
+      const leakedLayout = layout(`coercion-leak-${idSuffix}`);
+      const primitiveGetter = vi.fn(() => {
+        layouts.registerLayouts([leakedLayout as never]);
+        return () => 'poison';
+      });
+      const poison = {};
+      Reflect.defineProperty(poison, Symbol.toPrimitive, { get: primitiveGetter });
+      const configured = target === 'apiVersion'
+        ? { ...declaration, apiVersion: poison }
+        : {
+            ...declaration,
+            presentations: [{ ...declaration.presentations[0], resources: [poison] }],
+          };
+
+      await expect(activation.activateComponentKits(config([configured])))
+        .rejects.toThrow(target === 'apiVersion' ? /unsupported API version/ : /entries must be strings/);
+      expect(primitiveGetter).not.toHaveBeenCalled();
+      expect(layouts.getLayout(leakedLayout.id)).toBeUndefined();
+      expect(layouts.getLayout(declaration.layouts[0].id)).toBeUndefined();
+      expect(registry.getPresentationRecord(declaration.presentations[0].id)).toBeUndefined();
+      expect(activation.getSelectedPresentationId()).toBeUndefined();
+
+      await activation.activateComponentKits(config(
+        [declaration], { presentation: declaration.presentations[0].id },
+      ));
+      expect(activation.getSelectedPresentationId()).toBe(declaration.presentations[0].id);
+    },
+  );
+
   it('leaves every registry and selection unchanged on late failure, then permits same-id retry', async () => {
     const activation = await subject();
     const registry = await import('../../skins/registry');

--- a/frontend/src/component-kits/__tests__/activation.test.ts
+++ b/frontend/src/component-kits/__tests__/activation.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
-  ComponentKitDeclaration,
   FiniteControlAppearance,
   FrequencyRenderer,
+  HostedComponentKitDeclarationV1,
+  HostedFaceComponentV1,
+  HostedFacePresentationV1,
+  LayoutManifest,
   MeterAppearance,
   ScalarAppearance,
 } from '../../../component-kit-api/src/index';
@@ -14,6 +17,7 @@ const toggleRenderer = (() => ({})) as unknown as FiniteControlAppearance['toggl
 const choiceRenderer = (() => ({})) as unknown as FiniteControlAppearance['choice'];
 const signalMeterRenderer = (() => ({})) as unknown as MeterAppearance['signal'];
 const levelMeterRenderer = (() => ({})) as unknown as MeterAppearance['level'];
+const faceRenderer = (() => ({})) as unknown as HostedFaceComponentV1;
 
 function appearance(name: string): ScalarAppearance {
   return { name, knob: scalarRenderer };
@@ -29,14 +33,58 @@ function meterAppearance(): MeterAppearance {
 
 function kit(
   id: string,
-  overrides: Partial<ComponentKitDeclaration> = {},
-): ComponentKitDeclaration {
+  overrides: Partial<HostedComponentKitDeclarationV1> = {},
+): HostedComponentKitDeclarationV1 {
   return {
     apiVersion: 1,
     id,
     scalarAppearances: { [`${id}-scalar`]: appearance(`${id} scalar`) },
     frequencyReadouts: { [`${id}-frequency`]: renderer },
     ...overrides,
+  };
+}
+
+function layout(id: string): LayoutManifest {
+  return {
+    schemaVersion: 1,
+    id,
+    displayName: id,
+    zones: [{ id: 'main', surfaces: ['vfo'] }],
+    compatibleTopologies: ['1/single'],
+    requiredSemanticSurfaces: ['vfo'],
+    stageSizing: { mode: 'fluid', responsiveBreakpoints: [600] },
+    fallbackLayoutId: null,
+  };
+}
+
+function hostedKit(
+  id: string,
+  presentationId = `${id}-face`,
+  layoutId = `${id}-layout`,
+  appearanceId = 'shared',
+): HostedComponentKitDeclarationV1 & {
+  readonly layouts: readonly LayoutManifest[];
+  readonly presentations: readonly HostedFacePresentationV1[];
+} {
+  return kit(id, {
+    scalarAppearances: { [appearanceId]: appearance(`${id} scalar`) },
+    frequencyReadouts: { [appearanceId]: renderer },
+    finiteControlAppearances: { [appearanceId]: finiteAppearance() },
+    meterAppearances: { [appearanceId]: meterAppearance() },
+    layouts: [layout(layoutId)],
+    presentations: [{
+      hostMode: 'external-instruments-v1',
+      id: presentationId,
+      layoutId,
+      loader: async () => faceRenderer,
+      resources: ['hardware-scope', 'audio-fft'],
+      appearances: {
+        scalar: appearanceId, frequency: appearanceId, finite: appearanceId, meter: appearanceId,
+      },
+    }],
+  }) as HostedComponentKitDeclarationV1 & {
+    readonly layouts: readonly LayoutManifest[];
+    readonly presentations: readonly HostedFacePresentationV1[];
   };
 }
 
@@ -347,7 +395,7 @@ describe('component-kit activation transaction', () => {
     ]))).rejects.toThrow(/property/i);
   });
 
-  it.each(['designLanguages', 'layouts', 'instrumentGroups', 'presentations'] as const)(
+  it.each(['designLanguages', 'instrumentGroups'] as const)(
     'explicitly rejects the unsupported %s property, including an empty array',
     async (property) => {
       const activation = await subject();
@@ -411,5 +459,200 @@ describe('component-kit activation transaction', () => {
 
     await expect(activation.activateComponentKits(config([])))
       .rejects.toThrow(/already activated/i);
+  });
+
+  it('commits a hosted face with copied layouts and four family-resolved appearances', async () => {
+    const activation = await subject();
+    const registry = await import('../../skins/registry');
+    const layouts = await import('../../presentation/layouts/contract');
+    const declaration = hostedKit('hosted', 'hosted-face', 'hosted-face');
+    const authoredLayout = declaration.layouts![0] as LayoutManifest;
+    const authoredResources = declaration.presentations[0].resources as unknown as string[];
+
+    await activation.activateComponentKits(config([declaration], { presentation: 'hosted-face' }));
+
+    const record = registry.getPresentationRecord('hosted-face');
+    expect(activation.getSelectedPresentationId()).toBe('hosted-face');
+    expect(record).toMatchObject({
+      id: 'hosted-face', kind: 'external-instruments-v1', layoutId: 'hosted-face',
+      resources: ['hardware-scope', 'audio-fft'],
+    });
+    expect(record?.kind === 'external-instruments-v1' && record.appearances).toEqual({
+      scalar: appearance('hosted scalar'),
+      frequency: renderer,
+      finite: finiteAppearance(),
+      meter: meterAppearance(),
+    });
+    expect(Object.isFrozen(record)).toBe(true);
+    expect(record?.kind === 'external-instruments-v1' && Object.isFrozen(record.appearances)).toBe(true);
+    expect(Object.isFrozen(record?.resources)).toBe(true);
+    expect(layouts.getLayout('hosted-face')).not.toBe(authoredLayout);
+    expect(Object.isFrozen(layouts.getLayout('hosted-face')?.zones[0].surfaces)).toBe(true);
+
+    authoredResources.length = 0;
+    (authoredLayout.zones[0].surfaces as unknown as string[]).length = 0;
+    expect(registry.presentationResourcePlan('hosted-face')).toEqual(['hardware-scope', 'audio-fft']);
+    expect(layouts.getLayout('hosted-face')?.zones[0].surfaces).toEqual(['vfo']);
+    expect(await registry.loadSkin('hosted-face')).toBe(faceRenderer);
+  });
+
+  it('keeps empty hosted sections and appearance-only declarations compatible', async () => {
+    const activation = await subject();
+    await activation.activateComponentKits(config([
+      kit('legacy-shape'),
+      kit('empty-hosted', { layouts: [], presentations: [] }),
+    ]));
+
+    expect(activation.getSelectedPresentationId()).toBeUndefined();
+  });
+
+  it('activates two hosted records through one catalog and selects either one', async () => {
+    const activation = await subject();
+    const registry = await import('../../skins/registry');
+    const first = hostedKit('two-faces');
+    const secondLayout = layout('two-faces-layout-b');
+    const secondPresentation = {
+      ...first.presentations[0], id: 'two-faces-b', layoutId: secondLayout.id, resources: [],
+    };
+    const declaration = {
+      ...first,
+      layouts: [...first.layouts, secondLayout],
+      presentations: [...first.presentations, secondPresentation],
+    };
+
+    await activation.activateComponentKits(config([declaration], { presentation: 'two-faces-b' }));
+
+    expect(activation.getSelectedPresentationId()).toBe('two-faces-b');
+    expect(registry.getPresentationRecord('two-faces-face')).toBeDefined();
+    expect(registry.getPresentationRecord('two-faces-b')).toMatchObject({
+      layoutId: 'two-faces-layout-b', resources: [],
+    });
+  });
+
+  it.each([
+    ['legacy presentation shape', { id: 'legacy-face', loader: async () => faceRenderer, resources: [] }],
+    ['wrong host mode', { ...hostedKit('bad-mode').presentations![0], hostMode: 'self-contained' }],
+    ['missing layout', { ...hostedKit('bad-layout').presentations![0], layoutId: 'absent-layout' }],
+    ['unknown resource', { ...hostedKit('bad-resource').presentations![0], resources: ['network'] }],
+    ['duplicate resource', { ...hostedKit('duplicate-resource').presentations![0], resources: ['audio-fft', 'audio-fft'] }],
+    ['runtime-owned resource', { ...hostedKit('rx-audio').presentations![0], resources: ['rx-audio'] }],
+    ['non-function loader', { ...hostedKit('bad-loader').presentations![0], loader: false }],
+    ['missing scalar appearance', { ...hostedKit('missing-scalar').presentations![0], appearances: { scalar: 'absent', frequency: 'shared', finite: 'shared', meter: 'shared' } }],
+    ['missing frequency appearance', { ...hostedKit('missing-frequency').presentations![0], appearances: { scalar: 'shared', frequency: 'absent', finite: 'shared', meter: 'shared' } }],
+    ['missing finite appearance', { ...hostedKit('missing-finite').presentations![0], appearances: { scalar: 'shared', frequency: 'shared', finite: 'absent', meter: 'shared' } }],
+    ['missing meter appearance', { ...hostedKit('missing-meter').presentations![0], appearances: { scalar: 'shared', frequency: 'shared', finite: 'shared', meter: 'absent' } }],
+  ])('rejects a hosted face with %s before commit', async (_name, presentation) => {
+    const activation = await subject();
+    const registry = await import('../../skins/registry');
+    const layouts = await import('../../presentation/layouts/contract');
+    const base = hostedKit(`rejected-${_name.replaceAll(' ', '-')}`);
+    const declaration = { ...base, presentations: [presentation as never] };
+    const layoutId = declaration.layouts![0].id;
+    const presentationId = presentation.id as string;
+
+    await expect(activation.activateComponentKits(config([declaration]))).rejects.toThrow();
+    expect(registry.getPresentationRecord(presentationId)).toBeUndefined();
+    expect(layouts.getLayout(layoutId)).toBeUndefined();
+  });
+
+  it.each([
+    ['__proto__', 'reserved-prototype-layout'],
+    ['constructor', 'reserved-constructor-layout'],
+    ['toString', 'reserved-string-layout'],
+  ])('rejects reserved inherited id %s without pollution', async (reserved, layoutId) => {
+    const activation = await subject();
+    const registry = await import('../../skins/registry');
+    const declaration = hostedKit(`reserved-${layoutId}`, reserved, layoutId);
+
+    await expect(activation.activateComponentKits(config([declaration], { presentation: reserved })))
+      .rejects.toThrow(/reserved|registered|collision/i);
+    expect(registry.getPresentationRecord(reserved)).toBeUndefined();
+    expect(Object.getPrototypeOf({})).toBe(Object.prototype);
+  });
+
+  it('rejects a built-in id in either external id family', async () => {
+    const activation = await subject();
+    await expect(activation.activateComponentKits(config([
+      hostedKit('builtin-presentation', 'desktop-v2', 'external-layout'),
+    ]))).rejects.toThrow(/desktop-v2/);
+
+    await expect(activation.activateComponentKits(config([
+      hostedKit('builtin-layout', 'external-face', 'mobile'),
+    ]))).rejects.toThrow(/mobile/);
+  });
+
+  it.each(['desktop-v2', 'missing-external']) (
+    'rejects selected non-external presentation %s without committing',
+    async (presentation) => {
+      const activation = await subject();
+      const registry = await import('../../skins/registry');
+      const layouts = await import('../../presentation/layouts/contract');
+
+      await expect(activation.activateComponentKits(config([
+        hostedKit(`selection-${presentation}`),
+      ], { presentation }))).rejects.toThrow(presentation);
+      expect(registry.getPresentationRecord(`selection-${presentation}-face`)).toBeUndefined();
+      expect(layouts.getLayout(`selection-${presentation}-layout`)).toBeUndefined();
+    },
+  );
+
+  it('rejects duplicate layout and presentation ids across the complete batch', async () => {
+    const activation = await subject();
+    const duplicateLayoutBase = hostedKit('duplicate-layout');
+    const duplicateLayout = {
+      ...duplicateLayoutBase,
+      layouts: [...duplicateLayoutBase.layouts, layout('duplicate-layout-layout')],
+    };
+    await expect(activation.activateComponentKits(config([duplicateLayout])))
+      .rejects.toThrow(/duplicate layout/i);
+
+    const duplicatePresentationBase = hostedKit('duplicate-presentation');
+    const duplicatePresentation = {
+      ...duplicatePresentationBase,
+      presentations: [
+        ...duplicatePresentationBase.presentations, duplicatePresentationBase.presentations[0],
+      ],
+    };
+    await expect(activation.activateComponentKits(config([duplicatePresentation])))
+      .rejects.toThrow(/duplicate presentation/i);
+  });
+
+  it('rejects authored accessors without invoking them', async () => {
+    const activation = await subject();
+    const declaration = hostedKit('accessor-hosted');
+    const getter = vi.fn(() => 'audio-fft');
+    Reflect.defineProperty(declaration.presentations![0].resources, '0', {
+      get: getter, enumerable: true, configurable: true,
+    });
+
+    await expect(activation.activateComponentKits(config([declaration])))
+      .rejects.toThrow(/enumerable data property/i);
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  it('rolls back every registry on a late failure and permits the exact same-id retry', async () => {
+    const activation = await subject();
+    const registry = await import('../../skins/registry');
+    const layouts = await import('../../presentation/layouts/contract');
+    const valid = hostedKit('retry');
+    const invalidBase = hostedKit('late-invalid', 'late-invalid-face', 'late-invalid-layout', 'late');
+    const invalid = {
+      ...invalidBase,
+      presentations: [{
+        ...invalidBase.presentations[0],
+        appearances: { ...invalidBase.presentations[0].appearances, meter: 'missing' },
+      }],
+    };
+
+    await expect(activation.activateComponentKits(config([valid, invalid], { presentation: 'retry-face' })))
+      .rejects.toThrow(/missing/);
+    expect(activation.getSelectedPresentationId()).toBeUndefined();
+    expect(registry.getPresentationRecord('retry-face')).toBeUndefined();
+    expect(layouts.getLayout('retry-layout')).toBeUndefined();
+
+    await activation.activateComponentKits(config([valid], { presentation: 'retry-face' }));
+    expect(activation.getSelectedPresentationId()).toBe('retry-face');
+    expect(registry.getPresentationRecord('retry-face')).toBeDefined();
+    expect(layouts.getLayout('retry-layout')).toBeDefined();
   });
 });

--- a/frontend/src/component-kits/__tests__/activation.test.ts
+++ b/frontend/src/component-kits/__tests__/activation.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   FiniteControlAppearance,
   FrequencyRenderer,
@@ -108,6 +108,10 @@ async function subject() {
 }
 
 beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
   vi.resetModules();
 });
 

--- a/frontend/src/component-kits/__tests__/activation.test.ts
+++ b/frontend/src/component-kits/__tests__/activation.test.ts
@@ -676,6 +676,19 @@ describe('component-kit activation transaction', () => {
     }
   });
 
+  it('rejects a nested non-primitive before canonical validation can read toJSON', async () => {
+    const activation = await subject();
+    const declaration = hostedKit('nested-to-json');
+    const toJSON = vi.fn(() => () => 'vfo');
+    const poisonedSurface = {};
+    Reflect.defineProperty(poisonedSurface, 'toJSON', { get: toJSON });
+    (declaration.layouts[0].zones[0].surfaces as unknown as unknown[])[0] = poisonedSurface;
+
+    await expect(activation.activateComponentKits(config([declaration])))
+      .rejects.toThrow(/surface.*string/i);
+    expect(toJSON).not.toHaveBeenCalled();
+  });
+
   it('leaves every registry and selection unchanged on late failure, then permits same-id retry', async () => {
     const activation = await subject();
     const registry = await import('../../skins/registry');

--- a/frontend/src/component-kits/__tests__/activation.test.ts
+++ b/frontend/src/component-kits/__tests__/activation.test.ts
@@ -530,29 +530,67 @@ describe('component-kit activation transaction', () => {
   });
 
   it.each([
-    ['legacy presentation shape', { id: 'legacy-face', loader: async () => faceRenderer, resources: [] }],
-    ['wrong host mode', { ...hostedKit('bad-mode').presentations![0], hostMode: 'self-contained' }],
-    ['missing layout', { ...hostedKit('bad-layout').presentations![0], layoutId: 'absent-layout' }],
-    ['unknown resource', { ...hostedKit('bad-resource').presentations![0], resources: ['network'] }],
-    ['duplicate resource', { ...hostedKit('duplicate-resource').presentations![0], resources: ['audio-fft', 'audio-fft'] }],
-    ['runtime-owned resource', { ...hostedKit('rx-audio').presentations![0], resources: ['rx-audio'] }],
-    ['non-function loader', { ...hostedKit('bad-loader').presentations![0], loader: false }],
-    ['missing scalar appearance', { ...hostedKit('missing-scalar').presentations![0], appearances: { scalar: 'absent', frequency: 'shared', finite: 'shared', meter: 'shared' } }],
-    ['missing frequency appearance', { ...hostedKit('missing-frequency').presentations![0], appearances: { scalar: 'shared', frequency: 'absent', finite: 'shared', meter: 'shared' } }],
-    ['missing finite appearance', { ...hostedKit('missing-finite').presentations![0], appearances: { scalar: 'shared', frequency: 'shared', finite: 'absent', meter: 'shared' } }],
-    ['missing meter appearance', { ...hostedKit('missing-meter').presentations![0], appearances: { scalar: 'shared', frequency: 'shared', finite: 'shared', meter: 'absent' } }],
-  ])('rejects a hosted face with %s before commit', async (_name, presentation) => {
+    ['legacy presentation shape', (p: HostedFacePresentationV1) => ({ id: p.id, loader: p.loader, resources: p.resources }), /missing "hostMode"/],
+    ['wrong host mode', (p: HostedFacePresentationV1) => ({ ...p, hostMode: 'self-contained' }), /hostMode must be/],
+    ['missing layout', (p: HostedFacePresentationV1) => ({ ...p, layoutId: 'absent-layout' }), /not in the activated batch/],
+    ['unknown resource', (p: HostedFacePresentationV1) => ({ ...p, resources: ['network'] }), /unsupported resource "network"/],
+    ['duplicate resource', (p: HostedFacePresentationV1) => ({ ...p, resources: ['audio-fft', 'audio-fft'] }), /duplicate resource/],
+    ['runtime-owned resource', (p: HostedFacePresentationV1) => ({ ...p, resources: ['rx-audio'] }), /unsupported resource "rx-audio"/],
+    ['non-function loader', (p: HostedFacePresentationV1) => ({ ...p, loader: false }), /loader must be a function/],
+    ['missing scalar appearance', (p: HostedFacePresentationV1) => ({ ...p, appearances: { ...p.appearances, scalar: 'absent' } }), /scalar appearance "absent" is not registered/],
+    ['missing frequency appearance', (p: HostedFacePresentationV1) => ({ ...p, appearances: { ...p.appearances, frequency: 'absent' } }), /frequency appearance "absent" is not registered/],
+    ['missing finite appearance', (p: HostedFacePresentationV1) => ({ ...p, appearances: { ...p.appearances, finite: 'absent' } }), /finite appearance "absent" is not registered/],
+    ['missing meter appearance', (p: HostedFacePresentationV1) => ({ ...p, appearances: { ...p.appearances, meter: 'absent' } }), /meter appearance "absent" is not registered/],
+  ] as const)('rejects a hosted face with %s before commit', async (_name, mutate, error) => {
     const activation = await subject();
     const registry = await import('../../skins/registry');
     const layouts = await import('../../presentation/layouts/contract');
     const base = hostedKit(`rejected-${_name.replaceAll(' ', '-')}`);
+    const presentation = mutate(base.presentations[0]);
     const declaration = { ...base, presentations: [presentation as never] };
     const layoutId = declaration.layouts![0].id;
     const presentationId = presentation.id as string;
 
-    await expect(activation.activateComponentKits(config([declaration]))).rejects.toThrow();
+    await expect(activation.activateComponentKits(config([declaration]))).rejects.toThrow(error);
     expect(registry.getPresentationRecord(presentationId)).toBeUndefined();
     expect(layouts.getLayout(layoutId)).toBeUndefined();
+  });
+
+  it.each([
+    ['presentation missing field', (d: ReturnType<typeof hostedKit>) => {
+      delete (d.presentations[0] as unknown as Record<string, unknown>).resources;
+    }, /missing "resources"/],
+    ['presentation extra field', (d: ReturnType<typeof hostedKit>) => {
+      (d.presentations[0] as unknown as Record<string, unknown>).extra = true;
+    }, /unknown property "extra"/],
+    ['appearances missing field', (d: ReturnType<typeof hostedKit>) => {
+      delete (d.presentations[0].appearances as unknown as Record<string, unknown>).meter;
+    }, /missing "meter"/],
+    ['appearances symbol field', (d: ReturnType<typeof hostedKit>) => {
+      addUnknownOwnProperty(d.presentations[0].appearances, 'symbol');
+    }, /unknown property/],
+    ['layout missing field', (d: ReturnType<typeof hostedKit>) => {
+      delete (d.layouts[0] as unknown as Record<string, unknown>).stageSizing;
+    }, /missing "stageSizing"/],
+    ['layout prototype', (d: ReturnType<typeof hostedKit>) => {
+      Object.setPrototypeOf(d.layouts[0], { inherited: true });
+    }, /must be an object/],
+    ['zone prototype', (d: ReturnType<typeof hostedKit>) => {
+      Object.setPrototypeOf(d.layouts[0].zones[0], { inherited: true });
+    }, /zone 0 must be an object/],
+    ['non-enumerable surface', (d: ReturnType<typeof hostedKit>) => {
+      Reflect.defineProperty(d.layouts[0].zones[0].surfaces, '0', { value: 'vfo', enumerable: false });
+    }, /enumerable data property/],
+    ['sizing-array symbol field', (d: ReturnType<typeof hostedKit>) => {
+      const sizing = d.layouts[0].stageSizing;
+      if (sizing.mode === 'fluid') addUnknownOwnProperty(sizing.responsiveBreakpoints, 'symbol');
+    }, /unknown property/],
+  ] as const)('rejects exact nested shape: %s', async (_name, poison, error) => {
+    const activation = await subject();
+    const declaration = hostedKit(`nested-${_name.replaceAll(' ', '-')}`);
+    poison(declaration);
+
+    await expect(activation.activateComponentKits(config([declaration]))).rejects.toThrow(error);
   });
 
   it.each([
@@ -617,20 +655,28 @@ describe('component-kit activation transaction', () => {
       .rejects.toThrow(/duplicate presentation/i);
   });
 
-  it('rejects authored accessors without invoking them', async () => {
+  it('rejects authored array and sizing accessors without invoking them', async () => {
     const activation = await subject();
-    const declaration = hostedKit('accessor-hosted');
-    const getter = vi.fn(() => 'audio-fft');
-    Reflect.defineProperty(declaration.presentations![0].resources, '0', {
-      get: getter, enumerable: true, configurable: true,
-    });
+    for (const target of ['resources', 'sizing'] as const) {
+      const declaration = hostedKit(`accessor-${target}`);
+      const getter = vi.fn(() => target === 'resources' ? 'audio-fft' : 'fluid');
+      if (target === 'resources') {
+        Reflect.defineProperty(declaration.presentations[0].resources, '0', {
+          get: getter, enumerable: true, configurable: true,
+        });
+      } else {
+        Reflect.defineProperty(declaration.layouts[0].stageSizing, 'mode', {
+          get: getter, enumerable: true, configurable: true,
+        });
+      }
 
-    await expect(activation.activateComponentKits(config([declaration])))
-      .rejects.toThrow(/enumerable data property/i);
-    expect(getter).not.toHaveBeenCalled();
+      await expect(activation.activateComponentKits(config([declaration])))
+        .rejects.toThrow(/enumerable data property/i);
+      expect(getter).not.toHaveBeenCalled();
+    }
   });
 
-  it('rolls back every registry on a late failure and permits the exact same-id retry', async () => {
+  it('leaves every registry and selection unchanged on late failure, then permits same-id retry', async () => {
     const activation = await subject();
     const registry = await import('../../skins/registry');
     const layouts = await import('../../presentation/layouts/contract');
@@ -644,13 +690,28 @@ describe('component-kit activation transaction', () => {
       }],
     };
 
-    await expect(activation.activateComponentKits(config([valid, invalid], { presentation: 'retry-face' })))
+    const selection = {
+      scalarAppearance: 'shared',
+      frequencyReadout: 'shared',
+      finiteControlAppearance: 'shared',
+      meterAppearance: 'shared',
+      presentation: 'retry-face',
+    };
+    await expect(activation.activateComponentKits(config([valid, invalid], selection)))
       .rejects.toThrow(/missing/);
+    expect(activation.getSelectedScalarAppearance()).toBeUndefined();
+    expect(activation.getSelectedFrequencyReadout()).toBeUndefined();
+    expect(activation.getSelectedFiniteControlAppearance()).toBeUndefined();
+    expect(activation.getSelectedMeterAppearance()).toBeUndefined();
     expect(activation.getSelectedPresentationId()).toBeUndefined();
     expect(registry.getPresentationRecord('retry-face')).toBeUndefined();
     expect(layouts.getLayout('retry-layout')).toBeUndefined();
 
-    await activation.activateComponentKits(config([valid], { presentation: 'retry-face' }));
+    await activation.activateComponentKits(config([valid], selection));
+    expect(activation.getSelectedScalarAppearance()).toBeDefined();
+    expect(activation.getSelectedFrequencyReadout()).toBeDefined();
+    expect(activation.getSelectedFiniteControlAppearance()).toBeDefined();
+    expect(activation.getSelectedMeterAppearance()).toBeDefined();
     expect(activation.getSelectedPresentationId()).toBe('retry-face');
     expect(registry.getPresentationRecord('retry-face')).toBeDefined();
     expect(layouts.getLayout('retry-layout')).toBeDefined();

--- a/frontend/src/component-kits/activation.ts
+++ b/frontend/src/component-kits/activation.ts
@@ -2,16 +2,30 @@ import {
   COMPONENT_KIT_API_VERSION,
   type FiniteControlAppearance,
   type FrequencyRenderer,
+  type HostedFaceComponentV1,
+  type LayoutManifest,
   type MeterAppearance,
   type ScalarAppearance,
 } from '../../component-kit-api/src/index';
 import { skins as builtInScalarAppearances } from '../components-v2/controls/value-control/skins';
+import {
+  commitExternalPresentationBatch,
+  isPresentationIdReserved,
+  prepareExternalPresentationBatch,
+  type ExternalPresentationRecord,
+} from '../skins/registry';
+import {
+  getLayout,
+  registerLayouts,
+  validateLayoutManifest,
+} from '../presentation/layouts/contract';
 
 export interface ComponentKitSelection {
   readonly scalarAppearance?: string;
   readonly frequencyReadout?: string;
   readonly finiteControlAppearance?: string;
   readonly meterAppearance?: string;
+  readonly presentation?: string;
 }
 
 export interface ComponentKitHostConfig {
@@ -28,6 +42,13 @@ interface ActiveSnapshot {
   readonly selectedFrequencyReadout?: string;
   readonly selectedFiniteControlAppearance?: string;
   readonly selectedMeterAppearance?: string;
+  readonly selectedPresentation?: string;
+}
+
+interface PreparedActivation {
+  readonly snapshot: ActiveSnapshot;
+  readonly layouts: readonly LayoutManifest[];
+  readonly presentations: readonly ExternalPresentationRecord[];
 }
 
 const EMPTY_SNAPSHOT: ActiveSnapshot = Object.freeze({
@@ -38,7 +59,7 @@ const EMPTY_SNAPSHOT: ActiveSnapshot = Object.freeze({
 });
 const CONFIG_KEYS = ['kits', 'selection'] as const;
 const SELECTION_KEYS = [
-  'scalarAppearance', 'frequencyReadout', 'finiteControlAppearance', 'meterAppearance',
+  'scalarAppearance', 'frequencyReadout', 'finiteControlAppearance', 'meterAppearance', 'presentation',
 ] as const;
 const KIT_KEYS = [
   'apiVersion', 'id', 'scalarAppearances', 'frequencyReadouts', 'finiteControlAppearances',
@@ -47,9 +68,17 @@ const KIT_KEYS = [
 const APPEARANCE_KEYS = ['name', 'knob', 'hbar', 'bipolar', 'discrete'] as const;
 const FINITE_APPEARANCE_KEYS = ['action', 'toggle', 'choice'] as const;
 const METER_APPEARANCE_KEYS = ['signal', 'level'] as const;
-const UNSUPPORTED_SECTIONS = [
-  'designLanguages', 'layouts', 'instrumentGroups', 'presentations',
+const UNSUPPORTED_SECTIONS = ['designLanguages', 'instrumentGroups'] as const;
+const LAYOUT_KEYS = [
+  'schemaVersion', 'id', 'displayName', 'zones', 'compatibleTopologies',
+  'requiredSemanticSurfaces', 'stageSizing', 'fallbackLayoutId',
 ] as const;
+const ZONE_KEYS = ['id', 'surfaces', 'group'] as const;
+const PRESENTATION_KEYS = [
+  'hostMode', 'id', 'layoutId', 'loader', 'resources', 'appearances',
+] as const;
+const FACE_APPEARANCE_KEYS = ['scalar', 'frequency', 'finite', 'meter'] as const;
+const PRESENTATION_RESOURCES = ['hardware-scope', 'audio-fft'] as const;
 const hasOwn = (value: object, key: PropertyKey): boolean =>
   Object.prototype.hasOwnProperty.call(value, key);
 
@@ -90,6 +119,112 @@ function requireId(value: unknown, owner: string): string {
     throw new ComponentKitActivationError(`${owner} must have a non-empty id.`);
   }
   return value;
+}
+
+function requireExactRecord(
+  value: unknown,
+  owner: string,
+  allowed: readonly string[],
+  required: readonly string[] = allowed,
+): Record<string, unknown> {
+  if (!isPlainRecord(value)) {
+    throw new ComponentKitActivationError(`${owner} must be an object.`);
+  }
+  ownDataEntries(value, owner, allowed);
+  for (const key of required) {
+    if (!hasOwn(value, key)) throw new ComponentKitActivationError(`${owner} is missing "${key}".`);
+  }
+  return value;
+}
+
+/** Read an exact dense Array without invoking authored getters. */
+function readDataArray(value: unknown, owner: string): unknown[] {
+  if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype) {
+    throw new ComponentKitActivationError(`${owner} must be an array.`);
+  }
+  const allowed = new Set<PropertyKey>(['length']);
+  for (let index = 0; index < value.length; index++) allowed.add(String(index));
+  for (const key of Reflect.ownKeys(value)) {
+    if (!allowed.has(key)) throw new ComponentKitActivationError(`${owner} has unknown property "${String(key)}".`);
+  }
+  const copy: unknown[] = [];
+  for (let index = 0; index < value.length; index++) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+    if (descriptor === undefined || !descriptor.enumerable || !('value' in descriptor)) {
+      throw new ComponentKitActivationError(
+        `${owner} property "${index}" must be an enumerable data property.`,
+      );
+    }
+    copy.push(descriptor.value);
+  }
+  return copy;
+}
+
+function copyLayout(value: unknown, owner: string): LayoutManifest {
+  const manifest = requireExactRecord(value, owner, LAYOUT_KEYS);
+  const id = requireId(manifest.id, owner);
+  if (typeof manifest.displayName !== 'string' || manifest.displayName.trim() === '') {
+    throw new ComponentKitActivationError(`Layout "${id}" must have a non-empty displayName.`);
+  }
+  const zones = readDataArray(manifest.zones, `Layout "${id}" zones`).map((zoneValue, index) => {
+    const zone = requireExactRecord(
+      zoneValue, `Layout "${id}" zone ${index}`, ZONE_KEYS, ['id', 'surfaces'],
+    );
+    const zoneId = requireId(zone.id, `Layout "${id}" zone ${index}`);
+    if (zone.group !== undefined && (typeof zone.group !== 'string' || zone.group.trim() === '')) {
+      throw new ComponentKitActivationError(`Layout "${id}" zone "${zoneId}" group must be a non-empty string.`);
+    }
+    return Object.freeze({
+      id: zoneId,
+      surfaces: Object.freeze(readDataArray(zone.surfaces, `Layout "${id}" zone "${zoneId}" surfaces`)),
+      ...(zone.group === undefined ? {} : { group: zone.group }),
+    });
+  });
+  const compatibleTopologies = Object.freeze(
+    readDataArray(manifest.compatibleTopologies, `Layout "${id}" compatibleTopologies`),
+  );
+  const requiredSemanticSurfaces = Object.freeze(
+    readDataArray(manifest.requiredSemanticSurfaces, `Layout "${id}" requiredSemanticSurfaces`),
+  );
+  const sizingValue = requireExactRecord(
+    manifest.stageSizing,
+    `Layout "${id}" stageSizing`,
+    manifest.stageSizing !== null
+      && typeof manifest.stageSizing === 'object'
+      && Object.getOwnPropertyDescriptor(manifest.stageSizing, 'mode')?.value === 'fluid'
+      ? ['mode', 'responsiveBreakpoints']
+      : ['mode', 'nativeW', 'nativeH', 'minScale'],
+  );
+  const stageSizing = sizingValue.mode === 'fluid'
+    ? Object.freeze({
+        mode: 'fluid' as const,
+        responsiveBreakpoints: Object.freeze(
+          readDataArray(sizingValue.responsiveBreakpoints, `Layout "${id}" responsiveBreakpoints`),
+        ),
+      })
+    : Object.freeze({
+        mode: sizingValue.mode,
+        nativeW: sizingValue.nativeW,
+        nativeH: sizingValue.nativeH,
+        minScale: sizingValue.minScale,
+      });
+  if (manifest.fallbackLayoutId !== null) requireId(manifest.fallbackLayoutId, `Layout "${id}" fallbackLayoutId`);
+  const copied = Object.freeze({
+    schemaVersion: manifest.schemaVersion,
+    id,
+    displayName: manifest.displayName,
+    zones: Object.freeze(zones),
+    compatibleTopologies,
+    requiredSemanticSurfaces,
+    stageSizing,
+    fallbackLayoutId: manifest.fallbackLayoutId,
+  }) as unknown as LayoutManifest;
+  try {
+    validateLayoutManifest(copied);
+  } catch (error) {
+    throw new ComponentKitActivationError(error instanceof Error ? error.message : String(error));
+  }
+  return copied;
 }
 
 function copyAppearance(value: unknown, id: string): ScalarAppearance {
@@ -152,7 +287,7 @@ function readSelection(value: unknown): ComponentKitSelection {
   return { ...value } as ComponentKitSelection;
 }
 
-function prepareSnapshot(declarations: readonly unknown[], selectionValue: unknown): ActiveSnapshot {
+function prepareActivation(declarations: readonly unknown[], selectionValue: unknown): PreparedActivation {
   const scalarAppearances = new Map<string, ScalarAppearance>();
   const scalarOwners = new Map<string, string>();
   for (const [id, appearance] of ownDataEntries(builtInScalarAppearances, 'Built-in scalar appearances')) {
@@ -166,6 +301,8 @@ function prepareSnapshot(declarations: readonly unknown[], selectionValue: unkno
   const meterAppearances = new Map<string, MeterAppearance>();
   const meterAppearanceOwners = new Map<string, string>();
   const kitIds = new Set<string>();
+  const authoredLayouts: Array<{ owner: string; value: unknown }> = [];
+  const authoredPresentations: Array<{ owner: string; value: unknown }> = [];
 
   for (const value of declarations) {
     if (!isPlainRecord(value)) {
@@ -267,6 +404,91 @@ function prepareSnapshot(declarations: readonly unknown[], selectionValue: unkno
         meterAppearanceOwners.set(appearanceId, `component kit "${id}"`);
       }
     }
+
+    if (value.layouts !== undefined) {
+      for (const layout of readDataArray(value.layouts, `Component kit "${id}" layouts`)) {
+        authoredLayouts.push({ owner: `Component kit "${id}" layout`, value: layout });
+      }
+    }
+    if (value.presentations !== undefined) {
+      for (const presentation of readDataArray(
+        value.presentations, `Component kit "${id}" presentations`,
+      )) {
+        authoredPresentations.push({
+          owner: `Component kit "${id}" presentation`, value: presentation,
+        });
+      }
+    }
+  }
+
+  const layouts: LayoutManifest[] = [];
+  const layoutIds = new Set<string>();
+  for (const authored of authoredLayouts) {
+    const layout = copyLayout(authored.value, authored.owner);
+    if (layoutIds.has(layout.id)) {
+      throw new ComponentKitActivationError(`Duplicate layout id "${layout.id}".`);
+    }
+    if (getLayout(layout.id) !== undefined || isPresentationIdReserved(layout.id)) {
+      throw new ComponentKitActivationError(`Layout id "${layout.id}" is registered or reserved.`);
+    }
+    layoutIds.add(layout.id);
+    layouts.push(layout);
+  }
+
+  const presentations: ExternalPresentationRecord[] = [];
+  const presentationIds = new Set<string>();
+  for (const authored of authoredPresentations) {
+    const presentation = requireExactRecord(authored.value, authored.owner, PRESENTATION_KEYS);
+    const id = requireId(presentation.id, authored.owner);
+    if (presentation.hostMode !== 'external-instruments-v1') {
+      throw new ComponentKitActivationError(
+        `Presentation "${id}" hostMode must be "external-instruments-v1".`,
+      );
+    }
+    const layoutId = requireId(presentation.layoutId, `Presentation "${id}" layoutId`);
+    if (!layoutIds.has(layoutId)) {
+      throw new ComponentKitActivationError(
+        `Presentation "${id}" layout "${layoutId}" is not in the activated batch.`,
+      );
+    }
+    if (typeof presentation.loader !== 'function') {
+      throw new ComponentKitActivationError(`Presentation "${id}" loader must be a function.`);
+    }
+    const resourceValues = readDataArray(presentation.resources, `Presentation "${id}" resources`);
+    const resources = resourceValues.map((resource) => {
+      if (typeof resource !== 'string' || !PRESENTATION_RESOURCES.includes(resource as never)) {
+        throw new ComponentKitActivationError(`Presentation "${id}" has unsupported resource "${String(resource)}".`);
+      }
+      return resource as (typeof PRESENTATION_RESOURCES)[number];
+    });
+    if (new Set(resources).size !== resources.length) {
+      throw new ComponentKitActivationError(`Presentation "${id}" has a duplicate resource.`);
+    }
+    const appearanceIds = requireExactRecord(
+      presentation.appearances, `Presentation "${id}" appearances`, FACE_APPEARANCE_KEYS,
+    );
+    const scalarId = requireId(appearanceIds.scalar, `Presentation "${id}" scalar appearance`);
+    const frequencyId = requireId(appearanceIds.frequency, `Presentation "${id}" frequency appearance`);
+    const finiteId = requireId(appearanceIds.finite, `Presentation "${id}" finite appearance`);
+    const meterId = requireId(appearanceIds.meter, `Presentation "${id}" meter appearance`);
+    const scalar = scalarAppearances.get(scalarId);
+    const frequency = frequencyReadouts.get(frequencyId);
+    const finite = finiteControlAppearances.get(finiteId);
+    const meter = meterAppearances.get(meterId);
+    if (scalar === undefined) throw new ComponentKitActivationError(`Presentation "${id}" scalar appearance "${scalarId}" is not registered.`);
+    if (frequency === undefined) throw new ComponentKitActivationError(`Presentation "${id}" frequency appearance "${frequencyId}" is not registered.`);
+    if (finite === undefined) throw new ComponentKitActivationError(`Presentation "${id}" finite appearance "${finiteId}" is not registered.`);
+    if (meter === undefined) throw new ComponentKitActivationError(`Presentation "${id}" meter appearance "${meterId}" is not registered.`);
+    if (presentationIds.has(id)) throw new ComponentKitActivationError(`Duplicate presentation id "${id}".`);
+    presentationIds.add(id);
+    presentations.push(Object.freeze({
+      id,
+      kind: 'external-instruments-v1',
+      layoutId,
+      loader: presentation.loader as () => Promise<HostedFaceComponentV1>,
+      resources: Object.freeze(resources),
+      appearances: Object.freeze({ scalar, frequency, finite, meter }),
+    }));
   }
 
   const selection = readSelection(selectionValue);
@@ -288,15 +510,25 @@ function prepareSnapshot(declarations: readonly unknown[], selectionValue: unkno
       `Selected meter appearance "${selection.meterAppearance}" is not registered.`,
     );
   }
+  if (selection.presentation !== undefined && !presentationIds.has(selection.presentation)) {
+    throw new ComponentKitActivationError(
+      `Selected external presentation "${selection.presentation}" is not registered.`,
+    );
+  }
   return Object.freeze({
-    scalarAppearances,
-    frequencyReadouts,
-    finiteControlAppearances,
-    meterAppearances,
-    selectedScalarAppearance: selection.scalarAppearance,
-    selectedFrequencyReadout: selection.frequencyReadout,
-    selectedFiniteControlAppearance: selection.finiteControlAppearance,
-    selectedMeterAppearance: selection.meterAppearance,
+    snapshot: Object.freeze({
+      scalarAppearances,
+      frequencyReadouts,
+      finiteControlAppearances,
+      meterAppearances,
+      selectedScalarAppearance: selection.scalarAppearance,
+      selectedFrequencyReadout: selection.frequencyReadout,
+      selectedFiniteControlAppearance: selection.finiteControlAppearance,
+      selectedMeterAppearance: selection.meterAppearance,
+      selectedPresentation: selection.presentation,
+    }),
+    layouts: Object.freeze(layouts),
+    presentations: Object.freeze(presentations),
   });
 }
 
@@ -308,18 +540,22 @@ export async function activateComponentKits(configValue: unknown): Promise<void>
       throw new ComponentKitActivationError('Component-kit configuration must be an object.');
     }
     ownDataEntries(configValue, 'Component-kit configuration', CONFIG_KEYS);
-    if (!Array.isArray(configValue.kits) || configValue.kits.some((load) => typeof load !== 'function')) {
+    const kitLoaders = readDataArray(configValue.kits, 'Component-kit configuration kits');
+    if (kitLoaders.some((load) => typeof load !== 'function')) {
       throw new ComponentKitActivationError('Component-kit configuration kits must be an array of loaders.');
     }
-    const modules = await Promise.all(configValue.kits.map((load) => load()));
+    const modules = await Promise.all(kitLoaders.map((load) => (load as () => Promise<unknown>)()));
     const declarations = modules.map((module, index) => {
       if (!isPlainRecord(module) || !hasOwn(module, 'default')) {
         throw new ComponentKitActivationError(`Component-kit loader ${index} must return a module with a default export.`);
       }
       return module.default;
     });
-    const prepared = prepareSnapshot(declarations, configValue.selection);
-    snapshot = prepared;
+    const prepared = prepareActivation(declarations, configValue.selection);
+    const catalogBatch = prepareExternalPresentationBatch(prepared.presentations);
+    registerLayouts(prepared.layouts);
+    commitExternalPresentationBatch(catalogBatch);
+    snapshot = prepared.snapshot;
     phase = 'active';
   } catch (error) {
     phase = 'idle';
@@ -349,4 +585,8 @@ export function getSelectedMeterAppearance(): MeterAppearance | undefined {
   return snapshot.selectedMeterAppearance === undefined
     ? undefined
     : snapshot.meterAppearances.get(snapshot.selectedMeterAppearance);
+}
+
+export function getSelectedPresentationId(): string | undefined {
+  return snapshot.selectedPresentation;
 }

--- a/frontend/src/component-kits/activation.ts
+++ b/frontend/src/component-kits/activation.ts
@@ -340,7 +340,11 @@ function prepareActivation(declarations: readonly unknown[], selectionValue: unk
     ownDataEntries(value, 'Component kit', KIT_KEYS);
     const id = requireId(value.id, 'Component kit');
     if (value.apiVersion !== COMPONENT_KIT_API_VERSION) {
-      throw new ComponentKitActivationError(`Component kit "${id}" requires unsupported API version ${String(value.apiVersion)}.`);
+      const version = value.apiVersion;
+      const versionLabel = version === null || typeof version === 'object' || typeof version === 'function'
+        ? '<non-primitive>'
+        : String(version);
+      throw new ComponentKitActivationError(`Component kit "${id}" requires unsupported API version ${versionLabel}.`);
     }
     if (kitIds.has(id)) throw new ComponentKitActivationError(`Duplicate component-kit id "${id}".`);
     kitIds.add(id);
@@ -483,13 +487,14 @@ function prepareActivation(declarations: readonly unknown[], selectionValue: unk
     if (typeof presentation.loader !== 'function') {
       throw new ComponentKitActivationError(`Presentation "${id}" loader must be a function.`);
     }
-    const resourceValues = readDataArray(presentation.resources, `Presentation "${id}" resources`);
-    const resources = resourceValues.map((resource) => {
-      if (typeof resource !== 'string' || !PRESENTATION_RESOURCES.includes(resource as never)) {
-        throw new ComponentKitActivationError(`Presentation "${id}" has unsupported resource "${String(resource)}".`);
+    const resources = readStringArray(
+      presentation.resources, `Presentation "${id}" resources`,
+    ) as Array<(typeof PRESENTATION_RESOURCES)[number]>;
+    for (const resource of resources) {
+      if (!PRESENTATION_RESOURCES.includes(resource as never)) {
+        throw new ComponentKitActivationError(`Presentation "${id}" has unsupported resource "${resource}".`);
       }
-      return resource as (typeof PRESENTATION_RESOURCES)[number];
-    });
+    }
     if (new Set(resources).size !== resources.length) {
       throw new ComponentKitActivationError(`Presentation "${id}" has a duplicate resource.`);
     }

--- a/frontend/src/component-kits/activation.ts
+++ b/frontend/src/component-kits/activation.ts
@@ -160,9 +160,28 @@ function readDataArray(value: unknown, owner: string): unknown[] {
   return copy;
 }
 
+function readStringArray(value: unknown, owner: string): string[] {
+  const copy = readDataArray(value, owner);
+  if (copy.some((entry) => typeof entry !== 'string')) {
+    throw new ComponentKitActivationError(`${owner} entries must be strings.`);
+  }
+  return copy as string[];
+}
+
+function readNumberArray(value: unknown, owner: string): number[] {
+  const copy = readDataArray(value, owner);
+  if (copy.some((entry) => typeof entry !== 'number')) {
+    throw new ComponentKitActivationError(`${owner} entries must be numbers.`);
+  }
+  return copy as number[];
+}
+
 function copyLayout(value: unknown, owner: string): LayoutManifest {
   const manifest = requireExactRecord(value, owner, LAYOUT_KEYS);
   const id = requireId(manifest.id, owner);
+  if (typeof manifest.schemaVersion !== 'number') {
+    throw new ComponentKitActivationError(`Layout "${id}" schemaVersion must be a number.`);
+  }
   if (typeof manifest.displayName !== 'string' || manifest.displayName.trim() === '') {
     throw new ComponentKitActivationError(`Layout "${id}" must have a non-empty displayName.`);
   }
@@ -176,15 +195,15 @@ function copyLayout(value: unknown, owner: string): LayoutManifest {
     }
     return Object.freeze({
       id: zoneId,
-      surfaces: Object.freeze(readDataArray(zone.surfaces, `Layout "${id}" zone "${zoneId}" surfaces`)),
+      surfaces: Object.freeze(readStringArray(zone.surfaces, `Layout "${id}" zone "${zoneId}" surfaces`)),
       ...(zone.group === undefined ? {} : { group: zone.group }),
     });
   });
   const compatibleTopologies = Object.freeze(
-    readDataArray(manifest.compatibleTopologies, `Layout "${id}" compatibleTopologies`),
+    readStringArray(manifest.compatibleTopologies, `Layout "${id}" compatibleTopologies`),
   );
   const requiredSemanticSurfaces = Object.freeze(
-    readDataArray(manifest.requiredSemanticSurfaces, `Layout "${id}" requiredSemanticSurfaces`),
+    readStringArray(manifest.requiredSemanticSurfaces, `Layout "${id}" requiredSemanticSurfaces`),
   );
   const sizingValue = requireExactRecord(
     manifest.stageSizing,
@@ -195,11 +214,21 @@ function copyLayout(value: unknown, owner: string): LayoutManifest {
       ? ['mode', 'responsiveBreakpoints']
       : ['mode', 'nativeW', 'nativeH', 'minScale'],
   );
+  if (sizingValue.mode !== 'fluid' && sizingValue.mode !== 'fixed-native') {
+    throw new ComponentKitActivationError(
+      `Layout "${id}" stageSizing mode must be "fluid" or "fixed-native".`,
+    );
+  }
+  if (sizingValue.mode === 'fixed-native'
+    && [sizingValue.nativeW, sizingValue.nativeH, sizingValue.minScale]
+      .some((entry) => typeof entry !== 'number')) {
+    throw new ComponentKitActivationError(`Layout "${id}" fixed sizing entries must be numbers.`);
+  }
   const stageSizing = sizingValue.mode === 'fluid'
     ? Object.freeze({
         mode: 'fluid' as const,
         responsiveBreakpoints: Object.freeze(
-          readDataArray(sizingValue.responsiveBreakpoints, `Layout "${id}" responsiveBreakpoints`),
+          readNumberArray(sizingValue.responsiveBreakpoints, `Layout "${id}" responsiveBreakpoints`),
         ),
       })
     : Object.freeze({

--- a/frontend/src/components-v2/vfo/VfoPanel.svelte
+++ b/frontend/src/components-v2/vfo/VfoPanel.svelte
@@ -336,7 +336,7 @@
 
   .slot-choice:disabled { opacity: 0.55; cursor: not-allowed; }
   .slot-choice .vfo-role { font-size: 8px; }
-  .slot-choice .vfo-freq { font-size: 9px; }
+  .control-strip .slot-choice .vfo-freq { font-size: 9px; }
 
   .mode-badge-wrapper {
     cursor: pointer;

--- a/frontend/src/presentation/layouts/__tests__/stage-sizing-boundary.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/stage-sizing-boundary.test.ts
@@ -21,6 +21,13 @@ const SRC_ROOT = 'src';
 const LAYOUTS_DIR = path.join(SRC_ROOT, 'presentation', 'layouts') + path.sep;
 const SOURCE_EXTENSIONS = new Set(['.ts', '.svelte']);
 const GUARDED_NAMES = [/\bstageSizing\b/];
+// Component-kit startup may validate and copy this declaration field, but it
+// does not consume it for runtime sizing. The paired activation test pins the
+// copied/frozen graph and rejects authored accessors before registration.
+const DECLARATION_ADMISSION_ALLOWLIST = new Set([
+  path.join(SRC_ROOT, 'component-kits', 'activation.ts'),
+  path.join(SRC_ROOT, 'component-kits', '__tests__', 'activation.test.ts'),
+]);
 
 function collectSourceFiles(dir: string): string[] {
   const out: string[] = [];
@@ -36,7 +43,15 @@ describe('stageSizing stays declaration-only outside layouts/ (MOR-1247)', () =>
   it('no file outside presentation/layouts/ names stageSizing', () => {
     const offenders = collectSourceFiles(SRC_ROOT)
       .filter((file) => !file.startsWith(LAYOUTS_DIR))
+      .filter((file) => !DECLARATION_ADMISSION_ALLOWLIST.has(file))
       .filter((file) => GUARDED_NAMES.some((re) => re.test(readFileSync(file, 'utf8'))));
     expect(offenders).toEqual([]);
+  });
+
+  it('allows only the activation declaration admission and its direct test', () => {
+    expect([...DECLARATION_ADMISSION_ALLOWLIST]).toEqual([
+      path.join(SRC_ROOT, 'component-kits', 'activation.ts'),
+      path.join(SRC_ROOT, 'component-kits', '__tests__', 'activation.test.ts'),
+    ]);
   });
 });

--- a/frontend/src/skins/__tests__/registry.test.ts
+++ b/frontend/src/skins/__tests__/registry.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
 import type { AppResource } from '$lib/runtime/resource-demand';
+import type { HostedFaceComponentV1 } from '../../../component-kit-api/src/index';
 import type { SkinId } from '../registry';
 
 // MOR-2074: which SkinId is QA-gated, read off `resolveSkinId`'s actual
@@ -66,7 +67,10 @@ vi.mock('../dual-receiver-cockpit/DualReceiverCockpit.svelte', () => lazyImports
 vi.mock('../dual-sdr-face/DualSdrFaceSkin.svelte', () => lazyImports['dual-sdr-face']());
 
 import {
-  loadSkin, presentationHostMode, presentationResourcePlan, resolveSkinId,
+  commitExternalPresentationBatch, getPresentationRecord, isPresentationIdReserved,
+  loadSkin, prepareExternalPresentationBatch, presentationHostMode,
+  presentationResourcePlan, resolveSkinId,
+  type ExternalPresentationRecord,
   type PresentationHostMode,
 } from '../registry';
 
@@ -315,4 +319,91 @@ describe('presentation host mode', () => {
     'selects %s as %s',
     (skinId, mode) => expect(presentationHostMode(skinId)).toBe(mode),
   );
+});
+
+describe('external presentation records share the built-in catalog', () => {
+  const faceA = (() => ({})) as unknown as HostedFaceComponentV1;
+  const faceB = (() => ({})) as unknown as HostedFaceComponentV1;
+  const appearances = {
+    scalar: { name: 'External' },
+    frequency: (() => ({})),
+    finite: { action: () => ({}), toggle: () => ({}), choice: () => ({}) },
+    meter: { signal: () => ({}), level: () => ({}) },
+  } as unknown as ExternalPresentationRecord['appearances'];
+
+  function externalRecord(
+    id: string,
+    face: HostedFaceComponentV1,
+    resources: AppResource[] = [],
+  ): ExternalPresentationRecord {
+    return {
+      id,
+      kind: 'external-instruments-v1',
+      layoutId: `${id}-layout`,
+      loader: vi.fn(async () => face),
+      resources,
+      appearances,
+    };
+  }
+
+  it.each(['desktop-v2', '__proto__', 'constructor', 'toString'])(
+    'rejects registered or inherited catalog id %s before commit',
+    (id) => {
+      expect(isPresentationIdReserved(id)).toBe(true);
+      expect(() => prepareExternalPresentationBatch([externalRecord(id, faceA)]))
+        .toThrow(/registered or reserved/i);
+      if (id !== 'desktop-v2') expect(getPresentationRecord(id)).toBeUndefined();
+    },
+  );
+
+  it('rejects a duplicate external id before commit', () => {
+    expect(() => prepareExternalPresentationBatch([
+      externalRecord('duplicate-external', faceA),
+      externalRecord('duplicate-external', faceB),
+    ])).toThrow(/more than once/i);
+    expect(getPresentationRecord('duplicate-external')).toBeUndefined();
+  });
+
+  it('commits two immutable records and keeps their direct loaders lazy', async () => {
+    const resources: AppResource[] = ['hardware-scope'];
+    const first = externalRecord('external-face-one', faceA, resources);
+    const second = externalRecord('external-face-two', faceB, ['audio-fft']);
+    const prepared = prepareExternalPresentationBatch([first, second]);
+    resources.length = 0;
+
+    expect(first.loader).not.toHaveBeenCalled();
+    expect(second.loader).not.toHaveBeenCalled();
+    commitExternalPresentationBatch(prepared);
+
+    const committed = getPresentationRecord('external-face-one');
+    expect(committed).toMatchObject({
+      kind: 'external-instruments-v1',
+      layoutId: 'external-face-one-layout',
+      resources: ['hardware-scope'],
+    });
+    expect(Object.isFrozen(committed)).toBe(true);
+    expect(committed?.kind === 'external-instruments-v1'
+      && Object.isFrozen(committed.appearances)).toBe(true);
+    expect(Object.isFrozen(committed?.resources)).toBe(true);
+    expect(presentationHostMode('external-face-one')).toBe('external-instruments-v1');
+    expect(presentationResourcePlan('external-face-two')).toEqual(['audio-fft']);
+    await expect(loadSkin('external-face-one')).resolves.toBe(faceA);
+    await expect(loadSkin('external-face-two')).resolves.toBe(faceB);
+    expect(first.loader).toHaveBeenCalledTimes(1);
+    expect(second.loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fall back for unknown or inherited ids', async () => {
+    expect(getPresentationRecord('absent-external')).toBeUndefined();
+    await expect(loadSkin('absent-external')).rejects.toThrow(/not registered/i);
+    expect(() => presentationHostMode('toString')).toThrow(/not registered/i);
+    expect(() => presentationResourcePlan('__proto__')).toThrow(/not registered/i);
+  });
+
+  it('retains one literal catalog and one loader implementation', () => {
+    expect(registrySource.match(/const SKIN_LOADERS/g)).toHaveLength(1);
+    expect(registrySource.match(/export async function loadSkin/g)).toHaveLength(1);
+    expect(registrySource).not.toContain('EXTERNAL_SKIN_LOADERS');
+    expect(registrySource).not.toContain('EXTERNAL_PRESENTATION_CATALOG');
+  });
 });

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -10,6 +10,13 @@
 import type { Component } from 'svelte';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { AppResource } from '$lib/runtime/resource-demand';
+import type {
+  FiniteControlAppearance,
+  FrequencyRenderer,
+  HostedFaceComponentV1,
+  MeterAppearance,
+  ScalarAppearance,
+} from '../../component-kit-api/src/index';
 import type { InstrumentComposition } from '../components-v2/wiring/instrument-composition';
 import {
   normalizeLayoutMode,
@@ -20,10 +27,29 @@ export type SkinId =
   | 'desktop-v2' | 'dual-receiver-cockpit' | 'lcd-cockpit' | 'lcd-scope' | 'mobile' | 'peer-split'
   | 'sdr-test' | 'dual-sdr-face' | 'unified-instrument' | 'panadapter-first';
 
-export type PresentationHostMode = 'self-contained' | 'instrument-handles';
+export type PresentationId = string;
+export type PresentationHostMode =
+  'self-contained' | 'instrument-handles' | 'external-instruments-v1';
 export type InstrumentHandlesPresentation = Component<{ instruments: InstrumentComposition }>;
 export type SelfContainedPresentation = Component;
-export type PresentationComponent = InstrumentHandlesPresentation | SelfContainedPresentation;
+export type PresentationComponent =
+  InstrumentHandlesPresentation | SelfContainedPresentation | HostedFaceComponentV1;
+
+export interface ResolvedHostedFaceAppearancesV1 {
+  readonly scalar: ScalarAppearance;
+  readonly frequency: FrequencyRenderer;
+  readonly finite: FiniteControlAppearance;
+  readonly meter: MeterAppearance;
+}
+
+export interface ExternalPresentationRecord {
+  readonly id: string;
+  readonly kind: 'external-instruments-v1';
+  readonly loader: () => Promise<HostedFaceComponentV1>;
+  readonly resources: readonly AppResource[];
+  readonly layoutId: string;
+  readonly appearances: ResolvedHostedFaceAppearancesV1;
+}
 
 type BuiltInPresentationRecord<Id extends SkinId> =
   | {
@@ -43,10 +69,10 @@ type BuiltInPresentationCatalog = {
   readonly [Id in SkinId]: BuiltInPresentationRecord<Id>;
 };
 
-export function presentationHostMode(id: SkinId): PresentationHostMode {
-  return SKIN_LOADERS[id].kind === 'built-in-instrument-layout'
-    ? 'instrument-handles'
-    : 'self-contained';
+export type PresentationRecord = BuiltInPresentationRecord<SkinId> | ExternalPresentationRecord;
+
+export interface PreparedExternalPresentationBatch {
+  readonly records: readonly ExternalPresentationRecord[];
 }
 
 export interface SkinResolutionContext {
@@ -181,12 +207,75 @@ const SKIN_LOADERS = {
   },
 } satisfies BuiltInPresentationCatalog;
 
+const hasOwn = (value: object, key: PropertyKey): boolean =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+/**
+ * Built-in ids, previously committed external ids and Object.prototype names
+ * are all unavailable. The latter matters because SKIN_LOADERS intentionally
+ * remains the one normal-prototype literal catalog parsed by existing guards.
+ */
+export function isPresentationIdReserved(id: string): boolean {
+  return id in SKIN_LOADERS;
+}
+
+export function getPresentationRecord(id: PresentationId): PresentationRecord | undefined {
+  if (!hasOwn(SKIN_LOADERS, id)) return undefined;
+  return (SKIN_LOADERS as unknown as Record<string, PresentationRecord>)[id];
+}
+
+function requirePresentationRecord(id: PresentationId): PresentationRecord {
+  const record = getPresentationRecord(id);
+  if (record === undefined) throw new Error(`Presentation "${id}" is not registered.`);
+  return record;
+}
+
+export function prepareExternalPresentationBatch(
+  records: readonly ExternalPresentationRecord[],
+): PreparedExternalPresentationBatch {
+  const batchIds = new Set<string>();
+  const prepared: ExternalPresentationRecord[] = [];
+  for (const record of records) {
+    if (isPresentationIdReserved(record.id)) {
+      throw new Error(`Presentation id "${record.id}" is registered or reserved.`);
+    }
+    if (batchIds.has(record.id)) {
+      throw new Error(`Presentation id "${record.id}" appears more than once in the batch.`);
+    }
+    batchIds.add(record.id);
+    prepared.push(Object.freeze({
+      ...record,
+      resources: Object.freeze([...record.resources]),
+      appearances: Object.freeze({ ...record.appearances }),
+    }));
+  }
+  return Object.freeze({ records: Object.freeze(prepared) });
+}
+
+/** Commit only a synchronously prepared batch; all fallible work is upstream. */
+export function commitExternalPresentationBatch(batch: PreparedExternalPresentationBatch): void {
+  const catalog = SKIN_LOADERS as unknown as Record<string, PresentationRecord>;
+  for (const record of batch.records) catalog[record.id] = record;
+}
+
+export function presentationHostMode(id: SkinId): Exclude<PresentationHostMode, 'external-instruments-v1'>;
+export function presentationHostMode(id: PresentationId): PresentationHostMode;
+export function presentationHostMode(id: PresentationId): PresentationHostMode {
+  const record = requirePresentationRecord(id);
+  if (record.kind === 'built-in-instrument-layout') return 'instrument-handles';
+  if (record.kind === 'external-instruments-v1') return 'external-instruments-v1';
+  return 'self-contained';
+}
+
 type LoadedPresentation<Id extends SkinId> =
   Awaited<ReturnType<(typeof SKIN_LOADERS)[Id]['loader']>>['default'];
 
 export function loadSkin<Id extends SkinId>(id: Id): Promise<LoadedPresentation<Id>>;
-export async function loadSkin(id: SkinId): Promise<PresentationComponent> {
-  return (await SKIN_LOADERS[id].loader()).default;
+export function loadSkin(id: PresentationId): Promise<PresentationComponent>;
+export async function loadSkin(id: PresentationId): Promise<PresentationComponent> {
+  const record = requirePresentationRecord(id);
+  if (record.kind === 'external-instruments-v1') return record.loader();
+  return (await record.loader()).default;
 }
 
 /**
@@ -216,6 +305,6 @@ export async function loadSkin(id: SkinId): Promise<PresentationComponent> {
  * solely while it is already demanded, so a presentation choice can never
  * manufacture a live service (v3 ADR invariant 12).
  */
-export function presentationResourcePlan(id: SkinId): readonly AppResource[] {
-  return SKIN_LOADERS[id]?.resources ?? [];
+export function presentationResourcePlan(id: PresentationId): readonly AppResource[] {
+  return requirePresentationRecord(id).resources;
 }


### PR DESCRIPTION
## Linear owner

MOR-2425 — S2-B1 transactional external-face activation and unified presentation catalog.

## Result

- admits exact `external-instruments-v1` hosted declarations through the existing component-kit startup transaction;
- copies and freezes external layouts/resources and resolves scalar, frequency, finite, and meter appearances before global mutation;
- registers layouts through the existing atomic `registerLayouts` batch and appends external records to the one `SKIN_LOADERS` catalog;
- keeps the one `loadSkin` reader, including precise built-in generic typing, while allowing selected external IDs to load lazily;
- rejects `rx-audio`, legacy presentation declarations, unresolved references, duplicate/colliding IDs, and inherited/reserved catalog names.

## Transaction and safety proof

All descriptor checks, copies, freezes, reference resolution, resource validation, and catalog/layout collision checks complete before the first registry write. The synchronous no-await commit calls `registerLayouts`, performs only prepared catalog assignments, then publishes the activation snapshot. Failure leaves the appearance snapshot, layout registry, presentation catalog, and selected presentation unchanged; an exact same-ID retry succeeds.

Catalog readers use own-property checks. `__proto__`, `constructor`, and `toString` cannot be admitted or observed as registered records, and authored getters are rejected without invocation. External loaders remain lazy and activation starts no resource.

## Correction history

- `d3264df77d1e4383a46929078725cea671afeaef` had masked negative presentation cases; `8ad32d92e` made them exact.
- A nested `toJSON` falsifier showed canonical validation could read an unexpected object; `90dbc8915` added primitive admission first.
- Independent review BLOCKED `90dbc8915` for authored coercion in resource/API-version diagnostics and the old lexical sizing guard. `00b636d85` closed both.
- Both natural quick attempts at `00b636d85` failed the same seven knob assertions. The intentional `isolate: false` fast pool exposed missing activation-test teardown; `8fb4c0d30` added symmetric module reset, changing the exact serial witness from 7 failures to 152/152 passing.
- Natural quick at `8fb4c0d30` then reached the previously masked production geometry phase and failed four Standard main/sub widths. Exact cascade capture proved the new startup activation-to-registry edge split formerly co-located CSS: the compact slot 9px rule loaded before the equal-specificity StudioLine 34px rule. Final `efc08a4cba7631ea16c4094fc6b7aad9636b0110` adds the actual local parent to the existing VfoPanel selector, raising compiled specificity from 0,3,0 to 0,4,0 and preserving the existing 9px value independent of chunk order.

## Verification

- deterministic serial activation/ValueControl GREEN: 2 files, 152 tests;
- standard fast project: 258 files, 6944 tests;
- VfoPanel isolated suite: 56 tests;
- production Standard main/sub geometry at 1440/1200/1024/900: 4 tests;
- emitted selector confirmed as `.control-strip.svelte-* .slot-choice:where(.svelte-*) .vfo-freq:where(.svelte-*)`;
- `npm run check`: 0 errors, 0 warnings;
- changed-path ESLint and `git diff --check`: clean.

Exact-head natural quick `34107354798` and visual `34107354861` passed. Independent exact-head review [PASS `efc08a4cb`](https://github.com/rigplane/rigplane-core/pull/3335#issuecomment-5568755480); required `Agent Review Gate` is green.

## Scope census

Exactly 6 authorized code paths, 0 visual baselines: 861 additions and 34 deletions, 895 A+D, below the revised 900 checkpoint and 1000 hard limit. The fifth path is the narrow sizing-boundary declaration-admission exception. The sixth is the one-line VfoPanel specificity correction; it restores the pre-change 9px rendering and adds no baseline. No API/package/fixture, layout contract, config/bootstrap, App/SRS, host instrument, or visual baseline path changed.

This is S2-B1 only. Live host projection and installed runtime mounting remain S2-C.

## Root integration closeout

This is one startup-activation unit: declaration validation, atomic registration, unified catalog readers and their negative tests must agree, while the sizing admission exception and compact VFO selector preserve the existing host contracts exercised by that new startup import path. The six-file/895-line scope is intentional; there are no regenerated baselines.

Root fully read the complete source/test changes, implementation/mechanics evidence, final independent report, and exact PASS directive. Final natural quick34107354798 and visual34107354861 succeeded, including all 87 i18n/geometry cases. The report's final six-file census was corrected before merge.

Current accepted main is8e2dc56538f339fb404fc7513a1a1f068f640e49, whose aggregate quick34106956759 succeeded. A conflict-free merge-tree check against that main produced exactly the six reviewed paths, with every resulting changed blob identical to final efc08a4cb. The PR API-returned older base snapshot is not treated as the live branch head. Optional v2 metadata observation failure does not replace the successful required canonical Agent Review Gate and quick contexts.

Prior90/00b BLOCKED and8fb code-PASS/red-geometry outcomes remain recorded above. S2-C runtime mounting and public host projection remain outstanding.
