### PR TITLE
feat(MOR-2425): host Band frequency entry

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -335,6 +335,9 @@
 {#snippet bandControlLayout(bandInstruments: BandInstrumentHandles)}
   <div class="band-control-grid" data-testid="band-control-grid">
     <div class="band-control-seat" data-field="bandChoice">{@render bandInstruments.bandChoice()}</div>
+    <div class="band-control-seat" data-field="frequencyEntry">
+      {@render bandInstruments.frequencyEntry()}
+    </div>
   </div>
 {/snippet}
 

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
@@ -597,11 +597,11 @@ describe('RadioLayout structure', () => {
   });
 });
 
-describe('Band choice placement', () => {
+describe('Band instrument placement', () => {
   it.each([
     ['desktop-v2', true],
     ['sdr-test', false],
-  ] as const)('%s renders one choice before the one entry', (skinId, independent) => {
+  ] as const)('%s renders choice then entry exactly once', (skinId, independent) => {
     rt.state = structuredClone(stateFixture);
     rt.caps = structuredClone(capsFixture);
     const t = mountLayout(skinId);
@@ -614,6 +614,10 @@ describe('Band choice placement', () => {
     if (independent) {
       expect(grid?.querySelector('[data-field="bandChoice"] [data-testid="band-choices"]'))
         .not.toBeNull();
+      expect(grid?.querySelector('[data-field="frequencyEntry"] [data-testid="band-entry"]'))
+        .not.toBeNull();
+    } else {
+      expect(t.querySelector('[data-field="frequencyEntry"]')).toBeNull();
     }
     expect(choices[0]!.compareDocumentPosition(entries[0]!) & Node.DOCUMENT_POSITION_FOLLOWING)
       .toBeTruthy();

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -824,8 +824,7 @@
   let lastVfoFiniteAuthority: VfoFiniteAuthority | null | undefined;
   let lastFilterFiniteAuthority: FilterFiniteAuthority | null | undefined;
   let lastBandFiniteAuthority: BandFiniteAuthority | null | undefined;
-  const unsubscribeScopeFiniteAuthority = selectedFiniteAppearance === undefined ? undefined
-    : runtime.subscribeControlAuthority((publication) => {
+  const unsubscribeScopeFiniteAuthority = runtime.subscribeControlAuthority((publication) => {
       const next = scopeFiniteAuthority(publication.state, publication.caps, publication.session);
       if (!sameScopeFiniteAuthority(lastScopeFiniteAuthority, next)) {
         lastScopeFiniteAuthority = next;
@@ -1255,8 +1254,16 @@
     else tuneFrequency(active.receiver, choice.defaultHz, 'jump');
   }
   function enterFrequency(frequencyHz: number): void {
-    const active = view?.activeReceiver;
-    if (active?.status !== 'known') return;
+    const state = runtime.state, caps = runtime.caps, session = runtime.controlSession;
+    const model = toRadioViewModel(state, caps);
+    const authority = bandFiniteAuthority(state, caps, session);
+    const active = model?.activeReceiver;
+    const currentBand = model?.band;
+    if (authority === null || active?.status !== 'known'
+      || authority.activeReceiver !== active.receiver || currentBand === undefined
+      || currentBand.tuneMinHz === null || currentBand.tuneMaxHz === null
+      || !Number.isFinite(frequencyHz)
+      || frequencyHz < currentBand.tuneMinHz || frequencyHz > currentBand.tuneMaxHz) return;
     // MOR-1425 review round 2 (B1 residual): a typed frequency is the most
     // explicitly ABSOLUTE gesture in the UI — 'jump', same reasoning as
     // `selectBand` above.
@@ -1341,7 +1348,8 @@
   >
   {#snippet children(filterInstruments)}
   <BandInstrumentHost
-    {...bandFiniteRendererSelection} {view} onSelectBand={selectBand}
+    {...bandFiniteRendererSelection} {view} entryRendererContext={bandFiniteRendererContext}
+    onSelectBand={selectBand} onEnterFrequency={enterFrequency}
   >
   {#snippet children(bandInstruments)}
   <DspInstrumentHost
@@ -1824,7 +1832,7 @@
   -->
   {#snippet bandSurface(controlLayout?: BandControlLayout)}
     {#if view?.band}
-      <BandSurface {view} handles={bandInstruments} {controlLayout} onEnterFrequency={enterFrequency} />
+      <BandSurface {view} handles={bandInstruments} {controlLayout} />
     {/if}
   {/snippet}
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -416,6 +416,102 @@ describe('the live Band choice host uses current synchronous authority', () => {
   });
 });
 
+describe('the live Band frequency entry uses current synchronous authority', () => {
+  it('routes a retained pre-flush submit to the current receiver', () => {
+    render();
+    typeFrequency('7150000');
+    h.state = liveState({ active: 'SUB' } as Partial<ServerState>);
+
+    btn('entry-set')!.click();
+
+    expect(setFreqCalls()).toEqual([['set_freq', { freq: 7150000, receiver: 1 }]]);
+  });
+
+  it.each([
+    ['current bounds', () => {
+      h.caps = liveCaps([{ ...BAND_PLAN[0], start: 30000000, end: 60000000 }]);
+    }],
+    ['disconnected session', () => {
+      h.controlSession = { state: 'disconnected', epoch: 1 };
+    }],
+    ['provider mismatch', () => {
+      h.caps = { ...(h.caps as Capabilities), providerGeneration: 2 };
+    }],
+  ] as const)('refuses a retained pre-flush submit against %s', (_kind, invalidate) => {
+    render();
+    typeFrequency('14.200');
+    invalidate();
+
+    btn('entry-set')!.click();
+
+    expect(setFreqCalls()).toEqual([]);
+  });
+
+  it.each([
+    ['null', () => { h.controlSession = { state: 'disconnected', epoch: 1 }; },
+      () => { h.controlSession = { state: 'connected', epoch: 1 }; }],
+    ['session', () => { h.controlSession = { state: 'connected', epoch: 2 }; },
+      () => { h.controlSession = { state: 'connected', epoch: 1 }; }],
+    ['provider', () => {
+      h.state = { ...(h.state as ServerState), providerGeneration: 2 };
+      h.caps = { ...(h.caps as Capabilities), providerGeneration: 2 };
+    }, () => {
+      h.state = { ...(h.state as ServerState), providerGeneration: 1 };
+      h.caps = { ...(h.caps as Capabilities), providerGeneration: 1 };
+    }],
+    ['topology', () => {
+      h.caps = { ...(h.caps as Capabilities), receivers: 1, vfoScheme: 'single' };
+    }, () => {
+      h.caps = { ...(h.caps as Capabilities), receivers: 2, vfoScheme: 'main_sub' };
+    }],
+  ] as const)('keeps draft but revokes stale commands through %s A-B-A', (_kind, toB, toA) => {
+    render();
+    typeFrequency('7.100');
+    const retainedInput = q<HTMLInputElement>('[data-testid="band-entry-input"]')!;
+    const retainedSet = btn('entry-set')!;
+
+    toB(); publishAuthority();
+    toA(); publishAuthority();
+    retainedInput.value = '14.200';
+    retainedInput.dispatchEvent(new Event('input', { bubbles: true }));
+    retainedSet.click();
+
+    expect(setFreqCalls()).toEqual([]);
+    flushSync();
+    expect(q<HTMLInputElement>('[data-testid="band-entry-input"]')!.value).toBe('7.100');
+    btn('entry-set')!.click();
+    expect(setFreqCalls()).toEqual([['set_freq', { freq: 7100000, receiver: 0 }]]);
+  });
+
+  it('keeps draft but revokes the old renderer through coalesced structural A-absent-A', () => {
+    render();
+    typeFrequency('7.100');
+    const retainedInput = q<HTMLInputElement>('[data-testid="band-entry-input"]')!;
+    const retainedSet = btn('entry-set')!;
+
+    h.caps = liveCaps([]);
+    publishAuthority();
+    h.caps = liveCaps(BAND_PLAN);
+    publishAuthority();
+    flushSync();
+
+    const currentInput = q<HTMLInputElement>('[data-testid="band-entry-input"]')!;
+    expect(currentInput).not.toBe(retainedInput);
+    expect(currentInput.value).toBe('7.100');
+    expect(setFreqCalls()).toEqual([]);
+
+    retainedInput.value = '14.200';
+    retainedInput.dispatchEvent(new Event('input', { bubbles: true }));
+    retainedSet.click();
+    expect(currentInput.value).toBe('7.100');
+    expect(setFreqCalls()).toEqual([]);
+
+    h.state = liveState({ active: 'SUB' } as Partial<ServerState>);
+    btn('entry-set')!.click();
+    expect(setFreqCalls()).toEqual([['set_freq', { freq: 7100000, receiver: 1 }]]);
+  });
+});
+
 /*
  * ── MOR-1425 review round 2 (B1 residual) ──────────────────────────────
  *

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -370,11 +370,11 @@ describe('the meters surface mounts only when the view model carries the group',
   it('keeps one station host across delayed dual-receiver authority', () => {
     h.deferAuthority = true;
     render({ strips: 'dual' });
-    expect(h.authoritySubscribers.size).toBe(4);
+    expect(h.authoritySubscribers.size).toBe(5);
     expect(() => push({})).not.toThrow();
     expect(target.querySelectorAll('[data-testid="semantic-radio-surfaces"]')).toHaveLength(1);
     expect(target.querySelectorAll('[data-testid="meters-surface"]')).toHaveLength(1);
-    expect(h.authoritySubscribers.size).toBe(4);
+    expect(h.authoritySubscribers.size).toBe(5);
   });
 
   it('keeps mounted meter shells but clears readings across a provider generation mismatch', () => {

--- a/frontend/src/components-v2/wiring/__tests__/semantic-pbt-continuity.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-pbt-continuity.component.test.ts
@@ -53,7 +53,7 @@ describe('mounted PBT continuity is fenced by the live control session (MOR-1706
     render(); const initialInner = value('pbtInner'), initialOuter = value('pbtOuter'); expect(initialInner).not.toBeNull(); expect(initialOuter).not.toBeNull(); expect(h.commands).not.toHaveBeenCalled();
     const staleInput = target.querySelector<HTMLInputElement>('[data-testid="filter-pbtInner"] input'); expect(staleInput).not.toBeNull();
     accept(state(null, -200, 2)); flushSync(); expect(value('pbtInner')).toBe(initialInner); expect(value('pbtOuter')).toBe(initialOuter);
-    expect(h.listeners.size).toBe(5); transition('disconnected', 1, false); transition('connected', 1, false); flushSync(); expect(value('pbtInner')).toBeNull(); expect(value('pbtOuter')).toBeNull();
+    expect(h.listeners.size).toBe(6); transition('disconnected', 1, false); transition('connected', 1, false); flushSync(); expect(value('pbtInner')).toBeNull(); expect(value('pbtOuter')).toBeNull();
     staleInput!.value = '500'; staleInput!.dispatchEvent(new Event('input', { bubbles: true })); flushSync(); expect(h.commands).not.toHaveBeenCalled(); expect(txHarness.trace()).toEqual([]);
     transition('connected', 1); expect(value('pbtInner')).toBeNull(); accept(state(300, -400, 3)); flushSync(); expect(value('pbtInner')).not.toBeNull();
     transition('connected', 2); expect(value('pbtInner')).toBeNull(); accept(state(500, -600, 4)); flushSync(); expect(value('pbtOuter')).not.toBeNull();

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
@@ -371,7 +371,7 @@ describe('the hosted AF owner survives replaceable presentation layouts', () => 
     expect(target.querySelector('[data-af-layout="independent"]')).not.toBeNull();
     expect(target.querySelectorAll('[role="slider"][aria-label="AF"]')).toHaveLength(1);
     expect([...h.authoritySubscribers]).toEqual(originalSubscribers);
-    expect(h.authoritySubscribers.size).toBe(4);
+    expect(h.authoritySubscribers.size).toBe(5);
     expect(newSlider.closest<HTMLElement>('.vc-hbar')!.style
       .getPropertyValue('--vc-fill-percent')).toBe('42%');
     expect(newSlider.getAttribute('aria-valuenow')).toBe('0.42');

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
@@ -526,7 +526,7 @@ describe('selected finite Scope authority lifetime (MOR-2425)', () => {
     render();
     expect(el('scope-hold')).not.toBeNull();
     expect(el('external-HOLD')).toBeNull();
-    expect(h.authoritySubscribers.size).toBe(4);
+    expect(h.authoritySubscribers.size).toBe(5);
   });
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -307,7 +307,7 @@ describe('production receiver-indicator partitioning', () => {
   ) => {
     selectedFrequency.current = AlternateFrequencyReadoutHarness as FrequencyRenderer;
     render(caps('main_sub', 2), state(), {}, props);
-    expect(h.authoritySubscribers.size).toBe(4);
+    expect(h.authoritySubscribers.size).toBe(5);
     const digit = projectFrequencyReadout({ confirmedHz: 14_200_000 }).digits[0];
     const first = retainedInteractions().find((interaction) => !interaction.inert)!;
     first.handleDigitClick(digit, new MouseEvent('click'));

--- a/frontend/src/primitives/frequency/frequency-entry-renderer.svelte.ts
+++ b/frontend/src/primitives/frequency/frequency-entry-renderer.svelte.ts
@@ -1,0 +1,85 @@
+import type {
+  FiniteRendererContext, FiniteRendererSeat,
+} from '../control-instruments/control-instrument-renderer.svelte';
+
+export type FrequencyEntryValidation = 'empty' | 'accepted' | 'rejected' | 'unavailable';
+
+export interface FrequencyEntryRendererView {
+  readonly label: string;
+  readonly draft: string;
+  readonly validation: FrequencyEntryValidation;
+  readonly boundsAvailable: boolean;
+  readonly interpretedHz: number | null;
+  readonly inputAvailable: boolean;
+  readonly submitAvailable: boolean;
+  readonly hint: string;
+  readonly rangeText: string;
+  readonly unavailableReason?: string;
+}
+
+export interface FrequencyEntryRendererLease {
+  readonly active: boolean;
+  readonly view: Readonly<FrequencyEntryRendererView> | undefined;
+  setDraft(raw: string): void;
+  submit(): void;
+  cancel(): void;
+  handleKeyDown(event: KeyboardEvent): void;
+  dispose(): void;
+}
+
+export interface FrequencyEntryRendererProps {
+  readonly lease: FrequencyEntryRendererLease;
+}
+
+export interface FrequencyEntryRendererInput {
+  readonly context: FiniteRendererContext | null;
+  readonly view: Readonly<FrequencyEntryRendererView>;
+  setDraft(raw: string): void;
+  submit(): void;
+  cancel(): void;
+  handleKeyDown(event: KeyboardEvent): void;
+}
+
+export type FrequencyEntryRendererSeat = FiniteRendererSeat<FrequencyEntryRendererLease>;
+
+export function createFrequencyEntryRendererSeat(
+  readCurrent: () => FrequencyEntryRendererInput,
+): FrequencyEntryRendererSeat {
+  let destroyed = false;
+  const revokers = new Set<() => void>();
+  return {
+    attachRenderer() {
+      const captured = readCurrent().context;
+      let revoked = captured === null;
+      const revoke = () => {
+        if (revoked) return;
+        revoked = true;
+        revokers.delete(revoke);
+      };
+      if (!revoked) revokers.add(revoke);
+      const current = () => {
+        if (destroyed || revoked) return undefined;
+        const next = readCurrent();
+        if (next.context === null || !Object.is(next.context, captured)) {
+          revoke();
+          return undefined;
+        }
+        return next;
+      };
+      return {
+        get active() { return current() !== undefined; },
+        get view() { return current()?.view; },
+        setDraft(raw) { current()?.setDraft(raw); },
+        submit() { current()?.submit(); },
+        cancel() { current()?.cancel(); },
+        handleKeyDown(event) { current()?.handleKeyDown(event); },
+        dispose: revoke,
+      };
+    },
+    destroy() {
+      if (destroyed) return;
+      destroyed = true;
+      for (const revoke of [...revokers]) revoke();
+    },
+  };
+}

--- a/frontend/src/semantic/BandFrequencyEntry.svelte
+++ b/frontend/src/semantic/BandFrequencyEntry.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import type {
+    FrequencyEntryRendererLease,
+  } from '../primitives/frequency/frequency-entry-renderer.svelte';
+
+  let { lease }: { lease: FrequencyEntryRendererLease } = $props();
+  let entry = $derived(lease.view);
+</script>
+
+{#if entry}
+  <label class="band-row" data-testid="band-entry" data-bounds={entry.boundsAvailable}
+    data-validation={entry.validation}>
+    <span class="band-name">{entry.label}</span>
+    <input
+      type="text" inputmode="decimal" data-testid="band-entry-input" data-freq-entry
+      value={entry.draft} disabled={!entry.inputAvailable}
+      oninput={(event) => lease.setDraft(event.currentTarget.value)}
+      onkeydown={(event) => lease.handleKeyDown(event)}
+    />
+    {#if entry.hint}<span data-testid="band-entry-hint">{entry.hint}</span>{/if}
+    <span data-testid="band-entry-range">{entry.rangeText}</span>
+    <button type="button" data-testid="band-entry-set" disabled={!entry.submitAvailable}
+      onclick={() => lease.submit()}>Set</button>
+    {#if entry.unavailableReason}
+      <span data-testid="band-entry-reason">{entry.unavailableReason}</span>
+    {/if}
+  </label>
+{/if}
+
+<style>
+  .band-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin: 0; }
+  .band-name { min-width: 7ch; }
+  button:disabled, input:disabled { cursor: not-allowed; }
+</style>

--- a/frontend/src/semantic/BandInstrumentHost.svelte
+++ b/frontend/src/semantic/BandInstrumentHost.svelte
@@ -1,18 +1,30 @@
 <script lang="ts">
-  import { onDestroy, type Snippet } from 'svelte';
+  import { onDestroy, type Component, type Snippet } from 'svelte';
+  import { t } from '$lib/i18n';
   import { bindAbsoluteChoiceInstrument } from '../primitives/control-instruments/control-instrument-behavior';
   import ControlInstrumentRendererHost from '../primitives/control-instruments/ControlInstrumentRendererHost.svelte';
   import {
-    createAbsoluteChoiceRendererSeat,
+    createAbsoluteChoiceRendererSeat, createFiniteRendererContext,
     type FiniteControlAppearance,
     type FiniteRendererContext,
   } from '../primitives/control-instruments/control-instrument-renderer.svelte';
-  import { defaultPermitLabel, type BandInstrumentHandles } from './band-instruments';
+  import {
+    createFrequencyEntryRendererSeat,
+    type FrequencyEntryRendererProps,
+  } from '../primitives/frequency/frequency-entry-renderer.svelte';
+  import BandFrequencyEntry from './BandFrequencyEntry.svelte';
+  import {
+    defaultPermitLabel, interpretFrequencyEntry, mhz, UNKNOWN_TEXT,
+    type BandInstrumentHandles,
+  } from './band-instruments';
   import type { RadioViewModel } from './radio-view-model';
 
   interface ExistingProps {
     view: RadioViewModel | null;
     onSelectBand?: (name: string) => void;
+    onEnterFrequency?: (frequencyHz: number) => void;
+    entryRendererContext?: FiniteRendererContext | null;
+    entryRenderer?: Component<FrequencyEntryRendererProps>;
     children: Snippet<[BandInstrumentHandles]>;
   }
   type RendererSelection = { finiteAppearance?: undefined; rendererContext?: undefined } | {
@@ -21,9 +33,42 @@
   };
   type Props = ExistingProps & RendererSelection;
 
-  let { view, onSelectBand, finiteAppearance, rendererContext, children }: Props = $props();
+  let {
+    view, onSelectBand, onEnterFrequency, finiteAppearance, rendererContext,
+    entryRendererContext, entryRenderer, children,
+  }: Props = $props();
   let band = $derived(view?.band);
   let receiverKnown = $derived(view?.activeReceiver.status === 'known');
+  let boundsKnown = $derived(
+    band !== undefined && band.tuneMinHz !== null && band.tuneMaxHz !== null,
+  );
+  let entryAuthorityAvailable = $derived(entryRendererContext !== null);
+  let entryText = $state('');
+  let bandWasPresent = $state<boolean | undefined>(undefined);
+  let interpretedHz = $derived(
+    boundsKnown && band?.tuneMinHz != null && band?.tuneMaxHz != null
+      ? interpretFrequencyEntry(entryText, band.tuneMinHz, band.tuneMaxHz) : null,
+  );
+  let entryReady = $derived(
+    entryAuthorityAvailable && receiverKnown && boundsKnown && interpretedHz !== null,
+  );
+  let entryValidation = $derived(
+    !entryAuthorityAvailable || !receiverKnown || !boundsKnown ? 'unavailable' as const
+      : entryText.trim() === '' ? 'empty' as const
+        : interpretedHz === null ? 'rejected' as const : 'accepted' as const,
+  );
+  let entryHint = $derived(entryReady && interpretedHz !== null ? `→ ${mhz(interpretedHz)}` : '');
+  let entryRangeText = $derived(boundsKnown && band?.tuneMinHz != null && band?.tuneMaxHz != null
+    ? `${mhz(band.tuneMinHz)} … ${mhz(band.tuneMaxHz)}` : UNKNOWN_TEXT);
+  let entryUnavailableReason = $derived(!boundsKnown
+    ? t('core.band.entry.reason.boundsUnknown')
+    : !receiverKnown ? t('core.band.entry.reason.receiverUnconfirmed') : undefined);
+
+  $effect(() => {
+    const present = band !== undefined;
+    if (bandWasPresent === true && !present) entryText = '';
+    bandWasPresent = present;
+  });
 
   const selectBand = (name: string): void => {
     const choice = band?.bandChoices.find(candidate => candidate.name === name);
@@ -46,7 +91,59 @@
     })),
     invoke: selectBand,
   }));
-  onDestroy(() => bandChoiceSeat.destroy());
+  const fallbackEntryContext = createFiniteRendererContext();
+  let entryContext = $derived(band === undefined ? null
+    : entryRendererContext ?? fallbackEntryContext);
+  const frequencyEntrySeat = createFrequencyEntryRendererSeat(() => ({
+    context: entryContext,
+    view: {
+      label: 'FREQ', draft: entryText, validation: entryValidation,
+      boundsAvailable: boundsKnown, interpretedHz,
+      inputAvailable: entryAuthorityAvailable && receiverKnown && boundsKnown,
+      submitAvailable: entryReady,
+      hint: entryHint, rangeText: entryRangeText,
+      ...(entryUnavailableReason === undefined ? {} : { unavailableReason: entryUnavailableReason }),
+    },
+    setDraft: (raw) => { if (entryIsAvailable()) entryText = raw; },
+    submit: commitFrequency,
+    cancel: cancelEntry,
+    handleKeyDown: handleEntryKeydown,
+  }));
+  onDestroy(() => {
+    bandChoiceSeat.destroy();
+    frequencyEntrySeat.destroy();
+  });
+
+  function entryIsAvailable(): boolean {
+    const currentBand = view?.band;
+    return entryRendererContext !== null && view?.activeReceiver.status === 'known'
+      && currentBand !== undefined
+      && currentBand.tuneMinHz !== null && currentBand.tuneMaxHz !== null;
+  }
+
+  function commitFrequency(): void {
+    const currentBand = view?.band;
+    if (!entryIsAvailable() || currentBand?.tuneMinHz == null || currentBand.tuneMaxHz == null) return;
+    const currentHz = interpretFrequencyEntry(entryText, currentBand.tuneMinHz, currentBand.tuneMaxHz);
+    if (currentHz !== null) onEnterFrequency?.(currentHz);
+  }
+
+  function cancelEntry(): void {
+    entryText = '';
+  }
+
+  function handleEntryKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      event.stopPropagation();
+      commitFrequency();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      cancelEntry();
+      if (event.currentTarget instanceof HTMLElement) event.currentTarget.blur();
+    }
+  }
 </script>
 
 {#snippet externalChoice()}
@@ -76,7 +173,15 @@
   {/if}
 {/snippet}
 
-{@render children({ bandChoice })}
+{#snippet frequencyEntry()}
+  {#if band}
+    {#key entryContext}{#key entryRenderer}<ControlInstrumentRendererHost
+      seat={frequencyEntrySeat} renderer={entryRenderer ?? BandFrequencyEntry}
+    />{/key}{/key}
+  {/if}
+{/snippet}
+
+{@render children({ bandChoice, frequencyEntry })}
 
 <style>
   .band-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin: 0; }

--- a/frontend/src/semantic/BandSurface.svelte
+++ b/frontend/src/semantic/BandSurface.svelte
@@ -3,9 +3,9 @@
 
   Presentation only. It renders the MOR-1294 `band` fact group — the current
   band, the capability-derived band choice set, the live TX permit and the
-  tuning envelope — and emits intents as callbacks. It holds no state beyond
-  the operator's own unsubmitted keystrokes, consults no controller and owns
-  no command path.
+  tuning envelope — and emits intents as callbacks. The retained
+  `BandInstrumentHost` owns the operator's unsubmitted entry draft; this
+  surface consults no controller and owns no command path.
 
   SAFETY-ADJACENT. This surface renders TX-PERMISSION information: a fail-open
   bug here tells an operator "you may transmit" where transmission is not
@@ -54,11 +54,10 @@
   import { t } from '$lib/i18n';
   import type { BandField, DisabledReasonCode, RadioViewModel } from './radio-view-model';
   import type { BandControlLayout, BandInstrumentHandles } from './band-instruments';
-  import { mhz } from './band-instruments';
-  export { defaultPermitLabel, mhz } from './band-instruments';
-
-  /** The ONE rendering of "not measured". Never a band name, never a number. */
-  export const UNKNOWN_TEXT = '—';
+  import { UNKNOWN_TEXT } from './band-instruments';
+  export {
+    defaultPermitLabel, interpretFrequencyEntry, mhz, UNKNOWN_TEXT,
+  } from './band-instruments';
 
   /** The `disabledReasons` codes that can EXPLAIN a TX denial, in the order
    *  they are preferred. Rule (3): explanation only — the denial itself is
@@ -108,46 +107,6 @@
     f.reading.status === 'known' ? String(f.reading.value) : UNKNOWN_TEXT;
   export const isCurrent = (f: BandField<string>, name: string): boolean =>
     f.reading.status === 'known' && f.reading.value === name;
-
-  /**
-   * MOR-1462 (owner ruling B) — the standard ham direct-entry heuristic. A
-   * decimal point always means MHz, parsed as an EXACT DECIMAL STRING to
-   * integer Hz (never `Number(text) * 1e6` — a float round-trip can miss
-   * the exact Hz a double cannot represent, which rule 5's boundary
-   * comparison must never lose a digit to). A bare integer is read as kHz
-   * when that reading falls inside the radio's declared tunable range, Hz
-   * when only the raw reading does, and kHz WINS when both do (the
-   * ambiguous case — e.g. a range wide enough that both `7100` and
-   * `7100`×1000 are in-band). `null` means the SAME visible refusal a
-   * malformed or out-of-range entry already produced (rule 5, unrelaxed):
-   * `entryReady` stays false and nothing dispatches.
-   */
-  export function interpretFrequencyEntry(
-    raw: string, minHz: number, maxHz: number,
-  ): number | null {
-    const text = raw.trim();
-    if (text === '' || !Number.isFinite(minHz) || !Number.isFinite(maxHz)) return null;
-    if (text.includes('.')) return parseMhzToHz(text, minHz, maxHz);
-    if (!/^\d+$/.test(text)) return null;
-    const value = Number(text);
-    const asKhz = value * 1000;
-    if (asKhz >= minHz && asKhz <= maxHz) return asKhz;
-    if (value >= minHz && value <= maxHz) return value;
-    return null;
-  }
-
-  /** MHz decimal string -> exact integer Hz by scaling the DIGITS
-   *  themselves, so `14.0741` lands on exactly 14074100 with no
-   *  double-precision round-trip. More than 6 fractional digits is finer
-   *  than 1 Hz and is refused outright, same as an out-of-range value. */
-  function parseMhzToHz(text: string, minHz: number, maxHz: number): number | null {
-    const match = /^(\d+)\.(\d+)$/.exec(text);
-    if (!match) return null;
-    const [, whole, frac] = match;
-    if (frac.length > 6) return null;
-    const hz = Number(whole) * 1_000_000 + Number(frac.padEnd(6, '0'));
-    return hz >= minHz && hz <= maxHz ? hz : null;
-  }
 
   /** Rule (3): consulted ONLY once `currentBandTx` already said `denied` (or,
    *  from the fix-round F1 caveat, once the authoritative `txPermit` itself is
@@ -210,85 +169,11 @@
     view: RadioViewModel;
     handles: BandInstrumentHandles;
     controlLayout?: BandControlLayout;
-    onEnterFrequency?: (frequencyHz: number) => void;
   }
-  let { view, handles, controlLayout, onEnterFrequency }: Props = $props();
+  let { view, handles, controlLayout }: Props = $props();
 
   /** Absent group ⇒ this surface renders nothing (S0 optional-group doctrine). */
   let band = $derived(view.band);
-  /** Rule (4). */
-  let receiverKnown = $derived(view.activeReceiver.status === 'known');
-  /** Rule (5). */
-  let boundsKnown = $derived(
-    band !== undefined && band.tuneMinHz !== null && band.tuneMaxHz !== null,
-  );
-  /** The operator's raw keystrokes, kept as typed: an empty or malformed entry
-   *  must stay refusable rather than coerce to 0 Hz. */
-  let entryText = $state('');
-  /** MOR-1462: the smart kHz/MHz/Hz interpretation of `entryText`, or `null`
-   *  while it cannot resolve to an in-range Hz value. Bounds must be KNOWN
-   *  first (rule 5) — this stays `null`, never a guess, until they are. */
-  let interpretedHz = $derived(
-    boundsKnown && band?.tuneMinHz != null && band?.tuneMaxHz != null
-      ? interpretFrequencyEntry(entryText, band.tuneMinHz, band.tuneMaxHz)
-      : null,
-  );
-  let entryReady = $derived(receiverKnown && boundsKnown && interpretedHz !== null);
-  /** The operator-visible confirmation of what their keystrokes resolved to
-   *  — shown before commit so a kHz/MHz/Hz misread is caught before it
-   *  tunes, per the ticket's own "→ 7.100 MHz" example. Gated on
-   *  `entryReady` (review hardening), not just a resolvable `interpretedHz`
-   *  — otherwise a valid-looking target could render next to a Set button
-   *  the receiver-unknown gate has permanently disabled. */
-  let entryHint = $derived(
-    entryReady && interpretedHz !== null ? `→ ${mhz(interpretedHz)}` : '',
-  );
-
-  function commitFrequency(): void {
-    if (!entryReady || interpretedHz === null) return;
-    onEnterFrequency?.(interpretedHz);
-  }
-  /** MOR-1444: Escape cancels a typed entry — clears the keystrokes without
-   *  dispatching, mirroring the "never coerce a malformed entry" rule above
-   *  rather than adding a second dispatch guard. */
-  function cancelEntry(): void {
-    entryText = '';
-  }
-  /** MOR-1444: Enter commits through the same `commitFrequency` path (and
-   *  therefore the same `entryReady` guard) the Set button already uses;
-   *  Escape cancels. Template-only wiring — no new prop, import or hook. */
-  function handleEntryKeydown(event: KeyboardEvent): void {
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      // Round-3 review: preventDefault() alone never stops propagation —
-      // harmless here (Enter has no shipped window-level binding today),
-      // but this key is not itself the safety property, so it gets the
-      // same treatment as Escape rather than relying on that being true.
-      event.stopPropagation();
-      commitFrequency();
-    } else if (event.key === 'Escape') {
-      event.preventDefault();
-      // Round-3 review (REQUIRED FIX): preventDefault() does NOT stop
-      // propagation. Every rig profile ships "Escape -> clear_rit_xit"
-      // (rigs/_keyboard-default.toml) on KeyboardHandler's window-level
-      // listener. Without stopPropagation, this keydown — after the blur
-      // below already moved document.activeElement off the (ignored-tag)
-      // input — would bubble to that listener and fire a REAL radio write
-      // (makeRitXitHandlers().onClear()), silently clearing the operator's
-      // RIT/XIT offset on a frequency-entry cancel. The ticket's "Esc
-      // cancels entry without dispatch" means this dispatch too.
-      event.stopPropagation();
-      cancelEntry();
-      // Round-2 review, recorder item 3: leaving focus in the (now-empty)
-      // input keeps it an "ignored tag" for KeyboardHandler's
-      // shouldIgnoreEvent, silently suppressing band hotkeys until a Tab.
-      // Blurring un-suppresses them immediately. This does not attempt to
-      // return focus to wherever the gesture started (this file has no
-      // reference to that, and the entry may have been reached without one)
-      // — the next Tab resumes from the document's normal order.
-      if (event.currentTarget instanceof HTMLElement) event.currentTarget.blur();
-    }
-  }
 </script>
 
 {#if band}
@@ -322,43 +207,12 @@
       {/if}
     </p>
 
-    {#if controlLayout}{@render controlLayout(handles)}{:else}{@render handles.bandChoice()}{/if}
-
-    <label class="band-row" data-testid="band-entry" data-bounds={boundsKnown}>
-      <span class="band-name">FREQ</span>
-      <!-- MOR-1462: type="text"/inputmode="decimal" rather than
-           type="number" — the smart interpretation accepts kHz-scale
-           keystrokes numerically far below `tuneMinHz` (a valid kHz entry
-           for a band whose bounds are stated in Hz), which a native
-           number-input min/max would flag as invalid despite being
-           correct; unit resolution is entirely this file's own JS-side
-           `interpretFrequencyEntry`, not the browser's. The
-           `[data-freq-entry]` hook and the reset-on-first-digit routing in
-           KeyboardHandler.svelte are type-agnostic (`.value =`/`input`
-           event only) and are unaffected by this change. -->
-      <input
-        type="text" inputmode="decimal" data-testid="band-entry-input" data-freq-entry
-        value={entryText} disabled={!receiverKnown || !boundsKnown}
-        oninput={(event) => { entryText = event.currentTarget.value; }}
-        onkeydown={handleEntryKeydown}
-      />
-      {#if entryHint}
-        <span data-testid="band-entry-hint">{entryHint}</span>
-      {/if}
-      <span data-testid="band-entry-range">{boundsKnown && band.tuneMinHz !== null
-        && band.tuneMaxHz !== null
-        ? `${mhz(band.tuneMinHz)} … ${mhz(band.tuneMaxHz)}`
-        : UNKNOWN_TEXT}</span>
-      <button
-        type="button" data-testid="band-entry-set" disabled={!entryReady}
-        onclick={commitFrequency}
-      >Set</button>
-      {#if !boundsKnown || !receiverKnown}
-        <span data-testid="band-entry-reason">{boundsKnown
-          ? t('core.band.entry.reason.receiverUnconfirmed')
-          : t('core.band.entry.reason.boundsUnknown')}</span>
-      {/if}
-    </label>
+    {#if controlLayout}
+      {@render controlLayout(handles)}
+    {:else}
+      {@render handles.bandChoice()}
+      {@render handles.frequencyEntry()}
+    {/if}
   </section>
 {/if}
 
@@ -371,5 +225,4 @@
   /* Second channel beside `data-observed`/`data-tx`, never the only one: the
      rendered word itself is the primary one and survives forced-colors. */
   [data-observed='false'] { font-style: italic; }
-  input:disabled { cursor: not-allowed; }
 </style>

--- a/frontend/src/semantic/__tests__/BandInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/BandInstrumentHost.isolated.test.ts
@@ -5,6 +5,9 @@ import { proxy } from 'svelte/internal/client';
 import {
   createFiniteRendererContext, type FiniteControlAppearance,
 } from '../../primitives/control-instruments/control-instrument-renderer.svelte';
+import {
+  createFrequencyEntryRendererSeat,
+} from '../../primitives/frequency/frequency-entry-renderer.svelte';
 import FiniteControlRendererFixture, {
   resetRetainedInvocations, retainedInvocations,
 } from '../../primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte';
@@ -37,9 +40,16 @@ beforeEach(() => {
 });
 afterEach(() => target.remove());
 
+const input = () => target.querySelector<HTMLInputElement>('[data-testid="band-entry-input"]')!;
+const typeFrequency = (value: string) => {
+  input().value = value;
+  input().dispatchEvent(new Event('input', { bubbles: true }));
+  flushSync();
+};
+
 describe('BandInstrumentHost', () => {
   it.each(['grouped', 'independent'] as const)(
-    'renders its choice handle exactly once in the %s placement',
+    'renders choice then entry exactly once in the %s placement',
     (presentation) => {
       const component = mount(BandInstrumentHostFixture, {
         target, props: { view: base(), presentation },
@@ -47,9 +57,14 @@ describe('BandInstrumentHost', () => {
       flushSync();
       expect(target.querySelectorAll('[data-testid="band-choices"]')).toHaveLength(1);
       expect(target.querySelectorAll('[data-testid="band-choice-20m"]')).toHaveLength(1);
+      expect(target.querySelectorAll('[data-testid="band-entry"]')).toHaveLength(1);
       if (presentation === 'independent') {
         expect(target.querySelector('[data-slot="choice"] [data-testid="band-choices"]')).not.toBeNull();
+        expect(target.querySelector('[data-slot="entry"] [data-testid="band-entry"]')).not.toBeNull();
       }
+      const choice = target.querySelector('[data-testid="band-choices"]')!;
+      const entry = target.querySelector('[data-testid="band-entry"]')!;
+      expect(choice.compareDocumentPosition(entry) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
       unmount(component);
     },
   );
@@ -129,5 +144,110 @@ describe('BandInstrumentHost', () => {
     button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(onSelectBand).not.toHaveBeenCalled();
     unmount(component);
+  });
+
+  it('keeps one raw draft across placement and entry-context A-B-A replacement', () => {
+    const a = createFiniteRendererContext(), b = createFiniteRendererContext();
+    const onEnterFrequency = vi.fn();
+    const props = proxy({
+      view: base(), presentation: 'grouped' as 'grouped' | 'independent',
+      entryRendererContext: a, onEnterFrequency,
+    });
+    const component = mount(BandInstrumentHostFixture, { target, props });
+    flushSync();
+    typeFrequency('7.100');
+    const retainedA = input();
+
+    Object.assign(props, { presentation: 'independent', entryRendererContext: b });
+    flushSync();
+    retainedA.value = '14.200';
+    retainedA.dispatchEvent(new Event('input', { bubbles: true }));
+    retainedA.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(input().value).toBe('7.100');
+    expect(onEnterFrequency).not.toHaveBeenCalled();
+
+    Object.assign(props, { entryRendererContext: a });
+    flushSync();
+    retainedA.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(input().value).toBe('7.100');
+    typeFrequency('14.200');
+    input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(onEnterFrequency).toHaveBeenCalledExactlyOnceWith(14200000);
+    unmount(component);
+  });
+
+  it('refuses programmatic draft mutation while receiver or bounds are unknown', () => {
+    const props = proxy({
+      view: { ...base(), activeReceiver: { status: 'unknown' as const } },
+      presentation: 'grouped' as 'grouped' | 'independent',
+    });
+    const component = mount(BandInstrumentHostFixture, { target, props });
+    flushSync();
+    typeFrequency('7.100');
+    Object.assign(props, { presentation: 'independent' });
+    flushSync();
+    expect(input().value).toBe('');
+
+    Object.assign(props, {
+      view: { ...base(), band: { ...base().band!, tuneMinHz: null, tuneMaxHz: null } },
+    });
+    flushSync();
+    typeFrequency('14.200');
+    Object.assign(props, { presentation: 'grouped' });
+    flushSync();
+    expect(input().value).toBe('');
+    unmount(component);
+  });
+
+  it('clears the draft only after structural Band disappearance', () => {
+    const onEnterFrequency = vi.fn();
+    const props = proxy({ view: base() as RadioViewModel | null, onEnterFrequency });
+    const component = mount(BandInstrumentHostFixture, { target, props });
+    flushSync();
+    typeFrequency('7100');
+    Object.assign(props, { view: { ...base(), activeReceiver: { status: 'unknown' as const } } });
+    flushSync();
+    expect(input().value).toBe('7100');
+    const retainedInput = input();
+    const retainedSet = target.querySelector<HTMLButtonElement>('[data-testid="band-entry-set"]')!;
+    Object.assign(props, { view: { ...base(), band: undefined } });
+    retainedInput.value = '14.200';
+    retainedInput.dispatchEvent(new Event('input', { bubbles: true }));
+    retainedSet.click();
+    expect(onEnterFrequency).not.toHaveBeenCalled();
+    flushSync();
+    expect(target.querySelector('[data-testid="band-entry"]')).toBeNull();
+    Object.assign(props, { view: base() });
+    flushSync();
+    expect(input().value).toBe('');
+    unmount(component);
+  });
+
+  it('revokes a specialized lease after context replacement, dispose, and owner destroy', () => {
+    let context = createFiniteRendererContext();
+    const setDraft = vi.fn(), submit = vi.fn(), cancel = vi.fn(), handleKeyDown = vi.fn();
+    const seat = createFrequencyEntryRendererSeat(() => ({
+      context,
+      view: {
+        label: 'FREQ', draft: '', validation: 'empty', boundsAvailable: true,
+        interpretedHz: null, inputAvailable: true, submitAvailable: false,
+        hint: '', rangeText: '—',
+      },
+      setDraft, submit, cancel, handleKeyDown,
+    }));
+    const replaced = seat.attachRenderer();
+    context = createFiniteRendererContext();
+    expect(replaced.active).toBe(false);
+    replaced.setDraft('7100'); replaced.submit(); replaced.cancel();
+    expect(setDraft).not.toHaveBeenCalled();
+    expect(submit).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
+
+    const disposed = seat.attachRenderer();
+    disposed.dispose();
+    expect(disposed.active).toBe(false);
+    const destroyed = seat.attachRenderer();
+    seat.destroy();
+    expect(destroyed.active).toBe(false);
   });
 });

--- a/frontend/src/semantic/__tests__/BandSurface.test.ts
+++ b/frontend/src/semantic/__tests__/BandSurface.test.ts
@@ -152,10 +152,13 @@ describe('the band surface derives nothing (7B carry-forward 1)', () => {
     }
   });
 
-  it('declares view, instrument placement, and frequency-entry intent props', () => {
+  it('declares only view and the shared Band instrument placement', () => {
     const props = CODE.slice(CODE.indexOf('interface Props'), CODE.indexOf('}: Props'));
     expect([...props.matchAll(/^\s{4}(\w+)[?]?:/gm)].map((m) => m[1]))
-      .toEqual(['view', 'handles', 'controlLayout', 'onEnterFrequency']);
+      .toEqual(['view', 'handles', 'controlLayout']);
+    for (const displaced of ['entryText = $state', 'function commitFrequency', 'function parseMhzToHz']) {
+      expect(CODE).not.toContain(displaced);
+    }
   });
 
   it('renders nothing at all when the radio declares no band plan', () => {

--- a/frontend/src/semantic/__tests__/fixtures/BandInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/BandInstrumentHostFixture.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
+  import type { Component } from 'svelte';
   import type {
     FiniteControlAppearance, FiniteRendererContext,
   } from '../../../primitives/control-instruments/control-instrument-renderer.svelte';
+  import type {
+    FrequencyEntryRendererProps,
+  } from '../../../primitives/frequency/frequency-entry-renderer.svelte';
   import BandInstrumentHost from '../../BandInstrumentHost.svelte';
   import BandSurface from '../../BandSurface.svelte';
   import type { BandInstrumentHandles } from '../../band-instruments';
@@ -12,27 +16,32 @@
     presentation?: 'grouped' | 'independent' | 'surface';
     finiteAppearance?: FiniteControlAppearance<string>;
     rendererContext?: FiniteRendererContext | null;
+    entryRendererContext?: FiniteRendererContext | null;
+    entryRenderer?: Component<FrequencyEntryRendererProps>;
     onSelectBand?: (name: string) => void;
     onEnterFrequency?: (frequencyHz: number) => void;
   }
   let {
     view, presentation = 'grouped', finiteAppearance, rendererContext,
-    onSelectBand, onEnterFrequency,
+    entryRendererContext, entryRenderer, onSelectBand, onEnterFrequency,
   }: Props = $props();
   let selection = $derived(finiteAppearance === undefined
     ? {} : { finiteAppearance, rendererContext: rendererContext ?? null });
 </script>
 
-<BandInstrumentHost {view} {onSelectBand} {...selection}>
+<BandInstrumentHost
+  {view} {onSelectBand} {onEnterFrequency} {entryRendererContext} {entryRenderer} {...selection}
+>
   {#snippet children(handles: BandInstrumentHandles)}
     {#if presentation === 'surface'}
-      {#if view}<BandSurface {view} {handles} {onEnterFrequency} />{/if}
+      {#if view}<BandSurface {view} {handles} />{/if}
     {:else}
       <section data-testid={`${presentation}-band-composition`}>
         {#if presentation === 'grouped'}
-          {@render handles.bandChoice()}
+          {@render handles.bandChoice()}{@render handles.frequencyEntry()}
         {:else}
           <div data-slot="choice">{@render handles.bandChoice()}</div>
+          <div data-slot="entry">{@render handles.frequencyEntry()}</div>
         {/if}
       </section>
     {/if}

--- a/frontend/src/semantic/band-instruments.ts
+++ b/frontend/src/semantic/band-instruments.ts
@@ -4,9 +4,12 @@ import type { BandChoice } from './radio-view-model';
 
 export interface BandInstrumentHandles {
   readonly bandChoice: Snippet;
+  readonly frequencyEntry: Snippet;
 }
 
 export type BandControlLayout = Snippet<[BandInstrumentHandles]>;
+
+export const UNKNOWN_TEXT = '—';
 
 export const mhz = (hz: number): string => `${(hz / 1e6).toFixed(3)} MHz`;
 
@@ -21,3 +24,25 @@ export const defaultPermitLabel = (choice: BandChoice): string =>
     frequency: mhz(choice.defaultHz),
     status: t(DEFAULT_PERMIT_STATUS_KEY[choice.defaultHzTxPermit.status]),
   });
+
+/** Decimal means exact MHz; a bare integer prefers kHz when both readings fit. */
+export function interpretFrequencyEntry(raw: string, minHz: number, maxHz: number): number | null {
+  const text = raw.trim();
+  if (text === '' || !Number.isFinite(minHz) || !Number.isFinite(maxHz)) return null;
+  if (text.includes('.')) return parseMhzToHz(text, minHz, maxHz);
+  if (!/^\d+$/.test(text)) return null;
+  const value = Number(text);
+  const asKhz = value * 1000;
+  if (asKhz >= minHz && asKhz <= maxHz) return asKhz;
+  if (value >= minHz && value <= maxHz) return value;
+  return null;
+}
+
+function parseMhzToHz(text: string, minHz: number, maxHz: number): number | null {
+  const match = /^(\d+)\.(\d+)$/.exec(text);
+  if (!match) return null;
+  const [, whole, fraction] = match;
+  if (fraction.length > 6) return null;
+  const hz = Number(whole) * 1_000_000 + Number(fraction.padEnd(6, '0'));
+  return hz >= minHz && hz <= maxHz ? hz : null;
+}


### PR DESCRIPTION
17 code + 0 regenerated baselines = 17 files
Coordinator exception: approved five-path consumer-census correction after exact-head CI exposed the required +1 live default authority subscriber.

## Linear

- MOR-2425

## Summary

- move the existing Band frequency draft, parser, validation, Set/Enter/Escape behavior, and final command handoff into the permanent Band instrument host
- expose independent Band choice and frequency-entry seats while preserving Standard and SDR native placement
- revoke retained entry renderers on authority occurrence changes and re-read current receiver, bounds, session, and provider authority at final dispatch

## Draft lifetime contract

- actual rendered Band unmount remains the established draft-clear boundary
- session/provider/context A-B-A and same-turn structural A-absent-A retain the unsubmitted draft while stale renderer leases revoke synchronously
- no timer, parser fork, command engine, TX gate, SDK change, or generated baseline is added

## Authority subscriber census

- the existing shared finite-authority fan-in is now live for native Band, adding exactly one default runtime subscriber without introducing a second parallel authority mechanism
- strict subscriber-count consumers advance by one and retain identity and teardown-to-zero assertions

## Verification

- focused Band acceptance: 5 files, 199 tests passed
- focused subscriber census: 5 files, 148 tests passed
- npm run check: 0 errors, 0 warnings
- scoped ESLint: passed
- git diff --check: passed
- superseded head 4b02f38de2af2a0a8e4437218fe74f90b7b9c5c5: visual passed; quick 34107880086 exposed the seven exact subscriber-count expectations corrected here
- natural main quick baseline 34102466234: success at 3536ae765598a973ce0bc4a3306984eae4cbda66

## Root integration closeout

The 17-file scope is one live Band-entry migration: the permanent owner, revocable renderer, Standard/SDR placements and existing command route must change together. Five neighboring lifecycle suites require strict +1 subscriber census corrections because the existing authority fan-in now serves native entry; identity and teardown-to-zero assertions are retained. Root grants the file-count exception above; 721 A+D remains below the line limit, with zero baselines.

Prior head4b02f38de2af2a0a8e4437218fe74f90b7b9c5c5 had quick34107880086 FAILURE and [independent BLOCKED5568795236](https://github.com/rigplane/rigplane-core/pull/3337#issuecomment-5568795236). The final successor changes only six expected counts in five test files. Historical failure is retained; all production migration code remains the reviewed implementation.

Final head777ebcf792c6a344e087b7db85167ba68d6139bb has natural [quick34108659337](https://github.com/rigplane/rigplane-core/actions/runs/34108659337) SUCCESS, [visual34108659363](https://github.com/rigplane/rigplane-core/actions/runs/34108659363) SUCCESS and [independent PASS5568888599](https://github.com/rigplane/rigplane-core/pull/3337#issuecomment-5568888599). Root fully read all17 source/test paths, result, structural-draft mechanics adjudication, complete independent review and exact directive.

Root checked a conflict-free merge tree against accepted mainc0a31c76015fbed2bf75bdd5483166ec8903646e: 16 changed blobs equal the exact reviewed head; the one shared meters test retains exactly the previously accepted M2-4C native-meter section in addition to the two count corrections. No new conflict-resolution code. Main aggregate quick34108434649 succeeded. Canonical required Agent Review Gate and quick are successful; optional metadata observers' stale-base failures are recorded without treating them as candidate failures or bypassing any required context.

No additional publication-edge draft reset was introduced. Unsubmitted text survives a coalesced structural transition that never renders absence; stale input authority remains revoked and fresh submit rechecks current receiver/bounds. Public Band entry SDK/Kit exposure and the rest of MOR-2425 remain outstanding.
