### PR TITLE
feat(MOR-2425): show a bad-link chip when state updates stall

### DIFF
--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -167,6 +167,16 @@
   let httpState = $derived(
     getWsConnected() && getRadioHealth()?.serverReachable !== false ? 'connected' : 'disconnected',
   ); // server link — always real
+  // MOR-2425 R29(3): connection.svelte.ts already computes staleness from
+  // state_update timing (`isStale()`, exposed here as `runtime.connectionStale`)
+  // but had zero consumers before this chip. `getWsConnected()` is required
+  // because `setWsConnected(false)` (ws-client.ts's disconnect/reconnect
+  // path) is the only writer that clears it — `staleState` itself is never
+  // reset on disconnect — so gating on it here is what keeps this chip and
+  // the existing disconnected indicators from ever doubling up on one root
+  // cause: the WS transport can only be 'connected' (true) once it is fully
+  // up, never while connecting/reconnecting/disconnected.
+  let badLink = $derived(getWsConnected() && runtime.connectionStale);
   let rigConnected = $derived(getRigConnected());
   let radioReady = $derived(getRadioReady());
   let radioHealth = $derived(getRadioHealth());
@@ -308,6 +318,13 @@
       <span class="indicator-dot"></span>
       <Cable size={12} color="currentColor" strokeWidth={2.5} />
     </span>
