### PR TITLE
feat(MOR-2425): expose station meters to hosted external faces

### DIFF
--- a/frontend/component-kit-api/fixtures/external-kit/package.json
+++ b/frontend/component-kit-api/fixtures/external-kit/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "sideEffects": false,
   "peerDependencies": {
-    "@rigplane/component-kit-api": "0.5.0",
+    "@rigplane/component-kit-api": "0.6.0",
     "svelte": ">=5.45.2 <6"
   },
   "files": [

--- a/frontend/component-kit-api/fixtures/external-kit/src/FaceA.svelte
+++ b/frontend/component-kit-api/fixtures/external-kit/src/FaceA.svelte
@@ -42,6 +42,19 @@
       <div class="wide">{@render tx.monitorLevel({ form: 'hbar', showValue: true })}</div>
     </section>
   {/if}
+
+  {#if instruments.stationMeters !== null}
+    {@const station = instruments.stationMeters}
+    <section class="station-meters" data-family="stationMeters" aria-label="Station meters">
+      <div>{@render station.signal()}</div>
+      <div>{@render station.power()}</div>
+      <div>{@render station.swr()}</div>
+      <div>{@render station.alc()}</div>
+      <div>{@render station.drainCurrent()}</div>
+      <div>{@render station.drainVoltage()}</div>
+      <div>{@render station.compression()}</div>
+    </section>
+  {/if}
 </div>
 
 <style>
@@ -50,6 +63,7 @@
   .receiver { grid-template-columns: minmax(0, 2fr) minmax(0, 1fr); }
   .operations { grid-template-columns: repeat(4, minmax(0, 1fr)); }
   .tx-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .station-meters { grid-template-columns: repeat(7, minmax(0, 1fr)); }
   .wide { grid-column: span 2; }
-  @media (max-width: 44rem) { .operations, .tx-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+  @media (max-width: 44rem) { .operations, .tx-grid, .station-meters { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 </style>

--- a/frontend/component-kit-api/fixtures/external-kit/src/FaceB.svelte
+++ b/frontend/component-kit-api/fixtures/external-kit/src/FaceB.svelte
@@ -42,6 +42,19 @@
       {#if operations.speak}{@render operations.speak()}{/if}
     </section>
   {/if}
+
+  {#if instruments.stationMeters !== null}
+    {@const station = instruments.stationMeters}
+    <section class="station-meters" data-family="stationMeters" aria-label="Station meters">
+      <div>{@render station.compression()}</div>
+      <div>{@render station.drainVoltage()}</div>
+      <div>{@render station.drainCurrent()}</div>
+      <div>{@render station.alc()}</div>
+      <div>{@render station.swr()}</div>
+      <div>{@render station.power()}</div>
+      <div>{@render station.signal()}</div>
+    </section>
+  {/if}
 </div>
 
 <style>
@@ -50,5 +63,6 @@
   .tx-strip { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .receiver { grid-template-columns: minmax(0, 1fr) minmax(0, 2fr); }
   .operations { grid-column: 1 / -1; grid-template-columns: repeat(8, minmax(0, 1fr)); }
-  @media (max-width: 44rem) { .face { grid-template-columns: minmax(0, 1fr); } .operations { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+  .station-meters { grid-column: 1 / -1; grid-template-columns: repeat(7, minmax(0, 1fr)); }
+  @media (max-width: 44rem) { .face { grid-template-columns: minmax(0, 1fr); } .operations, .station-meters { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 </style>

--- a/frontend/component-kit-api/fixtures/external-kit/src/index.ts
+++ b/frontend/component-kit-api/fixtures/external-kit/src/index.ts
@@ -55,9 +55,10 @@ const faceALayout: LayoutManifest = {
   zones: [
     { id: 'receiver', surfaces: ['vfo'] },
     { id: 'transmit', surfaces: ['txAux'] },
+    { id: 'meters', surfaces: ['meters'] },
   ],
   compatibleTopologies: ['1/single', '1/ab', '2/ab_shared', '2/main_sub'],
-  requiredSemanticSurfaces: ['vfo', 'txAux'],
+  requiredSemanticSurfaces: ['vfo', 'txAux', 'meters'],
   stageSizing: { mode: 'fluid', responsiveBreakpoints: [640] },
   fallbackLayoutId: null,
 };
@@ -69,9 +70,10 @@ const faceBLayout: LayoutManifest = {
   zones: [
     { id: 'transmit', surfaces: ['txAux'] },
     { id: 'receiver', surfaces: ['vfo'] },
+    { id: 'meters', surfaces: ['meters'] },
   ],
   compatibleTopologies: ['1/single', '1/ab', '2/ab_shared', '2/main_sub'],
-  requiredSemanticSurfaces: ['txAux', 'vfo'],
+  requiredSemanticSurfaces: ['txAux', 'vfo', 'meters'],
   stageSizing: { mode: 'fluid', responsiveBreakpoints: [720] },
   fallbackLayoutId: null,
 };

--- a/frontend/component-kit-api/package.json
+++ b/frontend/component-kit-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rigplane/component-kit-api",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "sideEffects": false,

--- a/frontend/component-kit-api/src/index.ts
+++ b/frontend/component-kit-api/src/index.ts
@@ -218,10 +218,23 @@ export interface TxAuxInstrumentFamilyV1 {
   readonly monitorLevel: TxAuxScalarHandleV1;
 }
 
+export type StationMeterHandleV1 = Snippet<[]>;
+
+export interface StationMeterInstrumentFamilyV1 {
+  readonly signal: StationMeterHandleV1;
+  readonly power: StationMeterHandleV1;
+  readonly swr: StationMeterHandleV1;
+  readonly alc: StationMeterHandleV1;
+  readonly drainCurrent: StationMeterHandleV1;
+  readonly drainVoltage: StationMeterHandleV1;
+  readonly compression: StationMeterHandleV1;
+}
+
 export interface HostedInstrumentFamiliesV1 {
   readonly receiver: ReceiverInstrumentFamilyV1 | null;
   readonly vfoOperations: VfoOperationInstrumentFamilyV1 | null;
   readonly txAux: TxAuxInstrumentFamilyV1 | null;
+  readonly stationMeters: StationMeterInstrumentFamilyV1 | null;
 }
 
 export interface HostedFacePropsV1 {

--- a/frontend/component-kit-api/verify-package.mjs
+++ b/frontend/component-kit-api/verify-package.mjs
@@ -157,6 +157,9 @@ async function assertHostedFaceSources() {
     'rfPower', 'micGain', 'driveGain', 'voxGain', 'antiVoxGain',
     'voxDelay', 'compressorLevel', 'monitorLevel',
   ];
+  const stationMeters = [
+    'signal', 'power', 'swr', 'alc', 'drainCurrent', 'drainVoltage', 'compression',
+  ];
 
   for (const [index, source] of sources.entries()) {
     const imports = [...source.matchAll(/\bfrom\s+['"]([^'"]+)['"]/gu)]
@@ -169,6 +172,7 @@ async function assertHostedFaceSources() {
     assert(source.includes('receiver.subSMeter !== null'));
     assert(source.includes('instruments.vfoOperations !== null'));
     assert(source.includes('instruments.txAux !== null'));
+    assert(source.includes('instruments.stationMeters !== null'));
     for (const field of operations) {
       assert.equal(
         [...source.matchAll(new RegExp(`operations\\.${field}\\(`, 'gu'))].length,
@@ -183,6 +187,13 @@ async function assertHostedFaceSources() {
         `${path.basename(faceFiles[index])} must arrange ${field} exactly once`,
       );
     }
+    for (const field of stationMeters) {
+      assert.equal(
+        [...source.matchAll(new RegExp(`station\\.${field}\\(\\)`, 'gu'))].length,
+        1,
+        `${path.basename(faceFiles[index])} must place ${field} exactly once`,
+      );
+    }
     for (const forbidden of [
       '$lib', '/frontend/src/', 'InstrumentComposition', 'SignalMeterFrame',
       'vfoFreqHook', 'onFreqChange',
@@ -195,6 +206,14 @@ async function assertHostedFaceSources() {
   assert(sources.every((source) => source.includes('compact:')));
   assert(sources.every((source) => source.includes('showLabel:')));
   assert(sources.every((source) => source.includes('showValue:')));
+  const stationOrder = (source) => stationMeters
+    .map((field) => source.indexOf(`station.${field}()`));
+  assert(stationOrder(sources[0]).every((index) => index >= 0));
+  assert.notDeepEqual(stationOrder(sources[0]), stationOrder(sources[1]));
+  const fixtureSource = await readFile(path.join(fixtureRoot, 'src', 'index.ts'), 'utf8');
+  assert.match(fixtureSource, /id: 'meters', surfaces: \['meters'\]/u);
+  assert.match(fixtureSource, /requiredSemanticSurfaces: \['vfo', 'txAux', 'meters'\]/u);
+  assert.match(fixtureSource, /requiredSemanticSurfaces: \['txAux', 'vfo', 'meters'\]/u);
 }
 
 async function assertFixturePublicImports() {
@@ -313,6 +332,8 @@ try {
   assert(apiDeclarationSource.includes('ReceiverFrequencyHandleV1'));
   assert(apiDeclarationSource.includes('VfoOperationHandleV1'));
   assert(apiDeclarationSource.includes('TxAuxInstrumentFamilyV1'));
+  assert(apiDeclarationSource.includes('StationMeterInstrumentFamilyV1'));
+  assert.match(apiDeclarationSource, /type StationMeterHandleV1 = Snippet<\[\]>/u);
   assert(!apiDeclarationSource.includes('ReceiverMeterHandleV1'));
   assert(!apiDeclarationSource.includes('ReceiverVfoOperationsHandleV1'));
   assert(!apiDeclarationSource.includes('SignalMeterFrame'));
@@ -351,10 +372,20 @@ try {
     { name: 'compressorLevel', optional: false },
     { name: 'monitorLevel', optional: false },
   ]);
+  assert.deepEqual(interfaceMembers(apiDeclarationSource, 'StationMeterInstrumentFamilyV1'), [
+    { name: 'signal', optional: false },
+    { name: 'power', optional: false },
+    { name: 'swr', optional: false },
+    { name: 'alc', optional: false },
+    { name: 'drainCurrent', optional: false },
+    { name: 'drainVoltage', optional: false },
+    { name: 'compression', optional: false },
+  ]);
   assert.deepEqual(interfaceMembers(apiDeclarationSource, 'HostedInstrumentFamiliesV1'), [
     { name: 'receiver', optional: false },
     { name: 'vfoOperations', optional: false },
     { name: 'txAux', optional: false },
+    { name: 'stationMeters', optional: false },
   ]);
   assert.deepEqual(interfaceMembers(apiDeclarationSource, 'HostedFaceAppearanceIdsV1'), [
     { name: 'scalar', optional: false },
@@ -453,6 +484,8 @@ export default {
   type ScalarRendererSeat,
   type SignalMeterRendererProps,
   type SignalMeterEvidence,
+  type StationMeterHandleV1,
+  type StationMeterInstrumentFamilyV1,
   type TxAuxScalarPresentationV1,
 } from '@rigplane/component-kit-api';
 import type { Component } from 'svelte';
@@ -501,13 +534,26 @@ if (hosted !== undefined && 'hostMode' in hosted) {
 const txPresentation: TxAuxScalarPresentationV1 = {
   form: 'knob', compact: true, showLabel: false, showValue: true,
 };
+declare const stationMeter: StationMeterHandleV1;
+const completeStationMeters: StationMeterInstrumentFamilyV1 = {
+  signal: stationMeter, power: stationMeter, swr: stationMeter, alc: stationMeter,
+  drainCurrent: stationMeter, drainVoltage: stationMeter, compression: stationMeter,
+};
+const nullableStationMeters: HostedFacePropsV1['instruments'] = {
+  receiver: null, vfoOperations: null, txAux: null, stationMeters: null,
+};
 function inspectHostedFace(props: HostedFacePropsV1): void {
   const receiver = props.instruments.receiver;
   const operations = props.instruments.vfoOperations;
   const txAux = props.instruments.txAux;
+  const stationMeters = props.instruments.stationMeters;
   if (receiver !== null) void [receiver.mainFrequency, receiver.subFrequency, receiver.mainSMeter];
   if (operations !== null) void [operations.split, operations.equalize, operations.speak];
   if (txAux !== null) void [txAux.rfPower, txAux.voxDelay, txAux.monitorLevel];
+  if (stationMeters !== null) void [
+    stationMeters.signal, stationMeters.power, stationMeters.swr, stationMeters.alc,
+    stationMeters.drainCurrent, stationMeters.drainVoltage, stationMeters.compression,
+  ];
 }
 // @ts-expect-error a current numeric observation always carries its value
 const invalidCurrentEvidence: MeterNumericEvidence = { state: 'current', domain: { kind: 'engineering', unit: 'w' } };
@@ -547,6 +593,8 @@ void hostedA;
 void hostedB;
 void inferredMarker;
 void txPresentation;
+void completeStationMeters;
+void nullableStationMeters;
 void inspectHostedFace;
 void invalidCurrentEvidence;
 void invalidUnknownSignal;
@@ -573,6 +621,8 @@ import type {
   ReceiverFrequencyPresentationV1,
   ReceiverInstrumentFamilyV1,
   ReceiverSignalMeterHandleV1,
+  StationMeterHandleV1,
+  StationMeterInstrumentFamilyV1,
   TxAuxInstrumentFamilyV1,
   TxAuxScalarHandleV1,
   TxAuxScalarPresentationV1,
@@ -598,6 +648,7 @@ declare const frequency: ReceiverFrequencyHandleV1;
 declare const meter: ReceiverSignalMeterHandleV1;
 declare const scalar: TxAuxScalarHandleV1;
 declare const operation: VfoOperationHandleV1;
+declare const stationMeter: StationMeterHandleV1;
 declare const face: HostedFaceComponentV1;
 // @ts-expect-error the hosted discriminator is required
 const missingHostMode = { id: 'bad', layoutId: 'bad', loader: async () => face, resources: [], appearances: { scalar: 'x', frequency: 'x', finite: 'x', meter: 'x' } } satisfies HostedFacePresentationV1;
@@ -606,9 +657,13 @@ const receiverWithRawValue: ReceiverInstrumentFamilyV1 = { mainFrequency: freque
 // @ts-expect-error SUB structural absence is represented by required null fields
 const receiverWithoutSub: ReceiverInstrumentFamilyV1 = { mainFrequency: frequency, mainSMeter: meter };
 // @ts-expect-error every family key is required even though each family is nullable
-const propsWithoutOperations: HostedInstrumentFamiliesV1 = { receiver: null, txAux: null };
+const propsWithoutOperations: HostedInstrumentFamiliesV1 = { receiver: null, txAux: null, stationMeters: null };
 // @ts-expect-error family absence is null, never undefined
-const undefinedReceiver: HostedInstrumentFamiliesV1 = { receiver: undefined, vfoOperations: null, txAux: null };
+const undefinedReceiver: HostedInstrumentFamiliesV1 = { receiver: undefined, vfoOperations: null, txAux: null, stationMeters: null };
+// @ts-expect-error every family key is required even though each family is nullable
+const missingStationFamily: HostedInstrumentFamiliesV1 = { receiver: null, vfoOperations: null, txAux: null };
+// @ts-expect-error family absence is null, never undefined
+const undefinedStationFamily: HostedInstrumentFamiliesV1 = { receiver: null, vfoOperations: null, txAux: null, stationMeters: undefined };
 // @ts-expect-error all eight named VFO operation seats are required when admitted
 const operationsWithoutSpeak: VfoOperationInstrumentFamilyV1 = { split: operation, dualWatch: operation, activeReceiver: operation, equalize: operation, swap: operation, quickSplit: operation, quickDualWatch: operation };
 // @ts-expect-error operation-seat absence is null, never undefined
@@ -620,6 +675,18 @@ declare const oldAggregateOperation: Snippet<[appearance: 'semantic' | 'sdr' | '
 const publicOperation: VfoOperationHandleV1 = oldAggregateOperation;
 // @ts-expect-error all eight named TX scalar seats are required when admitted
 const txWithoutMonitor: TxAuxInstrumentFamilyV1 = { rfPower: scalar, micGain: scalar, driveGain: scalar, voxGain: scalar, antiVoxGain: scalar, voxDelay: scalar, compressorLevel: scalar };
+// @ts-expect-error all seven named station meter handles are required when admitted
+const stationWithoutCompression: StationMeterInstrumentFamilyV1 = { signal: stationMeter, power: stationMeter, swr: stationMeter, alc: stationMeter, drainCurrent: stationMeter, drainVoltage: stationMeter };
+// @ts-expect-error station meter handle absence is not encoded as undefined
+const undefinedStationSignal: StationMeterInstrumentFamilyV1 = { signal: undefined, power: stationMeter, swr: stationMeter, alc: stationMeter, drainCurrent: stationMeter, drainVoltage: stationMeter, compression: stationMeter };
+// @ts-expect-error aggregate meter calls are not admitted in the atomic station family
+const stationWithAggregate = { signal: stationMeter, power: stationMeter, swr: stationMeter, alc: stationMeter, drainCurrent: stationMeter, drainVoltage: stationMeter, compression: stationMeter, meters: stationMeter } satisfies StationMeterInstrumentFamilyV1;
+declare const privateStationHandle: Snippet<[frame: { readonly privateFrame: true }]>;
+// @ts-expect-error opaque station meter handles take no frames or reset leases
+const publicStationHandle: StationMeterHandleV1 = privateStationHandle;
+declare const privateResetStationHandle: Snippet<[resetLease: { readonly privateReset: true }]>;
+// @ts-expect-error opaque station meter handles cannot expose private reset leases
+const publicResetStationHandle: StationMeterHandleV1 = privateResetStationHandle;
 // @ts-expect-error layoutId is required on hosted declarations
 const missingLayout = { hostMode: 'external-instruments-v1', id: 'bad', loader: async () => face, resources: [], appearances: { scalar: 'x', frequency: 'x', finite: 'x', meter: 'x' } } satisfies HostedFacePresentationV1;
 // @ts-expect-error resources are required on hosted declarations
@@ -646,8 +713,9 @@ export type PrivateRootMustStayUnavailable = [
   ReceiverSMeterRenderer,
 ];
 void [wrongHostMode, privateFrequencyHook, discreteTxControl, invocationAppearance, missingHostMode];
-void [receiverWithRawValue, receiverWithoutSub, propsWithoutOperations, undefinedReceiver];
+void [receiverWithRawValue, receiverWithoutSub, propsWithoutOperations, undefinedReceiver, missingStationFamily, undefinedStationFamily];
 void [operationsWithoutSpeak, undefinedOperation, operationsWithAggregate, publicOperation, txWithoutMonitor];
+void [stationWithoutCompression, undefinedStationSignal, stationWithAggregate, publicStationHandle, publicResetStationHandle];
 void [missingLayout, missingResources, missingScalarAppearance, missingFrequencyAppearance];
 void [missingFiniteAppearance, missingMeterAppearance, missingLoader];
 `);
@@ -903,11 +971,12 @@ mount(App, { target: document.querySelector('#app')! });
   let subPresent = $state(true);
   let operationsPresent = $state(true);
   let txPresent = $state(true);
+  let stationMetersPresent = $state(true);
   let hiddenOperation = $state<string | null>(null);
   let operationInvocations = $state(0);
   const harness = globalThis as typeof globalThis & {
     __setFace: (value: 'a' | 'b') => void;
-    __setFamily: (family: 'receiver' | 'vfoOperations' | 'txAux', present: boolean) => void;
+    __setFamily: (family: 'receiver' | 'vfoOperations' | 'txAux' | 'stationMeters', present: boolean) => void;
     __setSub: (present: boolean) => void;
     __hideOperation: (name: string | null) => void;
     __operationInvocations: () => number;
@@ -917,6 +986,7 @@ mount(App, { target: document.querySelector('#app')! });
     if (family === 'receiver') receiverPresent = present;
     if (family === 'vfoOperations') operationsPresent = present;
     if (family === 'txAux') txPresent = present;
+    if (family === 'stationMeters') stationMetersPresent = present;
   };
   harness.__setSub = (present) => { subPresent = present; };
   harness.__hideOperation = (name) => { hiddenOperation = name; };
@@ -943,6 +1013,13 @@ mount(App, { target: document.querySelector('#app')! });
 {#snippet voxDelay(p = {})}<span data-seat="voxDelay" data-form={p.form}>VOX delay</span>{/snippet}
 {#snippet compressorLevel(p = {})}<span data-seat="compressorLevel" data-form={p.form}>Compressor</span>{/snippet}
 {#snippet monitorLevel(p = {})}<span data-seat="monitorLevel" data-form={p.form}>Monitor</span>{/snippet}
+{#snippet signal()}<span data-station-meter="signal">Signal</span>{/snippet}
+{#snippet power()}<span data-station-meter="power">Power</span>{/snippet}
+{#snippet swr()}<span data-station-meter="swr">SWR</span>{/snippet}
+{#snippet alc()}<span data-station-meter="alc">ALC</span>{/snippet}
+{#snippet drainCurrent()}<span data-station-meter="drainCurrent">Drain current</span>{/snippet}
+{#snippet drainVoltage()}<span data-station-meter="drainVoltage">Drain voltage</span>{/snippet}
+{#snippet compression()}<span data-station-meter="compression">Compression</span>{/snippet}
 {#snippet hostedFace()}
   {@const instruments = {
     receiver: receiverPresent ? {
@@ -964,6 +1041,9 @@ mount(App, { target: document.querySelector('#app')! });
     txAux: txPresent ? {
       rfPower, micGain, driveGain, voxGain, antiVoxGain,
       voxDelay, compressorLevel, monitorLevel,
+    } : null,
+    stationMeters: stationMetersPresent ? {
+      signal, power, swr, alc, drainCurrent, drainVoltage, compression,
     } : null,
   }}
   {#if face === 'a'}
@@ -1039,6 +1119,9 @@ mount(App, { target: document.querySelector('#app')! });
         'rfPower', 'micGain', 'driveGain', 'voxGain', 'antiVoxGain',
         'voxDelay', 'compressorLevel', 'monitorLevel',
       ];
+      const stationMeterNames = [
+        'signal', 'power', 'swr', 'alc', 'drainCurrent', 'drainVoltage', 'compression',
+      ];
       const scalarControl = page.locator('[data-fixture-scalar]');
       assert.equal(await scalarControl.count(), 1);
       assert.equal(await scalarControl.getAttribute('data-compact'), 'true');
@@ -1079,6 +1162,11 @@ mount(App, { target: document.querySelector('#app')! });
 
       assert.equal(await page.locator('[data-external-face="a"]').count(), 1);
       assert.equal(await page.locator('[data-seat]').count(), 20);
+      assert.deepEqual(
+        await page.locator('[data-family="stationMeters"] [data-station-meter]').evaluateAll((nodes) =>
+          nodes.map((node) => node.getAttribute('data-station-meter'))),
+        stationMeterNames,
+      );
       for (const name of seatNames) {
         assert.equal(await page.locator(`[data-seat="${name}"]`).count(), 1);
       }
@@ -1089,6 +1177,11 @@ mount(App, { target: document.querySelector('#app')! });
       });
       await page.locator('[data-external-face="b"]').waitFor();
       assert.equal(await page.locator('[data-seat]').count(), 20);
+      assert.deepEqual(
+        await page.locator('[data-family="stationMeters"] [data-station-meter]').evaluateAll((nodes) =>
+          nodes.map((node) => node.getAttribute('data-station-meter'))),
+        [...stationMeterNames].reverse(),
+      );
       for (const name of seatNames) {
         assert.equal(await page.locator(`[data-seat="${name}"]`).count(), 1);
       }
@@ -1126,14 +1219,19 @@ mount(App, { target: document.querySelector('#app')! });
       await page.evaluate(() => globalThis.__setFamily('txAux', false));
       await page.locator('[data-family="txAux"]').waitFor({ state: 'detached' });
       assert.equal(await page.locator('[data-seat="rfPower"]').count(), 0);
+      await page.evaluate(() => globalThis.__setFamily('stationMeters', false));
+      await page.locator('[data-family="stationMeters"]').waitFor({ state: 'detached' });
+      assert.equal(await page.locator('[data-station-meter]').count(), 0);
       await page.evaluate(() => {
         globalThis.__setFamily('txAux', true);
+        globalThis.__setFamily('stationMeters', true);
         globalThis.__setSub(true);
         globalThis.__hideOperation(null);
       });
       await page.locator('[data-seat="subFrequency"]').waitFor();
       await page.locator('[data-seat="speak"]').waitFor();
       assert.equal(await page.locator('[data-seat]').count(), 20);
+      assert.equal(await page.locator('[data-station-meter]').count(), 7);
       const signals = page.locator('[data-fixture-signal]');
       const levels = page.locator('[data-fixture-level]');
       assert.equal(await signals.count(), 5);
@@ -1249,9 +1347,9 @@ assert.deepEqual(fixtureKit.presentations?.map(({ id }) => id), ['fixture-face-a
     path.join(consumer, 'node_modules', 'svelte', 'package.json'),
     'utf8',
   ));
-  assert.equal(installedApi.version, '0.5.0');
+  assert.equal(installedApi.version, '0.6.0');
   assert.equal(installedApi.peerDependencies.svelte, '>=5.45.2 <6');
-  assert.equal(installedFixture.peerDependencies['@rigplane/component-kit-api'], '0.5.0');
+  assert.equal(installedFixture.peerDependencies['@rigplane/component-kit-api'], '0.6.0');
 
   console.log('component-kit-api portable package verification: OK');
   console.log(`runtime exports: COMPONENT_KIT_API_VERSION, defineComponentKit`);

--- a/frontend/src/__tests__/external-hosted-face.component.test.ts
+++ b/frontend/src/__tests__/external-hosted-face.component.test.ts
@@ -563,6 +563,16 @@ describe('external hosted face chain', () => {
     expect(stationKeys()).toEqual([...STATION_ORDER].reverse());
   });
 
+  it('renders station meters from the record appearance when the global selection is absent', async () => {
+    h.state = proxy(stationState()); h.meterAppearance = undefined;
+    const current = { value: {} }; const a = occurrence(await loadedRecord('station-global-absent', FaceA), current);
+    current.value = a;
+    target = document.createElement('div'); document.body.appendChild(target);
+    mountStation(a, writable<SurfacePlan | null>(fullPlan()));
+    expect(stationKeys()).toEqual(STATION_ORDER);
+    expect(target.querySelectorAll('[data-family="receiver"] [data-fixture-signal]')).toHaveLength(2);
+  });
+
   it('admits and withdraws the station family from the meters zone alone', async () => {
     h.state = proxy(stationState());
     const current = { value: {} }; const a = occurrence(await loadedRecord('station-zone', FaceA), current);

--- a/frontend/src/__tests__/external-hosted-face.component.test.ts
+++ b/frontend/src/__tests__/external-hosted-face.component.test.ts
@@ -9,7 +9,7 @@ import type { ControlSessionSnapshot } from '$lib/runtime/frontend-runtime';
 import { commitExternalPresentationBatch, getPresentationRecord, loadSkin,
   prepareExternalPresentationBatch, type ExternalPresentationRecord } from '../skins/registry';
 import type {
-  HostedFaceComponentV1, ScalarRendererLease, ScalarRendererSeat,
+  HostedFaceComponentV1, MeterAppearance, ScalarRendererLease, ScalarRendererSeat,
 } from '../../component-kit-api/src/index';
 import type { FiniteRendererLease } from '../primitives/control-instruments/control-instrument-renderer.svelte';
 import type { FrequencyInstrumentBinding } from '../primitives/frequency/frequency-instrument.svelte';
@@ -23,7 +23,8 @@ const h = vi.hoisted(() => ({
   radioListeners: new Set<(state: never) => void>(),
   calls: new Map<string, ReturnType<typeof vi.fn>>(),
   frequencyOwners: [] as FrequencyInstrumentBinding[], frequencyLeases: [] as FrequencyInteractionLease[],
-  meterOwners: [] as object[],
+  meterOwners: [] as object[], barMeterOwners: [] as object[],
+  meterAppearance: undefined as MeterAppearance | undefined,
   scalarOwners: [] as object[], finiteSeats: [] as object[],
   scalarSeats: [] as ScalarRendererSeat[], scalarLeases: [] as ScalarRendererLease[],
   finiteLeases: [] as FiniteRendererLease<unknown>[],
@@ -104,10 +105,24 @@ vi.mock('../primitives/frequency/frequency-instrument.svelte', async (importOrig
     h.frequencyOwners.push(captured); return captured;
   } };
 });
+// Station meters take their appearance from the module-level selection, as
+// `MetersSurface` does; only the receiver S meter gets a per-record override.
+// This file builds records directly, bypassing `activateComponentKits`, which
+// is what fills that selection in the app.
+vi.mock('../component-kits/activation', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../component-kits/activation')>(),
+  getSelectedMeterAppearance: () => h.meterAppearance,
+}));
 vi.mock('../components-v2/meters/signal-meter-motion.svelte', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../components-v2/meters/signal-meter-motion.svelte')>();
   return { ...actual, createSignalMeterMotion(...args: Parameters<typeof actual.createSignalMeterMotion>) {
     const owner = actual.createSignalMeterMotion(...args); h.meterOwners.push(owner); return owner;
+  } };
+});
+vi.mock('../components-v2/meters/bar-meter-motion.svelte', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../components-v2/meters/bar-meter-motion.svelte')>();
+  return { ...actual, createBarMeterMotion(...args: Parameters<typeof actual.createBarMeterMotion>) {
+    const owner = actual.createBarMeterMotion(...args); h.barMeterOwners.push(owner); return owner;
   } };
 });
 vi.mock('../primitives/scalar/continuous-scalar.svelte', async (importOriginal) => {
@@ -252,7 +267,32 @@ function occurrence(
   result = Object.freeze({ ...loaded, isCurrent: () => current.value === result });
   return result;
 }
-const fullPlan = () => new Map([['receiver-zone', ['vfo']], ['tx-zone', ['txAux']]]) as SurfacePlan;
+const fullPlan = () => new Map([['receiver-zone', ['vfo']], ['tx-zone', ['txAux']],
+  ['meters-zone', ['meters']]]) as SurfacePlan;
+const planWithoutMeters = () =>
+  new Map([['receiver-zone', ['vfo']], ['tx-zone', ['txAux']]]) as SurfacePlan;
+/** The six station LEVEL meters are structural only where `deriveMeters` sees
+ *  their raw field, and `projectBarMeters` additionally drops `compression`
+ *  while the compressor reads off. The signal meter needs none of these — it
+ *  comes from `state()`'s own `main.sMeter`. */
+function stationState(): ServerState {
+  return { ...state(), compressorOn: true, powerMeter: 40, swrMeter: 30, alcMeter: 20,
+    compMeter: 10, vdMeter: 60, idMeter: 50 } as unknown as ServerState;
+}
+/** Drops the active receiver's S meter, leaving SWR the only structural
+ *  member of the host's signal-or-SWR composite. */
+function stationStateWithoutSignal(): ServerState {
+  const base = stationState();
+  const { sMeter: _sMeter, ...main } = base.main as unknown as Record<string, unknown>;
+  return { ...base, main } as unknown as ServerState;
+}
+const stationSection = () => target.querySelector('[data-family="stationMeters"]');
+const stationKeys = () => Array.from(
+  target.querySelectorAll<HTMLElement>('[data-family="stationMeters"] [data-fixture-level],'
+    + ' [data-family="stationMeters"] [data-fixture-signal]'),
+  (node) => node.dataset.fixtureLevel ?? 'signal',
+);
+const STATION_ORDER = ['signal', 'power', 'swr', 'alc', 'drainCurrent', 'drainVoltage', 'compression'];
 let target: HTMLDivElement; let mounted: ReturnType<typeof mount> | null = null;
 const clearCalls = () => h.calls.forEach((fn) => fn.mockClear());
 const callCounts = () => Object.fromEntries([...h.calls].map(([name, fn]) => [name, fn.mock.calls.length]));
@@ -264,8 +304,9 @@ function expectOnly(name: string): void {
 beforeEach(() => { h.state = proxy(state()); h.caps = proxy(caps()); h.session = { state: 'connected', epoch: 7 };
   h.calls.forEach((fn) => fn.mockClear()); h.subscribers.clear(); h.radioListeners.clear();
   h.subscribeCount = 0; h.unsubscribeCount = 0;
-  h.omitSpeak = false;
+  h.omitSpeak = false; h.meterAppearance = appearances.meter;
   h.frequencyOwners.length = 0; h.frequencyLeases.length = 0; h.meterOwners.length = 0;
+  h.barMeterOwners.length = 0;
   h.scalarOwners.length = 0; h.finiteSeats.length = 0;
   h.scalarSeats.length = 0; h.scalarLeases.length = 0; h.finiteLeases.length = 0; });
 afterEach(() => { if (mounted) unmount(mounted); mounted = null; document.body.replaceChildren(); });
@@ -284,7 +325,7 @@ describe('external hosted face chain', () => {
       context: new Map([[SURFACE_PLAN_CONTEXT_KEY, () => livePlan.current]]) }); flushSync();
     expect(target.querySelector('[data-external-face="a"]')).not.toBeNull();
     expect(target.querySelectorAll('[data-fixture-frequency]')).toHaveLength(2);
-    expect(target.querySelectorAll('[data-fixture-signal]')).toHaveLength(2);
+    expect(target.querySelectorAll('[data-fixture-signal]')).toHaveLength(3);
     expect(target.querySelectorAll('[data-fixture-toggle],[data-fixture-choice],[data-fixture-action]')).toHaveLength(8);
     expect(target.querySelectorAll('[data-fixture-scalar]')).toHaveLength(8);
     expect(h.frequencyOwners).toHaveLength(2); expect(h.frequencyLeases).toHaveLength(2);
@@ -394,7 +435,7 @@ describe('external hosted face chain', () => {
     const face = target.querySelector('[data-external-face="a"]'); const subscriptions = h.subscribers.size;
     const owners = [...h.frequencyOwners, ...h.meterOwners, ...h.scalarOwners, ...h.finiteSeats];
     expect(Array.from(target.querySelectorAll<HTMLElement>('[data-fixture-signal]'),
-      (meter) => meter.dataset.value)).toEqual(['20', '-12']);
+      (meter) => meter.dataset.value)).toEqual(['20', '-12', '20']);
     plan.set(new Map([['tx-zone', ['txAux']]]) as SurfacePlan); flushSync();
     expect(target.querySelector('[data-family="receiver"]')).toBeNull();
     expect(target.querySelector('[data-family="vfoOperations"]')).toBeNull();
@@ -448,7 +489,7 @@ describe('external hosted face chain', () => {
     mounted = mount(SemanticRadioSurfaces, { target, props: { externalPresentation: probe },
       context: new Map([[SURFACE_PLAN_CONTEXT_KEY, () => livePlan.current]]) }); flushSync();
     const face = target.querySelector<HTMLElement>('[data-external-face="probe"]')!;
-    expect(face.dataset.topLevelKeys).toBe('receiver,txAux,vfoOperations');
+    expect(face.dataset.topLevelKeys).toBe('receiver,stationMeters,txAux,vfoOperations');
     expect(face.dataset.receiverKeys).toBe('mainFrequency,mainSMeter,subFrequency,subSMeter');
     expect(face.dataset.vfoKeys).toBe('activeReceiver,dualWatch,equalize,quickDualWatch,quickSplit,speak,split,swap');
     expect(face.dataset.txKeys).toBe('antiVoxGain,compressorLevel,driveGain,micGain,monitorLevel,rfPower,voxDelay,voxGain');
@@ -497,5 +538,104 @@ describe('external hosted face chain', () => {
     expect([...h.calls.values()].every((fn) => fn.mock.calls.length === 0)).toBe(true);
     clearCalls(); target.querySelector<HTMLButtonElement>('[data-fixture-action]')!.click();
     expectOnly('onEqual');
+  });
+
+  const mountStation = (
+    presentation: ExternalPresentation, plan: ReturnType<typeof writable<SurfacePlan | null>>,
+  ) => {
+    const props = proxy({ externalPresentation: presentation }); const livePlan = fromStore(plan);
+    mounted = mount(SemanticRadioSurfaces, { target, props,
+      context: new Map([[SURFACE_PLAN_CONTEXT_KEY, () => livePlan.current]]) }); flushSync();
+    return props;
+  };
+
+  it('renders the seven station meters in the order each face asks for', async () => {
+    h.state = proxy(stationState());
+    const current = { value: {} };
+    const loadedA = await loadedRecord('station-a', FaceA);
+    const loadedB = await loadedRecord('station-b', FaceB);
+    const a = occurrence(loadedA, current); current.value = a;
+    target = document.createElement('div'); document.body.appendChild(target);
+    const props = mountStation(a, writable<SurfacePlan | null>(fullPlan()));
+    expect(stationSection()).not.toBeNull();
+    expect(stationKeys()).toEqual(STATION_ORDER);
+    const b = occurrence(loadedB, current); current.value = b; props.externalPresentation = b; flushSync();
+    expect(stationKeys()).toEqual([...STATION_ORDER].reverse());
+  });
+
+  it('admits and withdraws the station family from the meters zone alone', async () => {
+    h.state = proxy(stationState());
+    const current = { value: {} }; const a = occurrence(await loadedRecord('station-zone', FaceA), current);
+    current.value = a; const plan = writable<SurfacePlan | null>(fullPlan());
+    target = document.createElement('div'); document.body.appendChild(target);
+    mountStation(a, plan);
+    expect(stationKeys()).toEqual(STATION_ORDER);
+    const subscriptions = h.subscribers.size;
+    const owners = [...h.meterOwners, ...h.barMeterOwners, ...h.frequencyOwners, ...h.scalarOwners];
+    plan.set(planWithoutMeters()); flushSync();
+    expect(stationSection()).toBeNull(); expect(stationKeys()).toEqual([]);
+    expect(h.subscribers.size).toBe(subscriptions);
+    plan.set(fullPlan()); flushSync();
+    expect(stationKeys()).toEqual(STATION_ORDER);
+    expect([...h.meterOwners, ...h.barMeterOwners, ...h.frequencyOwners, ...h.scalarOwners]).toEqual(owners);
+    expect(h.subscribers.size).toBe(subscriptions);
+  });
+
+  it('keeps one station owner set across an A-B-A occurrence swap', async () => {
+    h.state = proxy(stationState());
+    const current = { value: {} };
+    const loadedA = await loadedRecord('station-swap-a', FaceA);
+    const loadedB = await loadedRecord('station-swap-b', FaceB);
+    const a1 = occurrence(loadedA, current); current.value = a1;
+    target = document.createElement('div'); document.body.appendChild(target);
+    const props = mountStation(a1, writable<SurfacePlan | null>(fullPlan()));
+    expect(h.barMeterOwners).toHaveLength(6);
+    const stationOwners = [...h.barMeterOwners]; const signalOwners = [...h.meterOwners];
+    const subscriptions = h.subscribers.size;
+    const b = occurrence(loadedB, current); current.value = b; props.externalPresentation = b; flushSync();
+    expect(stationKeys()).toEqual([...STATION_ORDER].reverse());
+    const a2 = occurrence(loadedA, current); current.value = a2; props.externalPresentation = a2; flushSync();
+    expect(stationKeys()).toEqual(STATION_ORDER);
+    expect(h.barMeterOwners).toEqual(stationOwners); expect(h.meterOwners).toEqual(signalOwners);
+    expect(h.subscribers.size).toBe(subscriptions);
+  });
+
+  it('renders no station signal meter while only SWR is structural', async () => {
+    h.state = proxy(stationStateWithoutSignal());
+    const current = { value: {} }; const a = occurrence(await loadedRecord('station-swr', FaceA), current);
+    current.value = a;
+    target = document.createElement('div'); document.body.appendChild(target);
+    mountStation(a, writable<SurfacePlan | null>(fullPlan()));
+    expect(stationSection()!.querySelectorAll('[data-fixture-signal]')).toHaveLength(0);
+    expect(stationSection()!.querySelector('[data-fixture-level="swr"]')).not.toBeNull();
+    expect(stationKeys()).toEqual(STATION_ORDER.filter((key) => key !== 'signal'));
+    h.state = proxy(stationState());
+    h.subscribers.forEach((handler) => handler(authority() as never)); flushSync();
+    expect(stationKeys()).toEqual(STATION_ORDER);
+  });
+
+  it('disposes the station reset leases and its subscription on unmount', async () => {
+    h.state = proxy(stationState());
+    const current = { value: {} }; const loaded = await loadedRecord('station-dispose', FaceA);
+    const a = occurrence(loaded, current); current.value = a;
+    const plan = writable<SurfacePlan | null>(fullPlan());
+    target = document.createElement('div'); document.body.appendChild(target);
+    mountStation(a, plan);
+    expect(stationKeys()).toEqual(STATION_ORDER);
+    const withStation = h.finiteLeases.length;
+    // FaceA renders the station section last, so the trailing renderer leases
+    // are the reset-peak leases of the three meters `installResetSeat` seats a
+    // reset control for. The second mount below measures that count.
+    const disposals = h.finiteLeases.slice(-3).map((lease) => {
+      const release = lease.dispose.bind(lease); const spy = vi.fn(release);
+      (lease as { dispose: () => void }).dispose = spy; return spy;
+    });
+    unmount(mounted!); mounted = null;
+    for (const spy of disposals) expect(spy).toHaveBeenCalledOnce();
+    expect(h.subscribers.size).toBe(0); expect(h.unsubscribeCount).toBe(h.subscribeCount);
+    h.finiteLeases.length = 0; plan.set(planWithoutMeters());
+    const bare = occurrence(loaded, current); current.value = bare; mountStation(bare, plan);
+    expect(stationSection()).toBeNull();
+    expect(withStation - h.finiteLeases.length).toBe(3);
   });
 });

--- a/frontend/src/component-kits/HostedFaceInstrumentBridge.svelte
+++ b/frontend/src/component-kits/HostedFaceInstrumentBridge.svelte
@@ -2,6 +2,7 @@
   import type {
     HostedFaceComponentV1,
     HostedInstrumentFamiliesV1,
+    MeterAppearance,
     ReceiverFrequencyPresentationV1,
     TxAuxScalarPresentationV1,
   } from '../../component-kit-api/src/index';
@@ -25,6 +26,7 @@
     vfoOperations,
     txAuxScalars,
     stationMeters,
+    meterAppearance,
     receiverAdmitted,
     vfoOperationsAdmitted,
     txAuxAdmitted,
@@ -35,6 +37,7 @@
     vfoOperations: VfoOperationHandles;
     txAuxScalars: TxAuxScalarHandles;
     stationMeters: StationMeterInstrumentHandles;
+    meterAppearance: MeterAppearance;
     receiverAdmitted: boolean;
     vfoOperationsAdmitted: boolean;
     txAuxAdmitted: boolean;
@@ -95,7 +98,8 @@
 {#snippet noNativeLevel(_frame: StationLevelMeterFrame, _resetPeakSeat?: ActionRendererSeat)}{/snippet}
 {#snippet stationLevel(frame: StationLevelMeterFrame, resetPeakSeat?: ActionRendererSeat)}
   {#key resetPeakSeat}
-    <MeterRendererSeat kind="level" {frame} {resetPeakSeat} fallback={noNativeLevel} />
+    <MeterRendererSeat kind="level" {frame} {resetPeakSeat}
+      levelRenderer={meterAppearance.level} fallback={noNativeLevel} />
   {/key}
 {/snippet}
 {#snippet stationSignalMeter(
@@ -114,7 +118,8 @@
          S meter. `selectedPresent` carries that structural fact, and
          `MeterRendererSeat` renders no signal appearance when it is false. -->
     <MeterRendererSeat frame={signalFrame.motion} {reading} domain={facts.domain}
-      relevant={facts.relevant} selectedPresent={facts.availability.structural} />
+      relevant={facts.relevant} selectedPresent={facts.availability.structural}
+      signalRenderer={meterAppearance.signal} />
   {/if}
 {/snippet}
 {#snippet stationSignal()}{@render stationMeters.signal(stationSignalMeter)}{/snippet}

--- a/frontend/src/component-kits/HostedFaceInstrumentBridge.svelte
+++ b/frontend/src/component-kits/HostedFaceInstrumentBridge.svelte
@@ -5,30 +5,47 @@
     ReceiverFrequencyPresentationV1,
     TxAuxScalarPresentationV1,
   } from '../../component-kit-api/src/index';
+  import type { SignalMeterProjection } from '../components-v2/meters/smeter-scale';
+  import type { ActionRendererSeat } from '../primitives/control-instruments/control-instrument-renderer.svelte';
+  import type { MeterRfState } from '../semantic/radio-view-model';
   import type { ReceiverInstrumentHandles } from '../semantic/ReceiverInstrumentHost.svelte';
+  import type {
+    StationLevelMeterFrame,
+    StationMeterInstrumentHandles,
+    StationSignalFacts,
+    StationSignalMeterFrame,
+  } from '../semantic/StationMeterInstrumentHost.svelte';
   import type { TxAuxScalarHandles } from '../semantic/tx-aux-scalar';
   import type { VfoOperationHandles } from '../semantic/VfoOperationSeatHost.svelte';
+  import MeterRendererSeat from './MeterRendererSeat.svelte';
 
   let {
     component: Face,
     receiverInstruments,
     vfoOperations,
     txAuxScalars,
+    stationMeters,
     receiverAdmitted,
     vfoOperationsAdmitted,
     txAuxAdmitted,
+    stationMetersAdmitted,
   }: {
     component: HostedFaceComponentV1;
     receiverInstruments: ReceiverInstrumentHandles;
     vfoOperations: VfoOperationHandles;
     txAuxScalars: TxAuxScalarHandles;
+    stationMeters: StationMeterInstrumentHandles;
     receiverAdmitted: boolean;
     vfoOperationsAdmitted: boolean;
     txAuxAdmitted: boolean;
+    stationMetersAdmitted: boolean;
   } = $props();
   let subReceiverAdmitted = $derived(
     receiverInstruments.subFrequency !== undefined && receiverInstruments.subSMeter !== undefined,
   );
+  /** Readable now AND actually read — same two-part test `MetersSurface` applies. */
+  const observed = (facts: StationSignalFacts): boolean =>
+    facts.availability.operational && facts.reading.status === 'known';
 </script>
 
 {#snippet mainFrequency(presentation?: Readonly<ReceiverFrequencyPresentationV1>)}
@@ -73,6 +90,41 @@
   {@render txAuxScalars.monitorLevel(presentation)}
 {/snippet}
 
+<!-- An external Face gets no native DOM meter: absent an installed meter
+     appearance these seats render nothing, the way `mainSMeter` does. -->
+{#snippet noNativeLevel(_frame: StationLevelMeterFrame, _resetPeakSeat?: ActionRendererSeat)}{/snippet}
+{#snippet stationLevel(frame: StationLevelMeterFrame, resetPeakSeat?: ActionRendererSeat)}
+  {#key resetPeakSeat}
+    <MeterRendererSeat kind="level" {frame} {resetPeakSeat} fallback={noNativeLevel} />
+  {/key}
+{/snippet}
+{#snippet stationSignalMeter(
+  signalFrame: StationSignalMeterFrame | null,
+  _signalProjection: SignalMeterProjection | null,
+  _swrFrame: StationLevelMeterFrame<'swr'> | null,
+  _rfState: MeterRfState,
+  _presentGroup: boolean,
+)}
+  {#if signalFrame !== null}
+    {@const facts = signalFrame.field}
+    {@const reading = observed(facts) && facts.reading.status === 'known'
+      && Number.isFinite(facts.reading.value) ? facts.reading : { status: 'unknown' } as const}
+    <!-- The host's signal continuation runs whenever signal OR swr is
+         structural, so `signalFrame !== null` does not mean this radio has an
+         S meter. `selectedPresent` carries that structural fact, and
+         `MeterRendererSeat` renders no signal appearance when it is false. -->
+    <MeterRendererSeat frame={signalFrame.motion} {reading} domain={facts.domain}
+      relevant={facts.relevant} selectedPresent={facts.availability.structural} />
+  {/if}
+{/snippet}
+{#snippet stationSignal()}{@render stationMeters.signal(stationSignalMeter)}{/snippet}
+{#snippet stationPower()}{@render stationMeters.power(stationLevel)}{/snippet}
+{#snippet stationSwr()}{@render stationMeters.swr(stationLevel)}{/snippet}
+{#snippet stationAlc()}{@render stationMeters.alc(stationLevel)}{/snippet}
+{#snippet stationDrainCurrent()}{@render stationMeters.drainCurrent(stationLevel)}{/snippet}
+{#snippet stationDrainVoltage()}{@render stationMeters.drainVoltage(stationLevel)}{/snippet}
+{#snippet stationCompression()}{@render stationMeters.compression(stationLevel)}{/snippet}
+
 <Face instruments={{
   receiver: receiverAdmitted ? {
     mainFrequency,
@@ -83,5 +135,14 @@
   vfoOperations: vfoOperationsAdmitted ? vfoOperations : null,
   txAux: txAuxAdmitted ? {
     rfPower, micGain, driveGain, voxGain, antiVoxGain, voxDelay, compressorLevel, monitorLevel,
+  } : null,
+  stationMeters: stationMetersAdmitted ? {
+    signal: stationSignal,
+    power: stationPower,
+    swr: stationSwr,
+    alc: stationAlc,
+    drainCurrent: stationDrainCurrent,
+    drainVoltage: stationDrainVoltage,
+    compression: stationCompression,
   } : null,
 } satisfies HostedInstrumentFamiliesV1} />

--- a/frontend/src/component-kits/MeterRendererSeat.svelte
+++ b/frontend/src/component-kits/MeterRendererSeat.svelte
@@ -24,6 +24,7 @@
     kind: 'level';
     frame: StationLevelMeterFrame;
     resetPeakSeat?: ActionRendererSeat;
+    levelRenderer?: MeterAppearance['level'];
     fallback: Snippet<[frame: StationLevelMeterFrame, resetPeakSeat?: ActionRendererSeat]>;
   }
   type Props = SignalProps | LevelProps;
@@ -32,7 +33,8 @@
   const appearance = untrack(() => getSelectedMeterAppearance());
   const signalRenderer = untrack(() => props.kind === 'level'
     ? undefined : props.signalRenderer ?? appearance?.signal);
-  const levelRenderer = untrack(() => props.kind === 'level' ? appearance?.level : undefined);
+  const levelRenderer = untrack(() => props.kind === 'level'
+    ? props.levelRenderer ?? appearance?.level : undefined);
   const resetPeak = untrack(() => props.kind === 'level' && levelRenderer
     ? props.resetPeakSeat?.attachRenderer() : undefined);
   const signalView = $derived(props.kind === 'level' ? null

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -2080,9 +2080,11 @@
         {receiverInstruments}
         {vfoOperations}
         {txAuxScalars}
+        {stationMeters}
         receiverAdmitted={surfacePlan() !== null && zoneOwning('vfo') !== null}
         vfoOperationsAdmitted={surfacePlan() !== null && zoneOwning('vfo') !== null}
         txAuxAdmitted={surfacePlan() !== null && zoneOwning('txAux') !== null}
+        stationMetersAdmitted={surfacePlan() !== null && zoneOwning('meters') !== null}
       />
     {/key}
   {:else if hostedChildren}

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -2081,6 +2081,7 @@
         {vfoOperations}
         {txAuxScalars}
         {stationMeters}
+        meterAppearance={externalPresentation.record.appearances.meter}
         receiverAdmitted={surfacePlan() !== null && zoneOwning('vfo') !== null}
         vfoOperationsAdmitted={surfacePlan() !== null && zoneOwning('vfo') !== null}
         txAuxAdmitted={surfacePlan() !== null && zoneOwning('txAux') !== null}


### PR DESCRIPTION
11 code + 0 regenerated baselines = 11 files

## Size

One unit of work, above the 6-file soft threshold: the SDK 0.6 contract, the
fixtures that pin it, and the live producer that satisfies it are one change.
`stationMeters` is a REQUIRED key of `HostedInstrumentFamiliesV1`, so the
moment the SDK member lands the bridge's `satisfies` literal no longer
compiles — the live producer is not optional follow-up work, it is what makes
the contract buildable. Splitting it would land a tree that does not typecheck.

This head crosses the 10-file hard ceiling by one (11 files). Fixing the
verifier's BLOCKED finding — station meters silently falling back to a global
meter selection instead of the committed presentation record, while the
receiver S-meter already used the record — required extending
`MeterRendererSeat.svelte`, a file untouched by the rest of this PR, to add a
`levelRenderer` override mirroring its existing `signalRenderer` prop.
File-count exception granted by the coordinator under the owner's 2026-09-03
delegation (file count only; the 1000-changed-line ceiling stays the owner's
and is not approached here — 402 A+D at this head).

## Summary

- **SDK 0.6** adds the `stationMeters` family: seven zero-argument handles
  (`signal`, `power`, `swr`, `alc`, `drainCurrent`, `drainVoltage`,
  `compression`). The key is required on `HostedInstrumentFamiliesV1`; its
  value is nullable. `verify-package.mjs` rejects a missing family, an
  `undefined` family or member, and aggregate/private handles.
- **Bridge** (`HostedFaceInstrumentBridge.svelte`) adds seven zero-argument
  wrappers over the existing `StationMeterInstrumentHandles` passed down from
  `SemanticRadioSurfaces`, each seating `MeterRendererSeat` the way
  `MetersSurface.svelte` already does. No native DOM fallback: absent an
  installed meter appearance a hosted face renders nothing, as `mainSMeter`
  already does.
- **Admission** comes from the `meters` zone of the live surface plan
  (`surfacePlan() !== null && zoneOwning('meters') !== null`), matching the
  three existing families rather than the native surface's `view?.meters` gate.
- **Signal gating.** The host's `signal` continuation runs whenever signal OR
  SWR is structural (`applyPublication`'s `composite`), so a non-null signal
  frame does not mean the radio has an S meter. The wrapper passes
  `selectedPresent={facts.availability.structural}` — the field's own
  structural fact, which `MeterRendererSeat` already honours — so a
  standalone-SWR radio gets no fabricated signal reading.
- **No new owners.** The existing `StationMeterInstrumentHost` instance is
  reused; host placement is unchanged (outermost, as accepted `main` mounts
  it). No second subscription, no change to reset-seat or session-key
  derivation.
- **Station meters resolve from the committed record, not a bare global
  fallback.** The receiver S-meter already read its appearance from
  `externalPresentation.record.appearances.meter.signal` (`SignalRenderer` in
  `#3342`); the seven station meters did not have an equivalent override and
  fell through to the module-level `getSelectedMeterAppearance()` alone. Since
  a face's own appearances are validated as an exact record (a meter
  appearance is mandatory) while the global selection is optional and
  independent, a config with a face and no global meter selection rendered
  the receiver meters but zero station meters.
  `SemanticRadioSurfaces.svelte` now passes
  `meterAppearance={externalPresentation.record.appearances.meter}` into the
  bridge, which threads `levelRenderer={meterAppearance.level}` and
  `signalRenderer={meterAppearance.signal}` onto the shared `stationLevel` and
  `stationSignalMeter` seats. `MeterRendererSeat.svelte` gained the mirror
  prop: `levelRenderer` resolves as `props.levelRenderer ?? appearance?.level`,
  the same override-then-fallback shape `signalRenderer` already had. The
  global selection remains the fallback the native (non-hosted) surface uses;
  it is not a second, competing selection path for hosted faces.
- `presentationIsCurrent` is not threaded: no station seat accepts it
  (`grep -rn presentationIsCurrent frontend/ --exclude-dir=node_modules` finds
  it only on the frequency/scalar/finite paths), so nothing was invented.

## Witnesses (`frontend/src/__tests__/external-hosted-face.component.test.ts`)

- **D1** — both faces mounted with the `meters` zone admitted render exactly
  seven station nodes inside `[data-family="stationMeters"]`: FaceA
  `signal → power → swr → alc → drainCurrent → drainVoltage → compression`,
  FaceB the exact reverse. Falsified by a dropped, duplicated or misordered
  handle, or by matching only one face's order.
- **D2** — withdrawing the `meters` zone removes the section and all seven
  nodes with `h.subscribers.size` unchanged; re-admitting restores them with
  the same signal/bar/frequency/scalar owner arrays. Falsified by a leaked
  subscription or an owner recreated on zone loss.
- **D3** — an A → B → A occurrence swap keeps the six bar-meter bindings and
  the signal binding identical (both captured by new pass-through mocks around
  the real motion factories) and the subscriber count unchanged. Falsified by
  a second station host or a per-swap rebinding.
- **D4** — with the active receiver's S meter absent and SWR structural, the
  face renders NO `[data-fixture-signal]` inside the station section while
  `[data-fixture-level="swr"]` is present; restoring the S meter brings the
  signal node back. This is the previously unwitnessed gate.
- **D5** — unmount disposes the three reset-peak leases exactly once and
  leaves `h.unsubscribeCount === h.subscribeCount` with `h.subscribers.size`
  at zero; a second mount with the zone withdrawn measures the three-lease
  difference rather than assuming it.
- **D6** (new, this commit) — `renders station meters from the record
  appearance when the global selection is absent`: with `h.meterAppearance`
  set to `undefined` before mount, all seven station meters still render in
  `STATION_ORDER` from the record's own appearance, and the two receiver
  S-meters (already record-driven since `#3342`) also render — one assertion
  set that would catch the asymmetry breaking in either direction. Falsified
  by dropping the bridge's `levelRenderer`/`signalRenderer` overrides.

**Mutation, run on D4 (prior round).** Removing
`selectedPresent={facts.availability.structural}` from the bridge's
`stationSignalMeter` snippet: `Tests 1 failed | 8 passed (9)` — the failure
being exactly `renders no station signal meter while only SWR is structural`,
`expected <div data-fixture-signal …> to have a length of +0 but got 1`.
Restored with `git checkout --`; `git diff` on that file was empty and all 9
tests passed again.

**Mutation, run on D6 (this commit).** Reverted the two `MeterRendererSeat`
call sites in `HostedFaceInstrumentBridge.svelte`'s `stationLevel` and
`stationSignalMeter` snippets to drop `levelRenderer`/`signalRenderer`:
`Test Files 1 failed (1)`, `Tests 1 failed | 9 passed (10)` — the failure
being exactly D6, `expected [] to deeply equal [ 'signal', 'power', 'swr',
…(4) ]`. Restored `HostedFaceInstrumentBridge.svelte` byte-identically
(`git diff` on that file matched the pre-mutation diff exactly) and
reconfirmed `Test Files 1 passed (1)`, `Tests 10 passed (10)`.

**Reproduction, before/after.** Forcing the file's default global meter
appearance — `h.meterAppearance` in `beforeEach` — to `undefined` across the
whole file (the verifier's exact repro) previously produced `7 failed / 2
passed` with empty station lists; at this head the same edit produces
`Tests 10 passed (10)` with the station lists populated. Reverted the
`beforeEach` edit afterward — `git diff` on the test file shows only the D6
addition.

## Census (measured at this head, `git diff origin/main...HEAD`)

`11 files changed, 382 insertions(+), 20 deletions(-)` = **402 A+D**, against
the lane's 750 hard stop. Per file:

```
  1  1  frontend/component-kit-api/fixtures/external-kit/package.json
 15  1  frontend/component-kit-api/fixtures/external-kit/src/FaceA.svelte
 15  1  frontend/component-kit-api/fixtures/external-kit/src/FaceB.svelte
  4  2  frontend/component-kit-api/fixtures/external-kit/src/index.ts
  1  1  frontend/component-kit-api/package.json
 13  0  frontend/component-kit-api/src/index.ts
104  6  frontend/component-kit-api/verify-package.mjs
157  7  frontend/src/__tests__/external-hosted-face.component.test.ts
 66  0  frontend/src/component-kits/HostedFaceInstrumentBridge.svelte
  3  1  frontend/src/component-kits/MeterRendererSeat.svelte
  3  0  frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
```

## Verification

- Focused vitest matrix for this fix, run at this head: the changed test file
  plus every test file the fix's spec named — the isolated station host, the
  `MetersSurface` semantic tests, the meters wiring component tests, and
  `ReceiverInstrumentHost.isolated.test.ts` (the grep union of every test file
  naming `MeterRendererSeat` or `HostedFaceInstrumentBridge` resolves to the
  latter two). 5 files, 224 tests, all passing:
  `external-hosted-face.component.test.ts` 10, `StationMeterInstrumentHost
  .isolated.test.ts` 19, `MetersSurface.test.ts` 149,
  `semantic-meters-wiring.component.test.ts` 17,
  `ReceiverInstrumentHost.isolated.test.ts` 29. The prior round's broader
  80-file/2427-test matrix was not rerun for this incremental fix.
- `npm run check` — `COMPLETED 4820 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`.
- `npm run verify:component-kit-api` — `OK`, API declarations 16, fixture
  declarations 1, consumer peer `svelte@5.55.8`.
- `npx eslint` over the four changed source paths (the test file plus
  `MeterRendererSeat.svelte`, `HostedFaceInstrumentBridge.svelte`,
  `SemanticRadioSurfaces.svelte`) — exit 0, no output.
- `git diff --check` — exit 0.
- No full suite was run locally; the PR's own `quick` run at this head is the
  record.

internal-identifier self-check — empty.

Kit 0.2.7 rebind and consumer re-validation follow separately; they are not
part of this PR.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
