### PR TITLE
MOR-2425: route station meters through public appearance

### DIFF
--- a/frontend/src/component-kits/MeterRendererSeat.svelte
+++ b/frontend/src/component-kits/MeterRendererSeat.svelte
@@ -1,25 +1,56 @@
 <script lang="ts">
-  import { untrack, type Snippet } from 'svelte';
+  import { onDestroy, untrack, type Snippet } from 'svelte';
   import type { SignalMeterFrame } from '../components-v2/meters/signal-meter-motion.svelte';
+  import type { ActionRendererSeat } from '../primitives/control-instruments/control-instrument-renderer.svelte';
   import type { MeterReading, MeterValueDomain } from '../semantic/radio-view-model';
-  import { toSignalMeterRendererView } from '../semantic/meter-renderer-view';
+  import type { StationLevelMeterFrame } from '../semantic/StationMeterInstrumentHost.svelte';
+  import {
+    toLevelMeterRendererView, toSignalMeterRendererView,
+  } from '../semantic/meter-renderer-view';
   import { getSelectedMeterAppearance } from './activation';
 
-  interface Props {
+  interface SignalProps {
+    kind?: 'signal';
     frame: SignalMeterFrame;
     reading: MeterReading;
     domain?: MeterValueDomain;
+    relevant?: boolean;
+    selectedPresent?: boolean;
     fallback: Snippet<[frame: SignalMeterFrame]>;
   }
+  interface LevelProps {
+    kind: 'level';
+    frame: StationLevelMeterFrame;
+    resetPeakSeat?: ActionRendererSeat;
+    fallback: Snippet<[frame: StationLevelMeterFrame, resetPeakSeat?: ActionRendererSeat]>;
+  }
+  type Props = SignalProps | LevelProps;
 
-  let { frame, reading, domain, fallback }: Props = $props();
-  const selectedRenderer = untrack(() => getSelectedMeterAppearance()?.signal);
-  const view = $derived(toSignalMeterRendererView(frame, reading, domain));
+  let props: Props = $props();
+  const appearance = untrack(() => getSelectedMeterAppearance());
+  const signalRenderer = untrack(() => props.kind === 'level' ? undefined : appearance?.signal);
+  const levelRenderer = untrack(() => props.kind === 'level' ? appearance?.level : undefined);
+  const resetPeak = untrack(() => props.kind === 'level' && levelRenderer
+    ? props.resetPeakSeat?.attachRenderer() : undefined);
+  const signalView = $derived(props.kind === 'level' ? null
+    : toSignalMeterRendererView(props.frame, props.reading, props.domain, props.relevant));
+  const levelView = $derived(props.kind === 'level'
+    ? toLevelMeterRendererView(props.frame) : null);
+  onDestroy(() => resetPeak?.dispose());
 </script>
 
-{#if selectedRenderer}
-  {@const Renderer = selectedRenderer}
-  <Renderer {view} />
+{#if props.kind === 'level'}
+  {#if levelRenderer}
+    {@const Renderer = levelRenderer}
+    <Renderer view={levelView!} {resetPeak} />
+  {:else}
+    {@render props.fallback(props.frame, props.resetPeakSeat)}
+  {/if}
+{:else if signalRenderer}
+  {#if props.selectedPresent !== false}
+    {@const Renderer = signalRenderer}
+    <Renderer view={signalView!} />
+  {/if}
 {:else}
-  {@render fallback(frame)}
+  {@render props.fallback(props.frame)}
 {/if}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -655,9 +655,9 @@ describe('the cold-start window renders fail-closed', () => {
   });
 });
 
-// ── 4. R9: the meters surface is a readout, never an action path ─────────
+// ── 4. R9: native meters add no radio-command path ───────────────────────
 
-describe('the meters surface adds no control and no TX path', () => {
+describe('the native meters surface adds no control and no TX path', () => {
   it('keeps exactly one key/unkey authority in the composed tree', () => {
     render();
     expect(target.querySelectorAll('[data-testid="rx-tx-surface"]')).toHaveLength(1);
@@ -665,10 +665,10 @@ describe('the meters surface adds no control and no TX path', () => {
     expect(target.querySelectorAll('[data-testid="rx-tx-unkey"]')).toHaveLength(1);
   });
 
-  // MUTATION KILLED: a meters surface that grew a peak-reset / source-select
-  // control. Zero controls also keeps the cockpit's focus order and its
-  // zone-less-control count exactly as MOR-1069/1070 pinned them.
-  it('contributes no focusable control to the composition', () => {
+  // MUTATION KILLED: a native/default meters surface that grew a source-select
+  // or radio-command control. The separately tested public meter appearance
+  // may expose only its host-owned local peak-reset lease.
+  it('contributes no focusable control with no selected meter appearance', () => {
     render({ strips: 'dual' });
     const surface = q('[data-testid="meters-surface"]')!;
     expect(surface.querySelectorAll('button, input, select, a[href], [tabindex]'))

--- a/frontend/src/semantic/MetersSurface.svelte
+++ b/frontend/src/semantic/MetersSurface.svelte
@@ -68,6 +68,7 @@
 
 <script lang="ts">
   import LinearSMeter from '../components-v2/meters/LinearSMeter.svelte';
+  import MeterRendererSeat from '../component-kits/MeterRendererSeat.svelte';
   import { RF_LABEL, RF_MARK } from './rx-tx-surface';
   import StationMeterBarPlacement from './StationMeterBarPlacement.svelte';
   import type {
@@ -91,7 +92,7 @@
 {#if presentGroup}
   {@const display = signalProjection ? meterDisplay(signalProjection) : null}
   {@const signalDisplay = signalProjection?.crossoverFraction == null ? null : display}
-  {#snippet level(frame: StationLevelMeterFrame, resetPeakSeat?: ActionRendererSeat)}
+  {#snippet nativeLevel(frame: StationLevelMeterFrame, resetPeakSeat?: ActionRendererSeat)}
     {@const bar = frame.projection}
     <div class="meter-tile" data-meter-tile data-meter={bar.key} data-testid={`meter-${bar.key}`}
       data-relevant={bar.relevant} data-observed={bar.observed} data-fault={bar.fault}
@@ -103,7 +104,16 @@
       {:else}<span class="meter-unknown">{bar.displayText}</span>{/if}
     </div>
   {/snippet}
+  {#snippet level(frame: StationLevelMeterFrame, resetPeakSeat?: ActionRendererSeat)}
+    {#key resetPeakSeat}
+      <MeterRendererSeat kind="level" {frame} {resetPeakSeat} fallback={nativeLevel} />
+    {/key}
+  {/snippet}
   {#snippet power(frame: StationLevelMeterFrame<'power'>, seat?: ActionRendererSeat)}{@render level(frame, seat)}{/snippet}
+  {#snippet nativeSwr(_frame: StationLevelMeterFrame)}{/snippet}
+  {#snippet swr(frame: StationLevelMeterFrame<'swr'>)}
+    <MeterRendererSeat kind="level" {frame} fallback={nativeSwr} />
+  {/snippet}
   {#snippet alc(frame: StationLevelMeterFrame<'alc'>, seat?: ActionRendererSeat)}{@render level(frame, seat)}{/snippet}
   {#snippet drainCurrent(frame: StationLevelMeterFrame<'drainCurrent'>, seat?: ActionRendererSeat)}{@render level(frame, seat)}{/snippet}
   {#snippet drainVoltage(frame: StationLevelMeterFrame<'drainVoltage'>)}{@render level(frame)}{/snippet}
@@ -119,22 +129,29 @@
 
     {#if signalFrame !== null}
       {@const field = signalFrame.field}
-      <div
-        class="meter-tile" data-meter-tile data-meter={present(field) ? "signal" : "swr"} data-testid={present(field) ? "meter-signal" : "meter-swr"}
-        data-relevant={field.relevant} data-observed={observed(field)}
-        role="group" aria-label={present(field) ? "S meter" : "SWR meter"}
-        {...signalDisplay?.attributes ?? {}}
-      >
-        <LinearSMeter
-          frame={signalFrame.motion} label="S" compact
-          mainPresent={present(field)}
-          display={signalDisplay?.display ?? undefined}
-          lowerScale={swrFrame ? swrLowerScale(swrFrame) : undefined}
-          relevant={field.relevant}
-        />
-      </div>
+      {@const reading = observed(field) && field.reading.status === 'known'
+        && Number.isFinite(field.reading.value) ? field.reading : { status: 'unknown' } as const}
+      {#snippet nativeSignal(_frame: typeof signalFrame.motion)}
+        <div
+          class="meter-tile" data-meter-tile data-meter={present(field) ? "signal" : "swr"} data-testid={present(field) ? "meter-signal" : "meter-swr"}
+          data-relevant={field.relevant} data-observed={observed(field)}
+          role="group" aria-label={present(field) ? "S meter" : "SWR meter"}
+          {...signalDisplay?.attributes ?? {}}
+        >
+          <LinearSMeter
+            frame={signalFrame.motion} label="S" compact
+            mainPresent={present(field)}
+            display={signalDisplay?.display ?? undefined}
+            lowerScale={swrFrame ? swrLowerScale(swrFrame) : undefined}
+            relevant={field.relevant}
+          />
+        </div>
+      {/snippet}
+      <MeterRendererSeat frame={signalFrame.motion} {reading} domain={field.domain}
+        relevant={field.relevant} selectedPresent={present(field)} fallback={nativeSignal} />
     {/if}
     {@render handles.power(power)}
+    {@render handles.swr(swr)}
     {@render handles.alc(alc)}
     {@render handles.drainCurrent(drainCurrent)}
     {@render handles.drainVoltage(drainVoltage)}

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -505,6 +505,15 @@ describe('motion and forced-colors mechanisms are reused, not forked', () => {
     expect(SOURCE).toMatch(/import LinearSMeter from '\.\.\/components-v2\/meters\/LinearSMeter\.svelte'/);
   });
 
+  it('places the shared meter seat inside the station continuation without changing the owner', () => {
+    expect(SOURCE).toMatch(/import MeterRendererSeat from '\.\.\/component-kits\/MeterRendererSeat\.svelte'/);
+    expect(SOURCE.match(/handles\.swr\(swr\)/g)).toHaveLength(1);
+    expect(SOURCE).toMatch(/#snippet station\([\s\S]*handles\.power\(power\)[\s\S]*handles\.swr\(swr\)/);
+    expect(SOURCE).not.toMatch(/getSelectedMeterAppearance/);
+    expect(HOST_SOURCE).not.toMatch(/MeterRendererSeat/);
+    expect(HOST_SOURCE).toMatch(/@render renderer\(signalOwner\?\.frame/);
+  });
+
   // MUTATION KILLED: a CSS transition/animation on the relevance dim — under
   // `prefers-reduced-motion` the cockpit's harness assertion requires that
   // NOTHING inside it animates, and a surface that transitions its own opacity

--- a/frontend/src/semantic/__tests__/StationMeterInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/StationMeterInstrumentHost.isolated.test.ts
@@ -2,11 +2,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 // @ts-expect-error -- Svelte does not publish types for its reactive test harness.
 import { proxy } from 'svelte/internal/client';
-import type { MeterAppearance } from '../../../component-kit-api/src/index';
+import type { MeterAppearance, SignalMeterRendererView } from '../../../component-kit-api/src/index';
 const selectedMeter = vi.hoisted(() => ({ current: undefined as MeterAppearance | undefined }));
+const rendererViews = vi.hoisted(() => ({ signals: [] as SignalMeterRendererView[] }));
 vi.mock('../../component-kits/activation', () => ({
   getSelectedMeterAppearance: () => selectedMeter.current,
 }));
+vi.mock('../meter-renderer-view', async (original) => {
+  const actual = await original<typeof import('../meter-renderer-view')>();
+  return { ...actual,
+    toSignalMeterRendererView(...args: Parameters<typeof actual.toSignalMeterRendererView>) {
+      const projected = actual.toSignalMeterRendererView(...args);
+      rendererViews.signals.push(projected);
+      return projected;
+    },
+  };
+});
 const motion = vi.hoisted(() => ({ bars: [] as any[], signals: [] as any[] }));
 vi.mock('../../components-v2/meters/bar-meter-motion.svelte', async (original) => {
   const actual = await original<typeof import('../../components-v2/meters/bar-meter-motion.svelte')>();
@@ -57,6 +68,7 @@ let component: ReturnType<typeof mount> | null;
 beforeEach(() => {
   target = document.createElement('div'); document.body.appendChild(target);
   component = null; motion.bars = []; motion.signals = []; stationMeterProbe.clear();
+  rendererViews.signals = [];
   selectedMeter.current = undefined;
   window.matchMedia = vi.fn().mockReturnValue({ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() });
 });
@@ -135,6 +147,23 @@ describe('StationMeterInstrumentHost', () => {
     expect(meter('power').dataset).toMatchObject({ state: 'current', domain: 'engineering:w', value: '0.6' });
     expect(meter('alc').dataset).toMatchObject({ state: 'current', domain: 'raw', value: '40' });
     expect(meter('drainVoltage').dataset).toMatchObject({ state: 'current', domain: 'unknown', value: '200' });
+  });
+
+  it('keeps a structurally present unavailable-known signal external but fail-closed', () => {
+    selectedMeter.current = fixtureMeterAppearance;
+    const unavailable = field(view('receiving'), 'signal', {
+      reading: { status: 'known', value: 120 },
+      availability: { structural: true, operational: false },
+    });
+    render({ view: unavailable, session: { controlSessionEpoch: 1 } });
+    const signal = target.querySelector<HTMLElement>('[data-fixture-signal]')!;
+    const publicView = rendererViews.signals.at(-1)!;
+    expect(signal).not.toBeNull();
+    expect(signal.dataset.state).toBe('unknown');
+    expect(signal.hasAttribute('data-value')).toBe(false);
+    expect(publicView.evidence).toEqual({ state: 'unknown', domain: { kind: 'unknown' } });
+    expect(publicView.displayedFraction).toBeNull();
+    expect(publicView.peakFraction).toBeNull();
   });
 
   it('routes real external reset leases and revokes a retained A-B-A button', () => {

--- a/frontend/src/semantic/__tests__/StationMeterInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/StationMeterInstrumentHost.isolated.test.ts
@@ -2,6 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 // @ts-expect-error -- Svelte does not publish types for its reactive test harness.
 import { proxy } from 'svelte/internal/client';
+import type { MeterAppearance } from '../../../component-kit-api/src/index';
+const selectedMeter = vi.hoisted(() => ({ current: undefined as MeterAppearance | undefined }));
+vi.mock('../../component-kits/activation', () => ({
+  getSelectedMeterAppearance: () => selectedMeter.current,
+}));
 const motion = vi.hoisted(() => ({ bars: [] as any[], signals: [] as any[] }));
 vi.mock('../../components-v2/meters/bar-meter-motion.svelte', async (original) => {
   const actual = await original<typeof import('../../components-v2/meters/bar-meter-motion.svelte')>();
@@ -21,7 +26,9 @@ vi.mock('../../components-v2/meters/signal-meter-motion.svelte', async (original
     motion.signals.push(wrapped); return wrapped;
   } };
 });
-import Fixture, { StationMeterTestPublisher, stationMeterProbe } from './fixtures/StationMeterInstrumentHostFixture.svelte';
+import Fixture, {
+  StationMeterTestPublisher, fixtureMeterAppearance, stationMeterProbe,
+} from './fixtures/StationMeterInstrumentHostFixture.svelte';
 import { topologyFixtures, withMeters, withTxAux } from '../fixtures/topologies';
 import type { MeterSourceIdentity, MeterValueDomain, RadioViewModel } from '../radio-view-model';
 import type { StationMeterAuthorityPublication, SubscribeStationMeterAuthority } from '../StationMeterInstrumentHost.svelte';
@@ -50,9 +57,11 @@ let component: ReturnType<typeof mount> | null;
 beforeEach(() => {
   target = document.createElement('div'); document.body.appendChild(target);
   component = null; motion.bars = []; motion.signals = []; stationMeterProbe.clear();
+  selectedMeter.current = undefined;
   window.matchMedia = vi.fn().mockReturnValue({ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() });
 });
-afterEach(() => { if (component) unmount(component); target.remove(); vi.restoreAllMocks(); });
+afterEach(() => { if (component) unmount(component); target.remove(); vi.restoreAllMocks();
+  selectedMeter.current = undefined; });
 function render(initial: StationMeterAuthorityPublication = { view: view(), session: { controlSessionEpoch: 1 } }) {
   const publisher = new StationMeterTestPublisher(initial);
   const props = proxy({ subscribeStationMeterAuthority: publisher.subscribe, presentation: 'native', probe: true });
@@ -61,6 +70,115 @@ function render(initial: StationMeterAuthorityPublication = { view: view(), sess
 }
 const expectStopped = () => { expect(motion.signals[0].stop).toHaveBeenCalledOnce(); for (const binding of motion.bars) expect(binding.stop).toHaveBeenCalledOnce(); };
 describe('StationMeterInstrumentHost', () => {
+  it.each([
+    ['native', true, true], ['native', true, false], ['native', false, true], ['native', false, false],
+    ['external', true, true], ['external', true, false],
+    ['external', false, true], ['external', false, false],
+  ] as const)('%s selection keeps station siblings live for signal=%s SWR=%s',
+    (selection, signalPresent, swrPresent) => {
+      selectedMeter.current = selection === 'external' ? fixtureMeterAppearance : undefined;
+      let current = view();
+      current = field(current, 'signal', {
+        availability: { structural: signalPresent, operational: signalPresent },
+      });
+      current = field(current, 'swr', {
+        availability: { structural: swrPresent, operational: swrPresent },
+      });
+      render({ view: current, session: { controlSessionEpoch: 1 } });
+
+      const externalSignal = target.querySelectorAll('[data-fixture-signal]');
+      const externalLevels = [...target.querySelectorAll<HTMLElement>('[data-fixture-level]')]
+        .map((node) => node.dataset.fixtureLevel);
+      if (selection === 'external') {
+        expect(externalSignal).toHaveLength(signalPresent ? 1 : 0);
+        expect(externalLevels).toEqual([
+          'power', ...(swrPresent ? ['swr'] : []), 'alc',
+          'drainCurrent', 'drainVoltage', 'compression',
+        ]);
+        expect(target.querySelector('[data-meter-tile]')).toBeNull();
+      } else {
+        expect(externalSignal).toHaveLength(0);
+        expect(externalLevels).toEqual([]);
+        expect(target.querySelector('[data-testid="meter-power"]')).not.toBeNull();
+        expect(target.querySelector('[data-testid="meter-alc"]')).not.toBeNull();
+        expect(target.querySelector('[data-testid="meter-drainCurrent"]')).not.toBeNull();
+        expect(target.querySelector('[data-testid="meter-drainVoltage"]')).not.toBeNull();
+        expect(target.querySelector('[data-testid="meter-compression"]')).not.toBeNull();
+        expect(target.querySelector('[data-testid="meter-signal"]') !== null).toBe(signalPresent);
+        expect(target.querySelector('[data-testid="meter-swr"]') !== null)
+          .toBe(!signalPresent && swrPresent);
+      }
+    });
+
+  it('mounts all seven real external meter renderers without adding motion owners', () => {
+    selectedMeter.current = fixtureMeterAppearance;
+    render();
+    expect(target.querySelectorAll('[data-fixture-signal]')).toHaveLength(1);
+    expect([...target.querySelectorAll<HTMLElement>('[data-fixture-level]')]
+      .map((node) => node.dataset.fixtureLevel)).toEqual([
+        'power', 'swr', 'alc', 'drainCurrent', 'drainVoltage', 'compression',
+      ]);
+    expect([motion.signals.length, motion.bars.length]).toEqual([1, 6]);
+    expect([...target.querySelectorAll<HTMLElement>('[data-fixture-level] button')]
+      .map((button) => button.parentElement?.dataset.fixtureLevel)).toEqual([
+        'power', 'alc', 'drainCurrent',
+    ]);
+  });
+
+  it('shows exact engineering, raw, and unknown evidence through the real external fixture', () => {
+    selectedMeter.current = fixtureMeterAppearance;
+    let current = field(view(), 'power', { domain: { kind: 'engineering', unit: 'w' } });
+    current = field(current, 'alc', { domain: { kind: 'raw' } });
+    current = field(current, 'drainVoltage', { domain: undefined });
+    render({ view: current, session: { controlSessionEpoch: 1 } });
+    const meter = (key: string) => target.querySelector<HTMLElement>(`[data-fixture-level="${key}"]`)!;
+    expect(meter('power').dataset).toMatchObject({ state: 'current', domain: 'engineering:w', value: '0.6' });
+    expect(meter('alc').dataset).toMatchObject({ state: 'current', domain: 'raw', value: '40' });
+    expect(meter('drainVoltage').dataset).toMatchObject({ state: 'current', domain: 'unknown', value: '200' });
+  });
+
+  it('routes real external reset leases and revokes a retained A-B-A button', () => {
+    selectedMeter.current = fixtureMeterAppearance;
+    const { publisher } = render();
+    const button = (key: string) => target.querySelector<HTMLButtonElement>(
+      `[data-fixture-level="${key}"] button`,
+    );
+    button('power')!.click(); button('alc')!.click(); button('drainCurrent')!.click();
+    expect(motion.bars[0].resetPeak).toHaveBeenCalledOnce();
+    expect(motion.bars[1].resetPeak).toHaveBeenCalledOnce();
+    expect(motion.bars[2].resetPeak).toHaveBeenCalledOnce();
+    expect(button('swr')).toBeNull(); expect(button('drainVoltage')).toBeNull();
+    expect(button('compression')).toBeNull();
+
+    const retained = button('power')!;
+    publisher.emit({ view: field(view(), 'power', {
+      source: { ...source('powerMeter'), providerGeneration: 2 },
+    }), session: { controlSessionEpoch: 2 } });
+    publisher.emit({ view: view(), session: { controlSessionEpoch: 1 } });
+    flushSync();
+    retained.click();
+    expect(motion.bars[0].resetPeak).toHaveBeenCalledOnce();
+    button('power')!.click();
+    expect(motion.bars[0].resetPeak).toHaveBeenCalledTimes(2);
+
+    publisher.emit({ view: view('receiving'), session: { controlSessionEpoch: 1 } }); flushSync();
+    expect(button('power')).toBeNull();
+    publisher.emit({ view: view(), session: { controlSessionEpoch: 1 } }); flushSync();
+    expect(button('power')).not.toBeNull();
+  });
+
+  it('keeps owners stable across external-native-external surface replacement', () => {
+    selectedMeter.current = fixtureMeterAppearance;
+    const { props } = render();
+    expect(target.querySelectorAll('[data-fixture-signal], [data-fixture-level]')).toHaveLength(7);
+    selectedMeter.current = undefined; props.presentation = 'native-b'; flushSync();
+    expect(target.querySelectorAll('[data-fixture-signal], [data-fixture-level]')).toHaveLength(0);
+    expect(target.querySelector('[data-testid="meter-signal"]')).not.toBeNull();
+    selectedMeter.current = fixtureMeterAppearance; props.presentation = 'external-again'; flushSync();
+    expect(target.querySelectorAll('[data-fixture-signal], [data-fixture-level]')).toHaveLength(7);
+    expect([motion.signals.length, motion.bars.length]).toEqual([1, 6]);
+  });
+
   it('owns seven live bindings, stable passive frames, and tears them down once', () => {
     let id = 0; const add = vi.fn(); const remove = vi.fn();
     window.matchMedia = vi.fn().mockReturnValue({ matches: false, addEventListener: add, removeEventListener: remove });
@@ -138,11 +256,15 @@ describe('StationMeterInstrumentHost', () => {
     expect(motion.bars[0].resetPeak).not.toHaveBeenCalled();
   });
   it('preserves both SWR ratio-scale projections without exposing source', () => {
+    selectedMeter.current = fixtureMeterAppearance;
     const { publisher } = render({ view: domain(view(), undefined), session: { controlSessionEpoch: 1 } });
     const frame = () => stationMeterProbe.frames.get('swr') as any;
+    const external = () => target.querySelector<HTMLElement>('[data-fixture-level="swr"]')!;
     expect(frame().projection.ratioScale).toBe(true);
+    expect(external().dataset.ratioScale).toBe('true');
     publisher.emit({ view: domain(view(), { kind: 'raw' }), session: { controlSessionEpoch: 1 } }); flushSync();
-    expect(frame().projection.ratioScale).toBe(false); expect(Object.hasOwn(frame().projection, 'source')).toBe(false);
+    expect(frame().projection.ratioScale).toBe(false); expect(external().dataset.ratioScale).toBe('false');
+    expect(Object.hasOwn(frame().projection, 'source')).toBe(false);
   });
   it('keeps custom level palettes without admitting a signal owner or gauge', () => {
     const original = getDesignLanguage('fieldline')!; const zones = [{ end: 1, color: '#123456' }] as const;

--- a/frontend/src/semantic/__tests__/bar-meter-projector.test.ts
+++ b/frontend/src/semantic/__tests__/bar-meter-projector.test.ts
@@ -12,6 +12,7 @@ import type {
 import {
   projectBarMeters,
   projectSwrMeter,
+  projectTxMeterPresentation,
   type BarMeterKey,
 } from '../bar-meter-projector';
 
@@ -73,6 +74,25 @@ function calibratedCaps(): Capabilities {
 afterEach(() => clearCapabilities());
 
 describe('projectBarMeters', () => {
+  it('retains standardized TX evidence without changing live-value admission', () => {
+    const current = base();
+    setDisplay(current, 'power', { state: 'current', value: 75 });
+    expect(projectTxMeterPresentation(current.meters!.power, 'transmitting')).toMatchObject({
+      state: 'current', evidence: { state: 'current', value: 75 }, value: 75,
+    });
+
+    setDisplay(current, 'power', { state: 'stale', value: 75 });
+    expect(projectTxMeterPresentation(current.meters!.power, 'transmitting')).toMatchObject({
+      state: 'stale', evidence: { state: 'stale', value: 75 }, value: null,
+    });
+    expect(projectTxMeterPresentation({
+      ...current.meters!.power,
+      availability: { structural: false, operational: false },
+    }, 'transmitting')).toMatchObject({
+      state: 'unsupported', evidence: { state: 'unsupported' }, value: null,
+    });
+  });
+
   it('projects the five real rows in priority order with only consumed fields', () => {
     const view = base();
     const source = {
@@ -93,7 +113,7 @@ describe('projectBarMeters', () => {
       { key: 'compression', label: 'COMP' },
     ]);
     expect(Object.keys(projected[0]).sort()).toEqual([
-      'accessibleDescription', 'displayText', 'domain', 'fault', 'gauge', 'key',
+      'accessibleDescription', 'displayText', 'domain', 'evidence', 'fault', 'gauge', 'key',
       'label', 'motionFraction', 'observed', 'relevant', 'showPeak', 'source',
       'state', 'stateText',
     ]);
@@ -119,6 +139,7 @@ describe('projectBarMeters', () => {
 
     const projected = projectBarMeters(view);
     expect(projected.find(({ key }) => key === 'power')).toMatchObject({
+      evidence: { state: 'current', value: 50 },
       motionFraction: 0.25,
       displayText: '50W',
       observed: true,
@@ -144,6 +165,7 @@ describe('projectBarMeters', () => {
     setDisplay(view, 'power', { state: 'stale', value: 170 });
     setMeter(view, 'power', { domain: { kind: 'raw' } });
     expect(projectBarMeters(view)[0]).toMatchObject({
+      evidence: { state: 'stale', value: 170 },
       state: 'stale',
       domain: { kind: 'raw' },
       motionFraction: null,
@@ -156,6 +178,7 @@ describe('projectBarMeters', () => {
 
     setDisplay(view, 'power', { state: 'unknown', reason: 'not-observed' });
     expect(projectBarMeters(view)[0]).toMatchObject({
+      evidence: { state: 'unknown' },
       state: 'unknown',
       motionFraction: null,
       displayText: '?',
@@ -168,6 +191,7 @@ describe('projectBarMeters', () => {
     setMeter(view, 'power', { relevant: false });
     setDisplay(view, 'power', { state: 'current', value: 170 });
     expect(projectBarMeters(view)[0]).toMatchObject({
+      evidence: { state: 'idle' },
       state: 'idle',
       motionFraction: null,
       displayText: 'IDLE',
@@ -204,10 +228,23 @@ describe('projectBarMeters', () => {
       displayText: '?',
     });
     expect(projectBarMeters(view).find(({ key }) => key === 'drainCurrent')).toMatchObject({
+      evidence: { state: 'unknown' },
       gauge: false,
       observed: false,
       motionFraction: null,
       displayText: 'Id ?',
+    });
+  });
+
+  it('does not retain a known non-TX sample when operational availability is false', () => {
+    const view = base();
+    setMeter(view, 'drainVoltage', {
+      reading: { status: 'known', value: 13.8 },
+      availability: { structural: true, operational: false },
+    });
+    expect(projectBarMeters(view).find(({ key }) => key === 'drainVoltage')).toMatchObject({
+      evidence: { state: 'unknown' }, state: 'unknown', observed: false,
+      motionFraction: null, displayText: 'Vd ?',
     });
   });
 

--- a/frontend/src/semantic/__tests__/fixtures/StationMeterInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/StationMeterInstrumentHostFixture.svelte
@@ -1,6 +1,13 @@
 <script module lang="ts">
+  import type { MeterAppearance } from '../../../../component-kit-api/src/index';
+  import FixtureLevelMeter from '../../../../component-kit-api/fixtures/external-kit/src/FixtureLevelMeter.svelte';
+  import FixtureSignalMeter from '../../../../component-kit-api/fixtures/external-kit/src/FixtureSignalMeter.svelte';
   import type { StationMeterAuthorityPublication,
     SubscribeStationMeterAuthority } from '../../StationMeterInstrumentHost.svelte';
+  export const fixtureMeterAppearance = {
+    signal: FixtureSignalMeter,
+    level: FixtureLevelMeter,
+  } satisfies MeterAppearance;
   export class StationMeterTestPublisher {
     readonly handlers = new Set<(publication: StationMeterAuthorityPublication) => void>();
     current: StationMeterAuthorityPublication;

--- a/frontend/src/semantic/__tests__/meter-renderer-view.test.ts
+++ b/frontend/src/semantic/__tests__/meter-renderer-view.test.ts
@@ -3,7 +3,9 @@ import type { Capabilities } from '$lib/types/capabilities';
 import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
 import type { SignalMeterFrame } from '../../components-v2/meters/signal-meter-motion.svelte';
 import type { SignalMeterProjection } from '../../components-v2/meters/smeter-scale';
-import { toSignalMeterRendererView } from '../meter-renderer-view';
+import type { LevelMeterKey } from '../bar-meter-projector';
+import type { StationLevelMeterFrame } from '../StationMeterInstrumentHost.svelte';
+import { toLevelMeterRendererView, toSignalMeterRendererView } from '../meter-renderer-view';
 
 function capabilities(): Capabilities {
   return {
@@ -36,6 +38,45 @@ function frame(overrides: Partial<SignalMeterProjection> = {}): SignalMeterFrame
     smoothedFraction: 0.35,
     peakFraction: 0.6,
   };
+}
+
+function levelFrame(
+  key: LevelMeterKey = 'power',
+  projection: Record<string, unknown> = {},
+  motion: Record<string, unknown> = {},
+): StationLevelMeterFrame {
+  return {
+    projection: {
+      key, label: key === 'power' ? 'Po' : key, evidence: { state: 'current', value: 50 },
+      relevant: true, observed: true, state: 'current',
+      domain: { kind: 'engineering', unit: key === 'swr' ? 'ratio' : 'w' },
+      motionFraction: 0.25, displayText: '50W', stateText: '',
+      accessibleDescription: 'Po: Current observation. 50W', fault: false,
+      showPeak: true, gauge: true,
+      ...(key === 'swr' ? { ratioScale: true } : {}),
+      ...projection,
+    },
+    motion: { smoothedFraction: 0.2, peakFraction: 0.4, ...motion },
+  } as StationLevelMeterFrame;
+}
+
+function expectFrozenDataGraph(value: object): void {
+  const seen = new Set<object>();
+  const visit = (item: unknown): void => {
+    expect(typeof item).not.toBe('symbol');
+    expect(typeof item).not.toBe('function');
+    if (item === null || typeof item !== 'object' || seen.has(item)) return;
+    seen.add(item);
+    expect(Object.isFrozen(item)).toBe(true);
+    for (const key of Reflect.ownKeys(item)) {
+      expect(typeof key).toBe('string');
+      expect(String(key)).not.toMatch(/source|session|binding|frame|callback|getter|owner|resetPeak/i);
+      const descriptor = Object.getOwnPropertyDescriptor(item, key)!;
+      expect('value' in descriptor).toBe(true);
+      if ('value' in descriptor) visit(descriptor.value);
+    }
+  };
+  visit(value);
 }
 
 describe('toSignalMeterRendererView', () => {
@@ -163,5 +204,114 @@ describe('toSignalMeterRendererView', () => {
       scaleMode: 'none', displayedFraction: null, peakFraction: null,
       crossoverFraction: null, marks: [], ticks: [],
     });
+  });
+
+  it('copies explicit false station relevance without changing receiver keys', () => {
+    const receiver = toSignalMeterRendererView(
+      frame(), { status: 'known', value: -12 }, { kind: 'engineering', unit: 'db' },
+    );
+    const station = toSignalMeterRendererView(
+      frame(), { status: 'known', value: -12 }, { kind: 'engineering', unit: 'db' }, false,
+    );
+    expect(Object.hasOwn(receiver, 'relevant')).toBe(false);
+    expect(Object.hasOwn(station, 'relevant')).toBe(true);
+    expect(station.relevant).toBe(false);
+  });
+});
+
+describe('toLevelMeterRendererView', () => {
+  it('copies only the public level graph and freezes fresh evidence/domain objects', () => {
+    const source = levelFrame();
+    const view = toLevelMeterRendererView(source);
+    expect(Reflect.ownKeys(view)).toEqual([
+      'kind', 'key', 'label', 'evidence', 'relevant', 'observed',
+      'displayedFraction', 'peakFraction', 'displayText', 'stateText',
+      'accessibleDescription', 'gauge', 'fault', 'peakEnabled',
+    ]);
+    expect(view).toMatchObject({
+      kind: 'level', key: 'power',
+      evidence: { state: 'current', value: 50, domain: { kind: 'engineering', unit: 'w' } },
+      displayedFraction: 0.2, peakFraction: 0.4, peakEnabled: true,
+    });
+    expect(view.evidence).not.toBe(source.projection.evidence);
+    expect(view.evidence.domain).not.toBe(source.projection.domain);
+    expect([view, view.evidence, view.evidence.domain].every(Object.isFrozen)).toBe(true);
+    expectFrozenDataGraph(view);
+  });
+
+  it.each([
+    'power', 'swr', 'alc', 'drainCurrent', 'drainVoltage', 'compression',
+  ] as const)('keeps the exact public key set for %s and maps an omitted domain to unknown', (key) => {
+    const view = toLevelMeterRendererView(levelFrame(key, { domain: undefined }));
+    const expected = [
+      'accessibleDescription', 'displayText', 'displayedFraction', 'evidence', 'fault',
+      'gauge', 'key', 'kind', 'label', 'observed', 'peakEnabled', 'peakFraction',
+      'relevant', 'stateText', ...(key === 'swr' ? ['ratioScale'] : []),
+    ].sort();
+    expect(Reflect.ownKeys(view).sort()).toEqual(expected);
+    expect(view.evidence.domain).toEqual({ kind: 'unknown' });
+    expectFrozenDataGraph(view);
+  });
+
+  it('retains stale numeric evidence while suppressing live geometry', () => {
+    const view = toLevelMeterRendererView(levelFrame('power', {
+      evidence: { state: 'stale', value: 170 }, observed: false, state: 'stale',
+      domain: { kind: 'raw' }, motionFraction: null, displayText: 'STALE',
+      stateText: 'STALE', accessibleDescription: 'Po: Stale observation', showPeak: false,
+    }, { smoothedFraction: 0.8, peakFraction: 0.9 }));
+
+    expect(view).toMatchObject({
+      kind: 'level', key: 'power',
+      evidence: { state: 'stale', value: 170, domain: { kind: 'raw' } },
+      displayedFraction: null, peakFraction: null, peakEnabled: false,
+    });
+    expect(Object.isFrozen(view)).toBe(true);
+    expect(Object.isFrozen(view.evidence)).toBe(true);
+    expect(Object.isFrozen(view.evidence.domain)).toBe(true);
+  });
+
+  it.each([
+    ['idle', 'idle'], ['unknown', 'unknown'], ['unsupported', 'unsupported'],
+  ] as const)('keeps %s evidence nonnumeric and live geometry absent', (_name, state) => {
+    const view = toLevelMeterRendererView(levelFrame('power', {
+      evidence: { state }, state, observed: false, motionFraction: 0.25,
+    }));
+    expect(view.evidence).toEqual({ state, domain: { kind: 'engineering', unit: 'w' } });
+    expect(view.displayedFraction).toBeNull();
+    expect(view.peakFraction).toBeNull();
+    expect(Object.hasOwn(view.evidence, 'value')).toBe(false);
+  });
+
+  it('fails non-finite numeric evidence closed without rewriting passive text', () => {
+    const view = toLevelMeterRendererView(levelFrame('power', {
+      evidence: { state: 'current', value: Number.NaN }, displayText: 'bad sample',
+    }));
+    expect(view.evidence).toEqual({
+      state: 'unknown', domain: { kind: 'engineering', unit: 'w' },
+    });
+    expect(view.displayedFraction).toBeNull();
+    expect(view.peakFraction).toBeNull();
+    expect(view.displayText).toBe('bad sample');
+  });
+
+  it.each([
+    ['projected target', { motionFraction: 1.1 }, {}, null, null],
+    ['smoothed fill', {}, { smoothedFraction: Number.NaN }, null, null],
+    ['peak only', {}, { peakFraction: Infinity }, 0.2, null],
+    ['peak disabled', { showPeak: false }, {}, 0.2, null],
+  ] as const)('validates %s independently', (_name, projection, motion, fill, peak) => {
+    expect(toLevelMeterRendererView(levelFrame('power', projection, motion))).toMatchObject({
+      displayedFraction: fill, peakFraction: peak,
+    });
+  });
+
+  it('emits ratioScale only for the SWR discriminant', () => {
+    const swr = toLevelMeterRendererView(levelFrame('swr', {
+      label: 'SWR', ratioScale: false, showPeak: false,
+      domain: { kind: 'raw' }, displayText: '120 raw',
+    }));
+    const power = toLevelMeterRendererView(levelFrame());
+    expect(swr).toMatchObject({ key: 'swr', ratioScale: false });
+    expect(Object.hasOwn(power, 'ratioScale')).toBe(false);
   });
 });

--- a/frontend/src/semantic/bar-meter-projector.ts
+++ b/frontend/src/semantic/bar-meter-projector.ts
@@ -28,6 +28,9 @@ import type {
 export type BarMeterKey = Exclude<keyof MetersViewModel, 'rfState' | 'signal' | 'swr'>;
 export type LevelMeterKey = Exclude<keyof MetersViewModel, 'rfState' | 'signal'>;
 export type LevelMeterState = 'unsupported' | 'idle' | 'current' | 'stale' | 'unknown';
+export type LevelMeterEvidence =
+  | Readonly<{ state: 'current' | 'stale'; value: number }>
+  | Readonly<{ state: 'unsupported' | 'idle' | 'unknown' }>;
 
 export interface LevelMeterProjection<Key extends LevelMeterKey = LevelMeterKey> {
   readonly key: Key;
@@ -35,6 +38,7 @@ export interface LevelMeterProjection<Key extends LevelMeterKey = LevelMeterKey>
   readonly relevant: boolean;
   readonly observed: boolean;
   readonly state: LevelMeterState;
+  readonly evidence: LevelMeterEvidence;
   readonly domain: MeterValueDomain | undefined;
   readonly motionFraction: number | null;
   readonly displayText: string;
@@ -89,21 +93,33 @@ export function projectTxMeterPresentation(
   rfState: MeterRfState,
 ): {
   readonly state: LevelMeterState;
+  readonly evidence: LevelMeterEvidence;
   readonly value: number | null;
   readonly text: string;
   readonly description: string;
 } {
   const projected = projectTxMeterDisplay(field, rfState);
   if (!projected.supported) {
-    return { state: 'unsupported', value: null, text: '?', description: 'Not observed' };
+    return {
+      state: 'unsupported', evidence: { state: 'unsupported' },
+      value: null, text: '?', description: 'Not observed',
+    };
   }
   const { relevance, observation } = projected;
   if (relevance === 'idle') {
-    return { state: 'idle', value: null, text: 'IDLE', description: 'Not measuring in RX' };
+    return {
+      state: 'idle', evidence: { state: 'idle' },
+      value: null, text: 'IDLE', description: 'Not measuring in RX',
+    };
   }
   const cue = relevance === 'indeterminate' ? 'RF relevance indeterminate. ' : '';
+  const evidence: LevelMeterEvidence = observation.state === 'current'
+    || observation.state === 'stale'
+    ? { state: observation.state, value: observation.value }
+    : { state: observation.state };
   return {
     state: observation.state,
+    evidence,
     value: observation.state === 'current' ? observation.value : null,
     text: observation.state === 'stale' ? 'STALE' : observation.state === 'current'
       ? (relevance === 'indeterminate' ? ' ?' : '') : '?',
@@ -130,6 +146,8 @@ function projectLevelMeter<Key extends LevelMeterKey>(
     : `${label} ?`;
   const motionFraction = isObserved ? level(value, field.domain) : null;
   const state: LevelMeterState = tx?.state ?? (isObserved ? 'current' : 'unknown');
+  const evidence: LevelMeterEvidence = tx?.evidence
+    ?? (isObserved ? { state: 'current', value } : { state: 'unknown' });
 
   return {
     key,
@@ -137,6 +155,7 @@ function projectLevelMeter<Key extends LevelMeterKey>(
     relevant: field.relevant,
     observed: isObserved,
     state,
+    evidence,
     domain: field.domain,
     motionFraction,
     displayText,

--- a/frontend/src/semantic/meter-renderer-view.ts
+++ b/frontend/src/semantic/meter-renderer-view.ts
@@ -1,4 +1,6 @@
 import type {
+  LevelMeterRendererView,
+  MeterNumericEvidence,
   MeterDisplayDomain,
   SignalMeterEvidence,
   SignalMeterMark,
@@ -8,6 +10,7 @@ import type {
 import type { SignalMeterFrame } from '../components-v2/meters/signal-meter-motion.svelte';
 import { projectSignalMeter } from '../components-v2/meters/smeter-scale';
 import type { MeterReading, MeterValueDomain } from './radio-view-model';
+import type { StationLevelMeterFrame } from './StationMeterInstrumentHost.svelte';
 
 function validFraction(value: number | null): boolean {
   return value === null || (Number.isFinite(value) && value >= 0 && value <= 1);
@@ -51,6 +54,7 @@ export function toSignalMeterRendererView(
   frame: SignalMeterFrame,
   reading: MeterReading,
   domain: MeterValueDomain | undefined,
+  relevant?: boolean,
 ): SignalMeterRendererView {
   const current = reading.status === 'known' && Number.isFinite(reading.value);
   const projection = domain === undefined
@@ -69,6 +73,7 @@ export function toSignalMeterRendererView(
   return Object.freeze({
     kind: 'signal',
     evidence: evidence(reading, publicDomain),
+    ...(relevant === undefined ? {} : { relevant }),
     scaleMode: validStaticGeometry ? projection.scaleMode : 'none',
     displayedFraction: live ? frame.smoothedFraction : null,
     peakFraction: live ? frame.peakFraction : null,
@@ -79,4 +84,58 @@ export function toSignalMeterRendererView(
     marks: validStaticGeometry ? marks(projection.marks) : Object.freeze([]),
     ticks: validStaticGeometry ? ticks(projection.ticks) : Object.freeze([]),
   });
+}
+
+function levelEvidence(
+  frame: StationLevelMeterFrame,
+  domain: MeterDisplayDomain,
+): MeterNumericEvidence {
+  const evidence = frame.projection.evidence;
+  if ((evidence.state === 'current' || evidence.state === 'stale')
+    && Number.isFinite(evidence.value)) {
+    return Object.freeze({ state: evidence.state, value: evidence.value, domain });
+  }
+  return Object.freeze({
+    state: evidence.state === 'current' || evidence.state === 'stale'
+      ? 'unknown' : evidence.state,
+    domain,
+  });
+}
+
+/** Copy one Core-owned station frame into the smaller public, immutable renderer graph. */
+export function toLevelMeterRendererView(
+  frame: StationLevelMeterFrame,
+): LevelMeterRendererView {
+  const projection = frame.projection;
+  const domain = displayDomain(projection.domain);
+  const publicEvidence = levelEvidence(frame, domain);
+  const live = publicEvidence.state === 'current'
+    && projection.motionFraction !== null
+    && validFraction(projection.motionFraction)
+    && validFraction(frame.motion.smoothedFraction);
+  const base = {
+    kind: 'level' as const,
+    key: projection.key,
+    label: projection.label,
+    evidence: publicEvidence,
+    relevant: projection.relevant,
+    observed: projection.observed,
+    displayedFraction: live ? frame.motion.smoothedFraction : null,
+    peakFraction: live && projection.showPeak && validFraction(frame.motion.peakFraction)
+      ? frame.motion.peakFraction : null,
+    displayText: projection.displayText,
+    stateText: projection.stateText,
+    ...(projection.accessibleDescription === undefined
+      ? {} : { accessibleDescription: projection.accessibleDescription }),
+    gauge: projection.gauge,
+    fault: projection.fault,
+    peakEnabled: projection.showPeak,
+  };
+  return projection.key === 'swr'
+    ? Object.freeze({
+        ...base,
+        key: 'swr',
+        ratioScale: (projection as StationLevelMeterFrame<'swr'>['projection']).ratioScale,
+      })
+    : Object.freeze(base) as LevelMeterRendererView;
 }


### PR DESCRIPTION
Root file-count waiver: exact coordinator-approved 10-path lease; 10 code/test paths and 0 regenerated baselines.

## Linear owner

MOR-2425, M2-4C station public-meter integration.

## Summary

- retain projector-owned current and stale numeric evidence without changing native live-value admission
- copy source-stripped station signal and all six level views into the frozen public meter graph
- reuse the existing MeterRendererSeat for signal and level appearances, attaching only host-owned finite reset leases
- route all seats inside the unchanged station continuation, including standalone external SWR while preserving the native composite
- prove native/external structural matrices, real fixture evidence, reset A-B-A revocation, stable owner counts, and unchanged direct consumers

The implementation remains based on accepted M2-4B merge b1efd8d7ce96eafd7841cc24ccb17c67146d1e83. Current main advancement is file-disjoint from this exact lease.

## Verification

- RED: 3 expected failures for missing level evidence and public level copy; 21 passed
- focused and unchanged consumer matrix: 12 files, 528 tests passed
- independent correction mutation: raw unavailable-known signal admission fails the new regression 1/19; restored guarded admission passes 19/19 and the 3-file direct set 201/201
- npm run check: 0 errors, 0 warnings
- scoped ESLint: passed
- production build: passed with existing chunk warnings
- cold Chromium desktop geometry smoke: 40 passed
- git diff --check: passed
- mechanism audit: no second projector, selector, clock, timer, reset abstraction, or source/session comparison

## Completion boundary

This completes M2-4C Core station consumption only. It does not expose station handles through the public face family, change layouts, install Instrument Line, or complete M2-3B/MOR-2425.

## Exact-head acceptance and history

- Predecessor `2790837657f389fcaf4edc3caaa4ed93ccbd5c50`: natural quick 34103990656 and visual 34103990622 succeeded, but independent review [5568313205](https://github.com/rigplane/rigplane-core/pull/3336#issuecomment-5568313205) was BLOCKED for missing unavailable-known station-signal regression coverage. That verdict remains part of the history.
- Final `6b7062a127d1f26fafa1bb41ca23547a290951d3`: 10 code/test paths, 518 additions + 38 deletions = 556 A+D; zero baseline changes. The successor adds the missing discriminating regression without changing the previously reviewed production code.
- Final natural [quick 34105381523](https://github.com/rigplane/rigplane-core/actions/runs/34105381523) SUCCESS and [visual 34105381946](https://github.com/rigplane/rigplane-core/actions/runs/34105381946) SUCCESS. Fresh independent [PASS 5568457389](https://github.com/rigplane/rigplane-core/pull/3336#issuecomment-5568457389) binds the final head.
- Root read the complete final source/test diff, implementation and mechanics reports, independent review, and exact directive; verified both required branch contexts, Agent Review Gate and quick, as successful. The optional quick-v2 metadata observer failed to bind legacy metadata and left its observation pending; it is not a required context or a candidate test failure. No check was bypassed or rerun for this closeout.
