### PR TITLE
feat(MOR-2425): add state-backed feedback for PBT and IF-shift commands

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -67,7 +67,8 @@ import {
 } from '../panel-adapters';
 import {
   BREAK_IN_DELAY_COMMAND_DESCRIPTOR, CW_PITCH_COMMAND_DESCRIPTOR, FILTER_WIDTH_COMMAND_DESCRIPTOR,
-  DSP_COMMAND_DESCRIPTORS, KEY_SPEED_COMMAND_DESCRIPTOR,
+  DSP_COMMAND_DESCRIPTORS, IF_SHIFT_COMMAND_DESCRIPTOR, KEY_SPEED_COMMAND_DESCRIPTOR,
+  PBT_INNER_COMMAND_DESCRIPTOR, PBT_OUTER_COMMAND_DESCRIPTOR,
   RF_GAIN_COMMAND_DESCRIPTOR, SQUELCH_COMMAND_DESCRIPTOR,
   STATE_BACKED_COMMAND_DESCRIPTORS,
   TX_AUX_COMMAND_DESCRIPTORS,
@@ -118,6 +119,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
       'set_compressor_level', 'set_monitor_gain', 'set_nb_level', 'set_nb_width',
       'set_nr_level', 'set_nb_depth',
       'set_notch_filter', 'set_manual_notch_width', 'set_agc_time_constant',
+      'set_pbt_inner', 'set_pbt_outer', 'set_if_shift',
     ]);
     expect(RADIO_INTENT_NAMES).toContain(FILTER_WIDTH_COMMAND_DESCRIPTOR.intentName);
     const main = FILTER_WIDTH_COMMAND_DESCRIPTOR.scope(command({ params: { width: 3000, receiver: 0 } }))!;
@@ -602,6 +604,9 @@ describe('Break-in Delay ControlFeedback projection (MOR-1744)', () => {
       ['set_notch_filter', DSP_COMMAND_DESCRIPTORS.notchFilter],
       ['set_manual_notch_width', DSP_COMMAND_DESCRIPTORS.manualNotchWidth],
       ['set_agc_time_constant', DSP_COMMAND_DESCRIPTORS.agcTimeConstant],
+      ['set_pbt_inner', PBT_INNER_COMMAND_DESCRIPTOR],
+      ['set_pbt_outer', PBT_OUTER_COMMAND_DESCRIPTOR],
+      ['set_if_shift', IF_SHIFT_COMMAND_DESCRIPTOR],
     ]);
     const scope = BREAK_IN_DELAY_COMMAND_DESCRIPTOR.scope(delayCommand());
     expect(scope).toEqual({ control: 'break-in-delay', receiver: 0 });

--- a/frontend/src/lib/runtime/adapters/__tests__/pbt-if-shift-command-feedback.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/pbt-if-shift-command-feedback.isolated.test.ts
@@ -192,4 +192,70 @@ describe('IF-shift command feedback (real on Yaesu, derived on Icom PBT-only)', 
     h.caps = { ...ftx1Caps(), capabilities: [] } as unknown as Capabilities;
     expect(getIfShiftControlFeedback(connected).availability).toBe('unavailable');
   });
+
+  it('reports the non-confirmed outcome, not confirmed, when one PBT side confirms and the other fails', () => {
+    h.state = state(); h.caps = pbtCaps();
+    h.commands = [
+      command(PBT_INNER_COMMAND_DESCRIPTOR, 'value', 150, { status: 'confirmed' }),
+      command(PBT_OUTER_COMMAND_DESCRIPTOR, 'value', 160, { status: 'failed', error: 'echo mismatch' }),
+    ];
+    const feedback = getIfShiftControlFeedback(connected);
+    expect(feedback.busy).toBe(false);
+    expect(feedback.phase).toBe('failed');
+    expect(feedback.outcome).toMatchObject({ phase: 'failed' });
+  });
+
+  it('reports timed-out (not confirmed) when the confirmed side is the other one', () => {
+    h.state = state(); h.caps = pbtCaps();
+    h.commands = [
+      command(PBT_INNER_COMMAND_DESCRIPTOR, 'value', 150, { status: 'timed-out' }),
+      command(PBT_OUTER_COMMAND_DESCRIPTOR, 'value', 160, { status: 'confirmed' }),
+    ];
+    const feedback = getIfShiftControlFeedback(connected);
+    expect(feedback.busy).toBe(false);
+    expect(feedback.phase).toBe('timed-out');
+    expect(feedback.outcome).toMatchObject({ phase: 'timed-out' });
+  });
+
+  it('reports confirmed with the derived Hz value when both PBT sides confirm', () => {
+    h.state = state(); h.caps = pbtCaps();
+    h.commands = [
+      command(PBT_INNER_COMMAND_DESCRIPTOR, 'value', 150, { status: 'confirmed' }),
+      command(PBT_OUTER_COMMAND_DESCRIPTOR, 'value', 160, { status: 'confirmed' }),
+    ];
+    const expected = deriveIfShift(pbtRawToHz(131, PBT_SCALE), pbtRawToHz(140, PBT_SCALE));
+    const feedback = getIfShiftControlFeedback(connected);
+    expect(feedback.busy).toBe(false);
+    expect(feedback.phase).toBe('confirmed');
+    expect(feedback.outcome).toMatchObject({ phase: 'confirmed' });
+    expect(feedback.confirmed).toBe(expected);
+  });
+
+  it('while one side merely acknowledged and the other is only submitted, is never more settled than the submitted side', () => {
+    h.state = state(); h.caps = pbtCaps();
+    h.commands = [
+      command(PBT_INNER_COMMAND_DESCRIPTOR, 'value', 150, { status: 'acknowledged' }),
+      command(PBT_OUTER_COMMAND_DESCRIPTOR, 'value', 160, { status: 'pending' }),
+    ];
+    const feedback = getIfShiftControlFeedback(connected);
+    expect(feedback.busy).toBe(true);
+    expect(feedback.phase).toBe('submitted');
+    expect(feedback.phase).not.toBe('awaiting-confirmation');
+  });
+
+  it('composes a transitionId that changes with either half, distinct across two gestures', () => {
+    h.state = state(); h.caps = pbtCaps();
+    h.commands = [
+      command(PBT_INNER_COMMAND_DESCRIPTOR, 'value', 150, { id: 'gesture-a' }),
+      command(PBT_OUTER_COMMAND_DESCRIPTOR, 'value', 160),
+    ];
+    const first = getIfShiftControlFeedback(connected);
+    h.commands = [
+      command(PBT_INNER_COMMAND_DESCRIPTOR, 'value', 150, { id: 'gesture-b' }),
+      command(PBT_OUTER_COMMAND_DESCRIPTOR, 'value', 160),
+    ];
+    const second = getIfShiftControlFeedback(connected);
+    expect(first.transitionId).not.toBe(second.transitionId);
+    expect(first.lifecycleId ?? first.transitionId).not.toBe(second.lifecycleId ?? second.transitionId);
+  });
 });

--- a/frontend/src/lib/runtime/adapters/__tests__/pbt-if-shift-command-feedback.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/pbt-if-shift-command-feedback.isolated.test.ts
@@ -243,6 +243,24 @@ describe('IF-shift command feedback (real on Yaesu, derived on Icom PBT-only)', 
     expect(feedback.phase).not.toBe('awaiting-confirmation');
   });
 
+  it('ranks a held (queued) side as less advanced than a merely awaiting-confirmation side', () => {
+    h.state = state(); h.caps = pbtCaps();
+    h.commands = [
+      command(PBT_INNER_COMMAND_DESCRIPTOR, 'value', 150, {
+        status: 'acknowledged',
+        hold: {
+          commandId: PBT_INNER_COMMAND_DESCRIPTOR.intentName, originalEpoch: 7, eventEpoch: 1,
+          kind: 'held', reason: 'tx_active', expiresAt: 999,
+        },
+      }),
+      command(PBT_OUTER_COMMAND_DESCRIPTOR, 'value', 160, { status: 'acknowledged' }),
+    ];
+    const feedback = getIfShiftControlFeedback(connected);
+    expect(feedback.busy).toBe(true);
+    expect(feedback.phase).toBe('queued');
+    expect(feedback.phase).not.toBe('awaiting-confirmation');
+  });
+
   it('composes a transitionId that changes with either half, distinct across two gestures', () => {
     h.state = state(); h.caps = pbtCaps();
     h.commands = [
@@ -257,5 +275,18 @@ describe('IF-shift command feedback (real on Yaesu, derived on Icom PBT-only)', 
     const second = getIfShiftControlFeedback(connected);
     expect(first.transitionId).not.toBe(second.transitionId);
     expect(first.lifecycleId ?? first.transitionId).not.toBe(second.lifecycleId ?? second.transitionId);
+
+    h.commands = [
+      command(PBT_INNER_COMMAND_DESCRIPTOR, 'value', 150),
+      command(PBT_OUTER_COMMAND_DESCRIPTOR, 'value', 160, { id: 'gesture-c' }),
+    ];
+    const third = getIfShiftControlFeedback(connected);
+    h.commands = [
+      command(PBT_INNER_COMMAND_DESCRIPTOR, 'value', 150),
+      command(PBT_OUTER_COMMAND_DESCRIPTOR, 'value', 160, { id: 'gesture-d' }),
+    ];
+    const fourth = getIfShiftControlFeedback(connected);
+    expect(third.transitionId).not.toBe(fourth.transitionId);
+    expect(third.lifecycleId ?? third.transitionId).not.toBe(fourth.lifecycleId ?? fourth.transitionId);
   });
 });

