### PR TITLE
feat(MOR-2425): prepare the Memory surface and share the channel catalog

### DIFF
--- a/frontend/src/components-v2/panels/MemoryPanel.svelte
+++ b/frontend/src/components-v2/panels/MemoryPanel.svelte
@@ -8,21 +8,17 @@
    */
   import { deriveMemoryPanelProps, getMemoryHandlers } from '$lib/runtime/adapters/panel-adapters';
   import { formatFrequencyString } from '../display/frequency-format';
+  import {
+    loadMemoryChannels, persistMemoryChannels, MAX_MEMORY_CHANNELS, type MemoryEntry,
+  } from '../../semantic/memory-channels';
 
   let p = $derived(deriveMemoryPanelProps());
   const memory = getMemoryHandlers();
 
-  const STORAGE_KEY = 'rigplane:memory-channels';
-  const MAX_CHANNELS = 99;
-
-  interface MemoryEntry {
-    freq: number;
-    mode: string;
-    name: string;
-  }
+  const MAX_CHANNELS = MAX_MEMORY_CHANNELS;
 
   // Local state
-  let channels = $state<Map<number, MemoryEntry>>(new Map());
+  let channels = $state<Map<number, MemoryEntry>>(loadMemoryChannels());
   let selectedChannel = $state(1);
   let showEmpty = $state(false);
   let editingName = $state<number | null>(null);
@@ -30,29 +26,8 @@
   let confirmClear = $state<number | null>(null);
   let storeTarget = $state<number | null>(null);
 
