### PR TITLE
feat(MOR-2425): restore scan type, span, resume and PBT reset controls on the semantic surfaces

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -34,7 +34,7 @@
     InstrumentVfoAppearance,
   } from './instrument-composition';
   import { t } from '$lib/i18n';
-  import { getScopeSource } from '$lib/stores/capabilities.svelte';
+  import { getScopeSource, hasCapability } from '$lib/stores/capabilities.svelte';
   import { presentationResources, runtime } from '$lib/runtime';
   import * as componentKitActivation from '../../component-kits/activation';
   import { ScopeFrameHost, type ScopeFramePresentation } from '$lib/runtime/scope-frame-host';
@@ -445,6 +445,13 @@
    */
   const ritXitIntents = semanticHandlers.ritXit;
   const scanIntents = semanticHandlers.scan;
+  /** MOR-2425 restore — `RitXitScanSurface`'s TYPE/SPAN/RESUME button groups
+   * hide (not merely disable) unless the connected radio declares the
+   * `scan` capability: `makeScanHandlers()` gates every scan intent on it,
+   * but the `scan` view-model group itself is per-field "ever reported"
+   * with no capability check (see that surface's own file header). Same
+   * "caps-echo display metadata" seam as `hasDualReceiver` below. */
+  let scanCapable = $derived(hasCapability('scan'));
   /** MOR-1731: consume the shared validated tri-state boundary. `undefined`
    * keeps legacy servers compatible; `null` is the adapter's fail-closed
    * result for present-but-unusable metadata. */
@@ -1799,6 +1806,7 @@
         onIfShiftChange={filterIntents.onIfShiftChange}
         onPbtInnerChange={filterIntents.onPbtInnerChange}
         onPbtOuterChange={filterIntents.onPbtOuterChange}
+        onPbtReset={filterIntents.onPbtReset}
       />
     {/if}
   {/snippet}