--- a/frontend/src/lib/runtime/adapters/__tests__/pbt-if-shift-command-feedback.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/pbt-if-shift-command-feedback.isolated.test.ts
@@ -1,0 +1,195 @@
+/**
+ * MOR-2425 — PBT inner/outer and IF-shift state-backed feedback.
+ *
+ * Mirrors `dsp-command-feedback.isolated.test.ts`'s harness shape. PBT_INNER
+ * and PBT_OUTER read/confirm RAW state (0-255 BCD on IC-7300); IF-shift is
+ * real (identity-mapped Hz) on a radio that declares `if_shift`, and derived
+ * from the two PBT feedbacks (converted raw->Hz) everywhere else.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import type { CommandLifecycle } from '$lib/stores/commands.svelte';
+
+const h = vi.hoisted(() => ({
+  state: null as ServerState | null,
+  caps: null as Capabilities | null,
+  commands: [] as CommandLifecycle[],
+  session: { state: 'connected' as 'connected' | 'disconnected', epoch: 7 },
+  active: 'MAIN' as 'MAIN' | 'SUB' | null,
+  operational: true,
+  indicatorCount: 1,
+}));
+
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    get state() { return h.state; },
+    get caps() { return h.caps; },
+    get controlSession() { return h.session; },
+  },
+}));
+vi.mock('$lib/stores/commands.svelte', async (importOriginal) => ({
+  ...await importOriginal<typeof import('$lib/stores/commands.svelte')>(),
+  getCommandLifecycles: () => h.commands,
+  isCommandLifecycleSuperseded: (command: CommandLifecycle) => command.id.endsWith('-old'),
+}));
+vi.mock('$lib/runtime/adapters/radio-view-model-adapter', () => ({
+  toRadioViewModel: () => h.active === null
+    ? { activeReceiver: { status: 'unknown' }, receiverIndicators: [] }
+    : {
+      activeReceiver: { status: 'known', receiver: h.active },
+      receiverIndicators: Array.from({ length: h.indicatorCount }, () => ({
+        receiver: h.active,
+        availability: { structural: true, operational: h.operational },
+      })),
+    },
+}));
+
+import {
+  IF_SHIFT_COMMAND_DESCRIPTOR, PBT_INNER_COMMAND_DESCRIPTOR, PBT_OUTER_COMMAND_DESCRIPTOR,
+} from '$lib/stores/commands.svelte';
+import {
+  getIfShiftControlFeedback, getPbtInnerControlFeedback, getPbtOuterControlFeedback,
+} from '../panel-adapters';
+import { pbtRawToHz, deriveIfShift } from '$lib/radio/filter-controls';
+
+const PBT_SCALE = { rawCenter: 128, displayMin: -1200, displayMax: 1200 };
+const fresh = (marker = 5) => ({
+  storePath: 'fixture', observed: true, freshness: 'fresh' as const,
+  availability: 'available' as const, lastObservedMonotonic: marker,
+});
+const state = (over: Record<string, unknown> = {}): ServerState => ({
+  stateContractVersion: 1, providerGeneration: 3, active: 'MAIN',
+  main: { pbtInner: 131, pbtOuter: 140, ifShift: 60 },
+  sub: { pbtInner: 132, pbtOuter: 141, ifShift: 61 },
+  fieldStatus: {
+    'main.pbtInner': fresh(), 'main.pbtOuter': fresh(), 'main.ifShift': fresh(),
+    'sub.pbtInner': fresh(), 'sub.pbtOuter': fresh(), 'sub.ifShift': fresh(),
+  },
+  ...over,
+} as unknown as ServerState);
+const pbtCaps = (overCapabilities: readonly string[] = ['pbt']): Capabilities => ({
+  stateContractVersion: 1, providerGeneration: 3, receivers: 1, vfoScheme: 'single',
+  capabilities: overCapabilities,
+  controls: { pbt_inner: { raw_center: 128, display_min: -1200, display_max: 1200 } },
+} as unknown as Capabilities);
+const ftx1Caps = (): Capabilities => ({
+  stateContractVersion: 1, providerGeneration: 3, receivers: 1, vfoScheme: 'single',
+  capabilities: ['if_shift'],
+  controls: {},
+} as unknown as Capabilities);
+const connected = { state: 'connected' as const, epoch: 7 };
+const command = (
+  descriptor: typeof PBT_INNER_COMMAND_DESCRIPTOR, param: 'value' | 'offset', target: number,
+  over: Partial<CommandLifecycle> = {},
+): CommandLifecycle => ({
+  id: descriptor.intentName, name: descriptor.intentName,
+  params: { [param]: target, receiver: h.active === 'SUB' ? 1 : 0 },
+  originalEpoch: 7, createdAt: 1, updatedAt: 1, timeoutMs: 5_000,
+  status: 'pending', providerGeneration: 3, ...over,
+});
+
+function reset(): void {
+  h.state = null; h.caps = null; h.commands = [];
+  h.session = { state: 'connected', epoch: 7 }; h.active = 'MAIN'; h.operational = true;
+  h.indicatorCount = 1;
+}
+
+describe('qualified raw PBT inner/outer command feedback', () => {
+  afterEach(reset);
+
+  it('is unavailable before authority is present and available once state/caps/session line up', () => {
+    h.session = { state: 'disconnected', epoch: -1 };
+    expect(getPbtInnerControlFeedback()).toMatchObject({
+      confirmed: null, phase: 'unavailable', availability: 'unavailable',
+      scope: { control: 'pbt-inner', receiver: 0 },
+    });
+    h.state = state(); h.caps = pbtCaps(); h.session = connected;
+    expect(getPbtInnerControlFeedback(connected)).toMatchObject({
+      confirmed: 131, phase: 'idle', availability: 'available',
+    });
+    expect(getPbtOuterControlFeedback(connected)).toMatchObject({
+      confirmed: 140, phase: 'idle', availability: 'available',
+    });
+  });
+
+  it('projects an exact raw submitted target distinct from the confirmed reading', () => {
+    h.state = state(); h.caps = pbtCaps();
+    h.commands = [command(PBT_INNER_COMMAND_DESCRIPTOR, 'value', 150)];
+    expect(getPbtInnerControlFeedback(connected)).toMatchObject({
+      confirmed: 131, target: 150, requestedTarget: 150, phase: 'submitted', busy: true,
+    });
+  });
+
+  it('is structurally absent on a radio with no pbt capability (FTX-1-shaped caps)', () => {
+    h.state = state(); h.caps = ftx1Caps();
+    expect(getPbtInnerControlFeedback(connected).availability).toBe('unavailable');
+    expect(getPbtOuterControlFeedback(connected).availability).toBe('unavailable');
+  });
+
+  it('is structurally absent when the pbt capability is declared without a usable range', () => {
+    h.state = state();
+    h.caps = pbtCaps();
+    h.caps = { ...h.caps, controls: {} } as unknown as Capabilities;
+    expect(getPbtInnerControlFeedback(connected).availability).toBe('unavailable');
+  });
+
+  it('uses the active SUB receiver scope and field', () => {
+    h.active = 'SUB';
+    h.state = state({ active: 'SUB' });
+    h.caps = { ...pbtCaps(), receivers: 2, vfoScheme: 'main_sub' } as unknown as Capabilities;
+    expect(getPbtInnerControlFeedback(connected)).toMatchObject({
+      confirmed: 132, scope: { control: 'pbt-inner', receiver: 1 },
+    });
+    expect(getPbtOuterControlFeedback(connected)).toMatchObject({
+      confirmed: 141, scope: { control: 'pbt-outer', receiver: 1 },
+    });
+  });
+});
+
+describe('IF-shift command feedback (real on Yaesu, derived on Icom PBT-only)', () => {
+  afterEach(reset);
+
+  it('reads the real descriptor directly on a radio with its own if_shift command', () => {
+    h.state = state(); h.caps = ftx1Caps();
+    expect(getIfShiftControlFeedback(connected)).toMatchObject({
+      confirmed: 60, domain: 'hz', phase: 'idle', availability: 'available',
+      scope: { control: 'if-shift', receiver: 0 },
+    });
+    h.commands = [command(IF_SHIFT_COMMAND_DESCRIPTOR, 'offset', 80)];
+    expect(getIfShiftControlFeedback(connected)).toMatchObject({
+      confirmed: 60, target: 80, requestedTarget: 80, domain: 'hz', busy: true,
+    });
+  });
+
+  it('derives confirmed Hz from the two PBT feedbacks on a PBT-only radio', () => {
+    h.state = state(); h.caps = pbtCaps();
+    const expected = deriveIfShift(pbtRawToHz(131, PBT_SCALE), pbtRawToHz(140, PBT_SCALE));
+    expect(getIfShiftControlFeedback(connected)).toMatchObject({
+      confirmed: expected, domain: 'hz', phase: 'idle', availability: 'available', busy: false,
+    });
+  });
+
+  it('derives a pending target from whichever PBT side is busy, confirmed for the other', () => {
+    h.state = state(); h.caps = pbtCaps();
+    h.commands = [command(PBT_INNER_COMMAND_DESCRIPTOR, 'value', 150)];
+    const expectedTarget = deriveIfShift(pbtRawToHz(150, PBT_SCALE), pbtRawToHz(140, PBT_SCALE));
+    const feedback = getIfShiftControlFeedback(connected);
+    expect(feedback).toMatchObject({ target: expectedTarget, domain: 'hz', busy: true });
+    expect(feedback.phase).not.toBe('idle');
+  });
+
+  it('is unavailable when the underlying PBT feedback is unavailable (no real if_shift, no usable pbt range)', () => {
+    h.state = state();
+    h.caps = { ...pbtCaps(), controls: {} } as unknown as Capabilities;
+    expect(getIfShiftControlFeedback(connected)).toMatchObject({
+      confirmed: null, domain: 'hz', phase: 'unavailable', availability: 'unavailable',
+    });
+  });
+
+  it('is unavailable when the radio has neither a real if_shift command nor pbt at all', () => {
+    h.state = state();
+    h.caps = { ...ftx1Caps(), capabilities: [] } as unknown as Capabilities;
+    expect(getIfShiftControlFeedback(connected).availability).toBe('unavailable');
+  });
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/pbt-if-shift-terminal-outcome-retention.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/pbt-if-shift-terminal-outcome-retention.test.ts
@@ -1,0 +1,112 @@
+/**
+ * MOR-2425 regression — `getIfShiftControlFeedback`'s derived outcome across
+ * the real `commands.svelte` store's `OUTCOME_RETENTION_MS` window.
+ *
+ * The sibling `pbt-if-shift-command-feedback.isolated.test.ts` drives a
+ * hand-fed lifecycle array with no timers, so it cannot reach a race between
+ * a record's own retirement and the merge in `panel-adapters.ts:
+ * mergeTerminalOutcome`. This file drives the real store with fake timers.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+const runtimeState: { state: ServerState | null; caps: Capabilities | null } = { state: null, caps: null };
+const controlSession = { state: 'connected' as const, epoch: 7 };
+const radioStore: { current: { providerGeneration: number } | null } = { current: null };
+
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    get state() { return runtimeState.state; },
+    get caps() { return runtimeState.caps; },
+    get controlSession() { return controlSession; },
+  },
+}));
+vi.mock('$lib/runtime/adapters/radio-view-model-adapter', () => ({
+  toRadioViewModel: () => ({
+    activeReceiver: { status: 'known', receiver: 'MAIN' },
+    receiverIndicators: [{ receiver: 'MAIN', availability: { structural: true, operational: true } }],
+  }),
+}));
+vi.mock('$lib/stores/radio.svelte', () => ({
+  getRadioState: () => radioStore.current,
+  subscribeRadioState: () => () => {},
+}));
+
+const PBT_SCALE = { raw_center: 128, display_min: -1200, display_max: 1200 };
+const fresh = (marker = 5) => ({
+  storePath: 'fixture', observed: true, freshness: 'fresh' as const,
+  availability: 'available' as const, lastObservedMonotonic: marker,
+});
+const fixtureState = (): ServerState => ({
+  stateContractVersion: 1, providerGeneration: 3, active: 'MAIN',
+  main: { pbtInner: 131, pbtOuter: 140, ifShift: 60 },
+  sub: { pbtInner: 132, pbtOuter: 141, ifShift: 61 },
+  fieldStatus: {
+    'main.pbtInner': fresh(), 'main.pbtOuter': fresh(), 'main.ifShift': fresh(),
+    'sub.pbtInner': fresh(), 'sub.pbtOuter': fresh(), 'sub.ifShift': fresh(),
+  },
+} as unknown as ServerState);
+const pbtCaps = (): Capabilities => ({
+  stateContractVersion: 1, providerGeneration: 3, receivers: 1, vfoScheme: 'single',
+  capabilities: ['pbt'],
+  controls: { pbt_inner: PBT_SCALE },
+} as unknown as Capabilities);
+
+describe('IF-shift derived outcome across OUTCOME_RETENTION_MS (MOR-2425 regression)', () => {
+  let store: typeof import('$lib/stores/commands.svelte');
+  let getIfShiftControlFeedback: typeof import('../panel-adapters').getIfShiftControlFeedback;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    store = await import('$lib/stores/commands.svelte');
+    ({ getIfShiftControlFeedback } = await import('../panel-adapters'));
+    runtimeState.state = fixtureState();
+    runtimeState.caps = pbtCaps();
+    radioStore.current = { providerGeneration: 3 };
+  });
+
+  afterEach(() => {
+    store.resetCommandLifecycle();
+    runtimeState.state = null; runtimeState.caps = null; radioStore.current = null;
+    vi.useRealTimers();
+  });
+
+  it('does not surface confirmed once the failed half retires, then settles to idle once both retire', () => {
+    const { PBT_INNER_COMMAND_DESCRIPTOR, PBT_OUTER_COMMAND_DESCRIPTOR } = store;
+    store.beginCommand({
+      id: PBT_INNER_COMMAND_DESCRIPTOR.intentName, name: PBT_INNER_COMMAND_DESCRIPTOR.intentName,
+      params: { value: 90, receiver: 0 }, originalEpoch: 7,
+    });
+    store.beginCommand({
+      id: PBT_OUTER_COMMAND_DESCRIPTOR.intentName, name: PBT_OUTER_COMMAND_DESCRIPTOR.intentName,
+      params: { value: 150, receiver: 0 }, originalEpoch: 7,
+    });
+    store.acknowledgeCommand(PBT_INNER_COMMAND_DESCRIPTOR.intentName, 7, 1);
+    store.acknowledgeCommand(PBT_OUTER_COMMAND_DESCRIPTOR.intentName, 7, 1);
+    store.failCommand(PBT_INNER_COMMAND_DESCRIPTOR.intentName, 7, 1, 'echo mismatch');
+
+    vi.advanceTimersByTime(300);
+    store.confirmCommand(PBT_OUTER_COMMAND_DESCRIPTOR.intentName, 7, 1);
+
+    const atConfirm = getIfShiftControlFeedback();
+    expect(atConfirm.phase).toBe('failed');
+    expect(atConfirm.outcome).toMatchObject({ phase: 'failed' });
+
+    // Inner failed at t=0 (relative); its own OUTCOME_RETENTION_MS timer
+    // fires 5s after THAT transition, independent of outer's t=300ms confirm
+    // (whose own timer fires at t=5300ms). Land strictly between the two.
+    vi.advanceTimersByTime(5_000 - 300 + 1);
+    const afterInnerRetires = getIfShiftControlFeedback();
+    expect(afterInnerRetires.phase).not.toBe('confirmed');
+    expect(afterInnerRetires.outcome).toBeNull();
+    expect(afterInnerRetires.transitionId).toBeNull();
+    expect(afterInnerRetires.lifecycleId).toBeNull();
+
+    vi.advanceTimersByTime(300);
+    const afterBothRetire = getIfShiftControlFeedback();
+    expect(afterBothRetire.phase).toBe('idle');
+    expect(afterBothRetire.outcome).toBeNull();
+  });
+});

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -802,31 +802,56 @@ function mergeBusyPhase(
 }
 
 /**
- * Terminal outcomes ranked worst-first: a non-`'confirmed'` outcome on
- * either side always dominates a `'confirmed'` one on the other, so a
- * half-failed gesture is never reported as `'confirmed'`. The order among
- * the non-`'confirmed'` outcomes is otherwise arbitrary but fixed, so two
- * differently-failed sides still resolve to one deterministic outcome.
+ * Terminal outcomes ranked worst-first, used only when both sides' records
+ * are live and terminal: a non-`'confirmed'` outcome on either side beats a
+ * `'confirmed'` one on the other. The order among the non-`'confirmed'`
+ * outcomes is otherwise arbitrary but fixed, so two differently-failed
+ * sides still resolve to one deterministic outcome.
  */
 const TERMINAL_OUTCOME_PRIORITY: readonly ControlFeedbackOutcome[] = Object.freeze([
   'failed', 'timed-out', 'cancelled', 'superseded', 'confirmed',
 ]);
 
 /**
- * Combines two non-busy sides' phase/outcome. Each side's `outcome` here is
- * either `null` (idle — no lifecycle ran) or a terminal outcome; ranked by
- * `TERMINAL_OUTCOME_PRIORITY` when both are terminal, otherwise the
- * non-idle side wins outright.
+ * Combines two non-busy sides' phase/outcome. `outcome === null` here means
+ * idle under `getPbtInner/OuterControlFeedback`'s own definition: no
+ * lifecycle ever ran, or one did and its record already retired
+ * (`commands.svelte.ts: retainTerminalOutcome` expires each record
+ * `OUTCOME_RETENTION_MS` after its own terminal transition, independent of
+ * the other side's), or `projectControlFeedback` filtered it out
+ * (`locallyObsolete`, provider-generation mismatch). Idle is therefore not
+ * "no lifecycle ran" — it can equally mean "ran and the evidence is gone" —
+ * which is why an idle side may never promote the other to `'confirmed'`:
+ *
+ *   idle | idle                -> idle       (case A: no evidence either side)
+ *   idle | confirmed           -> idle       (case B: a lone confirmed half
+ *                                              is not corroborated once the
+ *                                              other half's record is gone;
+ *                                              not reported)
+ *   idle | non-confirmed       -> that outcome (case C: while its record
+ *                                                stays live)
+ *   live terminal | live terminal -> `TERMINAL_OUTCOME_PRIORITY` (case D)
+ *
+ * `'confirmed'` is reachable only through case D with both sides confirmed:
+ * a half-failed gesture is never derived as `'confirmed'`, at any point in
+ * its retention window or after.
  */
 function mergeTerminalOutcome(
   inner: Readonly<ControlFeedback<number>>, outer: Readonly<ControlFeedback<number>>,
 ): { phase: ControlFeedbackPhase; outcome: Readonly<{ phase: ControlFeedbackOutcome; error?: string }> | null } {
-  if (inner.outcome === null && outer.outcome === null) return { phase: 'idle', outcome: null };
-  if (inner.outcome === null) return { phase: outer.phase, outcome: outer.outcome };
-  if (outer.outcome === null) return { phase: inner.phase, outcome: inner.outcome };
-  const winner = TERMINAL_OUTCOME_PRIORITY.indexOf(inner.outcome.phase)
-    <= TERMINAL_OUTCOME_PRIORITY.indexOf(outer.outcome.phase) ? inner : outer;
-  return { phase: winner.phase, outcome: winner.outcome };
+  const bothIdle = inner.outcome === null && outer.outcome === null;
+  if (bothIdle) return { phase: 'idle', outcome: null }; // case A
+
+  const bothLiveTerminal = inner.outcome !== null && outer.outcome !== null;
+  if (bothLiveTerminal) { // case D
+    const winner = TERMINAL_OUTCOME_PRIORITY.indexOf(inner.outcome.phase)
+      <= TERMINAL_OUTCOME_PRIORITY.indexOf(outer.outcome.phase) ? inner : outer;
+    return { phase: winner.phase, outcome: winner.outcome };
+  }
+
+  const live = inner.outcome !== null ? inner : outer; // exactly one side idle
+  if (live.outcome!.phase === 'confirmed') return { phase: 'idle', outcome: null }; // case B
+  return { phase: live.phase, outcome: live.outcome }; // case C
 }
 
 function unavailableIfShiftFeedback(
@@ -894,9 +919,14 @@ export function getIfShiftControlFeedback(
   const { phase, outcome } = busy
     ? { phase: mergeBusyPhase(inner, outer), outcome: null }
     : mergeTerminalOutcome(inner, outer);
-  const lifecycleId = inner.lifecycleId === null && outer.lifecycleId === null
+  // Idle carries no ids anywhere else in this file (`empty()`,
+  // `unavailableIfShiftFeedback`) — including here, so that
+  // `mergeTerminalOutcome`'s idle-on-a-retired-confirmation case (case B
+  // above) does not compose a fresh id out of the surviving side's live
+  // outcome and trigger a one-shot announcement for a phase nobody reports.
+  const lifecycleId = phase === 'idle' || (inner.lifecycleId === null && outer.lifecycleId === null)
     ? null : JSON.stringify([inner.lifecycleId, outer.lifecycleId]);
-  const transitionId = inner.transitionId === null && outer.transitionId === null
+  const transitionId = phase === 'idle' || (inner.transitionId === null && outer.transitionId === null)
     ? null : JSON.stringify([inner.transitionId, outer.transitionId]);
   return Object.freeze({
     confirmed, target, requestedTarget, phase, busy, availability: 'available' as const,

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -771,20 +771,63 @@ export interface IfShiftControlFeedback extends ControlFeedback<number> {
 }
 
 /**
- * Total order over `ControlFeedbackPhase` from least to most settled, used
- * only to pick between two REAL phase values already produced by
- * `projectControlFeedback` — never to invent a new one. A terminal outcome
- * phase counts as more settled than any in-flight phase but less settled
- * than `idle`, so a just-finished side's outcome still surfaces over a
- * boringly idle counterpart.
+ * Non-terminal phases in lifecycle order, least advanced first. Read only
+ * from a side whose `busy` is true, which (per `projectControlFeedback`)
+ * means its `phase` is one of exactly these four — never `'idle'` or a
+ * terminal phase. A `'queued'` (held-for-tx) overlay can land on a command
+ * that is already `'acknowledged'` underneath
+ * (`commands.svelte.ts: applyCommandLifecycleProjection`'s `'held'` branch
+ * accepts both `'pending'` and `'acknowledged'`), so it ranks ahead of
+ * `'awaiting-confirmation'` here: a held command has made less progress
+ * toward confirmation than one merely awaiting its echo, regardless of the
+ * status it was held from.
  */
-const PHASE_PROGRESS: readonly ControlFeedbackPhase[] = Object.freeze([
-  'awaiting-confirmation', 'dispatched', 'queued', 'submitted',
-  'confirmed', 'failed', 'timed-out', 'cancelled', 'superseded',
-  'idle', 'unavailable',
+const IN_FLIGHT_ORDER: readonly ControlFeedbackPhase[] = Object.freeze([
+  'submitted', 'queued', 'dispatched', 'awaiting-confirmation',
 ]);
-const lessSettled = <T extends { phase: ControlFeedbackPhase }>(a: T, b: T): T =>
-  PHASE_PROGRESS.indexOf(a.phase) <= PHASE_PROGRESS.indexOf(b.phase) ? a : b;
+
+/**
+ * The least-advanced of two busy sides' phases, by `IN_FLIGHT_ORDER` — the
+ * derived IF-shift feedback is never more settled than the side that has
+ * made the least progress toward confirmation.
+ */
+function mergeBusyPhase(
+  inner: Readonly<ControlFeedback<number>>, outer: Readonly<ControlFeedback<number>>,
+): ControlFeedbackPhase {
+  if (inner.busy && outer.busy) {
+    return IN_FLIGHT_ORDER.indexOf(inner.phase) <= IN_FLIGHT_ORDER.indexOf(outer.phase)
+      ? inner.phase : outer.phase;
+  }
+  return inner.busy ? inner.phase : outer.phase;
+}
+
+/**
+ * Terminal outcomes ranked worst-first: a non-`'confirmed'` outcome on
+ * either side always dominates a `'confirmed'` one on the other, so a
+ * half-failed gesture is never reported as `'confirmed'`. The order among
+ * the non-`'confirmed'` outcomes is otherwise arbitrary but fixed, so two
+ * differently-failed sides still resolve to one deterministic outcome.
+ */
+const TERMINAL_OUTCOME_PRIORITY: readonly ControlFeedbackOutcome[] = Object.freeze([
+  'failed', 'timed-out', 'cancelled', 'superseded', 'confirmed',
+]);
+
+/**
+ * Combines two non-busy sides' phase/outcome. Each side's `outcome` here is
+ * either `null` (idle — no lifecycle ran) or a terminal outcome; ranked by
+ * `TERMINAL_OUTCOME_PRIORITY` when both are terminal, otherwise the
+ * non-idle side wins outright.
+ */
+function mergeTerminalOutcome(
+  inner: Readonly<ControlFeedback<number>>, outer: Readonly<ControlFeedback<number>>,
+): { phase: ControlFeedbackPhase; outcome: Readonly<{ phase: ControlFeedbackOutcome; error?: string }> | null } {
+  if (inner.outcome === null && outer.outcome === null) return { phase: 'idle', outcome: null };
+  if (inner.outcome === null) return { phase: outer.phase, outcome: outer.outcome };
+  if (outer.outcome === null) return { phase: inner.phase, outcome: inner.outcome };
+  const winner = TERMINAL_OUTCOME_PRIORITY.indexOf(inner.outcome.phase)
+    <= TERMINAL_OUTCOME_PRIORITY.indexOf(outer.outcome.phase) ? inner : outer;
+  return { phase: winner.phase, outcome: winner.outcome };
+}
 
 function unavailableIfShiftFeedback(
   scope: Readonly<ControlFeedbackScope>, sessionEpoch: number,
@@ -848,9 +891,9 @@ export function getIfShiftControlFeedback(
   const outerForRequested = outer.requestedTarget ?? outer.confirmed;
   const requestedTarget = inner.requestedTarget === null && outer.requestedTarget === null
     ? null : deriveIfShift(toHz(innerForRequested), toHz(outerForRequested));
-  const winner = lessSettled(inner, outer);
-  const phase = winner.phase;
-  const outcome = busy ? null : winner.outcome;
+  const { phase, outcome } = busy
+    ? { phase: mergeBusyPhase(inner, outer), outcome: null }
+    : mergeTerminalOutcome(inner, outer);
   const lifecycleId = inner.lifecycleId === null && outer.lifecycleId === null
     ? null : JSON.stringify([inner.lifecycleId, outer.lifecycleId]);
   const transitionId = inner.transitionId === null && outer.transitionId === null

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -38,7 +38,10 @@ import {
   CW_PITCH_COMMAND_DESCRIPTOR,
   DSP_COMMAND_DESCRIPTORS,
   FILTER_WIDTH_COMMAND_DESCRIPTOR,
+  IF_SHIFT_COMMAND_DESCRIPTOR,
   KEY_SPEED_COMMAND_DESCRIPTOR,
+  PBT_INNER_COMMAND_DESCRIPTOR,
+  PBT_OUTER_COMMAND_DESCRIPTOR,
   RF_GAIN_COMMAND_DESCRIPTOR,
   SQUELCH_COMMAND_DESCRIPTOR,
   TX_AUX_COMMAND_DESCRIPTORS,
@@ -56,7 +59,8 @@ import type { ServerState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
 import { qualifyDisplayObservation, qualifyRadioDisplayObservation } from './display-observation';
 import {
-  controlRangeFromCapsOrDefault, nbDepthRawToDisplay, projectNrLevel,
+  controlRangeFromCapsOrDefault, deriveIfShift, nbDepthRawToDisplay,
+  pbtRangeFromCaps, pbtRawToHz, projectNrLevel,
 } from '$lib/radio/filter-controls';
 
 // Re-export types for panel imports
@@ -677,6 +681,185 @@ export function getRfSqlControlFeedback(
     sql: lane(
       'set_squelch', SQUELCH_COMMAND_DESCRIPTOR, 'squelch', 'squelch', tags.includes('squelch'),
     ),
+  });
+}
+
+/**
+ * Shared qualification for a single raw receiver-scoped "echo" control
+ * (MOR-2425): PBT inner/outer, and the real `if_shift` command on a radio
+ * that has one. Mirrors `getDspControlFeedback`'s active-receiver/
+ * operational/observation gating; `structuralFor` supplies the one thing
+ * that differs per field (PBT needs both the `pbt` capability tag AND a
+ * usable `pbt_inner` range — MOR-1291 — while `if_shift` needs only its own
+ * capability tag).
+ */
+function getReceiverEchoControlFeedback(
+  currentControlSession: ControlSessionSnapshot | undefined,
+  descriptor: StateBackedCommandDescriptor<number>,
+  control: string,
+  field: 'pbtInner' | 'pbtOuter' | 'ifShift',
+  structuralFor: (caps: Capabilities | null | undefined, tags: readonly string[]) => boolean,
+): Readonly<ControlFeedback<number>> {
+  const state = runtime.state;
+  const caps = runtime.caps;
+  const commands = getCommandLifecycles();
+  const session = currentControlSession ?? runtime.controlSession;
+  const epoch = Number.isSafeInteger(session.epoch) && session.epoch >= 0 ? session.epoch : -1;
+  const receiver: 0 | 1 = state?.active === 'SUB' ? 1 : 0;
+  const scope = Object.freeze({ control, receiver });
+  const feedback = projectControlFeedback(
+    descriptor, state, commands, scope, epoch, isCommandLifecycleSuperseded,
+  );
+  try {
+    const view = toRadioViewModel(state, caps);
+    if (session.state !== 'connected' || epoch < 0
+      || view === null || view.activeReceiver.status !== 'known') {
+      return unavailableControlFeedback(feedback);
+    }
+    const activeReceiver = view.activeReceiver.receiver;
+    const receiverEntries = view.receiverIndicators?.filter(
+      entry => entry.receiver === activeReceiver,
+    ) ?? [];
+    if (receiverEntries.length !== 1 || !receiverEntries[0].availability.operational) {
+      return unavailableControlFeedback(feedback);
+    }
+    const receiverState = activeReceiver === 'SUB' ? state?.sub : state?.main;
+    const base = activeReceiver === 'SUB' ? 'sub' : 'main';
+    const tags = Array.isArray(caps?.capabilities) ? caps.capabilities : [];
+    const observation = qualifyDisplayObservation({
+      state, caps, receiver: activeReceiver, path: `${base}.${field}`,
+      structural: structuralFor(caps, tags), value: receiverState?.[field],
+    });
+    return observation.state === 'current' && Number.isSafeInteger(observation.value)
+      ? feedback : unavailableControlFeedback(feedback);
+  } catch {
+    return unavailableControlFeedback(feedback);
+  }
+}
+
+const pbtStructural = (caps: Capabilities | null | undefined, tags: readonly string[]): boolean =>
+  tags.includes('pbt') && pbtRangeFromCaps(caps) !== undefined;
+
+/** Qualified raw PBT Inner feedback (MOR-2425); receiver derives from active-receiver truth. */
+export function getPbtInnerControlFeedback(
+  currentControlSession?: ControlSessionSnapshot,
+): Readonly<ControlFeedback<number>> {
+  return getReceiverEchoControlFeedback(
+    currentControlSession, PBT_INNER_COMMAND_DESCRIPTOR, 'pbt-inner', 'pbtInner', pbtStructural,
+  );
+}
+
+/** Qualified raw PBT Outer feedback (MOR-2425); receiver derives from active-receiver truth. */
+export function getPbtOuterControlFeedback(
+  currentControlSession?: ControlSessionSnapshot,
+): Readonly<ControlFeedback<number>> {
+  return getReceiverEchoControlFeedback(
+    currentControlSession, PBT_OUTER_COMMAND_DESCRIPTOR, 'pbt-outer', 'pbtOuter', pbtStructural,
+  );
+}
+
+/**
+ * IF-shift feedback is always Hz-domain, never PBT's raw BCD domain: real on
+ * a radio with its own `if_shift` command (raw IS Hz there, identity-
+ * mapped), or derived from the two PBT feedbacks by converting each side's
+ * raw value with `pbtRawToHz` first. `domain` is a real, checkable field —
+ * not a comment that can rot — so a caller or test can assert it instead of
+ * trusting prose about which domain `confirmed`/`target` are in.
+ */
+export interface IfShiftControlFeedback extends ControlFeedback<number> {
+  readonly domain: 'hz';
+}
+
+/**
+ * Total order over `ControlFeedbackPhase` from least to most settled, used
+ * only to pick between two REAL phase values already produced by
+ * `projectControlFeedback` — never to invent a new one. A terminal outcome
+ * phase counts as more settled than any in-flight phase but less settled
+ * than `idle`, so a just-finished side's outcome still surfaces over a
+ * boringly idle counterpart.
+ */
+const PHASE_PROGRESS: readonly ControlFeedbackPhase[] = Object.freeze([
+  'awaiting-confirmation', 'dispatched', 'queued', 'submitted',
+  'confirmed', 'failed', 'timed-out', 'cancelled', 'superseded',
+  'idle', 'unavailable',
+]);
+const lessSettled = <T extends { phase: ControlFeedbackPhase }>(a: T, b: T): T =>
+  PHASE_PROGRESS.indexOf(a.phase) <= PHASE_PROGRESS.indexOf(b.phase) ? a : b;
+
+function unavailableIfShiftFeedback(
+  scope: Readonly<ControlFeedbackScope>, sessionEpoch: number,
+  providerGeneration: number | null,
+): Readonly<IfShiftControlFeedback> {
+  return Object.freeze({
+    confirmed: null, target: null, requestedTarget: null,
+    phase: 'unavailable' as const, busy: false, availability: 'unavailable' as const,
+    outcome: null, lifecycleId: null, transitionId: null,
+    providerGeneration, sessionEpoch, scope,
+    repeatPolicy: 'latest-target-wins' as const, domain: 'hz' as const,
+  });
+}
+
+/**
+ * Qualified IF-shift feedback (MOR-2425). Real on a radio with its own
+ * `if_shift` command (Yaesu FTX-1) — gated on the SAME predicate
+ * (`caps.capabilities.includes('if_shift')`) `radio-view-model-adapter.ts`'s
+ * `ifShiftControlStructural` uses to decide whether to show a real IF-shift
+ * control at all. Derived from the two PBT feedbacks on a PBT-only radio
+ * (Icom IC-7300): each side's raw value is converted to Hz with
+ * `pbtRawToHz(raw, pbtRangeFromCaps(caps))` before combining with
+ * `deriveIfShift`, mirroring `deriveFilterPassband`'s own `ifShiftValue`
+ * fallback — this is that same formula's pending-target-aware lifecycle
+ * layer, not a second, independent re-derivation of the confirmed reading.
+ */
+export function getIfShiftControlFeedback(
+  currentControlSession?: ControlSessionSnapshot,
+): Readonly<IfShiftControlFeedback> {
+  const caps = runtime.caps;
+  const tags = Array.isArray(caps?.capabilities) ? caps.capabilities : [];
+
+  if (tags.includes('if_shift')) {
+    const real = getReceiverEchoControlFeedback(
+      currentControlSession, IF_SHIFT_COMMAND_DESCRIPTOR, 'if-shift', 'ifShift',
+      (_c, t) => t.includes('if_shift'),
+    );
+    return Object.freeze({ ...real, domain: 'hz' as const });
+  }
+
+  const state = runtime.state;
+  const session = currentControlSession ?? runtime.controlSession;
+  const epoch = Number.isSafeInteger(session.epoch) && session.epoch >= 0 ? session.epoch : -1;
+  const receiver: 0 | 1 = state?.active === 'SUB' ? 1 : 0;
+  const scope = Object.freeze({ control: 'if-shift', receiver });
+  const inner = getPbtInnerControlFeedback(currentControlSession);
+  const outer = getPbtOuterControlFeedback(currentControlSession);
+  const scale = pbtRangeFromCaps(caps);
+  const providerGeneration = typeof inner.providerGeneration === 'number' ? inner.providerGeneration : null;
+  if (inner.availability !== 'available' || outer.availability !== 'available' || scale === undefined
+    || inner.confirmed === null || outer.confirmed === null) {
+    return unavailableIfShiftFeedback(scope, epoch, providerGeneration);
+  }
+  const toHz = (raw: number): number => pbtRawToHz(raw, scale);
+  const confirmed = deriveIfShift(toHz(inner.confirmed), toHz(outer.confirmed));
+  const busy = inner.busy || outer.busy;
+  const innerForTarget = inner.busy && inner.target !== null ? inner.target : inner.confirmed;
+  const outerForTarget = outer.busy && outer.target !== null ? outer.target : outer.confirmed;
+  const target = busy ? deriveIfShift(toHz(innerForTarget), toHz(outerForTarget)) : null;
+  const innerForRequested = inner.requestedTarget ?? inner.confirmed;
+  const outerForRequested = outer.requestedTarget ?? outer.confirmed;
+  const requestedTarget = inner.requestedTarget === null && outer.requestedTarget === null
+    ? null : deriveIfShift(toHz(innerForRequested), toHz(outerForRequested));
+  const winner = lessSettled(inner, outer);
+  const phase = winner.phase;
+  const outcome = busy ? null : winner.outcome;
+  const lifecycleId = inner.lifecycleId === null && outer.lifecycleId === null
+    ? null : JSON.stringify([inner.lifecycleId, outer.lifecycleId]);
+  const transitionId = inner.transitionId === null && outer.transitionId === null
+    ? null : JSON.stringify([inner.transitionId, outer.transitionId]);
+  return Object.freeze({
+    confirmed, target, requestedTarget, phase, busy, availability: 'available' as const,
+    outcome, lifecycleId, transitionId,
+    providerGeneration, sessionEpoch: inner.sessionEpoch,
+    scope, repeatPolicy: 'latest-target-wins' as const, domain: 'hz' as const,
   });
 }
 

--- a/frontend/src/lib/stores/__tests__/commands.test.ts
+++ b/frontend/src/lib/stores/__tests__/commands.test.ts
@@ -318,6 +318,7 @@ describe('command lifecycle store', () => {
         'set_compressor_level', 'set_monitor_gain', 'set_nb_level', 'set_nb_width',
         'set_nr_level', 'set_nb_depth',
         'set_notch_filter', 'set_manual_notch_width', 'set_agc_time_constant',
+        'set_pbt_inner', 'set_pbt_outer', 'set_if_shift',
       ]);
       expect(rfMain).toEqual({ control: 'rf-gain', receiver: 0 });
       expect(rfSub).toEqual({ control: 'rf-gain', receiver: 1 });
@@ -434,6 +435,7 @@ describe('command lifecycle store', () => {
         'set_compressor_level', 'set_monitor_gain', 'set_nb_level', 'set_nb_width',
         'set_nr_level', 'set_nb_depth',
         'set_notch_filter', 'set_manual_notch_width', 'set_agc_time_constant',
+        'set_pbt_inner', 'set_pbt_outer', 'set_if_shift',
       ]);
       const pitchScope = store.CW_PITCH_COMMAND_DESCRIPTOR.scope({ params: { value: 640 } })!;
       const speedScope = store.KEY_SPEED_COMMAND_DESCRIPTOR.scope({ params: { speed: 27 } })!;
@@ -763,6 +765,94 @@ describe('command lifecycle store', () => {
       expect(store.getCommandLifecycle('global-width', 7)?.status).toBe('acknowledged');
       expect(store.getCommandLifecycle('main-nr', 7)?.status).toBe('acknowledged');
       expect(store.getCommandLifecycle('global-depth', 7)?.status).toBe('acknowledged');
+    });
+  });
+
+  describe('PBT and IF-shift state-backed descriptors (MOR-2425)', () => {
+    it.each([
+      ['pbtInner', 'set_pbt_inner', 'pbt-inner', 'value', () => store.PBT_INNER_COMMAND_DESCRIPTOR],
+      ['pbtOuter', 'set_pbt_outer', 'pbt-outer', 'value', () => store.PBT_OUTER_COMMAND_DESCRIPTOR],
+      ['ifShift', 'set_if_shift', 'if-shift', 'offset', () => store.IF_SHIFT_COMMAND_DESCRIPTOR],
+    ] as const)('registers %s with exact MAIN/SUB raw scopes and a default receiver', (
+      field, intentName, control, param, descriptorOf,
+    ) => {
+      const descriptor = descriptorOf();
+      const main = descriptor.scope({ params: { [param]: -12, receiver: 0 } })!;
+      const sub = descriptor.scope({ params: { [param]: 300, receiver: 1 } })!;
+      const defaulted = descriptor.scope({ params: { [param]: 5 } })!;
+      expect(descriptor.intentName).toBe(intentName);
+      expect(store.getStateBackedCommandDescriptor(intentName)).toBe(descriptor);
+      expect(main).toEqual({ control, receiver: 0 });
+      expect(sub).toEqual({ control, receiver: 1 });
+      expect(defaulted).toEqual({ control, receiver: 0 });
+      expect(descriptor.fieldPath(main)).toBe(`main.${field}`);
+      expect(descriptor.fieldPath(sub)).toBe(`sub.${field}`);
+      expect(descriptor.target({ params: { [param]: -12, receiver: 0 } })).toBe(-12);
+      expect(descriptor.target({ params: { [param]: 3.5, receiver: 0 } })).toBeNull();
+      expect(descriptor.confirmed({ main: { [field]: -12 }, sub: { [field]: 300 } } as never, main)).toBe(-12);
+      expect(descriptor.confirmed({ main: { [field]: -12 }, sub: { [field]: 300 } } as never, sub)).toBe(300);
+    });
+
+    it.each([
+      ['pbtInner', () => store.PBT_INNER_COMMAND_DESCRIPTOR],
+      ['pbtOuter', () => store.PBT_OUTER_COMMAND_DESCRIPTOR],
+      ['ifShift', () => store.IF_SHIFT_COMMAND_DESCRIPTOR],
+    ] as const)('%s matches only exact raw equality — a one-step echo does not match', (
+      _field, descriptorOf,
+    ) => {
+      const descriptor = descriptorOf();
+      expect(descriptor.matches(131, 131)).toBe(true);
+      expect(descriptor.matches(130, 131)).toBe(false);
+      expect(descriptor.matches(132, 131)).toBe(false);
+    });
+
+    it.each([
+      ['pbtInner', 'set_pbt_inner', 'value', 131, 130],
+      ['pbtOuter', 'set_pbt_outer', 'value', 131, 130],
+      ['ifShift', 'set_if_shift', 'offset', 500, 480],
+    ] as const)('confirms %s only from a newer fresh exact raw field observation', (
+      field, name, param, target, mismatch,
+    ) => {
+      const observed = (value: number, marker: number, freshness: 'fresh' | 'stale' = 'fresh') => ({
+        stateContractVersion: 1, providerGeneration: 3, active: 'MAIN',
+        main: { [field]: value }, sub: {},
+        fieldStatus: { [`main.${field}`]: {
+          observed: true, freshness, availability: 'available', lastObservedMonotonic: marker,
+        } },
+      } as unknown as ServerState);
+      emitState(observed(mismatch, 4));
+      const command = store.beginCommand({
+        id: name, name, params: { [param]: target, receiver: 0 }, originalEpoch: 7,
+      });
+      store.acknowledgeCommand(command.id, 7, 7);
+      const status = () => store.getCommandLifecycle(command.id, 7)?.status;
+      expect(status()).toBe('acknowledged');
+      emitState(observed(target, 4));
+      emitState(observed(mismatch, 5));
+      emitState(observed(target, 6, 'stale'));
+      expect(status()).toBe('acknowledged');
+      emitState(observed(target, 7));
+      expect(status()).toBe('confirmed');
+    });
+
+    it('rejects a non-integer or non-numeric target without coercion', () => {
+      for (const value of ['1', true, 1.5, Number.POSITIVE_INFINITY, Number.NaN]) {
+        expect(store.PBT_INNER_COMMAND_DESCRIPTOR.target({ params: { value, receiver: 0 } })).toBeNull();
+        expect(store.PBT_OUTER_COMMAND_DESCRIPTOR.target({ params: { value, receiver: 0 } })).toBeNull();
+        expect(store.IF_SHIFT_COMMAND_DESCRIPTOR.target({ params: { offset: value, receiver: 0 } })).toBeNull();
+      }
+    });
+
+    it('rejects an out-of-range or malformed receiver at scope only', () => {
+      for (const receiver of [2, '0', false, null]) {
+        expect(store.PBT_INNER_COMMAND_DESCRIPTOR.scope({ params: { value: 1, receiver } })).toBeNull();
+        expect(store.PBT_OUTER_COMMAND_DESCRIPTOR.scope({ params: { value: 1, receiver } })).toBeNull();
+        expect(store.IF_SHIFT_COMMAND_DESCRIPTOR.scope({ params: { offset: 1, receiver } })).toBeNull();
+      }
+      // Receiver is optional (defaults to 0) — an ABSENT receiver is not malformed.
+      expect(store.PBT_INNER_COMMAND_DESCRIPTOR.scope({ params: { value: 1 } })).toEqual({
+        control: 'pbt-inner', receiver: 0,
+      });
     });
   });
 });

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -319,6 +319,60 @@ export const DSP_COMMAND_DESCRIPTORS = Object.freeze({
   ),
 }) satisfies Readonly<Record<DspCommandFeedbackField, StateBackedCommandDescriptor<number>>>;
 
+type RawReceiverEchoField = 'pbtInner' | 'pbtOuter' | 'ifShift';
+type RawReceiverEchoParam = 'value' | 'offset';
+type RawReceiverEchoIntent = 'set_pbt_inner' | 'set_pbt_outer' | 'set_if_shift';
+
+/**
+ * Mirrors `FILTER_WIDTH_COMMAND_DESCRIPTOR`'s exact-raw-equality shape
+ * (MOR-2425 census `pbt-descriptor-lane-census-20260907.md` §A/§F4): receiver
+ * defaults to 0 when omitted, `target` reads the named param directly (both
+ * `set_pbt_inner`/`set_pbt_outer`'s `value` and `set_if_shift`'s `offset` are
+ * already raw at dispatch — `panel-commands.ts`'s `onPbtInnerChange`/
+ * `onPbtOuterChange` call `pbtHzToRaw` before `dispatchRadioIntent`, and the
+ * FTX-1 `if_shift` command is identity-mapped Hz), and `confirmed` reads the
+ * SAME raw `ServerState` field the command's own CI-V/CAT echo populates —
+ * never the Hz-converted `filterPassband.*` view-model. Factors PBT inner,
+ * PBT outer, and IF-shift into one helper instead of three near-identical
+ * blocks, the same shape `rawReceiverDspCommandDescriptor` above uses for the
+ * DSP family.
+ */
+function rawReceiverEchoCommandDescriptor(
+  intentName: RawReceiverEchoIntent,
+  control: string,
+  field: RawReceiverEchoField,
+  param: RawReceiverEchoParam,
+): StateBackedCommandDescriptor<number> {
+  return Object.freeze({
+    intentName, repeatPolicy: 'latest-target-wins' as const,
+    scope: (command: Pick<CommandLifecycle, 'params'>) => {
+      const receiver = command.params.receiver;
+      return receiver === undefined || receiver === 0 || receiver === 1
+        ? Object.freeze({ control, receiver: receiver === 1 ? 1 : 0 }) : null;
+    },
+    fieldPath: (scope: ControlFeedbackScope) => `${scope.receiver === 1 ? 'sub' : 'main'}.${field}`,
+    target: (command: Pick<CommandLifecycle, 'params'>) => safeInteger(command.params[param]),
+    confirmed: (state: ServerState, scope: ControlFeedbackScope) =>
+      finiteNumber((scope.receiver === 1 ? state.sub : state.main)?.[field]),
+    matches: (confirmed: number, target: number) => confirmed === target,
+  });
+}
+
+export const PBT_INNER_COMMAND_DESCRIPTOR: StateBackedCommandDescriptor<number> =
+  rawReceiverEchoCommandDescriptor('set_pbt_inner', 'pbt-inner', 'pbtInner', 'value');
+export const PBT_OUTER_COMMAND_DESCRIPTOR: StateBackedCommandDescriptor<number> =
+  rawReceiverEchoCommandDescriptor('set_pbt_outer', 'pbt-outer', 'pbtOuter', 'value');
+/**
+ * Only meaningful where `if_shift` is a real command (Yaesu FTX-1) — Icom
+ * radios never dispatch `set_if_shift` (`onIfShiftChange`'s PBT-only branch
+ * dispatches `set_pbt_inner`/`set_pbt_outer` instead), so this descriptor
+ * simply never engages there. `panel-adapters.ts`'s `getIfShiftControlFeedback`
+ * derives a PBT-only radio's IF-shift feedback from the two PBT descriptors
+ * instead of using this one.
+ */
+export const IF_SHIFT_COMMAND_DESCRIPTOR: StateBackedCommandDescriptor<number> =
+  rawReceiverEchoCommandDescriptor('set_if_shift', 'if-shift', 'ifShift', 'offset');
+
 export const STATE_BACKED_COMMAND_DESCRIPTORS: ReadonlyMap<RadioIntentName, StateBackedCommandDescriptor<unknown>> =
   new Map([
     [FILTER_WIDTH_COMMAND_DESCRIPTOR.intentName, FILTER_WIDTH_COMMAND_DESCRIPTOR],
@@ -333,6 +387,9 @@ export const STATE_BACKED_COMMAND_DESCRIPTORS: ReadonlyMap<RadioIntentName, Stat
     ...Object.values(DSP_COMMAND_DESCRIPTORS).map(
       descriptor => [descriptor.intentName, descriptor] as const,
     ),
+    [PBT_INNER_COMMAND_DESCRIPTOR.intentName, PBT_INNER_COMMAND_DESCRIPTOR],
+    [PBT_OUTER_COMMAND_DESCRIPTOR.intentName, PBT_OUTER_COMMAND_DESCRIPTOR],
+    [IF_SHIFT_COMMAND_DESCRIPTOR.intentName, IF_SHIFT_COMMAND_DESCRIPTOR],
   ]);
 export const getStateBackedCommandDescriptor = (intentName: string): StateBackedCommandDescriptor<unknown> | undefined =>
   (STATE_BACKED_COMMAND_DESCRIPTORS as ReadonlyMap<string, StateBackedCommandDescriptor<unknown>>).get(intentName);


### PR DESCRIPTION
Summary

- `PBT_INNER_COMMAND_DESCRIPTOR`/`PBT_OUTER_COMMAND_DESCRIPTOR`/`IF_SHIFT_COMMAND_DESCRIPTOR` (`frontend/src/lib/stores/commands.svelte.ts`) mirror `FILTER_WIDTH_COMMAND_DESCRIPTOR`'s exact-raw-equality shape through one new parametrized helper (`rawReceiverEchoCommandDescriptor`), registered in `STATE_BACKED_COMMAND_DESCRIPTORS`. Target and confirmed are both raw integers (PBT: 0-255 BCD; FTX-1 `if_shift`: identity-mapped Hz) — the exactness ruling (MOR-2409) resolves entirely in the raw domain, no new conversion in the descriptor layer, `matches` is strict `===`.
- `getPbtInnerControlFeedback`/`getPbtOuterControlFeedback` (`frontend/src/lib/runtime/adapters/panel-adapters.ts`) are the WRAPPED form of the existing DSP/TX-aux siblings — `unavailableControlFeedback` on disconnected session, invalid epoch, non-operational receiver, or a missing/malformed `pbt_inner` capability range (MOR-1291 fail-closed, structural-absent-safe for FTX-1, which has no PBT at all).
- `getIfShiftControlFeedback` reads the real `IF_SHIFT_COMMAND_DESCRIPTOR` directly when the radio has its own `if_shift` command (Yaesu FTX-1, gated on the same `caps.capabilities.includes('if_shift')` predicate `radio-view-model-adapter.ts`'s `ifShiftControlStructural` uses); otherwise it derives from the two PBT feedbacks, converting each side's raw value to Hz with `pbtRawToHz(raw, pbtRangeFromCaps(caps))` before combining with `deriveIfShift` — mirroring `deriveFilterPassband`'s existing confirmed-reading fallback, now extended to the pending-target layer. The return type `IfShiftControlFeedback` carries a literal `domain: 'hz'` field (not a comment) so the domain is checkable rather than asserted in prose. The two composed PBT lifecycles are merged by two explicit rules rather than one ad-hoc phase order: while either side is busy, the derived phase is the least-advanced of the two (`IN_FLIGHT_ORDER`); once both are settled, `mergeTerminalOutcome` derives `'confirmed'` only when both sides' outcomes are live and equal to `'confirmed'` — an idle side (never ran, retired via `commands.svelte.ts: retainTerminalOutcome`'s `OUTCOME_RETENTION_MS` timer on that record's own terminal transition, or filtered by `projectControlFeedback`) never promotes the other side's live `'confirmed'` outcome, and a live non-`'confirmed'` outcome on either side always wins via `TERMINAL_OUTCOME_PRIORITY`. So a half-failed PBT gesture is never reported as confirmed, including after the failed half's own lifecycle record retires — the merged phase, outcome, `transitionId` and `lifecycleId` all resolve to idle together in that case, so no stale confirmation is announced either.
- No UI wiring change: `FilterSurface.svelte`, `SemanticRadioSurfaces.svelte`, `RadioLayout.svelte`, `instrument-composition.ts`, `panel-commands.ts` and every test that mounts SRS are untouched. The passband sliders still bind directly to confirmed radio state exactly as before — PR-2 wires these three accessors into `FilterSurface.svelte` via `createContinuousScalar`.

Census table

| Claim | Source |
|---|---|
| PBT commands dispatch already-raw `value`+`receiver`; `if_shift` dispatches already-Hz `offset`+`receiver` | `frontend/src/lib/runtime/commands/panel-commands.ts: onPbtInnerChange/onPbtOuterChange/onIfShiftChange`, read directly this session |
| `set_if_shift` never dispatches on a PBT-only radio (Icom); IF-shift there must be derived from the two PBT descriptors | `onIfShiftChange`'s `else if (caps.capabilities.includes('pbt'))` branch, read directly this session |
| `ifShiftControlStructural` predicate = `hasCap(caps, 'if_shift')` | `frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts: deriveFilterPassband`, read directly this session |
| PBT structural gate = `pbt` capability tag AND a usable `pbt_inner` range from THIS caps object (MOR-1291) | same function's `pbtInner`/`pbtOuter` fields and `pbtRangeFromCaps` doc comment, read directly this session |
| `FILTER_WIDTH_COMMAND_DESCRIPTOR`'s exact shape (scope defaults receiver to 0, target reads the param directly, confirmed reads raw state, matches is `===`) | `frontend/src/lib/stores/commands.svelte.ts`, read directly this session |
| `rawReceiverDspCommandDescriptor` is the existing one-helper-many-descriptors factoring pattern | same file, read directly this session |
| A `'queued'` (held-for-tx) overlay can land on a command already `'acknowledged'` underneath, so `'queued'` cannot be assumed to sit strictly before `'awaiting-confirmation'` in wall-clock progress | `frontend/src/lib/stores/commands.svelte.ts: applyCommandLifecycleProjection`'s `'held'` branch (accepts both `'pending'` and `'acknowledged'`), read directly this session |
| Coordinator's binding census (§A/§B/§C/§F item 4) and §Q2 mechanism findings | `pbt-descriptor-lane-census-20260907.md` and `availability-flap-and-pbt-jump-census-20260907.md`, handed to the builder in the dispatch, not independently re-derived beyond the source-code claims above |
| R1 verifier findings requiring a real merge rule, a true `PHASE_PROGRESS` claim (or its deletion), and a pinned `transitionId` | `pr3355-pbt-descriptors-verifier-report-r1.md`, persisted by the coordinator, addressed in fix-cycle 1 (`bf31cb693`) |
| R2 verifier finding: fix-cycle 1's merge rule still let a retired failed-half's evidence get overridden by the surviving side's live `'confirmed'` outcome (the retention-timer race), and the two docstring claims built on the wrong idle model | `pr3355-pbt-descriptors-verifier-report-r2.md`, persisted by the coordinator, addressed in fix-cycle 2 (this commit) |

Witnesses + mutations (verbatim)

New/changed tests exercising the raw-exactness, Hz-derivation, and merge-rule claims:
- `frontend/src/lib/stores/__tests__/commands.test.ts`: new `describe('PBT and IF-shift state-backed descriptors (MOR-2425)')` block (scope/fieldPath/target/confirmed registration, exact-match-only, confirms-from-fresh-exact-observation, malformed-envelope rejection).
- `frontend/src/lib/runtime/adapters/__tests__/pbt-if-shift-command-feedback.isolated.test.ts`: PBT inner/outer availability/structural-absence/SUB-receiver coverage; IF-shift real-descriptor vs derived-from-PBT coverage. Fix-cycle 1 addition (R1 findings): `confirmed+failed → failed`, `timed-out+confirmed → timed-out`, `both confirmed → confirmed with the derived Hz value`, `acknowledged+pending → not more settled than pending (busy)`, and a transitionId-pin case (composed id changes with either half). Fix-cycle 2 addition (R2 findings): the transitionId-pin case now also varies the OUTER half (two more assertions, inner held constant) so dropping either half from the `transitionId`/`lifecycleId` composition reddens; a new case pins `IN_FLIGHT_ORDER`'s `'queued'`-before-`'awaiting-confirmation'` placement (a held-but-acknowledged inner side vs. a merely-acknowledged outer side must merge to `'queued'`, not `'awaiting-confirmation'`).
- `frontend/src/lib/runtime/adapters/__tests__/pbt-if-shift-terminal-outcome-retention.test.ts` (new, fix-cycle 2): drives the REAL `commands.svelte` store with fake timers (dynamic import + `vi.resetModules()` per test, mirroring the pattern in `commands.test.ts` and `ws-client.isolated.test.ts`) rather than the hand-fed lifecycle array the sibling `.isolated.test.ts` uses, because the R2 bug is a race between a record's own `OUTCOME_RETENTION_MS` retirement and `getIfShiftControlFeedback`'s merge — a fixture with no timers cannot reach it. Sequence: `beginCommand` ×2 → both acknowledged → `failCommand(inner)` → +300ms → `confirmCommand(outer)` → asserts `phase: 'failed'`; advances to strictly between inner's and outer's own retirement deadlines → asserts `phase` is not `'confirmed'`, `outcome`/`transitionId`/`lifecycleId` are all `null`; advances past outer's retirement too → asserts `phase: 'idle'`.
- `frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts` and the two other `STATE_BACKED_COMMAND_DESCRIPTORS` key-list assertions in `commands.test.ts`: updated to include the 3 new intents (mechanical, not new coverage).

Mutations run against the working tree, one at a time, each reverted and confirmed byte-identical via `md5`/`git status --short` (empty/matching) before the next:

(a) [fix-cycle 1] `TERMINAL_OUTCOME_PRIORITY` reordered so success wins (`['failed','timed-out','cancelled','superseded','confirmed']` → `['confirmed','failed','timed-out','cancelled','superseded']`): killed exactly 2 tests — `reports the non-confirmed outcome, not confirmed, when one PBT side confirms and the other fails` and `reports timed-out (not confirmed) when the confirmed side is the other one`. Restored byte-identically.

(b) [fix-cycle 1] composed `transitionId` frozen to a constant string: killed exactly 1 test — `composes a transitionId that changes with either half, distinct across two gestures`. Restored byte-identically.

(c) [re-run after fix-cycle 1's changes] `matches` tolerates ±1 (`confirmed === target` → `Math.abs(confirmed - target) <= 1` in `rawReceiverEchoCommandDescriptor`, `commands.svelte.ts`): killed 5 tests in `commands.test.ts` — the 3 `%s matches only exact raw equality` cases (pbtInner/pbtOuter/ifShift) and the `confirms pbtInner/pbtOuter only from a newer fresh exact raw field observation` cases (2). Same 5 as R1; restored byte-identically.

(d) [re-run after fix-cycle 1's changes] `confirmed` reads a Hz-like view instead of raw (`finiteNumber(raw)` → `raw * 9.375` in the same descriptor's `confirmed`): killed 13 tests (R1 reported 12; the extra one is fix-cycle 1's new `reports confirmed with the derived Hz value when both PBT sides confirm`, which exercises the same both-confirmed Hz path) — in `commands.test.ts`: the 3 `registers %s with exact MAIN/SUB raw scopes...` tests and the 3 `confirms %s only from a newer fresh exact raw field observation` tests (6); in `pbt-if-shift-command-feedback.isolated.test.ts`: the same 6 R1 named cases plus the one new case above (7). Restored byte-identically.

(e) [re-run after fix-cycle 1's changes] derived IF-shift confirmed uses only inner (`deriveIfShift(toHz(inner.confirmed), toHz(outer.confirmed))` → `deriveIfShift(toHz(inner.confirmed), toHz(inner.confirmed))` in `getIfShiftControlFeedback`, `panel-adapters.ts`): killed 2 tests (R1 reported 1; the extra one is fix-cycle 1's `reports confirmed with the derived Hz value when both PBT sides confirm`) — `derives confirmed Hz from the two PBT feedbacks on a PBT-only radio` and the new case. Restored byte-identically.

After each revert (fix-cycle 1), `md5`/`git status --short` on the mutated file(s) matched the pre-mutation state.

**Fix-cycle 2 (this commit, `f075678378d583e18db7f7fc5f2d372e781f74cd`), mutations against the rewritten `mergeTerminalOutcome`/`lifecycleId`/`transitionId` code, each reverted and confirmed byte-identical via `diff`/`md5` before the next:**

(f) idle-beats-terminal: removed the `case B` branch so `mergeTerminalOutcome`'s idle-side check falls straight through to `return { phase: live.phase, outcome: live.outcome }` (an idle side promotes the live side unconditionally, fix-cycle 1's original bug). Run against the new end-to-end `pbt-if-shift-terminal-outcome-retention.test.ts`: killed exactly 1 test (that file's only test) — `afterInnerRetires.phase` came back `'confirmed'` instead of not-`'confirmed'`. Restored byte-identically (`diff` empty).

(g) drop the outer half from `transitionId`'s composition (`JSON.stringify([inner.transitionId, outer.transitionId])` → `JSON.stringify([inner.transitionId])`): killed exactly 1 test — the transitionId test's new outer-varying assertion (`third.transitionId).not.toBe(fourth.transitionId)`), which was undetected before this cycle's fix. Restored byte-identically.

(h) same drop for `lifecycleId`'s composition: killed exactly 1 test — the transitionId test's new outer-varying `lifecycleId` assertion. Restored byte-identically.

(i) `IN_FLIGHT_ORDER` rotated so `'queued'` lands after `'awaiting-confirmation'` (`['submitted','queued','dispatched','awaiting-confirmation']` → `['submitted','dispatched','awaiting-confirmation','queued']`; independent review also ran the plain two-element swap — each kills exactly the one named test): killed exactly 1 test — the new `ranks a held (queued) side as less advanced than a merely awaiting-confirmation side` case (R2's non-blocking finding #4, previously unpinned: this same mutation left 150/150 green before this cycle's addition). Restored byte-identically.

(j) `mergeBusyPhase` flipped to pick the most-advanced side (`<=` → `>=` on the `IN_FLIGHT_ORDER` index comparison): killed 2 tests — the pre-existing `while one side merely acknowledged...` case and the new queued-vs-awaiting-confirmation case above (R2 reported this mutation killed 1 test at the prior head; the second kill is this cycle's new coverage, not a change in the mutation's own effect). Restored byte-identically.

(k) `TERMINAL_OUTCOME_PRIORITY` re-run with `'confirmed'` moved first (the fix-cycle 1 mutation (a), re-run unmodified against this cycle's code): killed 3 tests — the same 2 as fix-cycle 1 plus the new retention test (`atConfirm.phase` at t+300ms came back `'confirmed'` instead of `'failed'`, since the both-live-terminal branch is unchanged code but now has one more test exercising it). Restored byte-identically.

(l) composed `transitionId` re-run frozen to a constant string (fix-cycle 1 mutation (b), re-run unmodified): killed exactly 1 test, same as fix-cycle 1 (the frozen constant is still distinguishable as non-null so the `phase === 'idle'` gate this cycle added does not additionally affect this mutation's kill count). Restored byte-identically.

`PHASE_PROGRESS`/`lessSettled` (fix-cycle 1's original bug, deleted then): re-confirmed zero references anywhere under `frontend/src` or `frontend/tests` — a `grep -rn` this session found none, matching R2's independent count.

After every mutation above, `git diff` against the committed tree (and, for cases (f)-(l), `diff` against a saved pre-mutation copy of `panel-adapters.ts`) showed no residual change before the next mutation or the final commit.

Verification

- Fix-cycle 2's mandated check set: `npx vitest run` on `pbt-if-shift-command-feedback.isolated.test.ts`, `pbt-if-shift-terminal-outcome-retention.test.ts`, `commands.test.ts`, `filter-width-command-lifecycle.isolated.test.ts` — 4 files / 152 tests, 0 failures. Widened this session to the grep union (`panel-adapters|commands\.svelte|STATE_BACKED|getPbtInner|getIfShift`) over `src/lib/runtime/adapters/__tests__`, `src/lib/stores/__tests__` and `src/__tests__` — 30 files / 683 tests, 0 failures (a narrower sweep than fix-cycle 1's reported 83-file/2344-test run; not re-run in full this cycle since fix-cycle 2 touches only `panel-adapters.ts` and its own tests).
- `npm run check` (svelte-check + tsc, both project configs): 4835 files, 0 errors, 0 warnings.
- `npx eslint` on the 3 files this fix-cycle touched (`panel-adapters.ts` and the two test files, one of them new): 0 violations.
- `git diff --check` (against the committed tree, including the new file staged): clean (no whitespace errors).
- `node frontend/fixtures/capture.mjs`: 65/65 captures pass, 0 invalid.
- Files touched (whole PR, at the current head `f075678378d583e18db7f7fc5f2d372e781f74cd`): 6 (`git diff origin/main...HEAD --name-only | wc -l`), 816 changed lines (`git diff origin/main...HEAD --shortstat`: 814 insertions + 2 deletions) — under the hard ceiling (10 files/1000 lines) but over the soft threshold on both axes (6 files, 816 > 600 lines). One unit of work: all three commits work the same descriptor lane this PR introduces — the base commit adds the PBT/IF-shift state-backed descriptors and their merge, fix-cycle 1 corrected the merge's terminal-priority ordering, and fix-cycle 2 (this commit, 3 files / 190 insertions + 17 deletions) closes a retention-timer race in that same merge function found by independent review of fix-cycle 1's head. No file outside `panel-adapters.ts` and its own tests was touched by either fix cycle.

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)