-  // Load from localStorage on init
-  if (typeof window !== 'undefined') {
-    try {
-      const stored = localStorage.getItem(STORAGE_KEY);
-      if (stored) {
-        const parsed = JSON.parse(stored) as Record<string, MemoryEntry>;
-        const map = new Map<number, MemoryEntry>();
-        for (const [k, v] of Object.entries(parsed)) {
-          map.set(Number(k), v);
-        }
-        channels = map;
-      }
-    } catch { /* ignore */ }
-  }
-
   function persist() {
-    try {
-      const obj: Record<string, MemoryEntry> = {};
-      for (const [k, v] of channels) {
-        obj[String(k)] = v;
-      }
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(obj));
-    } catch { /* ignore */ }
+    persistMemoryChannels(channels);
   }
 
   function recallChannel(ch: number) {

--- a/frontend/src/semantic/MemorySurface.svelte
+++ b/frontend/src/semantic/MemorySurface.svelte
@@ -1,0 +1,249 @@
+<!--
+  Semantic memory-channel surface (MOR-2425 phase A).
+
+  Presentation only, same discipline as every other file in this directory:
+  holds no radio state and consults no controller. Memory channels are not
+  in the MOR-1262 RadioViewModel vocabulary at all (the radio itself cannot
+  report their contents — see `MemoryPanel.svelte`'s own docstring), so
+  facts arrive as `toMemoryPanelProps`'s own shape (`activeFreqHz`/
+  `activeMode`/`vfoIdentityKnown`) via the `facts` prop, imported as a TYPE
+  ONLY from `lib/runtime/props/panel-props.ts` — reusing the one shape
+  rather than re-deriving it, with zero runtime dependency on the runtime
+  layer (the import is erased at build).
+
+  `onRecall`/`onStore`/`onClear` are the same three-callback shape
+  `MemoryPanel.svelte` already wires to `makeMemoryHandlers()`
+  (`panel-commands.ts`) — a caller does the same wiring for this surface.
+  `onRename` has no radio-side counterpart: nothing in `panel-commands.ts`
+  owns a rename intent, because a channel name is local-only bookkeeping
+  the radio never sees. It is an optional notification hook a caller may
+  ignore; the rename itself always persists through the shared
+  `memory-channels.ts` module below, whether or not a caller passes it.
+
+  WRONG-VFO GUARD, same doctrine as `RitXitScanSurface.svelte`'s header:
+  `activeFreqHz`/`activeMode` can be finite/real even while
+  `vfoIdentityKnown` is false (a dual-receiver bootstrap epoch can report a
+  real MAIN-receiver reading before the radio has confirmed MAIN is really
+  the active one) — attributing that reading to "the VFO about to be
+  stored" would be dishonest. The active-VFO readout below is gated on
+  `facts.vfoIdentityKnown` FIRST, never on `Number.isFinite` alone, and the
+  store affordance is refused (no callback fires) under the same gate.
+
+  NOT YET WIRED (MOR-2425 phase B). No zone mounts this component, and no
+  `memory` entry exists in `SEMANTIC_SURFACE_NAMES` yet — see the phase A
+  handoff report for why that specific step did not land in this change.
+-->
+<script module lang="ts">
+  import { MAX_MEMORY_CHANNELS, loadMemoryChannels, persistMemoryChannels } from './memory-channels';
+  export { MAX_MEMORY_CHANNELS };
+  export const UNKNOWN_TEXT = '—';
+</script>
+
+<script lang="ts">
+  import { formatFrequencyString } from '../components-v2/display/frequency-format';
+  import type { MemoryPanelProps } from '../lib/runtime/props/panel-props';
+
+  interface Props {
+    facts: MemoryPanelProps;
+    onRecall?: (channel: number) => boolean;
+    onStore?: (channel: number, frequencyHz: number, mode: string) => boolean;
+    onClear?: (channel: number) => boolean;
+    onRename?: (channel: number, name: string) => void;
+  }
+  let { facts, onRecall, onStore, onClear, onRename }: Props = $props();
+
+  let channels = $state(loadMemoryChannels());
+  let selectedChannel = $state(1);
+  let showEmpty = $state(false);
+  let editingName = $state<number | null>(null);
+  let editNameValue = $state('');
+  let confirmClear = $state<number | null>(null);
+  let storeTarget = $state<number | null>(null);
+
+  function findNextEmpty(): number {
+    for (let i = 1; i <= MAX_MEMORY_CHANNELS; i++) {
+      if (!channels.has(i)) return i;
+    }
+    return 1;
+  }
+
+  function recallChannel(ch: number): void {
+    if (!onRecall?.(ch)) return;
+    selectedChannel = ch;
+  }
+
+  function storeVfoToChannel(ch: number): void {
+    // Refusal, not merely a disabled control: an unattributed VFO reading
+    // must never reach `onStore`, even if a caller bypasses the disabled
+    // button (see the WRONG-VFO GUARD note above).
+    if (!facts.vfoIdentityKnown) return;
+    if (!onStore?.(ch, facts.activeFreqHz, facts.activeMode)) return;
+    const updated = new Map(channels);
+    updated.set(ch, { freq: facts.activeFreqHz, mode: facts.activeMode, name: channels.get(ch)?.name ?? '' });
+    channels = updated;
+    persistMemoryChannels(channels);
+    storeTarget = null;
+  }
+
+  function clearChannel(ch: number): void {
+    if (!onClear?.(ch)) return;
+    const updated = new Map(channels);
+    updated.delete(ch);
+    channels = updated;
+    persistMemoryChannels(channels);
+    confirmClear = null;
+  }
+
+  function startEditName(ch: number): void {
+    editingName = ch;
+    editNameValue = channels.get(ch)?.name ?? '';
+  }
+
+  function saveEditName(ch: number): void {
+    const entry = channels.get(ch);
+    const name = editNameValue.slice(0, 10);
+    if (entry) {
+      const updated = new Map(channels);
+      updated.set(ch, { ...entry, name });
+      channels = updated;
+      persistMemoryChannels(channels);
+      onRename?.(ch, name);
+    }
+    editingName = null;
+  }
+
+  let channelList = $derived(
+    Array.from({ length: MAX_MEMORY_CHANNELS }, (_, i) => i + 1)
+      .filter((ch) => showEmpty || channels.has(ch)),
+  );
+  let populatedCount = $derived(channels.size);
+  /** WRONG-VFO GUARD (file header) — gated on `vfoIdentityKnown` first, not
+   *  on whether the raw fields happen to be finite/non-sentinel. */
+  let activeFreqText = $derived(facts.vfoIdentityKnown ? formatFrequencyString(facts.activeFreqHz) : UNKNOWN_TEXT);
+  let activeModeText = $derived(facts.vfoIdentityKnown ? facts.activeMode : UNKNOWN_TEXT);
+</script>
+
+<section class="memory-surface" data-testid="memory-surface" aria-label="Memory channels">
+  <div class="memory-toolbar">
+    <label class="show-empty">
+      <input type="checkbox" bind:checked={showEmpty} />
+      <span>All</span>
+    </label>
+    <span class="channel-count" data-testid="memory-count">{populatedCount}/{MAX_MEMORY_CHANNELS}</span>
+    <span class="active-vfo" data-testid="memory-active-vfo" data-observed={facts.vfoIdentityKnown}>
+      {activeFreqText} {activeModeText}
+    </span>
+    <button
+      type="button"
+      class="store-btn"
+      data-testid="memory-store-toggle"
+      disabled={!facts.vfoIdentityKnown}
+      data-disabled-reason={!facts.vfoIdentityKnown ? 'vfo-identity-unknown' : undefined}
+      onclick={() => { storeTarget = storeTarget === null ? findNextEmpty() : null; }}
+    >
+      VFO {'->'} M
+    </button>
+  </div>
+
+  {#if storeTarget !== null}
+    <div class="store-bar">
+      <label class="store-label">
+        Store to CH
+        <input type="number" class="store-input" min="1" max={MAX_MEMORY_CHANNELS} bind:value={storeTarget} />
+      </label>
+      <button
+        type="button" class="action-btn store-confirm" data-testid="memory-store-confirm"
+        disabled={!facts.vfoIdentityKnown}
+        data-disabled-reason={!facts.vfoIdentityKnown ? 'vfo-identity-unknown' : undefined}
+        onclick={() => storeVfoToChannel(storeTarget!)}
+      >
+        Store
+      </button>
+      <button type="button" class="action-btn cancel-btn" onclick={() => (storeTarget = null)}>Cancel</button>
+    </div>
+  {/if}
+
+  <div class="channel-list" role="list">
+    {#each channelList as ch (ch)}
+      {@const entry = channels.get(ch)}
+      <div
+        class="channel-row" class:selected={ch === selectedChannel} class:empty={!entry}
+        role="listitem" data-channel={ch} data-testid={`memory-channel-${ch}`}
+      >
+        <span class="ch-number">{String(ch).padStart(2, '0')}</span>
+
+        {#if entry}
+          <span class="ch-freq" data-testid={`memory-channel-${ch}-freq`}>{formatFrequencyString(entry.freq)}</span>
+          <span class="ch-mode">{entry.mode || UNKNOWN_TEXT}</span>
+
+          {#if editingName === ch}
+            <input
+              type="text" class="ch-name-input" maxlength="10" bind:value={editNameValue}
+              data-testid={`memory-channel-${ch}-name-input`}
+              onkeydown={(e) => { if (e.key === 'Enter') saveEditName(ch); if (e.key === 'Escape') editingName = null; }}
+              onblur={() => saveEditName(ch)}
+            />
+          {:else}
+            <button
+              type="button" class="ch-name" title="Click to edit name"
+              data-testid={`memory-channel-${ch}-name`}
+              onclick={() => startEditName(ch)}
+            >
+              {entry.name || UNKNOWN_TEXT}
+            </button>
+          {/if}
+
+          <div class="ch-actions">
+            <button
+              type="button" class="action-btn recall-btn" title="Recall to VFO"
+              data-testid={`memory-channel-${ch}-recall`}
+              disabled={!facts.vfoIdentityKnown}
+              data-disabled-reason={!facts.vfoIdentityKnown ? 'vfo-identity-unknown' : undefined}
+              onclick={() => recallChannel(ch)}
+            >
+              {'>>'}VFO
+            </button>
+
+            {#if confirmClear === ch}
+              <button type="button" class="action-btn clear-confirm" onclick={() => clearChannel(ch)}>Yes</button>
+              <button type="button" class="action-btn cancel-btn" onclick={() => (confirmClear = null)}>No</button>
+            {:else}
+              <button
+                type="button" class="action-btn clear-btn" title="Clear channel"
+                data-testid={`memory-channel-${ch}-clear`}
+                onclick={() => (confirmClear = ch)}
+              >
+                CLR
+              </button>
+            {/if}
+          </div>
+        {:else}
+          <span class="ch-empty-label">-- empty --</span>
+          <div class="ch-actions">
+            <button
+              type="button" class="action-btn store-btn-inline" title="Store VFO to this channel"
+              data-testid={`memory-channel-${ch}-store`}
+              disabled={!facts.vfoIdentityKnown}
+              data-disabled-reason={!facts.vfoIdentityKnown ? 'vfo-identity-unknown' : undefined}
+              onclick={() => storeVfoToChannel(ch)}
+            >
+              {'<<'}VFO
+            </button>
+          </div>
+        {/if}
+      </div>
+    {/each}
+  </div>
+</section>
+
+<style>
+  /* Structure only — a design language owns colour (MOR-977, forced-colors). */
+  .memory-surface { display: flex; flex-direction: column; gap: 0.25rem; }
+  .memory-toolbar { display: flex; align-items: center; gap: 0.5rem; }
+  .channel-count { margin-left: auto; }
+  .channel-list { display: flex; flex-direction: column; }
+  .channel-row { display: flex; align-items: center; gap: 0.375rem; }
+  .ch-actions { display: flex; gap: 0.1875rem; margin-left: auto; }
+  [data-observed='false'] { font-style: italic; }
+  button:disabled, input:disabled { cursor: not-allowed; }
+</style>

--- a/frontend/src/semantic/__tests__/MemorySurface.test.ts
+++ b/frontend/src/semantic/__tests__/MemorySurface.test.ts
@@ -1,0 +1,220 @@
+/**
+ * MOR-2425 phase A — the semantic memory-channel surface.
+ *
+ * `MemorySurface` is not wired into any zone yet (no `memory` entry exists
+ * in `SEMANTIC_SURFACE_NAMES` — see the phase A handoff report for why).
+ * This file pins the surface in isolation: facts/callbacks in, the shared
+ * `memory-channels.ts` module as the one storage owner, no legacy
+ * `data-panel-id` markers.
+ *
+ * Every gate is pinned by a REAL click event dispatched past the `disabled`
+ * attribute (`forceClick`), not `.click()` — `.click()` is a documented
+ * no-op on a disabled button in this codebase's test suite
+ * (`AntennaSurface.test.ts`) and would make the handler-level guard pin
+ * vacuous.
+ */
+import { readFileSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import MemorySurface, { MAX_MEMORY_CHANNELS, UNKNOWN_TEXT } from '../MemorySurface.svelte';
+import { MEMORY_STORAGE_KEY, type MemoryEntry } from '../memory-channels';
+import type { MemoryPanelProps } from '../../lib/runtime/props/panel-props';
+
+const SOURCE = readFileSync('src/semantic/MemorySurface.svelte', 'utf8');
+/** Comments stripped, so the file's own doctrine prose can never be what a
+ *  source-scanning test matches (same idiom as `AntennaSurface.test.ts`). */
+const CODE = SOURCE.replace(/<!--[\s\S]*?-->/g, '');
+
+const KNOWN: MemoryPanelProps = { activeFreqHz: 14_074_000, activeMode: 'USB', vfoIdentityKnown: true };
+const UNKNOWN_IDENTITY: MemoryPanelProps = { activeFreqHz: 7_100_000, activeMode: 'LSB', vfoIdentityKnown: false };
+
+function seed(entries: Record<number, MemoryEntry>): void {
+  const obj: Record<string, MemoryEntry> = {};
+  for (const [k, v] of Object.entries(entries)) obj[k] = v;
+  localStorage.setItem(MEMORY_STORAGE_KEY, JSON.stringify(obj));
+}
+
+function render(facts: MemoryPanelProps, handlers: Record<string, unknown> = {}) {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(MemorySurface, { target, props: { facts, ...handlers } });
+  flushSync();
+  const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+  return {
+    target,
+    dispose: () => { unmount(component); target.remove(); },
+    row: (ch: number) => q<HTMLElement>(`[data-channel="${ch}"]`),
+    btn: (ch: number, suffix: string) => q<HTMLButtonElement>(`[data-testid="memory-channel-${ch}-${suffix}"]`),
+  };
+}
+
+/** The bypass pattern from `AntennaSurface.test.ts`: a REAL click event past
+ *  `disabled`, proving the handler's own guard rather than the attribute. */
+function forceClick(node: HTMLElement): void {
+  node.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  flushSync();
+}
+
+afterEach(() => { localStorage.clear(); });
+
+describe('the memory surface owns no radio state and duplicates no storage logic', () => {
+  it('imports only facts, display formatting and the shared storage module', () => {
+    const specifiers = [...CODE.matchAll(/from\s+'([^']+)'/g)].map((m) => m[1]);
+    expect(specifiers.length).toBeGreaterThan(0);
+    expect([...new Set(specifiers)].sort()).toEqual([
+      '../components-v2/display/frequency-format',
+      '../lib/runtime/props/panel-props',
+      './memory-channels',
+    ]);
+  });
+
+  // Kills: reintroducing a second copy of the localStorage key/persist logic
+  // inside the surface instead of routing through `memory-channels.ts`.
+  it('never spells out the storage key itself — it is owned once, by memory-channels.ts', () => {
+    expect(CODE).not.toContain(MEMORY_STORAGE_KEY);
+  });
+
+  it('declares no lifecycle hook and no effect', () => {
+    for (const forbidden of ['onMount', 'onDestroy', '$effect', 'import(']) {
+      expect(CODE).not.toContain(forbidden);
+    }
+  });
+
+  it('renders no legacy data-panel-id marker', () => {
+    const r = render(KNOWN);
+    expect(r.target.querySelector('[data-panel-id]')).toBeNull();
+    r.dispose();
+  });
+});
+
+describe('the channel list', () => {
+  it('renders all 99 channels once "All" is shown', () => {
+    const r = render(KNOWN);
+    const checkbox = r.target.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    checkbox.click();
+    flushSync();
+    expect(r.target.querySelectorAll('[role="listitem"]')).toHaveLength(MAX_MEMORY_CHANNELS);
+    expect(MAX_MEMORY_CHANNELS).toBe(99);
+    r.dispose();
+  });
+
+  it('renders only populated channels by default', () => {
+    seed({ 4: { freq: 7_074_000, mode: 'USB', name: 'net' }, 40: { freq: 3_573_000, mode: 'LSB', name: '' } });
+    const r = render(KNOWN);
+    expect(r.target.querySelectorAll('[role="listitem"]')).toHaveLength(2);
+    expect(r.row(4)).not.toBeNull();
+    expect(r.row(40)).not.toBeNull();
+    r.dispose();
+  });
+});
+
+describe('recall — per-channel wiring (MUTATION: wiring every button to channel 0)', () => {
+  it.each([2, 5, 9])('channel %d recalls itself, not channel 0 or another channel', (ch) => {
+    seed({ 2: { freq: 1, mode: 'USB', name: '' }, 5: { freq: 2, mode: 'USB', name: '' }, 9: { freq: 3, mode: 'USB', name: '' } });
+    const onRecall = vi.fn(() => true);
+    const r = render(KNOWN, { onRecall });
+    r.btn(ch, 'recall')!.click();
+    flushSync();
+    expect(onRecall).toHaveBeenCalledExactlyOnceWith(ch);
+    r.dispose();
+  });
+
+  it('does not recall when the button reports refusal', () => {
+    seed({ 2: { freq: 1, mode: 'USB', name: '' } });
+    const onRecall = vi.fn(() => false);
+    const r = render(KNOWN, { onRecall });
+    r.btn(2, 'recall')!.click();
+    flushSync();
+    expect(r.row(2)?.classList.contains('selected')).toBe(false);
+    r.dispose();
+  });
+});
+
+describe('store', () => {
+  it('calls onStore exactly once with the target channel, active frequency and mode', () => {
+    const onStore = vi.fn(() => true);
+    const r = render(KNOWN, { onStore });
+    const checkbox = r.target.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    checkbox.click();
+    flushSync();
+    r.btn(7, 'store')!.click();
+    flushSync();
+    expect(onStore).toHaveBeenCalledExactlyOnceWith(7, 14_074_000, 'USB');
+    r.dispose();
+  });
+
+  // MUTATION: removing the `!facts.vfoIdentityKnown` guard inside
+  // `storeVfoToChannel` must be caught even though the button is ALSO
+  // `disabled` — bypass the attribute with a real dispatched click.
+  it('is refused — onStore never fires — when vfoIdentityKnown is false, even past the disabled attribute', () => {
+    const onStore = vi.fn(() => true);
+    const r = render(UNKNOWN_IDENTITY, { onStore });
+    const checkbox = r.target.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    checkbox.click();
+    flushSync();
+    const button = r.btn(11, 'store')!;
+    expect(button.disabled).toBe(true);
+    forceClick(button);
+    expect(onStore).not.toHaveBeenCalled();
+    r.dispose();
+  });
+});
+
+describe('clear', () => {
+  it('calls onClear exactly once with the channel being cleared', () => {
+    seed({ 12: { freq: 1, mode: 'USB', name: '' }, 20: { freq: 2, mode: 'USB', name: '' } });
+    const onClear = vi.fn(() => true);
+    const r = render(KNOWN, { onClear });
+    r.btn(12, 'clear')!.click();
+    flushSync();
+    (r.row(12)!.querySelector('.clear-confirm') as HTMLButtonElement).click();
+    flushSync();
+    expect(onClear).toHaveBeenCalledExactlyOnceWith(12);
+    r.dispose();
+  });
+});
+
+describe('rename', () => {
+  it('calls onRename once with the channel and the new name, and persists through memory-channels.ts', () => {
+    seed({ 3: { freq: 14_200_000, mode: 'USB', name: '' } });
+    const onRename = vi.fn();
+    const r = render(KNOWN, { onRename });
+    r.btn(3, 'name')!.click();
+    flushSync();
+    const input = r.btn(3, 'name-input') as unknown as HTMLInputElement;
+    input.value = 'CLUB NET';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    flushSync();
+    expect(onRename).toHaveBeenCalledExactlyOnceWith(3, 'CLUB NET');
+    r.dispose();
+
+    // Survives remount — proof the write went through the shared module,
+    // not into this component instance's own memory.
+    const r2 = render(KNOWN);
+    expect(r2.btn(3, 'name')!.textContent?.trim()).toBe('CLUB NET');
+    r2.dispose();
+  });
+});
+
+describe('unknown VFO identity (WRONG-VFO GUARD)', () => {
+  // MUTATION: gating the readout on `Number.isFinite(activeFreqHz)` instead
+  // of `vfoIdentityKnown` — `UNKNOWN_IDENTITY` carries a real finite
+  // frequency, so that reversion would render a number here.
+  it('never renders a number for the active-VFO readout, even though the raw frequency is a real finite value', () => {
+    const r = render(UNKNOWN_IDENTITY);
+    const readout = r.target.querySelector('[data-testid="memory-active-vfo"]')!;
+    expect(readout.textContent).not.toMatch(/\d/);
+    expect(readout.textContent?.trim()).toBe(`${UNKNOWN_TEXT} ${UNKNOWN_TEXT}`);
+    expect(readout.getAttribute('data-observed')).toBe('false');
+    r.dispose();
+  });
+
+  it('renders the real frequency and mode once identity is known', () => {
+    const r = render(KNOWN);
+    const readout = r.target.querySelector('[data-testid="memory-active-vfo"]')!;
+    expect(readout.textContent).toContain('14.074');
+    expect(readout.textContent).toContain('USB');
+    r.dispose();
+  });
+});

--- a/frontend/src/semantic/memory-channels.ts
+++ b/frontend/src/semantic/memory-channels.ts
@@ -1,0 +1,51 @@
+/**
+ * memory-channels — the single owner of the 99-channel local memory catalog
+ * (MOR-2425 phase A extraction).
+ *
+ * The IC-7610 class does not support reading memory channel contents over
+ * CI-V (`components-v2/panels/MemoryPanel.svelte`'s own docstring), so the
+ * catalog is tracked client-side in `localStorage`, never on the radio. This
+ * module used to live inline inside `MemoryPanel.svelte`; it is pulled out
+ * here so the semantic `MemorySurface.svelte` can read/write the identical
+ * key without a second copy of the load/persist logic drifting out of sync
+ * with the legacy panel's.
+ */
+
+export const MEMORY_STORAGE_KEY = 'rigplane:memory-channels';
+export const MAX_MEMORY_CHANNELS = 99;
+
+export interface MemoryEntry {
+  freq: number;
+  mode: string;
+  name: string;
+}
+
+/** Reads the catalog from `localStorage`. Returns an empty map on a missing
+ *  key, unparsable JSON, or a `localStorage` access failure — never throws. */
+export function loadMemoryChannels(): Map<number, MemoryEntry> {
+  if (typeof window === 'undefined') return new Map();
+  try {
+    const stored = localStorage.getItem(MEMORY_STORAGE_KEY);
+    if (!stored) return new Map();
+    const parsed = JSON.parse(stored) as Record<string, MemoryEntry>;
+    const map = new Map<number, MemoryEntry>();
+    for (const [k, v] of Object.entries(parsed)) {
+      map.set(Number(k), v);
+    }
+    return map;
+  } catch {
+    return new Map();
+  }
+}
+
+/** Writes the whole catalog back to `localStorage`. Swallows a write failure
+ *  (quota, private-browsing) the same way the pre-extraction inline code did. */
+export function persistMemoryChannels(channels: ReadonlyMap<number, MemoryEntry>): void {
+  try {
+    const obj: Record<string, MemoryEntry> = {};
+    for (const [k, v] of channels) {
+      obj[String(k)] = v;
+    }
+    localStorage.setItem(MEMORY_STORAGE_KEY, JSON.stringify(obj));
+  } catch { /* ignore */ }
+}


### PR DESCRIPTION
## Summary

Prepares the Memory family for the v3 two-level model without touching any shared wiring file.

- `frontend/src/semantic/memory-channels.ts` (new): the localStorage-backed 99-channel catalog (`MEMORY_STORAGE_KEY`, `MAX_MEMORY_CHANNELS`, `MemoryEntry`, `loadMemoryChannels`, `persistMemoryChannels`) extracted out of `MemoryPanel.svelte`, so the catalog has exactly one owner.
- `frontend/src/components-v2/panels/MemoryPanel.svelte`: imports the shared module instead of carrying its own copy of the load/persist logic. Behaviour unchanged; the MOR-1409 authority-boundary regexes on `recallChannel` / `storeVfoToChannel` / `clearChannel` are untouched.
- `frontend/src/semantic/MemorySurface.svelte` (new): presentation-only leaf taking `facts: MemoryPanelProps` (the existing `toMemoryPanelProps` shape, type-only import) plus `onRecall` / `onStore` / `onClear` / `onRename`. Owns only local UI state (selection, edit, confirm) and the catalog via the shared module. Store is refused at the handler level when `vfoIdentityKnown` is false, the same wrong-VFO doctrine `RitXitScanSurface.svelte` documents.
- `frontend/src/semantic/__tests__/MemorySurface.test.ts` (new): 16 tests.

Not in this PR, by design: `memory` is not added to `SEMANTIC_SURFACE_NAMES` / `WORKSPACE_ZONE_IDS`, no zone is declared, and the surface is not mounted. Twelve `*-declarability.test.ts` files pin the 14-name vocabulary literal, so the vocabulary step is its own bounded change (next PR), followed by the live join in `SemanticRadioSurfaces.svelte` / `RadioLayout.svelte` with the legacy `MemoryPanel` mount suppressed behind the declared zone.

## Witnesses and mutations

Mutations run by the builder, each reverted byte-identically:

| # | Mutation | Result |
|---|---|---|
| a | every recall button wired to channel 0 | per-index recall tests fail (`0` vs `5`/`9`) |
| b | `if (!facts.vfoIdentityKnown) return;` removed from `storeVfoToChannel` | the refusal test fails (`onStore` called once) — the guard is load-bearing past `disabled` |
| c | surface reimplements its own storage key/load/persist inline | the single-owner test (`never spells out the storage key itself`) fails |

## Census

`git diff origin/main --stat`: 4 files, 526 insertions + 31 deletions = 557 changed lines. Under both guardrails.

## Verification

Run in the worktree (the full suite is CI's): `MemorySurface.test.ts` 16/16; the 9 test files referencing `MemoryPanel` / `toMemoryPanelProps` 413/413; `zone-ownership-coverage`, `semantic-controls.component.svelte`, `semantic-desktop-migration.component`, workspace `contract.test.ts` 241/241; `src/presentation/` 1219/1219; `src/semantic/` + `src/components-v2/panels/` 3150/3150; `npm run check` 0 errors; `npm run lint` clean; `git diff --check` clean; `node frontend/fixtures/capture.mjs --preflight-only` passes.

internal-identifier self-check — empty.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
