### PR TITLE
feat(MOR-2425): host the raw NB scalar instruments persistently

### DIFF
--- a/frontend/fixtures/stubs/panel-adapters.ts
+++ b/frontend/fixtures/stubs/panel-adapters.ts
@@ -81,15 +81,7 @@ export function getTxAuxControlFeedback(field: keyof typeof txAuxControls) {
   });
 }
 
-const dspScalarControls = Object.freeze({
-  nbLevel: 'nb-level',
-  nbWidth: 'nb-width',
-  nrLevel: 'nr-level',
-  nbDepth: 'nb-depth',
-  notchFilter: 'notch-position',
-  manualNotchWidth: 'manual-notch-width',
-  agcTimeConstant: 'agc-time',
-} as const);
+const dspScalarControls = Object.freeze({ nbLevel: 'nb-level', nbWidth: 'nb-width' } as const);
 
 /** MOR-2425 — offline fixtures never fabricate radio-global DSP command-feedback authority. */
 export function getDspControlFeedback(field: keyof typeof dspScalarControls) {

--- a/frontend/fixtures/stubs/panel-adapters.ts
+++ b/frontend/fixtures/stubs/panel-adapters.ts
@@ -81,6 +81,27 @@ export function getTxAuxControlFeedback(field: keyof typeof txAuxControls) {
   });
 }
 
