### PR TITLE
feat(MOR-2425): commit external presentations from the App loader

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -4,7 +4,7 @@
   import LocalExtensionsHost from './lib/local-extensions/LocalExtensionsHost.svelte';
   import { initMediaSession, destroyMediaSession } from './lib/media/media-session';
   import { presentationResources, runtime } from './lib/runtime/frontend-runtime';
-  import type { ResourceLease } from '$lib/runtime/resource-demand';
+  import type { AppResource, ResourceLease } from '$lib/runtime/resource-demand';
   import { systemController } from '$lib/runtime/system-controller';
   import { provideManagedAppTxHost } from '$lib/runtime/tx-controller/managed-app-host';
   import { hasAnyScope } from './lib/stores/capabilities.svelte';
@@ -35,11 +35,14 @@
     densityActivation, provideSurfacePlan, resolveSurfacePlan,
   } from './presentation/workspace/resolution';
   import { getWorkspace, initWorkspaceStore } from './presentation/workspace/store.svelte';
-  import SemanticRadioSurfaces from './components-v2/wiring/SemanticRadioSurfaces.svelte';
+  import SemanticRadioSurfaces, {
+    type ExternalPresentation as ExternalPresentationInput,
+  } from './components-v2/wiring/SemanticRadioSurfaces.svelte';
+  import { getSelectedPresentationId } from './component-kits/activation';
   import {
-    loadSkin, presentationHostMode, presentationResourcePlan, resolveSkinId,
+    getPresentationRecord, loadSkin, resolveSkinId,
     type InstrumentHandlesPresentation, type PresentationComponent,
-    type SelfContainedPresentation, type SkinId,
+    type PresentationId, type SelfContainedPresentation, type SkinId,
   } from './skins/registry';
   import { t } from '$lib/i18n';
   import './app.css';
@@ -79,10 +82,16 @@
   }));
 
   type CommittedPresentation =
-    | { id: SkinId; component: InstrumentHandlesPresentation; hostMode: 'instrument-handles' }
-    | { id: SkinId; component: SelfContainedPresentation; hostMode: 'self-contained' };
+    | { id: SkinId; layoutId: SkinId; component: InstrumentHandlesPresentation; hostMode: 'instrument-handles' }
+    | { id: SkinId; layoutId: SkinId; component: SelfContainedPresentation; hostMode: 'self-contained' }
+    | {
+        id: PresentationId;
+        layoutId: string;
+        hostMode: 'external-instruments-v1';
+        externalPresentation: ExternalPresentationInput;
+      };
   let presentation = $state<CommittedPresentation | null>(null);
-  let committedSkinId = $derived<SkinId | null>(presentation?.id ?? null);
+  let committedLayoutId = $derived<string | null>(presentation?.layoutId ?? null);
 
   // MOR-1081: the workspace's `designLanguage` is the ONLY source the
   // `[data-design-language]` activation attribute (MOR-1278) is written from,
