### PR TITLE
feat(MOR-2425): host the antenna instruments persistently

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -33,6 +33,7 @@
   import type { DspFiniteHandles } from '../../semantic/dsp-instruments';
   import type { FilterInstrumentHandles } from '../../semantic/filter-instruments';
   import type { BandInstrumentHandles } from '../../semantic/band-instruments';
+  import { ANTENNA_BLOCKED_LABEL } from '../../semantic/AntennaInstrumentHost.svelte';
   import { getManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
   import KeyboardHandler from './KeyboardHandler.svelte';
   import StatusBar from './StatusBar.svelte';
@@ -341,6 +342,28 @@
   </div>
 {/snippet}
 
+<!--
+  MOR-2425. The Standard face arranges the two persistent antenna seats itself
+  instead of mounting the grouped `AntennaSurface`, so the blocked-reason list
+  the seats' `aria-describedby` points at has to be rendered here too — the
+  host hands both the id and the reason codes on `instruments.antennaLayout`.
+-->
+{#snippet antennaControlLayout()}
+  <div class="antenna-control-grid" data-testid="antenna-control-grid">
+    <div class="antenna-control-seat" data-field="txPort">
+      {@render instruments.antennaInstruments.txPort()}
+    </div>
+    <div class="antenna-control-seat" data-field="rxAnt">
+      {@render instruments.antennaInstruments.rxAnt()}
+    </div>
+  </div>
+  <ul class="antenna-blocked" id={instruments.antennaLayout.blockedId} data-testid="antenna-blocked">
+    {#each instruments.antennaLayout.blocked as code (code)}
+      <li data-reason={code}>{ANTENNA_BLOCKED_LABEL[code]}</li>
+    {/each}
+  </ul>
+{/snippet}
+
 {#snippet vfoOperationControls()}
   <div class="vfo-operation-instrument-grid" data-testid="vfo-operation-instrument-grid">
     {#if instruments.vfoOperations.split}<div class="vfo-operation-instrument-seat" data-field="split">{@render instruments.vfoOperations.split()}</div>{/if}
@@ -402,7 +425,11 @@
         {:else}
           {@render instruments.band()}
         {/if}
-        {@render instruments.antenna()}
+        {#if skinId === 'desktop-v2'}
+          {@render instruments.antenna(undefined, antennaControlLayout)}
+        {:else}
+          {@render instruments.antenna()}
+        {/if}
         {@render instruments.ritXitScan()}
         <div class="content-left"><LeftSidebar hideTxPanel={semanticRxTx} {declared} /></div>
       </div>
@@ -717,6 +744,10 @@
     display: flex;
   }
   .band-control-grid, .band-control-seat { display: contents; }
+  .antenna-control-grid { display: flex; flex-direction: column; gap: 0.25rem; }
+  .antenna-control-seat { display: contents; }
+  .antenna-blocked { margin: 0; padding-inline-start: 1.2em; }
+  .antenna-blocked:empty { display: none; }
   .vfo-operation-instrument-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
   .tx-aux-scalar-grid {
     display: grid;

--- a/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
+++ b/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
@@ -12,6 +12,9 @@
   import type { VfoOperationHandles } from '../../../../semantic/VfoOperationSeatHost.svelte';
   import type { BandControlLayout } from '../../../../semantic/band-instruments';
   import type { CwKeyerInstrumentHandles } from '../../../../semantic/CwKeyerInstrumentHost.svelte';
+  import type {
+    AntennaInstrumentHandles, AntennaInstrumentLayout,
+  } from '../../../../semantic/AntennaInstrumentHost.svelte';
 
   const empty = createRawSnippet(() => ({ render: () => '' }));
   const vfo = createRawSnippet<[
@@ -29,6 +32,15 @@
     () => ({ render: () => '' }),
   );
   const cwKeyerInstruments = { keyerSpeed: empty } satisfies CwKeyerInstrumentHandles;
+  const antenna = createRawSnippet<[allowBare?: boolean, controlLayout?: FixtureSnippet]>(
+    () => ({ render: () => '' }),
+  );
+  const antennaInstruments = {
+    txPort: empty, rxAnt: empty,
+  } satisfies AntennaInstrumentHandles;
+  const antennaLayout = {
+    blockedId: 'fixture-antenna-blocked', blocked: [],
+  } satisfies AntennaInstrumentLayout;
   const frequency = createRawSnippet<[mount?: ReceiverFrequencyMount]>(() => ({ render: () => '' }));
   const meter = createRawSnippet<[renderer?: ReceiverSMeterRenderer]>(() => ({ render: () => '' }));
   const operations = createRawSnippet<[appearance: ReceiverVfoAppearance]>(() => ({ render: () => '' }));
@@ -60,7 +72,8 @@
     receiverInstruments,
     rxAudioInstruments, rfFrontEndInstruments,
     meters: empty, rxAudio: empty, rfFrontEnd: empty, filter: empty, dsp: empty,
-    band, antenna: empty, ritXitScan: empty, cwKeyerInstruments, cwKeyer,
+    band, antenna, antennaInstruments, antennaLayout,
+    ritXitScan: empty, cwKeyerInstruments, cwKeyer,
     scopeDisplay: empty, scopeControls: empty, txFaultRecovery: empty,
     modInputTxWarning: empty, managedScope: undefined,
   } satisfies FixtureInstrumentComposition;

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -1367,12 +1367,18 @@ describe("the SDR face's zones are placed as five regions (MOR-2231, batch 5)", 
   it.each(['sdr-test', 'desktop-v2'] as const)('%s owns each control once in its intended column', (skinId) => {
     const root = render(skinId);
     for (const [region, surfaces] of [
-      ['left', ['rf-front-end', 'filter', 'band', 'antenna', 'ritxit-scan']],
-      ['center', ['scope-controls', 'scope-display']],
-      ['right', ['rx-tx', 'rx-audio', 'dsp', 'cw-keyer', 'tx-aux']],
+      // MOR-2425: Standard arranges the two persistent antenna seats itself and
+      // mounts no grouped `antenna-surface`; SDR keeps the grouped one. Both
+      // stay inside the left column, so the column claim is unchanged.
+      ['left', ['rf-front-end-surface', 'filter-surface', 'band-surface',
+        skinId === 'desktop-v2' ? 'antenna-control-grid' : 'antenna-surface',
+        'ritxit-scan-surface']],
+      ['center', ['scope-controls-surface', 'scope-display-surface']],
+      ['right', ['rx-tx-surface', 'rx-audio-surface', 'dsp-surface', 'cw-keyer-surface',
+        'tx-aux-surface']],
     ] as const) {
       for (const surface of surfaces) {
-        const selector = `[data-testid="${surface}-surface"]`;
+        const selector = `[data-testid="${surface}"]`;
         expect(root.querySelectorAll(selector), surface).toHaveLength(1);
         expect(root.querySelector(`.desktop-controls-${region} ${selector}`), surface).not.toBeNull();
       }
@@ -2308,7 +2314,9 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
   it('the fixture actually emits all three groups (non-vacuity)', () => {
     const t = renderAll('desktop-v2');
     expect(t.querySelector('[data-testid="band-surface"]')).not.toBeNull();
-    expect(t.querySelector('[data-testid="antenna-surface"]')).not.toBeNull();
+    // MOR-2425: on Standard the antenna group emits as the two seats RadioLayout
+    // arranges itself, not as the grouped surface SDR still mounts.
+    expect(t.querySelector('[data-testid="antenna-control-grid"]')).not.toBeNull();
     expect(t.querySelector('[data-testid="ritxit-scan-surface"]')).not.toBeNull();
   });
 
@@ -2317,7 +2325,7 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
   // deck", which is the double-presentation defect this slice closes. Run
   // against the real resolved plan (see `renderWithPlan`), because that is the
   // read `zoneOwning()` makes.
-  it.each([['band', 'band-surface'], ['antenna', 'antenna-surface'],
+  it.each([['band', 'band-surface'], ['antenna', 'antenna-control-grid'],
     ['rit-xit-scan', 'ritxit-scan-surface']])(
     'mounts %s inside its own declared zone element', (zoneId, testid) => {
       const t = renderWithPlan('desktop-v2');
@@ -2346,7 +2354,7 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
   it('drops the legacy ANTENNA twin for the semantic surface', () => {
     const t = renderAll('desktop-v2');
     expect(t.querySelector('.left-sidebar [data-panel-id="antenna"]')).toBeNull();
-    expect(t.querySelector('[data-testid="antenna-surface"]')).not.toBeNull();
+    expect(t.querySelector('[data-testid="antenna-control-grid"]')).not.toBeNull();
   });
 
   /**
@@ -2410,7 +2418,7 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
   // covers only some of the three zones, or a second mount path.
   it('presents band, antenna and ritXitScan exactly ONCE each on desktop-v2', () => {
     const t = renderAll('desktop-v2');
-    for (const testid of ['band-surface', 'antenna-surface', 'ritxit-scan-surface']) {
+    for (const testid of ['band-surface', 'antenna-control-grid', 'ritxit-scan-surface']) {
       expect(t.querySelectorAll(`[data-testid="${testid}"]`).length, testid).toBe(1);
     }
     for (const selector of [

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -61,6 +61,7 @@
   } from '../../presentation/workspace/resolution';
   import { LAN_MOD_INPUT_SOURCE } from '$lib/radio/mod-input';
   import AntennaSurface from '../../semantic/AntennaSurface.svelte';
+  import AntennaInstrumentHost from '../../semantic/AntennaInstrumentHost.svelte';
   import BandSurface from '../../semantic/BandSurface.svelte';
   import BandInstrumentHost from '../../semantic/BandInstrumentHost.svelte';
   import type { BandControlLayout } from '../../semantic/band-instruments';
@@ -1373,6 +1374,14 @@
     onSelectBand={selectBand} onEnterFrequency={enterFrequency}
   >
   {#snippet children(bandInstruments)}
+  <AntennaInstrumentHost
+    {view} tx={txState} readTx={() => tx.snapshot()}
+    subscribeControlAuthority={(handler) => runtime.subscribeControlAuthority(handler)}
+    onSelectPort={(port) => ANTENNA_PORT_INTENT[port]?.()}
+    onToggleRxAnt={antennaIntents.onToggleRxAnt}
+    finiteAppearance={selectedFiniteAppearance}
+  >
+  {#snippet children(antennaInstruments, antennaLayout)}
   <CwKeyerInstrumentHost
     {view} {keySpeedFeedback}
     onLevelChange={(field, value) => CW_LEVEL_INTENT[field](value)}
@@ -1759,13 +1768,15 @@
     still takes no lease and keys nothing — exactly one `<RxTxSurface>`
     remains the key/unkey authority (R9).
   -->
-  {#snippet antennaSurface()}
+  {#snippet antennaSurface(controlLayout?: Snippet)}
     {#if view?.antenna}
-      <AntennaSurface
-        {view} tx={txState}
-        onSelectPort={(port) => ANTENNA_PORT_INTENT[port]?.()}
-        onToggleRxAnt={antennaIntents.onToggleRxAnt}
-      />
+      {#if controlLayout}
+        {@render controlLayout()}
+      {:else}
+        <AntennaSurface
+          {view} tx={txState} handles={antennaInstruments} layout={antennaLayout}
+        />
+      {/if}
     {/if}
   {/snippet}
 
@@ -2051,8 +2062,9 @@
     {#snippet body()}{@render bandSurface(controlLayout)}{/snippet}
     {@render zoned('band', view?.band !== undefined, body, allowBare)}
   {/snippet}
-  {#snippet hostedAntenna(allowBare = allowBareSurfaces)}
-    {@render zoned('antenna', view?.antenna !== undefined, antennaSurface, allowBare)}
+  {#snippet hostedAntenna(allowBare = allowBareSurfaces, controlLayout?: Snippet)}
+    {#snippet body()}{@render antennaSurface(controlLayout)}{/snippet}
+    {@render zoned('antenna', view?.antenna !== undefined, body, allowBare)}
   {/snippet}
   {#snippet hostedRitXitScan(allowBare = allowBareSurfaces)}
     {@render zoned(
@@ -2106,6 +2118,8 @@
       dsp: hostedDsp,
       band: hostedBand,
       antenna: hostedAntenna,
+      antennaInstruments,
+      antennaLayout,
       ritXitScan: hostedRitXitScan,
       cwKeyerInstruments,
       cwKeyer: hostedCwKeyer,
@@ -2295,6 +2309,8 @@
   </DspInstrumentHost>
   {/snippet}
   </CwKeyerInstrumentHost>
+  {/snippet}
+  </AntennaInstrumentHost>
   {/snippet}
   </BandInstrumentHost>
   {/snippet}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-antenna-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-antenna-wiring.component.test.ts
@@ -25,17 +25,21 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
+import type { ControlSessionSnapshot } from '$lib/runtime/frontend-runtime';
 import type { RxAudioTargetSnapshot } from '$lib/stores/audio.svelte';
 
 
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
+  controlSession: { state: 'connected', epoch: 1 } as ControlSessionSnapshot,
   authoritySubscribers: new Set<(next: {
-    state: unknown; caps: unknown; session: { state: 'connected'; epoch: 1 };
+    state: unknown; caps: unknown; session: ControlSessionSnapshot;
     rxAudioTarget: RxAudioTargetSnapshot;
   }) => void>(),
   txController: null as ManagedAppTxController | null,
@@ -52,12 +56,20 @@ vi.mock('$lib/stores/radio.svelte', () => ({
   getRadioState: vi.fn(() => h.state as ServerState | null),
   patchActiveReceiver: vi.fn(), patchRadioState: vi.fn(), patchReceiver: vi.fn(),
 }));
-vi.mock('$lib/stores/capabilities.svelte', () => ({
-  getCapabilities: vi.fn(() => h.caps as Capabilities | null),
-  getControlRange: vi.fn(() => null),
-  getSmeterCalibration: vi.fn(() => null),
-  getSmeterRedline: vi.fn(() => null),
-}));
+// Partial, not wholesale: the Standard/SDR replacement row below mounts the
+// REAL `RadioLayout`, which reads several more of this store's selectors
+// (`getKeyboardConfig`, `hasAnyScope`, …). Only the four this file steers are
+// replaced.
+vi.mock('$lib/stores/capabilities.svelte', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/stores/capabilities.svelte')>();
+  return {
+    ...actual,
+    getCapabilities: vi.fn(() => h.caps as Capabilities | null),
+    getControlRange: vi.fn(() => null),
+    getSmeterCalibration: vi.fn(() => null),
+    getSmeterRedline: vi.fn(() => null),
+  };
+});
 vi.mock('$lib/runtime/commands/radio-intents', async () => {
   const { sendCommand } = await import('$lib/transport/ws-client');
   return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
@@ -73,10 +85,11 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
     onTxAudioDied: () => () => {},
     get state() { return h.state; },
     get caps() { return h.caps; },
+    get controlSession() { return h.controlSession; },
     subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
       h.authoritySubscribers.add(handler);
       handler({
-        state: h.state, caps: h.caps, session: { state: 'connected', epoch: 1 },
+        state: h.state, caps: h.caps, session: h.controlSession,
         rxAudioTarget: Object.freeze({ muted: h.audio.muted, rxEnabled: h.audio.rxEnabled }),
       });
       return () => { h.authoritySubscribers.delete(handler); };
@@ -110,6 +123,8 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
 
 import { sendCommand } from '$lib/transport/ws-client';
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+import HostedRadioLayoutFixture from '../../layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte';
+import type { SkinId } from '../../../skins/registry';
 import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
 import { makeAntennaHandlers } from '$lib/runtime/commands/panel-commands';
 
@@ -134,6 +149,7 @@ function liveState(over: Partial<ServerState> = {}): ServerState {
     ...slot(hz), vfoA: slot(hz), vfoB: slot(hz + 50000), activeSlot: 'A', filter: 1,
   });
   return {
+    providerGeneration: 1,
     active: 'MAIN', split: false, dualWatch: false, ptt: false,
     txAntenna: 1, rxAntenna1: false, rxAntenna2: false, tunerStatus: 0,
     txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
@@ -144,6 +160,7 @@ function liveState(over: Partial<ServerState> = {}): ServerState {
 }
 
 const liveCaps = (antennas: number, tags: readonly string[]): Capabilities => ({
+  providerGeneration: 1,
   model: 'fixture', scope: false, audio: false, tx: true,
   capabilities: tags, antennas,
   receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: [], filters: [],
@@ -164,6 +181,38 @@ function render(props: { strips?: 'single' | 'dual' } = {}): void {
   document.body.appendChild(target);
   component = mount(SemanticRadioSurfaces, { target, props });
   flushSync();
+}
+
+/** Republishes the CURRENT `h` fixture through every retained runtime authority
+ *  subscriber — the same shape `semantic-band-wiring`/`semantic-dsp-wiring` use.
+ *  Deliberately does NOT flush: the before-flush rows below invoke between this
+ *  call and Svelte's next render. */
+function publishAuthority(): void {
+  for (const subscriber of h.authoritySubscribers) {
+    subscriber({
+      state: h.state, caps: h.caps, session: h.controlSession,
+      rxAudioTarget: Object.freeze({ muted: h.audio.muted, rxEnabled: h.audio.rxEnabled }),
+    });
+  }
+}
+
+/** Mounts the REAL `RadioLayout` above one mounted `SemanticRadioSurfaces`
+ *  through the shared hosted fixture, and returns the mutable props so a test
+ *  can replace the face without remounting the tree (the
+ *  `semantic-rf-front-end-wiring` recipe). */
+function renderHosted(skinId: SkinId): { skinId: SkinId } {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  const props = proxy<{ skinId: SkinId }>({ skinId });
+  component = mount(HostedRadioLayoutFixture, { target, props });
+  flushSync();
+  return props;
+}
+
+/** A click that does NOT flush — the only way to invoke between an authority
+ *  or managed-TX change and Svelte's next render. */
+function clickWithoutFlush(node: HTMLElement): void {
+  node.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 }
 
 const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
@@ -331,6 +380,153 @@ describe('no antenna command leaves the tree while the transmitter is not idle',
     expect(sendCommand).not.toHaveBeenCalled();
     txHarness.emitServerSnapshot({ intent: 'rx', observedPtt: 'off' });
     flushSync();
+    btn('port-2')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_antenna_2', { on: false });
+  });
+});
+
+/* ── (e) MOR-2425: the persistent host, LIVE ───────────────────── */
+
+/** One ATU publication, same session and generation as `liveState()`, with the
+ *  `tunerStatus` field's own status line replaced. */
+function withTunerStatus(value: unknown, status: unknown): ServerState {
+  const state = liveState({ tunerStatus: value } as Partial<ServerState>) as unknown as {
+    fieldStatus: Record<string, unknown>;
+  };
+  return {
+    ...state, fieldStatus: { ...state.fieldStatus, tunerStatus: status },
+  } as unknown as ServerState;
+}
+
+describe('the persistent host admits on CURRENT facts, not on rendered props', () => {
+  // MUTATION KILLED: reading the managed-TX snapshot from the reactive `tx`
+  // prop instead of calling `readTx()` at the moment of invocation. A gesture
+  // landing between a same-session TX transition and Svelte's next render
+  // would then throw the relay on pre-transition truth.
+  it('refuses both controls invoked after a TX change but before the flush', () => {
+    render();
+    const port = btn('port-2')!;
+    const rx = btn('rx-toggle')!;
+    expect(port.disabled).toBe(false);
+
+    txHarness.emitServerSnapshot(TRANSMITTING);
+    clickWithoutFlush(port);
+    clickWithoutFlush(rx);
+    expect(sendCommand).not.toHaveBeenCalled();
+
+    flushSync();
+    expect(port.disabled).toBe(true);
+  });
+
+  // MUTATION KILLED: retaining only the identity tuple (or only the rendered
+  // `view` prop) instead of every authority publication. All three rows keep
+  // the session epoch, provider generation and antenna structure fixed, so an
+  // identity-keyed cache would never see them.
+  it.each([
+    ['tuning', 2, fresh],
+    ['never observed', undefined, { ...fresh, observed: false }],
+    ['stale', 0, { ...fresh, freshness: 'stale' }],
+  ] as const)(
+    'refuses both controls after a same-session ATU %s publication, before the flush',
+    (_label, value, status) => {
+      render();
+      const port = btn('port-2')!;
+      const rx = btn('rx-toggle')!;
+      expect(port.disabled).toBe(false);
+
+      h.state = withTunerStatus(value, status);
+      publishAuthority();
+      clickWithoutFlush(port);
+      clickWithoutFlush(rx);
+      expect(sendCommand).not.toHaveBeenCalled();
+
+      // …and the retained publication is what closed the gate: the seat the
+      // host owns reads it back as unavailable on the next render.
+      flushSync();
+      expect(port.disabled).toBe(true);
+      expect(rx.disabled).toBe(true);
+    },
+  );
+
+  /**
+   * The two guards are DIFFERENT guards, and this row proves it in both
+   * directions from one publication — the trap the census named: mutating the
+   * store without publishing lets the HOST refuse (vacuous), and publishing
+   * without mutating proves nothing about the handler.
+   *
+   * MUTATION KILLED: folding the shipped `makeAntennaHandlers` destination-
+   * evidence check into host admission, or dropping it.
+   */
+  it('emits under host admission and still refuses at the shipped handler alone', () => {
+    render();
+
+    // Admission side, stated first: this exact gesture DOES reach the transport.
+    btn('port-2')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_antenna_2', { on: false });
+    vi.mocked(sendCommand).mockClear();
+
+    // Same session, same generation, same antenna structure — only ANT 2's own
+    // RX override stops being a known boolean. Mutated AND published.
+    h.state = liveState({ rxAntenna2: undefined } as Partial<ServerState>);
+    publishAuthority();
+    flushSync();
+
+    // Host admission is still open: no blocked reason, the port still enabled.
+    expect(el('blocked')!.textContent.trim()).toBe('');
+    expect(btn('port-2')!.disabled).toBe(false);
+    forceClick(btn('port-2')!);
+    expect(sendCommand).not.toHaveBeenCalled();
+
+    // …and the RX-ANT toggle, whose evidence this publication left intact,
+    // reaches the shipped command from the SAME host admission.
+    btn('rx-toggle')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_rx_antenna_ant1', { on: true });
+  });
+});
+
+describe('one mounted host outlives replacing the Standard face with the SDR face', () => {
+  const grouped = () => target.querySelectorAll('[data-testid="antenna-surface"]');
+  const independent = () => target.querySelectorAll('[data-testid="antenna-control-grid"]');
+  const seats = () => [
+    target.querySelectorAll('[data-testid="antenna-ports"]').length,
+    target.querySelectorAll('[data-testid="antenna-rx"]').length,
+  ];
+
+  // MUTATION KILLED: mounting the host inside a face-specific branch, or
+  // handing each face its own owner. Either way the seats below would be
+  // replaced with the face rather than outliving it.
+  it('arranges the seats independently on Standard, grouped on SDR, and back', () => {
+    const props = renderHosted('desktop-v2');
+    const subscribers = h.authoritySubscribers.size;
+
+    expect(independent()).toHaveLength(1);
+    expect(grouped()).toHaveLength(0);
+    expect(seats()).toEqual([1, 1]);
+    expect(btn('port-2')!.getAttribute('aria-describedby')).toBe(el('blocked')!.id);
+    // `blockedId` is minted once per HOST instance (`$props.id()`), so holding
+    // it across both replacements is what says ONE owner survived them.
+    const owner = el('blocked')!.id;
+
+    props.skinId = 'sdr-test';
+    flushSync();
+    expect(grouped()).toHaveLength(1);
+    expect(independent()).toHaveLength(0);
+    expect(seats()).toEqual([1, 1]);
+    expect(el('blocked')!.id).toBe(owner);
+    expect(h.authoritySubscribers.size).toBe(subscribers);
+
+    props.skinId = 'desktop-v2';
+    flushSync();
+    expect(independent()).toHaveLength(1);
+    expect(grouped()).toHaveLength(0);
+    expect(seats()).toEqual([1, 1]);
+    expect(el('blocked')!.id).toBe(owner);
+    expect(h.authoritySubscribers.size).toBe(subscribers);
+
+    // The seats the third face rendered still reach the shipped command.
     btn('port-2')!.click();
     flushSync();
     expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_antenna_2', { on: false });

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -579,8 +579,9 @@ describe('persistent finite DSP composition and authority (MOR-2425)', () => {
     expect(target.querySelectorAll('.dsp-toggle, .dsp-choice')).toHaveLength(0);
     for (const label of external) expect(q(`[data-testid="external-${label}"]`)).toBeNull();
     expect(ranges()).toHaveLength(7);
-    // Receiver + AF + RF level + station meter hosts + the single finite-renderer fan-in.
-    expect(h.authoritySubscribers.size).toBe(5);
+    // Receiver + AF + RF level + station meter + antenna hosts + the single
+    // finite-renderer fan-in.
+    expect(h.authoritySubscribers.size).toBe(6);
   });
 
   it.each([

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -370,11 +370,11 @@ describe('the meters surface mounts only when the view model carries the group',
   it('keeps one station host across delayed dual-receiver authority', () => {
     h.deferAuthority = true;
     render({ strips: 'dual' });
-    expect(h.authoritySubscribers.size).toBe(5);
+    expect(h.authoritySubscribers.size).toBe(6);
     expect(() => push({})).not.toThrow();
     expect(target.querySelectorAll('[data-testid="semantic-radio-surfaces"]')).toHaveLength(1);
     expect(target.querySelectorAll('[data-testid="meters-surface"]')).toHaveLength(1);
-    expect(h.authoritySubscribers.size).toBe(5);
+    expect(h.authoritySubscribers.size).toBe(6);
   });
 
   it('keeps mounted meter shells but clears readings across a provider generation mismatch', () => {

--- a/frontend/src/components-v2/wiring/__tests__/semantic-pbt-continuity.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-pbt-continuity.component.test.ts
@@ -53,7 +53,7 @@ describe('mounted PBT continuity is fenced by the live control session (MOR-1706
     render(); const initialInner = value('pbtInner'), initialOuter = value('pbtOuter'); expect(initialInner).not.toBeNull(); expect(initialOuter).not.toBeNull(); expect(h.commands).not.toHaveBeenCalled();
     const staleInput = target.querySelector<HTMLInputElement>('[data-testid="filter-pbtInner"] input'); expect(staleInput).not.toBeNull();
     accept(state(null, -200, 2)); flushSync(); expect(value('pbtInner')).toBe(initialInner); expect(value('pbtOuter')).toBe(initialOuter);
-    expect(h.listeners.size).toBe(6); transition('disconnected', 1, false); transition('connected', 1, false); flushSync(); expect(value('pbtInner')).toBeNull(); expect(value('pbtOuter')).toBeNull();
+    expect(h.listeners.size).toBe(7); transition('disconnected', 1, false); transition('connected', 1, false); flushSync(); expect(value('pbtInner')).toBeNull(); expect(value('pbtOuter')).toBeNull();
     staleInput!.value = '500'; staleInput!.dispatchEvent(new Event('input', { bubbles: true })); flushSync(); expect(h.commands).not.toHaveBeenCalled(); expect(txHarness.trace()).toEqual([]);
     transition('connected', 1); expect(value('pbtInner')).toBeNull(); accept(state(300, -400, 3)); flushSync(); expect(value('pbtInner')).not.toBeNull();
     transition('connected', 2); expect(value('pbtInner')).toBeNull(); accept(state(500, -600, 4)); flushSync(); expect(value('pbtOuter')).not.toBeNull();

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
@@ -371,7 +371,7 @@ describe('the hosted AF owner survives replaceable presentation layouts', () => 
     expect(target.querySelector('[data-af-layout="independent"]')).not.toBeNull();
     expect(target.querySelectorAll('[role="slider"][aria-label="AF"]')).toHaveLength(1);
     expect([...h.authoritySubscribers]).toEqual(originalSubscribers);
-    expect(h.authoritySubscribers.size).toBe(5);
+    expect(h.authoritySubscribers.size).toBe(6);
     expect(newSlider.closest<HTMLElement>('.vc-hbar')!.style
       .getPropertyValue('--vc-fill-percent')).toBe('42%');
     expect(newSlider.getAttribute('aria-valuenow')).toBe('0.42');

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
@@ -526,7 +526,7 @@ describe('selected finite Scope authority lifetime (MOR-2425)', () => {
     render();
     expect(el('scope-hold')).not.toBeNull();
     expect(el('external-HOLD')).toBeNull();
-    expect(h.authoritySubscribers.size).toBe(5);
+    expect(h.authoritySubscribers.size).toBe(6);
   });
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -691,7 +691,7 @@ describe('selected finite TX auxiliary authority lifetime', () => {
     expect(q('[data-testid="tx-aux-atu-tune"]')).toBeNull();
     expect(q('[data-testid="external-VOX"]')).toBeNull();
     expect(q('[data-testid="external-TUNE"]')).toBeNull();
-    expect(h.authoritySubscribers.size).toBe(5);
+    expect(h.authoritySubscribers.size).toBe(6);
   });
 
   it('revokes retained A1 synchronously on A-B-A before flush and admits only fresh A3', () => {
@@ -773,7 +773,7 @@ describe('hosted Filter Mode and Filter ownership', () => {
     expect(q('[data-testid="filter-mode"]')).toBeNull();
     expect(q('[data-testid="filter-select"]')).toBeNull();
     for (const id of residual) expect(target.querySelectorAll(`[data-testid="${id}"]`)).toHaveLength(1);
-    expect(h.authoritySubscribers.size).toBe(5);
+    expect(h.authoritySubscribers.size).toBe(6);
   });
 
   it.each(['session', 'provider', 'topology', 'receiver', 'unknown'] as const)(

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -307,7 +307,7 @@ describe('production receiver-indicator partitioning', () => {
   ) => {
     selectedFrequency.current = AlternateFrequencyReadoutHarness as FrequencyRenderer;
     render(caps('main_sub', 2), state(), {}, props);
-    expect(h.authoritySubscribers.size).toBe(5);
+    expect(h.authoritySubscribers.size).toBe(6);
     const digit = projectFrequencyReadout({ confirmedHz: 14_200_000 }).digits[0];
     const first = retainedInteractions().find((interaction) => !interaction.inert)!;
     first.handleDigitClick(digit, new MouseEvent('click'));

--- a/frontend/src/components-v2/wiring/instrument-composition.ts
+++ b/frontend/src/components-v2/wiring/instrument-composition.ts
@@ -10,6 +10,9 @@ import type { VfoOperationHandles } from '../../semantic/VfoOperationSeatHost.sv
 import type { FilterFiniteLayout } from '../../semantic/filter-instruments';
 import type { BandControlLayout } from '../../semantic/band-instruments';
 import type { CwKeyerInstrumentHandles } from '../../semantic/CwKeyerInstrumentHost.svelte';
+import type {
+  AntennaInstrumentHandles, AntennaInstrumentLayout,
+} from '../../semantic/AntennaInstrumentHost.svelte';
 
 export type InstrumentVfoAppearance = 'semantic' | 'sdr' | 'standard';
 
@@ -33,7 +36,9 @@ export interface InstrumentComposition {
   readonly filter: Snippet<[allowBare?: boolean, finiteLayout?: FilterFiniteLayout]>;
   readonly dsp: Snippet<[allowBare?: boolean, finiteLayout?: DspFiniteLayout]>;
   readonly band: Snippet<[allowBare?: boolean, controlLayout?: BandControlLayout]>;
-  readonly antenna: Snippet<[allowBare?: boolean]>;
+  readonly antenna: Snippet<[allowBare?: boolean, controlLayout?: Snippet]>;
+  readonly antennaInstruments: AntennaInstrumentHandles;
+  readonly antennaLayout: AntennaInstrumentLayout;
   readonly ritXitScan: Snippet<[allowBare?: boolean]>;
   readonly cwKeyerInstruments: CwKeyerInstrumentHandles;
   readonly cwKeyer: Snippet<[allowBare?: boolean, showKeyerSpeed?: boolean]>;

--- a/frontend/src/semantic/AntennaInstrumentHost.svelte
+++ b/frontend/src/semantic/AntennaInstrumentHost.svelte
@@ -54,7 +54,10 @@
   }
   export type SubscribeAntennaAuthority = (handler: (value: AntennaAuthorityPublication) => void) => () => void;
   export interface AntennaInstrumentHandles { readonly txPort: Snippet; readonly rxAnt: Snippet }
-  export interface AntennaInstrumentLayout { readonly blockedId: string }
+  export interface AntennaInstrumentLayout {
+    readonly blockedId: string;
+    readonly blocked: readonly AntennaSwitchBlock[];
+  }
 </script>
 
 <script lang="ts">
@@ -82,7 +85,10 @@
   let destroyed = false;
   let stop: (() => void) | undefined;
   const id = $props.id();
-  const layout = { blockedId: `antenna-blocked-${id}` };
+  const layout = {
+    blockedId: `antenna-blocked-${id}`,
+    get blocked() { return currentInput().blockedReasons; },
+  };
   const safe = (value: unknown): value is number =>
     typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
   function authority(source: AntennaAuthorityPublication): string | null {
@@ -98,7 +104,8 @@
     void tx;
     const currentTx = readTx();
     const current = published === null ? null : toRadioViewModel(published.state, published.caps, currentTx);
-    return { current, blocked: current === null || antennaSwitchBlocks(current, currentTx).length > 0 };
+    const blockedReasons = current === null ? [] : antennaSwitchBlocks(current, currentTx);
+    return { current, blocked: blockedReasons.length > 0, blockedReasons };
   }
   const txPortSeat = createAbsoluteChoiceRendererSeat<number>(() => {
     const { current, blocked } = currentInput();

--- a/frontend/src/semantic/AntennaInstrumentHost.svelte
+++ b/frontend/src/semantic/AntennaInstrumentHost.svelte
@@ -1,0 +1,183 @@
+<script module lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { Capabilities } from '$lib/types/capabilities';
+  import type { ServerState } from '$lib/types/state';
+  import type { AntennaField, RadioViewModel } from './radio-view-model';
+  import {
+    BLOCKED_LABEL, keyBlockedReasons, type KeyBlockedReason, type TxAuthoritySnapshot,
+  } from './rx-tx-surface';
+
+  export const ANTENNA_PORTS = [1, 2] as const;
+  export const UNKNOWN_TEXT = '—';
+
+  const RF_MUST_BE_IDLE: readonly KeyBlockedReason[] = [
+    'tx-busy', 'radio-transmitting', 'rf-state-unknown',
+  ];
+  export type AntennaSwitchBlock = KeyBlockedReason | 'tuner-not-ready';
+  export const ANTENNA_BLOCKED_LABEL: Record<AntennaSwitchBlock, string> = {
+    ...BLOCKED_LABEL,
+    'tx-busy': 'a TX lease is in progress — an antenna must not switch under power',
+    'radio-transmitting': 'the radio is transmitting — an antenna must not switch under power',
+    'rf-state-unknown': 'RF state unknown — an unconfirmed transmitter is treated as keyed',
+    'tuner-not-ready': 'ATU not confirmed idle — an unread tuner is treated as running',
+  };
+
+  export const usable = (f: AntennaField<unknown>): boolean =>
+    f.availability.structural && f.availability.operational && f.reading.status === 'known';
+  export const textOf = (f: AntennaField<unknown>): string =>
+    f.reading.status !== 'known' ? UNKNOWN_TEXT
+      : typeof f.reading.value === 'boolean' ? (f.reading.value ? 'on' : 'off')
+        : String(f.reading.value);
+  export const valueOf = <T>(f: AntennaField<T>): T | undefined =>
+    f.reading.status === 'known' ? f.reading.value : undefined;
+
+  export function tunerIdle(view: RadioViewModel): boolean {
+    const atu = view.txAux?.atu;
+    if (atu === undefined || !atu.availability.structural) return true;
+    return usable(atu) && atu.reading.status === 'known' && atu.reading.value !== 'tuning';
+  }
+
+  export function antennaSwitchBlocks(
+    view: RadioViewModel, tx: TxAuthoritySnapshot,
+  ): readonly AntennaSwitchBlock[] {
+    const blocks: AntennaSwitchBlock[] = keyBlockedReasons(view, tx)
+      .filter((reason) => RF_MUST_BE_IDLE.includes(reason));
+    if (!tunerIdle(view)) blocks.push('tuner-not-ready');
+    return blocks;
+  }
+
+
+  export interface AntennaAuthorityPublication {
+    readonly state: ServerState | null;
+    readonly caps: Capabilities | null;
+    readonly session: { readonly state: 'disconnected' | 'connecting' | 'connected' | 'reconnecting'; readonly epoch: number };
+  }
+  export type SubscribeAntennaAuthority = (handler: (value: AntennaAuthorityPublication) => void) => () => void;
+  export interface AntennaInstrumentHandles { readonly txPort: Snippet; readonly rxAnt: Snippet }
+  export interface AntennaInstrumentLayout { readonly blockedId: string }
+</script>
+
+<script lang="ts">
+  import { onMount, onDestroy, untrack } from 'svelte';
+  import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
+  import ControlInstrumentRendererHost from '../primitives/control-instruments/ControlInstrumentRendererHost.svelte';
+  import { createAbsoluteChoiceRendererSeat, createToggleRendererSeat, createFiniteRendererContext,
+    type FiniteControlAppearance, type FiniteRendererContext,
+  } from '../primitives/control-instruments/control-instrument-renderer.svelte';
+  interface Props {
+    view: RadioViewModel | null;
+    tx: TxAuthoritySnapshot;
+    readTx: () => TxAuthoritySnapshot;
+    subscribeControlAuthority: SubscribeAntennaAuthority;
+    onSelectPort?: (port: number) => void;
+    onToggleRxAnt?: () => void;
+    finiteAppearance?: FiniteControlAppearance<number>;
+    children: Snippet<[AntennaInstrumentHandles, AntennaInstrumentLayout]>;
+  }
+  let { view, tx, readTx, subscribeControlAuthority, onSelectPort, onToggleRxAnt,
+    finiteAppearance, children }: Props = $props();
+  let published = $state.raw<AntennaAuthorityPublication | null>(null);
+  let context = $state.raw<FiniteRendererContext | null>(null);
+  let identity: string | null = null;
+  let destroyed = false;
+  let stop: (() => void) | undefined;
+  const id = $props.id();
+  const layout = { blockedId: `antenna-blocked-${id}` };
+  const safe = (value: unknown): value is number =>
+    typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+  function authority(source: AntennaAuthorityPublication): string | null {
+    const generation = source.state?.providerGeneration;
+    if (source.session.state !== 'connected' || !safe(source.session.epoch)
+      || !safe(generation) || !safe(source.caps?.providerGeneration)
+      || generation !== source.caps?.providerGeneration) return null;
+    const current = toRadioViewModel(source.state, source.caps);
+    return current?.antenna ? JSON.stringify([source.session.epoch, generation, current.topologyId,
+      current.antenna.antennaCount, current.antenna.rxAnt.availability.structural]) : null;
+  }
+  function currentInput() {
+    void tx;
+    const currentTx = readTx();
+    const current = published === null ? null : toRadioViewModel(published.state, published.caps, currentTx);
+    return { current, blocked: current === null || antennaSwitchBlocks(current, currentTx).length > 0 };
+  }
+  const txPortSeat = createAbsoluteChoiceRendererSeat<number>(() => {
+    const { current, blocked } = currentInput();
+    return { context, label: 'Transmit antenna',
+      reading: current?.antenna?.txAntenna.reading ?? { status: 'unknown' },
+      available: current?.antenna !== undefined && onSelectPort !== undefined, blocked,
+      options: ANTENNA_PORTS.map(value => ({ value, label: `ANT ${value}` })),
+      invoke: (port) => onSelectPort?.(port) };
+  });
+  const rxAntSeat = createToggleRendererSeat(() => {
+    const { current, blocked } = currentInput();
+    return { context, label: 'RX-ANT', field: current?.antenna?.rxAnt,
+      blocked: blocked || onToggleRxAnt === undefined,
+      invoke: () => onToggleRxAnt?.() };
+  });
+  let ant = $derived(view?.antenna);
+  const handles = { txPort, rxAnt };
+  onMount(() => {
+    stop = subscribeControlAuthority(next => {
+      if (destroyed) return;
+      published = next;
+      const nextIdentity = authority(next);
+      if (nextIdentity !== identity) {
+        identity = nextIdentity;
+        context = identity === null ? null : createFiniteRendererContext();
+      }
+    });
+  });
+  onDestroy(() => {
+    destroyed = true;
+    try { stop?.(); } finally { txPortSeat.destroy(); rxAntSeat.destroy(); }
+  });
+</script>
+
+{#snippet txPort()}
+  {#if ant}
+    {#key context}{#key finiteAppearance?.choice}
+      {#if finiteAppearance}
+        <ControlInstrumentRendererHost seat={txPortSeat} renderer={finiteAppearance.choice} />
+      {:else}
+        {@const lease = untrack(() => txPortSeat.attachRenderer())}
+        <div class="antenna-row" role="radiogroup" aria-label="Transmit antenna"
+          data-testid="antenna-ports" data-observed={usable(ant.txAntenna)}
+          {@attach () => () => lease.dispose()}>
+          {#each ANTENNA_PORTS as port (port)}
+            <button type="button" role="radio" class="antenna-choice"
+              data-testid={`antenna-port-${port}`} data-port={port}
+              aria-checked={lease.view?.selected === port} aria-describedby={layout.blockedId}
+              disabled={!lease.view?.available} onclick={() => lease.invoke(port)}>ANT {port}</button>
+          {/each}
+          <output data-testid="antenna-port-value">{textOf(ant.txAntenna)}</output>
+        </div>
+      {/if}
+    {/key}{/key}
+  {/if}
+{/snippet}
+{#snippet rxAnt()}
+  {#if ant?.rxAnt.availability.structural}
+    {#key context}{#key finiteAppearance?.toggle}
+      {#if finiteAppearance}
+        <ControlInstrumentRendererHost seat={rxAntSeat} renderer={finiteAppearance.toggle} />
+      {:else}
+        {@const lease = untrack(() => rxAntSeat.attachRenderer())}
+        <div class="antenna-row" data-testid="antenna-rx" data-observed={usable(ant.rxAnt)}
+          {@attach () => () => lease.dispose()}>
+          <button type="button" class="antenna-choice" data-testid="antenna-rx-toggle"
+            aria-pressed={lease.view?.confirmed} aria-describedby={layout.blockedId}
+            disabled={!lease.view?.available} onclick={() => lease.invoke()}>
+            RX-ANT: {textOf(ant.rxAnt)}</button>
+        </div>
+      {/if}
+    {/key}{/key}
+  {/if}
+{/snippet}
+{@render children(handles, layout)}
+
+<style>
+  .antenna-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; }
+  .antenna-choice[aria-checked='true'], .antenna-choice[aria-pressed='true'] { font-weight: 700; }
+  [data-observed='false'] { font-style: italic; }
+  button:disabled { cursor: not-allowed; }
+</style>

--- a/frontend/src/semantic/AntennaInstrumentHost.svelte
+++ b/frontend/src/semantic/AntennaInstrumentHost.svelte
@@ -28,8 +28,6 @@
     f.reading.status !== 'known' ? UNKNOWN_TEXT
       : typeof f.reading.value === 'boolean' ? (f.reading.value ? 'on' : 'off')
         : String(f.reading.value);
-  export const valueOf = <T>(f: AntennaField<T>): T | undefined =>
-    f.reading.status === 'known' ? f.reading.value : undefined;
 
   export function tunerIdle(view: RadioViewModel): boolean {
     const atu = view.txAux?.atu;

--- a/frontend/src/semantic/AntennaSurface.svelte
+++ b/frontend/src/semantic/AntennaSurface.svelte
@@ -1,122 +1,13 @@
-<!--
-  Semantic antenna surface (MOR-1309, vocabulary slice 8C). SAFETY-ADJACENT.
-
-  Presentation only. It renders the MOR-1295 `antenna` fact group — the
-  selected TX port, the port-dependent RX-antenna override and the declared
-  port count — and emits control intents as callbacks. It holds no state,
-  consults no controller and takes no TX lease (v3 ADR invariant 11).
-
-  SAFETY. Four rules govern this file and nothing may relax them:
-
-  (1) AN ANTENNA MUST NOT SWITCH UNDER POWER. Throwing a TX antenna relay
-      while RF is present arcs the contacts and can destroy the PA, the relay
-      or whatever is on the other end of the feedline. The gate is
-      `antennaSwitchBlocks` below, enforced TWICE — on every control
-      (`disabled`) and again inside every handler, because a design language
-      may restyle these controls and a programmatic click must not switch a
-      relay the disabled attribute would have refused.
-
-  (2) UNKNOWN TX STATE IS TREATED AS KEYED. The RF half of the gate is the
-      SHARED `keyBlockedReasons` predicate, applied to the SAME App-owned TX
-      authority snapshot that gates `RxTxSurface`'s key button and
-      `TxAuxSurface`'s TUNE, filtered to the three reasons that mean "the
-      transmitter is not provably idle" (`tx-busy`, `radio-transmitting`,
-      `rf-state-unknown`). A local re-derivation could drift and disagree; the
-      shared import cannot, and this surface never computes TX truth itself
-      (R9). `radioTx: 'unknown'` therefore blocks exactly as hard as
-      `radioTx: 'on'`.
-
-  (3) AN UNREAD TUNER IS TREATED AS RUNNING (MOR-1295 §3 / MOR-1293
-      precedent). ATU state is family 1's `txAux.atu` — it is deliberately NOT
-      duplicated into the `antenna` group — and an ATU mid-cycle is emitting a
-      carrier. `tunerIdle` therefore requires a POSITIVELY observed, non-
-      `tuning` reading; an unobserved or stale `tunerStatus` is not-ready, and
-      this surface never infers "tuner idle, safe to switch".
-      A radio that declares NO tuner (`atu.availability.structural === false`,
-      or no `txAux` group at all — `deriveTxAux` only omits the group when the
-      radio declares no `tx` capability or reported nothing at all) is a
-      DIFFERENT claim from an unread one: there is no tuner that could be
-      running, so it is not a block. Conflating the two would permanently
-      disable antenna switching on every ATU-less radio — broken, not safe.
-
-  (4) NO FABRICATED PORT 1. The shipped v2 `toAntennaProps` defaults
-      `txAntenna = state?.txAntenna ?? 1`, so v2 silently claims port 1 and
-      then reports port 1's RX-ANT; slice 8A refused that and this surface
-      preserves the divergence (the same deliberate, documented pattern
-      6B/PRE and 9B/break-in carry). An unread port renders `UNKNOWN_TEXT`
-      with NO port marked selected — never ANT 1.
-
-  Two-level availability (MOR-977/1256): `structural: false` renders NOTHING —
-  "this radio has no RX-ANT" is a different claim from "RX-ANT is unreadable
-  right now", which renders present-and-disabled with a reason.
--->
 <script module lang="ts">
-  import type { AntennaField, RadioViewModel } from './radio-view-model';
-  import {
-    BLOCKED_LABEL, keyBlockedReasons, type KeyBlockedReason, type TxAuthoritySnapshot,
-  } from './rx-tx-surface';
+  import type { RadioViewModel } from './radio-view-model';
+  import type { TxAuthoritySnapshot } from './rx-tx-surface';
   import { pressedOf } from './pressed-of';
 
-  /** The TX ports the shipped command vocabulary can actually reach
-   *  (`set_antenna_1` / `set_antenna_2`) — and exactly what the shipped
-   *  `AntennaPanel` renders. `antennaCount` is this group's EVIDENCE GATE
-   *  (`> 1`), not a port enumerator: inventing a button for a port no command
-   *  can address would be a dead control (the "no speculative keys" rule), so
-   *  the count is published as `data-antenna-count` instead. Every shipped
-   *  profile declares 1 or 2. */
-  export const ANTENNA_PORTS = [1, 2] as const;
-  /** The ONE rendering of "not measured". Never `1`, never `off`. */
-  export const UNKNOWN_TEXT = '—';
-
-  /** The `keyBlockedReasons` subset that means "the transmitter is not
-   *  provably idle". The permit/target/fault reasons are deliberately NOT
-   *  here: an out-of-band frequency makes keying illegal, not antenna
-   *  switching dangerous, and gating on it would be theatre rather than
-   *  safety. */
-  const RF_MUST_BE_IDLE: readonly KeyBlockedReason[] = [
-    'tx-busy', 'radio-transmitting', 'rf-state-unknown',
-  ];
-  export type AntennaSwitchBlock = KeyBlockedReason | 'tuner-not-ready';
-  /** Each label names the CONSEQUENCE, not just the state — an operator who
-   *  sees a disabled antenna button must be told why it is disabled. */
-  export const ANTENNA_BLOCKED_LABEL: Record<AntennaSwitchBlock, string> = {
-    ...BLOCKED_LABEL,
-    'tx-busy': 'a TX lease is in progress — an antenna must not switch under power',
-    'radio-transmitting': 'the radio is transmitting — an antenna must not switch under power',
-    'rf-state-unknown': 'RF state unknown — an unconfirmed transmitter is treated as keyed',
-    'tuner-not-ready': 'ATU not confirmed idle — an unread tuner is treated as running',
-  };
-
-  /** Usable ⇔ the radio HAS it, it is readable NOW, and it was actually read. */
-  export const usable = (f: AntennaField<unknown>): boolean =>
-    f.availability.structural && f.availability.operational && f.reading.status === 'known';
-  /** Honest text: an unread fact reads as unknown, never as a default. */
-  export const textOf = (f: AntennaField<unknown>): string =>
-    f.reading.status !== 'known' ? UNKNOWN_TEXT
-      : typeof f.reading.value === 'boolean' ? (f.reading.value ? 'on' : 'off')
-        : String(f.reading.value);
-  /** Rule (4): `undefined` for an unread fact. There is no `?? 1` here and
-   *  there must never be one. */
-  export const valueOf = <T>(f: AntennaField<T>): T | undefined =>
-    f.reading.status === 'known' ? f.reading.value : undefined;
-
-  /** Rule (3). `true` only for a radio with no ATU at all, or a positively
-   *  observed ATU that is not mid-cycle. */
-  export function tunerIdle(view: RadioViewModel): boolean {
-    const atu = view.txAux?.atu;
-    if (atu === undefined || !atu.availability.structural) return true;
-    return usable(atu) && atu.reading.status === 'known' && atu.reading.value !== 'tuning';
-  }
-
-  /** Rules (1)–(3) as one ordered list of reasons; empty ⇔ switching is safe. */
-  export function antennaSwitchBlocks(
-    view: RadioViewModel, tx: TxAuthoritySnapshot,
-  ): readonly AntennaSwitchBlock[] {
-    const blocks: AntennaSwitchBlock[] = keyBlockedReasons(view, tx)
-      .filter((reason) => RF_MUST_BE_IDLE.includes(reason));
-    if (!tunerIdle(view)) blocks.push('tuner-not-ready');
-    return blocks;
-  }
+  export { ANTENNA_PORTS, UNKNOWN_TEXT, ANTENNA_BLOCKED_LABEL, usable, textOf, valueOf,
+    tunerIdle, antennaSwitchBlocks, type AntennaSwitchBlock } from './AntennaInstrumentHost.svelte';
+  import { ANTENNA_PORTS, ANTENNA_BLOCKED_LABEL, usable, textOf, valueOf,
+    antennaSwitchBlocks, type AntennaInstrumentHandles, type AntennaInstrumentLayout,
+  } from './AntennaInstrumentHost.svelte';
 
   /** Per-instance DOM id, so several mounted surfaces keep distinct aria targets. */
   let sequence = 0;
@@ -132,28 +23,17 @@
     tx: TxAuthoritySnapshot;
     onSelectPort?: (port: number) => void;
     onToggleRxAnt?: () => void;
+    handles?: AntennaInstrumentHandles;
+    layout?: AntennaInstrumentLayout;
   }
-  let { view, tx, onSelectPort, onToggleRxAnt }: Props = $props();
+  let { view, tx, onSelectPort, onToggleRxAnt, handles, layout }: Props = $props();
 
-  const blockedId = `antenna-blocked-${++sequence}`;
+  const legacyBlockedId = `antenna-blocked-${++sequence}`;
+  let blockedId = $derived(layout?.blockedId ?? legacyBlockedId);
   /** Absent group ⇒ this surface renders nothing (S0 optional-group doctrine):
    *  a single-port radio gets no empty panel and no zone had to learn about it. */
   let ant = $derived(view.antenna);
   let blocked = $derived(antennaSwitchBlocks(view, tx));
-  const portBehavior = bindAbsoluteChoiceInstrument<number>(() => ({
-    choices: ANTENNA_PORTS,
-    selected: ant ? valueOf(ant.txAntenna) : undefined,
-    available: ant !== undefined,
-    blocked: blocked.length > 0,
-    invoke: (port) => onSelectPort?.(port),
-  }));
-  /** RX-ANT remains relative: its own known boolean is required before the
-   *  existing zero-argument callback may invert it downstream. */
-  const rxAntBehavior = bindToggleInstrument(() => ({
-    field: ant?.rxAnt,
-    blocked: blocked.length > 0,
-    invoke: () => onToggleRxAnt?.(),
-  }));
 </script>
 
 {#if ant}
@@ -161,6 +41,18 @@
     class="antenna-surface" data-testid="antenna-surface" aria-label="Antenna selection"
     data-antenna-count={ant.antennaCount} data-switch-blocked={blocked.length > 0}
   >
+    {#if handles}
+      {@render handles.txPort()}
+      {@render handles.rxAnt()}
+    {:else}
+    {@const portBehavior = bindAbsoluteChoiceInstrument<number>(() => ({
+      choices: ANTENNA_PORTS, selected: ant ? valueOf(ant.txAntenna) : undefined,
+      available: ant !== undefined, blocked: blocked.length > 0,
+      invoke: (port) => onSelectPort?.(port),
+    }))}
+    {@const rxAntBehavior = bindToggleInstrument(() => ({
+      field: ant?.rxAnt, blocked: blocked.length > 0, invoke: () => onToggleRxAnt?.(),
+    }))}
     <div
       class="antenna-row" role="radiogroup" aria-label="Transmit antenna"
       data-testid="antenna-ports" data-observed={usable(ant.txAntenna)}
@@ -188,6 +80,7 @@
       </div>
     {/if}
 
+    {/if}
     <ul class="antenna-blocked" id={blockedId} data-testid="antenna-blocked">
       {#each blocked as code (code)}<li data-reason={code}>{ANTENNA_BLOCKED_LABEL[code]}</li>{/each}
     </ul>

--- a/frontend/src/semantic/AntennaSurface.svelte
+++ b/frontend/src/semantic/AntennaSurface.svelte
@@ -1,35 +1,23 @@
 <script module lang="ts">
   import type { RadioViewModel } from './radio-view-model';
   import type { TxAuthoritySnapshot } from './rx-tx-surface';
-  import { pressedOf } from './pressed-of';
 
-  export { ANTENNA_PORTS, UNKNOWN_TEXT, ANTENNA_BLOCKED_LABEL, usable, textOf, valueOf,
+  export { ANTENNA_PORTS, UNKNOWN_TEXT, ANTENNA_BLOCKED_LABEL, usable, textOf,
     tunerIdle, antennaSwitchBlocks, type AntennaSwitchBlock } from './AntennaInstrumentHost.svelte';
-  import { ANTENNA_PORTS, ANTENNA_BLOCKED_LABEL, usable, textOf, valueOf,
-    antennaSwitchBlocks, type AntennaInstrumentHandles, type AntennaInstrumentLayout,
+  import { ANTENNA_BLOCKED_LABEL, antennaSwitchBlocks,
+    type AntennaInstrumentHandles, type AntennaInstrumentLayout,
   } from './AntennaInstrumentHost.svelte';
-
-  /** Per-instance DOM id, so several mounted surfaces keep distinct aria targets. */
-  let sequence = 0;
 </script>
 
 <script lang="ts">
-  import {
-    bindAbsoluteChoiceInstrument, bindToggleInstrument,
-  } from '../primitives/control-instruments/control-instrument-behavior';
-
   interface Props {
     view: RadioViewModel;
     tx: TxAuthoritySnapshot;
-    onSelectPort?: (port: number) => void;
-    onToggleRxAnt?: () => void;
-    handles?: AntennaInstrumentHandles;
-    layout?: AntennaInstrumentLayout;
+    handles: AntennaInstrumentHandles;
+    layout: AntennaInstrumentLayout;
   }
-  let { view, tx, onSelectPort, onToggleRxAnt, handles, layout }: Props = $props();
+  let { view, tx, handles, layout }: Props = $props();
 
-  const legacyBlockedId = `antenna-blocked-${++sequence}`;
-  let blockedId = $derived(layout?.blockedId ?? legacyBlockedId);
   /** Absent group ⇒ this surface renders nothing (S0 optional-group doctrine):
    *  a single-port radio gets no empty panel and no zone had to learn about it. */
   let ant = $derived(view.antenna);
@@ -41,47 +29,9 @@
     class="antenna-surface" data-testid="antenna-surface" aria-label="Antenna selection"
     data-antenna-count={ant.antennaCount} data-switch-blocked={blocked.length > 0}
   >
-    {#if handles}
-      {@render handles.txPort()}
-      {@render handles.rxAnt()}
-    {:else}
-    {@const portBehavior = bindAbsoluteChoiceInstrument<number>(() => ({
-      choices: ANTENNA_PORTS, selected: ant ? valueOf(ant.txAntenna) : undefined,
-      available: ant !== undefined, blocked: blocked.length > 0,
-      invoke: (port) => onSelectPort?.(port),
-    }))}
-    {@const rxAntBehavior = bindToggleInstrument(() => ({
-      field: ant?.rxAnt, blocked: blocked.length > 0, invoke: () => onToggleRxAnt?.(),
-    }))}
-    <div
-      class="antenna-row" role="radiogroup" aria-label="Transmit antenna"
-      data-testid="antenna-ports" data-observed={usable(ant.txAntenna)}
-    >
-      {#each ANTENNA_PORTS as port (port)}
-        <button
-          type="button" role="radio" class="antenna-choice"
-          data-testid={`antenna-port-${port}`} data-port={port}
-          aria-checked={portBehavior.isSelected(port)} aria-describedby={blockedId}
-          disabled={!portBehavior.available}
-          onclick={() => portBehavior.invoke(port)}
-        >ANT {port}</button>
-      {/each}
-      <output data-testid="antenna-port-value">{textOf(ant.txAntenna)}</output>
-    </div>
-
-    {#if ant.rxAnt.availability.structural}
-      <div class="antenna-row" data-testid="antenna-rx" data-observed={usable(ant.rxAnt)}>
-        <button
-          type="button" class="antenna-choice" data-testid="antenna-rx-toggle"
-          aria-pressed={pressedOf(ant.rxAnt)} aria-describedby={blockedId}
-          disabled={!rxAntBehavior.available}
-          onclick={() => rxAntBehavior.invoke()}
-        >RX-ANT: {textOf(ant.rxAnt)}</button>
-      </div>
-    {/if}
-
-    {/if}
-    <ul class="antenna-blocked" id={blockedId} data-testid="antenna-blocked">
+    {@render handles.txPort()}
+    {@render handles.rxAnt()}
+    <ul class="antenna-blocked" id={layout.blockedId} data-testid="antenna-blocked">
       {#each blocked as code (code)}<li data-reason={code}>{ANTENNA_BLOCKED_LABEL[code]}</li>{/each}
     </ul>
   </section>
@@ -91,12 +41,6 @@
   /* Structure only — a design language owns colour and must never become the
      sole state channel (MOR-977, forced-colors). Nothing here animates. */
   .antenna-surface { display: flex; flex-direction: column; gap: 0.25rem; }
-  .antenna-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; }
-  .antenna-choice[aria-checked='true'], .antenna-choice[aria-pressed='true'] { font-weight: 700; }
   .antenna-blocked { margin: 0; padding-inline-start: 1.2em; }
   .antenna-blocked:empty { display: none; }
-  /* Second channel beside `data-observed`, never the only one: the unknown
-     text itself is the primary one and survives forced-colors. */
-  [data-observed='false'] { font-style: italic; }
-  button:disabled { cursor: not-allowed; }
 </style>

--- a/frontend/src/semantic/__tests__/AntennaInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/AntennaInstrumentHost.isolated.test.ts
@@ -5,7 +5,9 @@ import { proxy } from 'svelte/internal/client';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
-import type { AntennaAuthorityPublication as Publication, AntennaInstrumentHandles } from '../AntennaInstrumentHost.svelte';
+import { ANTENNA_BLOCKED_LABEL,
+  type AntennaAuthorityPublication as Publication, type AntennaInstrumentHandles,
+} from '../AntennaInstrumentHost.svelte';
 import type { TxAuthoritySnapshot } from '../rx-tx-surface';
 const seats = vi.hoisted(() => ({ destroy: [] as ReturnType<typeof vi.fn>[] }));
 vi.mock('../../primitives/control-instruments/control-instrument-renderer.svelte', async (original) => {
@@ -94,6 +96,23 @@ describe('persistent antenna handles', () => {
     expect(target.querySelectorAll('[role="radio"]')).toHaveLength(2); invoke(r.pair());
     expect(r.onSelectPort).toHaveBeenCalledExactlyOnceWith(2); expect(r.onToggleRxAnt).toHaveBeenCalledOnce();
     expect(r.captures.at(-1)).toBe(handles); expect(target.querySelector('[data-testid="antenna-surface"]')).toBeNull();
+  });
+  it('renders blocked reasons for an independent arrangement, keyed to each seat by aria-describedby', () => {
+    const r = render(false); r.props.arrangement = 'independent'; flushSync();
+    const list = target.querySelector('[data-testid="independent-blocked"]')!;
+    const port = target.querySelector('[data-testid="antenna-port-2"]')!;
+    const toggle = target.querySelector('[data-testid="antenna-rx-toggle"]')!;
+    expect(list.id).not.toBe(''); expect(port.getAttribute('aria-describedby')).toBe(list.id);
+    expect(toggle.getAttribute('aria-describedby')).toBe(list.id);
+    expect(list.children).toHaveLength(0);
+    const p = source(); p.state!.tunerStatus = 2;
+    p.state!.fieldStatus!.tunerStatus = { ...p.state!.fieldStatus!.tunerStatus!, freshness: 'fresh', observed: true };
+    r.publish(p); flushSync();
+    expect(list.children).toHaveLength(1);
+    expect(list.querySelector('[data-reason="tuner-not-ready"]')?.textContent)
+      .toBe(ANTENNA_BLOCKED_LABEL['tuner-not-ready']);
+    r.publish(source()); flushSync();
+    expect(list.children).toHaveLength(0);
   });
   it('admits an unknown absolute destination but refuses unknown relative RX and unoffered ports', () => {
     const r = render(); const p = source(); p.state!.txAntenna = undefined; r.publish(p); flushSync();

--- a/frontend/src/semantic/__tests__/AntennaInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/AntennaInstrumentHost.isolated.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+// @ts-expect-error -- Svelte's reactive test harness has no public types.
+import { proxy } from 'svelte/internal/client';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
+import type { AntennaAuthorityPublication as Publication, AntennaInstrumentHandles } from '../AntennaInstrumentHost.svelte';
+import type { TxAuthoritySnapshot } from '../rx-tx-surface';
+const seats = vi.hoisted(() => ({ destroy: [] as ReturnType<typeof vi.fn>[] }));
+vi.mock('../../primitives/control-instruments/control-instrument-renderer.svelte', async (original) => {
+  const actual = await original<typeof import('../../primitives/control-instruments/control-instrument-renderer.svelte')>();
+  const track = <T extends { destroy(): void }>(seat: T): T => {
+    const destroy = vi.fn(() => seat.destroy()); seats.destroy.push(destroy);
+    return { ...seat, destroy };
+  };
+  return { ...actual,
+    createAbsoluteChoiceRendererSeat: (...args: Parameters<typeof actual.createAbsoluteChoiceRendererSeat>) => track(actual.createAbsoluteChoiceRendererSeat(...args)),
+    createToggleRendererSeat: (...args: Parameters<typeof actual.createToggleRendererSeat>) => track(actual.createToggleRendererSeat(...args)),
+  };
+});
+import Renderer, { retainedInvocations, resetRetainedInvocations } from '../../primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte';
+import Fixture from './fixtures/AntennaInstrumentHostFixture.svelte';
+const idle: TxAuthoritySnapshot = { phase: 'idle', intent: null, radioTx: 'off', txRisk: 'none', fault: null };
+const appearance = { action: Renderer, choice: Renderer, toggle: Renderer };
+function source(): Publication {
+  return { session: { state: 'connected', epoch: 1 },
+    state: { providerGeneration: 1, active: 'MAIN', txAntenna: 1, rxAntenna1: false,
+      rxAntenna2: true, tunerStatus: 0, fieldStatus: Object.fromEntries(
+        ['active', 'txAntenna', 'rxAntenna1', 'rxAntenna2', 'tunerStatus'].map(key => [key,
+          { observed: true, freshness: 'fresh', availability: 'available' }])) } as unknown as ServerState,
+    caps: { model: 'fixture', providerGeneration: 1, receivers: 1, vfoScheme: 'single',
+      scope: false, audio: false, tx: true, freqRanges: [], modes: [], filters: [], txBands: null,
+      audioConfig: { sampleRate: 48000, channels: 1, codecs: [] }, webrtc: { available: false, enabled: false },
+      antennas: 2, capabilities: ['tx', 'rx_antenna', 'tuner'] } as Capabilities };
+}
+let component: ReturnType<typeof mount> | undefined;
+let target: HTMLDivElement;
+afterEach(async () => { if (component) await unmount(component); component = undefined;
+  target?.remove(); seats.destroy.length = 0; resetRetainedInvocations(); });
+function render(external = true) {
+  let publication = source(); let tx = idle; let subscriber: (p: Publication) => void = () => {};
+  const stop = vi.fn(); const onSelectPort = vi.fn(); const onToggleRxAnt = vi.fn();
+  const captures: AntennaInstrumentHandles[] = [];
+  const props = proxy({ view: toRadioViewModel(publication.state, publication.caps)!, tx,
+    finiteAppearance: external ? appearance : undefined, arrangement: 'grouped', body: true,
+    onSelectPort, onToggleRxAnt, readTx: () => tx,
+    capture: (handles: AntennaInstrumentHandles) => captures.push(handles),
+    subscribeControlAuthority: (handler: (p: Publication) => void) => {
+      subscriber = handler; handler(publication); return stop;
+    } });
+  target = document.createElement('div'); document.body.appendChild(target);
+  component = mount(Fixture, { target, props }); flushSync();
+  const pair = () => external
+    ? [retainedInvocations.get('Transmit antenna')!, retainedInvocations.get('RX-ANT')!]
+    : ['port-2', 'rx-toggle'].map(id => {
+      const button = target.querySelector(`[data-testid="antenna-${id}"]`)!;
+      return () => button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+  return { props, stop, onSelectPort, onToggleRxAnt, captures, pair,
+    publish(next: Publication) { publication = next; subscriber(next); props.view = toRadioViewModel(next.state, next.caps); },
+    tx(next: TxAuthoritySnapshot) { tx = next; }, source: () => publication,
+  };
+}
+const invoke = (pair: ReturnType<ReturnType<typeof render>['pair']>) => { pair[0](2); pair[1](); };
+describe('persistent antenna handles', () => {
+  it.each([false, true])('retains same-source facts and refuses TX/ATU before flush (external=%s)', external => {
+    const r = render(external); const callbacks = r.pair();
+    invoke(callbacks); expect(r.onSelectPort).toHaveBeenCalledOnce(); expect(r.onToggleRxAnt).toHaveBeenCalledOnce();
+    r.onSelectPort.mockClear(); r.onToggleRxAnt.mockClear();
+    for (const unsafe of [{ ...idle, radioTx: 'on' }, { ...idle, radioTx: 'unknown' },
+      { ...idle, phase: 'key-confirm-pending' }, { ...idle, txRisk: 'uncertain' },
+      { ...idle, phase: 'failed', txRisk: 'confirmed-on' }] as TxAuthoritySnapshot[]) {
+      r.tx(unsafe); invoke(callbacks);
+      expect(r.onSelectPort).not.toHaveBeenCalled(); expect(r.onToggleRxAnt).not.toHaveBeenCalled();
+    }
+    r.tx(idle);
+    for (const freshness of ['fresh', 'stale', 'unknown']) {
+      const p = source(); p.state!.tunerStatus = freshness === 'fresh' ? 2 : 0;
+      p.state!.fieldStatus!.tunerStatus = { ...p.state!.fieldStatus!.tunerStatus!,
+        freshness: freshness === 'stale' ? 'stale' : 'fresh', observed: freshness !== 'unknown' };
+      r.publish(p); invoke(callbacks);
+      expect(r.onSelectPort).not.toHaveBeenCalled(); expect(r.onToggleRxAnt).not.toHaveBeenCalled();
+    }
+    const p = source(); p.state!.txAntenna = 2; r.publish(p); invoke(callbacks);
+    expect(r.onSelectPort).toHaveBeenCalledOnce(); expect(r.onToggleRxAnt).toHaveBeenCalledOnce();
+    flushSync(); expect(r.captures.every(handles => handles === r.captures[0])).toBe(true);
+    expect(Object.keys(r.captures[0])).toEqual(['txPort', 'rxAnt']); expect(seats.destroy).toHaveLength(2);
+    expect(external ? target.querySelector('[data-reading]')?.getAttribute('data-reading')
+      : target.querySelector('[data-testid="antenna-port-value"]')?.textContent).toBe('2');
+  });
+  it('preserves native grouped and independent parity through the two stable handles', () => {
+    const r = render(false); const handles = r.captures[0]; r.props.arrangement = 'independent'; flushSync();
+    expect(target.querySelectorAll('[role="radio"]')).toHaveLength(2); invoke(r.pair());
+    expect(r.onSelectPort).toHaveBeenCalledExactlyOnceWith(2); expect(r.onToggleRxAnt).toHaveBeenCalledOnce();
+    expect(r.captures.at(-1)).toBe(handles); expect(target.querySelector('[data-testid="antenna-surface"]')).toBeNull();
+  });
+  it('admits an unknown absolute destination but refuses unknown relative RX and unoffered ports', () => {
+    const r = render(); const p = source(); p.state!.txAntenna = undefined; r.publish(p); flushSync();
+    const callbacks = r.pair(); callbacks[0](3); callbacks[1](); expect(r.onSelectPort).not.toHaveBeenCalled();
+    callbacks[0](2); expect(r.onSelectPort).toHaveBeenCalledExactlyOnceWith(2); expect(r.onToggleRxAnt).not.toHaveBeenCalled();
+    expect(target.querySelector('[data-reading]')?.getAttribute('data-reading')).toBe('unknown');
+  });
+  it('revokes both leases on session/provider/topology/structural A-B-A and invalid recovery', () => {
+    const r = render();
+    const variants = [
+      (p: Publication) => ({ ...p, session: { ...p.session, epoch: 2 } }),
+      (p: Publication) => ({ ...p, state: { ...p.state!, providerGeneration: 2 }, caps: { ...p.caps!, providerGeneration: 2 } }),
+      (p: Publication) => ({ ...p, caps: { ...p.caps!, vfoScheme: 'ab' as const } }),
+      (p: Publication) => ({ ...p, caps: { ...p.caps!, antennas: 1 } }),
+      (p: Publication) => ({ ...p, caps: { ...p.caps!, capabilities: ['tx', 'tuner'] } }),
+      (p: Publication) => ({ ...p, session: { ...p.session, state: 'disconnected' as const } }),
+      (p: Publication) => ({ ...p, state: null }), (p: Publication) => ({ ...p, caps: null }),
+      (p: Publication) => ({ ...p, caps: { ...p.caps!, providerGeneration: 3 } }),
+    ];
+    for (const change of variants) {
+      const old = r.pair(); r.publish(change(source())); r.publish(source()); invoke(old);
+      expect(r.onSelectPort).not.toHaveBeenCalled(); expect(r.onToggleRxAnt).not.toHaveBeenCalled();
+      flushSync(); invoke(r.pair()); expect(r.onSelectPort).toHaveBeenCalledOnce(); expect(r.onToggleRxAnt).toHaveBeenCalledOnce();
+      r.onSelectPort.mockClear(); r.onToggleRxAnt.mockClear();
+    }
+  });
+  it('retains radio-wide leases when activeReceiver changes', () => {
+    const r = render(); const old = r.pair(); const p = source(); p.state!.active = 'SUB';
+    r.publish(p); invoke(old); expect(r.onSelectPort).toHaveBeenCalledOnce(); expect(r.onToggleRxAnt).toHaveBeenCalledOnce();
+  });
+  it('revokes appearance A-B-A, null body and unmounted callbacks; releases seats/subscription', async () => {
+    const r = render(); const old = r.pair(); r.props.finiteAppearance = undefined; flushSync();
+    const native = ['port-2', 'rx-toggle'].map(id => target.querySelector(`[data-testid="antenna-${id}"]`)!);
+    r.props.finiteAppearance = appearance; flushSync(); invoke(old);
+    native.forEach(node => {
+      target.appendChild(node); node.dispatchEvent(new MouseEvent('click', { bubbles: true })); node.remove();
+    });
+    expect(r.onSelectPort).not.toHaveBeenCalled(); expect(r.onToggleRxAnt).not.toHaveBeenCalled();
+    const removed = r.pair(); r.props.body = false; flushSync(); r.props.body = true; flushSync(); invoke(removed);
+    expect(r.onSelectPort).not.toHaveBeenCalled(); invoke(r.pair()); expect(r.onSelectPort).toHaveBeenCalledOnce();
+    const last = r.pair(); await unmount(component!); component = undefined;
+    expect(r.stop).toHaveBeenCalledOnce(); expect(seats.destroy).toHaveLength(2);
+    seats.destroy.forEach(destroy => expect(destroy).toHaveBeenCalledOnce());
+    r.publish(source()); invoke(last); expect(r.onSelectPort).toHaveBeenCalledOnce(); expect(r.onToggleRxAnt).toHaveBeenCalledOnce();
+    expect(target.querySelector('button')).toBeNull();
+  });
+});

--- a/frontend/src/semantic/__tests__/AntennaSurface.test.ts
+++ b/frontend/src/semantic/__tests__/AntennaSurface.test.ts
@@ -23,9 +23,10 @@
 import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
-import AntennaSurface, {
+import {
   ANTENNA_BLOCKED_LABEL, ANTENNA_PORTS, UNKNOWN_TEXT, antennaSwitchBlocks, tunerIdle,
 } from '../AntennaSurface.svelte';
+import AntennaSurface from './fixtures/AntennaInstrumentHostFixture.svelte';
 import { topologyFixtures, withAntenna, withTxAux } from '../fixtures/topologies';
 import { keyBlockedReasons, type TxAuthoritySnapshot } from '../rx-tx-surface';
 import type {
@@ -33,6 +34,7 @@ import type {
 } from '../radio-view-model';
 
 const SOURCE = readFileSync('src/semantic/AntennaSurface.svelte', 'utf8');
+const HOST = readFileSync('src/semantic/AntennaInstrumentHost.svelte', 'utf8');
 /** Comments stripped, so the file's own doctrine prose can never be what a
  *  source-scanning test matches. */
 const CODE = SOURCE
@@ -130,7 +132,7 @@ describe('the antenna surface owns no state and no TX authority (R9)', () => {
     expect([...new Set(specifiers)].sort())
       .toEqual([
         '../primitives/control-instruments/control-instrument-behavior',
-        './pressed-of', './radio-view-model', './rx-tx-surface',
+        './AntennaInstrumentHost.svelte', './pressed-of', './radio-view-model', './rx-tx-surface',
       ]);
     expect(CODE).toContain('bindAbsoluteChoiceInstrument');
     expect(CODE).toContain('bindToggleInstrument');
@@ -162,7 +164,7 @@ describe('the antenna surface owns no state and no TX authority (R9)', () => {
   it('takes exactly two state props — the view model and the TX snapshot', () => {
     const props = CODE.slice(CODE.indexOf('interface Props'), CODE.indexOf('}: Props'));
     expect([...props.matchAll(/^\s{4}(\w+)[?]?:/gm)].map((m) => m[1]))
-      .toEqual(['view', 'tx', 'onSelectPort', 'onToggleRxAnt']);
+      .toEqual(['view', 'tx', 'onSelectPort', 'onToggleRxAnt', 'handles', 'layout']);
   });
 });
 
@@ -346,7 +348,7 @@ describe('antenna switching is gated while the transmitter is not provably idle'
 
   // Kills: a local re-derivation of TX truth drifting from the shared one.
   it('shares the transmitter-busy vocabulary with the key gate', () => {
-    expect(CODE).toContain('keyBlockedReasons');
+    expect(HOST).toContain('keyBlockedReasons');
     expect(antennaSwitchBlocks(base(), TRANSMITTING)).toContain('radio-transmitting');
     expect(antennaSwitchBlocks(base(), { ...RECEIVING, phase: 'key-confirm-pending' }))
       .toContain('tx-busy');
@@ -401,7 +403,7 @@ describe('ATU readiness comes from txAux.atu and fails closed (CF1, CF2)', () =>
   // quietly preferring it.
   it('reads no tuner fact from the antenna group, which carries none', () => {
     expect(Object.keys(base().antenna!).sort()).toEqual(['antennaCount', 'rxAnt', 'txAntenna']);
-    expect(CODE).toContain('view.txAux?.atu');
+    expect(HOST).toContain('view.txAux?.atu');
     expect(CODE).not.toMatch(/antenna[^\n]*\.(atu|tuner)/);
   });
 

--- a/frontend/src/semantic/__tests__/AntennaSurface.test.ts
+++ b/frontend/src/semantic/__tests__/AntennaSurface.test.ts
@@ -117,25 +117,17 @@ function forceClick(node: HTMLElement): void {
 describe('the antenna surface owns no state and no TX authority (R9)', () => {
   // Kills: importing the runtime, the command bus, transport or the capability
   // store — the layering the semantic vertical exists to remove.
-  // `./pressed-of` (MOR-1358, migrated onto this surface by MOR-1383) is
-  // allow-listed alongside the fact contract and the RX/TX vocabulary: it is
-  // a pure, dependency-free `aria-pressed` derivation shared with sibling
-  // surfaces, itself importing only a TYPE from `./radio-view-model` — it
-  // cannot reach the TX controller, the transport or the permit utility any
-  // more than the fact contract can. This check regexes THIS file's
-  // specifiers only, so that premise is pinned one level down by
-  // `pressed-of.test.ts`'s `'has no runtime import'` case (verify-MOR-1358
-  // F1) — the two together are the closure.
-  it('imports only facts, shared TX vocabulary and control behavior', () => {
+  // MOR-2425 — the control-behavior and `./pressed-of` imports are gone with
+  // the surface's own port/RX-ANT markup: both controls now arrive as the
+  // host's two rendered handles, so this file imports nothing but the fact
+  // contract, the RX/TX vocabulary and the host module it consumes.
+  it('imports only facts, shared TX vocabulary and the host module', () => {
     const specifiers = [...CODE.matchAll(/from\s+'([^']+)'/g)].map((m) => m[1]);
     expect(specifiers.length).toBeGreaterThan(0);
     expect([...new Set(specifiers)].sort())
-      .toEqual([
-        '../primitives/control-instruments/control-instrument-behavior',
-        './AntennaInstrumentHost.svelte', './pressed-of', './radio-view-model', './rx-tx-surface',
-      ]);
-    expect(CODE).toContain('bindAbsoluteChoiceInstrument');
-    expect(CODE).toContain('bindToggleInstrument');
+      .toEqual(['./AntennaInstrumentHost.svelte', './radio-view-model', './rx-tx-surface']);
+    expect(CODE).toContain('handles.txPort()');
+    expect(CODE).toContain('handles.rxAnt()');
   });
 
   // Kills: a lifecycle hook, an effect, or a dynamic import that could reach a
@@ -164,7 +156,7 @@ describe('the antenna surface owns no state and no TX authority (R9)', () => {
   it('takes exactly two state props — the view model and the TX snapshot', () => {
     const props = CODE.slice(CODE.indexOf('interface Props'), CODE.indexOf('}: Props'));
     expect([...props.matchAll(/^\s{4}(\w+)[?]?:/gm)].map((m) => m[1]))
-      .toEqual(['view', 'tx', 'onSelectPort', 'onToggleRxAnt', 'handles', 'layout']);
+      .toEqual(['view', 'tx', 'handles', 'layout']);
   });
 });
 

--- a/frontend/src/semantic/__tests__/fixtures/AntennaInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/AntennaInstrumentHostFixture.svelte
@@ -2,7 +2,9 @@
   import type { ComponentProps } from 'svelte';
   import type { Capabilities } from '$lib/types/capabilities';
   import type { ServerState } from '$lib/types/state';
-  import AntennaInstrumentHost, { type AntennaAuthorityPublication } from '../../AntennaInstrumentHost.svelte';
+  import AntennaInstrumentHost, {
+    ANTENNA_BLOCKED_LABEL, type AntennaAuthorityPublication,
+  } from '../../AntennaInstrumentHost.svelte';
   import AntennaSurface from '../../AntennaSurface.svelte';
   import type { RadioViewModel } from '../../radio-view-model';
   let { view, tx, onSelectPort = () => {}, onToggleRxAnt = () => {},
@@ -48,7 +50,10 @@
     {#if body}
       {#if arrangement === 'grouped'}<AntennaSurface {view} {tx} {handles} {layout} />
       {:else}<div data-testid="independent-tx">{@render handles.txPort()}</div>
-        <aside data-testid="independent-rx">{@render handles.rxAnt()}</aside>{/if}
+        <aside data-testid="independent-rx">{@render handles.rxAnt()}</aside>
+        <ul data-testid="independent-blocked" id={layout.blockedId}>
+          {#each layout.blocked as code (code)}<li data-reason={code}>{ANTENNA_BLOCKED_LABEL[code]}</li>{/each}
+        </ul>{/if}
     {/if}
   {/snippet}
 </AntennaInstrumentHost>

--- a/frontend/src/semantic/__tests__/fixtures/AntennaInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/AntennaInstrumentHostFixture.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import type { ComponentProps } from 'svelte';
+  import type { Capabilities } from '$lib/types/capabilities';
+  import type { ServerState } from '$lib/types/state';
+  import AntennaInstrumentHost, { type AntennaAuthorityPublication } from '../../AntennaInstrumentHost.svelte';
+  import AntennaSurface from '../../AntennaSurface.svelte';
+  import type { RadioViewModel } from '../../radio-view-model';
+  let { view, tx, onSelectPort = () => {}, onToggleRxAnt = () => {},
+    subscribeControlAuthority, readTx, finiteAppearance, arrangement = 'grouped', body = true,
+    capture = () => {},
+  }: Omit<ComponentProps<typeof AntennaInstrumentHost>, 'children' | 'subscribeControlAuthority' | 'readTx'> & {
+    view: RadioViewModel;
+    subscribeControlAuthority?: ComponentProps<typeof AntennaInstrumentHost>['subscribeControlAuthority'];
+    readTx?: ComponentProps<typeof AntennaInstrumentHost>['readTx'];
+    arrangement?: 'grouped' | 'independent'; body?: boolean;
+    capture?: (handles: import('../../AntennaInstrumentHost.svelte').AntennaInstrumentHandles) => void;
+  } = $props();
+  function subscribe(handler: (value: AntennaAuthorityPublication) => void) {
+    if (subscribeControlAuthority) return subscribeControlAuthority(handler);
+    const ant = view.antenna;
+    const fields = { txAntenna: ant?.txAntenna, rxAntenna1: ant?.rxAnt,
+      rxAntenna2: ant?.rxAnt, tunerStatus: view.txAux?.atu };
+    const state = Object.fromEntries(Object.entries(fields).map(([key, field]) => [key,
+      field?.reading.status === 'known' ? (key === 'tunerStatus'
+        ? { off: 0, on: 1, tuning: 2 }[field.reading.value as 'off'] : field.reading.value) : null]));
+    handler({ session: { state: 'connected', epoch: 1 },
+      state: { ...state, providerGeneration: 1, active: 'MAIN',
+        fieldStatus: Object.fromEntries(Object.entries(fields).map(([key, field]) => [key, {
+          observed: field?.reading.status === 'known', freshness: 'fresh',
+          availability: field?.availability.operational ? 'available' : 'unavailable',
+        }])) } as unknown as ServerState,
+      caps: { model: 'fixture', providerGeneration: 1, receivers: 1, vfoScheme: 'single',
+        scope: false, audio: false, tx: true, freqRanges: [], modes: [], filters: [], txBands: null,
+        audioConfig: { sampleRate: 48000, channels: 1, codecs: [] },
+        webrtc: { available: false, enabled: false },
+        antennas: ant?.antennaCount ?? 1, capabilities: ['tx',
+          ...(ant?.rxAnt.availability.structural ? ['rx_antenna'] : []),
+          ...(view.txAux?.atu.availability.structural ? ['tuner'] : [])],
+      } as Capabilities });
+    return () => {};
+  }
+</script>
+
+<AntennaInstrumentHost {view} {tx} {onSelectPort} {onToggleRxAnt} {finiteAppearance}
+  subscribeControlAuthority={subscribe} readTx={readTx ?? (() => tx)}>
+  {#snippet children(handles, layout)}
+    {@const captured = capture(handles)}
+    {#if body}
+      {#if arrangement === 'grouped'}<AntennaSurface {view} {tx} {handles} {layout} />
+      {:else}<div data-testid="independent-tx">{@render handles.txPort()}</div>
+        <aside data-testid="independent-rx">{@render handles.rxAnt()}</aside>{/if}
+    {/if}
+  {/snippet}
+</AntennaInstrumentHost>


### PR DESCRIPTION
18 code + 0 regenerated baselines = 18 files

This is one unit of work at 18 files: the persistent antenna host join (host, surface, composition type, layout, surfaces wiring, hosted fixture) plus the witnesses the acceptance rows require, plus the collateral that one more mounted authority subscriber forces on nine existing tests (subscriber-count assertions and the desktop-migration `antenna-surface` sites). No subset of these files is independently green.

## Summary

Hosts the antenna instruments persistently in `SemanticRadioSurfaces` and lets each face arrange them: Standard (`desktop-v2`) places `txPort` and `rxAnt` independently with the blocked-reason list, SDR keeps the grouped `AntennaSurface` in the same zone. Linear owner: MOR-2425 (Antenna A1 lane).

- `AntennaInstrumentHost` (from the private packet) is mounted once inside the provider chain, receives the existing authority subscription, the App-owned managed TX controller read at invocation (`readTx`), `ANTENNA_PORT_INTENT` and `antennaIntents.onToggleRxAnt`, and exposes two handles (`txPort`, `rxAnt`) plus a layout (`blockedId`, `blocked`). No new store, policy, command layer or renderer primitive: the host reuses the finite renderer seats, the authority subscriber and the shipped `makeAntennaHandlers`.
- `AntennaSurface` loses its fallback branch, its surface-local owners and the retired callback props; `handles`/`layout` are required. `valueOf` (read only by the deleted fallback) is deleted.
- `InstrumentComposition` gains `antennaInstruments` and `antennaLayout`; `antenna` carries an optional control layout, the same shape `txAuxControls`/`txAuxScalars` already use. `RadioLayout` adds an `antennaControlLayout` snippet on the `bandControlLayout` pattern, used by `desktop-v2` only.
- One more mounted authority consumer moves the absolute subscriber-count assertions in six wiring tests from 5 to 6 and in `semantic-pbt-continuity` from 6 to 7; five `desktop-v2` assertion sites in `semantic-desktop-migration` now target `antenna-control-grid`. The SDR-face and dual-cockpit sites are unchanged.

## Witnesses (semantic-antenna-wiring.component.test.ts, real adapter, real `makeAntennaHandlers`, `sendCommand` transport spy)

- W1 `refuses both controls invoked after a TX change but before the flush`.
- W2 `refuses both controls after a same-session ATU {tuning|never observed|stale} publication, before the flush` (three adapter paths, identity held fixed).
- W3 `emits under host admission and still refuses at the shipped handler alone`: ANT 2 emits; after mutating and publishing a state where only ANT 2's RX-override stops being a known boolean, the host still admits (empty reason list, port enabled), ANT 2 is refused by the handler's destination-evidence guard, and the RX-ANT toggle emits from the same publication.
- W4 `arranges the seats independently on Standard, grouped on SDR, and back`: exact seat counts, `aria-describedby` resolution, constant subscriber count, and a `blockedId` minted once per host instance surviving both replacements.
- Retained: the isolated A-B-A / null-body / receiver-independence cases, the surface's zone/legacy/dual canon rows (28 declarations unchanged), and the wiring `afterEach` teardown.

Mutations (each applied, run, reverted from a byte copy; final tree verified):

| Mutation | Result |
|---|---|
| `readTx()` at invocation → the `tx` prop | kills the two isolated before-flush rows (`retains same-source facts and refuses TX/ATU before flush`, external=false/true); **does not kill W1**. The invocation-time read is witnessed by those two fixture-level rows and not by the live witness: the `tx` prop is a reactive derived that is stale before a flush, while the direct controller read is fresh, so the two differ only before a flush |
| memoise `currentInput()` on `published` only | kills W1 plus the existing positive-receiving case and both isolated rows |
| retained publication updated only on identity change | kills all three W2 rows plus four isolated cases; **does not kill W3's admission side** |
| remove the handler's `rxAntenna2` destination-evidence guard | kills exactly W3 |
| `desktop-v2` renders the grouped surface | kills exactly W4 (arrangement half); the persistence half rests on the stable `blockedId` and constant subscriber count, not on a mutation |

## Size

Census vs `main` (4191b431): 744 additions, 234 deletions = 978 A+D across 18 files, from `git diff origin/main --shortstat` at head 64d741571d3fe8724e6af5ef2c85ead3d2a8cf2c. Zero PNG baselines in the file list. File-count exception (18 files) granted by the coordinating session under the owner's 2026-09-03 delegation; the eighteenth file is a subscriber-count collateral test the forecast missed. The planning stop at 950 was passed with witnesses and collateral only; the 1000 A+D ceiling holds.

## Verification

Focused checks at head 64d741571d3fe8724e6af5ef2c85ead3d2a8cf2c (the PR's natural `quick`/`visual` runs are the suite authority):
- Vitest focused matrix (every test naming RadioLayout / instrument-composition / HostedRadioLayoutFixture / SemanticRadioSurfaces plus the antenna, collateral, desktop-migration and tab-traversal files): 82 files / 2294 tests passed, 0 failed
- Collateral files before the edits: 7 failed files / 14 failed tests; after: 7 passed / 404 passed
- `npm run check`: 4823 files, 0 errors, 0 warnings
- ESLint over the 18 changed paths: passed
- `git diff --check`: passed
- internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

