### PR TITLE
feat(MOR-2425): host external instrument faces in the semantic surfaces

### DIFF
--- a/frontend/src/__tests__/external-hosted-face.component.test.ts
+++ b/frontend/src/__tests__/external-hosted-face.component.test.ts
@@ -1,0 +1,477 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+// @ts-expect-error -- Svelte's reactive test proxy is intentionally internal.
+import { proxy } from 'svelte/internal/client';
+import { fromStore, writable } from 'svelte/store';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import type { ControlSessionSnapshot } from '$lib/runtime/frontend-runtime';
+import { commitExternalPresentationBatch, getPresentationRecord, loadSkin,
+  prepareExternalPresentationBatch, type ExternalPresentationRecord } from '../skins/registry';
+import type {
+  HostedFaceComponentV1, ScalarRendererLease, ScalarRendererSeat,
+} from '../../component-kit-api/src/index';
+import type { FiniteRendererLease } from '../primitives/control-instruments/control-instrument-renderer.svelte';
+import type { FrequencyInstrumentBinding } from '../primitives/frequency/frequency-instrument.svelte';
+import type { FrequencyInteractionLease } from '../primitives/frequency/frequency-interaction.svelte';
+
+const h = vi.hoisted(() => ({
+  state: null as unknown,
+  caps: null as unknown,
+  session: { state: 'connected', epoch: 7 } as ControlSessionSnapshot,
+  subscribers: new Set<(publication: never) => void>(),
+  radioListeners: new Set<(state: never) => void>(),
+  calls: new Map<string, ReturnType<typeof vi.fn>>(),
+  frequencyOwners: [] as FrequencyInstrumentBinding[], frequencyLeases: [] as FrequencyInteractionLease[],
+  meterOwners: [] as object[],
+  scalarOwners: [] as object[], finiteSeats: [] as object[],
+  scalarSeats: [] as ScalarRendererSeat[], scalarLeases: [] as ScalarRendererLease[],
+  finiteLeases: [] as FiniteRendererLease<unknown>[],
+  subscribeCount: 0, unsubscribeCount: 0,
+  omitSpeak: false,
+}));
+const call = (name: string) => {
+  let fn = h.calls.get(name);
+  if (!fn) { fn = vi.fn(); h.calls.set(name, fn); }
+  return fn;
+};
+
+vi.mock('$lib/runtime', () => ({
+  presentationResources: { acquire: vi.fn(), release: vi.fn() },
+  runtime: {
+    onTxAudioDied: () => () => {},
+    get state() { return h.state; }, get caps() { return h.caps; },
+    get controlSession() { return h.session; },
+    get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
+    get connectionAudio() { return false; }, get radioPowerOn() { return null; },
+    get scope() { return { hardwareScopeConnected: false }; },
+    get defaultScopeStatus() { return { source: null, available: false, resourceSelected: false,
+      demand: 0, lifecycle: 'inactive', transport: 'disconnected', frameSeen: false }; },
+    subscribeControlSession: () => () => {},
+    subscribeControlAuthority(handler: (publication: never) => void) {
+      h.subscribeCount += 1; h.subscribers.add(handler); handler(authority() as never);
+      return () => { h.unsubscribeCount += 1; h.subscribers.delete(handler); };
+    },
+  },
+}));
+vi.mock('$lib/runtime/frontend-runtime', async () => ({
+  runtime: (await import('$lib/runtime')).runtime,
+}));
+vi.mock('$lib/runtime/tx-controller/managed-app-host', () => ({
+  getManagedAppTxController: () => ({
+    snapshot: () => ({ intent: 'receive', observedPtt: 'off', pending: false, blockedReason: null }),
+    transmitOn: vi.fn(), forceOff: vi.fn(), requestTune: vi.fn(), recover: vi.fn(), subscribe: () => () => {},
+  }),
+}));
+vi.mock('$lib/stores/radio.svelte', () => ({
+  radio: { get current() { return h.state; } }, getRadioState: () => h.state,
+  subscribeRadioState(listener: (state: never) => void) {
+    h.radioListeners.add(listener); listener(h.state as never);
+    return () => h.radioListeners.delete(listener);
+  },
+}));
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getScopeSource: () => null, getCapabilities: () => h.caps,
+  capabilitiesMatchGeneration: () => true, getControlRange: () => null,
+  getSmeterCalibration: () => (h.caps as Capabilities | null)?.meterCalibrations?.s_meter,
+}));
+vi.mock('$lib/runtime/adapters/radio-view-model-adapter', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/adapters/radio-view-model-adapter')>();
+  return { ...actual, toRadioViewModel(...args: Parameters<typeof actual.toRadioViewModel>) {
+    const view = actual.toRadioViewModel(...args);
+    if (view === null) return null;
+    return { ...view, radioWideIndicators: { ...view.radioWideIndicators,
+      actions: { ...view.radioWideIndicators?.actions,
+        quickSplit: { structural: true, operational: true },
+        quickDualWatch: { structural: true, operational: true },
+        ...(h.omitSpeak ? { speak: { structural: false, operational: false } } : {}) } } };
+  } };
+});
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: null }),
+  getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+}));
+vi.mock('../primitives/frequency/frequency-instrument.svelte', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../primitives/frequency/frequency-instrument.svelte')>();
+  return { ...actual, createFrequencyInstrumentBinding(
+    ...args: Parameters<typeof actual.createFrequencyInstrumentBinding>
+  ) {
+    const owner = actual.createFrequencyInstrumentBinding(...args);
+    const captured: FrequencyInstrumentBinding = { get context() { return owner.context; },
+      get model() { return owner.model; }, attachRenderer(isCurrent) {
+        const lease = owner.attachRenderer(isCurrent); h.frequencyLeases.push(lease); return lease;
+      } };
+    h.frequencyOwners.push(captured); return captured;
+  } };
+});
+vi.mock('../components-v2/meters/signal-meter-motion.svelte', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../components-v2/meters/signal-meter-motion.svelte')>();
+  return { ...actual, createSignalMeterMotion(...args: Parameters<typeof actual.createSignalMeterMotion>) {
+    const owner = actual.createSignalMeterMotion(...args); h.meterOwners.push(owner); return owner;
+  } };
+});
+vi.mock('../primitives/scalar/continuous-scalar.svelte', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../primitives/scalar/continuous-scalar.svelte')>();
+  return { ...actual, createContinuousScalar(...args: Parameters<typeof actual.createContinuousScalar>) {
+    const owner = actual.createContinuousScalar(...args); h.scalarOwners.push(owner); return owner;
+  }, createContinuousScalarRendererSeat(
+    ...args: Parameters<typeof actual.createContinuousScalarRendererSeat>
+  ) {
+    const seat = actual.createContinuousScalarRendererSeat(...args);
+    const captured: ScalarRendererSeat = Object.freeze({
+      get view() { return seat.view; }, cancel: (reason: 'authority') => seat.cancel(reason),
+      attachRenderer() { const lease = seat.attachRenderer(); h.scalarLeases.push(lease); return lease; },
+    });
+    h.scalarSeats.push(captured); return captured;
+  } };
+});
+vi.mock('../primitives/control-instruments/control-instrument-renderer.svelte', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../primitives/control-instruments/control-instrument-renderer.svelte')>();
+  const capture = <T extends { attachRenderer(): unknown; destroy(): void }>(seat: T): T => {
+    const captured = { attachRenderer() { const lease = seat.attachRenderer();
+      h.finiteLeases.push(lease as FiniteRendererLease<unknown>); return lease; },
+    destroy() { seat.destroy(); } } as T;
+    h.finiteSeats.push(captured); return captured;
+  };
+  return { ...actual,
+    createActionRendererSeat: (...args: Parameters<typeof actual.createActionRendererSeat>) =>
+      capture(actual.createActionRendererSeat(...args)),
+    createToggleRendererSeat: (...args: Parameters<typeof actual.createToggleRendererSeat>) =>
+      capture(actual.createToggleRendererSeat(...args)),
+    createAbsoluteChoiceRendererSeat: (...args: Parameters<typeof actual.createAbsoluteChoiceRendererSeat>) =>
+      capture(actual.createAbsoluteChoiceRendererSeat(...args)),
+  };
+});
+vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
+  const mockedMethods = (...names: string[]) => Object.fromEntries(names.map((name) => {
+    let fn = h.calls.get(name);
+    if (!fn) { fn = vi.fn(); h.calls.set(name, fn); }
+    return [name, fn];
+  }));
+  return {
+  ...(await importOriginal<typeof import('$lib/runtime/commands/panel-commands')>()),
+  makeVfoHandlers: () => mockedMethods('onVfoSelect', 'onMainFreqChange', 'onSubFreqChange', 'onSplitToggle', 'onDualWatchToggle',
+    'onMainVfoClick', 'onSubVfoClick', 'onEqual', 'onSwap', 'onQuickSplit', 'onQuickDw'),
+  makeSystemHandlers: () => mockedMethods('onSpeak'),
+  makeVoxHandlers: () => mockedMethods('onVoxToggle', 'onVoxGainChange', 'onAntiVoxGainChange', 'onVoxDelayChange'),
+  makeTxHandlers: () => mockedMethods('onRfPowerChange', 'onMicGainChange', 'onDriveGainChange',
+    'onAtuToggle', 'onAtuTune', 'onCompToggle', 'onCompLevelChange', 'onMonToggle', 'onMonLevelChange'),
+  makeModeHandlers: () => mockedMethods('onModInputChange', 'onModeChange', 'onDataModeChange'),
+  makeFilterHandlers: () => mockedMethods('onFilterChange', 'onFilterWidthChange', 'onFilterShapeChange',
+    'onIfShiftChange', 'onPbtInnerChange', 'onPbtOuterChange'),
+  makeRxAudioHandlers: () => mockedMethods('onMonitorModeChange', 'onAfLevelChange'),
+  makeAudioRoutingHandlers: () => mockedMethods('onFocusChange', 'onSplitStereoChange'),
+  makeDspHandlers: () => mockedMethods('onNrModeChange', 'onNrLevelChange', 'onNbToggle', 'onNbLevelChange',
+    'onNbDepthChange', 'onNbWidthChange', 'onNotchModeChange', 'onNotchFreqChange', 'onManualNotchWidthChange'),
+  makeAgcHandlers: () => mockedMethods('onAgcModeChange'), makeRfFrontEndHandlers: () => mockedMethods('onAttChange',
+    'onPreChange', 'onRfGainChange', 'onSquelchChange', 'onDigiSelToggle', 'onIpPlusToggle'),
+  makeBandHandlers: () => mockedMethods('onBandSelect'),
+  makeAntennaHandlers: () => mockedMethods('onSelectAnt1', 'onSelectAnt2', 'onToggleRxAnt'),
+  makeRitXitHandlers: () => mockedMethods('onRitToggle', 'onXitToggle', 'onRitOffsetChange', 'onXitOffsetChange', 'onClear'),
+  makeScanHandlers: () => mockedMethods('onScanStart', 'onScanStop', 'onDfSpanChange', 'onResumeChange'),
+  makeCwPanelHandlers: () => mockedMethods('onKeySpeedChange', 'onCwPitchChange', 'onBreakInDelayChange',
+    'onBreakInModeChange', 'onApfChange', 'onTwinPeakToggle', 'onReversePaddleToggle'),
+  makeScopeControlsHandlers: () => mockedMethods('onModeChange', 'onEdgeChange', 'onSpanChange', 'onSpeedChange',
+    'onHoldChange', 'onRefChange', 'onDualChange', 'onReceiverChange', 'onDuringTxChange',
+    'onCenterTypeChange', 'onVbwChange', 'onRbwChange'),
+  };
+});
+
+import SemanticRadioSurfaces, { type ExternalPresentation } from '../components-v2/wiring/SemanticRadioSurfaces.svelte';
+import FaceA from '../../component-kit-api/fixtures/external-kit/src/FaceA.svelte';
+import FaceB from '../../component-kit-api/fixtures/external-kit/src/FaceB.svelte';
+import ScalarRenderer from '../../component-kit-api/fixtures/external-kit/src/FixtureScalarRenderer.svelte';
+import FrequencyRenderer from '../../component-kit-api/fixtures/external-kit/src/FixtureFrequencyRenderer.svelte';
+import SignalRenderer from '../../component-kit-api/fixtures/external-kit/src/FixtureSignalMeter.svelte';
+import LevelRenderer from '../../component-kit-api/fixtures/external-kit/src/FixtureLevelMeter.svelte';
+import ActionRenderer from '../../component-kit-api/fixtures/external-kit/src/FixtureActionRenderer.svelte';
+import ToggleRenderer from '../../component-kit-api/fixtures/external-kit/src/FixtureToggleRenderer.svelte';
+import ChoiceRenderer from '../../component-kit-api/fixtures/external-kit/src/FixtureChoiceRenderer.svelte';
+import ExternalScalarRenderer from '../components-v2/controls/value-control/__tests__/ExternalScalarRendererFixture.svelte';
+import ProbeFace from './fixtures/ExternalHostedFaceProbe.svelte';
+import { SURFACE_PLAN_CONTEXT_KEY, type SurfacePlan } from '../presentation/workspace/resolution';
+
+const fresh = { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 1 };
+const txFields = ['tunerStatus', 'voxOn', 'voxGain', 'antiVoxGain', 'voxDelay', 'compressorOn',
+  'compressorLevel', 'monitorOn', 'monitorGain', 'powerLevel', 'micGain', 'driveGain'] as const;
+function state(receivers = 2): ServerState {
+  const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
+  const receiver = (freqHz: number, sMeter: number) => ({ ...slot(freqHz), filter: 1, activeSlot: 'A',
+    vfoA: slot(freqHz), vfoB: slot(freqHz + 50_000), sMeter, afLevel: 100, rfGain: 200, squelch: 0,
+    att: 0, preamp: 0, nb: false, nr: false });
+  const paths = ['active', 'split', 'dualWatch', 'main', 'main.freqHz', 'main.mode', 'main.filter',
+    'main.activeSlot', 'main.sMeter', ...txFields];
+  for (const vfo of ['vfoA', 'vfoB']) paths.push(`main.${vfo}.freqHz`, `main.${vfo}.mode`, `main.${vfo}.filterNum`);
+  if (receivers === 2) {
+    paths.push('sub', 'sub.freqHz', 'sub.mode', 'sub.filter', 'sub.activeSlot', 'sub.sMeter');
+    for (const vfo of ['vfoA', 'vfoB']) paths.push(`sub.${vfo}.freqHz`, `sub.${vfo}.mode`, `sub.${vfo}.filterNum`);
+  }
+  return { stateContractVersion: 1, providerGeneration: 1, revision: 1, stateRevision: 1,
+    freshnessRevision: 1, observationSeq: 1, active: 'MAIN', ptt: false, split: false, dualWatch: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14_250_000 },
+    main: receiver(14_250_000, 20), ...(receivers === 2 ? { sub: receiver(7_100_000, -12) } : {}),
+    tunerStatus: 0, voxOn: false, voxGain: 50, antiVoxGain: 30, voxDelay: 10,
+    compressorOn: false, compressorLevel: 40, monitorOn: false, monitorGain: 60,
+    powerLevel: 0.8, micGain: 128, driveGain: 128,
+    fieldStatus: Object.fromEntries(paths.map((path) => [path, fresh])), connection: {},
+  } as unknown as ServerState;
+}
+function caps(receivers = 2): Capabilities {
+  return { stateContractVersion: 1, providerGeneration: 1, model: 'fixture', scope: false, audio: false, tx: true,
+    capabilities: ['tx', 'split', 'dual_watch', 'vfo_equalize', 'vfo_swap', 'speech', 'vox',
+      'compressor', 'monitor', 'tuner', 'drive_gain', ...(receivers === 2 ? ['dual_rx'] : [])],
+    receivers, vfoScheme: receivers === 2 ? 'main_sub' : 'single', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48_000, channels: 1, codecs: [] },
+    webrtc: { available: false, enabled: false }, txBands: null,
+    meterCalibrations: { s_meter: [{ raw: 0, actual: -54, label: 'S0' }, { raw: 130, actual: 0, label: 'S9' }] },
+  } as unknown as Capabilities;
+}
+const authority = () => ({ state: h.state, caps: h.caps, session: h.session,
+  rxAudioTarget: { muted: true, rxEnabled: false } });
+const appearances = { scalar: { name: 'fixture-a', hbar: ScalarRenderer, knob: ScalarRenderer,
+  bipolar: ScalarRenderer, discrete: ScalarRenderer }, frequency: FrequencyRenderer,
+  finite: { action: ActionRenderer, toggle: ToggleRenderer, choice: ChoiceRenderer },
+  meter: { signal: SignalRenderer, level: LevelRenderer } } as const;
+let recordSequence = 0;
+async function loadedRecord(
+  id: string, component: HostedFaceComponentV1,
+  recordAppearances: ExternalPresentationRecord['appearances'] = appearances,
+  resources: ExternalPresentationRecord['resources'] = [],
+): Promise<Pick<ExternalPresentation, 'record' | 'component'>> {
+  const batch = prepareExternalPresentationBatch([{ id: `presentation-${id}-${recordSequence++}`,
+    kind: 'external-instruments-v1', loader: async () => component,
+    resources, layoutId: `layout-${id}`, appearances: recordAppearances } satisfies ExternalPresentationRecord]);
+  commitExternalPresentationBatch(batch); const record = batch.records[0];
+  expect(getPresentationRecord(record.id)).toBe(record);
+  return { record, component: await loadSkin(record) };
+}
+function occurrence(
+  loaded: Pick<ExternalPresentation, 'record' | 'component'>, current: { value: object },
+): ExternalPresentation {
+  let result!: ExternalPresentation;
+  result = Object.freeze({ ...loaded, isCurrent: () => current.value === result });
+  return result;
+}
+const fullPlan = () => new Map([['receiver-zone', ['vfo']], ['tx-zone', ['txAux']]]) as SurfacePlan;
+let target: HTMLDivElement; let mounted: ReturnType<typeof mount> | null = null;
+const clearCalls = () => h.calls.forEach((fn) => fn.mockClear());
+const callCounts = () => Object.fromEntries([...h.calls].map(([name, fn]) => [name, fn.mock.calls.length]));
+function expectOnly(name: string): void {
+  expect(call(name), name).toHaveBeenCalledOnce();
+  expect([...h.calls.values()].reduce((total, fn) => total + fn.mock.calls.length, 0)).toBe(1);
+}
+
+beforeEach(() => { h.state = proxy(state()); h.caps = proxy(caps()); h.session = { state: 'connected', epoch: 7 };
+  h.calls.forEach((fn) => fn.mockClear()); h.subscribers.clear(); h.radioListeners.clear();
+  h.subscribeCount = 0; h.unsubscribeCount = 0;
+  h.omitSpeak = false;
+  h.frequencyOwners.length = 0; h.frequencyLeases.length = 0; h.meterOwners.length = 0;
+  h.scalarOwners.length = 0; h.finiteSeats.length = 0;
+  h.scalarSeats.length = 0; h.scalarLeases.length = 0; h.finiteLeases.length = 0; });
+afterEach(() => { if (mounted) unmount(mounted); mounted = null; document.body.replaceChildren(); });
+
+describe('external hosted face chain', () => {
+  it('mounts the accepted faces through the exact 4+8+8 mapping and retires old occurrence commands', async () => {
+    const current = { value: {} };
+    const loadedA = await loadedRecord('a', FaceA);
+    const appearancesB = { ...appearances, scalar: { name: 'fixture-b',
+      hbar: ExternalScalarRenderer, knob: ExternalScalarRenderer } };
+    const loadedB = await loadedRecord('b', FaceB, appearancesB, ['hardware-scope']);
+    const a1 = occurrence(loadedA, current); current.value = a1;
+    const props = proxy({ externalPresentation: a1 }); const plan = writable<SurfacePlan | null>(fullPlan());
+    const livePlan = fromStore(plan); target = document.createElement('div'); document.body.appendChild(target);
+    mounted = mount(SemanticRadioSurfaces, { target, props,
+      context: new Map([[SURFACE_PLAN_CONTEXT_KEY, () => livePlan.current]]) }); flushSync();
+    expect(target.querySelector('[data-external-face="a"]')).not.toBeNull();
+    expect(target.querySelectorAll('[data-fixture-frequency]')).toHaveLength(2);
+    expect(target.querySelectorAll('[data-fixture-signal]')).toHaveLength(2);
+    expect(target.querySelectorAll('[data-fixture-toggle],[data-fixture-choice],[data-fixture-action]')).toHaveLength(8);
+    expect(target.querySelectorAll('[data-fixture-scalar]')).toHaveLength(8);
+    expect(h.frequencyOwners).toHaveLength(2); expect(h.frequencyLeases).toHaveLength(2);
+    expect(h.meterOwners.length).toBeGreaterThanOrEqual(2);
+    const receiverOwners = [...h.frequencyOwners, ...h.meterOwners.slice(-2)];
+    const finiteSeats = [...h.finiteSeats]; expect(finiteSeats.length).toBeGreaterThanOrEqual(8);
+    const txOwners = h.scalarOwners.slice(-8); expect(txOwners).toHaveLength(8);
+    expect(h.scalarSeats).toHaveLength(8); expect(h.scalarLeases).toHaveLength(8);
+    const oldScalarSeat = h.scalarSeats[0]; const automaticScalarLease = h.scalarLeases[0];
+    const cleanupScalarLease = h.scalarLeases[1];
+    const oldFiniteLease = h.finiteLeases[3] as FiniteRendererLease<unknown> & { invoke(): void };
+    const scalarPresentation = (field: string) => {
+      const host = target.querySelector<HTMLElement>(`[data-testid="tx-aux-${field}"]`)!;
+      const renderer = host.querySelector<HTMLElement>('[data-fixture-scalar]')!;
+      return [host.dataset.scalarForm, renderer.dataset.compact,
+        renderer.querySelector('span') !== null, renderer.querySelector('output') !== null];
+    };
+    expect(scalarPresentation('rfPower')).toEqual(['hbar', 'false', true, true]);
+    expect(scalarPresentation('micGain')).toEqual(['knob', 'true', true, true]);
+    expect(scalarPresentation('voxGain')).toEqual(['hbar', 'true', true, true]);
+    const operate = (selector: string, names: string[]) =>
+      Array.from(target.querySelectorAll<HTMLButtonElement>(selector)).forEach((button, index) => {
+        clearCalls(); button.click(); expectOnly(names[index]);
+      });
+    operate('[data-fixture-toggle]', ['onSplitToggle', 'onDualWatchToggle']);
+    operate('[data-fixture-action]', ['onEqual', 'onSwap', 'onQuickSplit', 'onQuickDw', 'onSpeak']);
+    clearCalls(); target.querySelectorAll<HTMLButtonElement>('[data-fixture-choice] button')[1].click();
+    expectOnly('onSubVfoClick');
+    const scalarCalls = ['onRfPowerChange', 'onMicGainChange', 'onDriveGainChange', 'onVoxGainChange',
+      'onAntiVoxGainChange', 'onVoxDelayChange', 'onCompLevelChange', 'onMonLevelChange'];
+    target.querySelectorAll<HTMLInputElement>('[data-fixture-scalar] input').forEach((input, index) => {
+      clearCalls(); input.value = String(index + 1);
+      input.dispatchEvent(new InputEvent('input', { bubbles: true })); expectOnly(scalarCalls[index]);
+    });
+    const frequencyButtons = target.querySelectorAll<HTMLButtonElement>('[data-fixture-frequency] button');
+    frequencyButtons[0].click();
+    frequencyButtons[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    expect(call('onMainFreqChange')).toHaveBeenCalledOnce();
+    const subFrequencyButton = frequencyButtons[frequencyButtons.length - 1];
+    clearCalls(); subFrequencyButton.click();
+    subFrequencyButton.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    expectOnly('onSubFreqChange');
+    clearCalls();
+    const oldButton = target.querySelector<HTMLButtonElement>('[data-fixture-action]')!;
+    const oldInput = target.querySelector<HTMLInputElement>('[data-fixture-scalar] input')!;
+    const oldFrequency = frequencyButtons[0];
+    const oldFrequencyLease = h.frequencyLeases[0];
+    clearCalls(); oldFiniteLease.invoke(); expectOnly('onEqual');
+    clearCalls(); automaticScalarLease.nativeInput(21); expectOnly('onRfPowerChange');
+    clearCalls();
+    const subscriptions = h.subscribers.size;
+
+    const b = occurrence(loadedB, current); current.value = b; props.externalPresentation = b;
+    oldButton.click(); oldInput.value = '17'; oldInput.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    oldFrequency.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    oldFrequencyLease.interaction.handleKeyDown(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+    oldFiniteLease.invoke();
+    const lateScalarLease = oldScalarSeat.attachRenderer();
+    lateScalarLease.nativeInput(22); lateScalarLease.cancel('authority'); lateScalarLease.dispose();
+    expect([...h.calls.values()].every((fn) => fn.mock.calls.length === 0)).toBe(true);
+    flushSync();
+    expect(target.querySelector('[data-external-face="b"]')).not.toBeNull();
+    expect(target.querySelectorAll('[data-external-scalar-renderer]')).toHaveLength(8);
+    expect(h.subscribers.size).toBe(subscriptions);
+    expect([...h.frequencyOwners, ...h.meterOwners.slice(-2)]).toEqual(receiverOwners);
+    expect(h.finiteSeats).toEqual(finiteSeats);
+    expect(h.scalarOwners.slice(-8)).toEqual(txOwners);
+    automaticScalarLease.nativeInput(21); oldFiniteLease.invoke();
+    oldButton.click(); oldInput.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    oldFrequency.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    expect([...h.calls.values()].every((fn) => fn.mock.calls.length === 0)).toBe(true);
+    const bRenderer = target.querySelector<HTMLButtonElement & { rendererLease: ScalarRendererLease }>(
+      '[data-testid="tx-aux-rfPower"] [data-external-scalar-renderer]',
+    )!;
+    const bLease = bRenderer.rendererLease; const token = bLease.beginPointer()!;
+    bLease.pointer(token, 0.5); const bInteraction = bLease.view.interaction;
+    cleanupScalarLease.cancel('authority'); cleanupScalarLease.dispose(); oldScalarSeat.cancel('authority');
+    expect(bLease.view.interaction).toBe(bInteraction);
+    clearCalls(); bLease.nativeInput(0.6); expectOnly('onRfPowerChange');
+    clearCalls();
+    target.querySelector<HTMLButtonElement>('[data-fixture-action]')!.click();
+    expect(call('onEqual')).toHaveBeenCalledOnce();
+
+    clearCalls();
+    const a2 = occurrence(loadedA, current); current.value = a2; props.externalPresentation = a2; flushSync();
+    expect(target.querySelector('[data-external-face="a"]')).not.toBeNull();
+    target.querySelector<HTMLButtonElement>('[data-fixture-action]')!.click();
+    expect(call('onEqual')).toHaveBeenCalledOnce();
+    oldButton.click(); expect(call('onEqual')).toHaveBeenCalledOnce();
+    const countsAtA2 = callCounts();
+    automaticScalarLease.nativeInput(23); oldFiniteLease.invoke();
+    oldFrequencyLease.interaction.handleKeyDown(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+    expect(callCounts()).toEqual(countsAtA2);
+    expect([...h.frequencyOwners, ...h.meterOwners.slice(-2)]).toEqual(receiverOwners);
+    expect(h.finiteSeats).toEqual(finiteSeats); expect(h.scalarOwners.slice(-8)).toEqual(txOwners);
+    unmount(mounted!); mounted = null;
+    expect(h.subscribers.size).toBe(0); expect(h.unsubscribeCount).toBe(h.subscribeCount);
+  });
+
+  it('derives family and SUB absence only from the live plan and structural owners', async () => {
+    const current = { value: {} }; const a = occurrence(await loadedRecord('plan', FaceA), current);
+    current.value = a;
+    const props = proxy({ externalPresentation: a }); const plan = writable<SurfacePlan | null>(fullPlan());
+    const livePlan = fromStore(plan); target = document.createElement('div'); document.body.appendChild(target);
+    mounted = mount(SemanticRadioSurfaces, { target, props,
+      context: new Map([[SURFACE_PLAN_CONTEXT_KEY, () => livePlan.current]]) }); flushSync();
+    const face = target.querySelector('[data-external-face="a"]'); const subscriptions = h.subscribers.size;
+    const owners = [...h.frequencyOwners, ...h.meterOwners, ...h.scalarOwners, ...h.finiteSeats];
+    expect(Array.from(target.querySelectorAll<HTMLElement>('[data-fixture-signal]'),
+      (meter) => meter.dataset.value)).toEqual(['20', '-12']);
+    plan.set(new Map([['tx-zone', ['txAux']]]) as SurfacePlan); flushSync();
+    expect(target.querySelector('[data-family="receiver"]')).toBeNull();
+    expect(target.querySelector('[data-family="vfoOperations"]')).toBeNull();
+    expect(target.querySelector('[data-family="txAux"]')).not.toBeNull();
+    plan.set(new Map([['receiver-zone', ['vfo']]]) as SurfacePlan); flushSync();
+    expect(target.querySelector('[data-family="txAux"]')).toBeNull();
+    expect(target.querySelector('[data-family="receiver"]')).not.toBeNull();
+    expect(target.querySelector('[data-external-face="a"]')).toBe(face);
+    expect(h.subscribers.size).toBe(subscriptions);
+    expect([...h.frequencyOwners, ...h.meterOwners, ...h.scalarOwners, ...h.finiteSeats]).toEqual(owners);
+
+    h.state = state(1); h.caps = caps(1); h.subscribers.forEach((handler) => handler(authority() as never)); flushSync();
+    const singleReceiverOwners = [...h.frequencyOwners, ...h.meterOwners, ...h.scalarOwners, ...h.finiteSeats];
+    expect(target.querySelectorAll('[data-fixture-frequency]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-fixture-signal]')).toHaveLength(1);
+    h.session = { state: 'disconnected', epoch: 7 };
+    h.subscribers.forEach((handler) => handler(authority() as never)); flushSync();
+    expect(target.querySelector('[data-family="receiver"]')).not.toBeNull();
+    expect(target.querySelector('[data-family="vfoOperations"]')).not.toBeNull();
+    plan.set(null); flushSync();
+    expect(target.querySelectorAll('[data-family]')).toHaveLength(0);
+    expect([...h.frequencyOwners, ...h.meterOwners, ...h.scalarOwners, ...h.finiteSeats])
+      .toEqual(singleReceiverOwners);
+
+    plan.set(fullPlan()); h.state = proxy({ ...state(), fieldStatus: {} });
+    h.caps = proxy({ ...caps(), capabilities: ['tx'] });
+    h.subscribers.forEach((handler) => handler(authority() as never)); flushSync();
+    expect(target.querySelector('[data-family="receiver"]')).not.toBeNull();
+    expect(target.querySelector('[data-family="vfoOperations"]')).not.toBeNull();
+    expect(target.querySelector('[data-family="txAux"]')).not.toBeNull();
+
+    unmount(mounted!); mounted = null; h.omitSpeak = true; h.session = { state: 'connected', epoch: 7 };
+    h.state = proxy(state()); h.caps = proxy({ ...caps(),
+      capabilities: caps().capabilities.filter((tag) => tag !== 'speech' && tag !== 'monitor') });
+    plan.set(fullPlan()); mounted = mount(SemanticRadioSurfaces, { target, props,
+      context: new Map([[SURFACE_PLAN_CONTEXT_KEY, () => livePlan.current]]) }); flushSync();
+    expect(target.querySelector('[data-family="vfoOperations"]')).not.toBeNull();
+    expect(target.querySelectorAll('[data-fixture-toggle],[data-fixture-choice],[data-fixture-action]')).toHaveLength(7);
+    expect(target.querySelector('[data-family="txAux"]')).not.toBeNull();
+    expect(target.querySelectorAll('[data-fixture-scalar]')).toHaveLength(7);
+    expect(h.subscribers.size).toBe(subscriptions);
+  });
+
+  it('forwards independent public options and exposes only the exact public keys', async () => {
+    const current = { value: {} };
+    const probeAppearances = { ...appearances, scalar: { name: 'probe',
+      hbar: ScalarRenderer, knob: ExternalScalarRenderer } };
+    const probe = occurrence(await loadedRecord('probe', ProbeFace, probeAppearances), current);
+    current.value = probe; const plan = writable<SurfacePlan | null>(fullPlan()); const livePlan = fromStore(plan);
+    target = document.createElement('div'); document.body.appendChild(target);
+    mounted = mount(SemanticRadioSurfaces, { target, props: { externalPresentation: probe },
+      context: new Map([[SURFACE_PLAN_CONTEXT_KEY, () => livePlan.current]]) }); flushSync();
+    const face = target.querySelector<HTMLElement>('[data-external-face="probe"]')!;
+    expect(face.dataset.topLevelKeys).toBe('receiver,txAux,vfoOperations');
+    expect(face.dataset.receiverKeys).toBe('mainFrequency,mainSMeter,subFrequency,subSMeter');
+    expect(face.dataset.vfoKeys).toBe('activeReceiver,dualWatch,equalize,quickDualWatch,quickSplit,speak,split,swap');
+    expect(face.dataset.txKeys).toBe('antiVoxGain,compressorLevel,driveGain,micGain,monitorLevel,rfPower,voxDelay,voxGain');
+    expect(target.querySelector('[data-probe="form-hbar"] [data-fixture-scalar]')).not.toBeNull();
+    const knob = target.querySelector<HTMLElement>('[data-probe="form-knob"] [data-external-scalar-renderer]')!;
+    expect(knob.dataset.externalScalarRenderer).toBe('knob');
+    expect(target.querySelector<HTMLElement>('[data-probe="compact"] [data-fixture-scalar]')!.dataset.compact).toBe('true');
+    expect(target.querySelector<HTMLElement>('[data-probe="label"] [data-external-scalar-renderer]')!.dataset)
+      .toMatchObject({ showLabel: 'false', showValue: 'true', compact: 'false' });
+    expect(target.querySelector<HTMLElement>('[data-probe="value"] [data-external-scalar-renderer]')!.dataset)
+      .toMatchObject({ showLabel: 'true', showValue: 'false', compact: 'false' });
+    const owners = [...h.scalarOwners];
+    const invoke = (selector: string, name: string, value?: string) => {
+      clearCalls(); const node = target.querySelector<HTMLInputElement | HTMLButtonElement>(selector)!;
+      if (node instanceof HTMLInputElement) { node.value = value!; node.dispatchEvent(new InputEvent('input', { bubbles: true })); }
+      else node.click();
+      expectOnly(name);
+    };
+    invoke('[data-probe="form-hbar"] input', 'onRfPowerChange', '0.7');
+    invoke('[data-probe="form-knob"] button', 'onMicGainChange');
+    invoke('[data-probe="compact"] input', 'onDriveGainChange', '70');
+    invoke('[data-probe="label"] button', 'onVoxGainChange');
+    invoke('[data-probe="value"] button', 'onAntiVoxGainChange');
+    expect(h.scalarOwners).toEqual(owners);
+  });
+});

--- a/frontend/src/__tests__/fixtures/ExternalHostedFaceProbe.svelte
+++ b/frontend/src/__tests__/fixtures/ExternalHostedFaceProbe.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import type { HostedFacePropsV1 } from '../../../component-kit-api/src/index';
+
+  let { instruments }: HostedFacePropsV1 = $props();
+  const keys = (value: object | null) => value === null ? '' : Object.keys(value).sort().join(',');
+</script>
+
+<div
+  data-external-face="probe"
+  data-top-level-keys={keys(instruments)}
+  data-receiver-keys={keys(instruments.receiver)}
+  data-vfo-keys={keys(instruments.vfoOperations)}
+  data-tx-keys={keys(instruments.txAux)}
+>
+  {#if instruments.txAux}
+    {@const tx = instruments.txAux}
+    <div data-probe="form-hbar">{@render tx.rfPower({ form: 'hbar' })}</div>
+    <div data-probe="form-knob">{@render tx.micGain({ form: 'knob' })}</div>
+    <div data-probe="compact">{@render tx.driveGain({ form: 'hbar', compact: true })}</div>
+    <div data-probe="label">{@render tx.voxGain({ form: 'knob', showLabel: false })}</div>
+    <div data-probe="value">{@render tx.antiVoxGain({ form: 'knob', showValue: false })}</div>
+  {/if}
+</div>

--- a/frontend/src/component-kits/HostedFaceInstrumentBridge.svelte
+++ b/frontend/src/component-kits/HostedFaceInstrumentBridge.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import type {
+    HostedFaceComponentV1,
+    HostedInstrumentFamiliesV1,
+    ReceiverFrequencyPresentationV1,
+    TxAuxScalarPresentationV1,
+  } from '../../component-kit-api/src/index';
+  import type { ReceiverInstrumentHandles } from '../semantic/ReceiverInstrumentHost.svelte';
+  import type { TxAuxScalarHandles } from '../semantic/tx-aux-scalar';
+  import type { VfoOperationHandles } from '../semantic/VfoOperationSeatHost.svelte';
+
+  let {
+    component: Face,
+    receiverInstruments,
+    vfoOperations,
+    txAuxScalars,
+    receiverAdmitted,
+    vfoOperationsAdmitted,
+    txAuxAdmitted,
+  }: {
+    component: HostedFaceComponentV1;
+    receiverInstruments: ReceiverInstrumentHandles;
+    vfoOperations: VfoOperationHandles;
+    txAuxScalars: TxAuxScalarHandles;
+    receiverAdmitted: boolean;
+    vfoOperationsAdmitted: boolean;
+    txAuxAdmitted: boolean;
+  } = $props();
+  let subReceiverAdmitted = $derived(
+    receiverInstruments.subFrequency !== undefined && receiverInstruments.subSMeter !== undefined,
+  );
+</script>
+
+{#snippet mainFrequency(presentation?: Readonly<ReceiverFrequencyPresentationV1>)}
+  {@render receiverInstruments.mainFrequency(presentation)}
+{/snippet}
+{#snippet subFrequency(presentation?: Readonly<ReceiverFrequencyPresentationV1>)}
+  {#if receiverInstruments.subFrequency}
+    {@render receiverInstruments.subFrequency(presentation)}
+  {/if}
+{/snippet}
+{#snippet mainSMeter()}
+  {@render receiverInstruments.mainSMeter()}
+{/snippet}
+{#snippet subSMeter()}
+  {#if receiverInstruments.subSMeter}
+    {@render receiverInstruments.subSMeter()}
+  {/if}
+{/snippet}
+
+{#snippet rfPower(presentation?: Readonly<TxAuxScalarPresentationV1>)}
+  {@render txAuxScalars.rfPower(presentation)}
+{/snippet}
+{#snippet micGain(presentation?: Readonly<TxAuxScalarPresentationV1>)}
+  {@render txAuxScalars.micGain(presentation)}
+{/snippet}
+{#snippet driveGain(presentation?: Readonly<TxAuxScalarPresentationV1>)}
+  {@render txAuxScalars.driveGain(presentation)}
+{/snippet}
+{#snippet voxGain(presentation?: Readonly<TxAuxScalarPresentationV1>)}
+  {@render txAuxScalars.voxGain(presentation)}
+{/snippet}
+{#snippet antiVoxGain(presentation?: Readonly<TxAuxScalarPresentationV1>)}
+  {@render txAuxScalars.antiVoxGain(presentation)}
+{/snippet}
+{#snippet voxDelay(presentation?: Readonly<TxAuxScalarPresentationV1>)}
+  {@render txAuxScalars.voxDelay(presentation)}
+{/snippet}
+{#snippet compressorLevel(presentation?: Readonly<TxAuxScalarPresentationV1>)}
+  {@render txAuxScalars.compressorLevel(presentation)}
+{/snippet}
+{#snippet monitorLevel(presentation?: Readonly<TxAuxScalarPresentationV1>)}
+  {@render txAuxScalars.monitorLevel(presentation)}
+{/snippet}
+
+<Face instruments={{
+  receiver: receiverAdmitted ? {
+    mainFrequency,
+    subFrequency: subReceiverAdmitted ? subFrequency : null,
+    mainSMeter,
+    subSMeter: subReceiverAdmitted ? subSMeter : null,
+  } : null,
+  vfoOperations: vfoOperationsAdmitted ? vfoOperations : null,
+  txAux: txAuxAdmitted ? {
+    rfPower, micGain, driveGain, voxGain, antiVoxGain, voxDelay, compressorLevel, monitorLevel,
+  } : null,
+} satisfies HostedInstrumentFamiliesV1} />

--- a/frontend/src/component-kits/MeterRendererSeat.svelte
+++ b/frontend/src/component-kits/MeterRendererSeat.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onDestroy, untrack, type Snippet } from 'svelte';
+  import type { MeterAppearance } from '../../component-kit-api/src/index';
   import type { SignalMeterFrame } from '../components-v2/meters/signal-meter-motion.svelte';
   import type { ActionRendererSeat } from '../primitives/control-instruments/control-instrument-renderer.svelte';
   import type { MeterReading, MeterValueDomain } from '../semantic/radio-view-model';
@@ -16,7 +17,8 @@
     domain?: MeterValueDomain;
     relevant?: boolean;
     selectedPresent?: boolean;
-    fallback: Snippet<[frame: SignalMeterFrame]>;
+    signalRenderer?: MeterAppearance['signal'];
+    fallback?: Snippet<[frame: SignalMeterFrame]>;
   }
   interface LevelProps {
     kind: 'level';
@@ -28,7 +30,8 @@
 
   let props: Props = $props();
   const appearance = untrack(() => getSelectedMeterAppearance());
-  const signalRenderer = untrack(() => props.kind === 'level' ? undefined : appearance?.signal);
+  const signalRenderer = untrack(() => props.kind === 'level'
+    ? undefined : props.signalRenderer ?? appearance?.signal);
   const levelRenderer = untrack(() => props.kind === 'level' ? appearance?.level : undefined);
   const resetPeak = untrack(() => props.kind === 'level' && levelRenderer
     ? props.resetPeakSeat?.attachRenderer() : undefined);
@@ -52,5 +55,5 @@
     <Renderer view={signalView!} />
   {/if}
 {:else}
-  {@render props.fallback(props.frame)}
+  {#if props.fallback}{@render props.fallback(props.frame)}{/if}
 {/if}

--- a/frontend/src/components-v2/controls/value-control/ValueControl.svelte
+++ b/frontend/src/components-v2/controls/value-control/ValueControl.svelte
@@ -53,6 +53,7 @@
     skin?: Skin;
     valueProjection?: Readonly<HBarValueProjection>;
     issuedStatusPresentation?: Readonly<HBarIssuedStatusPresentation>;
+    presentationIsCurrent?: () => boolean;
   }
 
   interface RawProps {
@@ -132,6 +133,7 @@
     skin,
     valueProjection,
     issuedStatusPresentation,
+    presentationIsCurrent,
   }: Props = $props();
 
   let effectiveOnChange = $derived(onChange ?? onchange ?? (() => {}));
@@ -244,28 +246,36 @@
   let attachedSeatRenderer = untrack(() => renderer);
   let attachedSeatAppearance = initialAppearance;
   let attachedSeatComponent = untrack(() => skinComponent);
+  let attachedPresentationIsCurrent = untrack(() => presentationIsCurrent);
   let currentRendererOccurrence: object;
 
-  function makeRendererSeat(binding: ContinuousScalarBinding): ContinuousScalarRendererSeat {
+  function makeRendererSeat(
+    binding: ContinuousScalarBinding,
+    isPresentationCurrent: (() => boolean) | undefined,
+  ): ContinuousScalarRendererSeat {
     const occurrence = Object.freeze({});
     currentRendererOccurrence = occurrence;
     return createContinuousScalarRendererSeat(
       binding,
-      () => currentRendererOccurrence === occurrence,
+      () => currentRendererOccurrence === occurrence && (isPresentationCurrent?.() ?? true),
     );
   }
 
-  let rendererSeat = $state(makeRendererSeat(untrack(() => scalarBinding)));
+  let rendererSeat = $state(makeRendererSeat(
+    untrack(() => scalarBinding), attachedPresentationIsCurrent,
+  ));
   $effect.pre(() => {
     if (scalarBinding === attachedSeatBinding
       && renderer === attachedSeatRenderer
       && effectiveAppearance === attachedSeatAppearance
-      && skinComponent === attachedSeatComponent) return;
+      && skinComponent === attachedSeatComponent
+      && presentationIsCurrent === attachedPresentationIsCurrent) return;
     attachedSeatBinding = scalarBinding;
     attachedSeatRenderer = renderer;
     attachedSeatAppearance = effectiveAppearance;
     attachedSeatComponent = skinComponent;
-    rendererSeat = makeRendererSeat(scalarBinding);
+    attachedPresentationIsCurrent = presentationIsCurrent;
+    rendererSeat = makeRendererSeat(scalarBinding, presentationIsCurrent);
   });
 
   let rendererProps = $derived({

--- a/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
+++ b/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
@@ -30,7 +30,7 @@
   );
   const cwKeyerInstruments = { keyerSpeed: empty } satisfies CwKeyerInstrumentHandles;
   const frequency = createRawSnippet<[mount?: ReceiverFrequencyMount]>(() => ({ render: () => '' }));
-  const meter = createRawSnippet<[renderer: ReceiverSMeterRenderer]>(() => ({ render: () => '' }));
+  const meter = createRawSnippet<[renderer?: ReceiverSMeterRenderer]>(() => ({ render: () => '' }));
   const operations = createRawSnippet<[appearance: ReceiverVfoAppearance]>(() => ({ render: () => '' }));
   const receiverInstruments = {
     mainFrequency: frequency, subFrequency: frequency,

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -12,10 +12,19 @@
   Both render the same server snapshot.
 -->
 <script module lang="ts">
+  import type { HostedFaceComponentV1 } from '../../../component-kit-api/src/index';
+  import type { ExternalPresentationRecord } from '../../skins/registry';
+
   export type {
     InstrumentComposition,
     InstrumentVfoAppearance,
   } from './instrument-composition';
+
+  export interface ExternalPresentation {
+    readonly record: ExternalPresentationRecord;
+    readonly component: HostedFaceComponentV1;
+    readonly isCurrent: () => boolean;
+  }
 </script>
 
 <script lang="ts">
@@ -89,6 +98,7 @@
     type ReceiverVfoAppearance,
   } from '../../semantic/ReceiverInstrumentHost.svelte';
   import TxAuxScalarHost from '../../semantic/TxAuxScalarHost.svelte';
+  import HostedFaceInstrumentBridge from '../../component-kits/HostedFaceInstrumentBridge.svelte';
   import TxAuxFiniteHost from '../../semantic/TxAuxFiniteHost.svelte';
   import TxAuxSurface, {
     TX_AUX_FEEDBACK_LEVELS, type TxAuxFeedbackLevelField, type TxAuxLevelFeedback,
@@ -136,6 +146,7 @@
    */
   interface Props {
     children?: Snippet<[InstrumentComposition]>;
+    externalPresentation?: ExternalPresentation | null;
     strips?: 'single' | 'dual';
     regions?: boolean;
     regionContent?: Snippet<[Snippet | undefined, ManagedScopeRegion | undefined]>;
@@ -166,7 +177,7 @@
    * `zoneOwning()` returns non-null on both faces.
    */
   let {
-    children: hostedChildren, strips = 'single', regions = false, regionContent, scopeControlsInRegionContent = false, regionExtras, vfoAppearance = 'semantic', displayFrameSource, readonlyDisplay,
+    children: hostedChildren, externalPresentation = null, strips = 'single', regions = false, regionContent, scopeControlsInRegionContent = false, regionExtras, vfoAppearance = 'semantic', displayFrameSource, readonlyDisplay,
   }: Props = $props();
 
   /**
@@ -880,10 +891,14 @@
     ? {} : {
       finiteAppearance: selectedFiniteAppearance, rendererContext: dspFiniteRendererContext,
     });
-  let vfoFiniteRendererSelection = $derived(selectedFiniteAppearance === undefined
-    ? {} : {
-      finiteAppearance: selectedFiniteAppearance, rendererContext: vfoFiniteRendererContext,
-    });
+  let vfoFiniteRendererSelection = $derived(externalPresentation !== null
+    ? {
+      finiteAppearance: externalPresentation.record.appearances.finite,
+      rendererContext: vfoFiniteRendererContext,
+    }
+    : selectedFiniteAppearance === undefined
+      ? {}
+      : { finiteAppearance: selectedFiniteAppearance, rendererContext: vfoFiniteRendererContext });
   let filterFiniteRendererSelection = $derived(selectedFiniteAppearance === undefined
     ? {} : {
       finiteAppearance: selectedFiniteAppearance, rendererContext: filterFiniteRendererContext,
@@ -1309,7 +1324,7 @@
   });
 </script>
 
-<div class="semantic-surfaces" class:hosted={hostedChildren !== undefined} data-testid="semantic-radio-surfaces">
+<div class="semantic-surfaces" class:hosted={hostedChildren !== undefined || externalPresentation !== null} data-testid="semantic-radio-surfaces">
   <StationMeterInstrumentHost {subscribeStationMeterAuthority}>
   {#snippet children(stationMeters: StationMeterInstrumentHandles)}
   {#snippet receiverVfoOperations(appearance: ReceiverVfoAppearance)}
@@ -1329,6 +1344,9 @@
     {pendingFrequencyHz}
     onTuneFrequency={tuneFrequency}
     vfoOperations={receiverVfoOperations}
+    frequencyRenderer={externalPresentation?.record.appearances.frequency}
+    signalRenderer={externalPresentation?.record.appearances.meter.signal}
+    presentationIsCurrent={externalPresentation?.isCurrent}
   >
   {#snippet children(receiverInstruments)}
   <RxAudioInstrumentHost
@@ -2055,7 +2073,19 @@
     {@render zoned('scopeControls', view?.scopeControls !== undefined, scopeControlsSurface, allowBare)}
   {/snippet}
 
-  {#if hostedChildren}
+  {#if externalPresentation}
+    {#key externalPresentation}
+      <HostedFaceInstrumentBridge
+        component={externalPresentation.component}
+        {receiverInstruments}
+        {vfoOperations}
+        {txAuxScalars}
+        receiverAdmitted={surfacePlan() !== null && zoneOwning('vfo') !== null}
+        vfoOperationsAdmitted={surfacePlan() !== null && zoneOwning('vfo') !== null}
+        txAuxAdmitted={surfacePlan() !== null && zoneOwning('txAux') !== null}
+      />
+    {/key}
+  {:else if hostedChildren}
     {@render hostedChildren({
       vfo: hostedVfo,
       vfoOperations,
@@ -2250,6 +2280,8 @@
   <TxAuxScalarHost
     {view} levelFeedback={txAuxLevelFeedback}
     onLevelChange={(field, value) => TX_AUX_LEVEL_INTENT[field](value)}
+    scalarAppearance={externalPresentation?.record.appearances.scalar}
+    presentationIsCurrent={externalPresentation?.isCurrent}
   >
   {#snippet children(txAuxScalars)}
     {@render txAuxFiniteComposition(txAuxScalars)}
@@ -2267,6 +2299,7 @@
   {/snippet}
   <VfoOperationSeatHost
     {...vfoFiniteRendererSelection} input={vfoOperationInput} scheme={view?.vfoScheme ?? null}
+    presentationIsCurrent={externalPresentation?.isCurrent}
   >
     {#snippet children(vfoOperations)}
       {@render vfoInstrumentComposition(vfoOperations)}

--- a/frontend/src/primitives/frequency/FrequencyRendererSeat.svelte
+++ b/frontend/src/primitives/frequency/FrequencyRendererSeat.svelte
@@ -12,6 +12,8 @@
     active: boolean;
     receiver: 'main' | 'sub';
     vfoFreqHook: boolean;
+    renderer?: FrequencyRenderer;
+    presentationIsCurrent?: () => boolean;
   }
 
   let {
@@ -21,34 +23,45 @@
     active,
     receiver,
     vfoFreqHook,
+    renderer,
+    presentationIsCurrent,
   }: Props = $props();
 
   let attachedBinding = untrack(() => binding);
   let attachedContext = untrack(() => attachedBinding.context);
-  let attachedRenderer = untrack(() => getSelectedFrequencyReadout());
+  let attachedRenderer = untrack(() => renderer ?? getSelectedFrequencyReadout());
+  let attachedPresentationIsCurrent = untrack(() => presentationIsCurrent);
   let selectedRenderer = $state.raw<FrequencyRenderer | undefined>(attachedRenderer);
   const attachLease = (
     owner: FrequencyInstrumentBinding,
-    renderer: FrequencyRenderer | undefined,
+    selected: FrequencyRenderer | undefined,
+    isPresentationCurrent: (() => boolean) | undefined,
   ) => owner.attachRenderer(
-    () => Object.is(binding, owner) && getSelectedFrequencyReadout() === renderer,
+    () => Object.is(binding, owner)
+      && (renderer ?? getSelectedFrequencyReadout()) === selected
+      && (isPresentationCurrent?.() ?? true),
   );
-  let lease = $state.raw(attachLease(attachedBinding, attachedRenderer));
+  let lease = $state.raw(attachLease(
+    attachedBinding, attachedRenderer, attachedPresentationIsCurrent,
+  ));
 
   $effect.pre(() => {
     const nextBinding = binding;
     const nextContext = nextBinding.context;
-    const nextRenderer = getSelectedFrequencyReadout();
+    const nextRenderer = renderer ?? getSelectedFrequencyReadout();
+    const nextPresentationIsCurrent = presentationIsCurrent;
     if (Object.is(nextBinding, attachedBinding)
       && Object.is(nextContext, attachedContext)
       && nextRenderer === attachedRenderer
+      && nextPresentationIsCurrent === attachedPresentationIsCurrent
       && (nextContext === null || !lease.revoked)) return;
     lease.revoke();
     attachedBinding = nextBinding;
     attachedContext = nextContext;
     attachedRenderer = nextRenderer;
+    attachedPresentationIsCurrent = nextPresentationIsCurrent;
     selectedRenderer = nextRenderer;
-    lease = attachLease(nextBinding, nextRenderer);
+    lease = attachLease(nextBinding, nextRenderer, nextPresentationIsCurrent);
   });
 
   onDestroy(() => lease.revoke());

--- a/frontend/src/semantic/ReceiverInstrumentHost.svelte
+++ b/frontend/src/semantic/ReceiverInstrumentHost.svelte
@@ -9,8 +9,8 @@
   export interface ReceiverInstrumentHandles {
     readonly mainFrequency: Snippet<[mount?: ReceiverFrequencyMount]>;
     readonly subFrequency?: Snippet<[mount?: ReceiverFrequencyMount]>;
-    readonly mainSMeter: Snippet<[renderer: ReceiverSMeterRenderer]>;
-    readonly subSMeter?: Snippet<[renderer: ReceiverSMeterRenderer]>;
+    readonly mainSMeter: Snippet<[renderer?: ReceiverSMeterRenderer]>;
+    readonly subSMeter?: Snippet<[renderer?: ReceiverSMeterRenderer]>;
     readonly frequencyTunable: (receiver: 'MAIN' | 'SUB') => boolean;
     readonly vfoOperations: Snippet<[appearance: ReceiverVfoAppearance]>;
   }
@@ -18,6 +18,7 @@
 
 <script lang="ts">
   import { onDestroy, onMount, untrack } from 'svelte';
+  import type { FrequencyRenderer, MeterAppearance } from '../../component-kit-api/src/index';
   import type { Capabilities } from '$lib/types/capabilities';
   import type { ServerState } from '$lib/types/state';
   import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
@@ -53,6 +54,9 @@
     subscribeControlAuthority: SubscribeReceiverAuthority;
     pendingFrequencyHz?: Partial<Record<ReceiverId, number>>;
     onTuneFrequency?: (receiver: ReceiverId, frequencyHz: number) => void;
+    frequencyRenderer?: FrequencyRenderer;
+    signalRenderer?: MeterAppearance['signal'];
+    presentationIsCurrent?: () => boolean;
     vfoOperations: Snippet<[appearance: ReceiverVfoAppearance]>;
     children: Snippet<[ReceiverInstrumentHandles]>;
   }
@@ -78,6 +82,9 @@
     subscribeControlAuthority,
     pendingFrequencyHz,
     onTuneFrequency,
+    frequencyRenderer,
+    signalRenderer,
+    presentationIsCurrent,
     vfoOperations,
     children,
   }: Props = $props();
@@ -318,7 +325,8 @@
   {#if mainOwner !== null}
     <FrequencyRendererSeat binding={mainOwner.frequency} presentation="interactive"
       compact={mount?.compact ?? false} active={mainOwner.active} receiver="main"
-      vfoFreqHook={mount?.vfoFreqHook ?? true} />
+      vfoFreqHook={mount?.vfoFreqHook ?? true} renderer={frequencyRenderer}
+      {presentationIsCurrent} />
   {/if}
 {/snippet}
 
@@ -326,23 +334,26 @@
   {#if subOwner !== null}
     <FrequencyRendererSeat binding={subOwner.frequency} presentation="interactive"
       compact={mount?.compact ?? false} active={subOwner.active} receiver="sub"
-      vfoFreqHook={mount?.vfoFreqHook ?? true} />
+      vfoFreqHook={mount?.vfoFreqHook ?? true} renderer={frequencyRenderer}
+      {presentationIsCurrent} />
   {/if}
 {/snippet}
 
-{#snippet mainSMeter(renderer: ReceiverSMeterRenderer)}
+{#snippet mainSMeter(renderer?: ReceiverSMeterRenderer)}
   {#if mainOwner !== null}
     {@const meter = receiverMeter(mainOwner.model, 'MAIN')}
     <MeterRendererSeat frame={mainOwner.motion.frame}
-      reading={meter?.reading ?? UNKNOWN_METER_READING} domain={meter?.domain} fallback={renderer} />
+      reading={meter?.reading ?? UNKNOWN_METER_READING} domain={meter?.domain}
+      fallback={renderer} {signalRenderer} />
   {/if}
 {/snippet}
 
-{#snippet subSMeter(renderer: ReceiverSMeterRenderer)}
+{#snippet subSMeter(renderer?: ReceiverSMeterRenderer)}
   {#if subOwner !== null}
     {@const meter = receiverMeter(subOwner.model, 'SUB')}
     <MeterRendererSeat frame={subOwner.motion.frame}
-      reading={meter?.reading ?? UNKNOWN_METER_READING} domain={meter?.domain} fallback={renderer} />
+      reading={meter?.reading ?? UNKNOWN_METER_READING} domain={meter?.domain}
+      fallback={renderer} {signalRenderer} />
   {/if}
 {/snippet}
 

--- a/frontend/src/semantic/TxAuxScalarHost.svelte
+++ b/frontend/src/semantic/TxAuxScalarHost.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onDestroy, type Snippet } from 'svelte';
+  import type { ScalarAppearance } from '../../component-kit-api/src/index';
   import { ValueControl } from '../components-v2/controls/value-control';
   import type {
     HBarIssuedStatusPresentation,
@@ -29,10 +30,14 @@
     view: RadioViewModel | null;
     levelFeedback?: TxAuxLevelFeedback;
     onLevelChange?: (field: TxAuxLevelField, value: number) => void;
+    scalarAppearance?: ScalarAppearance;
+    presentationIsCurrent?: () => boolean;
     children: Snippet<[TxAuxScalarHandles]>;
   }
 
-  let { view, levelFeedback, onLevelChange, children }: Props = $props();
+  let {
+    view, levelFeedback, onLevelChange, scalarAppearance, presentationIsCurrent, children,
+  }: Props = $props();
   let txAux = $derived(view?.txAux);
 
   const LEVEL_COMMAND: Readonly<Record<TxAuxFeedbackLevelField, string>> = {
@@ -213,6 +218,8 @@
           compact={explicitPresentation ? presentation?.compact ?? false : true}
           title={disabledReason}
           {accessibility}
+          skin={scalarAppearance}
+          {presentationIsCurrent}
         />
       {:else}
         <ValueControl
@@ -224,6 +231,8 @@
           compact={explicitPresentation ? presentation?.compact ?? false : true}
           title={disabledReason}
           {accessibility}
+          skin={scalarAppearance}
+          {presentationIsCurrent}
           issuedStatusPresentation={form === 'hbar'
             ? statusPresentations[field as TxAuxFeedbackLevelField]
             : undefined}

--- a/frontend/src/semantic/VfoOperationSeatHost.svelte
+++ b/frontend/src/semantic/VfoOperationSeatHost.svelte
@@ -24,6 +24,7 @@
   interface ExistingProps {
     input: VfoOperationProjectionInput | null;
     scheme: RadioViewModel['vfoScheme'] | null;
+    presentationIsCurrent?: () => boolean;
     children: Snippet<[VfoOperationHandles]>;
   }
   type RendererSelection =
@@ -41,7 +42,8 @@
   import { vfoEqualLabel, vfoSwapLabel } from '../components-v2/vfo/vfo-ops-utils';
   import ControlInstrumentRendererHost from '../primitives/control-instruments/ControlInstrumentRendererHost.svelte';
   import {
-    createAbsoluteChoiceRendererSeat, createActionRendererSeat, createToggleRendererSeat,
+    createAbsoluteChoiceRendererSeat, createActionRendererSeat, createFiniteRendererContext,
+    createToggleRendererSeat,
     type AbsoluteChoiceRendererInput, type AvailabilityActionRendererInput,
     type ToggleRendererInput,
   } from '../primitives/control-instruments/control-instrument-renderer.svelte';
@@ -50,7 +52,17 @@
     type VfoOperationIntent, type VfoOperationProjection, type VfoToggleOperation,
   } from './vfo-operation-projection';
 
-  let { input, finiteAppearance, rendererContext, scheme, children }: Props = $props();
+  let {
+    input, finiteAppearance, rendererContext, presentationIsCurrent, scheme, children,
+  }: Props = $props();
+  let combinedRendererContext = $derived.by<FiniteRendererContext | null>(() => {
+    const occurrencePredicate = presentationIsCurrent;
+    return rendererContext === null || rendererContext === undefined || occurrencePredicate === undefined
+      ? rendererContext ?? null
+      : createFiniteRendererContext();
+  });
+  const currentRendererContext = (): FiniteRendererContext | null =>
+    (presentationIsCurrent?.() ?? true) ? combinedRendererContext : null;
 
   const projection = (): VfoOperationProjection | null =>
     input === null ? null : projectVfoOperations(input);
@@ -65,7 +77,7 @@
     intent: VfoOperationIntent,
   ): ToggleRendererInput {
     return {
-      context: rendererContext ?? null,
+      context: currentRendererContext(),
       field: operation === undefined
         ? undefined
         : { availability: operation.availability, reading: operation.reading },
@@ -81,7 +93,7 @@
     intent: VfoOperationIntent,
   ): AvailabilityActionRendererInput {
     return {
-      context: rendererContext ?? null,
+      context: currentRendererContext(),
       availability: operation?.availability,
       label,
       title: operation?.availability.reason,
@@ -92,7 +104,7 @@
   function receiverInput(): AbsoluteChoiceRendererInput<VfoOperationReceiver> {
     const operation = projection()?.activeReceiver;
     return {
-      context: rendererContext ?? null,
+      context: currentRendererContext(),
       reading: operation?.reading.status === 'known'
         ? { status: 'known', value: operation.reading.receiver }
         : { status: 'unknown' },

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -257,7 +257,7 @@ function hostedReceiverInstruments(): ReceiverInstrumentHandles {
   const frequency = (receiver: ReceiverId) => createRawSnippet<[ReceiverFrequencyMount?]>(() => ({
     render: () => `<span data-hosted-frequency="${receiver}">${receiver} frequency</span>`,
   }));
-  const meter = (receiver: ReceiverId) => createRawSnippet<[ReceiverSMeterRenderer]>(() => ({
+  const meter = (receiver: ReceiverId) => createRawSnippet<[ReceiverSMeterRenderer?]>(() => ({
     render: () => `<span data-hosted-s-meter="${receiver}">${receiver} meter</span>`,
   }));
   return {

--- a/frontend/src/skins/__tests__/registry.test.ts
+++ b/frontend/src/skins/__tests__/registry.test.ts
@@ -393,6 +393,16 @@ describe('external presentation records share the built-in catalog', () => {
     expect(second.loader).toHaveBeenCalledTimes(1);
   });
 
+  it('loads the exact external record without looking it up again by id', async () => {
+    const catalogRecord = externalRecord('correlated-face', faceB);
+    commitExternalPresentationBatch(prepareExternalPresentationBatch([catalogRecord]));
+    const capturedRecord = externalRecord('correlated-face', faceA);
+
+    await expect(loadSkin(capturedRecord)).resolves.toBe(faceA);
+    expect(capturedRecord.loader).toHaveBeenCalledTimes(1);
+    expect(catalogRecord.loader).not.toHaveBeenCalled();
+  });
+
   it('does not fall back for unknown or inherited ids', async () => {
     expect(getPresentationRecord('absent-external')).toBeUndefined();
     await expect(loadSkin('absent-external')).rejects.toThrow(/not registered/i);

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -271,9 +271,12 @@ type LoadedPresentation<Id extends SkinId> =
   Awaited<ReturnType<(typeof SKIN_LOADERS)[Id]['loader']>>['default'];
 
 export function loadSkin<Id extends SkinId>(id: Id): Promise<LoadedPresentation<Id>>;
+export function loadSkin(record: ExternalPresentationRecord): Promise<HostedFaceComponentV1>;
 export function loadSkin(id: PresentationId): Promise<PresentationComponent>;
-export async function loadSkin(id: PresentationId): Promise<PresentationComponent> {
-  const record = requirePresentationRecord(id);
+export async function loadSkin(
+  source: PresentationId | ExternalPresentationRecord,
+): Promise<PresentationComponent> {
+  const record = typeof source === 'string' ? requirePresentationRecord(source) : source;
   if (record.kind === 'external-instruments-v1') return record.loader();
   return (await record.loader()).default;
 }


### PR DESCRIPTION
14 code + 0 regenerated baselines = 14 files

## Summary

Host side of the external hosted face join (`external-instruments-v1` presentations built against
the component-kit API). This PR lands the semantic-surfaces host, the face bridge and the renderer
seat predicates; it does **not** yet let `App.svelte` commit an external occurrence. That App-side
join (App.svelte, its lazy-presentation test and the registry-mock updates in five existing tests)
is a follow-on PR of 7 files, prepared and measured from the same candidate. `App.svelte` is
byte-identical to `main` here, and `grep -rn externalPresentation frontend/src` returns no call
site outside the new test, so nothing yet reaches this host; MOR-2425 C1 is not complete.

- `SemanticRadioSurfaces` accepts an optional `externalPresentation` occurrence (`record`,
  `component`, `isCurrent`) and stays one unkeyed host; only the external face bridge is wrapped in
  `{#key externalPresentation}`. Instrument owners survive occurrence replacement because the host
  around the bridge is not keyed — witnessed, see Uncovered below for what the keying itself does
  and does not have evidence for.
- `HostedFaceInstrumentBridge` exposes 4 receiver placements, 8 VFO operations and 8 TX scalar
  placements as opaque public handles. Family nullability follows actual layout admission
  (`surfacePlan()` and zone ownership), never missing telemetry; the SUB frequency/S-meter pair is
  published as one reactive conjunction.
- Frequency, scalar and finite renderer seats accept the occurrence currentness predicate; a
  lease retained from a replaced occurrence is inert, checked at each read. `VfoOperationSeatHost`
  derives its finite renderer context from both the radio context and the predicate identity.
- `loadSkin` gains a `loadSkin(record)` overload so a captured external record is loaded without a
  second catalog lookup by id.
- `MeterRendererSeat` accepts an explicit signal renderer and an optional fallback; the receiver
  S-meter snippets take an optional renderer.

## Witnesses

`frontend/src/__tests__/external-hosted-face.component.test.ts` mounts the accepted Face A and
Face B fixtures through the real host: exact 4+8+8 mapping and command routing; A1 → B → A2
occurrence replacement with retained frequency/scalar/finite leases proven live before replacement
and inert after it, automatic scalar lease retirement across occurrence replacement, a current-B
interaction surviving stale-A cancel/dispose, and all command counters unchanged at A2; family and
SUB nullability from the live plan and structural owners only, with ordered MAIN/SUB meter values;
a supplementary pure probe face (`fixtures/ExternalHostedFaceProbe.svelte`) that toggles `form`,
`compact`, `showLabel` and `showValue` independently through the public handles, with hbar and
knob mapped to two different real renderer constructors, and asserts the exact public key sets.
The generic queued A1/B/A2 seat proof is the existing test "fences renderer occurrences without
replacing or exposing the raw owner" in `continuous-scalar.test.ts`; `TxAuxScalarHost` has
`debounceMs: 0`, so no queue exists on the live TX path and none is claimed.

## Uncovered

Replacing `{#key externalPresentation}` with a constant key — which removes the bridge's
re-creation on occurrence change entirely — leaves all 97 files in the focused matrix green. No
test here distinguishes the bridge being re-created from it receiving a new `component` prop, so
the keying is stated as structure above, not as a witnessed guarantee. Reported rather than fixed:
adding that witness is outside this PR's scope.

## Size

Soft threshold (6 files / 600 lines) exceeded: every path is the same live join from the surfaces
host through the bridge to the renderer seats, plus the witnesses the root ruling required for it;
splitting further would leave the seats' predicate without the host that supplies it. File-count
exception (14 files) granted by the coordinating session under the owner's 2026-09-03 delegation.

Census vs `main` (5bef49c9): 730 additions, 39 deletions = 769 A+D across 14 files
(255 A+D in 9 source files / 514 A+D in 5 test files), from
`git diff 5bef49c9 --shortstat` at head 2f969451c0cf405f9d6cad96cca8390b95cd1d06.

## Verification

Focused checks at head 2f969451c0cf405f9d6cad96cca8390b95cd1d06 (the PR's natural `quick` run is
the suite authority):
- Vitest focused matrix (union of every test file naming a changed component, plus the candidate
  tests): 97 files / 2934 tests passed, 0 failed
- `npm run check`: 0 errors, 0 warnings
- ESLint over the 14 changed paths: passed
- `git diff --check`: passed
- internal-identifier self-check — empty

Mutation evidence, each applied to the frozen tree and then reverted (final tree verified
blob-for-blob against the candidate before the commit):
- Dropping `&& (isPresentationCurrent?.() ?? true)` from `ValueControl`'s seat predicate — the
  exact bug the scalar gate removes — fails the mapping test at line 347, the aggregate
  zero-counter assertion after the A1 → B swap.
- Reverting `VfoOperationSeatHost` to its `main` form fails the same assertion, reached by the
  stale `oldFiniteLease.invoke()` at line 344. A positive control at line 335 establishes that the
  same lease does route while A1 is current, so the assertion is not vacuous.
- The keying mutation described under Uncovered survived.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

