### PR TITLE
feat(MOR-2425): host the RIT/XIT and scan instruments persistently

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
+++ b/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
@@ -15,6 +15,7 @@
   import type {
     AntennaInstrumentHandles, AntennaInstrumentLayout,
   } from '../../../../semantic/AntennaInstrumentHost.svelte';
+  import type { RitXitScanInstrumentHandles } from '../../../../semantic/RitXitScanInstrumentHost.svelte';
 
   const empty = createRawSnippet(() => ({ render: () => '' }));
   const vfo = createRawSnippet<[
@@ -41,6 +42,9 @@
   const antennaLayout = {
     blockedId: 'fixture-antenna-blocked', blocked: [],
   } satisfies AntennaInstrumentLayout;
+  const ritXitInstruments = {
+    rit: empty, xit: empty, clear: empty,
+  } satisfies RitXitScanInstrumentHandles;
   const frequency = createRawSnippet<[mount?: ReceiverFrequencyMount]>(() => ({ render: () => '' }));
   const meter = createRawSnippet<[renderer?: ReceiverSMeterRenderer]>(() => ({ render: () => '' }));
   const operations = createRawSnippet<[appearance: ReceiverVfoAppearance]>(() => ({ render: () => '' }));
@@ -73,7 +77,7 @@
     rxAudioInstruments, rfFrontEndInstruments,
     meters: empty, rxAudio: empty, rfFrontEnd: empty, filter: empty, dsp: empty,
     band, antenna, antennaInstruments, antennaLayout,
-    ritXitScan: empty, cwKeyerInstruments, cwKeyer,
+    ritXitScan: empty, ritXitInstruments, cwKeyerInstruments, cwKeyer,
     scopeDisplay: empty, scopeControls: empty, txFaultRecovery: empty,
     modInputTxWarning: empty, managedScope: undefined,
   } satisfies FixtureInstrumentComposition;

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -91,6 +91,7 @@
   } from '../../semantic/RfFrontEndSurface.svelte';
   import RfFrontEndInstrumentHost from '../../semantic/RfFrontEndInstrumentHost.svelte';
   import RitXitScanSurface from '../../semantic/RitXitScanSurface.svelte';
+  import RitXitScanInstrumentHost from '../../semantic/RitXitScanInstrumentHost.svelte';
   import RxAudioSurface from '../../semantic/RxAudioSurface.svelte';
   import RxAudioInstrumentHost from '../../semantic/RxAudioInstrumentHost.svelte';
   import RxTxSurface from '../../semantic/RxTxSurface.svelte';
@@ -634,6 +635,12 @@
     topologyId: string;
     activeReceiver: 'MAIN' | 'SUB' | 'unknown';
   }>;
+  type RitXitFiniteAuthority = Readonly<{
+    sessionEpoch: number;
+    providerGeneration: number;
+    topologyId: string;
+    activeReceiver: 'MAIN' | 'SUB' | 'unknown';
+  }>;
   type VfoFiniteAuthority = Readonly<{
     sessionEpoch: number;
     providerGeneration: number;
@@ -764,6 +771,26 @@
         ? model.activeReceiver.receiver : 'unknown',
     });
   }
+  function ritXitFiniteAuthority(
+    state: typeof runtime.state,
+    caps: typeof runtime.caps,
+    session: typeof runtime.controlSession,
+  ): RitXitFiniteAuthority | null {
+    const stateGeneration = state?.providerGeneration;
+    const capsGeneration = caps?.providerGeneration;
+    if (session.state !== 'connected' || !Number.isSafeInteger(session.epoch) || session.epoch < 0
+      || !Number.isSafeInteger(stateGeneration) || stateGeneration! < 0
+      || stateGeneration !== capsGeneration) return null;
+    const model = toRadioViewModel(state, caps);
+    if (model?.ritXit === undefined) return null;
+    return Object.freeze({
+      sessionEpoch: session.epoch,
+      providerGeneration: stateGeneration as number,
+      topologyId: model.topologyId,
+      activeReceiver: model.activeReceiver.status === 'known'
+        ? model.activeReceiver.receiver : 'unknown',
+    });
+  }
   const sameScopeFiniteAuthority = (
     left: ScopeFiniteAuthority | null | undefined,
     right: ScopeFiniteAuthority | null,
@@ -824,6 +851,16 @@
         && left.topologyId === right.topologyId
         && left.activeReceiver === right.activeReceiver
   );
+  const sameRitXitFiniteAuthority = (
+    left: RitXitFiniteAuthority | null | undefined,
+    right: RitXitFiniteAuthority | null,
+  ): boolean => left !== undefined && (
+    left === null || right === null ? left === right
+      : left.sessionEpoch === right.sessionEpoch
+        && left.providerGeneration === right.providerGeneration
+        && left.topologyId === right.topologyId
+        && left.activeReceiver === right.activeReceiver
+  );
   const readSelectedFiniteAppearance = 'getSelectedFiniteControlAppearance' in componentKitActivation
     ? componentKitActivation.getSelectedFiniteControlAppearance : undefined;
   const selectedFiniteAppearance = readSelectedFiniteAppearance?.();
@@ -833,12 +870,14 @@
   let vfoFiniteRendererContext = $state.raw<FiniteRendererContext | null>(null);
   let filterFiniteRendererContext = $state.raw<FiniteRendererContext | null>(null);
   let bandFiniteRendererContext = $state.raw<FiniteRendererContext | null>(null);
+  let ritXitFiniteRendererContext = $state.raw<FiniteRendererContext | null>(null);
   let lastScopeFiniteAuthority: ScopeFiniteAuthority | null | undefined;
   let lastTxAuxFiniteAuthority: TxAuxFiniteAuthority | null | undefined;
   let lastDspFiniteAuthority: DspFiniteAuthority | null | undefined;
   let lastVfoFiniteAuthority: VfoFiniteAuthority | null | undefined;
   let lastFilterFiniteAuthority: FilterFiniteAuthority | null | undefined;
   let lastBandFiniteAuthority: BandFiniteAuthority | null | undefined;