+    {#if badLink}
+      <span class="indicator" role="status" data-testid="bad-link-chip" title={t('core.statusbar.badLink.tooltip')} style="--indicator-color: {stateColor('degraded')}">
+        <span class="indicator-dot"></span>
+        <Unplug size={12} color="currentColor" strokeWidth={2.5} />
+        <span class="bad-link-label">{t('core.statusbar.badLink.label')}</span>
+      </span>
+    {/if}
     {#if hasAnyScope() && !declared.has('scopeDisplay')}
       <span class="indicator" role="status" title={t('core.statusbar.indicator.scope', { state: scopeState })} style="--indicator-color: {stateColor(scopeState)}">
         <span class="indicator-dot"></span>
@@ -463,6 +480,18 @@
   .http-lost-label {
     font-size: 9px;
     color: var(--v2-accent-red, #ef4444);
+    font-weight: 700;
+    margin-left: 2px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  /* MOR-2425 R29(3): bad-link chip — the WS transport is up but state
+     updates have stalled, so it borrows the yellow "degraded" tone rather
+     than the red fault tone used for a real disconnect. */
+  .bad-link-label {
+    font-size: 9px;
+    color: var(--v2-accent-yellow, #facc15);
     font-weight: 700;
     margin-left: 2px;
     text-transform: uppercase;

--- a/frontend/src/components-v2/layout/__tests__/StatusBar.bad-link-chip.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/StatusBar.bad-link-chip.component.test.ts
@@ -1,7 +1,8 @@
 /**
  * MOR-2425 R29(3) — `connection.svelte.ts: isStale()` (exposed as
  * `frontend-runtime.ts: get connectionStale()`) computes WS-update
- * staleness from real timing, but no consumer ever displayed it: `isStale()` is read by two `frontend-runtime.ts` getters
+ * staleness from real timing, but no consumer ever displayed it:
+ * `isStale()` is read by two `frontend-runtime.ts` getters
  * (`connectionStale`, and `connection`'s `stale` field), and nothing
  * rendered either one until this chip. This test drives the REAL
  * staleness mechanism (real `setInterval`, real `markStateUpdated()`) under
@@ -83,9 +84,9 @@ describe('StatusBar bad-link chip (MOR-2425 R29(3))', () => {
 
   // Explicit budget, not vitest's 10s default: these four dynamic imports
   // (transformed here, not at collection time — see file header for why
-  // they must stay dynamic) cost ~4.8s cold — close enough to the 10s
-  // default that a loaded machine or a second concurrent vitest run turns
-  // it red (measured: 8 concurrent single-file runs all timed out).
+  // they must stay dynamic) cost ~4.8s cold, and 8 concurrent single-file
+  // runs all exceeded the 10s default (measured; 4 concurrent still passed
+  // at ~7.3s).
   beforeAll(async () => {
     vi.useFakeTimers();
     conn = await import('$lib/stores/connection.svelte');

--- a/frontend/src/components-v2/layout/__tests__/StatusBar.bad-link-chip.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/StatusBar.bad-link-chip.component.test.ts
@@ -1,8 +1,7 @@
 /**
  * MOR-2425 R29(3) — `connection.svelte.ts: isStale()` (exposed as
- * `frontend-runtime.ts: get connectionStale()`) has computed WS-update
- * staleness from real timing since MOR-1419, but no consumer ever displayed
- * it: `isStale()` is read by two `frontend-runtime.ts` getters
+ * `frontend-runtime.ts: get connectionStale()`) computes WS-update
+ * staleness from real timing, but no consumer ever displayed it: `isStale()` is read by two `frontend-runtime.ts` getters
  * (`connectionStale`, and `connection`'s `stale` field), and nothing
  * rendered either one until this chip. This test drives the REAL
  * staleness mechanism (real `setInterval`, real `markStateUpdated()`) under
@@ -84,8 +83,9 @@ describe('StatusBar bad-link chip (MOR-2425 R29(3))', () => {
 
   // Explicit budget, not vitest's 10s default: these four dynamic imports
   // (transformed here, not at collection time — see file header for why
-  // they must stay dynamic) cost ~4.8s cold, which blew the default hook
-  // timeout under concurrent test-file load.
+  // they must stay dynamic) cost ~4.8s cold — close enough to the 10s
+  // default that a loaded machine or a second concurrent vitest run turns
+  // it red (measured: 8 concurrent single-file runs all timed out).
   beforeAll(async () => {
     vi.useFakeTimers();
     conn = await import('$lib/stores/connection.svelte');

--- a/frontend/src/components-v2/layout/__tests__/StatusBar.bad-link-chip.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/StatusBar.bad-link-chip.component.test.ts
@@ -1,8 +1,10 @@
 /**
  * MOR-2425 R29(3) — `connection.svelte.ts: isStale()` (exposed as
  * `frontend-runtime.ts: get connectionStale()`) has computed WS-update
- * staleness from real timing since MOR-1419, but had zero consumers
- * anywhere in `frontend/src` until this chip. This test drives the REAL
+ * staleness from real timing since MOR-1419, but no consumer ever displayed
+ * it: `isStale()` is read by two `frontend-runtime.ts` getters
+ * (`connectionStale`, and `connection`'s `stale` field), and nothing
+ * rendered either one until this chip. This test drives the REAL
  * staleness mechanism (real `setInterval`, real `markStateUpdated()`) under
  * fake timers, rather than stubbing `connectionStale` directly, so a
  * regression in the wiring between the store and `StatusBar.svelte` cannot
@@ -80,13 +82,17 @@ describe('StatusBar bad-link chip (MOR-2425 R29(3))', () => {
   let flushSync: typeof import('svelte')['flushSync'];
   let StatusBar: (typeof import('../StatusBar.svelte'))['default'];
 
+  // Explicit budget, not vitest's 10s default: these four dynamic imports
+  // (transformed here, not at collection time — see file header for why
+  // they must stay dynamic) cost ~4.8s cold, which blew the default hook
+  // timeout under concurrent test-file load.
   beforeAll(async () => {
     vi.useFakeTimers();
     conn = await import('$lib/stores/connection.svelte');
     ({ t } = await import('$lib/i18n'));
     ({ mount, unmount, flushSync } = await import('svelte'));
     ({ default: StatusBar } = await import('../StatusBar.svelte'));
-  });
+  }, 30_000);
 
   afterAll(() => {
     vi.useRealTimers();
@@ -97,9 +103,9 @@ describe('StatusBar bad-link chip (MOR-2425 R29(3))', () => {
     instance = null;
     target?.remove();
     target = null;
-    // Resync the shared store for the next test: a healthy WS plus a
-    // just-arrived update never leaves the chip showing carryover
-    // staleness from this test's timer advance.
+    // Reset the shared store for the next test: WS disconnected (the
+    // default a fresh mount expects) plus a fresh state-update timestamp,
+    // so no test starts already stale from a prior test's timer advance.
     conn.setWsConnected(false);
     conn.markStateUpdated();
   });

--- a/frontend/src/components-v2/layout/__tests__/StatusBar.bad-link-chip.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/StatusBar.bad-link-chip.component.test.ts
@@ -1,0 +1,163 @@
+/**
+ * MOR-2425 R29(3) — `connection.svelte.ts: isStale()` (exposed as
+ * `frontend-runtime.ts: get connectionStale()`) has computed WS-update
+ * staleness from real timing since MOR-1419, but had zero consumers
+ * anywhere in `frontend/src` until this chip. This test drives the REAL
+ * staleness mechanism (real `setInterval`, real `markStateUpdated()`) under
+ * fake timers, rather than stubbing `connectionStale` directly, so a
+ * regression in the wiring between the store and `StatusBar.svelte` cannot
+ * hide behind a mock that always returns the value the test wants.
+ *
+ * All app modules are imported dynamically, once, in `beforeAll`, AFTER
+ * `vi.useFakeTimers()` — `connection.svelte.ts` registers its staleness
+ * `setInterval` at module load, and only a timer scheduled after fake
+ * timers are installed can be driven by `vi.advanceTimersByTime`. This
+ * file deliberately does NOT call `vi.resetModules()` (unlike
+ * `connection.test.ts`'s per-test reset): that would also invalidate the
+ * already-loaded `svelte` runtime module, producing a `mount`/component
+ * pair from two different module instances and an `effect_orphan` error.
+ * Instead, each test resets the store's own state via its real setters.
+ *
+ * `$lib/runtime` is still mocked (as in the sibling radio-link-chip test)
+ * for the properties `StatusBar.svelte` needs unconditionally on every
+ * render (`defaultScopeStatus`, `system.*`), but its `connectionStale`
+ * getter forwards to the real, unmocked `$lib/stores/connection.svelte`
+ * module — the same module `StatusBar.svelte` reads `getWsConnected()` from
+ * directly — so both paths observe one real, shared staleness state.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  hasAnyScope: vi.fn(() => false),
+  hasAudio: vi.fn(() => false),
+  hasSpectrum: vi.fn(() => false),
+}));
+
+vi.mock('$lib/stores/layout.svelte', () => ({
+  getLayoutMode: vi.fn(() => 'standard'),
+  setLayoutMode: vi.fn(),
+}));
+
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  getActiveFrequencyHz: vi.fn(() => null),
+}));
+
+vi.mock('$lib/runtime', async () => {
+  const conn = await import('$lib/stores/connection.svelte');
+  return {
+    runtime: {
+      defaultScopeStatus: {
+        source: null,
+        available: false,
+        resourceSelected: false,
+        demand: 0,
+        lifecycle: 'inactive',
+        transport: 'disconnected',
+        frameSeen: false,
+      },
+      system: {
+        disconnect: vi.fn(),
+        connect: vi.fn(),
+        powerOn: vi.fn(async () => {}),
+        powerOff: vi.fn(async () => {}),
+        identifyFrequency: vi.fn(async () => null),
+      },
+      // Forwards to the real, unmocked store — see file header.
+      get connectionStale() {
+        return conn.isStale();
+      },
+    },
+  };
+});
+
+describe('StatusBar bad-link chip (MOR-2425 R29(3))', () => {
+  let target: HTMLElement | null = null;
+  let instance: object | null = null;
+  let conn: typeof import('$lib/stores/connection.svelte');
+  let t: typeof import('$lib/i18n')['t'];
+  let mount: typeof import('svelte')['mount'];
+  let unmount: typeof import('svelte')['unmount'];
+  let flushSync: typeof import('svelte')['flushSync'];
+  let StatusBar: (typeof import('../StatusBar.svelte'))['default'];
+
+  beforeAll(async () => {
+    vi.useFakeTimers();
+    conn = await import('$lib/stores/connection.svelte');
+    ({ t } = await import('$lib/i18n'));
+    ({ mount, unmount, flushSync } = await import('svelte'));
+    ({ default: StatusBar } = await import('../StatusBar.svelte'));
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    if (instance) unmount(instance);
+    instance = null;
+    target?.remove();
+    target = null;
+    // Resync the shared store for the next test: a healthy WS plus a
+    // just-arrived update never leaves the chip showing carryover
+    // staleness from this test's timer advance.
+    conn.setWsConnected(false);
+    conn.markStateUpdated();
+  });
+
+  function mountBar(): void {
+    target = document.createElement('div');
+    document.body.appendChild(target);
+    instance = mount(StatusBar, { target }) as object;
+    flushSync();
+  }
+
+  function badLinkChip(): Element | null {
+    return target!.querySelector('[data-testid="bad-link-chip"]');
+  }
+
+  it('appears once state updates stall past the threshold while the WS stays connected', () => {
+    conn.setWsConnected(true);
+    conn.markStateUpdated();
+    mountBar();
+    expect(badLinkChip(), 'must not appear before the threshold').toBeNull();
+
+    vi.advanceTimersByTime(6000);
+    flushSync();
+
+    const chip = badLinkChip();
+    expect(chip).not.toBeNull();
+    // i18n key's rendered text, not a hardcoded string copy (per spec).
+    expect(chip!.textContent).toContain(t('core.statusbar.badLink.label'));
+  });
+
+  it('clears within one tick when a state_update lands', () => {
+    conn.setWsConnected(true);
+    conn.markStateUpdated();
+    mountBar();
+    vi.advanceTimersByTime(6000);
+    flushSync();
+    expect(badLinkChip(), 'precondition: chip must be showing').not.toBeNull();
+
+    conn.markStateUpdated();
+    flushSync();
+
+    expect(badLinkChip()).toBeNull();
+  });
+
+  it('does not double up with the disconnected indicator when the WS itself is down', () => {
+    conn.setWsConnected(true);
+    conn.markStateUpdated();
+    mountBar();
+    vi.advanceTimersByTime(6000);
+    flushSync();
+    expect(badLinkChip(), 'precondition: staleness alone must show the chip').not.toBeNull();
+
+    conn.setWsConnected(false);
+    flushSync();
+
+    // Exactly one indicator for the WS-down root cause: the existing
+    // disconnected banner, never the bad-link chip alongside it.
+    expect(target!.querySelector('.control-link-lost')).not.toBeNull();
+    expect(badLinkChip()).toBeNull();
+  });
+});

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -26,6 +26,8 @@
   "core.statusbar.indicator.scope": "Scope WebSocket: {state}",
   "core.statusbar.indicator.audio": "Audio WebSocket: {state}",
   "core.statusbar.indicator.http": "State HTTP: {state}",
+  "core.statusbar.badLink.label": "poor link",
+  "core.statusbar.badLink.tooltip": "Control WebSocket is connected, but no state update has arrived recently.",
   "core.statusbar.txCodecFallback.label": "PCM16",
   "core.statusbar.txCodecFallback.tooltip": "TX audio: this server cannot decode Opus, so the microphone is sending PCM16 instead. Transmission is working.",
   "core.statusbar.health.radioLinkLost": "radio link lost",

--- a/frontend/src/lib/i18n/locales/ja-JP.json
+++ b/frontend/src/lib/i18n/locales/ja-JP.json
@@ -26,6 +26,8 @@
   "core.statusbar.indicator.scope": "スコープ WebSocket: {state}",
   "core.statusbar.indicator.audio": "音声 WebSocket: {state}",
   "core.statusbar.indicator.http": "状態 HTTP: {state}",
+  "core.statusbar.badLink.label": "接続不良",
+  "core.statusbar.badLink.tooltip": "制御 WebSocket は接続していますが、状態の更新がしばらく届いていません。",
   "core.statusbar.health.radioLinkLost": "トランシーバーとの通信が切断されました",
   "core.statusbar.health.radioResponseDelayed": "トランシーバーの応答が遅延しています",
   "core.statusbar.health.radioNotResponding": "トランシーバーが応答しません",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -26,6 +26,8 @@
   "core.statusbar.indicator.scope": "WebSocket панорамы: {state}",
   "core.statusbar.indicator.audio": "Аудио WebSocket: {state}",
   "core.statusbar.indicator.http": "HTTP состояния: {state}",
+  "core.statusbar.badLink.label": "плохая связь",
+  "core.statusbar.badLink.tooltip": "Управляющий WebSocket подключён, но обновления состояния давно не поступали.",
   "core.statusbar.txCodecFallback.label": "PCM16",
   "core.statusbar.txCodecFallback.tooltip": "TX-аудио: сервер не умеет декодировать Opus, поэтому микрофон передаёт PCM16. Передача работает.",
   "core.statusbar.health.radioLinkLost": "связь с трансивером потеряна",


### PR DESCRIPTION
Summary (owner ruling R29): the link-quality signal was computed and unused; one chip, no availability change.

`connection.svelte.ts: isStale()` has computed WS-update staleness from real `state_update` timing since MOR-1419 (5s threshold, ticked every 1s), and is already exposed as `frontend-runtime.ts: get connectionStale()` / `connection().stale`. It had zero consumers anywhere in `frontend/src` before this PR. This adds one new chip to `StatusBar.svelte`: `badLink = getWsConnected() && runtime.connectionStale`, shown only while the WS transport is fully connected and no state update has landed in >5s. No control-availability, `ValueControl`, panel-adapter, or field-status logic is touched — that is out of scope for a separate PR per the census.

Witnesses + mutations (verbatim, run in the frontend worktree, restored byte-identically before the final green run — confirmed via `git diff --stat` showing only the intended 29-line `StatusBar.svelte` diff after restore):
- Mutation (a) — drop the `getWsConnected()` gate (`let badLink = $derived(runtime.connectionStale);`): the no-double-indicator test (`does not double up with the disconnected indicator when the WS itself is down`) failed as expected; the other two tests still passed.
- Mutation (b) — invert the stale condition (`let badLink = $derived(getWsConnected() && !runtime.connectionStale);`): all three tests failed, starting with `appears once state updates stall past the threshold while the WS stays connected`.
- After restoring the original file byte-for-byte (verified via `cp` + `git diff --stat` = `29 insertions(+)`, matching the pre-mutation diff), the full 3-test file passed again.

Census: `frontend/src/lib/stores/connection.svelte.ts: isStale()`/`markStateUpdated()` (single writer: `frontend/src/lib/transport/ws-client.ts`'s real `state_update` handler) and `frontend/src/lib/runtime/frontend-runtime.ts: get connectionStale()` were the only two references to the signal repo-wide before this PR (per the prior researcher's `git grep`). `getWsConnected()` in the same store is set `true` only for the fully `'connected'` WS transport state (`ws-client.ts:700-701`), so the chip's WS-connected gate and the existing disconnected/reconnecting chips are mutually exclusive by construction, not by an added guard.

Verification:
- New/extended tests: `frontend/src/components-v2/layout/__tests__/StatusBar.bad-link-chip.component.test.ts` (3 tests) — pass.
- Union of every test file naming StatusBar/connection.svelte/frontend-runtime (`grep -rlE "StatusBar|connection\.svelte|frontend-runtime" src --include="*.test.ts"`, 96 files): `npx vitest run <that list>` → 96 files / 2406 tests passed.
- `npm run check` (svelte-check + tsc ×2): `0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`.
- `npx eslint` on the two changed/added frontend files: clean.
- `npm run i18n:check`: `OK (3 locale file(s) checked, 277 source keys)` — the two informational notes are pre-existing coverage gaps unrelated to the new keys.
- `git diff --check`: clean.
- `node fixtures/capture.mjs`: 65/65 fixture captures passed, 0 invalid.
- Did NOT run the full pytest/vitest suite locally per CLAUDE.md — the head's `quick.yml` run is the record for full-suite numbers.

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)