### PR TITLE
docs: align coordinate-sessions skill with the 2026-09-07 operating mode

### DIFF
--- a/.claude/skills/coordinate-sessions/SKILL.md
+++ b/.claude/skills/coordinate-sessions/SKILL.md
@@ -3,16 +3,17 @@ name: coordinate-sessions
 description: >
   Method for a session coordinating several peer Claude Code sessions — each
   owning its own line of work — alongside its own subagents in this repository.
-  Covers roles, addressing peers whose names rotate, what a dispatch must
-  carry, the PR pipeline from baseline to squash-merge, cycle limits,
-  guardrail exceptions, escalation, measurement discipline, and session end.
+  Covers roles and model choice, how a peer session is created and controlled,
+  addressing peers whose names rotate, what a dispatch must carry, the PR
+  pipeline from baseline to squash-merge, cycle limits, guardrail exceptions,
+  escalation, measurement discipline, and session end.
   Use when running or joining a multi-session workstream; a single line of work
   needs only CLAUDE.md's pipeline.
 ---
 
 # Coordinate sessions
 
-Peers are not subagents. You cannot read a peer's context, cannot stop it, and
+Peers are not subagents. A peer runs its own turn, on its own model, and you
 cannot see what it has pushed except through git and `gh`. What you hold that
 nobody else does is the map: which line owns which branch, PR and ticket.
 
@@ -28,21 +29,68 @@ leave to the coordinator.
   §Agent working rules — The pipeline). The owner has carved out three things
   you do yourself: deleting a false line of prose in a change already under
   review, writing and correcting PR bodies, and merging.
