### PR TITLE
feat(MOR-2425): persist CW keyer speed ownership

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -423,7 +423,16 @@
         {:else}
           {@render instruments.dsp()}
         {/if}
-        {@render instruments.cwKeyer()}
+        {#if skinId === 'desktop-v2'}
+          <div class="cw-keyer-instrument-seat" data-cw-keyer-seat="keyerSpeed">
+            {@render instruments.cwKeyerInstruments.keyerSpeed({
+              form: 'hbar', compact: false, showLabel: true, showValue: true,
+            })}
+          </div>
+          {@render instruments.cwKeyer(undefined, false)}
+        {:else}
+          {@render instruments.cwKeyer()}
+        {/if}
         {@render instruments.txAuxControls(txAuxInstrumentLayout)}
         <div class="content-right"><RightSidebar hideTxPanel={semanticRxTx} {declared} /></div>
       </div>
@@ -715,6 +724,7 @@
     gap: 4px 8px;
   }
   .tx-aux-scalar-seat { min-width: 0; }
+  .cw-keyer-instrument-seat { min-width: 0; }
 
   .radio-layout, .radio-layout.semantic-deck {
     height: 100vh;

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
@@ -677,11 +677,15 @@ describe('App presentation selection', () => {
     };
     const liveState = {
       ...structuredClone(stateFixture),
-      micGain: 128,
+      micGain: 128, keySpeed: 24,
       fieldStatus: {
         ...stateFixture.fieldStatus,
         micGain: {
           storePath: 'global.operator_controls.mic_gain', observed: true,
+          freshness: 'fresh', availability: 'available', lastObservedMonotonic: 1,
+        },
+        keySpeed: {
+          storePath: 'global.cw.key_speed', observed: true,
           freshness: 'fresh', availability: 'available', lastObservedMonotonic: 1,
         },
       },
@@ -712,9 +716,15 @@ describe('App presentation selection', () => {
     const oldMic = t.querySelector<RendererNode>(
       '[data-testid="tx-aux-micGain"] [data-external-scalar-renderer]',
     );
+    const oldKeyerSpeed = t.querySelector<RendererNode>(
+      '[data-cw-keyer-seat="keyerSpeed"] [data-external-scalar-renderer]',
+    );
     if (oldMic === null) throw new Error('Standard did not render the external MIC probe');
+    if (oldKeyerSpeed === null) throw new Error('Standard did not render the Keyer Speed seat');
     const oldLease = oldMic.rendererLease;
     const micBinding = scalarCapture.bindingsByLease.get(oldLease);
+    const oldKeyerSpeedLease = oldKeyerSpeed.rendererLease;
+    const keyerSpeedBinding = scalarCapture.bindingsByLease.get(oldKeyerSpeedLease);
     const txController = txHarness.controller;
     const txListeners = txHarness.listenerCount();
     const releasedAudioDemand: number[] = [];
@@ -728,9 +738,13 @@ describe('App presentation selection', () => {
     expect(semanticHost).not.toBeNull();
     expect(globalHost).not.toBeNull();
     expect(micBinding).toBeDefined();
+    expect(keyerSpeedBinding).toBeDefined();
+    expect(t.querySelectorAll('[data-testid="cw-keyer-keyerSpeed"]')).toHaveLength(1);
     expect(rt.resources.snapshot('audio-fft').demand).toBeGreaterThan(0);
     const beforeDisplay = oldMic.dataset.display;
+    const beforeKeyerSpeedDisplay = oldKeyerSpeed.dataset.display;
     oldMic.click();
+    oldKeyerSpeed.click();
     flushSync();
     const pendingEvidence = {
       requested: oldMic.dataset.requested,
@@ -740,6 +754,15 @@ describe('App presentation selection', () => {
       oldMic.dataset.display !== beforeDisplay || pendingEvidence.requested !== '',
     ).toBe(true);
     expect(pendingEvidence.requested).not.toBe('');
+    const keyerSpeedPendingEvidence = {
+      requested: oldKeyerSpeed.dataset.requested,
+      phase: oldKeyerSpeed.dataset.phase,
+    };
+    expect(
+      oldKeyerSpeed.dataset.display !== beforeKeyerSpeedDisplay
+      || keyerSpeedPendingEvidence.requested !== ''
+    ).toBe(true);
+    expect(keyerSpeedPendingEvidence.requested).not.toBe('');
     expect(txHarness.trace()).toEqual([]);
 
     vi.mocked(resolveSkinId).mockReturnValue('sdr-test');
@@ -754,6 +777,9 @@ describe('App presentation selection', () => {
     const newMic = t.querySelector<RendererNode>(
       '[data-testid="tx-aux-micGain"] [data-external-scalar-renderer]',
     )!;
+    const newKeyerSpeed = t.querySelector<RendererNode>(
+      '[data-testid="cw-keyer-keyerSpeed"] [data-external-scalar-renderer]',
+    )!;
     expect(t.querySelector('.radio-layout.standard-face')).toBeNull();
     expect(t.querySelectorAll('[data-testid="semantic-radio-surfaces"]')).toHaveLength(1);
     expect(t.querySelector('[data-testid="semantic-radio-surfaces"]')).toBe(semanticHost);
@@ -762,8 +788,17 @@ describe('App presentation selection', () => {
     expect(t.querySelectorAll('[data-testid="app-global-host"]')).toHaveLength(1);
     expect(t.querySelector('[data-testid="app-global-host"]')).toBe(globalHost);
     expect(scalarCapture.bindingsByLease.get(newMic.rendererLease)).toBe(micBinding);
+    expect(scalarCapture.bindingsByLease.get(newKeyerSpeed.rendererLease)).toBe(keyerSpeedBinding);
     expect(newMic.rendererLease).not.toBe(oldLease);
+    expect(newKeyerSpeed.rendererLease).not.toBe(oldKeyerSpeedLease);
     expect(oldLease.key({ key: 'ArrowRight', fine: false })).toBe(false);
+    expect(oldKeyerSpeedLease.key({ key: 'ArrowRight', fine: false })).toBe(false);
+    expect(t.querySelector('[data-cw-keyer-seat="keyerSpeed"]')).toBeNull();
+    expect(t.querySelectorAll('[data-testid="cw-keyer-keyerSpeed"]')).toHaveLength(1);
+    expect({
+      requested: newKeyerSpeed.dataset.requested,
+      phase: newKeyerSpeed.dataset.phase,
+    }).toEqual(keyerSpeedPendingEvidence);
     expect({
       requested: newMic.dataset.requested,
       phase: newMic.dataset.phase,

--- a/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
+++ b/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
@@ -11,6 +11,7 @@
   import type { TxAuxFiniteHandles } from '../../../../semantic/tx-aux-finite';
   import type { VfoOperationHandles } from '../../../../semantic/VfoOperationSeatHost.svelte';
   import type { BandControlLayout } from '../../../../semantic/band-instruments';
+  import type { CwKeyerInstrumentHandles } from '../../../../semantic/CwKeyerInstrumentHost.svelte';
 
   const empty = createRawSnippet(() => ({ render: () => '' }));
   const vfo = createRawSnippet<[
@@ -24,6 +25,10 @@
   const band = createRawSnippet<[allowBare?: boolean, controlLayout?: BandControlLayout]>(
     () => ({ render: () => '' }),
   );
+  const cwKeyer = createRawSnippet<[allowBare?: boolean, showKeyerSpeed?: boolean]>(
+    () => ({ render: () => '' }),
+  );
+  const cwKeyerInstruments = { keyerSpeed: empty } satisfies CwKeyerInstrumentHandles;
   const frequency = createRawSnippet<[mount?: ReceiverFrequencyMount]>(() => ({ render: () => '' }));
   const meter = createRawSnippet<[renderer: ReceiverSMeterRenderer]>(() => ({ render: () => '' }));
   const operations = createRawSnippet<[appearance: ReceiverVfoAppearance]>(() => ({ render: () => '' }));
@@ -55,7 +60,7 @@
     receiverInstruments,
     rxAudioInstruments, rfFrontEndInstruments,
     meters: empty, rxAudio: empty, rfFrontEnd: empty, filter: empty, dsp: empty,
-    band, antenna: empty, ritXitScan: empty, cwKeyer: empty,
+    band, antenna: empty, ritXitScan: empty, cwKeyerInstruments, cwKeyer,
     scopeDisplay: empty, scopeControls: empty, txFaultRecovery: empty,
     modInputTxWarning: empty, managedScope: undefined,
   } satisfies FixtureInstrumentComposition;

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -107,6 +107,9 @@
   import SemanticControlPanel from '../layout/SemanticControlPanel.svelte';
   import ModInputTxWarning from '../panels/ModInputTxWarning.svelte';
   import CwKeyerSurface, { type CwLevelField } from '../../semantic/CwKeyerSurface.svelte';
+  import CwKeyerInstrumentHost, {
+    type CwKeyerInstrumentHandles,
+  } from '../../semantic/CwKeyerInstrumentHost.svelte';
   import ScopeControlsSurface, {
     type ScopeChoiceField, type ScopeToggleField,
   } from '../../semantic/ScopeControlsSurface.svelte';
@@ -1352,6 +1355,11 @@
     onSelectBand={selectBand} onEnterFrequency={enterFrequency}
   >
   {#snippet children(bandInstruments)}
+  <CwKeyerInstrumentHost
+    {view} {keySpeedFeedback}
+    onLevelChange={(field, value) => CW_LEVEL_INTENT[field](value)}
+  >
+  {#snippet children(cwKeyerInstruments)}
   <DspInstrumentHost
     {...dspFiniteRendererSelection} {view} {agcLabels} {pendingNb} {pendingNr}
     onToggle={(field, next) => DSP_TOGGLE_INTENT[field](next)}
@@ -1888,13 +1896,14 @@
     gated inside the surface on the model's one `txPermit`, and the key/unkey
     authority stays the single `<RxTxSurface>` above (decomposition R9).
   -->
-  {#snippet cwKeyerSurface()}
+  {#snippet cwKeyerSurface(showKeyerSpeed = true)}
     {#if view?.cwKeyer}
       <CwKeyerSurface
         {view}
+        continuousHandles={cwKeyerInstruments}
+        {showKeyerSpeed}
         {breakInDelayFeedback}
         {cwPitchFeedback}
-        {keySpeedFeedback}
         {autoTuneAvailable}
         onBreakInMode={(mode) => cwIntents.onBreakInModeChange(mode)}
         onLevelChange={(field, value) => CW_LEVEL_INTENT[field](value)}
@@ -2033,8 +2042,11 @@
       ritXitScanSurface, allowBare,
     )}
   {/snippet}
-  {#snippet hostedCwKeyer(allowBare = allowBareSurfaces)}
-    {@render zoned('cwKeyer', view?.cwKeyer !== undefined, cwKeyerSurface, allowBare)}
+  {#snippet hostedCwKeyer(
+    allowBare = allowBareSurfaces, showKeyerSpeed = true,
+  )}
+    {#snippet body()}{@render cwKeyerSurface(showKeyerSpeed)}{/snippet}
+    {@render zoned('cwKeyer', view?.cwKeyer !== undefined, body, allowBare)}
   {/snippet}
   {#snippet hostedScopeDisplay(allowBare = allowBareSurfaces)}
     {@render zoned('scopeDisplay', view?.scopeDisplay !== undefined, scopeDisplaySurface, allowBare)}
@@ -2062,6 +2074,7 @@
       band: hostedBand,
       antenna: hostedAntenna,
       ritXitScan: hostedRitXitScan,
+      cwKeyerInstruments,
       cwKeyer: hostedCwKeyer,
       scopeDisplay: hostedScopeDisplay,
       scopeControls: hostedScopeControls,
@@ -2245,6 +2258,8 @@
   {/if}
   {/snippet}
   </DspInstrumentHost>
+  {/snippet}
+  </CwKeyerInstrumentHost>
   {/snippet}
   </BandInstrumentHost>
   {/snippet}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
@@ -298,14 +298,42 @@ function submitDelay(value: number): string {
   return vi.mocked(sendCommand).mock.calls.at(-1)![2] as string;
 }
 
-function cwInput(field: 'pitchHz' | 'keyerSpeed'): HTMLInputElement {
-  return el(field)!.querySelector('input') as HTMLInputElement;
+function cwInput(field: 'pitchHz' | 'keyerSpeed'): HTMLElement {
+  const selector = field === 'keyerSpeed' ? '[role="slider"]' : 'input';
+  return el(field)!.querySelector(selector) as HTMLElement;
+}
+
+function cwValue(field: 'pitchHz' | 'keyerSpeed'): string | null {
+  const input = cwInput(field);
+  return input instanceof HTMLInputElement ? input.value : input.getAttribute('aria-valuenow');
+}
+
+function cwDisabled(field: 'pitchHz' | 'keyerSpeed'): boolean {
+  const input = cwInput(field);
+  return input instanceof HTMLInputElement
+    ? input.disabled : input.getAttribute('aria-disabled') === 'true';
 }
 
 function submitCw(field: 'pitchHz' | 'keyerSpeed', value: number): string {
   const input = cwInput(field);
-  input.value = String(value);
-  input.dispatchEvent(new Event('input', { bubbles: true }));
+  if (input instanceof HTMLInputElement) {
+    input.value = String(value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  } else {
+    const frame = input.closest<HTMLElement>('.vc-hbar')!;
+    vi.spyOn(frame, 'getBoundingClientRect').mockReturnValue({
+      left: 0, width: 84,
+    } as DOMRect);
+    Object.assign(input, {
+      setPointerCapture: () => undefined,
+      hasPointerCapture: () => false,
+      releasePointerCapture: () => undefined,
+    });
+    input.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true, clientX: (value - 6) * 2, pointerId: 1,
+    }));
+    input.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }));
+  }
   flushSync();
   return vi.mocked(sendCommand).mock.calls.at(-1)![2] as string;
 }
@@ -367,8 +395,9 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
     expect(cwInput('keyerSpeed').dataset.commandPhase).toBe('submitted');
     unmount(component!); component = null; target.remove();
     render();
-    expect(cwInput('pitchHz').value).toBe('725');
-    expect(cwInput('keyerSpeed').value).toBe('31');
+    expect(cwValue('pitchHz')).toBe('725');
+    expect(cwValue('keyerSpeed')).toBe('24');
+    expect(cwInput('keyerSpeed').getAttribute('aria-valuetext')).toContain('requested 31 WPM');
     expect(cwInput('pitchHz').dataset.commandPhase).toBe('submitted');
     expect(cwInput('keyerSpeed').dataset.commandPhase).toBe('submitted');
     expect(sendCommand).toHaveBeenCalledTimes(2);
@@ -380,11 +409,11 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
 
     advanceCw(725, 24, 11);
     expect(cwInput('pitchHz').dataset.commandPhase).toBe('confirmed');
-    expect(cwInput('pitchHz').value).toBe('725');
+    expect(cwValue('pitchHz')).toBe('725');
     expect(cwInput('keyerSpeed').dataset.commandPhase).toBe('awaiting-confirmation');
     deliver(speedId, 'response-error', 'speed rejected');
     expect(cwInput('keyerSpeed').dataset.commandPhase).toBe('failed');
-    expect(cwInput('keyerSpeed').value).toBe('24');
+    expect(cwValue('keyerSpeed')).toBe('24');
     expect(el('keyerSpeed')!.textContent).toContain('speed rejected');
     expect(txHarness.trace()).toEqual([]);
   });
@@ -396,7 +425,7 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
     submitCw('keyerSpeed', 31);
     deliver(oldId, 'response-error', 'late superseded failure');
     expect(cwInput('pitchHz').dataset.commandPhase).toBe('submitted');
-    expect(cwInput('pitchHz').value).toBe('700');
+    expect(cwValue('pitchHz')).toBe('700');
     expect(getCommandLifecycle(latestId, 1)?.status).toBe('pending');
     const oldPitchStatus = el('pitchHz')!.querySelector<HTMLElement>('[data-cw-feedback-status]')!;
     const oldPitchText = oldPitchStatus.textContent;
@@ -408,7 +437,7 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
     publishAuthority();
     flushSync();
     for (const field of ['pitchHz', 'keyerSpeed'] as const) {
-      expect(cwInput(field).disabled).toBe(true);
+      expect(cwDisabled(field)).toBe(true);
       expect(cwInput(field).dataset.commandPhase).toBe('unavailable');
       expect(el(field)!.dataset.observed).toBe('false');
     }
@@ -464,6 +493,8 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
         control.value = control.max;
         control.dispatchEvent(new Event('input', { bubbles: true }));
         control.dispatchEvent(new Event('change', { bubbles: true }));
+      } else if (control.getAttribute('role') === 'slider') {
+        control.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
       } else press(control);
     }
     flushSync();

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -433,7 +433,13 @@ describe('production receiver-indicator partitioning', () => {
       /keySpeedFeedback\s*=\s*\$derived\(getKeySpeedControlFeedback\(controlSession\)\)/,
     );
     expect(source).toMatch(
-      /<CwKeyerSurface[\s\S]*?\{cwPitchFeedback\}[\s\S]*?\{keySpeedFeedback\}[\s\S]*?\/>/,
+      /<CwKeyerInstrumentHost[\s\S]*?\{keySpeedFeedback\}[\s\S]*?\{#snippet children\(cwKeyerInstruments\)}/,
+    );
+    expect(source).toMatch(
+      /<CwKeyerSurface(?:(?!\/>)[\s\S])*?\{cwPitchFeedback\}(?:(?!\/>)[\s\S])*?\/>/,
+    );
+    expect(source).not.toMatch(
+      /<CwKeyerSurface(?:(?!\/>)[\s\S])*?\{keySpeedFeedback\}/,
     );
     expect(h.cwPitchFeedback()).toMatchObject({
       phase: 'unavailable', scope: { control: 'cw-pitch', receiver: 0 },

--- a/frontend/src/components-v2/wiring/instrument-composition.ts
+++ b/frontend/src/components-v2/wiring/instrument-composition.ts
@@ -9,6 +9,7 @@ import type { DspFiniteLayout } from '../../semantic/dsp-instruments';
 import type { VfoOperationHandles } from '../../semantic/VfoOperationSeatHost.svelte';
 import type { FilterFiniteLayout } from '../../semantic/filter-instruments';
 import type { BandControlLayout } from '../../semantic/band-instruments';
+import type { CwKeyerInstrumentHandles } from '../../semantic/CwKeyerInstrumentHost.svelte';
 
 export type InstrumentVfoAppearance = 'semantic' | 'sdr' | 'standard';
 
@@ -34,7 +35,8 @@ export interface InstrumentComposition {
   readonly band: Snippet<[allowBare?: boolean, controlLayout?: BandControlLayout]>;
   readonly antenna: Snippet<[allowBare?: boolean]>;
   readonly ritXitScan: Snippet<[allowBare?: boolean]>;
-  readonly cwKeyer: Snippet<[allowBare?: boolean]>;
+  readonly cwKeyerInstruments: CwKeyerInstrumentHandles;
+  readonly cwKeyer: Snippet<[allowBare?: boolean, showKeyerSpeed?: boolean]>;
   readonly scopeDisplay: Snippet<[allowBare?: boolean]>;
   readonly scopeControls: Snippet<[allowBare?: boolean]>;
   readonly txFaultRecovery: Snippet;

--- a/frontend/src/semantic/CwKeyerInstrumentHost.svelte
+++ b/frontend/src/semantic/CwKeyerInstrumentHost.svelte
@@ -1,0 +1,207 @@
+<script module lang="ts">
+  import type { Snippet } from 'svelte';
+
+  export const CW_KEYER_SPEED = [
+    'keyerSpeed', 'Keyer speed', 6, 48, 1, 'WPM', 'set_key_speed',
+  ] as const;
+  export const CW_CONTINUOUS_LEVELS = [CW_KEYER_SPEED] as const;
+  export type CwContinuousField = typeof CW_KEYER_SPEED[0];
+  export type CwContinuousForm = 'hbar' | 'knob';
+
+  export interface CwContinuousPresentation {
+    readonly form?: CwContinuousForm;
+    readonly compact?: boolean;
+    readonly showLabel?: boolean;
+    readonly showValue?: boolean;
+  }
+
+  export interface CwKeyerInstrumentHandles {
+    readonly keyerSpeed: Snippet<[
+      presentation?: Readonly<CwContinuousPresentation>,
+    ]>;
+  }
+</script>
+
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { ValueControl } from '../components-v2/controls/value-control';
+  import type {
+    HBarIssuedStatusPresentation,
+    HBarIssuedStatusSnapshot,
+  } from '../components-v2/controls/value-control/skin';
+  import {
+    createContinuousScalar,
+    createRenderedNativeRangeContinuousScalarPolicy,
+    type CommandScalarFeedback,
+    type ContinuousScalarInput,
+  } from '../primitives/scalar/continuous-scalar.svelte';
+  import type { CwKeyerField, RadioViewModel } from './radio-view-model';
+
+  interface Props {
+    view: RadioViewModel | null;
+    keySpeedFeedback?: Readonly<CommandScalarFeedback>;
+    onLevelChange?: (field: CwContinuousField, value: number) => void;
+    children: Snippet<[CwKeyerInstrumentHandles]>;
+  }
+
+  let { view, keySpeedFeedback, onLevelChange, children }: Props = $props();
+  let keyerSpeedField = $derived(view?.cwKeyer?.keyerSpeed);
+  const [field, label, min, max, step, unit, command] = CW_KEYER_SPEED;
+  const feedbackIntegratedControl = { 'feedback-policy': 'feedback-integrated' } as const;
+  const policy = createRenderedNativeRangeContinuousScalarPolicy();
+  const usable = (current: CwKeyerField<unknown> | undefined): boolean =>
+    current?.availability.structural === true
+    && current.availability.operational
+    && current.reading.status === 'known';
+  const formatValue = (value: number | null): string =>
+    value === null || !Number.isFinite(value) ? '—' : `${value} ${unit}`;
+
+  function request(value: number): void {
+    if (usable(keyerSpeedField)) onLevelChange?.(field, value);
+  }
+
+  function input(): Readonly<ContinuousScalarInput> {
+    const common = {
+      domain: { min, max, step, defaultValue: null, fineStepDivisor: 1 },
+      enabled: usable(keyerSpeedField),
+      request,
+    } as const;
+    if (keySpeedFeedback !== undefined) {
+      return {
+        ...common, evidence: 'command-feedback', feedback: keySpeedFeedback, command,
+      };
+    }
+    return {
+      ...common,
+      evidence: 'reading',
+      ownerKey: 'cw-keyer-keyerSpeed-reading',
+      reading: keyerSpeedField?.reading.status === 'known'
+        ? { status: 'known', value: keyerSpeedField.reading.value }
+        : { status: 'unknown' },
+    };
+  }
+
+  const binding = createContinuousScalar(input, policy);
+  let issuedStatus = $state<string | null>(null);
+  let issuedStatusKey = $state('');
+  const issuedStatusPresentation: Readonly<HBarIssuedStatusPresentation> = {
+    get text() { return null; },
+    format({ view: scalarView, announcement }: Readonly<HBarIssuedStatusSnapshot>) {
+      issuedStatusKey = JSON.stringify([
+        scalarView.feedback.providerGeneration ?? null,
+        scalarView.feedback.sessionEpoch,
+        scalarView.feedback.scope.control,
+        scalarView.feedback.scope.receiver,
+        scalarView.feedback.scope.slot ?? null,
+        announcement.transitionId,
+      ]);
+      return scalarView.error === null
+        ? announcement.message
+        : `${announcement.message.replace(/[.!?]$/, '')}: ${scalarView.error}`;
+    },
+    accept(text) { issuedStatus = text; },
+  };
+
+  function retireHBarStatus(
+    _node: HTMLElement,
+    placement: Readonly<{ form: CwContinuousForm }>,
+  ) {
+    const retire = (next: typeof placement) => {
+      if (next.form === 'knob') issuedStatus = null;
+    };
+    retire(placement);
+    return { update: retire };
+  }
+
+  function canonical(): number | null {
+    if (keySpeedFeedback !== undefined) {
+      return keySpeedFeedback.availability === 'available' ? keySpeedFeedback.confirmed : null;
+    }
+    return keyerSpeedField?.reading.status === 'known' ? keyerSpeedField.reading.value : null;
+  }
+
+  function status(): string {
+    if (keySpeedFeedback === undefined || keySpeedFeedback.phase === 'idle') return '';
+    const target = keySpeedFeedback.target ?? keySpeedFeedback.requestedTarget;
+    const requested = target === null ? '' : `; requested ${formatValue(target)}`;
+    const confirmed = `; confirmed ${formatValue(keySpeedFeedback.confirmed)}`;
+    const error = keySpeedFeedback.outcome?.error === undefined
+      ? '' : `; ${keySpeedFeedback.outcome.error}`;
+    return `${keySpeedFeedback.phase.replaceAll('-', ' ')}${requested}${confirmed}${error}`;
+  }
+
+  onDestroy(() => binding.destroy());
+</script>
+
+{#snippet keyerSpeedHandle(presentation?: Readonly<CwContinuousPresentation>)}
+  {#if keyerSpeedField?.availability.structural}
+    {@const explicitPresentation = presentation !== undefined}
+    {@const form = presentation?.form ?? 'hbar'}
+    {@const currentStatus = status()}
+    {@const disabledReason = usable(keyerSpeedField) ? undefined : 'Not yet observed'}
+    {@const accessibility = {
+      description: disabledReason ?? null,
+      valueText: `${label}: ${formatValue(canonical())}${currentStatus === '' ? '' : `; ${currentStatus}`}`,
+    }}
+    <div
+      class="cw-keyer-level"
+      class:cw-keyer-level--presented={explicitPresentation}
+      data-testid="cw-keyer-keyerSpeed"
+      data-field={field}
+      data-scalar-form={form}
+      data-observed={usable(keyerSpeedField) && canonical() !== null}
+      data-command-phase={keySpeedFeedback?.phase}
+      data-feedback-control={keySpeedFeedback?.scope.control}
+      data-min={min} data-max={max} data-step={step}
+      aria-busy={keySpeedFeedback?.busy}
+      title={disabledReason}
+      use:retireHBarStatus={{ form }}
+    >
+      <span class="cw-keyer-name" class:sr-only={explicitPresentation}
+        aria-hidden={explicitPresentation ? 'true' : undefined}>{label}</span>
+      <ValueControl
+        {...feedbackIntegratedControl}
+        {binding} {label} renderer={form}
+        displayFn={formatValue}
+        showLabel={explicitPresentation ? presentation?.showLabel ?? true : false}
+        showValue={explicitPresentation ? presentation?.showValue ?? true : false}
+        compact={explicitPresentation ? presentation?.compact ?? false : true}
+        title={disabledReason} {accessibility}
+        issuedStatusPresentation={form === 'hbar' ? issuedStatusPresentation : undefined}
+      />
+      <output data-testid="cw-keyer-keyerSpeed-value" data-canonical-value
+        class:sr-only={explicitPresentation} aria-hidden={explicitPresentation ? 'true' : undefined}
+      >{formatValue(canonical())}</output>
+      {#if currentStatus !== ''}
+        <span data-command-status class:command-pending={keySpeedFeedback?.busy}
+          class:sr-only={explicitPresentation || keySpeedFeedback?.phase === 'unavailable'}
+        >{currentStatus}</span>
+      {/if}
+    </div>
+  {/if}
+{/snippet}
+
+{#snippet keyerSpeed(presentation?: Readonly<CwContinuousPresentation>)}
+  {@render keyerSpeedHandle(presentation)}
+{/snippet}
+{@render children({ keyerSpeed })}
+
+{#if issuedStatus !== null}
+  {#key issuedStatusKey}
+    <span class="sr-only" role="status" aria-live="polite" aria-atomic="true"
+      data-control-feedback-status data-cw-feedback-status data-feedback-lane="keyerSpeed"
+    >{issuedStatus}</span>
+  {/key}
+{/if}
+
+<style>
+  .cw-keyer-level { display: flex; align-items: baseline; gap: 0.5rem; }
+  .cw-keyer-level--presented { display: inline-flex; min-width: 0; max-width: 100%; }
+  .cw-keyer-name { min-width: 12ch; }
+  .cw-keyer-level :global(.vc-hbar) { width: 100%; min-width: 0; }
+  .command-pending { font-style: italic; }
+  .sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+  }
+</style>

--- a/frontend/src/semantic/CwKeyerSurface.svelte
+++ b/frontend/src/semantic/CwKeyerSurface.svelte
@@ -52,6 +52,7 @@
 -->
 <script module lang="ts">
   import { t } from '$lib/i18n';
+  import { CW_CONTINUOUS_LEVELS } from './CwKeyerInstrumentHost.svelte';
   import type { BreakInMode, CwKeyerField, DisabledReasonCode } from './radio-view-model';
   import { pressedOf } from './pressed-of';
 
@@ -65,7 +66,8 @@
   /** `[field, label, min, max, step, unit]` in the RAW wire units `CwPanel`
    *  has always used — rescaling here would silently move a setting. */
   export const CW_LEVELS = [
-    ['keyerSpeed', 'Keyer speed', 6, 48, 1, 'WPM'],
+    ...CW_CONTINUOUS_LEVELS.map(([field, label, min, max, step, unit]) =>
+      [field, label, min, max, step, unit] as const),
     ['pitchHz', 'CW pitch', 300, 900, 5, 'Hz'],
     ['breakInDelay', 'Break-in delay', 0, 255, 1, ''],
   ] as const;
@@ -140,6 +142,7 @@
     bindChoiceInstrument,
     bindToggleInstrument,
   } from '../primitives/control-instruments/control-instrument-behavior';
+  import type { CwKeyerInstrumentHandles } from './CwKeyerInstrumentHost.svelte';
   import type { RadioViewModel } from './radio-view-model';
 
   type BreakInDelayFeedback = ControlFeedbackPresentationInput<number> & {
@@ -149,6 +152,8 @@
 
   interface Props {
     view: RadioViewModel;
+    continuousHandles: CwKeyerInstrumentHandles;
+    showKeyerSpeed?: boolean;
     onBreakInMode?: (mode: number) => void;
     onLevelChange?: (field: CwLevelField, value: number) => void;
     onApfOn?: (on: boolean) => void;
@@ -156,13 +161,13 @@
     onReversePaddleToggle?: () => void;
     breakInDelayFeedback?: Readonly<BreakInDelayFeedback>;
     cwPitchFeedback?: Readonly<CommandScalarFeedback>;
-    keySpeedFeedback?: Readonly<CommandScalarFeedback>;
     autoTuneAvailable?: boolean;
     onAutoTune?: () => void;
   }
   let {
-    view, onBreakInMode, onLevelChange, onApfOn, onTwinPeakToggle, onReversePaddleToggle,
-    breakInDelayFeedback, cwPitchFeedback, keySpeedFeedback,
+    view, continuousHandles, showKeyerSpeed = true,
+    onBreakInMode, onLevelChange, onApfOn, onTwinPeakToggle, onReversePaddleToggle,
+    breakInDelayFeedback, cwPitchFeedback,
     autoTuneAvailable = false, onAutoTune,
   }: Props = $props();
 
@@ -214,14 +219,13 @@
   function setLevel(field: CwLevelField, value: number): void {
     if (cw && usable(cw[field])) onLevelChange?.(field, value);
   }
-  type FeedbackLevelField = 'keyerSpeed' | 'pitchHz';
+  type FeedbackLevelField = 'pitchHz';
   const feedbackLevelDomain = {
-    keyerSpeed: { min: 6, max: 48, step: 1, defaultValue: null, fineStepDivisor: 1 },
     pitchHz: { min: 300, max: 900, step: 5, defaultValue: null, fineStepDivisor: 1 },
   } as const;
   function feedbackLevelInput(field: FeedbackLevelField): Readonly<ContinuousScalarInput> {
     const current = cw?.[field];
-    const feedback = field === 'keyerSpeed' ? keySpeedFeedback : cwPitchFeedback;
+    const feedback = cwPitchFeedback;
     const common = {
       domain: feedbackLevelDomain[field],
       enabled: current !== undefined && usable(current),
@@ -230,7 +234,7 @@
     if (feedback !== undefined) {
       return {
         ...common, evidence: 'command-feedback', feedback,
-        command: field === 'keyerSpeed' ? 'set_key_speed' : 'set_cw_pitch',
+        command: 'set_cw_pitch',
       };
     }
     return {
@@ -239,17 +243,11 @@
         ? { status: 'known', value: current.reading.value } : { status: 'unknown' },
     };
   }
-  const keySpeedScalar = createContinuousScalar(
-    () => feedbackLevelInput('keyerSpeed'), nativeRangeContinuousScalarPolicy,
-  );
   const cwPitchScalar = createContinuousScalar(
     () => feedbackLevelInput('pitchHz'), nativeRangeContinuousScalarPolicy,
   );
-  let keySpeedLease: ContinuousScalarRendererLease | null = $state(null);
   let cwPitchLease: ContinuousScalarRendererLease | null = $state(null);
-  const initialKeySpeedView = untrack(() => keySpeedScalar.view);
   const initialCwPitchView = untrack(() => cwPitchScalar.view);
-  let keySpeedView: Readonly<ContinuousScalarView> = $state(initialKeySpeedView);
   let cwPitchView: Readonly<ContinuousScalarView> = $state(initialCwPitchView);
   type IssuedLevelAnnouncement = Readonly<{
     authorityKey: string;
@@ -286,28 +284,13 @@
       text: current.error === null ? current.announcement : `${current.announcement}: ${current.error}`,
     });
   }
-  let keySpeedAnnouncement: IssuedLevelAnnouncement | null = $state(
-    nextLevelAnnouncement(initialKeySpeedView, null),
-  );
   let cwPitchAnnouncement: IssuedLevelAnnouncement | null = $state(
     nextLevelAnnouncement(initialCwPitchView, null),
   );
   $effect(() => {
-    const lease = keySpeedScalar.attachRenderer();
-    keySpeedLease = lease;
-    return () => lease.dispose();
-  });
-  $effect(() => {
     const lease = cwPitchScalar.attachRenderer();
     cwPitchLease = lease;
     return () => lease.dispose();
-  });
-  $effect(() => {
-    const next = keySpeedLease === null ? keySpeedScalar.view : keySpeedLease.view;
-    keySpeedView = next;
-    keySpeedAnnouncement = nextLevelAnnouncement(
-      next, untrack(() => keySpeedAnnouncement),
-    );
   });
   $effect(() => {
     const next = cwPitchLease === null ? cwPitchScalar.view : cwPitchLease.view;
@@ -317,7 +300,6 @@
     );
   });
   onDestroy(() => {
-    keySpeedScalar.destroy();
     cwPitchScalar.destroy();
     breakInDelayScalar.destroy();
   });
@@ -494,15 +476,17 @@
       </div>
     {/if}
 
-    {#each CW_LEVELS as [field, label, min, max, step, unit] (field)}
+    {#if showKeyerSpeed}
+      {@render continuousHandles.keyerSpeed()}
+    {/if}
+
+    {#each CW_LEVELS.filter(([field]) => field !== 'keyerSpeed') as [field, label, min, max, step, unit] (field)}
       {@const f = cw[field]}
       {#if f.availability.structural}
         <label
           class="cw-keyer-level" data-testid={`cw-keyer-${field}`}
           data-observed={field === 'breakInDelay' ? usable(f)
-            : field === 'keyerSpeed'
-              ? keySpeedView.canonical !== null && keySpeedView.editable
-              : cwPitchView.canonical !== null && cwPitchView.editable}
+            : cwPitchView.canonical !== null && cwPitchView.editable}
         >
           <span class="cw-keyer-name">{label}</span>
           {#if field === 'breakInDelay'}
@@ -539,12 +523,10 @@
               <output data-testid="cw-keyer-breakInDelay-value">{textOf(f)} {unit}</output>
             {/if}
           {:else}
-            {@const levelView = field === 'keyerSpeed' ? keySpeedView : cwPitchView}
-            {@const levelLease = field === 'keyerSpeed' ? keySpeedLease : cwPitchLease}
-            {@const hasFeedback = field === 'keyerSpeed'
-              ? keySpeedFeedback !== undefined : cwPitchFeedback !== undefined}
-            {@const announcement = field === 'keyerSpeed'
-              ? keySpeedAnnouncement : cwPitchAnnouncement}
+            {@const levelView = cwPitchView}
+            {@const levelLease = cwPitchLease}
+            {@const hasFeedback = cwPitchFeedback !== undefined}
+            {@const announcement = cwPitchAnnouncement}
             {@const levelDisplay = feedbackLevelDisplay(levelView)}
             <input
               {...INTEGRATED_RANGE_POLICY} type="range" {min} {max} {step}

--- a/frontend/src/semantic/__tests__/CwKeyerInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerInstrumentHost.isolated.test.ts
@@ -18,8 +18,8 @@ vi.mock('../../primitives/scalar/continuous-scalar.svelte', async (importOrigina
       const binding = actual.createContinuousScalar(...args);
       const attachRenderer = binding.attachRenderer.bind(binding);
       const destroy = binding.destroy.bind(binding);
-      binding.attachRenderer = () => {
-        const lease = attachRenderer();
+      binding.attachRenderer = (...rendererArgs: Parameters<typeof attachRenderer>) => {
+        const lease = attachRenderer(...rendererArgs);
         capture.leases.push({ binding, lease });
         return lease;
       };

--- a/frontend/src/semantic/__tests__/CwKeyerInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerInstrumentHost.isolated.test.ts
@@ -1,0 +1,363 @@
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
+
+const activation = vi.hoisted(() => ({ selected: undefined as unknown }));
+const capture = vi.hoisted(() => ({ bindings: [] as unknown[], leases: [] as unknown[] }));
+
+vi.mock('../../component-kits/activation', () => ({
+  getSelectedScalarAppearance: () => activation.selected,
+}));
+vi.mock('../../primitives/scalar/continuous-scalar.svelte', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../primitives/scalar/continuous-scalar.svelte')>();
+  return {
+    ...actual,
+    createContinuousScalar: (...args: Parameters<typeof actual.createContinuousScalar>) => {
+      const binding = actual.createContinuousScalar(...args);
+      const attachRenderer = binding.attachRenderer.bind(binding);
+      const destroy = binding.destroy.bind(binding);
+      binding.attachRenderer = () => {
+        const lease = attachRenderer();
+        capture.leases.push({ binding, lease });
+        return lease;
+      };
+      binding.destroy = vi.fn(() => destroy());
+      capture.bindings.push(binding);
+      return binding;
+    },
+  };
+});
+
+import ExternalScalarRenderer from '../../components-v2/controls/value-control/__tests__/ExternalScalarRendererFixture.svelte';
+import type { Skin } from '../../components-v2/controls/value-control/skin';
+import type {
+  CommandScalarFeedback,
+  ContinuousScalarBinding,
+  ContinuousScalarRendererLease,
+} from '../../primitives/scalar/continuous-scalar.svelte';
+import Fixture from './fixtures/CwKeyerInstrumentHostFixture.svelte';
+import { topologyFixtures, withCwKeyer } from '../fixtures/topologies';
+import type { CwKeyerViewModel, RadioViewModel } from '../radio-view-model';
+import {
+  CW_CONTINUOUS_LEVELS,
+  type CwContinuousField,
+  type CwContinuousPresentation,
+} from '../CwKeyerInstrumentHost.svelte';
+
+type Feedback = Readonly<CommandScalarFeedback>;
+type Props = {
+  view: RadioViewModel;
+  presentation: 'grouped' | 'independent';
+  scalarPresentation?: Readonly<CwContinuousPresentation>;
+  cwPitchFeedback?: Feedback;
+  keySpeedFeedback?: Feedback;
+  onLevelChange?: (field: CwContinuousField | 'pitchHz' | 'breakInDelay', value: number) => void;
+};
+type RendererNode = HTMLButtonElement & { readonly rendererLease: ContinuousScalarRendererLease };
+
+const initial = { keyerSpeed: 24 } as const;
+const control = { keyerSpeed: 'keyer-speed' } as const;
+const base = (): RadioViewModel => withCwKeyer(topologyFixtures['1/single']);
+const feedback = (
+  field: CwContinuousField,
+  over: Partial<CommandScalarFeedback> = {},
+): Feedback => Object.freeze({
+  confirmed: initial[field], target: null, requestedTarget: null,
+  phase: 'idle', busy: false, availability: 'available', outcome: null,
+  lifecycleId: null, transitionId: null, providerGeneration: 1, sessionEpoch: 1,
+  scope: Object.freeze({ control: control[field], receiver: 0 as const }),
+  repeatPolicy: 'latest-target-wins', ...over,
+});
+
+let target: HTMLDivElement;
+let mounted = new Set<ReturnType<typeof mount>>();
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  activation.selected = {
+    name: 'CW host test', hbar: ExternalScalarRenderer, knob: ExternalScalarRenderer,
+  } satisfies Skin;
+  capture.bindings = [];
+  capture.leases = [];
+});
+afterEach(() => {
+  for (const component of mounted) unmount(component);
+  mounted = new Set();
+  activation.selected = undefined;
+  target.remove();
+});
+
+function render(over: Partial<Props> = {}) {
+  const onLevelChange = vi.fn(over.onLevelChange ?? (() => {}));
+  const props = proxy<Props>({
+    view: base(), presentation: 'grouped',
+    keySpeedFeedback: feedback('keyerSpeed'),
+    ...over, onLevelChange,
+  });
+  const component = mount(Fixture, { target, props });
+  mounted.add(component);
+  flushSync();
+  const row = (field: CwContinuousField) => target.querySelector<HTMLElement>(
+    `[data-testid="cw-keyer-${field}"]`,
+  )!;
+  const renderer = (field: CwContinuousField) => row(field).querySelector<RendererNode>(
+    '[data-external-scalar-renderer]',
+  );
+  const dispose = () => { unmount(component); mounted.delete(component); };
+  return { props, component, onLevelChange, row, renderer, dispose };
+}
+
+function binding(field: CwContinuousField): ContinuousScalarBinding {
+  return capture.bindings[0] as ContinuousScalarBinding;
+}
+function currentLease(field: CwContinuousField): ContinuousScalarRendererLease {
+  const owner = binding(field);
+  for (let index = capture.leases.length - 1; index >= 0; index -= 1) {
+    const entry = capture.leases[index] as { binding: unknown; lease: ContinuousScalarRendererLease };
+    if (entry.binding === owner) return entry.lease;
+  }
+  throw new Error('renderer lease not captured');
+}
+
+describe('CwKeyerInstrumentHost', () => {
+  it('creates one persistent binding and destroys it once', () => {
+    const r = render();
+    // The second owner is the unchanged native pitch binding inside the Surface.
+    expect(capture.bindings).toHaveLength(2);
+    expect(target.querySelectorAll('[data-external-scalar-renderer]')).toHaveLength(1);
+    expect(CW_CONTINUOUS_LEVELS).toEqual([
+      ['keyerSpeed', 'Keyer speed', 6, 48, 1, 'WPM', 'set_key_speed'],
+    ]);
+    const owner = binding('keyerSpeed');
+    r.dispose();
+    expect(owner.destroy).toHaveBeenCalledOnce();
+  });
+
+  it('keeps binding identities across grouped-independent-grouped replacement', () => {
+    const r = render();
+    const owner = binding('keyerSpeed');
+    r.props.presentation = 'independent'; flushSync();
+    expect(binding('keyerSpeed')).toBe(owner);
+    expect(target.querySelectorAll('[data-external-scalar-renderer]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-testid="cw-keyer-surface"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-testid="cw-keyer-breakInDelay"]')).toHaveLength(1);
+    r.props.presentation = 'grouped'; flushSync();
+    expect(binding('keyerSpeed')).toBe(owner);
+    expect(target.querySelectorAll('[data-testid="cw-keyer-keyerSpeed"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-testid="cw-keyer-pitchHz"]')).toHaveLength(1);
+    r.dispose();
+  });
+
+  it.each(['hbar', 'knob'] as const)(
+    'uses the rendered-native lattice for every %s interaction', (form) => {
+      for (const field of ['keyerSpeed'] as const) {
+        const [, , min, max, step] = CW_CONTINUOUS_LEVELS.find(([name]) => name === field)!;
+        const exercise = (
+          invoke: (lease: ContinuousScalarRendererLease) => void,
+          expected?: number,
+        ) => {
+          capture.bindings = [];
+          capture.leases = [];
+          const r = render({ presentation: 'independent', scalarPresentation: { form } });
+          invoke(currentLease(field));
+          if (expected === undefined) expect(r.onLevelChange).not.toHaveBeenCalled();
+          else expect(r.onLevelChange).toHaveBeenCalledExactlyOnceWith(field, expected);
+          r.dispose();
+        };
+        for (const [key, expected] of [
+          ['ArrowLeft', initial[field] - step], ['ArrowRight', initial[field] + step],
+          ['ArrowDown', initial[field] - step], ['ArrowUp', initial[field] + step],
+          ['Home', min], ['End', max],
+        ] as const) exercise((lease) => {
+          expect(lease.key({ key, fine: false })).toBe(true);
+        }, expected);
+        exercise((lease) => lease.wheel({ direction: 1, fine: false }), initial[field] + step);
+        exercise((lease) => lease.wheel({ direction: 1, fine: true }), initial[field] + step);
+        exercise((lease) => lease.nativeInput(initial[field] + step * 2.4), initial[field] + step * 2);
+        exercise((lease) => {
+          const token = lease.beginPointer();
+          expect(token).not.toBeNull();
+          lease.pointer(token!, initial[field] + step * 3.4);
+          lease.endPointer(token!);
+        }, initial[field] + step * 3);
+        exercise((lease) => lease.reset());
+      }
+    },
+  );
+
+  it('cancels physical drafts and makes every retained renderer operation inert', () => {
+    const r = render({ presentation: 'independent', scalarPresentation: { form: 'hbar' } });
+    const stale = currentLease('keyerSpeed');
+    const token = stale.beginPointer(); expect(token).not.toBeNull();
+    stale.pointer(token!, 31);
+    r.onLevelChange.mockClear();
+
+    r.props.scalarPresentation = { form: 'knob' }; flushSync();
+    expect(currentLease('keyerSpeed').view.draft).toBeNull();
+    expect(stale.beginPointer()).toBeNull();
+    stale.pointer(token!, 32); stale.endPointer(token!); stale.cancelPointer(token!);
+    stale.nativeInput(33); stale.wheel({ direction: 1, fine: false });
+    expect(stale.key({ key: 'End', fine: false })).toBe(false);
+    stale.reset(); stale.dispose();
+    expect(r.onLevelChange).not.toHaveBeenCalled();
+
+    expect(currentLease('keyerSpeed').key({ key: 'End', fine: false })).toBe(true);
+    expect(r.onLevelChange).toHaveBeenCalledExactlyOnceWith('keyerSpeed', 48);
+    r.props.scalarPresentation = { form: 'hbar' }; flushSync();
+    expect(stale.key({ key: 'Home', fine: false })).toBe(false);
+    r.dispose();
+  });
+
+  it('preserves command evidence and invalidates a gesture on authority replacement', () => {
+    activation.selected = undefined;
+    const pending = feedback('keyerSpeed', {
+      target: 31, requestedTarget: 31, phase: 'awaiting-confirmation', busy: true,
+      lifecycleId: 'speed-31', transitionId: 'speed-awaiting-31',
+    });
+    const r = render({
+      presentation: 'independent', scalarPresentation: { form: 'hbar' },
+      keySpeedFeedback: pending,
+    });
+    expect(target.querySelector('.vc-value')?.textContent).toBe('24 WPM');
+    expect(target.querySelector('[role="slider"]')?.getAttribute('aria-valuetext'))
+      .toContain('requested 31 WPM');
+    expect(r.row('keyerSpeed').querySelector('[data-canonical-value]')?.textContent).toBe('24 WPM');
+    const before = binding('keyerSpeed').view;
+    expect(before).toMatchObject({
+      target: 31, requested: 31, phase: 'awaiting-confirmation', busy: true,
+      feedback: {
+        lifecycleId: 'speed-31', repeatPolicy: 'latest-target-wins',
+        providerGeneration: 1, sessionEpoch: 1,
+        scope: { control: 'keyer-speed', receiver: 0 },
+      },
+    });
+    const lease = currentLease('keyerSpeed');
+    const token = lease.beginPointer(); expect(token).not.toBeNull();
+    r.props.keySpeedFeedback = feedback('keyerSpeed', {
+      providerGeneration: 2, sessionEpoch: 2,
+      scope: { control: 'keyer-speed', receiver: 0, slot: 'sub' },
+    });
+    flushSync();
+    lease.pointer(token!, 32); lease.endPointer(token!);
+    expect(r.onLevelChange).not.toHaveBeenCalled();
+    expect(binding('keyerSpeed').view).toMatchObject({
+      draft: null,
+      feedback: { providerGeneration: 2, sessionEpoch: 2, scope: { slot: 'sub' } },
+    });
+    r.dispose();
+    const remounted = render({
+      presentation: 'independent', scalarPresentation: { form: 'hbar' },
+      keySpeedFeedback: pending,
+    });
+    expect(target.querySelector('.vc-value')?.textContent).toBe('24 WPM');
+    expect(target.querySelector('[role="slider"]')?.getAttribute('aria-valuetext'))
+      .toContain('requested 31 WPM');
+    expect(remounted.onLevelChange).not.toHaveBeenCalled();
+    remounted.dispose();
+  });
+
+  it('reads the current callback and preserves raw reading, unknown and absent truth', () => {
+    activation.selected = undefined;
+    const r = render({ presentation: 'independent', scalarPresentation: { form: 'hbar' } });
+    const replacement = vi.fn();
+    r.props.onLevelChange = replacement; flushSync();
+    currentLease('keyerSpeed').key({ key: 'ArrowRight', fine: false });
+    expect(replacement).toHaveBeenCalledExactlyOnceWith('keyerSpeed', 25);
+    expect(r.onLevelChange).not.toHaveBeenCalled();
+
+    const slider = () => r.row('keyerSpeed').querySelector<HTMLElement>('[role="slider"]')!;
+    r.props.keySpeedFeedback = feedback('keyerSpeed', {
+      confirmed: null, availability: 'unavailable', phase: 'unavailable',
+    });
+    flushSync();
+    expect(slider().getAttribute('aria-disabled')).toBe('true');
+    expect(target.querySelector('.vc-value')?.textContent).toBe('—');
+
+    r.props.keySpeedFeedback = undefined;
+    flushSync();
+    expect([
+      slider().getAttribute('aria-valuemin'), slider().getAttribute('aria-valuemax'),
+      slider().getAttribute('aria-valuenow'), target.querySelector('.vc-value')?.textContent,
+    ]).toEqual(['6', '48', '24', '24 WPM']);
+    currentLease('keyerSpeed').key({ key: 'ArrowRight', fine: false });
+    expect(replacement).toHaveBeenCalledTimes(2);
+
+    r.props.view = {
+      ...r.props.view,
+      cwKeyer: { ...r.props.view.cwKeyer!, keyerSpeed: {
+        reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+      } },
+    };
+    flushSync();
+    expect(target.querySelector('.vc-value')?.textContent).toBe('—');
+    expect(slider().getAttribute('aria-disabled')).toBe('true');
+    expect(r.row('keyerSpeed').dataset.observed).toBe('false');
+    currentLease('keyerSpeed').nativeInput(31);
+    expect(replacement).toHaveBeenCalledTimes(2);
+
+    r.props.view = {
+      ...r.props.view,
+      cwKeyer: { ...r.props.view.cwKeyer!, keyerSpeed: {
+        reading: { status: 'unknown' }, availability: { structural: false, operational: false },
+      } },
+    };
+    flushSync();
+    expect(target.querySelector('[data-testid="cw-keyer-keyerSpeed"]')).toBeNull();
+    r.dispose();
+  });
+
+  it('keeps one status lane while moving HBar-knob-HBar', () => {
+    activation.selected = undefined;
+    const failed = (transitionId: string, providerGeneration = 1): Feedback => feedback('keyerSpeed', {
+      requestedTarget: 31, phase: 'failed', lifecycleId: 'speed-31', transitionId,
+      providerGeneration,
+      outcome: { phase: 'failed', error: 'radio refused' },
+    });
+    const r = render({
+      presentation: 'independent', scalarPresentation: { form: 'hbar' },
+      keySpeedFeedback: failed('speed-failed-hbar'),
+    });
+    const live = () => target.querySelectorAll('[role="status"][aria-live="polite"]');
+    expect(live()).toHaveLength(1);
+    expect(target.querySelector('[data-cw-feedback-status]')?.textContent).toContain('radio refused');
+    expect(target.querySelector('.vc-value')?.textContent).toBe('24 WPM');
+    expect(target.querySelector('.vc-value')?.textContent).not.toContain('31');
+    expect(target.querySelector('[role="slider"]')?.getAttribute('aria-valuenow')).toBe('24');
+    const initialStatus = target.querySelector('[data-cw-feedback-status]');
+    r.props.keySpeedFeedback = failed('speed-failed-hbar'); flushSync();
+    expect(target.querySelector('[data-cw-feedback-status]')).toBe(initialStatus);
+    r.props.keySpeedFeedback = failed('speed-failed-hbar', 2); flushSync();
+    expect(target.querySelector('[data-cw-feedback-status]')).not.toBe(initialStatus);
+    r.props.keySpeedFeedback = feedback('keyerSpeed', {
+      confirmed: null, availability: 'unavailable', phase: 'unavailable', providerGeneration: 3,
+    });
+    flushSync();
+    expect(target.querySelector('[data-cw-feedback-status]')).toBeNull();
+    r.props.keySpeedFeedback = failed('speed-failed-hbar', 3); flushSync();
+    expect(target.querySelector('[data-cw-feedback-status]')).not.toBeNull();
+
+    r.props.scalarPresentation = { form: 'knob' };
+    r.props.keySpeedFeedback = failed('speed-failed-knob');
+    flushSync();
+    expect(live()).toHaveLength(1);
+    expect(target.querySelector('[data-cw-feedback-status]')).toBeNull();
+
+    r.props.scalarPresentation = { form: 'hbar' };
+    r.props.keySpeedFeedback = failed('speed-failed-hbar-next');
+    flushSync();
+    expect(live()).toHaveLength(1);
+    expect(target.querySelectorAll('[data-cw-feedback-status]')).toHaveLength(1);
+    r.dispose();
+  });
+
+  it('uses no second projector or form-dependent scalar policy', () => {
+    const hostSource = readFileSync('src/semantic/CwKeyerInstrumentHost.svelte', 'utf8');
+    expect(hostSource).not.toContain('projectControlFeedbackPresentation');
+    expect(hostSource).not.toMatch(/bindings\.[\s\S]*?\.view/);
+    expect(hostSource.match(/createRenderedNativeRangeContinuousScalarPolicy\(\)/g)).toHaveLength(1);
+    expect(hostSource.match(/createContinuousScalar\(/g)).toHaveLength(1);
+    expect(hostSource).not.toMatch(/form[\s\S]{0,80}(?:Policy|policy)/);
+  });
+});

--- a/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
@@ -30,10 +30,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 // @ts-expect-error -- Svelte does not publish types for its reactive test harness.
 import { proxy } from 'svelte/internal/client';
-import CwKeyerSurface, {
+import {
   APF_CHOICES, BREAK_IN_CHOICES, BREAK_IN_REASON_KEY, CW_LEVELS, MUTEX_LABEL, POSTURE_LABEL,
   UNKNOWN_TEXT, breakInBlockedLabel, breakInPosture, type CwLevelField,
 } from '../CwKeyerSurface.svelte';
+import CwKeyerInstrumentHostFixture from './fixtures/CwKeyerInstrumentHostFixture.svelte';
 import { topologyFixtures, withCwKeyer, withTxAux } from '../fixtures/topologies';
 import type {
   Availability, BreakInMode, CwKeyerField, CwKeyerViewModel, DisabledReason, RadioViewModel,
@@ -92,7 +93,7 @@ type Handlers = {
 };
 
 function render(view: RadioViewModel, handlers: Handlers = {}) {
-  const component = mount(CwKeyerSurface, { target, props: { view, ...handlers } });
+  const component = mount(CwKeyerInstrumentHostFixture, { target, props: { view, ...handlers } });
   flushSync();
   const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
   return {
@@ -109,7 +110,7 @@ function render(view: RadioViewModel, handlers: Handlers = {}) {
 function renderReactiveFeedback(initial: BreakInDelayFeedback) {
   const onLevelChange = vi.fn();
   const props = proxy({ view: base(), onLevelChange, breakInDelayFeedback: initial });
-  const component = mount(CwKeyerSurface, { target, props });
+  const component = mount(CwKeyerInstrumentHostFixture, { target, props });
   flushSync();
   const input = () => target.querySelector<HTMLInputElement>(
     '[data-testid="cw-keyer-breakInDelay"] input',
@@ -156,7 +157,7 @@ function renderReactiveCwLevels(
   const props = proxy({
     view: base(), onLevelChange, cwPitchFeedback: pitch, keySpeedFeedback: speed,
   });
-  const component = mount(CwKeyerSurface, { target, props });
+  const component = mount(CwKeyerInstrumentHostFixture, { target, props });
   flushSync();
   const input = (field: 'pitchHz' | 'keyerSpeed') => target.querySelector<HTMLInputElement>(
     `[data-testid="cw-keyer-${field}"] input`,
@@ -190,7 +191,7 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
     // module (no transport, no controller, no permit utility) and cannot
     // widen this file's reach any more than `./pressed-of` does.
     expect([...new Set(specifiers)]).toEqual([
-      '$lib/i18n', './radio-view-model', './pressed-of',
+      '$lib/i18n', './CwKeyerInstrumentHost.svelte', './radio-view-model', './pressed-of',
       'svelte',
       '../primitives/control-feedback/control-feedback-presentation',
       '../primitives/scalar/committed-scalar.svelte',
@@ -207,6 +208,9 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
     expect(CODE).toContain('value: field.reading.value > 0');
     expect(CODE).toContain('invoke: () => onTwinPeakToggle?.()');
     expect(CODE).toContain('invoke: () => onReversePaddleToggle?.()');
+    expect(CODE).toContain('{@render continuousHandles.keyerSpeed()}');
+    expect(CODE).not.toContain('keySpeedScalar');
+    expect(CODE).toContain('const cwPitchScalar = createContinuousScalar');
   });
 
   // Kills: `onMount(() => …)` and every relative of it, plus a dynamic import
@@ -236,15 +240,15 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
   it('takes exactly one state prop — the view model — plus SETTING intents', () => {
     const props = CODE.slice(CODE.indexOf('interface Props'), CODE.indexOf('}: Props'));
     expect([...props.matchAll(/^\s{4}(\w+)[?]?:/gm)].map((m) => m[1])).toEqual([
-      'view', 'onBreakInMode', 'onLevelChange', 'onApfOn', 'onTwinPeakToggle',
-      'onReversePaddleToggle', 'breakInDelayFeedback', 'cwPitchFeedback',
-      'keySpeedFeedback', 'autoTuneAvailable', 'onAutoTune',
+      'view', 'continuousHandles', 'showKeyerSpeed', 'onBreakInMode', 'onLevelChange',
+      'onApfOn', 'onTwinPeakToggle', 'onReversePaddleToggle', 'breakInDelayFeedback',
+      'cwPitchFeedback', 'autoTuneAvailable', 'onAutoTune',
     ]);
   });
 
   it('renders an available RX frequency-correction control and emits exactly once', () => {
     const onAutoTune = vi.fn();
-    const component = mount(CwKeyerSurface, {
+    const component = mount(CwKeyerInstrumentHostFixture, {
       target,
       props: { view: base(), autoTuneAvailable: true, onAutoTune },
     });
@@ -259,7 +263,7 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
 
   it('omits the RX frequency-correction control when unavailable or callback-free', () => {
     const unavailableCallback = vi.fn();
-    const unavailable = mount(CwKeyerSurface, {
+    const unavailable = mount(CwKeyerInstrumentHostFixture, {
       target,
       props: { view: base(), autoTuneAvailable: false, onAutoTune: unavailableCallback },
     });
@@ -268,7 +272,7 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
     expect(unavailableCallback).not.toHaveBeenCalled();
     unmount(unavailable);
 
-    const callbackFree = mount(CwKeyerSurface, {
+    const callbackFree = mount(CwKeyerInstrumentHostFixture, {
       target,
       props: { view: base(), autoTuneAvailable: true },
     });
@@ -285,7 +289,7 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
     delete (view as { cwKeyer?: unknown }).cwKeyer;
     const r = render(view);
     expect(r.root()).toBeNull();
-    expect(target.textContent).toBe('');
+    expect(target.textContent?.trim()).toBe('');
     r.dispose();
   });
 
@@ -315,7 +319,7 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
     flushSync();
     expect(seen).toEqual([
       'breakIn:0', 'breakIn:1', 'breakIn:2',
-      'level:keyerSpeed:48', 'level:pitchHz:900', 'level:breakInDelay:255',
+      'level:pitchHz:900', 'level:breakInDelay:255',
       'reversePaddle', 'apf:false', 'apf:true', 'twinPeak',
     ]);
     r.dispose();
@@ -331,27 +335,22 @@ describe('CW pitch and keyer speed own independent command feedback', () => {
         confirmed: null, availability: 'unavailable', sessionEpoch: 2,
       },
     );
-    const r = renderReactiveCwLevels(unavailable('cw-pitch'), unavailable('keyer-speed'));
-    for (const field of ['pitchHz', 'keyerSpeed'] as const) {
-      expect(r.input(field).disabled).toBe(true);
-      expect(r.input(field).dataset.commandPhase).toBe('unavailable');
-      expect(r.row(field).dataset.observed).toBe('false');
-      expect(r.row(field).textContent).toContain(UNKNOWN_TEXT);
-      slide(r.input(field), Number(r.input(field).max));
-    }
+    const r = renderReactiveCwLevels(unavailable('cw-pitch'));
+    const field = 'pitchHz';
+    expect(r.input(field).disabled).toBe(true);
+    expect(r.input(field).dataset.commandPhase).toBe('unavailable');
+    expect(r.row(field).dataset.observed).toBe('false');
+    expect(r.row(field).textContent).toContain(UNKNOWN_TEXT);
+    slide(r.input(field), Number(r.input(field).max));
     expect(r.onLevelChange).not.toHaveBeenCalled();
     r.dispose();
   });
 
-  it('maps each native input immediately and exactly once to its own setting intent', () => {
+  it('keeps the remaining native pitch input mapped exactly once', () => {
     const r = renderReactiveCwLevels();
     slide(r.input('pitchHz'), 725);
-    slide(r.input('keyerSpeed'), 31);
-    expect(r.onLevelChange.mock.calls).toEqual([
-      ['pitchHz', 725], ['keyerSpeed', 31],
-    ]);
+    expect(r.onLevelChange.mock.calls).toEqual([['pitchHz', 725]]);
     expect(r.input('pitchHz').value).toBe('725');
-    expect(r.input('keyerSpeed').value).toBe('31');
     r.dispose();
   });
 
@@ -389,7 +388,6 @@ describe('CW pitch and keyer speed own independent command feedback', () => {
 
   it.each([
     ['pitchHz', 'cw-pitch', 600, 725],
-    ['keyerSpeed', 'keyer-speed', 24, 31],
   ] as const)('mounts and remounts %s at its pre-existing active target', (
     field, control, confirmed, targetValue,
   ) => {
@@ -411,7 +409,6 @@ describe('CW pitch and keyer speed own independent command feedback', () => {
 
   it.each([
     ['pitchHz', 'cw-pitch', 600, 725],
-    ['keyerSpeed', 'keyer-speed', 24, 31],
   ] as const)('keeps terminal %s requested target distinct from canonical display', (
     field, control, confirmed, requestedTarget,
   ) => {
@@ -430,7 +427,6 @@ describe('CW pitch and keyer speed own independent command feedback', () => {
 
   it.each([
     ['pitchHz', 'cw-pitch', 600, 605, 725],
-    ['keyerSpeed', 'keyer-speed', 24, 25, 31],
   ] as const)('invalidates and reissues the %s live event across authority replacement', (
     field, control, confirmed, rerendered, requestedTarget,
   ) => {
@@ -485,7 +481,7 @@ describe('CW pitch and keyer speed own independent command feedback', () => {
     });
     const r = renderReactiveCwLevels(pitch, speed);
     expect(r.input('pitchHz').dataset.commandPhase).toBe('failed');
-    expect(r.input('keyerSpeed').dataset.commandPhase).toBe('timed-out');
+    expect(r.row('keyerSpeed').dataset.commandPhase).toBe('timed-out');
     expect(r.row('pitchHz').textContent).toContain('pitch rejected');
     const announcements = [...target.querySelectorAll<HTMLElement>(
       '[data-cw-feedback-status]',
@@ -501,34 +497,24 @@ describe('CW pitch and keyer speed own independent command feedback', () => {
     const r = renderReactiveCwLevels();
     slide(r.input('pitchHz'), 650);
     slide(r.input('pitchHz'), 700);
-    slide(r.input('keyerSpeed'), 31);
     expect(r.input('pitchHz').value).toBe('700');
-    expect(r.input('keyerSpeed').value).toBe('31');
 
     r.props.cwPitchFeedback = cwFeedback('cw-pitch', 'unavailable', {
       confirmed: null, availability: 'unavailable', providerGeneration: 2, sessionEpoch: 2,
     });
-    r.props.keySpeedFeedback = cwFeedback('keyer-speed', 'idle', {
-      confirmed: 22, providerGeneration: 2, sessionEpoch: 2,
-    });
     flushSync();
     expect(r.input('pitchHz').disabled).toBe(true);
     expect(r.input('pitchHz').value).toBe('300');
-    expect(r.input('keyerSpeed').value).toBe('22');
-    expect(r.onLevelChange.mock.calls).toEqual([
-      ['pitchHz', 650], ['pitchHz', 700], ['keyerSpeed', 31],
-    ]);
+    expect(r.onLevelChange.mock.calls).toEqual([['pitchHz', 650], ['pitchHz', 700]]);
     r.dispose();
   });
 
-  it('retains reading compatibility when both optional feedback props are omitted', () => {
+  it('retains pitch reading compatibility when its optional feedback prop is omitted', () => {
     const onLevelChange = vi.fn();
     const r = render(base(), { onLevelChange });
     expect(r.input('pitchHz')?.dataset.commandPhase).toBeUndefined();
-    expect(r.input('keyerSpeed')?.dataset.commandPhase).toBeUndefined();
     slide(r.input('pitchHz')!, 725);
-    slide(r.input('keyerSpeed')!, 31);
-    expect(onLevelChange.mock.calls).toEqual([['pitchHz', 725], ['keyerSpeed', 31]]);
+    expect(onLevelChange.mock.calls).toEqual([['pitchHz', 725]]);
     r.dispose();
   });
 });
@@ -723,10 +709,10 @@ describe('Break-in Delay separates draft, submitted target and confirmed truth',
     const current = feedback('failed', {
       requestedTarget: 111, transitionId: 'shared-transition', outcome: { phase: 'failed' },
     });
-    const first = mount(CwKeyerSurface, {
+    const first = mount(CwKeyerInstrumentHostFixture, {
       target, props: { view: base(), breakInDelayFeedback: current },
     });
-    const second = mount(CwKeyerSurface, {
+    const second = mount(CwKeyerInstrumentHostFixture, {
       target: secondTarget, props: { view: base(), breakInDelayFeedback: { ...current } },
     });
     flushSync();
@@ -1031,7 +1017,9 @@ describe('the mutex reasons are rendered with the other mode NAMED (MOR-1296 O1)
 /* ── facts render honestly ─────────────────────────────────────── */
 
 describe('every unread fact renders honestly, never as a v2 default', () => {
-  it.each(CW_LEVELS)('renders the %s fact verbatim on its raw wire scale', (field, _l, min, max) => {
+  const NATIVE_LEVELS = CW_LEVELS.filter(([field]) => field !== 'keyerSpeed');
+
+  it.each(NATIVE_LEVELS)('renders the %s fact verbatim on its raw wire scale', (field, _l, min, max) => {
     const r = render(withCw({ [field]: known(max) } as Partial<CwKeyerViewModel>));
     expect(r.input(field)!.valueAsNumber).toBe(max);
     expect([r.input(field)!.min, r.input(field)!.max]).toEqual([String(min), String(max)]);
@@ -1040,7 +1028,7 @@ describe('every unread fact renders honestly, never as a v2 default', () => {
 
   // Kills: an unread level rendering as a number, and a thumb free to claim
   // any position (the MOR-1279 F1 / MOR-1304 F2 precedent).
-  it.each(CW_LEVELS)('renders an unread %s as unknown and parks the thumb at min', (field, _l, min) => {
+  it.each(NATIVE_LEVELS)('renders an unread %s as unknown and parks the thumb at min', (field, _l, min) => {
     const onLevelChange = vi.fn();
     const r = render(
       withCw({ [field]: unread<number>() } as Partial<CwKeyerViewModel>), { onLevelChange },
@@ -1055,7 +1043,7 @@ describe('every unread fact renders honestly, never as a v2 default', () => {
     r.dispose();
   });
 
-  it.each(CW_LEVELS)('emits the %s intent verbatim when observed', (field, _l, _min, max) => {
+  it.each(NATIVE_LEVELS)('emits the %s intent verbatim when observed', (field, _l, _min, max) => {
     const onLevelChange = vi.fn();
     const r = render(base(), { onLevelChange });
     slide(r.input(field)!, max);
@@ -1064,7 +1052,7 @@ describe('every unread fact renders honestly, never as a v2 default', () => {
     r.dispose();
   });
 
-  it.each(CW_LEVELS)('renders no %s block when it is structurally absent', (field) => {
+  it.each(NATIVE_LEVELS)('renders no %s block when it is structurally absent', (field) => {
     const r = render(withCw({ [field]: unread(OFF) } as Partial<CwKeyerViewModel>));
     expect(r.el(field)).toBeNull();
     r.dispose();

--- a/frontend/src/semantic/__tests__/fixtures/CwKeyerInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/CwKeyerInstrumentHostFixture.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import type { CommandScalarFeedback } from '../../../primitives/scalar/continuous-scalar.svelte';
+  import type { ControlFeedbackPresentationInput } from '../../../primitives/control-feedback/control-feedback-presentation';
+  import CwKeyerInstrumentHost, {
+    type CwContinuousPresentation,
+    type CwKeyerInstrumentHandles,
+  } from '../../CwKeyerInstrumentHost.svelte';
+  import CwKeyerSurface, { type CwLevelField } from '../../CwKeyerSurface.svelte';
+  import type { RadioViewModel } from '../../radio-view-model';
+
+  type BreakInDelayFeedback = ControlFeedbackPresentationInput<number> & {
+    readonly sessionEpoch?: number;
+    readonly scope?: Readonly<{ control: string; receiver: number; slot?: string }>;
+  };
+
+  interface Props {
+    view: RadioViewModel;
+    presentation?: 'grouped' | 'independent';
+    scalarPresentation?: Readonly<CwContinuousPresentation>;
+    breakInDelayFeedback?: Readonly<BreakInDelayFeedback>;
+    cwPitchFeedback?: Readonly<CommandScalarFeedback>;
+    keySpeedFeedback?: Readonly<CommandScalarFeedback>;
+    autoTuneAvailable?: boolean;
+    onBreakInMode?: (mode: number) => void;
+    onLevelChange?: (field: CwLevelField, value: number) => void;
+    onApfOn?: (on: boolean) => void;
+    onTwinPeakToggle?: () => void;
+    onReversePaddleToggle?: () => void;
+    onAutoTune?: () => void;
+  }
+
+  let {
+    view, presentation = 'grouped', scalarPresentation,
+    breakInDelayFeedback, cwPitchFeedback, keySpeedFeedback, autoTuneAvailable = false,
+    onBreakInMode, onLevelChange, onApfOn, onTwinPeakToggle, onReversePaddleToggle, onAutoTune,
+  }: Props = $props();
+</script>
+
+<CwKeyerInstrumentHost {view} {keySpeedFeedback} {onLevelChange}>
+  {#snippet children(handles: CwKeyerInstrumentHandles)}
+    {#key presentation}
+      {#if presentation === 'grouped'}
+        <CwKeyerSurface
+          {view} continuousHandles={handles} {breakInDelayFeedback} {autoTuneAvailable}
+          {cwPitchFeedback}
+          {onBreakInMode} {onLevelChange} {onApfOn} {onTwinPeakToggle}
+          {onReversePaddleToggle} {onAutoTune}
+        />
+      {:else}
+        <section data-testid="independent-cw-keyer-composition">
+          <div data-slot="keyer-speed">{@render handles.keyerSpeed(scalarPresentation)}</div>
+          <CwKeyerSurface
+            {view} continuousHandles={handles} showKeyerSpeed={false}
+            {breakInDelayFeedback} {cwPitchFeedback} {autoTuneAvailable}
+            {onBreakInMode} {onLevelChange} {onApfOn} {onTwinPeakToggle}
+            {onReversePaddleToggle} {onAutoTune}
+          />
+        </section>
+      {/if}
+    {/key}
+  {/snippet}
+</CwKeyerInstrumentHost>


### PR DESCRIPTION
12 code + 0 regenerated baselines = 12 files

Linear: https://linear.app/morozsm/issue/MOR-2425/expose-a-supported-v3-host-boundary-for-independently-installed

## Summary

- mount one permanent CW Keyer Speed owner around the replaceable semantic/layout composition
- reuse the existing continuous-scalar owner and rendered native-range policy with a required handle and no raw fallback
- render Keyer Speed once in grouped/SDR and once in a named Standard seat while preserving CW Pitch, Break-in Delay, and every other CW control
- retain canonical 24 WPM while exposing requested 31 WPM, feedback phase/error, authority identity, and stale-lease revocation across renderer/layout replacement

## Scope and census

- 12 paths, 815 additions + 109 deletions = 924 A+D
- 308 source A+D and 616 tests/fixtures A+D
- the authorized twelfth path only updates an existing source-boundary assertion after natural quick proved it stale
- no SDK, registry, scalar primitive, provider, command, legacy CwPanel, product-path successor, or regenerated baseline changes

## RED / GREEN evidence

RED before the host existed:
- host and Surface suites failed at the missing CwKeyerInstrumentHost import
- real semantic wiring/layout suites failed because the required handle was absent
- the first integrated wiring run exposed four harness expectations: missing pointer-capture shims, canonical-vs-requested HBar presentation, the issued-status lane, and the all-controls gesture driver

Corrections changed only the test driver/expectations to exercise the rendered HBar contract. Product semantics stayed canonical 24 WPM with requested 31 WPM retained as accessible evidence.

The first natural quick, run 34111337527 on `cb153154db0484a06cd9adefbc40b38260ea7260`, ran 11,238 tests and failed only a stale assertion in `semantic-vfo-indicator-wiring.component.test.ts`: it still required Keyer Speed feedback on `CwKeyerSurface`. The authorized test-only successor now requires that feedback on `CwKeyerInstrumentHost`, keeps CW Pitch on the Surface, and forbids Keyer Speed from returning there. It also forwards the SDK 0.5 renderer-currentness predicate through the host-test capture wrapper.

GREEN on exact successor `058479ca805719155cc6a91df1784983af439c88`, based on `07ff1d3d8d144a9e2f0a52573d5554662288fe4e`:
- focused Vitest: 7 files, 276 tests passed
- successor boundary + host tests: 2 files, 39 tests passed
- `npm run check`: 0 errors, 0 warnings
- exact changed-path ESLint: passed
- `git diff --check origin/main...HEAD`: passed
- predecessor natural visual run 34111337338: passed

## Review notes

- one `createContinuousScalar` and one `createRenderedNativeRangeContinuousScalarPolicy` live in the permanent host
- Keyer Speed remains 6..48 WPM, step 1, and sends only `set_key_speed { speed }`
- CW Pitch remains on its native scalar path; Break-in Delay retains the accepted committed-scalar destroy/lease path
- no deployment and no registry publication

## Terminal independent review and integration

- Exact successor `058479ca805719155cc6a91df1784983af439c88`: natural quick [34111955893](https://github.com/rigplane/rigplane-core/actions/runs/34111955893) SUCCESS and natural visual [34111956015](https://github.com/rigplane/rigplane-core/actions/runs/34111956015) SUCCESS.
- Independent [PASS 5569385753](https://github.com/rigplane/rigplane-core/pull/3339#issuecomment-5569385753) clears both test corrections and the full product mechanism. The predecessor [BLOCKED 5569341177](https://github.com/rigplane/rigplane-core/pull/3339#issuecomment-5569341177) and quick failure remain part of the recorded history.
- Root fully read the final author handoff and independent review, checked the exact directive and required checks, and confirmed that all 12 touched-file blobs in the prospective merge onto `1ffd2a68c9e9458080efe311097afda3eed41b8b` match the reviewed head.
- Coordinator approves the 12-file exception for this cohesive ownership transfer and its actual-consumer regression witnesses. Total remains 924 A+D, below the hard 1,000 limit.
- No deployment or package publication. The full MOR-2425 objective remains in progress.