@@ -100,7 +109,7 @@
   // rules arrive with the cutover — and it is absent entirely wherever the
   // language is not active, so no shipped v2 skin sees a new attribute.
   $effect(() => {
-    const layoutId = committedSkinId;
+    const layoutId = committedLayoutId;
     if (layoutId === null) {
       delete document.documentElement.dataset.designLanguage;
       delete document.documentElement.dataset.languageMode;
@@ -146,7 +155,7 @@
   // against the ACTIVE layout manifest and handed down as a getter.
   // A getter, so a consumer's `$derived` re-runs when either input changes.
   provideSurfacePlan(() => {
-    const layoutId = committedSkinId;
+    const layoutId = committedLayoutId;
     if (layoutId === null) return null;
     const manifest = getLayout(layoutId);
     return manifest === undefined ? null : resolveSurfacePlan(manifest, getWorkspace());
@@ -171,21 +180,59 @@
   let SelfContainedComponent = $derived(
     presentation?.hostMode === 'self-contained' ? presentation.component : null,
   );
+  let ExternalPresentation = $derived(
+    presentation?.hostMode === 'external-instruments-v1'
+      ? presentation.externalPresentation
+      : null,
+  );
   let loaderGeneration = 0;
+  let requestedPresentationId: PresentationId | null = null;
   /** Cleared by App teardown; a resolution that lands afterwards is inert. */
   let presentationActive = true;
 
   $effect(() => {
-    const requested = skinId;
+    const builtInFallback = skinId;
+    const requested = getSelectedPresentationId() ?? builtInFallback;
     if (demoMode === 'control-buttons') return;
+    if (requested === requestedPresentationId) return;
+    requestedPresentationId = requested;
     void requestPresentation(requested);
   });
 
-  async function requestPresentation(id: SkinId): Promise<void> {
+  async function requestPresentation(id: PresentationId): Promise<void> {
     const generation = ++loaderGeneration;
-    let loaded: PresentationComponent;
+    let bridge: ResourceLease[] = [];
     try {
-      loaded = await loadSkin(id);
+      const record = getPresentationRecord(id);
+      if (record === undefined) throw new Error(`Presentation "${id}" is not registered.`);
+      if (record.kind === 'external-instruments-v1') {
+        const component = await loadSkin(record);
+        if (!presentationActive || generation !== loaderGeneration) return;
+        bridge = acquireSwapBridge(id, record.resources);
+        let occurrence: ExternalPresentationInput;
+        occurrence = Object.freeze({
+          record,
+          component,
+          isCurrent: () => presentationActive
+            && presentation?.hostMode === 'external-instruments-v1'
+            && presentation.externalPresentation === occurrence,
+        });
+        presentation = Object.freeze({
+          id: record.id,
+          layoutId: record.layoutId,
+          hostMode: record.kind,
+          externalPresentation: occurrence,
+        });
+      } else {
+        const loaded: PresentationComponent = await loadSkin(id);
+        if (!presentationActive || generation !== loaderGeneration) return;
+        bridge = acquireSwapBridge(id, record.resources);
+        presentation = record.kind === 'built-in-instrument-layout'
+          ? { id: record.id, layoutId: record.id, component: loaded as InstrumentHandlesPresentation, hostMode: 'instrument-handles' }
+          : { id: record.id, layoutId: record.id, component: loaded as SelfContainedPresentation, hostMode: 'self-contained' };
+      }
+      presentationFailed = false;
+      await tick();
     } catch (err) {
       // A stale or post-teardown failure is inert: only the newest request
       // owns the error surface (same guard doctrine as the bootstrap catch).
@@ -196,21 +243,6 @@
       // runtime teardown.
       presentationFailed = presentation === null;
       return;
-    }
-    if (!presentationActive || generation !== loaderGeneration) return;
-
-    // Hold the incoming presentation's demand BEFORE the swap so destroying
-    // the outgoing subtree can never drop a live resource to zero and bounce
-    // it (MOR-973). Released only after the commit has flushed, by which time
-    // the new subtree owns its own leases.
-    const bridge = acquireSwapBridge(id);
-    try {
-      presentationFailed = false;
-      const hostMode = presentationHostMode(id);
-      presentation = hostMode === 'instrument-handles'
-        ? { id, component: loaded as InstrumentHandlesPresentation, hostMode }
-        : { id, component: loaded as SelfContainedPresentation, hostMode };
-      await tick();
     } finally {
       releaseSwapBridge(bridge);
     }
@@ -221,9 +253,9 @@
    * to those already demanded: a presentation choice must not manufacture a
    * live service (v3 ADR invariant 12).
    */
-  function acquireSwapBridge(id: SkinId): ResourceLease[] {
+  function acquireSwapBridge(id: PresentationId, resources: readonly AppResource[]): ResourceLease[] {
     const leases: ResourceLease[] = [];
-    for (const resource of presentationResourcePlan(id)) {
+    for (const resource of resources) {
       try {
         if (presentationResources.snapshot(resource).demand <= 0) continue;
         // Every acquisition returns its own distinct lease object, so a
@@ -356,12 +388,12 @@
       {/if}
     </div>
   </div>
-{:else if HostedPresentation}
+{:else if HostedPresentation || ExternalPresentation}
   <!-- One unkeyed host outlives replacement of either hosted presentation.
        The child places radio instruments; SRS retains bindings and authority. -->
-  <SemanticRadioSurfaces>
+  <SemanticRadioSurfaces externalPresentation={ExternalPresentation}>
     {#snippet children(instruments)}
-      <HostedPresentation {instruments} />
+      {#if HostedPresentation}<HostedPresentation {instruments} />{/if}
     {/snippet}
   </SemanticRadioSurfaces>
 {:else if SelfContainedComponent}

--- a/frontend/src/__tests__/app-global-host.component.test.ts
+++ b/frontend/src/__tests__/app-global-host.component.test.ts
@@ -93,8 +93,7 @@ vi.mock('$lib/stores/layout.svelte', () => ({ getLayoutMode: () => 'standard' })
 vi.mock('../skins/registry', () => ({
   resolveSkinId: h.resolveSkin,
   loadSkin: h.loadSkin,
-  presentationHostMode: () => 'self-contained',
-  presentationResourcePlan: () => [],
+  getPresentationRecord: (id: unknown) => ({ id, kind: 'built-in-self-contained', resources: [] }),
 }));
 vi.mock('../lib/utils/battery', () => ({ initBatteryMonitor: h.initBattery }));
 vi.mock('../lib/media/media-session', () => ({ initMediaSession: vi.fn(), destroyMediaSession: vi.fn() }));

--- a/frontend/src/__tests__/external-hosted-face.component.test.ts
+++ b/frontend/src/__tests__/external-hosted-face.component.test.ts
@@ -474,4 +474,28 @@ describe('external hosted face chain', () => {
     invoke('[data-probe="value"] button', 'onAntiVoxGainChange');
     expect(h.scalarOwners).toEqual(owners);
   });
+
+  it('re-creates the face on an occurrence change with the same component and keeps its owners', async () => {
+    const current = { value: {} };
+    const loaded = await loadedRecord('keying', FaceA);
+    const a1 = occurrence(loaded, current); current.value = a1;
+    const props = proxy({ externalPresentation: a1 }); const plan = writable<SurfacePlan | null>(fullPlan());
+    const livePlan = fromStore(plan); target = document.createElement('div'); document.body.appendChild(target);
+    mounted = mount(SemanticRadioSurfaces, { target, props,
+      context: new Map([[SURFACE_PLAN_CONTEXT_KEY, () => livePlan.current]]) }); flushSync();
+    const faceA1 = target.querySelector('[data-external-face="a"]');
+    const owners = [...h.frequencyOwners, ...h.meterOwners, ...h.scalarOwners, ...h.finiteSeats];
+    const subscriptions = h.subscribers.size;
+    const oldButton = target.querySelector<HTMLButtonElement>('[data-fixture-action]')!;
+    const oldLease = h.finiteLeases[3] as FiniteRendererLease<unknown> & { invoke(): void };
+    const a1b = occurrence(loaded, current); current.value = a1b; props.externalPresentation = a1b; flushSync();
+    const faceA1b = target.querySelector('[data-external-face="a"]');
+    expect(faceA1b).not.toBeNull(); expect(faceA1b).not.toBe(faceA1);
+    expect([...h.frequencyOwners, ...h.meterOwners, ...h.scalarOwners, ...h.finiteSeats]).toEqual(owners);
+    expect(h.subscribers.size).toBe(subscriptions);
+    clearCalls(); oldLease.invoke(); oldButton.click();
+    expect([...h.calls.values()].every((fn) => fn.mock.calls.length === 0)).toBe(true);
+    clearCalls(); target.querySelector<HTMLButtonElement>('[data-fixture-action]')!.click();
+    expectOnly('onEqual');
+  });
 });

--- a/frontend/src/__tests__/lazy-presentation.component.test.ts
+++ b/frontend/src/__tests__/lazy-presentation.component.test.ts
@@ -15,14 +15,16 @@
 import { readFileSync } from 'node:fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, tick, unmount } from 'svelte';
-import type { SkinId } from '../skins/registry';
+import type { ExternalPresentationRecord, PresentationId, SkinId } from '../skins/registry';
 
-type Pending = { id: SkinId; resolve: (component: unknown) => void; reject: (err: unknown) => void };
+type Pending = { id: PresentationId; resolve: (component: unknown) => void; reject: (err: unknown) => void };
 type LeaseEvent = { op: 'acquire' | 'release'; resource: string; consumer: string; mounted: string | null };
 
 const h = vi.hoisted(() => ({
   pending: [] as Pending[],
   loadSkin: vi.fn(),
+  getPresentationRecord: vi.fn(),
+  selectedPresentationId: undefined as string | undefined,
   resolveSkinId: vi.fn(),
   plan: vi.fn(),
   demand: new Map<string, number>(),
@@ -37,6 +39,9 @@ const h = vi.hoisted(() => ({
   registerBarrier: vi.fn(),
   txHost: undefined as { refreshAuthority: ReturnType<typeof vi.fn>; dispose: ReturnType<typeof vi.fn> } | undefined,
   surfacePlanSource: undefined as (() => ReadonlyMap<string, readonly string[]> | null) | undefined,
+  surfaceHosts: [] as Array<{ externalPresentation?: {
+    record: ExternalPresentationRecord; component: unknown; isCurrent: () => boolean;
+  } | null }>,
 }));
 
 // The presentation subtree under test is the *loader result*, so the skin
@@ -45,12 +50,20 @@ const h = vi.hoisted(() => ({
 vi.mock('../skins/registry', () => ({
   resolveSkinId: h.resolveSkinId,
   loadSkin: h.loadSkin,
+  getPresentationRecord: h.getPresentationRecord,
   presentationHostMode: () => 'self-contained',
   presentationResourcePlan: h.plan,
 }));
-vi.mock('../components-v2/wiring/SemanticRadioSurfaces.svelte', async () => ({
-  default: (await import('./LayoutStub.svelte')).default,
+vi.mock('../component-kits/activation', () => ({
+  getSelectedPresentationId: () => h.selectedPresentationId,
 }));
+vi.mock('../components-v2/wiring/SemanticRadioSurfaces.svelte', async () => {
+  const Stub = (await import('./LayoutStub.svelte')).default;
+  return { default: ((anchor: unknown, props: (typeof h.surfaceHosts)[number]) => {
+    h.surfaceHosts.push(props);
+    return (Stub as unknown as ClientComponent)(anchor, props);
+  }) };
+});
 vi.mock('../presentation/workspace/resolution', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../presentation/workspace/resolution')>();
   return {
@@ -134,6 +147,17 @@ function presentationStub(id: string): ClientComponent {
   return stub;
 }
 
+function externalRecord(
+  id: string, layoutId: string, resources: ExternalPresentationRecord['resources'],
+): ExternalPresentationRecord {
+  const component = presentationStub(id);
+  return {
+    id, layoutId, resources, kind: 'external-instruments-v1',
+    loader: async () => component as never,
+    appearances: {} as ExternalPresentationRecord['appearances'],
+  };
+}
+
 const mountedSkin = (): string | null =>
   document.querySelector('.layout-stub')?.getAttribute('data-skin') ?? null;
 const mountedCount = () => document.querySelectorAll('.layout-stub').length;
@@ -173,13 +197,13 @@ function selectSkin(id: SkinId): void {
  * that resolution hands back, so two pending requests for the same skin can
  * be told apart in the DOM.
  */
-function completeLoad(id: SkinId, as: string = id): void {
+function completeLoad(id: PresentationId, as: string = id): void {
   const index = h.pending.findIndex((entry) => entry.id === id);
   if (index < 0) throw new Error(`no pending load for ${id}`);
   h.pending.splice(index, 1)[0].resolve(presentationStub(as));
 }
 
-function failLoad(id: SkinId, message = 'chunk load failed'): void {
+function failLoad(id: PresentationId, message = 'chunk load failed'): void {
   const index = h.pending.findIndex((entry) => entry.id === id);
   if (index < 0) throw new Error(`no pending load for ${id}`);
   h.pending.splice(index, 1)[0].reject(new Error(message));
@@ -198,15 +222,21 @@ beforeEach(() => {
   h.demand.clear();
   h.resourcesEnded = false;
   h.surfacePlanSource = undefined;
+  h.surfaceHosts.length = 0;
+  h.selectedPresentationId = undefined;
   document.body.innerHTML = '';
   Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1200 });
   Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
   h.bootstrap.mockResolvedValue(h.bootstrapCleanup);
   h.initBattery.mockResolvedValue(vi.fn());
   h.resolveSkinId.mockImplementation(({ isMobile }: { isMobile: boolean }) => (isMobile ? 'mobile' : 'desktop-v2'));
-  h.loadSkin.mockImplementation(
-    (id: SkinId) => new Promise((resolve, reject) => { h.pending.push({ id, resolve, reject }); }),
-  );
+  h.getPresentationRecord.mockImplementation((id: SkinId) => ({
+    id, kind: 'built-in-self-contained', loader: vi.fn(), resources: h.plan(id),
+  }));
+  h.loadSkin.mockImplementation((source: PresentationId | ExternalPresentationRecord) => {
+    const id = typeof source === 'string' ? source : source.id;
+    return new Promise((resolve, reject) => { h.pending.push({ id, resolve, reject }); });
+  });
   h.plan.mockImplementation((id: SkinId) => (id === 'mobile' ? ['hardware-scope'] : ['hardware-scope', 'audio-fft']));
   h.provide.mockImplementation(() => {
     h.txHost = { refreshAuthority: vi.fn(), dispose: vi.fn() };
@@ -338,7 +368,7 @@ describe('stale-resolution cancellation', () => {
 
     expect(mountedCount()).toBe(0);
     expect(mountedSkin()).toBeNull();
-    // A discarded resolution touches no resources either.
+    // A discarded resolution never reaches the ready-to-commit bridge.
     expect(h.leaseEvents).toEqual([]);
 
     completeLoad('desktop-v2');           // request 3 — the current one
@@ -375,6 +405,77 @@ describe('stale-resolution cancellation', () => {
     expect(mountedCount()).toBe(1);
 
     unmount(instance);
+  });
+});
+
+describe('external presentation occurrences', () => {
+  it('keeps exact-record LKG current and never revives an earlier A occurrence', async () => {
+    const recordA = externalRecord('face-a', 'desktop-v2', ['audio-fft']);
+    const recordB = externalRecord('face-b', 'mobile', ['hardware-scope']);
+    const recordC = externalRecord('face-c', 'layout-for-c', []);
+    const records = new Map([recordA, recordB, recordC].map((record) => [record.id, record]));
+    h.getPresentationRecord.mockImplementation((id: string) => records.get(id));
+    h.selectedPresentationId = recordA.id;
+    h.demand.set('audio-fft', 1);
+    h.demand.set('hardware-scope', 1);
+    const request = async (id: string, skin: SkinId) => {
+      h.selectedPresentationId = id; selectSkin(skin); await settle();
+    };
+
+    const instance = mountApp();
+    await settle();
+    completeLoad(recordA.id);
+    await settle();
+
+    const hostProps = h.surfaceHosts[0];
+    const a1 = hostProps.externalPresentation!;
+    expect(a1.record).toBe(recordA);
+    expect(a1.isCurrent()).toBe(true);
+    expect(surfacePlanSnapshot()).not.toBeNull();
+    expect(h.plan).not.toHaveBeenCalled();
+    h.leaseEvents.length = 0;
+
+    await request(recordB.id, 'mobile');
+    expect(a1.isCurrent()).toBe(true);
+    failLoad(recordB.id);
+    await settle();
+    expect(a1.isCurrent()).toBe(true);
+    expect(h.leaseEvents.filter((event) => event.consumer === 'App:face-b'))
+      .toEqual([]);
+
+    await request(recordA.id, 'desktop-v2');
+    completeLoad(recordA.id);
+    await settle();
+    const a2 = hostProps.externalPresentation!;
+    expect(a1.isCurrent()).toBe(false);
+
+    const demandBeforeUnresolvedB = h.demand.get('hardware-scope');
+    await request(recordB.id, 'mobile');
+    expect(h.demand.get('hardware-scope')).toBe(demandBeforeUnresolvedB);
+    await request(recordC.id, 'desktop-v2');
+    completeLoad(recordC.id);
+    await settle();
+    const c = hostProps.externalPresentation!;
+    expect(h.pending.some(({ id }) => id === recordB.id)).toBe(true);
+    expect(h.demand.get('hardware-scope')).toBe(demandBeforeUnresolvedB);
+    expect(h.leaseEvents.filter((event) => event.consumer === 'App:face-b')).toEqual([]);
+
+    await request(recordA.id, 'mobile');
+    completeLoad(recordA.id);
+    await settle();
+    const a3 = hostProps.externalPresentation!;
+
+    expect([a1, a2, c, a3]).toHaveLength(new Set([a1, a2, c, a3]).size);
+    expect(a1.isCurrent()).toBe(false);
+    expect(a2.isCurrent()).toBe(false);
+    expect(c.isCurrent()).toBe(false);
+    expect(a3.isCurrent()).toBe(true);
+    expect(h.loadSkin.mock.calls.map(([source]) => source)).toEqual([
+      recordA, recordB, recordA, recordB, recordC, recordA,
+    ]);
+
+    unmount(instance);
+    expect(a3.isCurrent()).toBe(false);
   });
 });
 

--- a/frontend/src/__tests__/presentation-switch-resources.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-resources.component.test.ts
@@ -172,8 +172,9 @@ vi.mock('$lib/stores/layout.svelte', () => ({
 vi.mock('../skins/registry', () => ({
   resolveSkinId: () => widthToSkin(),
   loadSkin: h.loadSkin,
-  presentationHostMode: () => 'self-contained',
-  presentationResourcePlan: (id: SkinId) => SKIN_PLAN[id] ?? [],
+  getPresentationRecord: (id: SkinId) => ({
+    id, kind: 'built-in-self-contained', resources: SKIN_PLAN[id] ?? [],
+  }),
 }));
 vi.mock('../components-v2/wiring/SemanticRadioSurfaces.svelte', async () => ({
   default: (await import('./LayoutStub.svelte')).default,

--- a/frontend/src/__tests__/presentation-switch-tx.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-tx.component.test.ts
@@ -82,8 +82,7 @@ vi.mock('$lib/stores/layout.svelte', () => ({ getLayoutMode: () => 'standard' })
 vi.mock('../skins/registry', () => ({
   resolveSkinId: () => widthToSkin(),
   loadSkin: h.loadSkin,
-  presentationHostMode: () => 'self-contained',
-  presentationResourcePlan: () => [],
+  getPresentationRecord: (id: unknown) => ({ id, kind: 'built-in-self-contained', resources: [] }),
 }));
 vi.mock('../components-v2/wiring/SemanticRadioSurfaces.svelte', async () => ({
   default: (await import('./LayoutStub.svelte')).default,

--- a/frontend/src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts
@@ -37,8 +37,7 @@ vi.mock('$lib/stores/layout.svelte', () => ({ getLayoutMode: () => 'standard' })
 vi.mock('../../../../skins/registry', () => ({
   resolveSkinId: h.resolveSkin,
   loadSkin: async () => (await import('../../../../components-v2/layout/__tests__/SpectrumPanelStub.svelte')).default,
-  presentationHostMode: () => 'self-contained',
-  presentationResourcePlan: () => [],
+  getPresentationRecord: (id: unknown) => ({ id, kind: 'built-in-self-contained', resources: [] }),
 }));
 vi.mock('../../../../components-v2/wiring/SemanticRadioSurfaces.svelte', async () => ({
   default: (await import('../../../../components-v2/layout/__tests__/SpectrumPanelStub.svelte')).default,
@@ -138,6 +137,20 @@ describe('App TX lifecycle', () => {
     await settle();
     expect(h.provide).toHaveBeenCalledOnce();
     expect(h.host!.refreshAuthority).toHaveBeenCalledOnce();
+    // MOR-2425 C1 PR-2 follow-up: the loaded presentation (SpectrumPanelStub,
+    // via `loadSkin`) must actually be in the mounted tree, not merely
+    // implied by the TX-host assertions above — AppGlobalHost and
+    // LocalExtensionsHost are stubbed with the same component and always
+    // render as siblings, so a failed presentation load (2 stubs) is
+    // distinguishable from a successful one (3 stubs: presentation + the
+    // two siblings). `loadSkin`'s dynamic import settles a macrotask after
+    // `settle()`'s microtask drain, so poll rather than assert immediately —
+    // same idiom as `integration-page-lifecycle.isolated.test.ts`'s
+    // `capturedController` wait.
+    await vi.waitFor(() => {
+      flushSync();
+      expect(document.querySelectorAll('.spectrum-panel-stub')).toHaveLength(3);
+    });
     h.radio!.ptt = true;
     h.radio!.observationSeq++;
     h.caps!.capabilities.push('voice_tx');

--- a/frontend/src/lib/runtime/tx-controller/__tests__/integration-page-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/integration-page-lifecycle.isolated.test.ts
@@ -106,8 +106,7 @@ vi.mock('$lib/stores/layout.svelte', () => ({ getLayoutMode: () => 'standard' })
 vi.mock('../../../../skins/registry', () => ({
   resolveSkinId: () => 'desktop-v2',
   loadSkin: async () => (await import('./support/TxControllerProbe.svelte')).default,
-  presentationHostMode: () => 'self-contained',
-  presentationResourcePlan: () => [],
+  getPresentationRecord: (id: unknown) => ({ id, kind: 'built-in-self-contained', resources: [] }),
 }));
 vi.mock('../../../../components-v2/wiring/SemanticRadioSurfaces.svelte', async () => ({
   default: (await import('../../../../components-v2/layout/__tests__/SpectrumPanelStub.svelte')).default,

--- a/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
@@ -83,7 +83,7 @@ const panadapterFirstShellSource = readFileSync('src/skins/lcd-panadapter-first/
  *
  */
 const persistentHostPassesInstruments =
-  /<SemanticRadioSurfaces>/.test(appSource)
+  /<SemanticRadioSurfaces[^>]*>/.test(appSource)
   && /\{#snippet children\(instruments\)\}[\s\S]*<(?:HostedPresentation|Presentation) \{instruments\} \/>/.test(appSource)
   && /children\?: Snippet<\[InstrumentComposition\]>;/.test(semanticHostSource)
   && /\{@render hostedChildren\(\{/.test(semanticHostSource);


### PR DESCRIPTION
This is one unit of work at 9 files: the App commit path (`App.svelte`) plus
seven existing tests whose registry mock needed to widen for the new
`getPresentationRecord`-based export set, plus one new case in the existing
external-hosted-face test witnessing the keying behavior that path relies on — one seam, split across
its consumers. The ninth file is a same-seam follow-up: an independent
verifier's sweep of every test that mocks `skins/registry` and mounts
`App.svelte` found one more member of that class still on the pre-cutover
mock shape, silently swallowing the presentation load as a caught failure
with nothing in the file to notice; see "Registry-mock class" below.

## Summary

`App.svelte` resolves the presentation record once, loads external records
through `loadSkin(record)`, and commits a frozen occurrence
`{record, component, isCurrent}`. The surface plan now comes from
`record.layoutId`. Resource bridges are acquired only after a load that is
still current when it resolves, and released after the commit tick.
Failed, stale, or never-resolving loaders acquire no bridge.

Five existing tests update their registry mocks (swapping
`presentationHostMode`/`presentationResourcePlan` for
`getPresentationRecord`) or widen the `forward-declaration-inventory` tag
regex to match the new registry export set — no assertion, setup, or mocked
surface changed beyond that export shape.

A sixth test file, `external-hosted-face.component.test.ts`, gets one new
case covering a gap disclosed as uncovered in #3342: `{#key
externalPresentation}` in `SemanticRadioSurfaces.svelte` keys the hosted-face
bridge on occurrence identity, not component identity, so a same-component
occurrence swap (as `App.svelte`'s commit path now performs on every
successful reload) still tears down and rebuilds the DOM bridge while the
unkeyed host-level owners/seats survive underneath it.

With this PR, MOR-2425 C1 (the live external-face join) is complete at the
code level. The wider MOR-2425 objective is not.

## Witnesses

Lazy-presentation cases (`lazy-presentation.component.test.ts`):
- exact-record LKG (last-known-good) continuity across a reload
- a failed load acquires no resource bridge
- a stale or never-resolving candidate is discarded without acquiring
- an empty resource plan still commits and succeeds
- acquire → commit → release ordering around the commit tick
- a non-null surface plan from `record.layoutId` even when it differs from
  the presentation id

New witness (`external-hosted-face.component.test.ts`, "re-creates the face
on an occurrence change with the same component and keeps its owners"):
mounts with occurrence `a1` (built from one loaded `FaceA` record), then
commits a second occurrence `a1b` built from the *same* loaded record and
component (new `isCurrent` closure). Asserts: the `[data-external-face="a"]`
DOM node from `a1b` is a different node than the one from `a1` (the keyed
bridge tears down and rebuilds), the `frequencyOwners`/`meterOwners`/
`scalarOwners`/`finiteSeats` identity arrays are unchanged (the unkeyed host
survives), subscriber count is unchanged, `a1`'s retained lease and button
are inert after the swap, and a command routed through the new (`a1b`) face
still fires exactly once.

Mutation proof: replaced `{#key externalPresentation}` with a constant key
literal in `SemanticRadioSurfaces.svelte`, re-ran
`external-hosted-face.component.test.ts` — 1 failed / 3 passed, with the new
test's DOM-identity assertion (`expect(faceA1b).not.toBe(faceA1)`) as the
sole failure. Restored the file; `git diff` on it came back empty
afterward, and the full file re-ran 4/4 passed.

## Registry-mock class (8 tests that mock `skins/registry` and mount `App.svelte`)

An independent verifier enumerated every test that mocks `skins/registry`
and mounts `App.svelte`: 8 members. Five were already reconciled earlier in
this PR; a follow-up swept the remaining three.

- `frontend/src/__tests__/presentation-switch-resources.component.test.ts` —
  changed: `presentationHostMode`/`presentationResourcePlan` replaced with
  `getPresentationRecord`. Witness: yes (asserts on the switched
  presentation's DOM).
- `frontend/src/__tests__/presentation-switch-tx.component.test.ts` —
  changed: same replacement. Witness: yes.
- `frontend/src/lib/runtime/tx-controller/__tests__/integration-page-lifecycle.isolated.test.ts`
  — changed: same replacement. Witness: yes (`capturedController()`,
  polled with `vi.waitFor`).
- `frontend/src/__tests__/app-global-host.component.test.ts` — changed:
  same replacement. Witness: yes.
- `frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts`
  — changed: a tag regex widened to the new registry export set. Witness: yes.
- `frontend/src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts`
  — changed (this follow-up): the mock had no `getPresentationRecord` at
  all, so `App`'s `requestPresentation` threw on that call and the catch
  swallowed it as a presentation failure; nothing in the file asserted the
  presentation was ever mounted, so it stayed green regardless. Added
  `getPresentationRecord` (mirroring the other five) plus one new assertion
  that the presentation subtree is actually in the DOM, polled with
  `vi.waitFor` because `loadSkin`'s dynamic import settles a macrotask
  after the file's existing microtask-only `settle()`. Mutation-tested:
  removing `getPresentationRecord` from the mock reproduces the exact
  swallowed failure and fails only the new assertion — the other 5 tests
  in the file stay green, confirming the file's prior vacuity and this
  assertion's cover. Witness: yes (new).
- `frontend/src/__tests__/first-browser-auth.component.test.ts` —
  unchanged: it spreads the real `skins/registry` module, so
  `getPresentationRecord` is already the real implementation, not a forced
  stub. Traced through `App.svelte`: the file's only DOM assertions are
  "no `[role=alert]`" and "a `.retry-indicator` is present", neither
  sensitive to which host mode or resource list the record carries.
  Confirmed empirically — instrumented the mock to log the real record
  resolved in this test's environment (`desktop-v2`,
  `built-in-instrument-layout`, `["hardware-scope","audio-fft"]`, vs. the
  file's previously-forced `self-contained`/`[]`) and reran unmodified: all
  11 tests still pass. Witness: no (unchanged; the file has never asserted
  on mounted presentation content).
- `frontend/src/__tests__/design-language-activation.component.test.ts` —
  unchanged: also spreads the real module. Its own witness
  (`document.documentElement.dataset.designLanguage`/`languageMode`/
  `density`) is driven by `presentation.layoutId`, which `App.svelte` sets
  to `record.id` for both built-in host modes — so the real record's
  `kind` never changes that witness's input. Its mocked
  `presentationResources` always reports `demand: 0`, so
  `acquireSwapBridge` is a no-op regardless of the record's real resource
  list. Reran the file unmodified against the real record (which includes
  `desktop-v2`'s real `built-in-instrument-layout` kind, exercised in case
  C): all 3 tests still pass. Witness: yes (unchanged; its own).

## Census (head c9cf0a9344a8648c0a0ed35125f448a1121a7e9d)

```
$ git diff origin/main --shortstat
 9 files changed, 222 insertions(+), 54 deletions(-)

$ git diff origin/main --numstat
65   33  frontend/src/App.svelte
1    2   frontend/src/__tests__/app-global-host.component.test.ts
24   0   frontend/src/__tests__/external-hosted-face.component.test.ts
111  10  frontend/src/__tests__/lazy-presentation.component.test.ts
3    2   frontend/src/__tests__/presentation-switch-resources.component.test.ts
1    2   frontend/src/__tests__/presentation-switch-tx.component.test.ts
15   2   frontend/src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts
1    2   frontend/src/lib/runtime/tx-controller/__tests__/integration-page-lifecycle.isolated.test.ts
1    1   frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
```
9 files, 276 A+D (222+54). Under the hard ceiling (10 files / 1000 lines);
over the 6-file/600-line soft threshold on file count, justified above and
in the opening paragraph — one seam, all consumers of the same
`getPresentationRecord` cutover.

## Verification

- `npx vitest run` on the 8 changed test files + the 97-file related matrix
  (union, still 97 files after dedup — all 8 changed test files are already
  members of the matrix): 97 test files passed (97), 2936 tests passed
  (2936).
- `npm run check`: `COMPLETED 4820 FILES 0 ERRORS 0 WARNINGS 0
  FILES_WITH_PROBLEMS`.
- `npx eslint` over the 9 changed paths: exit 0, no output.
- `git diff --check`: exit 0.
- `git status --short` before commit showed only the intended follow-up
  file modified; `first-browser-auth.component.test.ts` and
  `design-language-activation.component.test.ts` have an empty diff.

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)


