### PR TITLE
feat(MOR-2425): host the CW pitch scalar persistently

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -464,6 +464,11 @@
               form: 'hbar', compact: false, showLabel: true, showValue: true,
             })}
           </div>
+          <div class="cw-keyer-instrument-seat" data-cw-keyer-seat="pitchHz" data-field="pitchHz">
+            {@render instruments.cwKeyerInstruments.pitchHz({
+              form: 'hbar', compact: false, showLabel: true, showValue: true,
+            })}
+          </div>
           {@render instruments.cwKeyer(undefined, false)}
         {:else}
           {@render instruments.cwKeyer()}

--- a/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
+++ b/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
@@ -32,7 +32,7 @@
   const cwKeyer = createRawSnippet<[allowBare?: boolean, showKeyerSpeed?: boolean]>(
     () => ({ render: () => '' }),
   );
-  const cwKeyerInstruments = { keyerSpeed: empty } satisfies CwKeyerInstrumentHandles;
+  const cwKeyerInstruments = { keyerSpeed: empty, pitchHz: empty } satisfies CwKeyerInstrumentHandles;
   const antenna = createRawSnippet<[allowBare?: boolean, controlLayout?: FixtureSnippet]>(
     () => ({ render: () => '' }),
   );

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -1452,8 +1452,10 @@
   >
   {#snippet children(antennaInstruments, antennaLayout)}
   <CwKeyerInstrumentHost
-    {view} {keySpeedFeedback}
+    {view} {keySpeedFeedback} pitchFeedback={cwPitchFeedback}
     onLevelChange={(field, value) => CW_LEVEL_INTENT[field](value)}
+    scalarAppearance={externalPresentation?.record.appearances.scalar}
+    presentationIsCurrent={externalPresentation?.isCurrent}
   >
   {#snippet children(cwKeyerInstruments)}
   <DspInstrumentHost
@@ -2011,14 +2013,14 @@
     gated inside the surface on the model's one `txPermit`, and the key/unkey
     authority stays the single `<RxTxSurface>` above (decomposition R9).
   -->
-  {#snippet cwKeyerSurface(showKeyerSpeed = true)}
+  {#snippet cwKeyerSurface(showKeyerSpeed = true, showPitchHz = true)}
     {#if view?.cwKeyer}
       <CwKeyerSurface
         {view}
         continuousHandles={cwKeyerInstruments}
         {showKeyerSpeed}
+        {showPitchHz}
         {breakInDelayFeedback}
-        {cwPitchFeedback}
         {autoTuneAvailable}
         onBreakInMode={(mode) => cwIntents.onBreakInModeChange(mode)}
         onLevelChange={(field, value) => CW_LEVEL_INTENT[field](value)}
@@ -2162,7 +2164,7 @@
   {#snippet hostedCwKeyer(
     allowBare = allowBareSurfaces, showKeyerSpeed = true,
   )}
-    {#snippet body()}{@render cwKeyerSurface(showKeyerSpeed)}{/snippet}
+    {#snippet body()}{@render cwKeyerSurface(showKeyerSpeed, showKeyerSpeed)}{/snippet}
     {@render zoned('cwKeyer', view?.cwKeyer !== undefined, body, allowBare)}
   {/snippet}
   {#snippet hostedScopeDisplay(allowBare = allowBareSurfaces)}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
@@ -123,11 +123,53 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
   getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
 }));
 
+/**
+ * MOR-2425 — the same `createContinuousScalar` capture wrapper
+ * `semantic-dsp-wiring.component.test.ts` establishes for its own persistent
+ * scalar host, lifted here so the pitch persistence witness below can name
+ * the binding OBJECT, not just its DOM projection.
+ */
+const scalars = vi.hoisted(() => ({
+  bindings: [] as Array<{ command: string | null; binding: unknown }>,
+  leases: [] as Array<{ binding: unknown; lease: unknown }>,
+}));
+vi.mock('../../../primitives/scalar/continuous-scalar.svelte', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../../../primitives/scalar/continuous-scalar.svelte')>();
+  return {
+    ...actual,
+    createContinuousScalar: (...args: Parameters<typeof actual.createContinuousScalar>) => {
+      const binding = actual.createContinuousScalar(...args);
+      const attachRenderer = binding.attachRenderer.bind(binding);
+      binding.attachRenderer = (...attachArgs) => {
+        const lease = attachRenderer(...attachArgs);
+        scalars.leases.push({ binding, lease });
+        return lease;
+      };
+      const source = args[0]();
+      scalars.bindings.push({
+        command: source.evidence === 'command-feedback' ? source.command : null, binding,
+      });
+      return binding;
+    },
+  };
+});
+
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
 import { sendCommand } from '$lib/transport/ws-client';
-import { getCommandLifecycle, resetCommandLifecycle } from '$lib/stores/commands.svelte';
+import { beginCommand, getCommandLifecycle, resetCommandLifecycle } from '$lib/stores/commands.svelte';
 import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
 import { setCapabilities } from '$lib/stores/capabilities.svelte';
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+import { CW_CONTINUOUS_LEVELS } from '../../../semantic/CwKeyerInstrumentHost.svelte';
+import HostedRadioLayoutFixture from '../../layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte';
+import type {
+  ContinuousScalarBinding, ContinuousScalarRendererLease, ContinuousScalarView,
+} from '../../../primitives/scalar/continuous-scalar.svelte';
+import { desktopV2Layout, sdrTestLayout } from '../../../presentation/layouts/declarations';
+import { readWorkspace } from '../../../presentation/workspace/contract';
+import { resolveSurfacePlan, SURFACE_PLAN_CONTEXT_KEY } from '../../../presentation/workspace/resolution';
 import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
 
 /**
@@ -215,6 +257,44 @@ function render(props: { strips?: 'single' | 'dual' } = {}): void {
   flushSync();
 }
 
+/** Mounts the REAL `RadioLayout` behind a reactive `skinId`, for the
+ *  Standard↔SDR persistence witness below — `props.skinId` can be reassigned
+ *  and `flushSync()`'d without remounting the fixture. */
+function renderHosted() {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  const props = proxy({ skinId: 'desktop-v2' as 'desktop-v2' | 'sdr-test' });
+  const context = new Map<unknown, unknown>([[SURFACE_PLAN_CONTEXT_KEY, () =>
+    resolveSurfacePlan(props.skinId === 'desktop-v2' ? desktopV2Layout : sdrTestLayout,
+      readWorkspace({ version: 1 }).workspace)]]);
+  component = mount(HostedRadioLayoutFixture, { target, props, context });
+  flushSync();
+  return props;
+}
+
+/** The pitch scalar binding, as an OBJECT (there is exactly one). */
+const cwBinding = (command: string): ContinuousScalarBinding => {
+  const found = scalars.bindings.filter((entry) => entry.command === command);
+  expect(found).toHaveLength(1);
+  return found[0]!.binding as ContinuousScalarBinding;
+};
+const latestCwLease = (binding: unknown): ContinuousScalarRendererLease => {
+  for (let index = scalars.leases.length - 1; index >= 0; index -= 1) {
+    if (scalars.leases[index]!.binding === binding) {
+      return scalars.leases[index]!.lease as ContinuousScalarRendererLease;
+    }
+  }
+  throw new Error('renderer lease not captured');
+};
+/** The command-feedback evidence a persistent binding must carry across a switch. */
+const cwLifecycle = (binding: ContinuousScalarBinding) => {
+  const view = binding.view as Extract<ContinuousScalarView, { evidence: 'command-feedback' }>;
+  return {
+    requested: view.requested, confirmed: view.confirmed, phase: view.phase,
+    error: view.error, transitionId: view.feedback.transitionId,
+  };
+};
+
 const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
 const el = (id: string) => q<HTMLElement>(`[data-testid="cw-keyer-${id}"]`);
 const press = (node: HTMLElement) => node.dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -299,8 +379,7 @@ function submitDelay(value: number): string {
 }
 
 function cwInput(field: 'pitchHz' | 'keyerSpeed'): HTMLElement {
-  const selector = field === 'keyerSpeed' ? '[role="slider"]' : 'input';
-  return el(field)!.querySelector(selector) as HTMLElement;
+  return el(field)!.querySelector('[role="slider"]') as HTMLElement;
 }
 
 function cwValue(field: 'pitchHz' | 'keyerSpeed'): string | null {
@@ -314,29 +393,41 @@ function cwDisabled(field: 'pitchHz' | 'keyerSpeed'): boolean {
     ? input.disabled : input.getAttribute('aria-disabled') === 'true';
 }
 
+const HBAR_WIDTH = 84;
+
+function cwDomain(field: 'pitchHz' | 'keyerSpeed'): { min: number; max: number } {
+  const [, , min, max] = CW_CONTINUOUS_LEVELS.find(([f]) => f === field)!;
+  return { min, max };
+}
+
 function submitCw(field: 'pitchHz' | 'keyerSpeed', value: number): string {
   const input = cwInput(field);
-  if (input instanceof HTMLInputElement) {
-    input.value = String(value);
-    input.dispatchEvent(new Event('input', { bubbles: true }));
-  } else {
-    const frame = input.closest<HTMLElement>('.vc-hbar')!;
-    vi.spyOn(frame, 'getBoundingClientRect').mockReturnValue({
-      left: 0, width: 84,
-    } as DOMRect);
-    Object.assign(input, {
-      setPointerCapture: () => undefined,
-      hasPointerCapture: () => false,
-      releasePointerCapture: () => undefined,
-    });
-    input.dispatchEvent(new PointerEvent('pointerdown', {
-      bubbles: true, clientX: (value - 6) * 2, pointerId: 1,
-    }));
-    input.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }));
-  }
+  const frame = input.closest<HTMLElement>('.vc-hbar')!;
+  vi.spyOn(frame, 'getBoundingClientRect').mockReturnValue({
+    left: 0, width: HBAR_WIDTH,
+  } as DOMRect);
+  Object.assign(input, {
+    setPointerCapture: () => undefined,
+    hasPointerCapture: () => false,
+    releasePointerCapture: () => undefined,
+  });
+  const { min, max } = cwDomain(field);
+  const clientX = (value - min) * HBAR_WIDTH / (max - min);
+  input.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX, pointerId: 1 }));
+  input.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }));
   flushSync();
   return vi.mocked(sendCommand).mock.calls.at(-1)![2] as string;
 }