+  let lastRitXitFiniteAuthority: RitXitFiniteAuthority | null | undefined;
   const unsubscribeScopeFiniteAuthority = runtime.subscribeControlAuthority((publication) => {
       const next = scopeFiniteAuthority(publication.state, publication.caps, publication.session);
       if (!sameScopeFiniteAuthority(lastScopeFiniteAuthority, next)) {
@@ -880,6 +919,13 @@
         lastBandFiniteAuthority = nextBand;
         bandFiniteRendererContext = nextBand === null ? null : createFiniteRendererContext();
       }
+      const nextRitXit = ritXitFiniteAuthority(
+        publication.state, publication.caps, publication.session,
+      );
+      if (!sameRitXitFiniteAuthority(lastRitXitFiniteAuthority, nextRitXit)) {
+        lastRitXitFiniteAuthority = nextRitXit;
+        ritXitFiniteRendererContext = nextRitXit === null ? null : createFiniteRendererContext();
+      }
     });
   onDestroy(() => unsubscribeScopeFiniteAuthority?.());
   let scopeFiniteRendererSelection = $derived(selectedFiniteAppearance === undefined
@@ -907,6 +953,10 @@
   let bandFiniteRendererSelection = $derived(selectedFiniteAppearance === undefined
     ? {} : {
       finiteAppearance: selectedFiniteAppearance, rendererContext: bandFiniteRendererContext,
+    });
+  let ritXitFiniteRendererSelection = $derived(selectedFiniteAppearance === undefined
+    ? {} : {
+      finiteAppearance: selectedFiniteAppearance, rendererContext: ritXitFiniteRendererContext,
     });
 
   let scopeFrameSource = $derived(
@@ -1394,6 +1444,13 @@
     onAgcModeChange={agcIntents.onAgcModeChange}
   >
   {#snippet children(dspInstruments)}
+  <RitXitScanInstrumentHost
+    {...ritXitFiniteRendererSelection} {view}
+    onRitToggle={ritXitIntents.onRitToggle}
+    onXitToggle={ritXitIntents.onXitToggle}
+    onClear={ritXitIntents.onClear}
+  >
+  {#snippet children(ritXitInstruments)}
   {#if readonlyDisplay}
     {#if view}{@render readonlyDisplay(view, selectedDisplayFrame)}{/if}
   {:else}
@@ -1890,11 +1947,9 @@
     {#if view?.ritXit || view?.scan}
       <RitXitScanSurface
         {view} {ritDomain}
-        onRitToggle={ritXitIntents.onRitToggle}
-        onXitToggle={ritXitIntents.onXitToggle}
+        handles={ritXitInstruments}
         onRitOffsetChange={ritXitIntents.onRitOffsetChange}
         onXitOffsetChange={ritXitIntents.onXitOffsetChange}
-        onClear={ritXitIntents.onClear}
         onScanStart={(type) => scanIntents.onScanStart(type)}
         onScanStop={scanIntents.onScanStop}
         onResumeModeChange={(mode) => scanIntents.onResumeChange(mode)}
@@ -2121,6 +2176,7 @@
       antennaInstruments,
       antennaLayout,
       ritXitScan: hostedRitXitScan,
+      ritXitInstruments,
       cwKeyerInstruments,
       cwKeyer: hostedCwKeyer,
       scopeDisplay: hostedScopeDisplay,
@@ -2305,6 +2361,8 @@
   {/snippet}
   </TxAuxScalarHost>
   {/if}
+  {/snippet}
+  </RitXitScanInstrumentHost>
   {/snippet}
   </DspInstrumentHost>
   {/snippet}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
@@ -43,8 +43,13 @@ const h = vi.hoisted(() => ({
   audio: { muted: true, rxEnabled: false, volume: 0 },
   audioConnected: false,
   guardVisible: false,
+  selectedFiniteAppearance: undefined as unknown,
 }));
 
+vi.mock('../../../component-kits/activation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../component-kits/activation')>();
+  return { ...actual, getSelectedFiniteControlAppearance: () => h.selectedFiniteAppearance };
+});
 vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
 vi.mock('$lib/runtime/commands/radio-intents', async () => {
   const { sendCommand } = await import('$lib/transport/ws-client');
@@ -95,6 +100,10 @@ import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
 import { setCapabilities } from '$lib/stores/capabilities.svelte';
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
+import type { FiniteControlAppearance } from '../../../primitives/control-instruments/control-instrument-renderer.svelte';
+import FiniteControlRendererFixture, {
+  resetRetainedInvocations, retainedInvocations,
+} from '../../../primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte';
 
 const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
 const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
@@ -176,6 +185,16 @@ function useState(state: ServerState): void {
   setRadioState(state);
 }
 
+/** Re-publishes control authority to every currently-mounted subscriber —
+ *  used only by the finite-appearance A-B-A witness below; the initial
+ *  publication on subscribe (above) covers every other test in this file. */
+function publishAuthority(state: unknown, caps: unknown): void {
+  for (const handler of h.authoritySubscribers) handler({
+    state, caps, session: { state: 'connected', epoch: 1 },
+    rxAudioTarget: Object.freeze({ muted: h.audio.muted, rxEnabled: h.audio.rxEnabled }),
+  });
+}
+
 beforeEach(() => {
   txHarness = new ManagedAppTxHarness();
   h.txController = txHarness.controller;
@@ -186,6 +205,8 @@ beforeEach(() => {
   h.audio = { muted: true, rxEnabled: false, volume: 0 };
   h.audioConnected = false;
   h.guardVisible = false;
+  h.selectedFiniteAppearance = undefined;
+  resetRetainedInvocations();
   vi.mocked(sendCommand).mockClear();
 });
 
@@ -403,6 +424,72 @@ describe('the surface intents reach the shipped command vocabulary', () => {
     el('scan-resume-cycle')!.click();
     flushSync();
     expect(sendCommand).toHaveBeenCalledExactlyOnceWith('scan_set_resume', { mode: 0xD2 });
+  });
+});
+
+/* ── MOR-2425: RIT/XIT/CLEAR now live in `RitXitScanInstrumentHost`, joined
+ * into `SemanticRadioSurfaces`'s provider chain. These witnesses prove the
+ * two refusal shapes the host itself defines (`control-instrument-behavior`'s
+ * `canInvoke`: an unknown reading and a `blocked` field both refuse
+ * invocation) survive being wired through the real command bus, and that a
+ * finite-appearance renderer swap keeps the composed tree's owner identity
+ * discipline `semantic-dsp-wiring.component.test.ts`'s own A-B-A describe
+ * already proves for that sibling host. ────────────────────────────────── */
+
+describe('MOR-2425: the host refuses the same two shapes it defines, end to end', () => {
+  it('an unread RIT/XIT reading disables both toggles and reaches no command', () => {
+    useState(liveState({ ritOn: undefined, ritTx: undefined } as Partial<ServerState>));
+    render();
+    const rit = el('ritxit-rit-toggle') as HTMLButtonElement;
+    const xit = el('ritxit-xit-toggle') as HTMLButtonElement;
+    expect(rit.disabled).toBe(true);
+    expect(xit.disabled).toBe(true);
+    rit.click();
+    xit.click();
+    flushSync();
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('an unknown active receiver blocks RIT, XIT and CLEAR alike and reaches no command', () => {
+    useState(liveState({ active: undefined } as Partial<ServerState>));
+    render();
+    const rit = el('ritxit-rit-toggle') as HTMLButtonElement;
+    const xit = el('ritxit-xit-toggle') as HTMLButtonElement;
+    const clear = el('ritxit-clear') as HTMLButtonElement;
+    expect(rit.disabled).toBe(true);
+    expect(xit.disabled).toBe(true);
+    expect(clear.disabled).toBe(true);
+    rit.click();
+    xit.click();
+    clear.click();
+    flushSync();
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+});
+
+describe('MOR-2425: persistent finite RIT/XIT authority', () => {
+  const finiteAppearance = {
+    action: FiniteControlRendererFixture as FiniteControlAppearance<string | number>['action'],
+    toggle: FiniteControlRendererFixture as FiniteControlAppearance<string | number>['toggle'],
+    choice: FiniteControlRendererFixture as FiniteControlAppearance<string | number>['choice'],
+  } satisfies FiniteControlAppearance<string | number>;
+
+  it('synchronously fences RIT across an active-receiver A-B-A and admits only the current seat', () => {
+    h.selectedFiniteAppearance = finiteAppearance;
+    render();
+    const state = h.state as ServerState;
+    const caps = h.caps as Capabilities;
+    const retainedA1 = retainedInvocations.get('RIT')!;
+    publishAuthority({ ...state, active: 'SUB' } as ServerState, caps);
+    publishAuthority(state, caps);
+    retainedA1();
+    expect(sendCommand).not.toHaveBeenCalled();
+
+    flushSync();
+    const retainedA2 = retainedInvocations.get('RIT')!;
+    expect(retainedA2).not.toBe(retainedA1);
+    retainedA2();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_rit_status', { on: false });
   });
 });
 

--- a/frontend/src/components-v2/wiring/instrument-composition.ts
+++ b/frontend/src/components-v2/wiring/instrument-composition.ts
@@ -13,6 +13,7 @@ import type { CwKeyerInstrumentHandles } from '../../semantic/CwKeyerInstrumentH
 import type {
   AntennaInstrumentHandles, AntennaInstrumentLayout,
 } from '../../semantic/AntennaInstrumentHost.svelte';
+import type { RitXitScanInstrumentHandles } from '../../semantic/RitXitScanInstrumentHost.svelte';
 
 export type InstrumentVfoAppearance = 'semantic' | 'sdr' | 'standard';
 
@@ -40,6 +41,7 @@ export interface InstrumentComposition {
   readonly antennaInstruments: AntennaInstrumentHandles;
   readonly antennaLayout: AntennaInstrumentLayout;
   readonly ritXitScan: Snippet<[allowBare?: boolean]>;
+  readonly ritXitInstruments: RitXitScanInstrumentHandles;
   readonly cwKeyerInstruments: CwKeyerInstrumentHandles;
   readonly cwKeyer: Snippet<[allowBare?: boolean, showKeyerSpeed?: boolean]>;
   readonly scopeDisplay: Snippet<[allowBare?: boolean]>;

--- a/frontend/src/semantic/RitXitScanInstrumentHost.svelte
+++ b/frontend/src/semantic/RitXitScanInstrumentHost.svelte
@@ -1,0 +1,111 @@
+<script module lang="ts">
+  import type { Snippet } from 'svelte';
+
+  export interface RitXitScanInstrumentHandles {
+    readonly rit: Snippet;
+    readonly xit: Snippet;
+    readonly clear: Snippet;
+  }
+
+  export type RitXitScanInstrumentLayout = Snippet<[
+    handles: RitXitScanInstrumentHandles,
+    offsetSlot: Snippet,
+  ]>;
+</script>
+
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { bindActionInstrument, bindToggleInstrument } from '../primitives/control-instruments/control-instrument-behavior';
+  import ControlInstrumentRendererHost from '../primitives/control-instruments/ControlInstrumentRendererHost.svelte';
+  import {
+    createActionRendererSeat, createToggleRendererSeat,
+    type FiniteControlAppearance, type FiniteRendererContext,
+  } from '../primitives/control-instruments/control-instrument-renderer.svelte';
+  import type { RadioViewModel } from './radio-view-model';
+
+  interface ExistingProps {
+    view: RadioViewModel | null;
+    onRitToggle?: () => void;
+    onXitToggle?: () => void;
+    onClear?: () => void;
+    children: Snippet<[RitXitScanInstrumentHandles]>;
+  }
+  type RendererSelection = { finiteAppearance?: undefined; rendererContext?: undefined } | {
+    finiteAppearance: FiniteControlAppearance<string | number>;
+    rendererContext: FiniteRendererContext | null;
+  };
+  type Props = ExistingProps & RendererSelection;
+
+  let {
+    view, onRitToggle, onXitToggle, onClear,
+    finiteAppearance, rendererContext, children,
+  }: Props = $props();
+
+  let ritXit = $derived(view?.ritXit);
+  let activeKnown = $derived(view?.activeReceiver.status === 'known');
+  const groupAvailability = { structural: true, operational: true } as const;
+  const ritToggle = bindToggleInstrument(() => ({
+    field: ritXit?.ritActive, blocked: !activeKnown, invoke: () => onRitToggle?.(),
+  }));
+  const xitToggle = bindToggleInstrument(() => ({
+    field: ritXit?.xitActive, blocked: !activeKnown, invoke: () => onXitToggle?.(),
+  }));
+  const clearAction = bindActionInstrument(() => ({
+    availability: ritXit ? groupAvailability : undefined,
+    blocked: !activeKnown, invoke: () => onClear?.(),
+  }));
+
+  const ritSeat = createToggleRendererSeat(() => ({
+    context: rendererContext ?? null, field: ritXit?.ritActive, blocked: !activeKnown,
+    label: 'RIT', invoke: () => onRitToggle?.(),
+  }));
+  const xitSeat = createToggleRendererSeat(() => ({
+    context: rendererContext ?? null, field: ritXit?.xitActive, blocked: !activeKnown,
+    label: 'XIT', invoke: () => onXitToggle?.(),
+  }));
+  const clearSeat = createActionRendererSeat<boolean>(() => ({
+    context: rendererContext ?? null,
+    availability: ritXit ? groupAvailability : undefined,
+    blocked: !activeKnown, label: 'CLEAR', invoke: () => onClear?.(),
+  }));
+  onDestroy(() => { ritSeat.destroy(); xitSeat.destroy(); clearSeat.destroy(); });
+</script>
+
+{#snippet toggle(kind: 'rit' | 'xit')}
+  {@const field = kind === 'rit' ? ritXit?.ritActive : ritXit?.xitActive}
+  {@const behavior = kind === 'rit' ? ritToggle : xitToggle}
+  {@const seat = kind === 'rit' ? ritSeat : xitSeat}
+  {@const label = kind === 'rit' ? 'RIT' : 'XIT'}
+  {#if field?.availability.structural}
+    {#if finiteAppearance}
+      {#key rendererContext}{#key finiteAppearance.toggle}<ControlInstrumentRendererHost
+        {seat} renderer={finiteAppearance.toggle}
+      />{/key}{/key}
+    {:else}
+      <button type="button" data-testid={`ritxit-${kind}-toggle`}
+        aria-pressed={behavior.confirmed} disabled={!behavior.available}
+        onclick={() => behavior.invoke()}>{label}</button>
+    {/if}
+  {/if}
+{/snippet}
+{#snippet rit()}{@render toggle('rit')}{/snippet}
+{#snippet xit()}{@render toggle('xit')}{/snippet}
+{#snippet clear()}
+  {#if ritXit}
+    {#if finiteAppearance}
+      {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
+        seat={clearSeat} renderer={finiteAppearance.action}
+      />{/key}{/key}
+    {:else}
+      <button type="button" data-testid="ritxit-clear" disabled={!clearAction.available}
+        onclick={() => clearAction.invoke()}>CLEAR</button>
+    {/if}
+  {/if}
+{/snippet}
+
+{@render children({ rit, xit, clear })}
+
+<style>
+  button[aria-pressed='true'] { font-weight: 700; }
+  button:disabled { cursor: not-allowed; }
+</style>

--- a/frontend/src/semantic/RitXitScanSurface.svelte
+++ b/frontend/src/semantic/RitXitScanSurface.svelte
@@ -78,27 +78,26 @@
   import { decodeControlDomain, encodeControlDomain } from '$lib/radio/control-domain';
   import { exactDecimalNumber } from '$lib/types/exact-decimal';
   import type { ControlDomain } from '$lib/types/capabilities';
-  import {
-    bindActionInstrument,
-    bindToggleInstrument,
-  } from '../primitives/control-instruments/control-instrument-behavior';
+  import { bindActionInstrument, bindToggleInstrument } from '../primitives/control-instruments/control-instrument-behavior';
+  import type {
+    RitXitScanInstrumentHandles, RitXitScanInstrumentLayout,
+  } from './RitXitScanInstrumentHost.svelte';
   import type { RadioViewModel } from './radio-view-model';
 
   interface Props {
     view: RadioViewModel;
-    onRitToggle?: () => void;
-    onXitToggle?: () => void;
     onRitOffsetChange?: (hz: number) => void;
     onXitOffsetChange?: (hz: number) => void;
-    onClear?: () => void;
     onScanStart?: (type: number) => void;
     onScanStop?: () => void;
     onResumeModeChange?: (mode: number) => void;
     ritDomain?: ControlDomain | null;
+    handles: RitXitScanInstrumentHandles;
+    instrumentLayout?: RitXitScanInstrumentLayout;
   }
   let {
-    view, onRitToggle, onXitToggle, onRitOffsetChange, onXitOffsetChange, onClear,
-    onScanStart, onScanStop, onResumeModeChange, ritDomain,
+    view, onRitOffsetChange, onXitOffsetChange,
+    onScanStart, onScanStop, onResumeModeChange, ritDomain, handles, instrumentLayout,
   }: Props = $props();
 
   let rx = $derived(view.ritXit);
@@ -131,20 +130,6 @@
    *  gate: it is honest about what it is from the moment it exists. */
   let selectedType = $state(DEFAULT_SCAN_TYPE);
 
-  const ritToggle = bindToggleInstrument(() => ({
-    field: rx?.ritActive,
-    blocked: !activeKnown,
-    // The handler owns its zero-argument inversion; the binding's next value
-    // is intentionally not forwarded.
-    invoke: () => onRitToggle?.(),
-  }));
-  const xitToggle = bindToggleInstrument(() => ({
-    field: rx?.xitActive,
-    blocked: !activeKnown,
-    // The handler owns its zero-argument inversion; the binding's next value
-    // is intentionally not forwarded.
-    invoke: () => onXitToggle?.(),
-  }));
   const scanToggle = bindToggleInstrument(() => ({
     field: sc?.scanning,
     invoke: (next) => {
@@ -184,46 +169,38 @@
     event.preventDefault();
     changeOffset(next);
   }
-  // CLEAR is correctly LEFT UNGATED on field observation (F2 fix round):
-  // `onClear` writes `freq: 0` absolutely, not a read-modify-write of the
-  // current offset, so it is honest even while the offset is unobserved —
-  // unlike the toggles, it never reads a guessed value to decide what to
-  // send. Still gated on `activeKnown` (S3b — no receiver to attribute it to).
-  function clear(): void { if (activeKnown) onClear?.(); }
 </script>
+
+{#snippet offsetSlot()}
+  <label class="offset" data-testid="ritxit-offset"
+    data-observed={offset !== undefined && usable(offset)}>
+    <span>Offset</span>
+    <input
+      type="range"
+      min={ritDomain?.raw_min ?? OFFSET_MIN}
+      max={ritDomain?.raw_max ?? OFFSET_MAX}
+      step={ritDomain?.raw_step ?? OFFSET_STEP}
+      value={decodedOffset?.value ?? ritDomain?.raw_origin ?? 0}
+      disabled={!canAdjustOffset}
+      onkeydown={offsetKeydown}
+      oninput={(event) => changeOffset(event.currentTarget.valueAsNumber)}
+    />
+    <output data-testid="ritxit-offset-value">{decodedOffset?.text ?? UNKNOWN_TEXT}</output>
+  </label>
+{/snippet}
 
 {#if rx || sc}
   <section class="ritxit-scan-surface" data-testid="ritxit-scan-surface" aria-label="RIT, XIT and scan">
     {#if rx}
       <div class="row" data-testid="ritxit" data-active-vfo-known={activeKnown}>
-        {#if rx.ritActive.availability.structural}
-          <button
-            type="button" data-testid="ritxit-rit-toggle" aria-pressed={pressedOf(rx.ritActive)}
-            disabled={!ritToggle.available} onclick={() => ritToggle.invoke()}
-          >RIT</button>
+        {#if instrumentLayout}
+          {@render instrumentLayout(handles, offsetSlot)}
+        {:else}
+          {@render handles.rit()}
+          {@render handles.xit()}
+          {@render offsetSlot()}
+          {@render handles.clear()}
         {/if}
-        {#if rx.xitActive.availability.structural}
-          <button
-            type="button" data-testid="ritxit-xit-toggle" aria-pressed={pressedOf(rx.xitActive)}
-            disabled={!xitToggle.available} onclick={() => xitToggle.invoke()}
-          >XIT</button>
-        {/if}
-        <label class="offset" data-testid="ritxit-offset"
-          data-observed={offset !== undefined && usable(offset)}>
-          <span>Offset</span>
-          <input
-            type="range"
-            min={ritDomain?.raw_min ?? OFFSET_MIN}
-            max={ritDomain?.raw_max ?? OFFSET_MAX}
-            step={ritDomain?.raw_step ?? OFFSET_STEP}
-            value={decodedOffset?.value ?? ritDomain?.raw_origin ?? 0}
-            disabled={!canAdjustOffset}
-            onkeydown={offsetKeydown}
-            oninput={(event) => changeOffset(event.currentTarget.valueAsNumber)}
-          />
-          <output data-testid="ritxit-offset-value">{decodedOffset?.text ?? UNKNOWN_TEXT}</output>
-        </label>
-        <button type="button" data-testid="ritxit-clear" disabled={!activeKnown} onclick={clear}>CLEAR</button>
       </div>
     {/if}
 

--- a/frontend/src/semantic/__tests__/RitXitScanInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/RitXitScanInstrumentHost.isolated.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
+import type { FiniteControlAppearance } from '../../primitives/control-instruments/control-instrument-renderer.svelte';
+import { createFiniteRendererContext } from '../../primitives/control-instruments/control-instrument-renderer.svelte';
+import FiniteControlRendererFixture, {
+  resetRetainedInvocations, retainedInvocations,
+} from '../../primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte';
+import type { RadioViewModel, RitXitViewModel } from '../radio-view-model';
+import { topologyFixtures, withRitXit, withScan } from '../fixtures/topologies';
+import RitXitScanInstrumentHostFixture from './fixtures/RitXitScanInstrumentHostFixture.svelte';
+
+const base = (): RadioViewModel => withScan(withRitXit(topologyFixtures['1/single']));
+const appearance = {
+  action: FiniteControlRendererFixture as FiniteControlAppearance<string | number>['action'],
+  toggle: FiniteControlRendererFixture as FiniteControlAppearance<string | number>['toggle'],
+  choice: FiniteControlRendererFixture as FiniteControlAppearance<string | number>['choice'],
+} satisfies FiniteControlAppearance<string | number>;
+
+let target: HTMLDivElement;
+beforeEach(() => {
+  target = document.createElement('div'); document.body.appendChild(target); resetRetainedInvocations();
+});
+afterEach(() => target.remove());
+
+function withRx(view: RadioViewModel, over: Partial<RitXitViewModel>): RadioViewModel {
+  return { ...view, ritXit: { ...view.ritXit!, ...over } };
+}
+
+describe('RitXitScanInstrumentHost finite ownership', () => {
+  it('keeps native RIT, XIT, offset and CLEAR in order across both arrangements', () => {
+    const onRitToggle = vi.fn(), onXitToggle = vi.fn(), onClear = vi.fn();
+    const props = proxy({ view: base(), presentation: 'grouped' as 'grouped' | 'independent',
+      onRitToggle, onXitToggle, onClear });
+    const component = mount(RitXitScanInstrumentHostFixture, { target, props }); flushSync();
+    const order = () => [...target.querySelectorAll('[data-testid="ritxit"] button, [data-testid="ritxit"] label')]
+      .map(element => element.getAttribute('data-testid'));
+    expect(order()).toEqual(['ritxit-rit-toggle', 'ritxit-xit-toggle', 'ritxit-offset', 'ritxit-clear']);
+    (target.querySelector('[data-testid="ritxit-rit-toggle"]') as HTMLButtonElement).click();
+    (target.querySelector('[data-testid="ritxit-xit-toggle"]') as HTMLButtonElement).click();
+    (target.querySelector('[data-testid="ritxit-clear"]') as HTMLButtonElement).click();
+    expect(onRitToggle).toHaveBeenCalledExactlyOnceWith();
+    expect(onXitToggle).toHaveBeenCalledExactlyOnceWith();
+    expect(onClear).toHaveBeenCalledExactlyOnceWith();
+    props.presentation = 'independent'; flushSync();
+    expect(order()).toEqual(['ritxit-rit-toggle', 'ritxit-xit-toggle', 'ritxit-offset', 'ritxit-clear']);
+    for (const slot of ['rit', 'xit', 'offset', 'clear']) {
+      expect(target.querySelectorAll(`[data-slot="${slot}"]`)).toHaveLength(1);
+    }
+    unmount(component);
+  });
+
+  it('keeps external truth, availability and current callbacks honest', () => {
+    const firstRit = vi.fn(), nextRit = vi.fn(), onClear = vi.fn();
+    const props = proxy({ view: base(), finiteAppearance: appearance,
+      rendererContext: createFiniteRendererContext(), onRitToggle: firstRit, onClear });
+    const component = mount(RitXitScanInstrumentHostFixture, { target, props }); flushSync();
+    expect(target.querySelector('[data-testid="external-RIT"]')?.getAttribute('aria-pressed')).toBe('true');
+    expect(target.querySelector('[data-testid="external-XIT"]')?.getAttribute('aria-pressed')).toBe('false');
+    props.view = withRx(props.view, {
+      ritActive: { ...props.view.ritXit!.ritActive, reading: { status: 'unknown' } },
+      xitActive: { ...props.view.ritXit!.xitActive, reading: { status: 'unknown' } },
+    });
+    props.onRitToggle = nextRit; flushSync();
+    expect(target.querySelector('[data-testid="external-RIT"]')?.hasAttribute('aria-pressed')).toBe(false);
+    expect((target.querySelector('[data-testid="external-RIT"]') as HTMLButtonElement).disabled).toBe(true);
+    (target.querySelector('[data-testid="external-CLEAR"]') as HTMLButtonElement).click();
+    retainedInvocations.get('RIT')?.();
+    expect(firstRit).not.toHaveBeenCalled(); expect(nextRit).not.toHaveBeenCalled();
+    expect(onClear).toHaveBeenCalledExactlyOnceWith();
+    props.view = withRx(props.view, {
+      ritActive: { ...props.view.ritXit!.ritActive, reading: { status: 'known', value: false } },
+    }); flushSync();
+    retainedInvocations.get('RIT')?.();
+    expect(firstRit).not.toHaveBeenCalled(); expect(nextRit).toHaveBeenCalledExactlyOnceWith();
+    props.view = { ...props.view, activeReceiver: { status: 'unknown' } }; flushSync();
+    expect((target.querySelector('[data-testid="external-CLEAR"]') as HTMLButtonElement).disabled).toBe(true);
+    retainedInvocations.get('CLEAR')?.(); expect(onClear).toHaveBeenCalledTimes(1);
+    unmount(component);
+  });
+
+  it('revokes detached, A-B-A and host-teardown renderer callbacks', () => {
+    const onRitToggle = vi.fn(), onClear = vi.fn();
+    const a = createFiniteRendererContext(), b = createFiniteRendererContext();
+    const props = proxy({ view: base(), presentation: 'grouped' as 'grouped' | 'independent',
+      finiteAppearance: appearance, rendererContext: null as typeof a | null, onRitToggle, onClear });
+    const component = mount(RitXitScanInstrumentHostFixture, { target, props }); flushSync();
+    expect(target.querySelector('[data-testid="external-RIT"]')).toBeNull();
+    props.rendererContext = a; flushSync();
+    const groupedA = retainedInvocations.get('RIT')!;
+    props.presentation = 'independent'; flushSync(); const independentA = retainedInvocations.get('RIT')!;
+    groupedA(); expect(onRitToggle).not.toHaveBeenCalled();
+    independentA(); expect(onRitToggle).toHaveBeenCalledTimes(1);
+    props.rendererContext = b; flushSync(); const activeB = retainedInvocations.get('RIT')!;
+    independentA(); expect(onRitToggle).toHaveBeenCalledTimes(1);
+    props.rendererContext = a; flushSync(); const activeA2 = retainedInvocations.get('RIT')!;
+    activeB(); expect(onRitToggle).toHaveBeenCalledTimes(1);
+    const clearA2 = retainedInvocations.get('CLEAR')!;
+    unmount(component); activeA2(); clearA2();
+    expect(onRitToggle).toHaveBeenCalledTimes(1); expect(onClear).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
@@ -18,7 +18,8 @@
 import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
-import RitXitScanSurface, { OFFSET_MAX, OFFSET_MIN, OFFSET_STEP, UNKNOWN_TEXT } from '../RitXitScanSurface.svelte';
+import { OFFSET_MAX, OFFSET_MIN, OFFSET_STEP, UNKNOWN_TEXT } from '../RitXitScanSurface.svelte';
+import RitXitScanInstrumentHostFixture from './fixtures/RitXitScanInstrumentHostFixture.svelte';
 import { topologyFixtures, withRitXit, withScan } from '../fixtures/topologies';
 import type {
   Availability, RadioViewModel, RitXitField, RitXitViewModel, ScanField, ScanViewModel,
@@ -26,6 +27,7 @@ import type {
 
 const ON: Availability = { structural: true, operational: true };
 const SOURCE = readFileSync('src/semantic/RitXitScanSurface.svelte', 'utf8');
+const HOST_SOURCE = readFileSync('src/semantic/RitXitScanInstrumentHost.svelte', 'utf8');
 
 const base = (): RadioViewModel => withScan(withRitXit(topologyFixtures['1/single']));
 const withRx = (over: Partial<RitXitViewModel>): RadioViewModel => {
@@ -55,10 +57,12 @@ type Handlers = {
   onScanStart?: (type: number) => void;
   onScanStop?: () => void;
   onResumeModeChange?: (mode: number) => void;
+  presentation?: 'grouped' | 'independent';
+  ritDomain?: import('$lib/types/capabilities').ControlDomain | null;
 };
 
 function render(view: RadioViewModel, handlers: Handlers = {}) {
-  const component = mount(RitXitScanSurface, { target, props: { view, ...handlers } });
+  const component = mount(RitXitScanInstrumentHostFixture, { target, props: { view, ...handlers } });
   flushSync();
   const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
   return {
@@ -76,15 +80,27 @@ const bypassClick = (el: HTMLElement) => el.dispatchEvent(new MouseEvent('click'
 describe('current-input action bindings', () => {
   it('uses toggles for RIT, XIT and scan, plus an action for the resume cycle', () => {
     expect(SOURCE).toContain('bindToggleInstrument');
-    expect(SOURCE).toContain('const ritToggle = bindToggleInstrument');
-    expect(SOURCE).toContain('const xitToggle = bindToggleInstrument');
+    expect(HOST_SOURCE).toContain('const ritToggle = bindToggleInstrument');
+    expect(HOST_SOURCE).toContain('const xitToggle = bindToggleInstrument');
     expect(SOURCE).toContain('const scanToggle = bindToggleInstrument');
     expect(SOURCE).toContain('const resumeCycle = bindActionInstrument');
   });
 
   it('keeps RIT and XIT callbacks as zero-argument intents', () => {
-    expect(SOURCE).toContain('invoke: () => onRitToggle?.()');
-    expect(SOURCE).toContain('invoke: () => onXitToggle?.()');
+    expect(HOST_SOURCE).toContain('invoke: () => onRitToggle?.()');
+    expect(HOST_SOURCE).toContain('invoke: () => onXitToggle?.()');
+  });
+});
+
+describe('hosted finite placement', () => {
+  it.each(['grouped', 'independent'] as const)('preserves RIT, XIT, offset, CLEAR order in %s', (presentation) => {
+    const r = render(base(), { presentation });
+    const order = [...target.querySelectorAll('[data-testid="ritxit"] button, [data-testid="ritxit"] label')]
+      .map(element => element.getAttribute('data-testid'));
+    expect(order).toEqual(['ritxit-rit-toggle', 'ritxit-xit-toggle', 'ritxit-offset', 'ritxit-clear']);
+    expect(r.all('ritxit-offset')).toHaveLength(1);
+    expect(r.all('scan')).toHaveLength(1);
+    r.dispose();
   });
 });
 

--- a/frontend/src/semantic/__tests__/fixtures/RitXitScanInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/RitXitScanInstrumentHostFixture.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { FiniteControlAppearance, FiniteRendererContext } from '../../../primitives/control-instruments/control-instrument-renderer.svelte';
+  import RitXitScanInstrumentHost, {
+    type RitXitScanInstrumentHandles, type RitXitScanInstrumentLayout,
+  } from '../../RitXitScanInstrumentHost.svelte';
+  import RitXitScanSurface from '../../RitXitScanSurface.svelte';
+  import type { ControlDomain } from '$lib/types/capabilities';
+  import type { RadioViewModel } from '../../radio-view-model';
+
+  interface Props {
+    view: RadioViewModel;
+    presentation?: 'grouped' | 'independent';
+    finiteAppearance?: FiniteControlAppearance<string | number>;
+    rendererContext?: FiniteRendererContext | null;
+    ritDomain?: ControlDomain | null;
+    onRitToggle?: () => void;
+    onXitToggle?: () => void;
+    onRitOffsetChange?: (hz: number) => void;
+    onXitOffsetChange?: (hz: number) => void;
+    onClear?: () => void;
+    onScanStart?: (type: number) => void;
+    onScanStop?: () => void;
+    onResumeModeChange?: (mode: number) => void;
+  }
+  let {
+    view, presentation = 'grouped', finiteAppearance, rendererContext = null, ritDomain,
+    onRitToggle, onXitToggle, onRitOffsetChange, onXitOffsetChange, onClear,
+    onScanStart, onScanStop, onResumeModeChange,
+  }: Props = $props();
+  let selection = $derived(finiteAppearance === undefined ? {} : { finiteAppearance, rendererContext });
+</script>
+
+{#snippet independent(handles: RitXitScanInstrumentHandles, offsetSlot: Snippet)}
+  <div data-slot="rit">{@render handles.rit()}</div>
+  <div data-slot="xit">{@render handles.xit()}</div>
+  <div data-slot="offset">{@render offsetSlot()}</div>
+  <div data-slot="clear">{@render handles.clear()}</div>
+{/snippet}
+
+<RitXitScanInstrumentHost {view} {onRitToggle} {onXitToggle} {onClear} {...selection}>
+  {#snippet children(handles: RitXitScanInstrumentHandles)}
+    <RitXitScanSurface
+      {view} {handles}
+      instrumentLayout={presentation === 'independent' ? independent as RitXitScanInstrumentLayout : undefined}
+      {ritDomain} {onRitOffsetChange} {onXitOffsetChange}
+      {onScanStart} {onScanStop} {onResumeModeChange}
+    />
+  {/snippet}
+</RitXitScanInstrumentHost>


### PR DESCRIPTION
This is one unit of work across 9 files: the prepared RIT/XIT finite-family host and its own tests (5 files, already on this branch from the prior phase) plus the persistent join into `SemanticRadioSurfaces` and the repair the join forces on the one shared wiring test that mounts `RitXitScanSurface` (4 files) — no subset is independently green, since the prepared host's `handles` prop is required and the shared wiring test fails without the join.

## Summary

Mounts `RitXitScanInstrumentHost` in `SemanticRadioSurfaces`'s existing provider chain (innermost, inside `DspInstrumentHost`'s children), threads its `{ rit, xit, clear }` handles into `RitXitScanSurface` via a new `ritXitInstruments` field on `InstrumentComposition`, and relocates the `onRitToggle`/`onXitToggle`/`onClear` callbacks from the Surface's mount site to the Host's (the Surface keeps only `onRitOffsetChange`/`onXitOffsetChange`/scan callbacks, which stay Surface-native). No new store, policy, command layer or renderer primitive: the host reuses `createToggleRendererSeat`/`createActionRendererSeat` and imports no handler factory or command module — the three callbacks arrive as props from `SemanticRadioSurfaces`'s `ritXitIntents`, which the panel adapters source from the shipped `makeRitXitHandlers()`; the SRS-level `ritXitFiniteRendererSelection` plumbing (authority type, comparison, context state, subscription-callback branch) is the identical shape already shipped for Dsp/Filter/Band, added once more for this host.

**Placement**: kept grouped in both faces. I looked for a document ruling that Standard should arrange RIT/XIT/scan independently (the way the Antenna PR's `antennaControlLayout` ruling did for `txPort`/`rxAnt`) and found none — `presentation/layouts/declarations.ts:107` declares the `rit-xit-scan` zone as the single `ritXitScan` surface, and `InstrumentComposition.ritXitScan` carries no layout parameter (unlike `filter`/`dsp`/`band`/`antenna`, which do). I did not invent an arrangement; `RadioLayout.svelte` needed no changes because it only calls `instruments.ritXitScan(allowBare)`, never `instruments.ritXitInstruments` directly.

**Authority subscriber counts are unchanged.** `RitXitScanInstrumentHost` has zero calls to `subscribeControlAuthority` (re-verified by grep on this head, matching the phase-A finding), so the six `authoritySubscribers.size).toBe(6)` wiring-test assertions and `semantic-pbt-continuity`'s `listeners.size).toBe(7)` are untouched and still pass — confirmed by running all of them in the focused suite below, not merely by leaving their files unedited.

## Witnesses (`semantic-ritxit-scan-wiring.component.test.ts`, real adapter, real `makeRitXitHandlers`/`makeScanHandlers`, `sendCommand` transport spy)

- The 23 cases broken by the prepared host's required `handles` prop (`TypeError: Cannot read properties of undefined (reading 'rit')`) are repaired at the root cause — the join itself — not by editing the test.
- Two new refusal witnesses, mirroring the two shapes `control-instrument-behavior`'s `canInvoke` defines: an unread RIT/XIT boolean disables both toggles and reaches no command; an unknown active receiver blocks RIT, XIT and CLEAR alike and reaches no command.
- One new persistence witness: `synchronously fences RIT across an active-receiver A-B-A and admits only the current seat` — republishing authority through an alternate active receiver and back, before a flush, leaves the original retained renderer callback inert; after the flush, a new (distinct) retained callback dispatches the real command. Mirrors the shape `semantic-dsp-wiring.component.test.ts`'s own `persistent finite DSP composition and authority (MOR-2425)` A-B-A describe already proves for that sibling host.
- The three positive routing tests already in this file (toggling RIT/XIT/CLEAR reach `set_rit_status`/`set_rit_tx_status`/`set_rit_frequency`) and the existing teardown `afterEach` (`authoritySubscribers.size` stays 0 for this surface's isolated mount) are unchanged and still pass.

**Mutation (mandatory, applied and reverted from a byte copy; final tree verified clean by `git diff --check` and a fresh `git status`):** replaced `handles={ritXitInstruments}` at the live mount site with a constant object of no-op snippets, simulating the host being bypassed. Result: exactly the 6 tests that depend on the live host→handles wiring failed (the 3 pre-existing positive routing tests, both new refusal tests, and the new A-B-A test); the other 24 tests in the file were unaffected. Restored before the final suite run below.

## Census

vs `origin/main` (`e3bcf0d78`): `git diff origin/main --shortstat` → 9 files changed, 474 insertions(+), 66 deletions(-) = 540 A+D. Zero PNG baselines. Under the 10-file hard ceiling and the 1000 A+D ceiling; no exception needed. (5 of the 9 files — the host, its isolated test and fixture, and the Surface's own required-`handles` change — were already on this branch from the prior phase's cherry-pick; this PR's own commit is 4 files, 155 insertions, 4 deletions.)

## Verification

At head `7368b3f9d1830d54dfdfecc32b64794748da465e`:
- Focused vitest matrix (every test naming `RitXitScan` / `SemanticRadioSurfaces` / `instrument-composition` / `HostedRadioLayoutFixture`, grep-union of 67 files): 67 files / 1974 tests passed, 0 failed
- `npm run check` (svelte-check + tsc×2): 4826 files, 0 errors, 0 warnings
- ESLint over the 9 changed paths: clean, no output
- `git diff --check origin/main HEAD`: clean

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