+const dspScalarControls = Object.freeze({
+  nbLevel: 'nb-level',
+  nbWidth: 'nb-width',
+  nrLevel: 'nr-level',
+  nbDepth: 'nb-depth',
+  notchFilter: 'notch-position',
+  manualNotchWidth: 'manual-notch-width',
+  agcTimeConstant: 'agc-time',
+} as const);
+
+/** MOR-2425 — offline fixtures never fabricate radio-global DSP command-feedback authority. */
+export function getDspControlFeedback(field: keyof typeof dspScalarControls) {
+  return Object.freeze({
+    confirmed: null, target: null, requestedTarget: null,
+    phase: 'unavailable' as const, busy: false, availability: 'unavailable' as const,
+    outcome: null, lifecycleId: null, transitionId: null, sessionEpoch: 1,
+    scope: Object.freeze({ control: dspScalarControls[field], receiver: 0 as const }),
+    repeatPolicy: 'latest-target-wins' as const,
+  });
+}
+
 /** The offline fixture has no qualified RF/SQL command-feedback authority. */
 export function getRfSqlControlFeedback(_controlSession: unknown): null {
   return null;

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -31,6 +31,7 @@
   import VfoHeader from './VfoHeader.svelte';
   import type { InstrumentComposition } from '../wiring/instrument-composition';
   import type { DspFiniteHandles } from '../../semantic/dsp-instruments';
+  import type { DspScalarHandles } from '../../semantic/dsp-scalars';
   import type { FilterInstrumentHandles } from '../../semantic/filter-instruments';
   import type { BandInstrumentHandles } from '../../semantic/band-instruments';
   import { ANTENNA_BLOCKED_LABEL } from '../../semantic/AntennaInstrumentHost.svelte';
@@ -326,6 +327,13 @@
   </div>
 {/snippet}
 
+{#snippet dspScalarLayout(dspScalars: DspScalarHandles)}
+  <div class="dsp-scalar-grid">
+    <div class="dsp-scalar-seat" data-field="nbLevel">{@render dspScalars.nbLevel()}</div>
+    <div class="dsp-scalar-seat" data-field="nbWidth">{@render dspScalars.nbWidth()}</div>
+  </div>
+{/snippet}
+
 {#snippet filterFiniteLayout(filterInstruments: FilterInstrumentHandles)}
   <div class="filter-finite-grid" data-testid="filter-finite-grid">
     <div class="filter-finite-seat" data-field="mode">{@render filterInstruments.mode()}</div>
@@ -446,7 +454,7 @@
         {@render instruments.modInputTxWarning()}
         {@render instruments.rxAudio()}
         {#if skinId === 'desktop-v2'}
-          {@render instruments.dsp(undefined, dspFiniteLayout)}
+          {@render instruments.dsp(undefined, dspFiniteLayout, dspScalarLayout)}
         {:else}
           {@render instruments.dsp()}
         {/if}
@@ -734,6 +742,12 @@
   .desktop-control-face :global([data-zone-id='meters']) { grid-area: 5 / 1 / 6 / -1; }
   .tx-aux-finite-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
   .dsp-finite-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+  .dsp-scalar-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 4px 8px;
+  }
+  .dsp-scalar-seat { min-width: 0; }
   .filter-finite-grid { display: flex; flex-direction: column; gap: 0.5rem; }
   .filter-finite-seat { display: contents; }
   .filter-finite-grid .filter-finite-seat[data-field='mode'] :global(.filter-choice-group) {

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -47,7 +47,8 @@
   } from '../../semantic/pbt-presentation-continuity';
   import { getManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
   import {
-    bindSemanticSurfaceHandlers, getBreakInDelayControlFeedback, getFilterWidthControlFeedback,
+    bindSemanticSurfaceHandlers, getBreakInDelayControlFeedback, getDspControlFeedback,
+    getFilterWidthControlFeedback,
     getCwPitchControlFeedback, getKeySpeedControlFeedback, getRfSqlControlFeedback,
     getTxAuxControlFeedback, type TxAuxControlFeedbackField,
     getPendingFrequencyHz,
@@ -70,6 +71,8 @@
   } from '../../semantic/DspSurface.svelte';
   import DspInstrumentHost from '../../semantic/DspInstrumentHost.svelte';
   import type { DspFiniteHandles, DspFiniteLayout } from '../../semantic/dsp-instruments';
+  import DspScalarHost from '../../semantic/DspScalarHost.svelte';
+  import type { DspScalarLayout } from '../../semantic/dsp-scalars';
   import FilterSurface from '../../semantic/FilterSurface.svelte';
   import FilterInstrumentHost from '../../semantic/FilterInstrumentHost.svelte';
   import type { FilterFiniteLayout } from '../../semantic/filter-instruments';
@@ -1214,6 +1217,15 @@
   let filterWidthFeedback = $derived(getFilterWidthControlFeedback());
   let cwPitchFeedback = $derived(getCwPitchControlFeedback(controlSession));
   let keySpeedFeedback = $derived(getKeySpeedControlFeedback(controlSession));
+  /**
+   * MOR-2425. RAW command feedback for the two NB scalars — no projector:
+   * `nbLevel`/`nbWidth` are wire-raw, unlike `nrLevel`/`nbDepth`, which
+   * `DspSurface` still renders natively from the adapter's display-scaled
+   * projection (carry-forward 3).
+   */
+  let dspScalarFeedback = $derived({
+    nbLevel: getDspControlFeedback('nbLevel'), nbWidth: getDspControlFeedback('nbWidth'),
+  });
   let txAuxLevelFeedback = $derived.by<TxAuxLevelFeedback>(() => Object.fromEntries(
     TX_AUX_FEEDBACK_LEVELS.map(field => [
       field, getTxAuxControlFeedback(TX_AUX_FEEDBACK_FIELD[field], controlSession),
@@ -1444,6 +1456,13 @@
     onAgcModeChange={agcIntents.onAgcModeChange}
   >
   {#snippet children(dspInstruments)}
+  <DspScalarHost
+    {view} feedback={dspScalarFeedback} {nbLevelMax} {nbLevelPercent}
+    onLevelChange={(field, value) => DSP_LEVEL_INTENT[field](value)}
+    scalarAppearance={externalPresentation?.record.appearances.scalar}
+    presentationIsCurrent={externalPresentation?.isCurrent}
+  >
+  {#snippet children(dspScalars)}
   <RitXitScanInstrumentHost
     {...ritXitFiniteRendererSelection} {view}
     onRitToggle={ritXitIntents.onRitToggle}
@@ -1845,7 +1864,7 @@
 
     Like `rxAudioSurface` and UNLIKE `txAuxSurface`/`metersSurface`, it is
     control-bearing (MOR-1304/MOR-1305 zone-mount ruling). `DspSurface`
-    renders up to 8 range inputs and 7 buttons, and `desktop-v2` declared a
+    renders focusable range and choice controls, and `desktop-v2` declared a
     `dsp` zone in MOR-1368 (S9) while the cockpit still declares none; the
     cockpit's MOR-1069 rule forbids mounting any control-bearing surface bare
     in the dual composition: every focusable control must live inside a
@@ -1858,12 +1877,15 @@
 
     `agcLabels`/`nbLevelMax`/`nbLevelPercent` are the caps-echo metadata
     carry-forward (1) requires stay OUT of the view model — read at this seam,
-    from `runtime.caps`, and handed down as plain props.
+    from `runtime.caps`, and handed to the two persistent DSP hosts as plain
+    props (`agcLabels` to the finite host, the two `nbLevel*` to the scalar
+    host), never to this surface.
   -->
-  {#snippet dspSurface(finiteLayout?: DspFiniteLayout)}
+  {#snippet dspSurface(finiteLayout?: DspFiniteLayout, scalarLayout?: DspScalarLayout)}
     {#if view?.dsp}
       <DspSurface
-        {view} finiteHandles={dspInstruments} {finiteLayout} {nbLevelMax} {nbLevelPercent}
+        {view} finiteHandles={dspInstruments} {finiteLayout}
+        scalarHandles={dspScalars} {scalarLayout}
         onLevelChange={(field, value) => DSP_LEVEL_INTENT[field](value)}
       />
     {/if}
@@ -2109,8 +2131,9 @@
   {/snippet}
   {#snippet hostedDsp(
     allowBare = allowBareSurfaces, finiteLayout?: DspFiniteLayout,
+    scalarLayout?: DspScalarLayout,
   )}
-    {#snippet body()}{@render dspSurface(finiteLayout)}{/snippet}
+    {#snippet body()}{@render dspSurface(finiteLayout, scalarLayout)}{/snippet}
     {@render zoned('dsp', view?.dsp !== undefined, body, allowBare)}
   {/snippet}
   {#snippet hostedBand(allowBare = allowBareSurfaces, controlLayout?: BandControlLayout)}
@@ -2363,6 +2386,8 @@
   {/if}
   {/snippet}
   </RitXitScanInstrumentHost>
+  {/snippet}
+  </DspScalarHost>
   {/snippet}
   </DspInstrumentHost>
   {/snippet}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -84,6 +84,26 @@ vi.mock('$lib/runtime', () => ({
     get scope() { return { hardwareScopeConnected: false }; },
   },
 }));
+// `panel-adapters.ts` reads the runtime through `$lib/runtime/frontend-runtime`,
+// not `$lib/runtime`, so the hosted NB scalars' command feedback needs this
+// second seam stubbed too; `semantic-tx-aux-wiring.component.test.ts` stubs both.
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    get state() { return h.state; },
+    get caps() { return h.caps; },
+    get controlSession() { return h.controlSession; },
+  },
+}));
+// `beginCommand` stamps each lifecycle with the radio store's `providerGeneration`,
+// and the feedback projection discards a command whose generation does not match.
+vi.mock('$lib/stores/radio.svelte', () => ({
+  radio: { get current() { return h.state; } },
+  getRadioState: () => h.state,
+  subscribeRadioState: (listener: (state: unknown) => void) => {
+    listener(h.state);
+    return () => {};
+  },
+}));
 vi.mock('$lib/runtime/tx-controller/managed-app-host', () => ({
   getManagedAppTxController: () => h.txController,
 }));
@@ -179,6 +199,36 @@ vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
   };
 });
 
+/** MOR-2425 — the `createContinuousScalar` capture wrapper
+ *  `DspScalarHost.isolated.test.ts` establishes, lifted to the composed tree so
+ *  the persistence witness below can name the binding OBJECTS. Every scalar in
+ *  the tree passes through here; `command` separates the two DSP ones. */
+const scalars = vi.hoisted(() => ({
+  bindings: [] as Array<{ command: string | null; binding: unknown }>,
+  leases: [] as Array<{ binding: unknown; lease: unknown }>,
+}));
+vi.mock('../../../primitives/scalar/continuous-scalar.svelte', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../../../primitives/scalar/continuous-scalar.svelte')>();
+  return {
+    ...actual,
+    createContinuousScalar: (...args: Parameters<typeof actual.createContinuousScalar>) => {
+      const binding = actual.createContinuousScalar(...args);
+      const attachRenderer = binding.attachRenderer.bind(binding);
+      binding.attachRenderer = (...attachArgs) => {
+        const lease = attachRenderer(...attachArgs);
+        scalars.leases.push({ binding, lease });
+        return lease;
+      };
+      const source = args[0]();
+      scalars.bindings.push({
+        command: source.evidence === 'command-feedback' ? source.command : null, binding,
+      });
+      return binding;
+    },
+  };
+});
+
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 import HostedRadioLayoutFixture from '../../layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte';
 import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
@@ -192,9 +242,18 @@ import FiniteControlRendererFixture, {
 } from '../../../primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte';
 import type { FiniteControlAppearance } from '../../../primitives/control-instruments/control-instrument-renderer.svelte';
 import { beginCommand, resetCommandLifecycle } from '$lib/stores/commands.svelte';
+import type {
+  ContinuousScalarBinding, ContinuousScalarRendererLease, ContinuousScalarView,
+} from '../../../primitives/scalar/continuous-scalar.svelte';
 
 
-const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+/** `lastObservedMonotonic` is what `display-observation.ts: validEvidence`
+ *  requires before a field counts as evidence, and therefore what the two
+ *  hosted NB scalars need before their command feedback reports `available`. */
+const fresh = {
+  storePath: 'x', observed: true, freshness: 'fresh', availability: 'available',
+  lastObservedMonotonic: 0,
+};
 const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
 
 /** Every raw dsp field the MOR-1290 adapter reads, all observed fresh. */
@@ -301,10 +360,41 @@ function publishAuthority(
 }
 
 const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+const slider = (field: string) => q(`[data-testid="dsp-${field}"] [role="slider"]`)!;
+const arrowRight = (field: string) => slider(field)
+  .dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+
+/** The two DSP scalar bindings, in creation order, as OBJECTS. */
+const dspBindings = (): unknown[] => scalars.bindings
+  .filter(({ command }) => command === 'set_nb_level' || command === 'set_nb_width')
+  .map(({ binding }) => binding);
+const dspBinding = (command: string): ContinuousScalarBinding => {
+  const found = scalars.bindings.filter((entry) => entry.command === command);
+  expect(found).toHaveLength(1);
+  return found[0]!.binding as ContinuousScalarBinding;
+};
+const latestLease = (binding: unknown): ContinuousScalarRendererLease => {
+  for (let index = scalars.leases.length - 1; index >= 0; index -= 1) {
+    if (scalars.leases[index]!.binding === binding) {
+      return scalars.leases[index]!.lease as ContinuousScalarRendererLease;
+    }
+  }
+  throw new Error('renderer lease not captured');
+};
+/** The command-feedback evidence a persistent binding must carry across a switch. */
+const lifecycle = (binding: ContinuousScalarBinding) => {
+  const view = binding.view as Extract<ContinuousScalarView, { evidence: 'command-feedback' }>;
+  return {
+    requested: view.requested, confirmed: view.confirmed, phase: view.phase,
+    error: view.error, transitionId: view.feedback.transitionId,
+  };
+};
 
 beforeEach(() => {
   resetCommandLifecycle();
   resetRetainedInvocations();
+  scalars.bindings = [];
+  scalars.leases = [];
   txHarness = new ManagedAppTxHarness();
   h.txController = txHarness.controller;
   h.state = liveState(true);
@@ -421,17 +511,29 @@ describe('every dsp intent reaches its own command-bus handler', () => {
   });
 
   it.each([
-    ['nrLevel', 5, () => h.nrLevel], ['nbLevel', 30, () => h.nbLevel],
-    ['nbDepth', 3, () => h.nbDepth], ['nbWidth', 100, () => h.nbWidth],
+    ['nrLevel', 5, () => h.nrLevel],
+    ['nbDepth', 3, () => h.nbDepth],
     ['notchFreq', 128, () => h.notchFreq], ['manualNotchWidth', 2, () => h.manualNotchWidth],
     ['agcTimeConstant', 4, () => h.agcTime],
-  ] as const)('routes the "%s" level with its raw value', (field, value, spy) => {
+  ] as const)('routes the natively rendered "%s" level with its raw value', (field, value, spy) => {
     render();
     const input = q<HTMLInputElement>(`[data-testid="dsp-${field}"] input`)!;
     input.value = String(value);
     input.dispatchEvent(new Event('input', { bubbles: true }));
     flushSync();
     expect(spy()).toHaveBeenCalledExactlyOnceWith(value);
+  });
+
+  /** MOR-2425: `nbLevel`/`nbWidth` are no longer native ranges — they are
+   *  `DspScalarHost` handles, stepped from their confirmed raw value
+   *  (`DSP_STATE`: 64 and 2) through the shared continuous-scalar lease. */
+  it.each([
+    ['nbLevel', 65, () => h.nbLevel], ['nbWidth', 3, () => h.nbWidth],
+  ] as const)('routes the hosted "%s" scalar with its raw value', (field, next, spy) => {
+    render();
+    arrowRight(field);
+    flushSync();
+    expect(spy()).toHaveBeenCalledExactlyOnceWith(next);
   });
 
   it('routes notchMode as its own three-way callback, not the level/toggle map', () => {
@@ -504,15 +606,13 @@ describe('carry-forward (1): caps-echo display metadata is read at this seam', (
   it('passes agcLabels/nbLevelMax/nbLevelPercent from runtime.caps down as props', () => {
     render();
     expect(q('[data-testid="dsp-agcMode-1"]')!.textContent).toBe('FAST');
-    const input = q<HTMLInputElement>('[data-testid="dsp-nbLevel"] input')!;
-    expect(input.max).toBe('200');
+    expect(slider('nbLevel').getAttribute('aria-valuemax')).toBe('200');
   });
 
   it('falls back to the toDspProps defaults when caps carries no nb_level range', () => {
     h.caps = { ...liveCaps(true), controls: undefined } as unknown as Capabilities;
     render();
-    const input = q<HTMLInputElement>('[data-testid="dsp-nbLevel"] input')!;
-    expect(input.max).toBe('10');
+    expect(slider('nbLevel').getAttribute('aria-valuemax')).toBe('10');
   });
 
   it('does not fabricate FAST/MID/SLOW labels when caps declares no agcLabels (MOR-1547 follow-up)', () => {
@@ -541,7 +641,20 @@ describe('desktop-v2 declares a real dsp zone; the cockpit does not (MOR-1368, S
 
 describe('persistent finite DSP composition and authority (MOR-2425)', () => {
   const external = ['NR', 'NB', 'Notch mode', 'AGC mode'] as const;
-  const ranges = () => target.querySelectorAll('[data-testid="dsp-surface"] input[type="range"]');
+  /**
+   * MOR-2425: the DSP levels `DspSurface` still owns natively, in
+   * `DSP_LEVELS` order. Named rather than counted — a bare cardinality is
+   * satisfied by ANY two controls going missing, including the regression
+   * where a hosted scalar renders neither natively nor as a handle.
+   */
+  const NATIVE_RANGE_FIELDS = [
+    'nrLevel', 'nbDepth', 'notchFreq', 'manualNotchWidth', 'agcTimeConstant',
+  ];
+  const rangeFields = () => [...target.querySelectorAll<HTMLInputElement>(
+    '[data-testid="dsp-surface"] input[type="range"]',
+  )].map((input) => input.closest<HTMLElement>('[data-field]')?.dataset.field);
+  const seatFields = (selector: string) => [...target.querySelectorAll<HTMLElement>(selector)]
+    .map((seat) => seat.dataset.field);
 
   it('moves one hosted set from named Standard seats to grouped SDR without replacing its host', () => {
     h.selectedFiniteAppearance = finiteAppearance;
@@ -550,10 +663,11 @@ describe('persistent finite DSP composition and authority (MOR-2425)', () => {
     const root = q('[data-testid="semantic-radio-surfaces"]');
     const staleStandardNr = retainedInvocations.get('NR')!;
 
-    expect([...target.querySelectorAll('.dsp-finite-seat')].map(seat => seat.getAttribute('data-field')))
+    expect(seatFields('.dsp-finite-seat'))
       .toEqual(['nrActive', 'nbActive', 'notchMode', 'agcMode']);
+    expect(seatFields('.dsp-scalar-seat')).toEqual(['nbLevel', 'nbWidth']);
     for (const label of external) expect(target.querySelectorAll(`[data-testid="external-${label}"]`)).toHaveLength(1);
-    expect(ranges()).toHaveLength(7);
+    expect(rangeFields()).toEqual(NATIVE_RANGE_FIELDS);
 
     (h.state as { main: Record<string, unknown> }).main.nr = false;
     props.skinId = 'sdr-test';
@@ -561,8 +675,12 @@ describe('persistent finite DSP composition and authority (MOR-2425)', () => {
     expect(q('[data-testid="semantic-radio-surfaces"]')).toBe(root);
     expect(target.querySelectorAll('[data-testid="dsp-surface"]')).toHaveLength(1);
     expect(target.querySelectorAll('.dsp-finite-seat')).toHaveLength(0);
+    expect(target.querySelectorAll('.dsp-scalar-seat')).toHaveLength(0);
     for (const label of external) expect(target.querySelectorAll(`[data-testid="external-${label}"]`)).toHaveLength(1);
-    expect(ranges()).toHaveLength(7);
+    expect(rangeFields()).toEqual(NATIVE_RANGE_FIELDS);
+    for (const field of ['nbLevel', 'nbWidth']) {
+      expect(target.querySelectorAll(`[data-testid="dsp-${field}"]`)).toHaveLength(1);
+    }
 
     staleStandardNr();
     expect(h.nrMode).not.toHaveBeenCalled();
@@ -572,13 +690,70 @@ describe('persistent finite DSP composition and authority (MOR-2425)', () => {
     expect(h.nrMode).toHaveBeenCalledExactlyOnceWith(1);
   });
 
+  /**
+   * MOR-2425 — the witness the persistent scalar host exists for, in the
+   * order its parts must be read. A test that only drove the retained
+   * pre-switch lease and asserted `not.toHaveBeenCalled()` would be GREENER
+   * under the very defect it is meant to exclude: a host torn down and
+   * rebuilt per face loses the binding, and a destroyed binding commands
+   * nothing either. So identity comes first, then proof that the current
+   * lease still commands, then the surviving evidence — and only then the
+   * inertness claim.
+   */
+  it('keeps the nbWidth binding, its pending evidence and its live lease across Standard→SDR', () => {
+    h.selectedFiniteAppearance = finiteAppearance;
+    h.state = proxy(liveState(true) as object);
+    const props = renderHosted();
+    beginCommand({
+      id: 'pending-nb-width', name: 'set_nb_width', params: { level: 7 }, originalEpoch: 1,
+    });
+    flushSync();
+    const before = dspBindings();
+    expect(before).toHaveLength(2);
+    const nbWidth = dspBinding('set_nb_width');
+    const beforeLifecycle = lifecycle(nbWidth);
+    expect(beforeLifecycle).toMatchObject({ phase: 'submitted', requested: 7, confirmed: 2 });
+    const staleLease = latestLease(nbWidth);
+
+    props.skinId = 'sdr-test';
+    flushSync();
+    const afterLifecycle = lifecycle(nbWidth);
+
+    // (i) Identity, positively: the SAME two binding objects, not rebuilt ones.
+    const after = dspBindings();
+    expect(after).toHaveLength(2);
+    expect(after[0]).toBe(before[0]);
+    expect(after[1]).toBe(before[1]);
+
+    // (ii) Admission proven open: the CURRENT lease emits exactly one command,
+    // stepped from the CONFIRMED raw 2 (`DSP_STATE`) — the policy dispatches
+    // canonical, so the in-flight target 7 is not the interaction base.
+    expect(latestLease(nbWidth)).not.toBe(staleLease);
+    arrowRight('nbWidth');
+    flushSync();
+    expect(h.nbWidth).toHaveBeenCalledExactlyOnceWith(3);
+
+    // (iii) Evidence survival, read at the moment after the switch.
+    expect(afterLifecycle).toEqual(beforeLifecycle);
+    expect(target.querySelectorAll('[data-feedback-lane="nbWidth"]')).toHaveLength(1);
+    expect(q('[data-testid="dsp-nbWidth"]')!.dataset.feedbackReceiver).toBe('0');
+
+    // Only now: the retained Standard lease is inert, and adds no command.
+    expect(staleLease.beginPointer()).toBeNull();
+    expect(staleLease.key({ key: 'ArrowRight', fine: false })).toBe(false);
+    staleLease.nativeInput(200);
+    staleLease.wheel({ direction: 1, fine: false });
+    flushSync();
+    expect(h.nbWidth).toHaveBeenCalledOnce();
+  });
+
   it('keeps selected controls inert without authority and adds no DSP subscriber', () => {
     h.selectedFiniteAppearance = finiteAppearance;
     h.controlSession = { state: 'disconnected', epoch: 1 };
     render();
     expect(target.querySelectorAll('.dsp-toggle, .dsp-choice')).toHaveLength(0);
     for (const label of external) expect(q(`[data-testid="external-${label}"]`)).toBeNull();
-    expect(ranges()).toHaveLength(7);
+    expect(rangeFields()).toEqual(NATIVE_RANGE_FIELDS);
     // Receiver + AF + RF level + station meter + antenna hosts + the single
     // finite-renderer fan-in.
     expect(h.authoritySubscribers.size).toBe(6);

--- a/frontend/src/components-v2/wiring/instrument-composition.ts
+++ b/frontend/src/components-v2/wiring/instrument-composition.ts
@@ -6,6 +6,7 @@ import type { ReceiverInstrumentHandles } from '../../semantic/ReceiverInstrumen
 import type { RxAudioInstrumentHandles } from '../../semantic/rx-audio-instruments';
 import type { RfFrontEndLevelHandles } from '../../semantic/rf-front-end-instruments';
 import type { DspFiniteLayout } from '../../semantic/dsp-instruments';
+import type { DspScalarLayout } from '../../semantic/dsp-scalars';
 import type { VfoOperationHandles } from '../../semantic/VfoOperationSeatHost.svelte';
 import type { FilterFiniteLayout } from '../../semantic/filter-instruments';
 import type { BandControlLayout } from '../../semantic/band-instruments';
@@ -35,7 +36,9 @@ export interface InstrumentComposition {
   readonly rxAudio: Snippet<[allowBare?: boolean]>;
   readonly rfFrontEnd: Snippet<[allowBare?: boolean]>;
   readonly filter: Snippet<[allowBare?: boolean, finiteLayout?: FilterFiniteLayout]>;
-  readonly dsp: Snippet<[allowBare?: boolean, finiteLayout?: DspFiniteLayout]>;
+  readonly dsp: Snippet<[
+    allowBare?: boolean, finiteLayout?: DspFiniteLayout, scalarLayout?: DspScalarLayout,
+  ]>;
   readonly band: Snippet<[allowBare?: boolean, controlLayout?: BandControlLayout]>;
   readonly antenna: Snippet<[allowBare?: boolean, controlLayout?: Snippet]>;
   readonly antennaInstruments: AntennaInstrumentHandles;

--- a/frontend/src/semantic/DspScalarHost.svelte
+++ b/frontend/src/semantic/DspScalarHost.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+  import { onDestroy, type Snippet } from 'svelte';
+  import { ValueControl } from '../components-v2/controls/value-control';
+  import type { HBarIssuedStatusPresentation, HBarIssuedStatusSnapshot }
+    from '../components-v2/controls/value-control/skin';
+  import {
+    createContinuousScalar,
+    createRenderedNativeRangeContinuousScalarPolicy,
+    type ContinuousScalarInput,
+    type ScalarDomain,
+  } from '../primitives/scalar/continuous-scalar.svelte';
+  import { rawToPercentDisplay } from '../primitives/scalar/value-control-core';
+  import type { DspField, RadioViewModel } from './radio-view-model';
+  import { DSP_SCALAR_FIELDS, type DspScalarFeedback, type DspScalarField,
+    type DspScalarHandles, type DspScalarPresentation } from './dsp-scalars';
+
+  interface Props {
+    view: RadioViewModel | null;
+    feedback: DspScalarFeedback;
+    nbLevelMax?: number;
+    nbLevelPercent?: boolean;
+    onLevelChange?: (field: DspScalarField, value: number) => void;
+    children: Snippet<[DspScalarHandles]>;
+  }
+
+  let { view, feedback, nbLevelMax = 255, nbLevelPercent = false,
+    onLevelChange, children }: Props = $props();
+  let dsp = $derived(view?.dsp);
+
+  const LABELS = { nbLevel: 'NB level', nbWidth: 'NB width' } as const;
+  const COMMANDS = { nbLevel: 'set_nb_level', nbWidth: 'set_nb_width' } as const;
+  const feedbackIntegratedControl = { 'feedback-policy': 'feedback-integrated' } as const;
+  const safeInteger = (value: unknown): value is number =>
+    typeof value === 'number' && Number.isSafeInteger(value);
+  const usable = (field: DspField<unknown> | undefined): boolean => field !== undefined
+    && field.availability.structural && field.availability.operational
+    && field.reading.status === 'known';
+
+  function domain(field: DspScalarField): Readonly<{ domain: ScalarDomain; valid: boolean }> {
+    const max = field === 'nbLevel' ? nbLevelMax : 255;
+    const valid = safeInteger(max) && max > 0;
+    return {
+      valid,
+      domain: { min: 0, max, step: 1, defaultValue: null, fineStepDivisor: 1 },
+    };
+  }
+  function enabled(field: DspScalarField): boolean {
+    const current = domain(field);
+    return current.valid && usable(dsp?.[field]) && feedback[field].availability === 'available';
+  }
+  function input(field: DspScalarField): Readonly<ContinuousScalarInput> {
+    const current = domain(field);
+    return {
+      evidence: 'command-feedback', domain: current.domain,
+      enabled: current.valid && usable(dsp?.[field]) && feedback[field].availability === 'available',
+      request: (value) => { if (enabled(field)) onLevelChange?.(field, value); },
+      feedback: feedback[field], command: COMMANDS[field],
+    };
+  }
+
+  const nbLevelPolicy = createRenderedNativeRangeContinuousScalarPolicy();
+  const nbWidthPolicy = createRenderedNativeRangeContinuousScalarPolicy();
+  const nbLevelBinding = createContinuousScalar(() => input('nbLevel'), nbLevelPolicy);
+  const nbWidthBinding = createContinuousScalar(() => input('nbWidth'), nbWidthPolicy);
+  const bindings = { nbLevel: nbLevelBinding, nbWidth: nbWidthBinding } as const;
+
+  let issuedStatus = $state<Record<DspScalarField, string | null>>({ nbLevel: null, nbWidth: null });
+  let issuedStatusKey = $state<Record<DspScalarField, string>>({ nbLevel: '', nbWidth: '' });
+  function statusPresentation(field: DspScalarField): Readonly<HBarIssuedStatusPresentation> {
+    return {
+      get text() { return null; },
+      format({ view: scalarView, announcement }: Readonly<HBarIssuedStatusSnapshot>) {
+        issuedStatusKey[field] = JSON.stringify([
+          scalarView.feedback.providerGeneration ?? null, scalarView.feedback.sessionEpoch,
+          scalarView.feedback.scope.control, scalarView.feedback.scope.receiver,
+          scalarView.feedback.scope.slot ?? null, announcement.transitionId,
+        ]);
+        return scalarView.error === null
+          ? announcement.message
+          : `${announcement.message.replace(/[.!?]$/, '')}: ${scalarView.error}`;
+      },
+      accept(text) { issuedStatus[field] = text; },
+    };
+  }
+  const statusPresentations = {
+    nbLevel: statusPresentation('nbLevel'), nbWidth: statusPresentation('nbWidth'),
+  } as const;
+
+  function retireHBarStatus(
+    _node: HTMLElement,
+    placement: Readonly<{ field: DspScalarField; form: 'hbar' | 'knob' }>,
+  ) {
+    const retire = (next: typeof placement) => {
+      if (next.form === 'knob') issuedStatus[next.field] = null;
+    };
+    retire(placement);
+    return { update: retire };
+  }
+  function formatValue(field: DspScalarField, value: number | null): string {
+    if (value === null || !Number.isFinite(value)) return '?';
+    return field === 'nbLevel' && nbLevelPercent
+      ? rawToPercentDisplay(value, 0, nbLevelMax) : String(value);
+  }
+  function canonical(field: DspScalarField): number | null {
+    const current = feedback[field];
+    return current.availability === 'available' ? current.confirmed : null;
+  }
+  function status(field: DspScalarField): string {
+    const current = feedback[field];
+    if (current.phase === 'idle') return '';
+    const target = current.target ?? current.requestedTarget;
+    const requested = target === null ? '' : `; requested ${formatValue(field, target)}`;
+    const confirmed = `; confirmed ${formatValue(field, current.confirmed)}`;
+    const error = current.outcome?.error === undefined ? '' : `; ${current.outcome.error}`;
+    return `${LABELS[field]}: ${current.phase.replaceAll('-', ' ')}${requested}${confirmed}${error}`;
+  }
+
+  onDestroy(() => { nbLevelBinding.destroy(); nbWidthBinding.destroy(); });
+</script>
+
+{#snippet scalar(field: DspScalarField, presentation?: Readonly<DspScalarPresentation>)}
+  {#if dsp?.[field].availability.structural}
+    {@const explicit = presentation !== undefined}
+    {@const form = presentation?.form ?? 'hbar'}
+    {@const label = LABELS[field]}
+    {@const current = feedback[field]}
+    {@const currentStatus = status(field)}
+    {@const reason = enabled(field) ? undefined : 'Not yet observed'}
+    {@const accessibility = {
+      description: reason ?? null,
+      valueText: `${label}: ${formatValue(field, canonical(field))}${currentStatus === '' ? '' : `; ${currentStatus}`}`,
+    }}
+    <div class="dsp-scalar" class:dsp-scalar--presented={explicit}
+      data-testid={`dsp-${field}`} data-scalar-field={field} data-scalar-form={form}
+      data-feedback-control={current.scope.control} data-feedback-receiver={current.scope.receiver}
+      data-disabled-reason={reason === undefined ? undefined : 'field-not-observed'}
+      aria-busy={current.busy} title={reason} use:retireHBarStatus={{ field, form }}>
+      <span class="dsp-scalar-name" class:sr-only={explicit}
+        aria-hidden={explicit ? 'true' : undefined}>{label}</span>
+      <ValueControl {...feedbackIntegratedControl} binding={bindings[field]} {label} renderer={form}
+        displayFn={(value) => formatValue(field, value)}
+        showLabel={explicit ? presentation?.showLabel ?? true : false}
+        showValue={explicit ? presentation?.showValue ?? true : false}
+        compact={explicit ? presentation?.compact ?? false : true}
+        title={reason} {accessibility}
+        issuedStatusPresentation={form === 'hbar' ? statusPresentations[field] : undefined} />
+      <output data-canonical-value class:sr-only={explicit}
+        aria-hidden={explicit ? 'true' : undefined}>{formatValue(field, canonical(field))}</output>
+      {#if currentStatus !== ''}
+        <span data-command-status class:command-pending={current.busy}
+          class:sr-only={explicit || current.phase === 'unavailable'}>{currentStatus}</span>
+      {/if}
+    </div>
+  {/if}
+{/snippet}
+
+{#snippet nbLevel(presentation?: Readonly<DspScalarPresentation>)}
+  {@render scalar('nbLevel', presentation)}
+{/snippet}
+{#snippet nbWidth(presentation?: Readonly<DspScalarPresentation>)}
+  {@render scalar('nbWidth', presentation)}
+{/snippet}
+
+{@render children({ nbLevel, nbWidth })}
+
+{#each DSP_SCALAR_FIELDS as field (field)}
+  {#if issuedStatus[field] !== null}
+    {#key issuedStatusKey[field]}
+      <span class="sr-only" role="status" aria-live="polite" aria-atomic="true"
+        data-control-feedback-status data-feedback-lane={field}>{issuedStatus[field]}</span>
+    {/key}
+  {/if}
+{/each}
+
+<style>
+  .dsp-scalar { display: grid; grid-template-columns: 9ch 8rem auto; align-items: center; gap: 0.5rem; }
+  .dsp-scalar--presented { display: inline-flex; min-width: 0; max-width: 100%; }
+  .dsp-scalar-name { white-space: nowrap; }
+  .dsp-scalar :global(.vc-hbar) { width: 100%; min-width: 0; }
+  .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+</style>

--- a/frontend/src/semantic/DspScalarHost.svelte
+++ b/frontend/src/semantic/DspScalarHost.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onDestroy, type Snippet } from 'svelte';
+  import type { ScalarAppearance } from '../../component-kit-api/src/index';
   import { ValueControl } from '../components-v2/controls/value-control';
   import type { HBarIssuedStatusPresentation, HBarIssuedStatusSnapshot }
     from '../components-v2/controls/value-control/skin';
@@ -10,6 +11,7 @@
     type ScalarDomain,
   } from '../primitives/scalar/continuous-scalar.svelte';
   import { rawToPercentDisplay } from '../primitives/scalar/value-control-core';
+  import { disabledReasonText } from './disabled-reason';
   import type { DspField, RadioViewModel } from './radio-view-model';
   import { DSP_SCALAR_FIELDS, type DspScalarFeedback, type DspScalarField,
     type DspScalarHandles, type DspScalarPresentation } from './dsp-scalars';
@@ -20,11 +22,13 @@
     nbLevelMax?: number;
     nbLevelPercent?: boolean;
     onLevelChange?: (field: DspScalarField, value: number) => void;
+    scalarAppearance?: ScalarAppearance;
+    presentationIsCurrent?: () => boolean;
     children: Snippet<[DspScalarHandles]>;
   }
 
   let { view, feedback, nbLevelMax = 255, nbLevelPercent = false,
-    onLevelChange, children }: Props = $props();
+    onLevelChange, scalarAppearance, presentationIsCurrent, children }: Props = $props();
   let dsp = $derived(view?.dsp);
 
   const LABELS = { nbLevel: 'NB level', nbWidth: 'NB width' } as const;
@@ -58,14 +62,18 @@
     };
   }
 
-  const nbLevelPolicy = createRenderedNativeRangeContinuousScalarPolicy();
-  const nbWidthPolicy = createRenderedNativeRangeContinuousScalarPolicy();
-  const nbLevelBinding = createContinuousScalar(() => input('nbLevel'), nbLevelPolicy);
-  const nbWidthBinding = createContinuousScalar(() => input('nbWidth'), nbWidthPolicy);
-  const bindings = { nbLevel: nbLevelBinding, nbWidth: nbWidthBinding } as const;
+  const policies = Object.fromEntries(DSP_SCALAR_FIELDS.map((field) => [
+    field, createRenderedNativeRangeContinuousScalarPolicy(),
+  ])) as Record<DspScalarField, ReturnType<typeof createRenderedNativeRangeContinuousScalarPolicy>>;
+  const bindings = Object.fromEntries(DSP_SCALAR_FIELDS.map((field) => [
+    field, createContinuousScalar(() => input(field), policies[field]),
+  ])) as Record<DspScalarField, ReturnType<typeof createContinuousScalar>>;
 
-  let issuedStatus = $state<Record<DspScalarField, string | null>>({ nbLevel: null, nbWidth: null });
-  let issuedStatusKey = $state<Record<DspScalarField, string>>({ nbLevel: '', nbWidth: '' });
+  const record = <T,>(value: T) => Object.fromEntries(
+    DSP_SCALAR_FIELDS.map((field) => [field, value]),
+  ) as Record<DspScalarField, T>;
+  let issuedStatus = $state(record<string | null>(null));
+  let issuedStatusKey = $state(record(''));
   function statusPresentation(field: DspScalarField): Readonly<HBarIssuedStatusPresentation> {
     return {
       get text() { return null; },
@@ -82,9 +90,9 @@
       accept(text) { issuedStatus[field] = text; },
     };
   }
-  const statusPresentations = {
-    nbLevel: statusPresentation('nbLevel'), nbWidth: statusPresentation('nbWidth'),
-  } as const;
+  const statusPresentations = Object.fromEntries(DSP_SCALAR_FIELDS.map((field) => [
+    field, statusPresentation(field),
+  ])) as Record<DspScalarField, Readonly<HBarIssuedStatusPresentation>>;
 
   function retireHBarStatus(
     _node: HTMLElement,
@@ -114,8 +122,13 @@
     const error = current.outcome?.error === undefined ? '' : `; ${current.outcome.error}`;
     return `${LABELS[field]}: ${current.phase.replaceAll('-', ' ')}${requested}${confirmed}${error}`;
   }
+  function disabledReason(field: DspScalarField): string | undefined {
+    return enabled(field) ? undefined : disabledReasonText({ structural: true, operational: false });
+  }
 
-  onDestroy(() => { nbLevelBinding.destroy(); nbWidthBinding.destroy(); });
+  onDestroy(() => {
+    for (const field of DSP_SCALAR_FIELDS) bindings[field].destroy();
+  });
 </script>
 
 {#snippet scalar(field: DspScalarField, presentation?: Readonly<DspScalarPresentation>)}
@@ -125,7 +138,7 @@
     {@const label = LABELS[field]}
     {@const current = feedback[field]}
     {@const currentStatus = status(field)}
-    {@const reason = enabled(field) ? undefined : 'Not yet observed'}
+    {@const reason = disabledReason(field)}
     {@const accessibility = {
       description: reason ?? null,
       valueText: `${label}: ${formatValue(field, canonical(field))}${currentStatus === '' ? '' : `; ${currentStatus}`}`,
@@ -143,6 +156,7 @@
         showValue={explicit ? presentation?.showValue ?? true : false}
         compact={explicit ? presentation?.compact ?? false : true}
         title={reason} {accessibility}
+        skin={scalarAppearance} {presentationIsCurrent}
         issuedStatusPresentation={form === 'hbar' ? statusPresentations[field] : undefined} />
       <output data-canonical-value class:sr-only={explicit}
         aria-hidden={explicit ? 'true' : undefined}>{formatValue(field, canonical(field))}</output>

--- a/frontend/src/semantic/DspSurface.svelte
+++ b/frontend/src/semantic/DspSurface.svelte
@@ -1,10 +1,10 @@
 <!--
   Semantic DSP surface (MOR-1305, vocabulary slice 5B).
 
-  Presentation only. It renders five native continuous controls and places
-  two scalar handles plus four finite-control handles owned by the persistent
-  DSP hosts. It holds no state and consults no controller (v3 ADR invariant
-  11), the same discipline `TxAuxSurface` (MOR-1265) established.
+  Presentation only. It renders native continuous controls and
+  finite-control handles owned by the persistent DSP hosts. It holds no
+  state and consults no controller (v3 ADR invariant 11), the same
+  discipline `TxAuxSurface` (MOR-1265) established.
 
   CARRY-FORWARDS (binding, from the MOR-1290 fact-layer decisions this
   surface must not relax):
@@ -45,8 +45,7 @@
   /** `[field, label, min, max, step, format?]` — `nrLevel`/`nbDepth` are
    *  ALREADY the adapter's display-scaled values (carry-forward 3); the rest
    *  are raw wire ranges, verbatim `DspPanel.svelte`'s own slider bounds.
-   *  `nbLevel` is excluded — its ceiling is the caps-echoed `nbLevelMax` prop,
-   *  not a static bound, and is rendered separately below. */
+   *  `nbLevel` is excluded from this array. */
   export const DSP_LEVELS = [
     ['nrLevel', 'NR level', 0, 15, 1],
     ['nbDepth', 'NB depth', 1, 10, 1],
@@ -130,8 +129,6 @@
     finiteLayout?: DspFiniteLayout;
     scalarHandles?: DspScalarHandles;
     scalarLayout?: DspScalarLayout;
-    nbLevelMax?: number;
-    nbLevelPercent?: boolean;
     onLevelChange?: (field: DspLevelField, value: number) => void;
   }
   let {

--- a/frontend/src/semantic/DspSurface.svelte
+++ b/frontend/src/semantic/DspSurface.svelte
@@ -1,10 +1,10 @@
 <!--
   Semantic DSP surface (MOR-1305, vocabulary slice 5B).
 
-  Presentation only. It renders the seven continuous controls in the MOR-1290
-  `dsp` fact group and places four finite-control handles owned by
-  `DspInstrumentHost`. It holds no state and consults no controller (v3 ADR
-  invariant 11), the same discipline `TxAuxSurface` (MOR-1265) established.
+  Presentation only. It renders five native continuous controls and places
+  two scalar handles plus four finite-control handles owned by the persistent
+  DSP hosts. It holds no state and consults no controller (v3 ADR invariant
+  11), the same discipline `TxAuxSurface` (MOR-1265) established.
 
   CARRY-FORWARDS (binding, from the MOR-1290 fact-layer decisions this
   surface must not relax):
@@ -15,8 +15,8 @@
       precedent). They arrive as plain props, read directly off `caps` at the
       wiring seam (`SemanticRadioSurfaces.svelte`, which already holds
       `runtime.caps` for the view-model adapter call) — never folded into
-      `DspViewModel`. The finite host consumes `agcLabels`; this surface
-      consumes only the two scalar display props.
+      `DspViewModel`. The finite host consumes `agcLabels`; the scalar host
+      consumes the two scalar display props.
   (2) `agcTimeConstant` may be `structural: true` with no real control on a
       radio that borrows the `agc` capability tag optimistically. That is an
       accepted fact-layer optimism, not something this surface special-cases
@@ -33,14 +33,13 @@
   a present-but-unusable control stays visible and disabled rather than
   guessing a value.
 
-  PENDING AFFORDANCE (MOR-1441 leg 2) is owned by `DspInstrumentHost`.
-  `pendingNb`/`pendingNr` stay command-bus-blind display facts there and never
-  become the arithmetic base for a toggle.
+  FINITE PENDING AFFORDANCE (MOR-1441 leg 2) is owned by
+  `DspInstrumentHost`. `pendingNb`/`pendingNr` stay command-bus-blind display
+  facts there and never become the arithmetic base for a toggle.
 -->
 <script module lang="ts">
   import type { DspField, DspViewModel } from './radio-view-model';
   import { NOTCH_WIDTH_LABELS, formatAgcTime } from '../components-v2/panels/dsp-panel-logic';
-  import { rawToPercentDisplay } from '../primitives/scalar/value-control-core';
   export { DSP_TOGGLES, type DspToggleField } from './dsp-instruments';
 
   /** `[field, label, min, max, step, format?]` — `nrLevel`/`nbDepth` are
@@ -123,24 +122,24 @@
 <script lang="ts">
   import type { RadioViewModel } from './radio-view-model';
   import type { DspFiniteHandles, DspFiniteLayout } from './dsp-instruments';
+  import type { DspScalarHandles, DspScalarLayout } from './dsp-scalars';
 
   interface Props {
     view: RadioViewModel;
     finiteHandles: DspFiniteHandles;
     finiteLayout?: DspFiniteLayout;
+    scalarHandles?: DspScalarHandles;
+    scalarLayout?: DspScalarLayout;
     nbLevelMax?: number;
     nbLevelPercent?: boolean;
     onLevelChange?: (field: DspLevelField, value: number) => void;
   }
   let {
-    view, finiteHandles, finiteLayout, nbLevelMax = 255, nbLevelPercent = false, onLevelChange,
+    view, finiteHandles, finiteLayout, scalarHandles, scalarLayout, onLevelChange,
   }: Props = $props();
 
   /** Absent group ⇒ this surface renders nothing (S0 optional-group doctrine). */
   let dsp = $derived(view.dsp);
-  let nbLevelFormat = $derived(
-    nbLevelPercent ? (v: number) => rawToPercentDisplay(v, 0, nbLevelMax) : undefined,
-  );
 
   function level(field: DspLevelField, value: number): void {
     if (!dsp) return;
@@ -166,8 +165,14 @@
       </div>
     {/if}
 
+    {#if scalarHandles && scalarLayout}
+      {@render scalarLayout(scalarHandles)}
+    {/if}
+
     {#each DSP_LEVELS as [field, label, min, max, step, format] (field)}
-      {#if dsp[field].availability.structural}
+      {#if field === 'nbWidth'}
+        {#if scalarHandles && !scalarLayout}{@render scalarHandles.nbWidth()}{/if}
+      {:else if dsp[field].availability.structural}
         {@const nr = field === 'nrLevel' ? nrPresentation(dsp) : null}
         <label
           class="dsp-level" data-testid={`dsp-${field}`} data-field={field}
@@ -185,17 +190,7 @@
       {/if}
     {/each}
 
-    {#if dsp.nbLevel.availability.structural}
-      <label class="dsp-level" data-testid="dsp-nbLevel" data-field="nbLevel" data-disabled-reason={reasonOf(dsp.nbLevel)}>
-        <span class="dsp-name">NB level</span>
-        <input
-          type="range" min={0} max={nbLevelMax} step={1} value={numberOf(dsp.nbLevel, 0)}
-          disabled={!usable(dsp.nbLevel)}
-          oninput={(event) => level('nbLevel', event.currentTarget.valueAsNumber)}
-        />
-        <output>{fmt(dsp.nbLevel, nbLevelFormat)}</output>
-      </label>
-    {/if}
+    {#if scalarHandles && !scalarLayout}{@render scalarHandles.nbLevel()}{/if}
 
     {#if !finiteLayout}
       {@render finiteHandles.notchMode()}

--- a/frontend/src/semantic/__tests__/DspScalarHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/DspScalarHost.isolated.test.ts
@@ -1,0 +1,309 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
+
+const activation = vi.hoisted(() => ({ selected: undefined as unknown }));
+const capture = vi.hoisted(() => ({
+  bindings: [] as unknown[], leases: [] as Array<{ binding: unknown; lease: unknown }>,
+}));
+vi.mock('../../component-kits/activation', () => ({
+  getSelectedScalarAppearance: () => activation.selected,
+}));
+vi.mock('../../primitives/scalar/continuous-scalar.svelte', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../primitives/scalar/continuous-scalar.svelte')>();
+  return {
+    ...actual,
+    createContinuousScalar: (...args: Parameters<typeof actual.createContinuousScalar>) => {
+      const binding = actual.createContinuousScalar(...args);
+      const attachRenderer = binding.attachRenderer.bind(binding);
+      binding.attachRenderer = () => {
+        const lease = attachRenderer();
+        capture.leases.push({ binding, lease });
+        return lease;
+      };
+      capture.bindings.push(binding);
+      return binding;
+    },
+  };
+});
+
+import ExternalScalarRenderer from '../../components-v2/controls/value-control/__tests__/ExternalScalarRendererFixture.svelte';
+import type { Skin } from '../../components-v2/controls/value-control/skin';
+import type { CommandScalarFeedback, ContinuousScalarRendererLease }
+  from '../../primitives/scalar/continuous-scalar.svelte';
+import DspScalarHostFixture from './fixtures/DspScalarHostFixture.svelte';
+import { topologyFixtures, withDsp } from '../fixtures/topologies';
+import type { RadioViewModel } from '../radio-view-model';
+import type { DspScalarFeedback, DspScalarField, DspScalarPresentation } from '../dsp-scalars';
+
+const FIELDS = ['nbLevel', 'nbWidth'] as const satisfies readonly DspScalarField[];
+const CONFIRMED = { nbLevel: 64, nbWidth: 2 } as const;
+function commandFeedback(
+  field: DspScalarField, over: Partial<CommandScalarFeedback> = {},
+): Readonly<CommandScalarFeedback> {
+  return Object.freeze({
+    confirmed: CONFIRMED[field], target: null, requestedTarget: null,
+    phase: 'idle', busy: false, availability: 'available', outcome: null,
+    lifecycleId: null, transitionId: null, providerGeneration: 3, sessionEpoch: 7,
+    scope: Object.freeze({ control: field === 'nbLevel' ? 'nb-level' : 'nb-width', receiver: 0 }),
+    repeatPolicy: 'latest-target-wins', ...over,
+  });
+}
+function feedback(
+  over: Partial<Record<DspScalarField, Readonly<CommandScalarFeedback>>> = {},
+): DspScalarFeedback {
+  return Object.freeze({
+    nbLevel: over.nbLevel ?? commandFeedback('nbLevel'),
+    nbWidth: over.nbWidth ?? commandFeedback('nbWidth'),
+  });
+}
+const view = (): RadioViewModel => withDsp(topologyFixtures['1/single']);
+
+type RendererNode = HTMLButtonElement & { readonly rendererLease: ContinuousScalarRendererLease };
+type Props = {
+  view: RadioViewModel; feedback: DspScalarFeedback; presentation: 'grouped' | 'independent';
+  scalarPresentation?: Readonly<DspScalarPresentation>; nbLevelMax?: number;
+  nbLevelPercent?: boolean; onLevelChange?: (field: DspScalarField, value: number) => void;
+};
+let target: HTMLDivElement;
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  activation.selected = {
+    name: 'DSP test appearance', hbar: ExternalScalarRenderer, knob: ExternalScalarRenderer,
+  } satisfies Skin;
+  capture.bindings = [];
+  capture.leases = [];
+});
+afterEach(() => { activation.selected = undefined; target.remove(); });
+
+function render(over: Partial<Props> = {}) {
+  const onLevelChange = vi.fn(over.onLevelChange ?? (() => {}));
+  const props = proxy<Props>({
+    view: view(), feedback: feedback(), presentation: 'grouped', ...over, onLevelChange,
+  });
+  const component = mount(DspScalarHostFixture, { target, props });
+  flushSync();
+  const row = (field: DspScalarField) =>
+    target.querySelector<HTMLElement>(`[data-testid="dsp-${field}"]`);
+  const scalar = (field: DspScalarField) =>
+    row(field)?.querySelector<RendererNode>('[data-external-scalar-renderer]');
+  return { props, onLevelChange, row, scalar, dispose: () => unmount(component) };
+}
+function currentLease(binding: unknown): ContinuousScalarRendererLease {
+  for (let index = capture.leases.length - 1; index >= 0; index -= 1) {
+    const entry = capture.leases[index]!;
+    if (entry.binding === binding) return entry.lease as ContinuousScalarRendererLease;
+  }
+  throw new Error('renderer lease not captured');
+}
+
+describe('two-scalar DSP family host', () => {
+  it('places both handles through the real Surface with five native and four finite controls', () => {
+    const r = render();
+    expect(capture.bindings).toHaveLength(2);
+    expect(target.querySelectorAll('[data-external-scalar-renderer]')).toHaveLength(2);
+    expect(target.querySelectorAll('.dsp-surface input[type="range"]')).toHaveLength(5);
+    for (const field of FIELDS) {
+      expect(r.row(field)?.closest('[data-testid="dsp-surface"]')).not.toBeNull();
+      expect(target.querySelectorAll(`[data-testid="dsp-${field}"]`)).toHaveLength(1);
+    }
+    for (const field of ['nrActive', 'nbActive', 'notchMode', 'agcMode']) {
+      expect(target.querySelectorAll(`[data-testid="dsp-${field}"]`)).toHaveLength(1);
+    }
+    r.props.presentation = 'independent';
+    r.props.scalarPresentation = { form: 'knob', compact: true, showLabel: false, showValue: false };
+    flushSync();
+    expect(target.querySelectorAll('[data-testid="independent-dsp-scalars"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-external-scalar-renderer]')).toHaveLength(2);
+    expect(capture.bindings).toHaveLength(2);
+    expect(target.querySelectorAll('.dsp-surface input[type="range"]')).toHaveLength(5);
+    r.dispose();
+  });
+
+  it.each([
+    ['hbar', 'knob', 'hbar'], ['knob', 'hbar', 'knob'],
+  ] as const)('preserves both bindings and fences stale leases across %s-%s-%s and teardown',
+    (first, middle, last) => {
+      activation.selected = undefined;
+      const r = render({ presentation: 'independent', scalarPresentation: { form: first } });
+      const bindings = [...capture.bindings];
+      const stale = bindings.map(currentLease);
+      const tokens = stale.map(lease => lease.beginPointer());
+      r.props.scalarPresentation = { form: middle };
+      flushSync();
+      expect(capture.bindings).toEqual(bindings);
+      for (const [index, lease] of stale.entries()) {
+        expect(lease.beginPointer()).toBeNull();
+        const token = tokens[index];
+        if (token !== null) { lease.pointer(token, 9); lease.endPointer(token); }
+        lease.nativeInput(9);
+        lease.wheel({ direction: 1, fine: false });
+        expect(lease.key({ key: 'ArrowRight', fine: false })).toBe(false);
+      }
+      const middleLeases = bindings.map(currentLease);
+      r.props.scalarPresentation = { form: last };
+      flushSync();
+      expect(capture.bindings).toEqual(bindings);
+      for (const lease of middleLeases) {
+        lease.nativeInput(7);
+        lease.wheel({ direction: -1, fine: true });
+        expect(lease.key({ key: 'ArrowLeft', fine: true })).toBe(false);
+      }
+      const current = bindings.map(currentLease);
+      const teardownTokens = current.map(lease => lease.beginPointer());
+      r.dispose();
+      for (const [index, lease] of current.entries()) {
+        expect(lease.beginPointer()).toBeNull();
+        const token = teardownTokens[index];
+        if (token !== null) { lease.pointer(token, 7); lease.endPointer(token); }
+        lease.nativeInput(7);
+        lease.wheel({ direction: 1, fine: false });
+        expect(lease.key({ key: 'ArrowRight', fine: false })).toBe(false);
+      }
+      expect(r.onLevelChange).not.toHaveBeenCalled();
+    });
+
+  it.each(['hbar', 'knob'] as const)(
+    'uses six native range keys, one-step wheel, inert reset, and immediate optimistic input in %s',
+    (form) => {
+      activation.selected = undefined;
+      const r = render({ presentation: 'independent', scalarPresentation: { form } });
+      const lease = currentLease(capture.bindings[0]);
+      for (const key of ['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown', 'Home', 'End']) {
+        expect(lease.key({ key, fine: true })).toBe(true);
+      }
+      lease.wheel({ direction: 1, fine: true });
+      lease.nativeInput(64.6);
+      const callsBeforeReset = r.onLevelChange.mock.calls.length;
+      lease.reset();
+      expect(r.onLevelChange.mock.calls).toEqual([
+        ['nbLevel', 65], ['nbLevel', 64], ['nbLevel', 65], ['nbLevel', 64],
+        ['nbLevel', 0], ['nbLevel', 255], ['nbLevel', 255], ['nbLevel', 65],
+      ]);
+      expect(r.onLevelChange).toHaveBeenCalledTimes(callsBeforeReset);
+      expect(lease.view.displayed).toBe(65);
+      r.dispose();
+    });
+
+  it('keeps NB Level raw, caps-bounded, and percent-formatted without rescaling commands', () => {
+    const r = render({ nbLevelMax: 200, nbLevelPercent: true });
+    const level = r.scalar('nbLevel')!;
+    expect(currentLease(capture.bindings[0]).view.domain).toMatchObject({ min: 0, max: 200, step: 1 });
+    expect(level.dataset.confirmed).toBe('64');
+    expect(level.dataset.display).toBe('32%');
+    level.click();
+    expect(r.onLevelChange).toHaveBeenCalledExactlyOnceWith('nbLevel', 65);
+    r.props.nbLevelPercent = false;
+    flushSync();
+    expect(r.scalar('nbLevel')?.dataset.display).toBe('65');
+    r.dispose();
+  });
+
+  it('passes current global NB Width lifecycle, errors, and receiver-0 evidence through one binding', () => {
+    const r = render({ feedback: feedback({ nbWidth: commandFeedback('nbWidth', {
+      target: 3, requestedTarget: 3, phase: 'submitted', busy: true,
+      lifecycleId: 'width-3', transitionId: 'width-submitted-3',
+    }) }) });
+    const binding = capture.bindings[1];
+    expect(r.row('nbWidth')?.dataset).toMatchObject({
+      feedbackControl: 'nb-width', feedbackReceiver: '0',
+    });
+    expect(r.scalar('nbWidth')?.dataset).toMatchObject({ confirmed: '2', requested: '3', phase: 'submitted' });
+    r.props.feedback = feedback({ nbWidth: commandFeedback('nbWidth', {
+      confirmed: 3, requestedTarget: 3, phase: 'confirmed', busy: false,
+      lifecycleId: 'width-3', transitionId: 'width-confirmed-3', outcome: { phase: 'confirmed' },
+    }) });
+    flushSync();
+    expect(r.scalar('nbWidth')?.dataset.phase).toBe('confirmed');
+    r.props.feedback = feedback({ nbWidth: commandFeedback('nbWidth', {
+      confirmed: 3, requestedTarget: 4, phase: 'failed', busy: false,
+      lifecycleId: 'width-4', transitionId: 'width-failed-4',
+      outcome: { phase: 'failed', error: 'radio refused' },
+    }) });
+    flushSync();
+    expect(r.scalar('nbWidth')?.dataset).toMatchObject({ phase: 'failed', error: 'radio refused' });
+    r.props.feedback = feedback({ nbWidth: commandFeedback('nbWidth', {
+      confirmed: null, availability: 'unavailable', phase: 'unavailable',
+    }) });
+    flushSync();
+    expect(r.scalar('nbWidth')?.getAttribute('aria-disabled')).toBe('true');
+    expect(r.scalar('nbWidth')?.dataset.display).toBe('?');
+    expect(capture.bindings[1]).toBe(binding);
+    r.dispose();
+  });
+
+  it('distinguishes structural absence from visible unknown/unavailable feedback', () => {
+    const current = view();
+    const r = render({
+      view: { ...current, dsp: { ...current.dsp!,
+        nbLevel: { ...current.dsp!.nbLevel, availability: { structural: false, operational: false } },
+        nbWidth: { reading: { status: 'unknown' }, availability: { structural: true, operational: false } },
+      } },
+      feedback: feedback({ nbWidth: commandFeedback('nbWidth', {
+        confirmed: null, availability: 'unavailable', phase: 'unavailable',
+      }) }),
+    });
+    expect(r.row('nbLevel')).toBeNull();
+    expect(r.row('nbWidth')).not.toBeNull();
+    expect(r.scalar('nbWidth')?.getAttribute('aria-disabled')).toBe('true');
+    expect(r.scalar('nbWidth')?.dataset.accessibilityValueText).toContain('?');
+    r.dispose();
+  });
+
+  it('reads replacement callbacks and feedback without remounting bindings', () => {
+    const r = render();
+    const bindings = [...capture.bindings];
+    const replacement = vi.fn();
+    r.props.onLevelChange = replacement;
+    r.props.feedback = feedback({ nbLevel: commandFeedback('nbLevel', {
+      confirmed: 64, target: 65, requestedTarget: 65, phase: 'submitted', busy: true,
+      lifecycleId: 'level-65', transitionId: 'level-submitted-65',
+    }) });
+    flushSync();
+    expect(r.scalar('nbLevel')?.dataset.requested).toBe('65');
+    r.scalar('nbLevel')?.click();
+    expect(replacement).toHaveBeenCalledExactlyOnceWith('nbLevel', 65);
+    expect(r.onLevelChange).not.toHaveBeenCalled();
+    expect(capture.bindings).toEqual(bindings);
+    r.dispose();
+  });
+
+  it('exposes actual slider accessibility and retires stale HBar status for one fresh lane', () => {
+    activation.selected = undefined;
+    const failed = (transitionId: string) => feedback({ nbLevel: commandFeedback('nbLevel', {
+      confirmed: 64, requestedTarget: 65, phase: 'failed', busy: false,
+      lifecycleId: 'level-65', transitionId, outcome: { phase: 'failed', error: 'radio refused' },
+    }) });
+    const r = render({
+      presentation: 'independent', scalarPresentation: { form: 'hbar' },
+      nbLevelPercent: true, feedback: failed('failed-hbar'),
+    });
+    const bindings = [...capture.bindings];
+    const live = () => target.querySelectorAll('[role="status"][aria-live="polite"]');
+    const slider = r.row('nbLevel')!.querySelector<HTMLElement>('[role="slider"]')!;
+    expect(slider.getAttribute('aria-label')).toBe('NB level');
+    expect(slider.getAttribute('aria-valuetext')).toContain('NB level: 25%');
+    expect(slider.getAttribute('aria-valuetext')).toContain('radio refused');
+    expect(target.querySelectorAll('[data-feedback-lane="nbLevel"]')).toHaveLength(1);
+    expect(live()).toHaveLength(1);
+    r.props.scalarPresentation = { form: 'knob' };
+    flushSync();
+    expect(capture.bindings).toEqual(bindings);
+    expect(target.querySelector('[data-feedback-lane="nbLevel"]')).toBeNull();
+    expect(live()).toHaveLength(0);
+    r.props.feedback = failed('failed-knob');
+    flushSync();
+    expect(live()).toHaveLength(1);
+    expect(target.querySelector('[data-feedback-lane="nbLevel"]')).toBeNull();
+    r.props.scalarPresentation = { form: 'hbar' };
+    flushSync();
+    expect(live()).toHaveLength(0);
+    r.props.feedback = failed('failed-hbar-fresh');
+    flushSync();
+    expect(target.querySelectorAll('[data-feedback-lane="nbLevel"]')).toHaveLength(1);
+    expect(live()).toHaveLength(1);
+    r.dispose();
+  });
+});

--- a/frontend/src/semantic/__tests__/DspScalarHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/DspScalarHost.isolated.test.ts
@@ -65,6 +65,7 @@ type Props = {
   view: RadioViewModel; feedback: DspScalarFeedback; presentation: 'grouped' | 'independent';
   scalarPresentation?: Readonly<DspScalarPresentation>; nbLevelMax?: number;
   nbLevelPercent?: boolean; onLevelChange?: (field: DspScalarField, value: number) => void;
+  scalarAppearance?: Skin; presentationIsCurrent?: () => boolean;
 };
 let target: HTMLDivElement;
 beforeEach(() => {
@@ -304,6 +305,27 @@ describe('two-scalar DSP family host', () => {
     flushSync();
     expect(target.querySelectorAll('[data-feedback-lane="nbLevel"]')).toHaveLength(1);
     expect(live()).toHaveLength(1);
+    r.dispose();
+  });
+
+  it('forwards scalarAppearance to the renderer and fences a lease whose presentationIsCurrent is false', () => {
+    activation.selected = undefined;
+    const r = render({
+      scalarAppearance: {
+        name: 'DSP scalar host external appearance', hbar: ExternalScalarRenderer, knob: ExternalScalarRenderer,
+      },
+      presentationIsCurrent: () => false,
+    });
+    // With no global appearance configured, the explicit prop is the only
+    // source of a skin — its reaching the renderer is what makes the
+    // external marker render instead of a bare native slider.
+    expect(target.querySelectorAll('[data-external-scalar-renderer]')).toHaveLength(2);
+    const lease = r.scalar('nbLevel')!.rendererLease;
+    expect(lease.beginPointer()).toBeNull();
+    lease.nativeInput(65);
+    lease.wheel({ direction: 1, fine: false });
+    expect(lease.key({ key: 'ArrowRight', fine: false })).toBe(false);
+    expect(r.onLevelChange).not.toHaveBeenCalled();
     r.dispose();
   });
 });

--- a/frontend/src/semantic/__tests__/DspSurface.test.ts
+++ b/frontend/src/semantic/__tests__/DspSurface.test.ts
@@ -17,7 +17,7 @@ import { flushSync, mount, unmount } from 'svelte';
 import { DSP_LEVELS, DSP_TOGGLES, type DspLevelField, type DspToggleField } from '../DspSurface.svelte';
 import { topologyFixtures, withDsp } from '../fixtures/topologies';
 import type { Availability, DspViewModel, RadioViewModel } from '../radio-view-model';
-import DspInstrumentHostFixture from './fixtures/DspInstrumentHostFixture.svelte';
+import DspScalarHostFixture from './fixtures/DspScalarHostFixture.svelte';
 
 /** `1/single` + a fully-observed dsp group (nrActive true, nbActive false —
  *  both toggles exercised at least once by the base fixture). */
@@ -39,6 +39,7 @@ type AnyField = keyof DspViewModel;
 const NUMERIC_FIELDS: readonly AnyField[] = [
   ...DSP_TOGGLES.map(([f]) => f), ...DSP_LEVELS.map(([f]) => f), 'nbLevel',
 ] as readonly AnyField[];
+const NATIVE_LEVELS = DSP_LEVELS.filter(([field]) => field !== 'nbWidth');
 /** The thumb position an unread level control MUST claim (MOR-1304/1305 F2)
  *  — `numberOf`'s own fallback, verbatim, so a fallback-value mutation is
  *  pinned rather than left free to claim any position. `nbLevel` falls back
@@ -98,7 +99,7 @@ type Props = Handlers & {
 };
 
 function render(view: RadioViewModel, props: Props = {}) {
-  const component = mount(DspInstrumentHostFixture, {
+  const component = mount(DspScalarHostFixture, {
     target, props: { view, presentation: 'grouped', ...props },
   });
   flushSync();
@@ -108,6 +109,7 @@ function render(view: RadioViewModel, props: Props = {}) {
     root: () => q('[data-testid="dsp-surface"]'),
     control: (field: string) => q<HTMLElement>(`[data-testid="dsp-${field}"]`),
     input: (field: string) => q<HTMLInputElement>(`[data-testid="dsp-${field}"] input`),
+    slider: (field: string) => q<HTMLElement>(`[data-testid="dsp-${field}"] [role="slider"]`),
     notchButton: (mode: string) => q<HTMLButtonElement>(`[data-testid="dsp-notchMode-${mode}"]`),
     agcButton: (mode: number) => q<HTMLButtonElement>(`[data-testid="dsp-agcMode-${mode}"]`),
   };
@@ -122,7 +124,8 @@ function withSurface(view: RadioViewModel, fn: (s: ReturnType<typeof render>) =>
 function isDisabled(s: ReturnType<typeof render>, field: string): boolean {
   const el = s.control(field)!;
   if (el instanceof HTMLButtonElement) return el.disabled;
-  return s.input(field)!.disabled;
+  const input = s.input(field);
+  return input ? input.disabled : s.slider(field)?.getAttribute('aria-disabled') === 'true';
 }
 
 // ── 1. Structural gating: absent, never a disabled promise ─────────────────
@@ -266,7 +269,7 @@ describe('toggle intents compute the next boolean from the current reading', () 
 // ── 4. Level intents carry the field and the raw value ─────────────────────
 
 describe('level intents reach the caller with the field and the raw value', () => {
-  it.each(DSP_LEVELS)('emits (%s, value) on input with the declared range', (field, _label, min, max, step, _fmt?) => {
+  it.each(NATIVE_LEVELS)('emits (%s, value) on input with the declared range', (field, _label, min, max, step, _fmt?) => {
     const onLevelChange = vi.fn();
     withSurface(base(), (s) => {
       const input = s.input(field)!;
@@ -441,15 +444,15 @@ describe('manual-notch position stays in the documented raw domain', () => {
 describe('nbLevel is range-parameterised by the caps-echoed nbLevelMax/nbLevelPercent props', () => {
   it('uses the default 0..255 raw range when no props are supplied', () => {
     withSurface(base(), (s) => {
-      expect(s.input('nbLevel')!.max).toBe('255');
-      expect(s.input('nbLevel')!.valueAsNumber).toBe(64); // withDsp() fixture value
+      expect(s.slider('nbLevel')!.getAttribute('aria-valuemax')).toBe('255');
+      expect(s.slider('nbLevel')!.getAttribute('aria-valuenow')).toBe('64');
       expect(s.control('nbLevel')!.textContent).toContain('64');
     });
   });
 
   it('uses a caller-supplied ceiling (FTX-1-shaped: native 0..10, raw display)', () => {
     withSurface(base(), (s) => {
-      expect(s.input('nbLevel')!.max).toBe('10');
+      expect(s.slider('nbLevel')!.getAttribute('aria-valuemax')).toBe('10');
       // Raw pass-through display (carry-forward 3): the fixture's raw
       // reading (64) renders verbatim, regardless of the ceiling prop.
       expect(s.control('nbLevel')!.textContent).toContain('64');
@@ -465,12 +468,14 @@ describe('nbLevel is range-parameterised by the caps-echoed nbLevelMax/nbLevelPe
 
   it('emits the raw nbLevel value unrescaled regardless of display mode', () => {
     const onLevelChange = vi.fn();
-    withSurface(base(), (s) => {
-      const input = s.input('nbLevel')!;
-      input.value = '5';
-      input.dispatchEvent(new Event('input', { bubbles: true }));
+    const view = base();
+    const withLevelFive = { ...view, dsp: { ...view.dsp!, nbLevel: {
+      ...view.dsp!.nbLevel, reading: { status: 'known' as const, value: 5 },
+    } } };
+    withSurface(withLevelFive, (s) => {
+      s.slider('nbLevel')!.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
       flushSync();
-      expect(onLevelChange).toHaveBeenCalledExactlyOnceWith('nbLevel', 5);
+      expect(onLevelChange).toHaveBeenCalledExactlyOnceWith('nbLevel', 6);
     }, { onLevelChange, nbLevelMax: 10, nbLevelPercent: false });
   });
 });

--- a/frontend/src/semantic/__tests__/fixtures/DspInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/DspInstrumentHostFixture.svelte
@@ -38,7 +38,7 @@
   {#snippet children(handles: DspFiniteHandles)}
     {#key presentation}
       {#if presentation === 'grouped'}
-        <DspSurface {view} finiteHandles={handles} {nbLevelMax} {nbLevelPercent} {onLevelChange} />
+        <DspSurface {view} finiteHandles={handles} {onLevelChange} />
       {:else}
         <section data-testid="independent-dsp-composition">
           <div data-slot="toggles">{@render handles.nrActive()}{@render handles.nbActive()}</div>

--- a/frontend/src/semantic/__tests__/fixtures/DspScalarHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/DspScalarHostFixture.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import type { FiniteControlAppearance, FiniteRendererContext }
+    from '../../../primitives/control-instruments/control-instrument-renderer.svelte';
+  import type { CommandScalarFeedback } from '../../../primitives/scalar/continuous-scalar.svelte';
+  import DspInstrumentHost from '../../DspInstrumentHost.svelte';
+  import DspScalarHost from '../../DspScalarHost.svelte';
+  import DspSurface, { type DspLevelField } from '../../DspSurface.svelte';
+  import type { DspFiniteChoiceValue, DspFiniteHandles, DspNotchMode,
+    DspToggleField } from '../../dsp-instruments';
+  import type { DspScalarFeedback, DspScalarField, DspScalarHandles,
+    DspScalarPresentation } from '../../dsp-scalars';
+  import type { RadioViewModel } from '../../radio-view-model';
+
+  interface Props {
+    view: RadioViewModel;
+    feedback?: DspScalarFeedback;
+    presentation?: 'grouped' | 'independent';
+    scalarPresentation?: Readonly<DspScalarPresentation>;
+    agcLabels?: Record<string, string>;
+    nbLevelMax?: number;
+    nbLevelPercent?: boolean;
+    pendingNb?: boolean | null;
+    pendingNr?: boolean | null;
+    finiteAppearance?: FiniteControlAppearance<DspFiniteChoiceValue>;
+    rendererContext?: FiniteRendererContext | null;
+    onToggle?: (field: DspToggleField, next: boolean) => void;
+    onLevelChange?: (field: DspLevelField, value: number) => void;
+    onNotchModeChange?: (mode: DspNotchMode) => void;
+    onAgcModeChange?: (mode: number) => void;
+  }
+  let { view, feedback, presentation = 'grouped', scalarPresentation,
+    agcLabels = {}, nbLevelMax = 255, nbLevelPercent = false,
+    pendingNb = null, pendingNr = null, finiteAppearance, rendererContext = null,
+    onToggle, onLevelChange, onNotchModeChange, onAgcModeChange }: Props = $props();
+  let finiteSelection = $derived(finiteAppearance === undefined
+    ? {} : { finiteAppearance, rendererContext });
+
+  function defaultFeedback(field: DspScalarField): Readonly<CommandScalarFeedback> {
+    const fact = view.dsp?.[field];
+    const confirmed = fact?.reading.status === 'known' ? fact.reading.value : null;
+    const available = fact?.availability.operational === true && confirmed !== null;
+    return Object.freeze({
+      confirmed: available ? confirmed : null,
+      target: null, requestedTarget: null, phase: available ? 'idle' : 'unavailable',
+      busy: false, availability: available ? 'available' : 'unavailable', outcome: null,
+      lifecycleId: null, transitionId: null, providerGeneration: 1, sessionEpoch: 1,
+      scope: Object.freeze({ control: field === 'nbLevel' ? 'nb-level' : 'nb-width', receiver: 0 }),
+      repeatPolicy: 'latest-target-wins',
+    });
+  }
+  let scalarFeedback = $derived(feedback ?? Object.freeze({
+    nbLevel: defaultFeedback('nbLevel'), nbWidth: defaultFeedback('nbWidth'),
+  }));
+</script>
+
+<DspInstrumentHost {view} {agcLabels} {pendingNb} {pendingNr} {onToggle}
+  {onNotchModeChange} {onAgcModeChange} {...finiteSelection}>
+  {#snippet children(finiteHandles: DspFiniteHandles)}
+    <DspScalarHost {view} feedback={scalarFeedback} {nbLevelMax} {nbLevelPercent}
+      onLevelChange={(field, value) => onLevelChange?.(field, value)}>
+      {#snippet children(scalarHandles: DspScalarHandles)}
+        {#snippet independentFinite(handles: DspFiniteHandles)}
+          <section data-testid="independent-dsp-finite">
+            <div data-slot="toggles">{@render handles.nrActive()}{@render handles.nbActive()}</div>
+            <div data-slot="notch">{@render handles.notchMode()}</div>
+            <div data-slot="agc">{@render handles.agcMode()}</div>
+          </section>
+        {/snippet}
+        {#snippet independentScalars(handles: DspScalarHandles)}
+          <section data-testid="independent-dsp-scalars">
+            <div data-slot="nb-level">{@render handles.nbLevel(scalarPresentation)}</div>
+            <div data-slot="nb-width">{@render handles.nbWidth(scalarPresentation)}</div>
+          </section>
+        {/snippet}
+        {#key presentation}
+          <DspSurface {view} {finiteHandles} scalarHandles={scalarHandles}
+            finiteLayout={presentation === 'independent' ? independentFinite : undefined}
+            scalarLayout={presentation === 'independent' ? independentScalars : undefined}
+            {nbLevelMax} {nbLevelPercent}
+            onLevelChange={(field, value) => onLevelChange?.(field, value)} />
+        {/key}
+      {/snippet}
+    </DspScalarHost>
+  {/snippet}
+</DspInstrumentHost>

--- a/frontend/src/semantic/__tests__/fixtures/DspScalarHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/DspScalarHostFixture.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { ScalarAppearance } from '../../../../component-kit-api/src/index';
   import type { FiniteControlAppearance, FiniteRendererContext }
     from '../../../primitives/control-instruments/control-instrument-renderer.svelte';
   import type { CommandScalarFeedback } from '../../../primitives/scalar/continuous-scalar.svelte';
@@ -19,6 +20,8 @@
     agcLabels?: Record<string, string>;
     nbLevelMax?: number;
     nbLevelPercent?: boolean;
+    scalarAppearance?: ScalarAppearance;
+    presentationIsCurrent?: () => boolean;
     pendingNb?: boolean | null;
     pendingNr?: boolean | null;
     finiteAppearance?: FiniteControlAppearance<DspFiniteChoiceValue>;
@@ -30,6 +33,7 @@
   }
   let { view, feedback, presentation = 'grouped', scalarPresentation,
     agcLabels = {}, nbLevelMax = 255, nbLevelPercent = false,
+    scalarAppearance, presentationIsCurrent,
     pendingNb = null, pendingNr = null, finiteAppearance, rendererContext = null,
     onToggle, onLevelChange, onNotchModeChange, onAgcModeChange }: Props = $props();
   let finiteSelection = $derived(finiteAppearance === undefined
@@ -57,6 +61,7 @@
   {onNotchModeChange} {onAgcModeChange} {...finiteSelection}>
   {#snippet children(finiteHandles: DspFiniteHandles)}
     <DspScalarHost {view} feedback={scalarFeedback} {nbLevelMax} {nbLevelPercent}
+      {scalarAppearance} {presentationIsCurrent}
       onLevelChange={(field, value) => onLevelChange?.(field, value)}>
       {#snippet children(scalarHandles: DspScalarHandles)}
         {#snippet independentFinite(handles: DspFiniteHandles)}
@@ -76,7 +81,6 @@
           <DspSurface {view} {finiteHandles} scalarHandles={scalarHandles}
             finiteLayout={presentation === 'independent' ? independentFinite : undefined}
             scalarLayout={presentation === 'independent' ? independentScalars : undefined}
-            {nbLevelMax} {nbLevelPercent}
             onLevelChange={(field, value) => onLevelChange?.(field, value)} />
         {/key}
       {/snippet}

--- a/frontend/src/semantic/dsp-scalars.ts
+++ b/frontend/src/semantic/dsp-scalars.ts
@@ -1,0 +1,18 @@
+import type { Snippet } from 'svelte';
+import type { CommandScalarFeedback } from '../primitives/scalar/continuous-scalar.svelte';
+
+export const DSP_SCALAR_FIELDS = ['nbLevel', 'nbWidth'] as const;
+export type DspScalarField = (typeof DSP_SCALAR_FIELDS)[number];
+export type DspScalarFeedback = Readonly<Record<DspScalarField, Readonly<CommandScalarFeedback>>>;
+export type DspScalarForm = 'hbar' | 'knob';
+
+export interface DspScalarPresentation {
+  readonly form?: DspScalarForm;
+  readonly compact?: boolean;
+  readonly showLabel?: boolean;
+  readonly showValue?: boolean;
+}
+
+export type DspScalarHandle = Snippet<[presentation?: Readonly<DspScalarPresentation>]>;
+export type DspScalarHandles = Readonly<Record<DspScalarField, DspScalarHandle>>;
+export type DspScalarLayout = Snippet<[DspScalarHandles]>;


### PR DESCRIPTION
12 code + 0 regenerated baselines = 12 files

The twelfth file, `frontend/fixtures/stubs/panel-adapters.ts`, is fixture-harness stub collateral: the quick run on this PR's prior head (`ef2c9deb7`, run 34143545489, step "Frontend fixture-harness capture") failed the Vite build with `"getDspControlFeedback" is not exported by "frontend/fixtures/stubs/panel-adapters.ts"`, because `SemanticRadioSurfaces.svelte`'s new import (this PR's own change, listed below) has no counterpart in the stub the fixture harness aliases the real adapter module to. The fix adds that one export, in the file's existing per-field "unavailable" convention (see `getTxAuxControlFeedback` just above it in the same file). File count (12) exceeds the 10-file hard ceiling; the coordinating session grants that exception under the owner's 2026-09-03 delegation (file count only — the line ceiling stays the owner's own call).

**One unit of work.** The soft threshold (6 files / 600 changed lines) is crossed because a scalar host that is mounted but not joined is the defect this change exists to remove: at the six-file shape the two NB scalars render *nothing* in production — the natives are gone and the handles are never passed. Host, surface, wiring seam, composition type, layout seats and the wiring witness are one cut or none.

## Summary

`nbLevel` and `nbWidth` move from native `DspSurface` ranges to a single mechanical `DspScalarHost`, mounted beside `DspInstrumentHost` inside the persistent tree exactly as `TxAuxScalarHost` is.

- The host reuses the shipped mechanism verbatim — `createContinuousScalar`, `createRenderedNativeRangeContinuousScalarPolicy`, `ValueControl`, and `TxAuxScalarHost`'s issued-status announcement lane. No new scalar owner, policy, comparator, conversion or announcement engine.
- **Prop-driven.** The host takes `view` + `feedback` and subscribes to no authority: the DSP subscriber count is unchanged and no `authoritySubscribers.size` assertion moves (verified: the diff contains no `authoritySubscribers`, `listenerCount` or `h.listeners` line, and `semantic-pbt-continuity.component.test.ts` is not in the diff).
- **Raw feedback, no projector.** `SemanticRadioSurfaces` derives both records from `getDspControlFeedback('nbLevel')` / `('nbWidth')`. `nbLevel`/`nbWidth` are wire-raw; the transformed pair is untouched.
- **Standard seats vs grouped SDR.** `RadioLayout` adds a `dspScalarLayout` snippet passed as the third `instruments.dsp(...)` argument in the `desktop-v2` branch only; SDR and generic keep the grouped path unchanged.
- **Five natives retained.** `nrLevel`, `nbDepth`, `notchFreq`, `manualNotchWidth`, `agcTimeConstant` still render as native ranges from `DSP_LEVELS`.
- **Follow-up, named, not done here (D2b):** `nrLevel` and `nbDepth` stay native. They are display-transformed and need `projectDspControlFeedbackToDisplay` plus a decision on the NR domain — including extracting `DspSurface.svelte: nrPresentation` rather than growing a second NR-domain normalisation path beside it. `notchFreq`, `manualNotchWidth` and `agcTimeConstant` stay native by ruling.

## Witnesses

In `semantic-dsp-wiring.component.test.ts`:

- **Persistence, in the order the parts must be read** (`keeps the nbWidth binding, its pending evidence and its live lease across Standard→SDR`): (i) the two `createContinuousScalar` binding objects captured before a `desktop-v2` → `sdr-test` switch are the *same objects* after it; (ii) the current post-switch lease emits exactly one command (raw 3, stepped from the confirmed 2); (iii) the pending `nbWidth` lifecycle (`requested` 7 / `confirmed` 2 / `phase` `submitted` / `error` / `transitionId`) is unchanged across the switch and exactly one announcement lane exists. Only after all three is the retained Standard lease asserted inert.
- The five surviving natives are asserted **by name and in order**, not as a cardinality, at all three former `toHaveLength(7)` sites.
- The four finite DSP controls and both hosted scalars each appear exactly once, by name, in both layouts; the named `.dsp-scalar-seat` grid exists in Standard and is absent in SDR.
- `data-feedback-receiver="0"` on `nbWidth` (global receiver identity).
- The caps-echo ceilings (`200`, `10`) are now read as `aria-valuemax` on the slider handles.

### Mutations run (each reverted; `git diff` clean afterwards)

| # | Mutation | Result |
|---|---|---|
| a | Wrap the `<DspScalarHost>` mount in `{#key surfacePlan()}` — i.e. remount the host per face | **Kills** the identity witness only: `expected [...] to have a length of 2 but got 4`. The other 35 cases stay green — this is exactly the trap: the inertness-only form of this test is *greener* under the defect. |
| b | `ValueControl.svelte`: replace the renderer seat's `() => currentRendererOccurrence === occurrence && (isPresentationCurrent?.() ?? true)` with `() => true` | **Survives, 36/36 green.** Reported as specified but it does not reinstate the bug: the binding's own single-active-renderer generation check still fences the stale lease. |
| b′ | *Additionally* `continuous-scalar.svelte.ts: rendererIsCurrent` — drop `\|\| renderer !== activeRenderer` | b′ alone also **survives**. **b + b′ together kill** the inertness assertion: `expected 1 to be null` at `staleLease.beginPointer()`. So the retained lease is doubly fenced, and the honest statement is that only removing *both* fences reinstates it. |
| c | Drop `scalarHandles={dspScalars}` from the `DspSurface` invocation (constant/absent handles) | **Kills 6** cases: both hosted-scalar routing cases, both caps-echo cases, the Standard→SDR seat-move case and the persistence witness. |

## Census

`git diff origin/main...HEAD` at `e7344b985` (new head, after merging `origin/main` past #3349 and reshaping the fixture stub): **12 files, 926 insertions + 66 deletions = 992 changed lines.** This is the same 12 files as the prior head; the merge itself added no files to this side's diff (it only resolved `SemanticRadioSurfaces.svelte`'s independent hunks — see Verification), and the stub reshape below removed 8 net lines from `panel-adapters.ts`, bringing the total from 1000 (exactly on the hard ceiling, zero headroom) down to 992.

| File | + | − |
|---|---:|---:|
| `frontend/src/semantic/__tests__/DspScalarHost.isolated.test.ts` | 331 | 0 |
| `frontend/src/semantic/DspScalarHost.svelte` | 195 | 0 |
| `frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts` | 190 | 15 |
| `frontend/src/semantic/__tests__/fixtures/DspScalarHostFixture.svelte` | 89 | 0 |
| `frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte` | 31 | 6 |
| `frontend/src/semantic/DspSurface.svelte` | 22 | 30 |
| `frontend/src/semantic/dsp-scalars.ts` | 18 | 0 |
| `frontend/src/semantic/__tests__/DspSurface.test.ts` | 17 | 12 |
| `frontend/src/components-v2/layout/RadioLayout.svelte` | 15 | 1 |
| `frontend/fixtures/stubs/panel-adapters.ts` | 13 | 0 |
| `frontend/src/components-v2/wiring/instrument-composition.ts` | 4 | 1 |
| `frontend/src/semantic/__tests__/fixtures/DspInstrumentHostFixture.svelte` | 1 | 1 |

## Verification

Run locally at `ef2c9deb7` (the full suite is CI's, not run here):

- `npx vitest run` over the 87 test files matching `DspScalarHost|DspSurface|SemanticRadioSurfaces|instrument-composition|RadioLayout|dsp-scalars` — **87 files, 2450 tests, 0 failures.**
- `npm run check` — **0 errors, 0 warnings** across 4830 files.
- `npx eslint` over all 11 changed files — clean.
- `git diff --check` — clean; `git status` clean after every mutation was reverted.

At `002aab33f` (the fixture-harness fix commit): `npx vitest run src/components-v2/wiring/__tests__/fixture-capture-root-cwd.isolated.test.ts` — 1 file, 1 test, 0 failures; `node frontend/fixtures/capture.mjs` (the same script the quick run's "Frontend fixture-harness capture" step invokes) — 65 captures, 0 invalid; `npm run check` — 0 errors, 0 warnings across 4830 files; `git diff --check` clean. Mutation (dropping the `export` keyword on the new `getDspControlFeedback` stub) was applied, confirmed to reproduce the same Rollup "not exported" build failure via the isolated test above, then reverted — `git diff` afterwards showed only the intended 21-line addition.

**Merge of `origin/main` past #3349** (`4e6bb9db7`, which added `scanCapable`/`onDfSpanChange`/`onPbtReset` to `RitXitScanSurface`/`FilterSurface`'s mounts in this same file): `git merge origin/main` auto-resolved `SemanticRadioSurfaces.svelte` via git's `ort` strategy with no conflict markers — the two branches touched disjoint hunks (this branch's `DspScalarHost` mount at what was line 1459 pre-merge vs. #3349's prop additions at the `FilterSurface`/`RitXitScanSurface` mounts 352/511 lines further down). Confirmed post-merge: `grep -n "DspScalarHost\|scanCapable\|onDfSpanChange\|onPbtReset" SemanticRadioSurfaces.svelte` shows both the `DspScalarHost` mount (lines 1466, 2399) and all three of #3349's props (lines 457, 1828, 1985) present; `grep -rn "<<<<<<<\|=======\|>>>>>>>"` across `frontend/` found nothing.

**Stub reshape at the new head** (`e7344b985`): `getDspControlFeedback`'s per-field control map carried all 7 DSP scalar fields (`nrLevel`, `nbDepth`, `notchFilter`, `manualNotchWidth`, `agcTimeConstant` included) though `DSP_SCALAR_FIELDS` in `dsp-scalars.ts` and the only two call sites (`SemanticRadioSurfaces.svelte`'s `dspScalarFeedback` derivation) use just `nbLevel`/`nbWidth`. Narrowed the map to those two fields and collapsed it to one line (two entries no longer need one-per-line layout), mirroring `getTxAuxControlFeedback`'s form: field in → the same frozen "unavailable" shape out, `scope.control` derived from the field, one doc comment line, 12 lines total (map + blank + comment + function). No test or assertion was touched — `git diff --check` clean, `git status` clean.

Re-run at the new head: `npx vitest run` over `fixture-capture-root-cwd.isolated.test.ts`, `semantic-dsp-wiring.component.test.ts`, `DspScalarHost.isolated.test.ts`, `DspSurface.test.ts`, `semantic-ritxit-scan-wiring.component.test.ts` (the seam the merge touched), `external-hosted-face.component.test.ts` — **7 files, 192 tests, 0 failures** (includes `fixture-adapter-command-seam.isolated.test.ts`, which source-scans this same stub file for `getTxAuxControlFeedback`'s field/control pairs and still passes unchanged); `node frontend/fixtures/capture.mjs` — 65 captures, 0 invalid; `npm run check` — 0 errors, 0 warnings across 4830 files; `npx eslint` over the 12 changed source paths — 0 errors (the stub file itself falls outside eslint's `src/**` glob and is reported "no matching configuration", unchanged from before this reshape); `git diff --check` — clean.

Mutation on the reshape: replaced `nbLevel: 'nb-level', nbWidth: 'nb-width'` with `nbLevel: 'WRONG-level', nbWidth: 'WRONG-width'` in the stub, then re-ran `semantic-dsp-wiring.component.test.ts`, `DspScalarHost.isolated.test.ts`, `DspSurface.test.ts` (all 133 tests still passed) and `capture.mjs` (still 65/0 invalid) — neither catches it, because both exercise the production adapter path (mocked separately) or don't assert the feedback's `scope.control` string. This confirms the reshape has no test witness, same as the file's convention for every other single-field getter here (`getBreakInDelayControlFeedback`, `getFilterWidthControlFeedback`, `unavailableGlobalCwFeedback`) — only `getTxAuxControlFeedback`'s 7-field map is source-scanned, by `fixture-adapter-command-seam.isolated.test.ts`. Reverted; `git diff` afterwards shows only the intended 8-line-net reshape.

Two fixture facts this file did not previously need, both fixed here and both precedented in `semantic-tx-aux-wiring.component.test.ts`: `panel-adapters.ts` reads the runtime through `$lib/runtime/frontend-runtime` (not `$lib/runtime`), and `beginCommand` stamps the radio store's `providerGeneration`. Until both seams were stubbed, every DSP command feedback in this file projected as `unavailable`; `fresh` also gains the `lastObservedMonotonic` that `display-observation.ts: validEvidence` requires.

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