+
+// The Host's announcement lane is a SIBLING of every field's own
+// `data-testid="cw-keyer-{field}"` seat (see `CwKeyerInstrumentHost.svelte`'s
+// `{#each CW_CONTINUOUS_LEVELS}` block after `{@render children(...)}`), not
+// nested inside it — so it is located by `data-feedback-lane`, not by
+// querying inside `el(field)`.
+const feedbackStatus = (field: 'pitchHz' | 'keyerSpeed') =>
+  q<HTMLElement>(`[data-feedback-lane="${field}"]`);
+const feedbackStatuses = (field: 'pitchHz' | 'keyerSpeed') =>
+  target.querySelectorAll<HTMLElement>(`[data-feedback-lane="${field}"]`);
 
 function deliver(commandId: string, kind: CommandDeliveryEvent['kind'], error?: string): void {
   expect(h.delivery).toBeTypeOf('function');
@@ -345,6 +436,8 @@ function deliver(commandId: string, kind: CommandDeliveryEvent['kind'], error?: 
 }
 
 beforeEach(() => {
+  scalars.bindings = [];
+  scalars.leases = [];
   txHarness = new ManagedAppTxHarness();
   h.txController = txHarness.controller;
   setCapabilities(liveCaps(CW_TAGS));
@@ -395,8 +488,9 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
     expect(cwInput('keyerSpeed').dataset.commandPhase).toBe('submitted');
     unmount(component!); component = null; target.remove();
     render();
-    expect(cwValue('pitchHz')).toBe('725');
+    expect(cwValue('pitchHz')).toBe('600');
     expect(cwValue('keyerSpeed')).toBe('24');
+    expect(cwInput('pitchHz').getAttribute('aria-valuetext')).toContain('requested 725 Hz');
     expect(cwInput('keyerSpeed').getAttribute('aria-valuetext')).toContain('requested 31 WPM');
     expect(cwInput('pitchHz').dataset.commandPhase).toBe('submitted');
     expect(cwInput('keyerSpeed').dataset.commandPhase).toBe('submitted');
@@ -425,9 +519,9 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
     submitCw('keyerSpeed', 31);
     deliver(oldId, 'response-error', 'late superseded failure');
     expect(cwInput('pitchHz').dataset.commandPhase).toBe('submitted');
-    expect(cwValue('pitchHz')).toBe('700');
+    expect(cwInput('pitchHz').getAttribute('aria-valuetext')).toContain('requested 700 Hz');
     expect(getCommandLifecycle(latestId, 1)?.status).toBe('pending');
-    const oldPitchStatus = el('pitchHz')!.querySelector<HTMLElement>('[data-cw-feedback-status]')!;
+    const oldPitchStatus = feedbackStatus('pitchHz')!;
     const oldPitchText = oldPitchStatus.textContent;
     expect(target.querySelectorAll('[data-cw-feedback-status]')).toHaveLength(2);
 
@@ -450,10 +544,10 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
     publishAuthority();
     flushSync();
     submitCw('pitchHz', 700);
-    const newPitchStatus = el('pitchHz')!.querySelector<HTMLElement>('[data-cw-feedback-status]')!;
+    const newPitchStatus = feedbackStatus('pitchHz')!;
     expect(newPitchStatus.textContent).toBe(oldPitchText);
     expect(newPitchStatus).not.toBe(oldPitchStatus);
-    expect(el('pitchHz')!.querySelectorAll('[data-cw-feedback-status]')).toHaveLength(1);
+    expect(feedbackStatuses('pitchHz')).toHaveLength(1);
     expect(sendCommand).toHaveBeenCalledTimes(4);
     expect(txHarness.trace()).toEqual([]);
   });
@@ -833,5 +927,87 @@ describe('the surface mounts only where a declared zone can hold it', () => {
       .filter((node) => !node.matches(':disabled') && node.tabIndex >= 0
         && node.closest('[data-zone-id]') === null);
     expect(outside).toEqual([]);
+  });
+});
+
+/**
+ * `RadioLayout`'s `desktop-v2` branch seats `pitchHz` (like `keyerSpeed`)
+ * outside `<CwKeyerSurface>` and suppresses the surface's own copy
+ * (`showPitchHz={false}`, coupled to the existing `showKeyerSpeed`
+ * suppression); every other layout still renders it inside the surface via
+ * the grouped handle. Both must produce exactly one control per field.
+ *
+ * MUTATION KILLED (b1): dropping `pitchHz` from the RadioLayout seat while
+ * leaving `showPitchHz` true duplicates the control under `desktop-v2`.
+ * MUTATION KILLED (b2): dropping the seat only (suppression untouched)
+ * leaves `desktop-v2` with zero `pitchHz` controls.
+ */
+describe('pitch mounts exactly once regardless of the hosting layout', () => {
+  it.each(['desktop-v2', 'sdr-test'] as const)(
+    'renders exactly one pitchHz and one keyerSpeed control under %s',
+    (skinId) => {
+      target = document.createElement('div');
+      document.body.appendChild(target);
+      component = mount(HostedRadioLayoutFixture, { target, props: { skinId } });
+      flushSync();
+      for (const field of ['pitchHz', 'keyerSpeed'] as const) {
+        expect(target.querySelectorAll(
+          `[data-testid="cw-keyer-${field}"] [role="slider"][aria-label="${
+            field === 'pitchHz' ? 'CW pitch' : 'Keyer speed'}"]`,
+        )).toHaveLength(1);
+      }
+    },
+  );
+});
+
+/**
+ * MOR-2425 — the witness the persistent pitch binding exists for, in the
+ * order its parts must be read (mirrors `semantic-dsp-wiring.component.test.ts`'s
+ * `nbWidth` witness for the same host lineage). A test that only drove the
+ * retained pre-switch lease and asserted `not.toHaveBeenCalled()` would be
+ * GREENER under the very defect it excludes: a host torn down and rebuilt per
+ * face loses the binding, and a destroyed binding commands nothing either. So
+ * identity comes first, then proof the CURRENT lease still commands, then the
+ * surviving evidence — and only then the inertness claim.
+ */
+describe('the pitch binding survives a Standard→SDR switch (MOR-2425)', () => {
+  it('keeps the pitch binding, its pending evidence and its live lease across the switch', () => {
+    const props = renderHosted();
+    beginCommand({
+      id: 'pending-cw-pitch', name: 'set_cw_pitch', params: { value: 725 }, originalEpoch: 1,
+    });
+    flushSync();
+    const before = cwBinding('set_cw_pitch');
+    const beforeLifecycle = cwLifecycle(before);
+    expect(beforeLifecycle).toMatchObject({ phase: 'submitted', requested: 725, confirmed: 600 });
+    const staleLease = latestCwLease(before);
+
+    props.skinId = 'sdr-test';
+    flushSync();
+    const afterLifecycle = cwLifecycle(before);
+
+    // (i) Identity, positively: the SAME binding object, not a rebuilt one.
+    const after = cwBinding('set_cw_pitch');
+    expect(after).toBe(before);
+
+    // (ii) Admission proven open: the CURRENT lease emits exactly one command.
+    expect(latestCwLease(after)).not.toBe(staleLease);
+    expect(submitCw('pitchHz', 800)).toEqual(expect.any(String));
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith(
+      'set_cw_pitch', { value: 800 }, expect.any(String),
+    );
+
+    // (iii) Evidence survival, read at the moment after the switch — BEFORE
+    // the (ii) submission moved the target on to 800.
+    expect(afterLifecycle).toEqual(beforeLifecycle);
+    expect(feedbackStatuses('pitchHz')).toHaveLength(1);
+
+    // Only now: the retained Standard lease is inert, and adds no command.
+    expect(staleLease.beginPointer()).toBeNull();
+    expect(staleLease.key({ key: 'ArrowRight', fine: false })).toBe(false);
+    staleLease.nativeInput(900);
+    staleLease.wheel({ direction: 1, fine: false });
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
@@ -123,12 +123,9 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
   getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
 }));
 
-/**
- * MOR-2425 — the same `createContinuousScalar` capture wrapper
- * `semantic-dsp-wiring.component.test.ts` establishes for its own persistent
- * scalar host, lifted here so the pitch persistence witness below can name
- * the binding OBJECT, not just its DOM projection.
- */
+/** MOR-2425 — the `createContinuousScalar` capture wrapper
+ *  `semantic-dsp-wiring.component.test.ts` establishes, so the persistence
+ *  witness below can name the binding OBJECT, not just its DOM projection. */
 const scalars = vi.hoisted(() => ({
   bindings: [] as Array<{ command: string | null; binding: unknown }>,
   leases: [] as Array<{ binding: unknown; lease: unknown }>,
@@ -931,16 +928,11 @@ describe('the surface mounts only where a declared zone can hold it', () => {
 });
 
 /**
- * `RadioLayout`'s `desktop-v2` branch seats `pitchHz` (like `keyerSpeed`)
- * outside `<CwKeyerSurface>` and suppresses the surface's own copy
- * (`showPitchHz={false}`, coupled to the existing `showKeyerSpeed`
- * suppression); every other layout still renders it inside the surface via
- * the grouped handle. Both must produce exactly one control per field.
- *
- * MUTATION KILLED (b1): dropping `pitchHz` from the RadioLayout seat while
- * leaving `showPitchHz` true duplicates the control under `desktop-v2`.
- * MUTATION KILLED (b2): dropping the seat only (suppression untouched)
- * leaves `desktop-v2` with zero `pitchHz` controls.
+ * `desktop-v2` seats `pitchHz` outside `<CwKeyerSurface>` (like `keyerSpeed`)
+ * and suppresses the surface's own copy; every other layout still renders it
+ * via the grouped handle. MUTATION KILLED (b1): dropping the seat while the
+ * surface's copy stays shown duplicates it. (b2): dropping the seat without
+ * restoring the surface's copy leaves zero.
  */
 describe('pitch mounts exactly once regardless of the hosting layout', () => {
   it.each(['desktop-v2', 'sdr-test'] as const)(
@@ -962,13 +954,9 @@ describe('pitch mounts exactly once regardless of the hosting layout', () => {
 
 /**
  * MOR-2425 — the witness the persistent pitch binding exists for, in the
- * order its parts must be read (mirrors `semantic-dsp-wiring.component.test.ts`'s
- * `nbWidth` witness for the same host lineage). A test that only drove the
- * retained pre-switch lease and asserted `not.toHaveBeenCalled()` would be
- * GREENER under the very defect it excludes: a host torn down and rebuilt per
- * face loses the binding, and a destroyed binding commands nothing either. So
- * identity comes first, then proof the CURRENT lease still commands, then the
- * surviving evidence — and only then the inertness claim.
+ * order its parts must be read (mirrors the `nbWidth` witness in
+ * `semantic-dsp-wiring.component.test.ts`): identity first, then proof the
+ * CURRENT lease still commands, then surviving evidence — only then inertness.
  */
 describe('the pitch binding survives a Standard→SDR switch (MOR-2425)', () => {
   it('keeps the pitch binding, its pending evidence and its live lease across the switch', () => {

--- a/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
@@ -416,9 +416,9 @@ function submitCw(field: 'pitchHz' | 'keyerSpeed', value: number): string {
   return vi.mocked(sendCommand).mock.calls.at(-1)![2] as string;
 }
 
-// The Host's announcement lane is a SIBLING of every field's own
-// `data-testid="cw-keyer-{field}"` seat (see `CwKeyerInstrumentHost.svelte`'s
-// `{#each CW_CONTINUOUS_LEVELS}` block after `{@render children(...)}`), not
+// The Host's announcement lane is emitted at the Host's own root (see
+// `CwKeyerInstrumentHost.svelte`'s `{#each CW_CONTINUOUS_LEVELS}` block after
+// `{@render children(...)}`), wherever the consumer places each field's seat, not
 // nested inside it — so it is located by `data-feedback-lane`, not by
 // querying inside `el(field)`.
 const feedbackStatus = (field: 'pitchHz' | 'keyerSpeed') =>
@@ -930,8 +930,8 @@ describe('the surface mounts only where a declared zone can hold it', () => {
 /**
  * `desktop-v2` seats `pitchHz` outside `<CwKeyerSurface>` (like `keyerSpeed`)
  * and suppresses the surface's own copy; every other layout still renders it
- * via the grouped handle. MUTATION KILLED (b1): dropping the seat while the
- * surface's copy stays shown duplicates it. (b2): dropping the seat without
+ * via the grouped handle. MUTATION KILLED (b1): keeping the seat while the
+ * surface's copy is also shown duplicates it. (b2): dropping the seat without
  * restoring the surface's copy leaves zero.
  */
 describe('pitch mounts exactly once regardless of the hosting layout', () => {

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -436,7 +436,7 @@ describe('production receiver-indicator partitioning', () => {
       /<CwKeyerInstrumentHost[\s\S]*?\{keySpeedFeedback\}[\s\S]*?\{#snippet children\(cwKeyerInstruments\)}/,
     );
     expect(source).toMatch(
-      /<CwKeyerSurface(?:(?!\/>)[\s\S])*?\{cwPitchFeedback\}(?:(?!\/>)[\s\S])*?\/>/,
+      /<CwKeyerInstrumentHost[\s\S]*?pitchFeedback=\{cwPitchFeedback\}[\s\S]*?\{#snippet children\(cwKeyerInstruments\)}/,
     );
     expect(source).not.toMatch(
       /<CwKeyerSurface(?:(?!\/>)[\s\S])*?\{keySpeedFeedback\}/,

--- a/frontend/src/semantic/CwKeyerInstrumentHost.svelte
+++ b/frontend/src/semantic/CwKeyerInstrumentHost.svelte
@@ -4,8 +4,11 @@
   export const CW_KEYER_SPEED = [
     'keyerSpeed', 'Keyer speed', 6, 48, 1, 'WPM', 'set_key_speed',
   ] as const;
-  export const CW_CONTINUOUS_LEVELS = [CW_KEYER_SPEED] as const;
-  export type CwContinuousField = typeof CW_KEYER_SPEED[0];
+  export const CW_PITCH_HZ = [
+    'pitchHz', 'CW pitch', 300, 900, 5, 'Hz', 'set_cw_pitch',
+  ] as const;
+  export const CW_CONTINUOUS_LEVELS = [CW_KEYER_SPEED, CW_PITCH_HZ] as const;
+  export type CwContinuousField = typeof CW_CONTINUOUS_LEVELS[number][0];
   export type CwContinuousForm = 'hbar' | 'knob';
 
   export interface CwContinuousPresentation {
@@ -15,15 +18,15 @@
     readonly showValue?: boolean;
   }
 
-  export interface CwKeyerInstrumentHandles {
-    readonly keyerSpeed: Snippet<[
-      presentation?: Readonly<CwContinuousPresentation>,
-    ]>;
-  }
+  export type CwContinuousHandle = Snippet<[
+    presentation?: Readonly<CwContinuousPresentation>,
+  ]>;
+  export type CwKeyerInstrumentHandles = Readonly<Record<CwContinuousField, CwContinuousHandle>>;
 </script>
 
 <script lang="ts">
   import { onDestroy } from 'svelte';
+  import type { ScalarAppearance } from '../../component-kit-api/src/index';
   import { ValueControl } from '../components-v2/controls/value-control';
   import type {
     HBarIssuedStatusPresentation,
@@ -40,141 +43,180 @@
   interface Props {
     view: RadioViewModel | null;
     keySpeedFeedback?: Readonly<CommandScalarFeedback>;
+    pitchFeedback?: Readonly<CommandScalarFeedback>;
     onLevelChange?: (field: CwContinuousField, value: number) => void;
+    scalarAppearance?: ScalarAppearance;
+    presentationIsCurrent?: () => boolean;
     children: Snippet<[CwKeyerInstrumentHandles]>;
   }
 
-  let { view, keySpeedFeedback, onLevelChange, children }: Props = $props();
-  let keyerSpeedField = $derived(view?.cwKeyer?.keyerSpeed);
-  const [field, label, min, max, step, unit, command] = CW_KEYER_SPEED;
+  let {
+    view, keySpeedFeedback, pitchFeedback, onLevelChange,
+    scalarAppearance, presentationIsCurrent, children,
+  }: Props = $props();
+
   const feedbackIntegratedControl = { 'feedback-policy': 'feedback-integrated' } as const;
-  const policy = createRenderedNativeRangeContinuousScalarPolicy();
+  const row = (field: CwContinuousField) => CW_CONTINUOUS_LEVELS.find(([f]) => f === field)!;
   const usable = (current: CwKeyerField<unknown> | undefined): boolean =>
     current?.availability.structural === true
     && current.availability.operational
     && current.reading.status === 'known';
-  const formatValue = (value: number | null): string =>
-    value === null || !Number.isFinite(value) ? '—' : `${value} ${unit}`;
+  const formatValue = (field: CwContinuousField, value: number | null): string => {
+    if (value === null || !Number.isFinite(value)) return '—';
+    const [, , , , , unit] = row(field);
+    return `${value} ${unit}`;
+  };
+  const fieldOf = (field: CwContinuousField): CwKeyerField<number> | undefined =>
+    view?.cwKeyer?.[field];
+  const feedbackOf = (field: CwContinuousField): Readonly<CommandScalarFeedback> | undefined =>
+    field === 'keyerSpeed' ? keySpeedFeedback : pitchFeedback;
 
-  function request(value: number): void {
-    if (usable(keyerSpeedField)) onLevelChange?.(field, value);
+  function request(field: CwContinuousField, value: number): void {
+    const current = fieldOf(field);
+    if (current !== undefined && usable(current)) onLevelChange?.(field, value);
   }
 
-  function input(): Readonly<ContinuousScalarInput> {
+  function input(field: CwContinuousField): Readonly<ContinuousScalarInput> {
+    const [, , min, max, step, , command] = row(field);
+    const current = fieldOf(field);
     const common = {
       domain: { min, max, step, defaultValue: null, fineStepDivisor: 1 },
-      enabled: usable(keyerSpeedField),
-      request,
+      enabled: usable(current),
+      request: (value: number) => request(field, value),
     } as const;
-    if (keySpeedFeedback !== undefined) {
+    const feedback = feedbackOf(field);
+    if (feedback !== undefined) {
       return {
-        ...common, evidence: 'command-feedback', feedback: keySpeedFeedback, command,
+        ...common, evidence: 'command-feedback', feedback, command,
       };
     }
     return {
       ...common,
       evidence: 'reading',
-      ownerKey: 'cw-keyer-keyerSpeed-reading',
-      reading: keyerSpeedField?.reading.status === 'known'
-        ? { status: 'known', value: keyerSpeedField.reading.value }
+      ownerKey: `cw-keyer-${field}-reading`,
+      reading: current?.reading.status === 'known'
+        ? { status: 'known', value: current.reading.value }
         : { status: 'unknown' },
     };
   }
 
-  const binding = createContinuousScalar(input, policy);
-  let issuedStatus = $state<string | null>(null);
-  let issuedStatusKey = $state('');
-  const issuedStatusPresentation: Readonly<HBarIssuedStatusPresentation> = {
-    get text() { return null; },
-    format({ view: scalarView, announcement }: Readonly<HBarIssuedStatusSnapshot>) {
-      issuedStatusKey = JSON.stringify([
-        scalarView.feedback.providerGeneration ?? null,
-        scalarView.feedback.sessionEpoch,
-        scalarView.feedback.scope.control,
-        scalarView.feedback.scope.receiver,
-        scalarView.feedback.scope.slot ?? null,
-        announcement.transitionId,
-      ]);
-      return scalarView.error === null
-        ? announcement.message
-        : `${announcement.message.replace(/[.!?]$/, '')}: ${scalarView.error}`;
-    },
-    accept(text) { issuedStatus = text; },
-  };
+  const policies = Object.fromEntries(CW_CONTINUOUS_LEVELS.map(([field]) => [
+    field, createRenderedNativeRangeContinuousScalarPolicy(),
+  ])) as Record<CwContinuousField, ReturnType<typeof createRenderedNativeRangeContinuousScalarPolicy>>;
+  const bindings = Object.fromEntries(CW_CONTINUOUS_LEVELS.map(([field]) => [
+    field, createContinuousScalar(() => input(field), policies[field]),
+  ])) as Record<CwContinuousField, ReturnType<typeof createContinuousScalar>>;
+
+  const record = <T,>(value: T) => Object.fromEntries(
+    CW_CONTINUOUS_LEVELS.map(([field]) => [field, value]),
+  ) as Record<CwContinuousField, T>;
+  let issuedStatus = $state(record<string | null>(null));
+  let issuedStatusKey = $state(record(''));
+  function statusPresentation(field: CwContinuousField): Readonly<HBarIssuedStatusPresentation> {
+    return {
+      get text() { return null; },
+      format({ view: scalarView, announcement }: Readonly<HBarIssuedStatusSnapshot>) {
+        issuedStatusKey[field] = JSON.stringify([
+          scalarView.feedback.providerGeneration ?? null,
+          scalarView.feedback.sessionEpoch,
+          scalarView.feedback.scope.control,
+          scalarView.feedback.scope.receiver,
+          scalarView.feedback.scope.slot ?? null,
+          announcement.transitionId,
+        ]);
+        return scalarView.error === null
+          ? announcement.message
+          : `${announcement.message.replace(/[.!?]$/, '')}: ${scalarView.error}`;
+      },
+      accept(text) { issuedStatus[field] = text; },
+    };
+  }
+  const statusPresentations = Object.fromEntries(CW_CONTINUOUS_LEVELS.map(([field]) => [
+    field, statusPresentation(field),
+  ])) as Record<CwContinuousField, Readonly<HBarIssuedStatusPresentation>>;
 
   function retireHBarStatus(
     _node: HTMLElement,
-    placement: Readonly<{ form: CwContinuousForm }>,
+    placement: Readonly<{ field: CwContinuousField; form: CwContinuousForm }>,
   ) {
     const retire = (next: typeof placement) => {
-      if (next.form === 'knob') issuedStatus = null;
+      if (next.form === 'knob') issuedStatus[next.field] = null;
     };
     retire(placement);
     return { update: retire };
   }
 
-  function canonical(): number | null {
-    if (keySpeedFeedback !== undefined) {
-      return keySpeedFeedback.availability === 'available' ? keySpeedFeedback.confirmed : null;
+  function canonical(field: CwContinuousField): number | null {
+    const feedback = feedbackOf(field);
+    if (feedback !== undefined) {
+      return feedback.availability === 'available' ? feedback.confirmed : null;
     }
-    return keyerSpeedField?.reading.status === 'known' ? keyerSpeedField.reading.value : null;
+    const current = fieldOf(field);
+    return current?.reading.status === 'known' ? current.reading.value : null;
   }
 
-  function status(): string {
-    if (keySpeedFeedback === undefined || keySpeedFeedback.phase === 'idle') return '';
-    const target = keySpeedFeedback.target ?? keySpeedFeedback.requestedTarget;
-    const requested = target === null ? '' : `; requested ${formatValue(target)}`;
-    const confirmed = `; confirmed ${formatValue(keySpeedFeedback.confirmed)}`;
-    const error = keySpeedFeedback.outcome?.error === undefined
-      ? '' : `; ${keySpeedFeedback.outcome.error}`;
-    return `${keySpeedFeedback.phase.replaceAll('-', ' ')}${requested}${confirmed}${error}`;
+  function status(field: CwContinuousField): string {
+    const feedback = feedbackOf(field);
+    if (feedback === undefined || feedback.phase === 'idle') return '';
+    const target = feedback.target ?? feedback.requestedTarget;
+    const requested = target === null ? '' : `; requested ${formatValue(field, target)}`;
+    const confirmed = `; confirmed ${formatValue(field, feedback.confirmed)}`;
+    const error = feedback.outcome?.error === undefined ? '' : `; ${feedback.outcome.error}`;
+    return `${feedback.phase.replaceAll('-', ' ')}${requested}${confirmed}${error}`;
   }
 
-  onDestroy(() => binding.destroy());
+  onDestroy(() => {
+    for (const [, binding] of Object.entries(bindings)) binding.destroy();
+  });
 </script>
 
-{#snippet keyerSpeedHandle(presentation?: Readonly<CwContinuousPresentation>)}
-  {#if keyerSpeedField?.availability.structural}
+{#snippet scalar(field: CwContinuousField, presentation?: Readonly<CwContinuousPresentation>)}
+  {@const current = fieldOf(field)}
+  {#if current?.availability.structural}
+    {@const [, label, min, max, step] = row(field)}
     {@const explicitPresentation = presentation !== undefined}
     {@const form = presentation?.form ?? 'hbar'}
-    {@const currentStatus = status()}
-    {@const disabledReason = usable(keyerSpeedField) ? undefined : 'Not yet observed'}
+    {@const currentStatus = status(field)}
+    {@const currentFeedback = feedbackOf(field)}
+    {@const disabledReason = usable(current) ? undefined : 'Not yet observed'}
     {@const accessibility = {
       description: disabledReason ?? null,
-      valueText: `${label}: ${formatValue(canonical())}${currentStatus === '' ? '' : `; ${currentStatus}`}`,
+      valueText: `${label}: ${formatValue(field, canonical(field))}${currentStatus === '' ? '' : `; ${currentStatus}`}`,
     }}
     <div
       class="cw-keyer-level"
       class:cw-keyer-level--presented={explicitPresentation}
-      data-testid="cw-keyer-keyerSpeed"
+      data-testid={`cw-keyer-${field}`}
       data-field={field}
       data-scalar-form={form}
-      data-observed={usable(keyerSpeedField) && canonical() !== null}
-      data-command-phase={keySpeedFeedback?.phase}
-      data-feedback-control={keySpeedFeedback?.scope.control}
+      data-observed={usable(current) && canonical(field) !== null}
+      data-command-phase={currentFeedback?.phase}
+      data-feedback-control={currentFeedback?.scope.control}
       data-min={min} data-max={max} data-step={step}
-      aria-busy={keySpeedFeedback?.busy}
+      aria-busy={currentFeedback?.busy}
       title={disabledReason}
-      use:retireHBarStatus={{ form }}
+      use:retireHBarStatus={{ field, form }}
     >
       <span class="cw-keyer-name" class:sr-only={explicitPresentation}
         aria-hidden={explicitPresentation ? 'true' : undefined}>{label}</span>
       <ValueControl
         {...feedbackIntegratedControl}
-        {binding} {label} renderer={form}
-        displayFn={formatValue}
+        binding={bindings[field]} {label} renderer={form}
+        displayFn={(value) => formatValue(field, value)}
         showLabel={explicitPresentation ? presentation?.showLabel ?? true : false}
         showValue={explicitPresentation ? presentation?.showValue ?? true : false}
         compact={explicitPresentation ? presentation?.compact ?? false : true}
         title={disabledReason} {accessibility}
-        issuedStatusPresentation={form === 'hbar' ? issuedStatusPresentation : undefined}
+        skin={scalarAppearance}
+        {presentationIsCurrent}
+        issuedStatusPresentation={form === 'hbar' ? statusPresentations[field] : undefined}
       />
-      <output data-testid="cw-keyer-keyerSpeed-value" data-canonical-value
+      <output data-testid={`cw-keyer-${field}-value`} data-canonical-value
         class:sr-only={explicitPresentation} aria-hidden={explicitPresentation ? 'true' : undefined}
-      >{formatValue(canonical())}</output>
+      >{formatValue(field, canonical(field))}</output>
       {#if currentStatus !== ''}
-        <span data-command-status class:command-pending={keySpeedFeedback?.busy}
-          class:sr-only={explicitPresentation || keySpeedFeedback?.phase === 'unavailable'}
+        <span data-command-status class:command-pending={currentFeedback?.busy}
+          class:sr-only={explicitPresentation || currentFeedback?.phase === 'unavailable'}
         >{currentStatus}</span>
       {/if}
     </div>
@@ -182,17 +224,22 @@
 {/snippet}
 
 {#snippet keyerSpeed(presentation?: Readonly<CwContinuousPresentation>)}
-  {@render keyerSpeedHandle(presentation)}
+  {@render scalar('keyerSpeed', presentation)}
 {/snippet}
-{@render children({ keyerSpeed })}
+{#snippet pitchHz(presentation?: Readonly<CwContinuousPresentation>)}
+  {@render scalar('pitchHz', presentation)}
+{/snippet}
+{@render children({ keyerSpeed, pitchHz })}
 
-{#if issuedStatus !== null}
-  {#key issuedStatusKey}
-    <span class="sr-only" role="status" aria-live="polite" aria-atomic="true"
-      data-control-feedback-status data-cw-feedback-status data-feedback-lane="keyerSpeed"
-    >{issuedStatus}</span>
-  {/key}
-{/if}
+{#each CW_CONTINUOUS_LEVELS as [field] (field)}
+  {#if issuedStatus[field] !== null}
+    {#key issuedStatusKey[field]}
+      <span class="sr-only" role="status" aria-live="polite" aria-atomic="true"
+        data-control-feedback-status data-cw-feedback-status data-feedback-lane={field}
+      >{issuedStatus[field]}</span>
+    {/key}
+  {/if}
+{/each}
 
 <style>
   .cw-keyer-level { display: flex; align-items: baseline; gap: 0.5rem; }

--- a/frontend/src/semantic/CwKeyerSurface.svelte
+++ b/frontend/src/semantic/CwKeyerSurface.svelte
@@ -68,7 +68,6 @@
   export const CW_LEVELS = [
     ...CW_CONTINUOUS_LEVELS.map(([field, label, min, max, step, unit]) =>
       [field, label, min, max, step, unit] as const),
-    ['pitchHz', 'CW pitch', 300, 900, 5, 'Hz'],
     ['breakInDelay', 'Break-in delay', 0, 255, 1, ''],
   ] as const;
   export type CwLevelField = (typeof CW_LEVELS)[number][0];
@@ -132,11 +131,6 @@
     type PresentationPhase,
   } from '../primitives/control-feedback/control-feedback-presentation';
   import { createCommittedScalar } from '../primitives/scalar/committed-scalar.svelte';
-  import {
-    createContinuousScalar, nativeRangeContinuousScalarPolicy,
-    type CommandScalarFeedback, type ContinuousScalarInput,
-    type ContinuousScalarRendererLease, type ContinuousScalarView,
-  } from '../primitives/scalar/continuous-scalar.svelte';
   import { clamp, snapToStep } from '../primitives/scalar/value-control-core';
   import {
     bindChoiceInstrument,
@@ -154,20 +148,20 @@
     view: RadioViewModel;
     continuousHandles: CwKeyerInstrumentHandles;
     showKeyerSpeed?: boolean;
+    showPitchHz?: boolean;
     onBreakInMode?: (mode: number) => void;
     onLevelChange?: (field: CwLevelField, value: number) => void;
     onApfOn?: (on: boolean) => void;
     onTwinPeakToggle?: () => void;
     onReversePaddleToggle?: () => void;
     breakInDelayFeedback?: Readonly<BreakInDelayFeedback>;
-    cwPitchFeedback?: Readonly<CommandScalarFeedback>;
     autoTuneAvailable?: boolean;
     onAutoTune?: () => void;
   }
   let {
-    view, continuousHandles, showKeyerSpeed = true,
+    view, continuousHandles, showKeyerSpeed = true, showPitchHz = true,
     onBreakInMode, onLevelChange, onApfOn, onTwinPeakToggle, onReversePaddleToggle,
-    breakInDelayFeedback, cwPitchFeedback,
+    breakInDelayFeedback,
     autoTuneAvailable = false, onAutoTune,
   }: Props = $props();
 
@@ -219,101 +213,9 @@
   function setLevel(field: CwLevelField, value: number): void {
     if (cw && usable(cw[field])) onLevelChange?.(field, value);
   }
-  type FeedbackLevelField = 'pitchHz';
-  const feedbackLevelDomain = {
-    pitchHz: { min: 300, max: 900, step: 5, defaultValue: null, fineStepDivisor: 1 },
-  } as const;
-  function feedbackLevelInput(field: FeedbackLevelField): Readonly<ContinuousScalarInput> {
-    const current = cw?.[field];
-    const feedback = cwPitchFeedback;
-    const common = {
-      domain: feedbackLevelDomain[field],
-      enabled: current !== undefined && usable(current),
-      request: (value: number) => setLevel(field, value),
-    } as const;
-    if (feedback !== undefined) {
-      return {
-        ...common, evidence: 'command-feedback', feedback,
-        command: 'set_cw_pitch',
-      };
-    }
-    return {
-      ...common, evidence: 'reading', ownerKey: `cw-keyer-${field}-reading`,
-      reading: current?.reading.status === 'known'
-        ? { status: 'known', value: current.reading.value } : { status: 'unknown' },
-    };
-  }
-  const cwPitchScalar = createContinuousScalar(
-    () => feedbackLevelInput('pitchHz'), nativeRangeContinuousScalarPolicy,
-  );
-  let cwPitchLease: ContinuousScalarRendererLease | null = $state(null);
-  const initialCwPitchView = untrack(() => cwPitchScalar.view);
-  let cwPitchView: Readonly<ContinuousScalarView> = $state(initialCwPitchView);
-  type IssuedLevelAnnouncement = Readonly<{
-    authorityKey: string;
-    eventKey: string;
-    text: string;
-  }>;
-  function feedbackAuthorityKey(current: Readonly<ContinuousScalarView>): string {
-    const domain = current.domain;
-    const shared = [
-      current.evidence, current.editable, domain.min, domain.max, domain.step,
-      domain.defaultValue, domain.fineStepDivisor, domain.keyboardStep,
-    ];
-    if (current.evidence === 'reading') {
-      return JSON.stringify([...shared, current.reading.status]);
-    }
-    const feedback = current.feedback;
-    return JSON.stringify([
-      ...shared, feedback.providerGeneration ?? null, feedback.sessionEpoch,
-      feedback.availability, feedback.scope.control, feedback.scope.receiver, feedback.scope.slot,
-    ]);
-  }
-  function nextLevelAnnouncement(
-    current: Readonly<ContinuousScalarView>,
-    previous: IssuedLevelAnnouncement | null,
-  ): IssuedLevelAnnouncement | null {
-    const authorityKey = feedbackAuthorityKey(current);
-    const issued = current.presentation?.politeAnnouncement;
-    if (issued === null || issued === undefined || current.announcement === null) {
-      return previous?.authorityKey === authorityKey ? previous : null;
-    }
-    return Object.freeze({
-      authorityKey,
-      eventKey: JSON.stringify([authorityKey, issued.transitionId]),
-      text: current.error === null ? current.announcement : `${current.announcement}: ${current.error}`,
-    });
-  }
-  let cwPitchAnnouncement: IssuedLevelAnnouncement | null = $state(
-    nextLevelAnnouncement(initialCwPitchView, null),
-  );
-  $effect(() => {
-    const lease = cwPitchScalar.attachRenderer();
-    cwPitchLease = lease;
-    return () => lease.dispose();
-  });
-  $effect(() => {
-    const next = cwPitchLease === null ? cwPitchScalar.view : cwPitchLease.view;
-    cwPitchView = next;
-    cwPitchAnnouncement = nextLevelAnnouncement(
-      next, untrack(() => cwPitchAnnouncement),
-    );
-  });
   onDestroy(() => {
-    cwPitchScalar.destroy();
     breakInDelayScalar.destroy();
   });
-  function feedbackLevelValueText(
-    label: string, current: Readonly<ContinuousScalarView>, displayed: number | null, unit: string,
-  ): string {
-    if (displayed === null) return `${label} unavailable`;
-    const phase = current.phase?.replaceAll('-', ' ');
-    const error = current.error === null ? '' : `; ${current.error}`;
-    return `${label} ${displayed}${unit === '' ? '' : ` ${unit}`}${phase ? `; ${phase}` : ''}${error}`;
-  }
-  const feedbackLevelDisplay = (current: Readonly<ContinuousScalarView>): number | null =>
-    current.draft ?? (current.evidence === 'command-feedback' && current.busy
-      ? current.target : null) ?? current.canonical;
   const BUSY_BREAK_IN_DELAY_PHASES: ReadonlySet<PresentationPhase> = new Set([
     'submitted', 'queued', 'dispatched', 'awaiting-confirmation',
   ]);
@@ -479,14 +381,16 @@
     {#if showKeyerSpeed}
       {@render continuousHandles.keyerSpeed()}
     {/if}
+    {#if showPitchHz}
+      {@render continuousHandles.pitchHz()}
+    {/if}
 
-    {#each CW_LEVELS.filter(([field]) => field !== 'keyerSpeed') as [field, label, min, max, step, unit] (field)}
+    {#each CW_LEVELS.filter(([field]) => field !== 'keyerSpeed' && field !== 'pitchHz') as [field, label, min, max, step, unit] (field)}
       {@const f = cw[field]}
       {#if f.availability.structural}
         <label
           class="cw-keyer-level" data-testid={`cw-keyer-${field}`}
-          data-observed={field === 'breakInDelay' ? usable(f)
-            : cwPitchView.canonical !== null && cwPitchView.editable}
+          data-observed={usable(f)}
         >
           <span class="cw-keyer-name">{label}</span>
           {#if field === 'breakInDelay'}
@@ -521,38 +425,6 @@
             {/if}
             {:else}
               <output data-testid="cw-keyer-breakInDelay-value">{textOf(f)} {unit}</output>
-            {/if}
-          {:else}
-            {@const levelView = cwPitchView}
-            {@const levelLease = cwPitchLease}
-            {@const hasFeedback = cwPitchFeedback !== undefined}
-            {@const announcement = cwPitchAnnouncement}
-            {@const levelDisplay = feedbackLevelDisplay(levelView)}
-            <input
-              {...INTEGRATED_RANGE_POLICY} type="range" {min} {max} {step}
-              value={levelDisplay ?? min}
-              disabled={!levelView.editable}
-              data-command-phase={levelView.phase ?? undefined}
-              aria-busy={hasFeedback ? levelView.busy : undefined}
-              aria-valuenow={hasFeedback && levelDisplay !== null ? levelDisplay : undefined}
-              aria-valuetext={hasFeedback
-                ? feedbackLevelValueText(label, levelView, levelDisplay, unit) : undefined}
-              oninput={(event) => levelLease?.nativeInput(event.currentTarget.valueAsNumber)}
-            />
-            <output data-testid={`cw-keyer-${field}-value`} data-command-phase={levelView.phase ?? undefined}
-            >{levelDisplay === null ? UNKNOWN_TEXT : levelDisplay} {unit}
-              {#if hasFeedback && levelView.phase !== null}
-                <span class:command-pending={levelView.busy}>{levelView.phase.replaceAll('-', ' ')}</span>
-                {#if levelView.error !== null}<span>{levelView.error}</span>{/if}
-              {/if}
-            </output>
-            {#if hasFeedback && announcement !== null}
-              {#key announcement.eventKey}
-                <span
-                  class="sr-only" role="status" aria-live="polite" aria-atomic="true"
-                  data-control-feedback-status data-cw-feedback-status data-feedback-lane={field}
-                >{announcement.text}</span>
-              {/key}
             {/if}
           {/if}
         </label>

--- a/frontend/src/semantic/__tests__/CwKeyerInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerInstrumentHost.isolated.test.ts
@@ -51,14 +51,14 @@ type Props = {
   view: RadioViewModel;
   presentation: 'grouped' | 'independent';
   scalarPresentation?: Readonly<CwContinuousPresentation>;
-  cwPitchFeedback?: Feedback;
+  pitchFeedback?: Feedback;
   keySpeedFeedback?: Feedback;
-  onLevelChange?: (field: CwContinuousField | 'pitchHz' | 'breakInDelay', value: number) => void;
+  onLevelChange?: (field: CwContinuousField | 'breakInDelay', value: number) => void;
 };
 type RendererNode = HTMLButtonElement & { readonly rendererLease: ContinuousScalarRendererLease };
 
-const initial = { keyerSpeed: 24 } as const;
-const control = { keyerSpeed: 'keyer-speed' } as const;
+const initial = { keyerSpeed: 24, pitchHz: 600 } as const;
+const control = { keyerSpeed: 'keyer-speed', pitchHz: 'cw-pitch' } as const;
 const base = (): RadioViewModel => withCwKeyer(topologyFixtures['1/single']);
 const feedback = (
   field: CwContinuousField,
@@ -110,7 +110,8 @@ function render(over: Partial<Props> = {}) {
 }
 
 function binding(field: CwContinuousField): ContinuousScalarBinding {
-  return capture.bindings[0] as ContinuousScalarBinding;
+  const index = CW_CONTINUOUS_LEVELS.findIndex(([f]) => f === field);
+  return capture.bindings[index] as ContinuousScalarBinding;
 }
 function currentLease(field: CwContinuousField): ContinuousScalarRendererLease {
   const owner = binding(field);
@@ -122,29 +123,35 @@ function currentLease(field: CwContinuousField): ContinuousScalarRendererLease {
 }
 
 describe('CwKeyerInstrumentHost', () => {
-  it('creates one persistent binding and destroys it once', () => {
+  it('creates one persistent binding per field and destroys each exactly once', () => {
     const r = render();
-    // The second owner is the unchanged native pitch binding inside the Surface.
     expect(capture.bindings).toHaveLength(2);
-    expect(target.querySelectorAll('[data-external-scalar-renderer]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-external-scalar-renderer]')).toHaveLength(2);
     expect(CW_CONTINUOUS_LEVELS).toEqual([
       ['keyerSpeed', 'Keyer speed', 6, 48, 1, 'WPM', 'set_key_speed'],
+      ['pitchHz', 'CW pitch', 300, 900, 5, 'Hz', 'set_cw_pitch'],
     ]);
-    const owner = binding('keyerSpeed');
+    const speedOwner = binding('keyerSpeed');
+    const pitchOwner = binding('pitchHz');
+    expect(speedOwner).not.toBe(pitchOwner);
     r.dispose();
-    expect(owner.destroy).toHaveBeenCalledOnce();
+    expect(speedOwner.destroy).toHaveBeenCalledOnce();
+    expect(pitchOwner.destroy).toHaveBeenCalledOnce();
   });
 
-  it('keeps binding identities across grouped-independent-grouped replacement', () => {
+  it('keeps both field binding identities across grouped-independent-grouped replacement', () => {
     const r = render();
-    const owner = binding('keyerSpeed');
+    const speedOwner = binding('keyerSpeed');
+    const pitchOwner = binding('pitchHz');
     r.props.presentation = 'independent'; flushSync();
-    expect(binding('keyerSpeed')).toBe(owner);
-    expect(target.querySelectorAll('[data-external-scalar-renderer]')).toHaveLength(1);
+    expect(binding('keyerSpeed')).toBe(speedOwner);
+    expect(binding('pitchHz')).toBe(pitchOwner);
+    expect(target.querySelectorAll('[data-external-scalar-renderer]')).toHaveLength(2);
     expect(target.querySelectorAll('[data-testid="cw-keyer-surface"]')).toHaveLength(1);
     expect(target.querySelectorAll('[data-testid="cw-keyer-breakInDelay"]')).toHaveLength(1);
     r.props.presentation = 'grouped'; flushSync();
-    expect(binding('keyerSpeed')).toBe(owner);
+    expect(binding('keyerSpeed')).toBe(speedOwner);
+    expect(binding('pitchHz')).toBe(pitchOwner);
     expect(target.querySelectorAll('[data-testid="cw-keyer-keyerSpeed"]')).toHaveLength(1);
     expect(target.querySelectorAll('[data-testid="cw-keyer-pitchHz"]')).toHaveLength(1);
     r.dispose();
@@ -152,7 +159,7 @@ describe('CwKeyerInstrumentHost', () => {
 
   it.each(['hbar', 'knob'] as const)(
     'uses the rendered-native lattice for every %s interaction', (form) => {
-      for (const field of ['keyerSpeed'] as const) {
+      for (const field of ['keyerSpeed', 'pitchHz'] as const) {
         const [, , min, max, step] = CW_CONTINUOUS_LEVELS.find(([name]) => name === field)!;
         const exercise = (
           invoke: (lease: ContinuousScalarRendererLease) => void,
@@ -187,26 +194,49 @@ describe('CwKeyerInstrumentHost', () => {
     },
   );
 
-  it('cancels physical drafts and makes every retained renderer operation inert', () => {
-    const r = render({ presentation: 'independent', scalarPresentation: { form: 'hbar' } });
-    const stale = currentLease('keyerSpeed');
-    const token = stale.beginPointer(); expect(token).not.toBeNull();
-    stale.pointer(token!, 31);
+  it.each(['keyerSpeed', 'pitchHz'] as const)(
+    'cancels physical drafts and makes every retained %s renderer operation inert', (field) => {
+      const [, , , max] = CW_CONTINUOUS_LEVELS.find(([name]) => name === field)!;
+      const r = render({ presentation: 'independent', scalarPresentation: { form: 'hbar' } });
+      const stale = currentLease(field);
+      const token = stale.beginPointer(); expect(token).not.toBeNull();
+      stale.pointer(token!, initial[field] + 1);
+      r.onLevelChange.mockClear();
+
+      r.props.scalarPresentation = { form: 'knob' }; flushSync();
+      expect(currentLease(field).view.draft).toBeNull();
+      expect(stale.beginPointer()).toBeNull();
+      stale.pointer(token!, initial[field] + 2); stale.endPointer(token!); stale.cancelPointer(token!);
+      stale.nativeInput(initial[field] + 3); stale.wheel({ direction: 1, fine: false });
+      expect(stale.key({ key: 'End', fine: false })).toBe(false);
+      stale.reset(); stale.dispose();
+      expect(r.onLevelChange).not.toHaveBeenCalled();
+
+      expect(currentLease(field).key({ key: 'End', fine: false })).toBe(true);
+      expect(r.onLevelChange).toHaveBeenCalledExactlyOnceWith(field, max);
+      r.props.scalarPresentation = { form: 'hbar' }; flushSync();
+      expect(stale.key({ key: 'Home', fine: false })).toBe(false);
+      r.dispose();
+    },
+  );
+
+  it('routes pitch through its own command exactly once, independently of keyerSpeed', () => {
+    const r = render();
+    currentLease('pitchHz').key({ key: 'ArrowRight', fine: false });
+    expect(r.onLevelChange).toHaveBeenCalledExactlyOnceWith('pitchHz', initial.pitchHz + 5);
     r.onLevelChange.mockClear();
+    currentLease('keyerSpeed').key({ key: 'ArrowRight', fine: false });
+    expect(r.onLevelChange).toHaveBeenCalledExactlyOnceWith('keyerSpeed', initial.keyerSpeed + 1);
+    r.dispose();
+  });
 
-    r.props.scalarPresentation = { form: 'knob' }; flushSync();
-    expect(currentLease('keyerSpeed').view.draft).toBeNull();
-    expect(stale.beginPointer()).toBeNull();
-    stale.pointer(token!, 32); stale.endPointer(token!); stale.cancelPointer(token!);
-    stale.nativeInput(33); stale.wheel({ direction: 1, fine: false });
-    expect(stale.key({ key: 'End', fine: false })).toBe(false);
-    stale.reset(); stale.dispose();
-    expect(r.onLevelChange).not.toHaveBeenCalled();
-
-    expect(currentLease('keyerSpeed').key({ key: 'End', fine: false })).toBe(true);
-    expect(r.onLevelChange).toHaveBeenCalledExactlyOnceWith('keyerSpeed', 48);
-    r.props.scalarPresentation = { form: 'hbar' }; flushSync();
-    expect(stale.key({ key: 'Home', fine: false })).toBe(false);
+  it('reads pitch from command feedback when supplied and falls back to the raw reading otherwise', () => {
+    const r = render({ pitchFeedback: feedback('pitchHz', { confirmed: 725 }) });
+    expect(target.querySelector('[data-testid="cw-keyer-pitchHz-value"]')?.textContent)
+      .toBe('725 Hz');
+    r.props.pitchFeedback = undefined; flushSync();
+    expect(target.querySelector('[data-testid="cw-keyer-pitchHz-value"]')?.textContent)
+      .toBe('600 Hz');
     r.dispose();
   });
 
@@ -220,8 +250,8 @@ describe('CwKeyerInstrumentHost', () => {
       presentation: 'independent', scalarPresentation: { form: 'hbar' },
       keySpeedFeedback: pending,
     });
-    expect(target.querySelector('.vc-value')?.textContent).toBe('24 WPM');
-    expect(target.querySelector('[role="slider"]')?.getAttribute('aria-valuetext'))
+    expect(r.row('keyerSpeed').querySelector('.vc-value')?.textContent).toBe('24 WPM');
+    expect(r.row('keyerSpeed').querySelector('[role="slider"]')?.getAttribute('aria-valuetext'))
       .toContain('requested 31 WPM');
     expect(r.row('keyerSpeed').querySelector('[data-canonical-value]')?.textContent).toBe('24 WPM');
     const before = binding('keyerSpeed').view;
@@ -251,8 +281,8 @@ describe('CwKeyerInstrumentHost', () => {
       presentation: 'independent', scalarPresentation: { form: 'hbar' },
       keySpeedFeedback: pending,
     });
-    expect(target.querySelector('.vc-value')?.textContent).toBe('24 WPM');
-    expect(target.querySelector('[role="slider"]')?.getAttribute('aria-valuetext'))
+    expect(remounted.row('keyerSpeed').querySelector('.vc-value')?.textContent).toBe('24 WPM');
+    expect(remounted.row('keyerSpeed').querySelector('[role="slider"]')?.getAttribute('aria-valuetext'))
       .toContain('requested 31 WPM');
     expect(remounted.onLevelChange).not.toHaveBeenCalled();
     remounted.dispose();
@@ -273,13 +303,13 @@ describe('CwKeyerInstrumentHost', () => {
     });
     flushSync();
     expect(slider().getAttribute('aria-disabled')).toBe('true');
-    expect(target.querySelector('.vc-value')?.textContent).toBe('—');
+    expect(r.row('keyerSpeed').querySelector('.vc-value')?.textContent).toBe('—');
 
     r.props.keySpeedFeedback = undefined;
     flushSync();
     expect([
       slider().getAttribute('aria-valuemin'), slider().getAttribute('aria-valuemax'),
-      slider().getAttribute('aria-valuenow'), target.querySelector('.vc-value')?.textContent,
+      slider().getAttribute('aria-valuenow'), r.row('keyerSpeed').querySelector('.vc-value')?.textContent,
     ]).toEqual(['6', '48', '24', '24 WPM']);
     currentLease('keyerSpeed').key({ key: 'ArrowRight', fine: false });
     expect(replacement).toHaveBeenCalledTimes(2);
@@ -291,7 +321,7 @@ describe('CwKeyerInstrumentHost', () => {
       } },
     };
     flushSync();
-    expect(target.querySelector('.vc-value')?.textContent).toBe('—');
+    expect(r.row('keyerSpeed').querySelector('.vc-value')?.textContent).toBe('—');
     expect(slider().getAttribute('aria-disabled')).toBe('true');
     expect(r.row('keyerSpeed').dataset.observed).toBe('false');
     currentLease('keyerSpeed').nativeInput(31);
@@ -322,9 +352,9 @@ describe('CwKeyerInstrumentHost', () => {
     const live = () => target.querySelectorAll('[role="status"][aria-live="polite"]');
     expect(live()).toHaveLength(1);
     expect(target.querySelector('[data-cw-feedback-status]')?.textContent).toContain('radio refused');
-    expect(target.querySelector('.vc-value')?.textContent).toBe('24 WPM');
-    expect(target.querySelector('.vc-value')?.textContent).not.toContain('31');
-    expect(target.querySelector('[role="slider"]')?.getAttribute('aria-valuenow')).toBe('24');
+    expect(r.row('keyerSpeed').querySelector('.vc-value')?.textContent).toBe('24 WPM');
+    expect(r.row('keyerSpeed').querySelector('.vc-value')?.textContent).not.toContain('31');
+    expect(r.row('keyerSpeed').querySelector('[role="slider"]')?.getAttribute('aria-valuenow')).toBe('24');
     const initialStatus = target.querySelector('[data-cw-feedback-status]');
     r.props.keySpeedFeedback = failed('speed-failed-hbar'); flushSync();
     expect(target.querySelector('[data-cw-feedback-status]')).toBe(initialStatus);
@@ -349,6 +379,31 @@ describe('CwKeyerInstrumentHost', () => {
     flushSync();
     expect(live()).toHaveLength(1);
     expect(target.querySelectorAll('[data-cw-feedback-status]')).toHaveLength(1);
+    r.dispose();
+  });
+
+  it('keeps each field issued-status lane independent, exactly one announcement per field', () => {
+    activation.selected = undefined;
+    const pitchFailed = feedback('pitchHz', {
+      requestedTarget: 725, phase: 'failed', lifecycleId: 'pitch-command',
+      transitionId: 'pitch-failed', outcome: { phase: 'failed', error: 'pitch rejected' },
+    });
+    const speedFailed = feedback('keyerSpeed', {
+      requestedTarget: 31, phase: 'failed', lifecycleId: 'speed-command',
+      transitionId: 'speed-failed', outcome: { phase: 'failed', error: 'speed rejected' },
+    });
+    const r = render({
+      presentation: 'independent', scalarPresentation: { form: 'hbar' },
+      keySpeedFeedback: speedFailed, pitchFeedback: pitchFailed,
+    });
+    const lanes = [...target.querySelectorAll<HTMLElement>('[data-cw-feedback-status]')];
+    expect(lanes).toHaveLength(2);
+    expect(lanes.map((node) => node.dataset.feedbackLane).sort()).toEqual(['keyerSpeed', 'pitchHz']);
+    expect(lanes.find((n) => n.dataset.feedbackLane === 'pitchHz')?.textContent)
+      .toContain('pitch rejected');
+    expect(lanes.find((n) => n.dataset.feedbackLane === 'keyerSpeed')?.textContent)
+      .toContain('speed rejected');
+    expect(lanes.every((node) => node.getAttribute('aria-live') === 'polite')).toBe(true);
     r.dispose();
   });
 

--- a/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
@@ -43,13 +43,11 @@ import { t } from '$lib/i18n';
 import type {
   ControlFeedbackPresentationInput, PresentationPhase,
 } from '../../primitives/control-feedback/control-feedback-presentation';
-import type { CommandScalarFeedback } from '../../primitives/scalar/continuous-scalar.svelte';
 
 type BreakInDelayFeedback = ControlFeedbackPresentationInput<number> & {
   readonly sessionEpoch?: number;
   readonly scope?: Readonly<{ control: string; receiver: number; slot?: string }>;
 };
-type CwLevelFeedback = Readonly<CommandScalarFeedback>;
 
 const SOURCE = readFileSync('src/semantic/CwKeyerSurface.svelte', 'utf8');
 /** Comments stripped, so the file's own doctrine prose can never be what a
@@ -87,8 +85,6 @@ type Handlers = {
   onTwinPeakToggle?: () => void;
   onReversePaddleToggle?: () => void;
   breakInDelayFeedback?: Readonly<BreakInDelayFeedback>;
-  cwPitchFeedback?: CwLevelFeedback;
-  keySpeedFeedback?: CwLevelFeedback;
   onAutoTune?: () => void;
 };
 
@@ -136,38 +132,6 @@ const feedback = (
   confirmed: 64, target: null, requestedTarget: null, phase,
   transitionId: null, outcome: null, ...over,
 });
-const cwFeedback = (
-  control: 'cw-pitch' | 'keyer-speed',
-  phase: PresentationPhase = 'idle',
-  over: Partial<CommandScalarFeedback> = {},
-): CwLevelFeedback => Object.freeze({
-  confirmed: 600, target: null, requestedTarget: null, phase,
-  busy: ['submitted', 'queued', 'dispatched', 'awaiting-confirmation'].includes(phase),
-  availability: 'available', outcome: null, lifecycleId: null, transitionId: null,
-  providerGeneration: 1, sessionEpoch: 1,
-  scope: Object.freeze({ control, receiver: 0 as const }),
-  repeatPolicy: 'latest-target-wins', ...over,
-});
-
-function renderReactiveCwLevels(
-  pitch: CwLevelFeedback = cwFeedback('cw-pitch'),
-  speed: CwLevelFeedback = cwFeedback('keyer-speed', 'idle', { confirmed: 24 }),
-) {
-  const onLevelChange = vi.fn();
-  const props = proxy({
-    view: base(), onLevelChange, cwPitchFeedback: pitch, keySpeedFeedback: speed,
-  });
-  const component = mount(CwKeyerInstrumentHostFixture, { target, props });
-  flushSync();
-  const input = (field: 'pitchHz' | 'keyerSpeed') => target.querySelector<HTMLInputElement>(
-    `[data-testid="cw-keyer-${field}"] input`,
-  )!;
-  const row = (field: 'pitchHz' | 'keyerSpeed') => target.querySelector<HTMLElement>(
-    `[data-testid="cw-keyer-${field}"]`,
-  )!;
-  return { dispose: () => unmount(component), input, row, onLevelChange, props };
-}
-
 /* ── (a) the surface is not a key path ────────────────────────── */
 
 describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
@@ -195,7 +159,6 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
       'svelte',
       '../primitives/control-feedback/control-feedback-presentation',
       '../primitives/scalar/committed-scalar.svelte',
-      '../primitives/scalar/continuous-scalar.svelte',
       '../primitives/scalar/value-control-core',
       '../primitives/control-instruments/control-instrument-behavior',
     ]);
@@ -209,8 +172,9 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
     expect(CODE).toContain('invoke: () => onTwinPeakToggle?.()');
     expect(CODE).toContain('invoke: () => onReversePaddleToggle?.()');
     expect(CODE).toContain('{@render continuousHandles.keyerSpeed()}');
+    expect(CODE).toContain('{@render continuousHandles.pitchHz()}');
     expect(CODE).not.toContain('keySpeedScalar');
-    expect(CODE).toContain('const cwPitchScalar = createContinuousScalar');
+    expect(CODE).not.toContain('cwPitchScalar');
   });
 
   // Kills: `onMount(() => …)` and every relative of it, plus a dynamic import
@@ -240,9 +204,9 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
   it('takes exactly one state prop — the view model — plus SETTING intents', () => {
     const props = CODE.slice(CODE.indexOf('interface Props'), CODE.indexOf('}: Props'));
     expect([...props.matchAll(/^\s{4}(\w+)[?]?:/gm)].map((m) => m[1])).toEqual([
-      'view', 'continuousHandles', 'showKeyerSpeed', 'onBreakInMode', 'onLevelChange',
+      'view', 'continuousHandles', 'showKeyerSpeed', 'showPitchHz', 'onBreakInMode', 'onLevelChange',
       'onApfOn', 'onTwinPeakToggle', 'onReversePaddleToggle', 'breakInDelayFeedback',
-      'cwPitchFeedback', 'autoTuneAvailable', 'onAutoTune',
+      'autoTuneAvailable', 'onAutoTune',
     ]);
   });
 
@@ -317,204 +281,14 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
       else press(control);
     }
     flushSync();
+    // pitchHz is now a hosted ValueControl scalar (pointer/keyboard driven, no
+    // native <input>) — its own routing is proven in
+    // CwKeyerInstrumentHost.isolated.test.ts, not by this DOM sweep.
     expect(seen).toEqual([
       'breakIn:0', 'breakIn:1', 'breakIn:2',
-      'level:pitchHz:900', 'level:breakInDelay:255',
+      'level:breakInDelay:255',
       'reversePaddle', 'apf:false', 'apf:true', 'twinPeak',
     ]);
-    r.dispose();
-  });
-});
-
-/* ── MOR-2411 — native CW scalar feedback ownership ──────────── */
-
-describe('CW pitch and keyer speed own independent command feedback', () => {
-  it('treats explicit unavailable feedback as authoritative over retained raw readings', () => {
-    const unavailable = (control: 'cw-pitch' | 'keyer-speed'): CwLevelFeedback => cwFeedback(
-      control, 'unavailable', {
-        confirmed: null, availability: 'unavailable', sessionEpoch: 2,
-      },
-    );
-    const r = renderReactiveCwLevels(unavailable('cw-pitch'));
-    const field = 'pitchHz';
-    expect(r.input(field).disabled).toBe(true);
-    expect(r.input(field).dataset.commandPhase).toBe('unavailable');
-    expect(r.row(field).dataset.observed).toBe('false');
-    expect(r.row(field).textContent).toContain(UNKNOWN_TEXT);
-    slide(r.input(field), Number(r.input(field).max));
-    expect(r.onLevelChange).not.toHaveBeenCalled();
-    r.dispose();
-  });
-
-  it('keeps the remaining native pitch input mapped exactly once', () => {
-    const r = renderReactiveCwLevels();
-    slide(r.input('pitchHz'), 725);
-    expect(r.onLevelChange.mock.calls).toEqual([['pitchHz', 725]]);
-    expect(r.input('pitchHz').value).toBe('725');
-    r.dispose();
-  });
-
-  it.each([
-    ['idle', false, 600, null],
-    ['submitted', true, 725, null],
-    ['queued', true, 725, null],
-    ['dispatched', true, 725, null],
-    ['awaiting-confirmation', true, 725, null],
-    ['confirmed', false, 725, 'confirmed'],
-    ['failed', false, 600, 'failed'],
-    ['timed-out', false, 600, 'timed-out'],
-    ['cancelled', false, 600, 'cancelled'],
-    ['superseded', false, 600, 'superseded'],
-  ] as const)('projects pitch phase %s through its scalar owner', (phase, busy, shown, outcome) => {
-    const active = busy;
-    const terminal = outcome === null ? null : {
-      phase: outcome, ...(outcome === 'failed' ? { error: 'pitch rejected' } : {}),
-    };
-    const pitch = cwFeedback('cw-pitch', phase, {
-      confirmed: phase === 'confirmed' ? 725 : 600,
-      target: active ? 725 : null,
-      requestedTarget: phase === 'idle' ? null : 725,
-      lifecycleId: phase === 'idle' ? null : 'pitch-command',
-      transitionId: phase === 'idle' ? null : `pitch-${phase}`,
-      outcome: terminal,
-    });
-    const r = renderReactiveCwLevels(pitch);
-    expect(r.input('pitchHz').value).toBe(String(shown));
-    expect(r.input('pitchHz').dataset.commandPhase).toBe(phase);
-    expect(r.input('pitchHz').getAttribute('aria-busy')).toBe(String(busy));
-    if (phase === 'failed') expect(r.row('pitchHz').textContent).toContain('pitch rejected');
-    r.dispose();
-  });
-
-  it.each([
-    ['pitchHz', 'cw-pitch', 600, 725],
-  ] as const)('mounts and remounts %s at its pre-existing active target', (
-    field, control, confirmed, targetValue,
-  ) => {
-    const pending = cwFeedback(control, 'awaiting-confirmation', {
-      confirmed, target: targetValue, requestedTarget: targetValue,
-      lifecycleId: `${control}-command`, transitionId: `${control}-awaiting`,
-    });
-    const renderPending = () => field === 'pitchHz'
-      ? renderReactiveCwLevels(pending) : renderReactiveCwLevels(undefined, pending);
-    let r = renderPending();
-    expect(r.input(field).value).toBe(String(targetValue));
-    expect(r.onLevelChange).not.toHaveBeenCalled();
-    r.dispose(); target.innerHTML = '';
-    r = renderPending();
-    expect(r.input(field).value).toBe(String(targetValue));
-    expect(r.onLevelChange).not.toHaveBeenCalled();
-    r.dispose();
-  });
-
-  it.each([
-    ['pitchHz', 'cw-pitch', 600, 725],
-  ] as const)('keeps terminal %s requested target distinct from canonical display', (
-    field, control, confirmed, requestedTarget,
-  ) => {
-    const terminal = cwFeedback(control, 'failed', {
-      confirmed, requestedTarget, lifecycleId: `${control}-command`,
-      transitionId: `${control}-failed`, outcome: { phase: 'failed', error: 'rejected' },
-    });
-    const r = field === 'pitchHz'
-      ? renderReactiveCwLevels(terminal) : renderReactiveCwLevels(undefined, terminal);
-    expect(r.input(field).value).toBe(String(confirmed));
-    expect(r.input(field).getAttribute('aria-valuenow')).toBe(String(confirmed));
-    expect(r.row(field).querySelector('output')?.textContent).toContain(String(confirmed));
-    expect(r.row(field).querySelector('output')?.textContent).not.toContain(String(requestedTarget));
-    r.dispose();
-  });
-
-  it.each([
-    ['pitchHz', 'cw-pitch', 600, 605, 725],
-  ] as const)('invalidates and reissues the %s live event across authority replacement', (
-    field, control, confirmed, rerendered, requestedTarget,
-  ) => {
-    const failed = (canonical: number, providerGeneration = 1, sessionEpoch = 1) => cwFeedback(
-      control, 'failed', {
-        confirmed: canonical, requestedTarget, providerGeneration, sessionEpoch,
-        lifecycleId: `${control}-command`, transitionId: `${control}-failed`,
-        outcome: { phase: 'failed', error: 'rejected' },
-      },
-    );
-    const r = field === 'pitchHz'
-      ? renderReactiveCwLevels(failed(confirmed))
-      : renderReactiveCwLevels(undefined, failed(confirmed));
-    const status = () => r.row(field).querySelector<HTMLElement>('[data-cw-feedback-status]');
-    const initial = status()!;
-    const initialText = initial.textContent;
-    const update = (next: CwLevelFeedback) => {
-      if (field === 'pitchHz') r.props.cwPitchFeedback = next;
-      else r.props.keySpeedFeedback = next;
-      flushSync();
-    };
-    update(failed(rerendered));
-    expect(status()).toBe(initial);
-    expect(status()?.textContent).toBe(initialText);
-
-    update(failed(rerendered, 2, 2));
-    const replaced = status()!;
-    expect(replaced).not.toBe(initial);
-    expect(replaced.textContent).toBe(initialText);
-    expect(r.row(field).querySelectorAll('[data-cw-feedback-status]')).toHaveLength(1);
-
-    update(cwFeedback(control, 'unavailable', {
-      confirmed: null, availability: 'unavailable', providerGeneration: 3, sessionEpoch: 3,
-    }));
-    expect(status()).toBeNull();
-    update(failed(rerendered, 3, 3));
-    expect(status()).not.toBeNull();
-    expect(status()).not.toBe(replaced);
-    expect(status()?.textContent).toBe(initialText);
-    expect(r.row(field).querySelectorAll('[data-cw-feedback-status]')).toHaveLength(1);
-    r.dispose();
-  });
-
-  it('keeps mixed phases, errors and polite announcements lane-local and nonduplicated', () => {
-    const pitch = cwFeedback('cw-pitch', 'failed', {
-      requestedTarget: 725, lifecycleId: 'pitch-command', transitionId: 'pitch-failed',
-      outcome: { phase: 'failed', error: 'pitch rejected' },
-    });
-    const speed = cwFeedback('keyer-speed', 'timed-out', {
-      confirmed: 24, requestedTarget: 31, lifecycleId: 'speed-command',
-      transitionId: 'speed-timeout', outcome: { phase: 'timed-out' },
-    });
-    const r = renderReactiveCwLevels(pitch, speed);
-    expect(r.input('pitchHz').dataset.commandPhase).toBe('failed');
-    expect(r.row('keyerSpeed').dataset.commandPhase).toBe('timed-out');
-    expect(r.row('pitchHz').textContent).toContain('pitch rejected');
-    const announcements = [...target.querySelectorAll<HTMLElement>(
-      '[data-cw-feedback-status]',
-    )];
-    expect(announcements).toHaveLength(2);
-    expect(announcements.map((node) => node.dataset.feedbackLane).sort())
-      .toEqual(['keyerSpeed', 'pitchHz']);
-    expect(announcements.every((node) => node.getAttribute('aria-live') === 'polite')).toBe(true);
-    r.dispose();
-  });
-
-  it('clears a rapid optimistic target when either lane receives replacement authority', () => {
-    const r = renderReactiveCwLevels();
-    slide(r.input('pitchHz'), 650);
-    slide(r.input('pitchHz'), 700);
-    expect(r.input('pitchHz').value).toBe('700');
-
-    r.props.cwPitchFeedback = cwFeedback('cw-pitch', 'unavailable', {
-      confirmed: null, availability: 'unavailable', providerGeneration: 2, sessionEpoch: 2,
-    });
-    flushSync();
-    expect(r.input('pitchHz').disabled).toBe(true);
-    expect(r.input('pitchHz').value).toBe('300');
-    expect(r.onLevelChange.mock.calls).toEqual([['pitchHz', 650], ['pitchHz', 700]]);
-    r.dispose();
-  });
-
-  it('retains pitch reading compatibility when its optional feedback prop is omitted', () => {
-    const onLevelChange = vi.fn();
-    const r = render(base(), { onLevelChange });
-    expect(r.input('pitchHz')?.dataset.commandPhase).toBeUndefined();
-    slide(r.input('pitchHz')!, 725);
-    expect(onLevelChange.mock.calls).toEqual([['pitchHz', 725]]);
     r.dispose();
   });
 });
@@ -1017,7 +791,7 @@ describe('the mutex reasons are rendered with the other mode NAMED (MOR-1296 O1)
 /* ── facts render honestly ─────────────────────────────────────── */
 
 describe('every unread fact renders honestly, never as a v2 default', () => {
-  const NATIVE_LEVELS = CW_LEVELS.filter(([field]) => field !== 'keyerSpeed');
+  const NATIVE_LEVELS = CW_LEVELS.filter(([field]) => field !== 'keyerSpeed' && field !== 'pitchHz');
 
   it.each(NATIVE_LEVELS)('renders the %s fact verbatim on its raw wire scale', (field, _l, min, max) => {
     const r = render(withCw({ [field]: known(max) } as Partial<CwKeyerViewModel>));

--- a/frontend/src/semantic/__tests__/fixtures/CwKeyerInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/CwKeyerInstrumentHostFixture.svelte
@@ -18,7 +18,7 @@
     presentation?: 'grouped' | 'independent';
     scalarPresentation?: Readonly<CwContinuousPresentation>;
     breakInDelayFeedback?: Readonly<BreakInDelayFeedback>;
-    cwPitchFeedback?: Readonly<CommandScalarFeedback>;
+    pitchFeedback?: Readonly<CommandScalarFeedback>;
     keySpeedFeedback?: Readonly<CommandScalarFeedback>;
     autoTuneAvailable?: boolean;
     onBreakInMode?: (mode: number) => void;
@@ -31,27 +31,27 @@
 
   let {
     view, presentation = 'grouped', scalarPresentation,
-    breakInDelayFeedback, cwPitchFeedback, keySpeedFeedback, autoTuneAvailable = false,
+    breakInDelayFeedback, pitchFeedback, keySpeedFeedback, autoTuneAvailable = false,
     onBreakInMode, onLevelChange, onApfOn, onTwinPeakToggle, onReversePaddleToggle, onAutoTune,
   }: Props = $props();
 </script>
 
-<CwKeyerInstrumentHost {view} {keySpeedFeedback} {onLevelChange}>
+<CwKeyerInstrumentHost {view} {keySpeedFeedback} {pitchFeedback} {onLevelChange}>
   {#snippet children(handles: CwKeyerInstrumentHandles)}
     {#key presentation}
       {#if presentation === 'grouped'}
         <CwKeyerSurface
           {view} continuousHandles={handles} {breakInDelayFeedback} {autoTuneAvailable}
-          {cwPitchFeedback}
           {onBreakInMode} {onLevelChange} {onApfOn} {onTwinPeakToggle}
           {onReversePaddleToggle} {onAutoTune}
         />
       {:else}
         <section data-testid="independent-cw-keyer-composition">
           <div data-slot="keyer-speed">{@render handles.keyerSpeed(scalarPresentation)}</div>
+          <div data-slot="pitch-hz">{@render handles.pitchHz(scalarPresentation)}</div>
           <CwKeyerSurface
-            {view} continuousHandles={handles} showKeyerSpeed={false}
-            {breakInDelayFeedback} {cwPitchFeedback} {autoTuneAvailable}
+            {view} continuousHandles={handles} showKeyerSpeed={false} showPitchHz={false}
+            {breakInDelayFeedback} {autoTuneAvailable}
             {onBreakInMode} {onLevelChange} {onApfOn} {onTwinPeakToggle}
             {onReversePaddleToggle} {onAutoTune}
           />


### PR DESCRIPTION
This PR crosses the 600-line soft threshold (999 changed lines, 10 files) as one unit of work: it is the full CW pitch-scalar relocation into the persistent `CwKeyerInstrumentHost`, phases A and B of one join, opened together because Phase A was never pushed on its own. The two production files it touches most, `CwKeyerInstrumentHost.svelte` and `CwKeyerSurface.svelte`, together net-shrink by 81 lines (+134/-87 and +8/-136); the rest of the total is the test coverage that necessarily moves with the mechanism (see Census).

## Summary

- **Phase A** (`47a48f73b`, unpushed until now): generalised `CwKeyerInstrumentHost` from a single `keyerSpeed` field to a table-driven `keyerSpeed`+`pitchHz` host (mirroring the shipped `TxAuxScalarHost`/`DspScalarHost` pattern) and deleted `CwKeyerSurface`'s own native pitch-scalar mechanism.
- **Phase B** (this PR's own commits, on top of merging `origin/main` past #3348/#3349): the live join —
  - `SemanticRadioSurfaces.svelte`: passes `pitchFeedback={cwPitchFeedback}` and `scalarAppearance`/`presentationIsCurrent` to `<CwKeyerInstrumentHost>` (same shape as `keySpeedFeedback`); removed the now-unsupported `{cwPitchFeedback}` prop from `<CwKeyerSurface>`; `cwKeyerSurface`'s `showKeyerSpeed` suppression now also drives `showPitchHz` (one boolean, not a duplicated one — see `hostedCwKeyer`).
  - `RadioLayout.svelte`: the `desktop-v2` branch seats `pitchHz` as its own Standard control beside the existing `keyerSpeed` seat (`data-field="pitchHz"`); the existing `showKeyerSpeed=false` grouped-surface suppression now hides pitch too, so it renders exactly once per layout.
  - `HostedRadioLayoutFixture.svelte`: `cwKeyerInstruments` now satisfies `CwKeyerInstrumentHandles` with both fields.
  - `semantic-cw-keyer-wiring.component.test.ts`: fixed the 2 cases Phase A's report predicted would break (pitch is now a `role="slider"` `ValueControl`, not a raw `<input>`, so `cwInput`/`submitCw` needed the same pointer-gesture math as `keyerSpeed`, scaled per field's own domain; the announcement lane lives at the Host level via `data-feedback-lane`, not nested under the field's own testid); added an exactly-once test across `desktop-v2` and `sdr-test`; added the Standard→SDR persistence witness for the pitch binding.

## Witnesses and mutations (verbatim)

**Exactly-once witness** (`pitch mounts exactly once regardless of the hosting layout`): mounts the real `HostedRadioLayoutFixture` under `desktop-v2` and `sdr-test`, asserting exactly one `[role="slider"][aria-label="CW pitch"]` (and one for `"Keyer speed"`) inside `[data-testid="cw-keyer-pitchHz"]`/`keyerSpeed"` in both.
- Mutation (b1) — kept the RadioLayout seat but forced the grouped surface's own copy to stay shown (`showPitchHz` decoupled from `showKeyerSpeed`): `expected [ …(2) ] to have a length of 1 but got 2` under `desktop-v2`.
- Mutation (b2) — dropped the RadioLayout seat only, suppression untouched: `expected  to have a length of 1 but got +0` under `desktop-v2`.

**Persistence witness** (`the pitch binding survives a Standard→SDR switch`), same three-part shape as `semantic-dsp-wiring.component.test.ts`'s `nbWidth` witness: (i) the SAME `createContinuousScalar` binding object before/after the switch, (ii) the CURRENT lease still emits exactly one `set_cw_pitch` with the submitted value, (iii) the pending lifecycle and its one `data-feedback-lane="pitchHz"` announcement survive unchanged — only then the retained pre-switch lease's inertness.
- Mutation (a) — wrapped the Host mount in `{#key surfacePlan()}` (with a real per-skin `SURFACE_PLAN_CONTEXT_KEY`, so the key value genuinely differs across the switch): `expected [ …(2) ] to have a length of 1 but got 2` — a second `set_cw_pitch` binding was created, proving the identity check is load-bearing.
- Mutation (c) — wired `pitchFeedback={keySpeedFeedback}` instead of `cwPitchFeedback`: killed both the pre-existing feedback-projection test (`expected '600' to be '24'`) and the session-replacement test (`expected 'CW pitch: 24 Hz...' to contain 'requested 700 Hz'`).

All three mutations were restored byte-identically (`diff` confirmed `IDENTICAL` after each revert).

## Census

| File | + | - |
|---|---|---|
| `RadioLayout.svelte` | 5 | 0 |
| `HostedRadioLayoutFixture.svelte` | 1 | 1 |
| `SemanticRadioSurfaces.svelte` | 6 | 4 |
| `semantic-cw-keyer-wiring.component.test.ts` | 190 | 26 |
| `CwKeyerInstrumentHost.svelte` | 134 | 87 |
| `CwKeyerSurface.svelte` | 8 | 136 |
| `CwKeyerInstrumentHost.isolated.test.ts` | 99 | 44 |
| `CwKeyerSurface.test.ts` | 9 | 235 |
| `CwKeyerInstrumentHostFixture.svelte` | 6 | 6 |

**10 files, 459 insertions + 540 deletions = 999 changed lines** (`git diff origin/main...HEAD --shortstat` at `84c0ca09a`) — at, not over, both hard limits (10 files, 1000 lines), over the 600-line soft threshold (justified above). The tenth file is `semantic-vfo-indicator-wiring.component.test.ts`, whose facade regex tracked the moved prop (see Verification). Two commits changed the count: `c8bed1456` trimmed docblocks in the new wiring-test describe blocks (−12 lines, no assertion touched) after the total reached 1009; `84c0ca09a` added the regex fix (+1/−1).

## Verification

- `semantic-cw-keyer-wiring.component.test.ts`: 34/34 pass.
- `CwKeyerInstrumentHost.isolated.test.ts` + `CwKeyerSurface.test.ts`: 105/105 pass.
- Every test file naming `CwKeyer`/`SemanticRadioSurfaces`/`RadioLayout`/`HostedRadioLayoutFixture` (grep union, 87 files): 86/87 files pass, 2482/2483 tests pass. The one failure at the earlier head, `semantic-vfo-indicator-wiring.component.test.ts`'s `keeps the complete panel-adapter facade while wiring both CW lanes to the live session`, was a source-regex assertion expecting the now-removed `{cwPitchFeedback}` literal inside `<CwKeyerSurface .../>`; `84c0ca09a` replaces that one regex so it asserts `pitchFeedback={cwPitchFeedback}` inside `<CwKeyerInstrumentHost …>` (mutation: dropping the prop from the host fails it; 30/30 in that file, 64/64 together with the CW keyer wiring test). `CwPanel.svelte`'s own `cwPitchFeedback` is an unrelated local variable, unaffected.
- `npm run check`: 0 errors, 0 warnings.
- `npx eslint` on all 9 leased files: 0 findings.
- `git diff --check`: clean.
- `node frontend/fixtures/capture.mjs`: 65/65 captures pass, 0 invalid.

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