@@ -1946,12 +1954,13 @@
   {#snippet ritXitScanSurface()}
     {#if view?.ritXit || view?.scan}
       <RitXitScanSurface
-        {view} {ritDomain}
+        {view} {ritDomain} {scanCapable}
         handles={ritXitInstruments}
         onRitOffsetChange={ritXitIntents.onRitOffsetChange}
         onXitOffsetChange={ritXitIntents.onXitOffsetChange}
         onScanStart={(type) => scanIntents.onScanStart(type)}
         onScanStop={scanIntents.onScanStop}
+        onDfSpanChange={(span) => scanIntents.onDfSpanChange(span)}
         onResumeModeChange={(mode) => scanIntents.onResumeChange(mode)}
       />
     {/if}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
@@ -26,6 +26,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
+import { DF_SPANS, RESUME_MODES, SCAN_TYPES } from '../../../semantic/RitXitScanSurface.svelte';
 import type { Capabilities, ControlDomain } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
@@ -163,6 +164,17 @@ const FTX_RIT_DOMAIN: ControlDomain = {
  *  scan commands additionally require the declared `scan` capability. */
 const RIT_XIT_TAGS = ['tx', 'rit', 'xit', 'scan'] as const;
 const SILENT_TAGS = ['tx'] as const;
+/** MOR-2425 restore: `rit`/`xit` present but `scan` absent — the scan FACT
+ *  group still renders (per-field "ever reported", no capability check),
+ *  but the command layer's `hasCapability('scan')` gate means the new
+ *  TYPE/SPAN/RESUME button groups must HIDE while the pre-existing
+ *  toggle/readouts stay unaffected (census §3's "silent trap"). */
+const NO_SCAN_TAGS = ['tx', 'rit', 'xit'] as const;
+const hexId = (value: number) => `0x${value.toString(16).padStart(2, '0')}`;
+const scanTypeCases = SCAN_TYPES.map(([value, label]) => ({ value, label, hex: hexId(value) }));
+const dfSpanSample = [DF_SPANS[0]!, DF_SPANS[DF_SPANS.length - 1]!]
+  .map(([value, label]) => ({ value, label, hex: hexId(value) }));
+const resumeCases = RESUME_MODES.map(([value, label]) => ({ value, label, hex: hexId(value) }));
 
 let target: HTMLDivElement;
 let component: ReturnType<typeof mount> | null = null;
@@ -418,12 +430,97 @@ describe('the surface intents reach the shipped command vocabulary', () => {
     flushSync();
     expect(sendCommand).toHaveBeenCalledExactlyOnceWith('scan_stop', {});
   });
+});
 
-  it('cycling resume mode sends scan_set_resume with the advanced mask', () => {
+/* ── MOR-2425 restore: TYPE, ΔF SPAN, RESUME reach the real command bus ── */
+
+describe('MOR-2425: scan TYPE buttons reach the real command bus', () => {
+  it.each(scanTypeCases)('$label ($hex) sends scan_start with its own byte exactly once', ({ value, hex }) => {
     render();
-    el('scan-resume-cycle')!.click();
+    el(`scan-type-${hex}`)!.click();
     flushSync();
-    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('scan_set_resume', { mode: 0xD2 });
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('scan_start', { type: value });
+  });
+
+  it('hides the TYPE group — not merely disables it — when the radio has no scan capability', () => {
+    h.caps = liveCaps(NO_SCAN_TAGS);
+    setCapabilities(liveCaps(NO_SCAN_TAGS));
+    render();
+    expect(el('scan-type-group')).toBeNull();
+    // The pre-existing scan toggle/readouts stay unaffected — this PR adds
+    // no new gate on them.
+    expect(el('scan-toggle')).not.toBeNull();
+    expect(el('scan-type-value')).not.toBeNull();
+  });
+});
+
+describe('MOR-2425: ΔF SPAN buttons reach the real command bus', () => {
+  it('is absent by default (PROG selected, no active ΔF scan)', () => {
+    render();
+    expect(el('scan-span-group')).toBeNull();
+  });
+
+  // Representative sample, not the full seven: `RitXitScanSurface.test.ts`
+  // already exhaustively pins all seven ΔF-SPAN bytes against the surface's
+  // own `onDfSpanChange` callback (its `dfSpanCases` `it.each`) — this layer
+  // additionally proves the wire shape (`scan_set_df_span`, `span` key) is
+  // correct, which the surface-level test cannot see.
+  it.each(dfSpanSample)('$label ($hex) sends scan_set_df_span with its own byte exactly once, once ΔF is selected', ({ value, hex }) => {
+    render();
+    el('scan-type-0x03')!.click();
+    flushSync();
+    // Selecting ΔF itself fires `scan_start` (v2.11.1 `handleTypeClick`,
+    // restored above) — clear it so the assertion below is about the SPAN
+    // click alone, not "was ever called with this value".
+    vi.mocked(sendCommand).mockClear();
+    el(`scan-span-${hex}`)!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('scan_set_df_span', { span: value });
+  });
+
+  it('hides the SPAN group when the radio has no scan capability, even were ΔF selectable', () => {
+    h.caps = liveCaps(NO_SCAN_TAGS);
+    setCapabilities(liveCaps(NO_SCAN_TAGS));
+    render();
+    expect(el('scan-type-group')).toBeNull();
+    expect(el('scan-span-group')).toBeNull();
+  });
+});
+
+describe('MOR-2425: RESUME buttons reach the real command bus (replacing the cycle)', () => {
+  it.each(resumeCases)('$label ($hex) sends scan_set_resume with its own literal byte exactly once', ({ value, hex }) => {
+    render();
+    el(`scan-resume-${hex}`)!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('scan_set_resume', { mode: value });
+  });
+
+  // The load-bearing divergence from the old single cycle button (which
+  // required a KNOWN reading to compute its next value): none of the four
+  // explicit buttons reads `scanResumeMode.reading` at all, so all four must
+  // still reach the wire even when the radio has never reported it.
+  it('fires even while scanResumeMode is unobserved (stale/unavailable, not merely absent)', () => {
+    const state = liveState();
+    useState({
+      ...state,
+      fieldStatus: {
+        ...state.fieldStatus,
+        scanResumeMode: { ...fresh, freshness: 'stale', availability: 'stale' },
+      },
+    } as ServerState);
+    render();
+    expect(el('scan-resume-value')!.textContent?.trim()).toBe('—');
+    el('scan-resume-0xd1')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('scan_set_resume', { mode: 0xD1 });
+  });
+
+  it('hides the RESUME group when the radio has no scan capability', () => {
+    h.caps = liveCaps(NO_SCAN_TAGS);
+    setCapabilities(liveCaps(NO_SCAN_TAGS));
+    render();
+    expect(el('scan-resume-group')).toBeNull();
+    expect(el('scan-resume-value')).not.toBeNull();
   });
 });
 

--- a/frontend/src/semantic/FilterSurface.svelte
+++ b/frontend/src/semantic/FilterSurface.svelte
@@ -110,11 +110,12 @@
     onIfShiftChange?: (value: number) => void;
     onPbtInnerChange?: (value: number) => void;
     onPbtOuterChange?: (value: number) => void;
+    onPbtReset?: () => void;
   }
   let {
     view, handles, finiteLayout, pendingDataMode = null, filterWidthFeedback,
     onDataModeChange, onFilterWidthChange,
-    onFilterShapeChange, onIfShiftChange, onPbtInnerChange, onPbtOuterChange,
+    onFilterShapeChange, onIfShiftChange, onPbtInnerChange, onPbtOuterChange, onPbtReset,
   }: Props = $props();
 
   const pendingFilterId = $props.id();
@@ -330,6 +331,12 @@
           {/if}
         {/if}
       {/each}
+      {#if filterPassband.pbtInner.availability.structural && filterPassband.pbtOuter.availability.structural}
+        <button
+          type="button" class="pbt-reset-button" data-testid="filter-pbt-reset"
+          onclick={() => onPbtReset?.()}
+        >Reset</button>
+      {/if}
       {#if filterPassband.dataMode.availability.structural}
         {@const behavior = dataModeInstrument()}
         <div
@@ -374,6 +381,7 @@
   .pbt-cue { width: 1ch; }
   .filter-choice[aria-pressed='true'] { font-weight: 700; }
   .filter-choice:disabled { cursor: not-allowed; }
+  .pbt-reset-button { align-self: flex-start; }
   /* MOR-1441 leg 2 — a pending (unconfirmed) target never renders identically
      to confirmed truth. Structural (italic + reduced opacity), never a
      color-only tell — same doctrine `.freq[data-freq-status='pending']`

--- a/frontend/src/semantic/RitXitScanSurface.svelte
+++ b/frontend/src/semantic/RitXitScanSurface.svelte
@@ -33,12 +33,19 @@
   `scan`'s commands carry no such per-receiver ambiguity in v2 to diverge
   from, so this gate applies to `ritXit` only.
 
-  `scan` HAS NO CAPABILITY TAG anywhere (MOR-1295 ruling): evidence is
-  per-field "ever reported", so a partial reporter surfaces exactly the
-  fields it has reported, no more — expected, not a bug. Scan TYPE and
-  RESUME-MODE label tables are UI-only in v2 and are deliberately not
-  reproduced here (out of scope, not backed by any 8A fact): resume mode
-  is cycled by its raw masked value.
+  `scan` HAS NO CAPABILITY TAG anywhere AT THE FACT LAYER (MOR-1295
+  ruling): evidence is per-field "ever reported", so a partial reporter
+  surfaces exactly the fields it has reported, no more — expected, not a
+  bug. The COMMAND layer disagrees: `makeScanHandlers()`
+  (panel-commands.ts) gates every scan intent on `hasCapability('scan')`,
+  so a TYPE/SPAN/RESUME control that renders purely from "ever reported"
+  evidence could still silently no-op on a radio that lacks the tag
+  (MOR-2425 restore census §3). `scanCapable` below is that command-layer
+  fact, read at the wiring seam (`SemanticRadioSurfaces.svelte`, the same
+  "caps-echo display metadata" seam `hasDualReceiver` uses) and passed
+  down as a plain prop — RadioViewModel carries no capabilities field, so
+  this is not a fact-layer change. It HIDES, not merely disables, the
+  TYPE/SPAN/RESUME button groups when false.
 
   SCAN TYPE OWNERSHIP (MOR-1495 review R2 — verifier-caught bootstrap
   deadlock). CI-V 0x0E is SET-ONLY: `scanType` can never become "known"
@@ -54,6 +61,17 @@
   selection. `scanType`'s OWN displayed reading (`scan-type-value`) is
   untouched by this and still shows only the genuinely last-observed
   value, `UNKNOWN_TEXT` until one exists.
+
+  MOR-2425 restores v2.11.1's TYPE/SPAN/RESUME affordances on
+  `selectedType`'s foundation: six TYPE buttons set it and immediately
+  call `onScanStart` (v2's own `handleTypeClick` — unconditional, even
+  mid-scan, so picking a new type restarts the scan with it); the seven
+  ΔF-SPAN buttons show only while the selection (or an observed active
+  scan) is ΔF (0x03); RESUME is four buttons sending a literal value each
+  (OFF/5s/10s/15s), replacing the single masked-cycle action — and,
+  because none of the three reads `sc.scan*.reading` to decide whether it
+  may fire, all three work even from a cold start where nothing has ever
+  been observed, exactly like v2.11.1's did.
 -->
 <script module lang="ts">
   import type { RitXitField, ScanField } from './radio-view-model';
@@ -66,6 +84,19 @@
   export const OFFSET_STEP = 50;
   /** v2 `ScanPanel`'s own default scan type for the next START — PROG. */
   export const DEFAULT_SCAN_TYPE = 0x01;
+  /** v2.11.1 `ScanPanel`'s own `scanTypes`/`dfSpans`/`resumeModes` tables,
+   *  verbatim (`[value, label]`). */
+  export const SCAN_TYPES = [
+    [0x01, 'PROG'], [0x02, 'P2'], [0x03, 'ΔF'], [0x12, 'FINE'], [0x22, 'MEM'], [0x23, 'SEL'],
+  ] as const;
+  export const DF_SPANS = [
+    [0xa1, '±5k'], [0xa2, '±10k'], [0xa3, '±20k'], [0xa4, '±50k'],
+    [0xa5, '±100k'], [0xa6, '±500k'], [0xa7, '±1M'],
+  ] as const;
+  export const RESUME_MODES = [
+    [0xd0, 'OFF'], [0xd1, '5s'], [0xd2, '10s'], [0xd3, '15s'],
+  ] as const;
+  const hex = (value: number): string => value.toString(16).padStart(2, '0');
 
   export const usable = (f: RitXitField<unknown> | ScanField<unknown>): boolean =>
     f.availability.structural && f.availability.operational && f.reading.status === 'known';
@@ -78,7 +109,7 @@
   import { decodeControlDomain, encodeControlDomain } from '$lib/radio/control-domain';
   import { exactDecimalNumber } from '$lib/types/exact-decimal';
   import type { ControlDomain } from '$lib/types/capabilities';
-  import { bindActionInstrument, bindToggleInstrument } from '../primitives/control-instruments/control-instrument-behavior';
+  import { bindToggleInstrument } from '../primitives/control-instruments/control-instrument-behavior';
   import type {
     RitXitScanInstrumentHandles, RitXitScanInstrumentLayout,
   } from './RitXitScanInstrumentHost.svelte';
@@ -90,14 +121,20 @@
     onXitOffsetChange?: (hz: number) => void;
     onScanStart?: (type: number) => void;
     onScanStop?: () => void;
+    onDfSpanChange?: (span: number) => void;
     onResumeModeChange?: (mode: number) => void;
+    /** `hasCapability('scan')` at the wiring seam — see file header. Hides
+     *  (never merely disables) the TYPE/SPAN/RESUME button groups. Fails
+     *  closed: absent controls until a caller proves the tag is present. */
+    scanCapable?: boolean;
     ritDomain?: ControlDomain | null;
     handles: RitXitScanInstrumentHandles;
     instrumentLayout?: RitXitScanInstrumentLayout;
   }
   let {
     view, onRitOffsetChange, onXitOffsetChange,
-    onScanStart, onScanStop, onResumeModeChange, ritDomain, handles, instrumentLayout,
+    onScanStart, onScanStop, onDfSpanChange, onResumeModeChange, scanCapable = false,
+    ritDomain, handles, instrumentLayout,
   }: Props = $props();
 
   let rx = $derived(view.ritXit);
@@ -129,6 +166,11 @@
    *  file header). NOT an observed radio fact, so it needs no `usable()`
    *  gate: it is honest about what it is from the moment it exists. */
   let selectedType = $state(DEFAULT_SCAN_TYPE);
+  /** v2.11.1 `isDfSelected || (scanning && scanType === 0x03)`, verbatim —
+   *  never reads `sc.scanType` to decide whether the SELECTION itself is
+   *  ΔF, only whether an ALREADY-ACTIVE observed scan is. */
+  let isDfSelected = $derived(selectedType === 0x03 || (scanningOn
+    && sc?.scanType.reading.status === 'known' && sc.scanType.reading.value === 0x03));
 
   const scanToggle = bindToggleInstrument(() => ({
     field: sc?.scanning,
@@ -137,13 +179,13 @@
       else onScanStop?.();
     },
   }));
-  const resumeCycle = bindActionInstrument(() => ({
-    field: sc?.scanResumeMode,
-    invoke: () => {
-      if (sc?.scanResumeMode.reading.status !== 'known') return;
-      onResumeModeChange?.(0xD0 | ((sc.scanResumeMode.reading.value + 1) % 4));
-    },
-  }));
+  /** v2.11.1 `handleTypeClick`, verbatim: sets the selection AND fires
+   *  START immediately and unconditionally — even mid-scan, restarting it
+   *  with the new type. Never reads `sc.scanType`; never disabled. */
+  function selectScanType(type: number): void {
+    selectedType = type;
+    onScanStart?.(type);
+  }
   function changeOffset(displayHz: number): void {
     if (!canAdjustOffset || !Number.isFinite(displayHz)) return;
     let raw = displayHz;
@@ -213,16 +255,42 @@
             disabled={!scanToggle.available}
             onclick={() => scanToggle.invoke()}
           >{scanningOn ? 'STOP' : 'START'}</button>
+          {#if scanCapable}
+            <div class="scan-choice-group" data-testid="scan-type-group">
+              {#each SCAN_TYPES as [value, label] (value)}
+                <button
+                  type="button" class="scan-choice" data-testid={`scan-type-0x${hex(value)}`}
+                  onclick={() => selectScanType(value)}
+                >{label}</button>
+              {/each}
+            </div>
+            {#if isDfSelected}
+              <div class="scan-choice-group" data-testid="scan-span-group">
+                {#each DF_SPANS as [value, label] (value)}
+                  <button
+                    type="button" class="scan-choice" data-testid={`scan-span-0x${hex(value)}`}
+                    onclick={() => onDfSpanChange?.(value)}
+                  >{label}</button>
+                {/each}
+              </div>
+            {/if}
+          {/if}
         {/if}
         {#if sc.scanType.availability.structural}
           <output data-testid="scan-type-value">{textOf(sc.scanType)}</output>
         {/if}
         {#if sc.scanResumeMode.availability.structural}
           <output data-testid="scan-resume-value">{textOf(sc.scanResumeMode)}</output>
-          <button
-            type="button" data-testid="scan-resume-cycle" disabled={!resumeCycle.available}
-            onclick={() => resumeCycle.invoke()}
-          >RESUME ▶</button>
+          {#if scanCapable}
+            <div class="scan-choice-group" data-testid="scan-resume-group">
+              {#each RESUME_MODES as [value, label] (value)}
+                <button
+                  type="button" class="scan-choice" data-testid={`scan-resume-0x${hex(value)}`}
+                  onclick={() => onResumeModeChange?.(value)}
+                >{label}</button>
+              {/each}
+            </div>
+          {/if}
         {/if}
       </div>
     {/if}
@@ -234,6 +302,7 @@
   .ritxit-scan-surface { display: flex; flex-direction: column; gap: 0.25rem; }
   .row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin: 0; }
   .offset { display: flex; align-items: baseline; gap: 0.5rem; }
+  .scan-choice-group { display: flex; flex-wrap: wrap; gap: 0.25rem; }
   [aria-pressed='true'] { font-weight: 700; }
   [data-observed='false'] { font-style: italic; }
   button:disabled, input:disabled { cursor: not-allowed; }

--- a/frontend/src/semantic/__tests__/FilterSurface.test.ts
+++ b/frontend/src/semantic/__tests__/FilterSurface.test.ts
@@ -10,14 +10,15 @@
  */
 import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { flushSync, mount, unmount } from 'svelte';
+import { createRawSnippet, flushSync, mount, unmount } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import { getLocale, setLocale } from '$lib/i18n';
-import {
+import FilterSurface, {
   FILTER_PASSBAND_LEVELS, FILTER_SHAPES, type FilterPassbandLevelField,
 } from '../FilterSurface.svelte';
 import FilterInstrumentHostFixture from './fixtures/FilterInstrumentHostFixture.svelte';
 import { topologyFixtures, withFilterPassband, withModeFilter } from '../fixtures/topologies';
+import type { FilterInstrumentHandles } from '../filter-instruments';
 import type {
   Availability, FilterPassbandViewModel, ModeFilterViewModel, RadioViewModel,
 } from '../radio-view-model';
@@ -1157,5 +1158,73 @@ describe('explicit PBT display (MOR-1692)', () => {
       expect(s.input('filter-pbtInner')).toBeNull(); expect(group.querySelector('[aria-valuenow]')).toBeNull();
       group.dispatchEvent(new Event('input', { bubbles: true })); flushSync(); expect(onChange).not.toHaveBeenCalled();
     }, { onPbtInnerChange: onChange });
+  });
+});
+
+/**
+ * MOR-2425 restore — PBT reset. Mounted directly (no `modeFilter`, so
+ * `handles.mode()/filter()` are never invoked) rather than through
+ * `FilterInstrumentHostFixture`, whose fixed prop list does not forward
+ * `onPbtReset` and no other test in this file needs widening for it.
+ *
+ * The exact caps-derived CENTER value `onPbtReset` sends over
+ * `set_pbt_inner`/`set_pbt_outer` is already pinned end to end, against the
+ * REAL `makeFilterHandlers()` factory and a spied `sendCommand`, in
+ * `lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts`
+ * (its `onPbtReset` case: `['set_pbt_inner', { value: 128, receiver: 0 }]`,
+ * `['set_pbt_outer', { value: 128, receiver: 0 }]`) — unmodified by this PR.
+ * This describe block proves the surface's OWN half of that chain: the
+ * button renders only when PBT is structural, and a click reaches whatever
+ * `onPbtReset` callback the wiring seam hands it, exactly once.
+ */
+const pbtStubHandles: FilterInstrumentHandles = {
+  mode: createRawSnippet(() => ({ render: () => '<span></span>' })),
+  filter: createRawSnippet(() => ({ render: () => '<span></span>' })),
+};
+function renderPbtOnly(view: RadioViewModel, onPbtReset?: () => void) {
+  const component = mount(FilterSurface, {
+    target, props: { view, handles: pbtStubHandles, onPbtReset },
+  });
+  flushSync();
+  return {
+    dispose: () => unmount(component),
+    button: () => target.querySelector<HTMLButtonElement>('[data-testid="filter-pbt-reset"]'),
+  };
+}
+
+describe('PBT reset (MOR-2425 restore)', () => {
+  it('renders only when BOTH pbtInner and pbtOuter are structural', () => {
+    const r = renderPbtOnly(withFilterPassband(topologyFixtures['1/single']));
+    expect(r.button()).not.toBeNull();
+    r.dispose();
+  });
+
+  it('is absent when pbtInner is not structural (e.g. no PBT capability)', () => {
+    const view = withPassbandField(
+      withFilterPassband(topologyFixtures['1/single']), 'pbtInner',
+      { availability: { structural: false, operational: false } },
+    );
+    const r = renderPbtOnly(view);
+    expect(r.button()).toBeNull();
+    r.dispose();
+  });
+
+  it('is absent when pbtOuter is not structural, even if pbtInner is', () => {
+    const view = withPassbandField(
+      withFilterPassband(topologyFixtures['1/single']), 'pbtOuter',
+      { availability: { structural: false, operational: false } },
+    );
+    const r = renderPbtOnly(view);
+    expect(r.button()).toBeNull();
+    r.dispose();
+  });
+
+  it('click calls onPbtReset exactly once', () => {
+    const onPbtReset = vi.fn();
+    const r = renderPbtOnly(withFilterPassband(topologyFixtures['1/single']), onPbtReset);
+    r.button()!.click();
+    flushSync();
+    expect(onPbtReset).toHaveBeenCalledExactlyOnceWith();
+    r.dispose();
   });
 });

--- a/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
@@ -17,8 +17,11 @@
  */
 import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { flushSync, mount, unmount } from 'svelte';
-import { OFFSET_MAX, OFFSET_MIN, OFFSET_STEP, UNKNOWN_TEXT } from '../RitXitScanSurface.svelte';
+import { createRawSnippet, flushSync, mount, unmount } from 'svelte';
+import RitXitScanSurface, {
+  DF_SPANS, OFFSET_MAX, OFFSET_MIN, OFFSET_STEP, RESUME_MODES, SCAN_TYPES, UNKNOWN_TEXT,
+} from '../RitXitScanSurface.svelte';
+import type { RitXitScanInstrumentHandles } from '../RitXitScanInstrumentHost.svelte';
 import RitXitScanInstrumentHostFixture from './fixtures/RitXitScanInstrumentHostFixture.svelte';
 import { topologyFixtures, withRitXit, withScan } from '../fixtures/topologies';
 import type {
@@ -77,13 +80,47 @@ function render(view: RadioViewModel, handlers: Handlers = {}) {
 /** MOR-1304 F3 recipe: bypasses jsdom's disabled-button `.click()` no-op. */
 const bypassClick = (el: HTMLElement) => el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
+/**
+ * MOR-2425 restore — the TYPE/SPAN/RESUME groups live entirely in the SCAN
+ * row, which never renders `handles` (that only happens inside `{#if rx}`).
+ * Mounting `RitXitScanSurface` directly with a stub `handles` (never invoked
+ * for a scan-only view) avoids widening `RitXitScanInstrumentHostFixture`'s
+ * fixed prop list for props only these tests need.
+ */
+const stubHandles: RitXitScanInstrumentHandles = {
+  rit: createRawSnippet(() => ({ render: () => '<span></span>' })),
+  xit: createRawSnippet(() => ({ render: () => '<span></span>' })),
+  clear: createRawSnippet(() => ({ render: () => '<span></span>' })),
+};
+type ScanHandlers = {
+  onScanStart?: (type: number) => void;
+  onScanStop?: () => void;
+  onDfSpanChange?: (span: number) => void;
+  onResumeModeChange?: (mode: number) => void;
+  scanCapable?: boolean;
+};
+function renderScan(view: RadioViewModel, handlers: ScanHandlers = {}) {
+  const component = mount(RitXitScanSurface, {
+    target, props: { view, handles: stubHandles, ...handlers },
+  });
+  flushSync();
+  const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+  return {
+    dispose: () => unmount(component),
+    el: (id: string) => q<HTMLElement>(`[data-testid="${id}"]`),
+    all: (id: string) => target.querySelectorAll(`[data-testid="${id}"]`),
+  };
+}
+
 describe('current-input action bindings', () => {
-  it('uses toggles for RIT, XIT and scan, plus an action for the resume cycle', () => {
+  // MOR-2425 restore: the single-action resume CYCLE is gone (superseded by
+  // four explicit literal-value buttons below), so this no longer pins a
+  // `bindActionInstrument` action — only the toggles remain.
+  it('uses toggles for RIT, XIT and scan', () => {
     expect(SOURCE).toContain('bindToggleInstrument');
     expect(HOST_SOURCE).toContain('const ritToggle = bindToggleInstrument');
     expect(HOST_SOURCE).toContain('const xitToggle = bindToggleInstrument');
     expect(SOURCE).toContain('const scanToggle = bindToggleInstrument');
-    expect(SOURCE).toContain('const resumeCycle = bindActionInstrument');
   });
 
   it('keeps RIT and XIT callbacks as zero-argument intents', () => {
@@ -463,7 +500,13 @@ describe('scan start/stop: guarded on a KNOWN scanning state only (MOR-1495 revi
     r.dispose();
   });
 
-  it('starts with the surface\'s own default type (PROG, 0x01) via a normal click, from a cold start where scanType has never been reported', () => {
+  // MOR-2425 restore supersedes this title's OLD framing ("always starts
+  // with PROG regardless of the last-observed type"): the new contract is
+  // "starts with the surface's own SELECTED type; default still PROG until
+  // a TYPE button changes it" (see the `scan TYPE selection` describe block
+  // below for the selection half). This case never clicks a TYPE button, so
+  // the selection stays at its default and the assertion is unchanged.
+  it('starts with the surface\'s own SELECTED type (default PROG, 0x01) via a normal click, from a cold start where scanType has never been reported', () => {
     const onScanStart = vi.fn();
     const r = render(
       withSc({ scanning: knownScan(false), scanType: unreadScan<number>(OFF_AVAIL) }), { onScanStart },
@@ -474,7 +517,11 @@ describe('scan start/stop: guarded on a KNOWN scanning state only (MOR-1495 revi
     r.dispose();
   });
 
-  it('starts with the local default even when a DIFFERENT type happens to be the last-observed one — type is never read from the observed fact', () => {
+  // MOR-2425 restore supersedes this title's OLD framing too — same
+  // rationale as above: the SELECTED type (not the OBSERVED `scanType`
+  // fact) still decides START's argument; no TYPE button is clicked here,
+  // so the selection is still the default.
+  it('starts with the locally SELECTED type (still the default here) even when a DIFFERENT type happens to be the last-observed one — type is never read from the observed fact', () => {
     const onScanStart = vi.fn();
     const r = render(withSc({ scanning: knownScan(false), scanType: knownScan(0x22) }), { onScanStart });
     r.el('scan-toggle')!.click();
@@ -493,54 +540,135 @@ describe('scan start/stop: guarded on a KNOWN scanning state only (MOR-1495 revi
   });
 });
 
-describe('scan resume mode: a single honest cycle over the raw masked value', () => {
-  it('disables the cycle control while resumeMode is unobserved', () => {
-    const r = render(withSc({ scanResumeMode: unreadScan<number>() }));
-    expect(r.el('scan-resume-cycle')!.hasAttribute('disabled')).toBe(true);
+/**
+ * MOR-2425 restore. `renderScan` mounts `RitXitScanSurface` directly (no
+ * `ritXit` group, so `handles` is never invoked) — the shared fixture-backed
+ * `render()`/`withSc()` above cannot express `scanCapable` or `onDfSpanChange`
+ * without widening `RitXitScanInstrumentHostFixture`'s fixed prop list, which
+ * no other test in this file needs.
+ */
+function coldStart(over: Partial<ScanViewModel> = {}): RadioViewModel {
+  const view = withScan(topologyFixtures['1/single']);
+  return {
+    ...view,
+    scan: {
+      ...view.scan!, scanning: knownScan(false), scanType: unreadScan<number>(OFF_AVAIL), ...over,
+    },
+  };
+}
+const hexId = (value: number) => `0x${value.toString(16).padStart(2, '0')}`;
+const scanTypeCases = SCAN_TYPES.map(([value, label]) => ({ value, label, hex: hexId(value) }));
+const dfSpanCases = DF_SPANS.map(([value, label]) => ({ value, label, hex: hexId(value) }));
+const resumeCases = RESUME_MODES.map(([value, label]) => ({ value, label, hex: hexId(value) }));
+
+describe('scan TYPE selection: six buttons restore v2.11.1, MOR-2425', () => {
+  it('is hidden entirely — not merely disabled — while scanCapable is false', () => {
+    const r = renderScan(coldStart(), { scanCapable: false });
+    expect(r.el('scan-type-group')).toBeNull();
     r.dispose();
   });
 
-  it('refuses to dispatch when the click bypasses disabled', () => {
-    const onResumeModeChange = vi.fn();
-    const r = render(withSc({ scanResumeMode: unreadScan<number>() }), { onResumeModeChange });
-    bypassClick(r.el('scan-resume-cycle')!);
+  it.each(scanTypeCases)(
+    '$label ($hex) dispatches onScanStart with its own byte exactly once, from a cold start where scanType has never been reported',
+    ({ value, hex }) => {
+      const onScanStart = vi.fn();
+      const r = renderScan(coldStart(), { onScanStart, scanCapable: true });
+      r.el(`scan-type-${hex}`)!.click();
+      flushSync();
+      expect(onScanStart).toHaveBeenCalledExactlyOnceWith(value);
+      r.dispose();
+    },
+  );
+
+  it('restarts an ACTIVE scan with the newly selected type — v2.11.1 handleTypeClick fires unconditionally, even mid-scan', () => {
+    const onScanStart = vi.fn();
+    const r = renderScan(coldStart({ scanning: knownScan(true) }), { onScanStart, scanCapable: true });
+    r.el('scan-type-0x22')!.click();
     flushSync();
-    expect(onResumeModeChange).not.toHaveBeenCalled();
+    expect(onScanStart).toHaveBeenCalledExactlyOnceWith(0x22);
     r.dispose();
   });
 
-  it('advances the masked resume value by one, encoded as the full CI-V byte', () => {
-    const onResumeModeChange = vi.fn();
-    const r = render(withSc({ scanResumeMode: knownScan(1) }), { onResumeModeChange });
-    r.el('scan-resume-cycle')!.click();
+  it('a SUBSEQUENT click on scan-toggle START reuses the just-selected type, not the PROG default', () => {
+    const onScanStart = vi.fn();
+    const r = renderScan(coldStart(), { onScanStart, scanCapable: true });
+    r.el('scan-type-0x22')!.click();
+    r.el('scan-toggle')!.click();
     flushSync();
-    expect(onResumeModeChange).toHaveBeenCalledExactlyOnceWith(0xD2);
+    expect(onScanStart).toHaveBeenNthCalledWith(1, 0x22);
+    expect(onScanStart).toHaveBeenNthCalledWith(2, 0x22);
+    r.dispose();
+  });
+});
+
+describe('ΔF SPAN: seven buttons, visible only for the ΔF type, MOR-2425', () => {
+  it('is absent from the DOM by default (PROG selected, no active ΔF scan)', () => {
+    const r = renderScan(coldStart(), { scanCapable: true });
+    expect(r.el('scan-span-group')).toBeNull();
     r.dispose();
   });
 
-  it('wraps from the last masked value back to 0xD0', () => {
-    const onResumeModeChange = vi.fn();
-    const r = render(withSc({ scanResumeMode: knownScan(3) }), { onResumeModeChange });
-    r.el('scan-resume-cycle')!.click();
-    flushSync();
-    expect(onResumeModeChange).toHaveBeenCalledExactlyOnceWith(0xD0);
+  it('stays absent while scanCapable is false — the TYPE group that would select ΔF is itself hidden', () => {
+    const r = renderScan(coldStart(), { scanCapable: false });
+    expect(r.el('scan-type-group')).toBeNull();
+    expect(r.el('scan-span-group')).toBeNull();
     r.dispose();
   });
 
-  // F1 (fix round) — the backend validator is `if resume_mode not in
-  // range(0xD0, 0xD4): raise ValueError(...)` (control.py:2283-2289). Every
-  // one of the four masked cycle positions must dispatch a value inside that
-  // accepted range — the assertion whose absence let the masked-only bug ship.
-  it.each([
-    [0, 0xD1], [1, 0xD2], [2, 0xD3], [3, 0xD0],
-  ])('dispatches an accepted-range value (0xD0..0xD3) from masked %i', (masked, expected) => {
-    const onResumeModeChange = vi.fn();
-    const r = render(withSc({ scanResumeMode: knownScan(masked) }), { onResumeModeChange });
-    r.el('scan-resume-cycle')!.click();
-    flushSync();
-    expect(onResumeModeChange).toHaveBeenCalledExactlyOnceWith(expected);
-    expect(expected).toBeGreaterThanOrEqual(0xD0);
-    expect(expected).toBeLessThanOrEqual(0xD3);
+  it.each(dfSpanCases)(
+    '$label ($hex) dispatches onDfSpanChange with its own byte exactly once, once ΔF is SELECTED — never observed',
+    ({ value, hex }) => {
+      const onDfSpanChange = vi.fn();
+      // Cold start: scanType has never been reported at all (matches the
+      // TYPE describe block's bootstrap case) — only the LOCAL selection
+      // (set by clicking the ΔF type button) may decide SPAN's visibility.
+      const r = renderScan(coldStart(), { onDfSpanChange, scanCapable: true });
+      r.el('scan-type-0x03')!.click();
+      flushSync();
+      r.el(`scan-span-${hex}`)!.click();
+      flushSync();
+      expect(onDfSpanChange).toHaveBeenCalledExactlyOnceWith(value);
+      r.dispose();
+    },
+  );
+
+  it('also shows once an OBSERVED active scan reports ΔF, independent of the local selection', () => {
+    const r = renderScan(
+      coldStart({ scanning: knownScan(true), scanType: knownScan(0x03) }), { scanCapable: true },
+    );
+    expect(r.el('scan-span-group')).not.toBeNull();
     r.dispose();
   });
+});
+
+describe('scan RESUME mode: four explicit literal buttons, MOR-2425 (replacing the cycle)', () => {
+  it('renders only when scanResumeMode is structural', () => {
+    const r = renderScan(coldStart({
+      scanResumeMode: { reading: { status: 'unknown' }, availability: { structural: false, operational: false } },
+    }), { scanCapable: true });
+    expect(r.el('scan-resume-group')).toBeNull();
+    r.dispose();
+  });
+
+  it('is hidden entirely — not merely disabled — while scanCapable is false', () => {
+    const r = renderScan(coldStart(), { scanCapable: false });
+    expect(r.el('scan-resume-group')).toBeNull();
+    r.dispose();
+  });
+
+  // The load-bearing divergence from the old cycle button (which required
+  // `reading.status === 'known'` to compute a next value): v2.11.1's four
+  // explicit buttons carried no such precondition, and this restoration
+  // preserves that — none of the four reads `scanResumeMode.reading` at all.
+  it.each(resumeCases)(
+    '$label ($hex) dispatches onResumeModeChange with its own literal byte exactly once, WHILE scanResumeMode is unobserved',
+    ({ value, hex }) => {
+      const onResumeModeChange = vi.fn();
+      const r = renderScan(coldStart({ scanResumeMode: unreadScan<number>() }), { onResumeModeChange, scanCapable: true });
+      r.el(`scan-resume-${hex}`)!.click();
+      flushSync();
+      expect(onResumeModeChange).toHaveBeenCalledExactlyOnceWith(value);
+      r.dispose();
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Restores four control families v2.11.1 had on Standard (desktop-v2) that today's semantic surfaces lack (parent audit F3, MOR-2425):

- **Scan TYPE selection** (6 buttons: PROG 0x01, P2 0x02, ΔF 0x03, FINE 0x12, MEM 0x22, SEL 0x23) — `RitXitScanSurface.svelte`, routed through `onScanStart` (`scanIntents.onScanStart`, already wired). Uses the surface's existing local `selectedType` mechanism (default PROG); clicking a type sets the selection and immediately calls `onScanStart` (v2.11.1 `handleTypeClick`, unconditional — restarts an active scan too).
- **ΔF SPAN** (7 buttons: 0xA1–0xA7) — shown only while the selected type is ΔF, or an observed active scan reports ΔF (v2.11.1's `isDfSelected || (scanning && scanType === 0x03)`, verbatim). Routed through `onDfSpanChange` (`scanIntents.onDfSpanChange`), newly wired at the `SemanticRadioSurfaces.svelte` mount site (it was not passed before).
- **RESUME** as four explicit literal-value buttons (OFF/5s/10s/15s = 0xD0–0xD3), replacing the single masked-cycle button. Routed through the existing `onResumeModeChange` prop (already wired to `scanIntents.onResumeChange`).
- **PBT reset** — `FilterSurface.svelte`, one button gated on `filterPassband.pbtInner.availability.structural && filterPassband.pbtOuter.availability.structural`, routed through a new `onPbtReset` prop wired to `filterIntents.onPbtReset` (`makeFilterHandlers()`, already exists, newly wired at the mount site).

No new store, handler, command, or `RadioViewModel` field. `SemanticRadioSurfaces.svelte` needed touching because `onDfSpanChange`, `onResumeModeChange`→literal semantics, and `onPbtReset` were not previously passed through to the two surfaces.

**`hasCapability('scan')` hide rule.** The command layer (`makeScanHandlers()`) gates every scan intent on `hasCapability('scan')`, but the `scan` view-model group is per-field "ever reported" with no capability check — a restored TYPE/SPAN/RESUME button could otherwise render and silently no-op on a radio lacking the tag. `RitXitScanSurface` has no existing prop or view field carrying this fact (`RadioViewModel` carries no capabilities array), so I added a `scanCapable?: boolean` prop, computed at the wiring seam (`SemanticRadioSurfaces.svelte`) as `hasCapability('scan')` — the same "caps-echo display metadata" seam `hasDualReceiver`/`agcLabels`/`rfSqlControlModel` already use there. The three new button groups HIDE (not merely disable) when it is false; the pre-existing scan-toggle/status/readouts are untouched.

**RESUME-while-unobserved decision.** v2.11.1's four RESUME buttons sent a literal value unconditionally, with no dependency on the current `scanResumeMode` reading. The old single cycle button *did* require a known reading (to compute `current + 1`). This PR follows v2.11.1: none of the four new buttons reads `scanResumeMode.reading` at all, so all four fire even from a radio that has never reported resume mode — witnessed explicitly (see below).

**Superseded test titles**, rewritten to the new contract (not deleted silently) in `RitXitScanSurface.test.ts`:
- `'uses toggles for RIT, XIT and scan, plus an action for the resume cycle'` → `'uses toggles for RIT, XIT and scan'` (the `resumeCycle`/`bindActionInstrument` mechanism it pinned is gone).
- `'starts with the surface's own default type (PROG, 0x01) via a normal click, from a cold start where scanType has never been reported'` → `'starts with the surface's own SELECTED type (default PROG, 0x01) via a normal click, from a cold start where scanType has never been reported'`.
- `'starts with the local default even when a DIFFERENT type happens to be the last-observed one — type is never read from the observed fact'` → `'starts with the locally SELECTED type (still the default here) even when a DIFFERENT type happens to be the last-observed one — type is never read from the observed fact'`.
- The whole `'scan resume mode: a single honest cycle over the raw masked value'` describe block (5 cases pinning the removed cycle button) is replaced by `'scan RESUME mode: four explicit literal buttons, MOR-2425 (replacing the cycle)'`.
The two `'starts with...'` renames keep their original assertions (no TYPE button is clicked in either case, so the selection is still the default) — only the title's framing changes to name the new SELECTED-type contract; the underlying behavior these titles pin is unchanged.

## Witnesses

Each of the six TYPE buttons, seven ΔF-SPAN buttons (once ΔF is selected) and four RESUME buttons is witnessed with an exact-byte assertion (`toHaveBeenCalledExactlyOnceWith`), never a count-only or "called" check:
- `RitXitScanSurface.test.ts` (pure surface, mocked callbacks): all 6 TYPE bytes, all 7 SPAN bytes, all 4 RESUME bytes — including from a COLD START where `scanType` has never been reported (the MOR-1495 bootstrap case), and the RESUME buttons firing while `scanResumeMode` is unread.
- `semantic-ritxit-scan-wiring.component.test.ts` (real `makeScanHandlers()`, spied `sendCommand`): all 6 TYPE bytes → `scan_start`, all 4 RESUME bytes → `scan_set_resume`, a 2-value ΔF-SPAN sample → `scan_set_df_span` (the pure-surface test already exhaustively covers all seven SPAN bytes against the surface's own callback; this layer additionally proves the wire shape), plus the capability-hide tests (SPAN/TYPE/RESUME groups absent when `scan` is not a declared capability, while the pre-existing toggle/readouts stay present) and the unobserved-resumeMode wiring case.
- PBT reset: `FilterSurface.test.ts` proves the button renders only when both `pbtInner`/`pbtOuter` are structural and a click calls `onPbtReset` exactly once (mocked callback — this file's own established idiom for every other control). The exact caps-derived CENTER value `onPbtReset` sends over `set_pbt_inner`/`set_pbt_outer` is already pinned end to end against the real `makeFilterHandlers()` factory in `lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts` (unmodified by this PR) — duplicating that wiring-level assertion here would need a 7th file (a dedicated filter wiring test) or a large mock-harness addition to `FilterSurface.test.ts`; I judged that not worth the size for a value already correctly proven elsewhere, and split the claim across the two existing files instead of asserting it in one that doesn't fully establish it.

**Mutations run and reverted** (verified via `git diff` after restore — see Verification):
1. `RitXitScanSurface.svelte`'s `selectScanType` hardcoded to always send `0x01` — killed 12 tests (byte assertions in both `RitXitScanSurface.test.ts` and the wiring test, across 5 non-PROG types plus two selection-persistence tests).
2. ΔF-SPAN group's `{#if isDfSelected}` forced to `{#if true}` — killed 2 tests (the two "absent by default" assertions in the surface test and the wiring test).
3. `FilterSurface.svelte`'s PBT-reset gate forced to `{#if true}` — killed 2 tests (the "absent when pbtInner/pbtOuter not structural" assertions in `FilterSurface.test.ts`).

## Census

Read `standard-scan-pbt-restore-census-20260907.md` and `standard-area4-panel-separation-audit-20260907.md` §F3/§5. The census was written against an older `RitXitScanSurface.svelte` (before the RIT/XIT host-join PR, #3347, landed at `origin/main` = `10302c696`); I re-read the file at that head as instructed — RIT/XIT rendering now goes through `handles`/`instrumentLayout` snippets rather than inline markup, and the scan block (unaffected by that PR) was unchanged, so the census's scan-side findings held. Two test-infrastructure gaps the census's 5-file forecast didn't anticipate (both from that same host-join restructuring): `RitXitScanInstrumentHostFixture.svelte`'s fixed prop list has no room for `scanCapable`/`onDfSpanChange`, and `FilterInstrumentHostFixture.svelte`'s has none for `onPbtReset`. I avoided widening either (would have made a 7th/8th file) by mounting `RitXitScanSurface`/`FilterSurface` directly in the two test files, using `createRawSnippet` stub handles that are never invoked in the scan-only / modeFilter-absent views these tests use.

## Verification

- `git diff --stat`: 6 files, 448 insertions / 68 deletions (516 A+D) — at the soft-threshold file count (6) but under its line count (600); no exception needed.
- `npx vitest run` on the two surface tests, the ritxit wiring test, and the full grep-union of every test file naming `RitXitScanSurface`/`FilterSurface`/`SemanticRadioSurfaces` (`grep -rlE "RitXitScanSurface|FilterSurface|SemanticRadioSurfaces" src --include="*.test.ts"` → 71 files, `semantic-desktop-migration.component.test.ts` among them): **2390/2390 passed**.
- `npm run check`: 4826 files, 0 errors, 0 warnings.
- `npx eslint` on all 6 changed files: clean.
- `git diff --check`: clean.
- Never ran the full backend/frontend suite.

`git diff --name-only | grep png` is empty — no PNG moved. The i18n production-root screenshot fixture (`frontend/tests/e2e/i18n/fixtures.ts`) declares no `rit`/`xit`/`scan`/`pbt` capability tags and no scan state, so the entire RIT/XIT/SCAN panel and the PBT rows in FILTER don't render under that fixture either before or after this change (census §2) — consistent with the empty PNG diff.

`internal-identifier self-check — empty`

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)