-- **`builder`** — implements from a spec. Pass `model: opus` and ask for high
-  thinking effort explicitly in every dispatch rather than relying on the
-  default (owner's instruction, 2026-09-03).
-- **`verifier`** (opus, pinned in `.claude/agents/verifier.md`) — independent
-  adversarial review. Tell it in the dispatch to review the code only and not
+- **`builder`** — implements from a spec. Default to a mid-tier model, and
+  choose the effort from the complexity of the task in hand. Escalate the model
+  only for the specific bounded piece that stalls, and only after clarifying
+  the contract or shrinking the task first. Record the model, the effort and a
+  one-line reason for both in the delegation card (owner's instruction,
+  2026-09-07, superseding the 2026-09-03 instruction to pass `model: opus` with
+  high effort in every dispatch).
+- **`verifier`** — independent adversarial review. Choose a mid-tier model for
+  a local edit, and a strong one for contracts, lifetimes, concurrency and
+  architecture; record the choice on each dispatch (owner's instruction,
+  2026-09-07). The `model` in an agent's frontmatter under `.claude/agents/` is
+  the default that a `model` passed on the dispatch replaces. Tell it in the
+  dispatch to review the code only and not
   to grade documentation, comments, changelog rows or PR-body prose. Its own
   rules already block on defects *inside* the diff and return PASS with a
   named correction for a false claim in a PR body, comment or commit message.
 - **`scout`, `researcher`, `auditor`** — read-only, per `.claude/agents/`.
+- **Mechanical helper** — a cheaper model at small or medium effort, for
+  inventories, diff counts, artifact comparisons and known documentation or
+  metadata edits. A conclusion it is unsure of goes back to the coordinator
+  rather than into its result (owner's instruction, 2026-09-07).
 - **Non-code finder/coordinator** — consolidates PR-body, evidence, and prose
   findings separately from the code-only verifier.
 - The author never reviews, and **you are an author too**: the dispatch brief
   is your claim about the code, not the code. Brief the verifier against the
   brief as well as the diff. Never review the output of your own dispatch
   yourself — hand it to a verifier or to a peer that did not write it.
+
+## Sessions as the unit of delegation
+
+When the owner asks for sessions rather than subagents, each executor runs as
+its own desktop session, not as a subagent inside yours. You create one with
+`spawn_task`, which raises a chip the owner starts with one click; the session
+it spins off gets a fresh worktree of its own. Install dependencies inside that
+worktree — a real `npm ci`, never a shared or symlinked `node_modules`
+(AGENTS.md §Multi-agent Git hygiene).
+
+What you can do to a peer session is narrower than what you can do to a
+subagent, so plan around the tools that exist:
+
+- `send_message` delivers a message that arrives in the target session as a
+  user turn. It is unavailable in unattended sessions and cannot deliver to
+  them, so a scheduled or remote-dispatched line is reachable only through the
+  owner.
+- `list_events` reads the target session's recent transcript, and
+  `search_session_transcripts` searches transcript content across sessions.
+  Reading a peer's transcript tells you what it says it did; the result you
+  accept still comes only through git and `gh`.
+- `list_sessions` and `get_session` give addresses and per-session metadata,
+  including worktree and branch.
+- `archive_session` stops a session's process and cleans up its worktree. It
+  needs the owner's explicit agreement per call, and it does not archive a
+  session that is still working. Stopping a peer is therefore not yours to do
+  on your own.
+
+Two authors never hold the same working file at once, and every shared live
+seam of the application has one named owner (owner's instruction, 2026-09-07).
+Keep the operating table outside this repository, in the private handoff: task,
+role with its actual model and effort, worktree/branch/head, path ownership,
+status, blocker, next step, and a link to the report. Linear holds the goal,
+priorities, dependencies and acceptance criteria; do not build a competing plan
+beside it.
 
 ## Addressing peers
 
@@ -64,9 +112,30 @@ leave to the coordinator.
 ## What a dispatch carries
 
 Print the delegation card before the call, never after: the task in one
-sentence; complexity; why delegate and why that level; the role and its pinned
-model plus effort; the acceptance criterion, stating explicitly whether the
-agent may mutate state or is read-only.
+sentence; complexity; why delegate and why that level; the acceptance
+criterion, stating explicitly whether the agent may mutate state or is
+read-only. Beyond that, the owner's instruction of 2026-09-07 requires every
+dispatch to carry:
+
+- the goal, its Linear owner, and checkable acceptance criteria;
+- the role, the model and effort actually chosen, and why they fit;
+- the repository, worktree, branch and exact base commit;
+- the allowed paths, the owner of any shared file, and the agreed interfaces;
+- what is in scope, what is left to another task, and which decisions are
+  already taken;
+- the size limits, with the rule that on approaching one the agent recounts and
+  reports rather than squeezing the code or dropping evidence of behaviour;
+- the behaviour checks and required project checks to run, and the path where
+  the report goes;
+- the handback conditions: exact commit, full list of changes, checks run with
+  their results, limits, remaining findings, and either a clean tree or an
+  exact description of the work in progress;
+- which actions are authorized — preparation, push/PR, integration and
+  deployment are distinct permissions and are never implied by one another.
+
+An executor does not widen the architecture silently: a contract mismatch, a
+file-ownership collision, a failed material check or an exceeded budget is
+reported at once, with concrete options.
 
 In the prompt itself:
 
@@ -96,13 +165,21 @@ whose commit changed the tree being compared, valid only while `git diff
 --name-only <that sha>..<your base> -- <those paths>` is empty (CLAUDE.md
 §Agent working rules). One tree state, one instrument.
 
-Then: push → `gh pr create --draft` → `quick` runs on the PR → `gh pr ready` →
-the implementation or integration owner directly dispatches a fresh independent
-review on the final candidate → receive its immutable packet → confirm required
-checks green at the exact head → merge → remove the worktree.
+Then, following the cadence in AGENTS.md §Delivery batching and CI cadence:
+run focused changed-scope checks during development, and not the full `quick`
+suite → push the final candidate → open the PR, or mark an existing one, Ready
+once, so that one immutable head receives one natural `quick` run, with
+`visual` running only when its own paths are selected → the implementation or
+integration owner directly dispatches a fresh independent review on that exact
+head → receive its immutable packet → confirm required checks green at the
+exact head → merge → remove the worktree.
 
-- There is no window before the PR: `quick.yml` triggers only on push/PR to
-  `main`, so a pushed branch has no run of its own until a PR exists.
+- A draft PR must not merge, and it runs neither `quick` nor `visual`; the
+  `ready_for_review` event starts the required CI. Marking Ready once, on the
+  final candidate, is what buys the single run.
+- The verifier reviews that exact head and consumes the CI evidence already
+  there, rather than rerunning suites. A correction changes the head, and the
+  new head gets its own run and its own exact-head review.
 - Read the gate's verdict from the commit status — `gh pr checks <n>`, the
   `Agent Review Gate` row — never from a run list. The publisher job is green
   when it has successfully published a *refusal*, and `issue_comment` runs
@@ -135,10 +212,13 @@ checks green at the exact head → merge → remove the worktree.
 ## Cycle limits
 
 Two execution attempts, two review rounds, two test-fix cycles; exceeding one
-means FAILED with a classification (CLAUDE.md §Failure handling). A third
-round is the owner's call, not yours and not the peer's. Ask before the round
-starts, not after the BLOCKED has been handed back, and scope the request to
-the delta the round would cover rather than to a re-review of the whole PR.
+means FAILED with a classification (CLAUDE.md §Failure handling). A negative
+review is returned to the executor with concrete fixes; negative reviews are
+not by themselves grounds to abandon the work (owner's instruction,
+2026-09-07). A third round is the owner's call, not yours and not the peer's.
+Ask before the round starts, not after the BLOCKED has been handed back, and
+scope the request to the delta the round would cover rather than to a re-review
+of the whole PR.
 
 ## Direct review dispatch
 
@@ -238,6 +318,11 @@ or red answer on the same instrument.
   measures a tree that no longer exists.
 - **False prose is deleted, not softened** (CLAUDE.md §Testing). A deleted
   sentence cannot be wrong; a weakened one still can.
+- **A status word is a claim about how far the work got.** To the owner,
+  distinguish implemented privately, verified, reviewed, merged, built and
+  running, and say which one holds. A whole programme is never reported
+  complete because one family, one package or one PR is (owner's instruction,
+  2026-09-07).
 - The verifier does not grade prose, so a prose-only finding is yours: delete
   the line in the same commit and confirm the delta, rather than spending a
   review round on it.

--- a/.claude/skills/coordinate-sessions/SKILL.md
+++ b/.claude/skills/coordinate-sessions/SKILL.md
@@ -195,9 +195,9 @@ exact head → merge → remove the worktree.
 - Put a `Linear:` reference in the **body only**. A ticket id in the branch
   name or in a commit message auto-attaches the PR and flips that ticket to
   Done on merge; the body does not.
-- `gh pr merge <n> --squash --match-head-commit "$head_sha"`. AGENTS.md gives
-  the fused check-and-merge snippet for the queued-run race, and the rule
-  against `--delete-branch` while a child PR is based on the branch.
+- `gh pr merge <n> --squash --match-head-commit "$head_sha"`. AGENTS.md
+  requires that guard on every merge, and gives the rule against
+  `--delete-branch` while a child PR is based on the branch.
 - After merge or a FAILED/SKIPPED outcome: `git worktree remove <path>
   --force`, then `git worktree prune`. Never `rm -rf`.
 - **Conflicts with `main` are resolved by merging `main` into the branch, not


### PR DESCRIPTION
## What changed

`.claude/skills/coordinate-sessions/SKILL.md` only. Documentation, no code.

The skill still instructed the coordinator to pass `model: opus` and ask for
high thinking effort on every `builder` dispatch, citing the owner's
instruction of 2026-09-03. The owner's instruction of 2026-09-07 supersedes
that: executors default to a mid-tier model, effort follows the complexity of
the task in hand, and the model is escalated only for the specific bounded
piece that stalls, after the contract has been clarified or the task shrunk.
The model, effort and a one-line reason are recorded per dispatch.

The same instruction is now reflected in the rest of the file:

- **`verifier`** — model chosen per dispatch (mid-tier for a local edit, a
  strong model for contracts, lifetimes, concurrency and architecture). The
  `model` in an agent's frontmatter under `.claude/agents/` is named as the
  default that a dispatch-level `model` replaces. No agent definition file is
  touched by this PR.
- **Mechanical helper** — a new role line: cheaper model, small or medium
  effort, for inventories, diff counts, artifact comparisons and known
  documentation or metadata edits; an uncertain conclusion goes back to the
  coordinator.
- **New section, "Sessions as the unit of delegation"** — how a peer session is
  created and what can actually be done to it. Written against the tools that
  exist in this environment rather than against an idea of them: the task chip
  that spawns a session with a fresh worktree of its own, per-worktree `npm ci`
  (AGENTS.md "Multi-agent Git hygiene"), messaging a session, reading and
  searching its transcript, listing sessions and their metadata, and archiving
  a session, which needs the owner's agreement per call and refuses while the
  session is still working. One author per working file, one named owner per
  shared live seam, and the operating table kept outside this public
  repository.
- **Delegation card** — extended with the operating mode's required items:
  goal, Linear owner and acceptance criteria; role, actual model and effort;
  repository, worktree, branch and exact base commit; allowed paths, shared-file
  owner, agreed interfaces; scope boundaries and decisions already taken; size
  limits with a recount-and-report rule near the limit; checks and report path;
  handback conditions; and which actions are authorized, with preparation,
  push/PR, integration and deployment kept as distinct permissions.
- **PR pipeline** — the draft-first chain (`gh pr create --draft` → quick →
  `gh pr ready`) is replaced by the cadence AGENTS.md "Delivery batching and CI
  cadence" actually specifies: focused changed-scope checks during development,
  push the final candidate, open or mark the PR Ready once so one immutable
  head receives one natural `quick` (and `visual` when its own paths select
  it). Draft PRs run neither and must not merge. The verifier reviews that
  exact head and consumes the CI evidence already there. Gate reading,
  directive format, squash body, `Linear:` in the body only, `--match-head-commit`
  merge, worktree removal and conflict handling are unchanged.
- **Cycle limits** — the owner's ruling of 2026-09-07 added: a negative review
  goes back to the executor with concrete fixes and is not by itself grounds to
  abandon the work. The existing "ask the owner, scoped to the delta" sentence
  was merged with it, not duplicated.
- **Claims** — status words to the owner distinguish implemented privately,
  verified, reviewed, merged, built and running; a whole programme is never
  reported complete because one family, one package or one PR is.

The opening paragraph claimed a coordinator "cannot read a peer's context,
cannot stop it". Transcript reading and archiving both exist, so that sentence
was corrected rather than left standing against the new section.

A second commit deletes one false sentence in the same section: the merge
bullet claimed AGENTS.md gives a "fused check-and-merge snippet for the
queued-run race". It does not. AGENTS.md mentions `--match-head-commit` once,
in its train-merge bullet, as a guard required on every merge, and carries no
such snippet. Established by reading AGENTS.md, not by paraphrase. The two
claims it does support — that guard, and the rule against `--delete-branch`
while a child PR is based on the branch — are kept and restated as what
AGENTS.md actually says.

## Merge from main

PR #3324 rewrote the same block of this section and merged first. `main` was
merged into this branch (no rebase) and that one conflict resolved so the
cadence text here stands, with the mechanism facts folded in and quoted from
the files at this merge rather than from the other PR's prose:

- the `quick` job's `if:` in `.github/workflows/quick.yml` requires
  `github.event.pull_request.draft == false`, and `ready_for_review` is one of
  that workflow's `pull_request` `types:`;
- that workflow's `paths-ignore` covers `docs/**`, `.claude/**` and `**/*.md`
  on both `push` and `pull_request`, so a documentation-only head starts no run
  of it at all, and `.github/workflows/docs-only-quick.yml` publishes the
  required `quick` context green without numbers.

#3324 changed nothing else in this file, so none of its wording is lost. In
this file the resolution adds 10 lines and removes 3 (`git diff --numstat`
against the pre-merge head), turning one bullet into two; the rest of the merge
is that PR's own files arriving unchanged.

## Checks

Documentation-only change, so per AGENTS.md only the GitHub-hosted classifier
runs and `quick` reports skipped/neutral. No pytest or vitest was run.

- Internal-identifier self-check on the diff and on the commit message — empty.
- The added text introduces no relative markdown links and no `file:line`
  citations; the file contains none at all. Verified by grepping the diff.
- `check-doc-citations.sh --check-links` could not be run locally: it uses
  `declare -A`, which the bash 3.2 on this host does not support, and no
  bash 4+ is installed. The manual checks above cover what it would inspect
  for this file.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
