### PR TITLE
feat(MOR-2425): mount the memory surface in its own zone

### DIFF
--- a/frontend/fixtures/stubs/panel-adapters.ts
+++ b/frontend/fixtures/stubs/panel-adapters.ts
@@ -135,3 +135,26 @@ export function getPendingNrOn(_receiver: 0 | 1): boolean | null {
 export function getDataModeArmed(): { armed: false; value: null } {
   return { armed: false, value: null };
 }
+
+/**
+ * MOR-2425 — `SemanticRadioSurfaces.svelte` now also imports
+ * `deriveMemoryPanelProps`/`getMemoryHandlers` unconditionally (same
+ * MOR-1271/MOR-1320 module-resolution lesson as `getPendingFrequencyHz`
+ * above: a missing export here fails the whole fixture harness, not just
+ * the memory surface). The offline fixture has no real VFO identity or
+ * command authority, so this reports the same unavailable/inert shape
+ * `getBreakInDelayControlFeedback` and friends use above: `vfoIdentityKnown:
+ * false` (the "unknown identity" sentinel `toMemoryPanelProps` itself
+ * returns during a relative-VFO bootstrap epoch) and handlers that report
+ * "refused" without dispatching anything.
+ */
+export function deriveMemoryPanelProps() {
+  return Object.freeze({ activeFreqHz: Number.NaN, activeMode: '---', vfoIdentityKnown: false });
+}
+
+const memoryHandlers = Object.freeze({
+  onRecall: (_channel: number): boolean => false,
+  onStore: (_channel: number, _frequencyHz: number, _mode: string): boolean => false,
+  onClear: (_channel: number): boolean => false,
+});
+export function getMemoryHandlers() { return memoryHandlers; }

--- a/frontend/src/components-v2/layout/LeftSidebar.svelte
+++ b/frontend/src/components-v2/layout/LeftSidebar.svelte
@@ -152,7 +152,7 @@
     </CollapsiblePanel>
   {/if}
 
-  {#if drag.order.includes('memory')}
+  {#if drag.order.includes('memory') && !declared.has('memory')}
     <CollapsiblePanel title="MEMORY" panelId="memory" draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('memory')}>
       <MemoryPanel />
     </CollapsiblePanel>

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -470,6 +470,7 @@
             })}
           </div>
           {@render instruments.cwKeyer(undefined, false)}
+          {@render instruments.memory()}
         {:else}
           {@render instruments.cwKeyer()}
         {/if}

--- a/frontend/src/components-v2/layout/RightSidebar.svelte
+++ b/frontend/src/components-v2/layout/RightSidebar.svelte
@@ -72,7 +72,7 @@
     </CollapsiblePanel>
   {/if}
 
-  {#if drag.order.includes('memory')}
+  {#if drag.order.includes('memory') && !declared.has('memory')}
     <CollapsiblePanel title="MEMORY" panelId="memory" draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('memory')}>
       <MemoryPanel />
     </CollapsiblePanel>

--- a/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
+++ b/frontend/src/components-v2/layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte
@@ -77,7 +77,7 @@
     rxAudioInstruments, rfFrontEndInstruments,
     meters: empty, rxAudio: empty, rfFrontEnd: empty, filter: empty, dsp: empty,
     band, antenna, antennaInstruments, antennaLayout,
-    ritXitScan: empty, ritXitInstruments, cwKeyerInstruments, cwKeyer,
+    ritXitScan: empty, ritXitInstruments, cwKeyerInstruments, cwKeyer, memory: empty,
     scopeDisplay: empty, scopeControls: empty, txFaultRecovery: empty,
     modInputTxWarning: empty, managedScope: undefined,
   } satisfies FixtureInstrumentComposition;

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -471,16 +471,17 @@ describe('desktop-v2 resolves through the v3 path (MOR-1313)', () => {
   // deliberately NOT asserted here any more (MOR-1341): it is now itself a
   // suppressed twin, not part of "the rest" — its own matrix entry is the
   // dedicated test above. `rx-audio` left this list for the same reason
-  // (MOR-1368/S9): it is a suppressed twin now, pinned by its own row in the
-  // channel describe below. `memory` stays — it has no semantic twin at all,
-  // so it is the panel that proves suppression did not widen into "the rest".
+  // (MOR-1368/S9), and `memory` (MOR-2425, phase B2) just joined it: it now
+  // has a semantic twin and a declared zone, so this test asserts its swap
+  // directly instead of using it as "the rest" witness.
   it('leaves the rest of the layout intact', () => {
     vi.mocked(hasAnyScope).mockReturnValue(true);
     const t = render('desktop-v2');
     expect(t.querySelector('.content-left .left-sidebar')).not.toBeNull();
     expect(t.querySelector('.content-right .right-sidebar')).not.toBeNull();
     expect(t.querySelector('.center-column .spectrum-slot')).not.toBeNull();
-    expect(t.querySelector('[data-panel-id="memory"]')).not.toBeNull();
+    expect(t.querySelector('[data-panel-id="memory"]')).toBeNull();
+    expect(t.querySelectorAll('[data-testid="memory-surface"]')).toHaveLength(1);
   });
 
   // The manifest declares all four canonical classes (MOR-1266) — desktop-v2
@@ -1757,6 +1758,10 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
   // `desktop-dsp`/`desktop-agc`/`desktop-cw` — ten ids, the largest single
   // retirement in the tail. Non-vacuous proof is in the dedicated "drops the
   // legacy ..." tests below, which use caps that make each evidence gate fire.
+  //
+  // MOR-2425 (Memory lane, phase B2) removes both `memory` ids too: the zone
+  // is now real on `desktop-v2`, so both sidebars' legacy `MemoryPanel`
+  // retire on the same `declared` channel.
   it('renders exactly the panel inventory desktop-v2 renders post-S9', () => {
     const ids = [...renderAll('desktop-v2').querySelectorAll('[data-panel-id]:not(.semantic-control-panel [data-panel-id])')]
       .map((el) => el.getAttribute('data-panel-id'))
@@ -1764,7 +1769,6 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
     expect(ids).toEqual([
       'band',
       'desktop-language', 'desktop-vfo-ops', 'desktop-workspace',
-      'memory', 'memory',
     ]);
   });
 
@@ -1784,6 +1788,8 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
   // (filter/rfFrontEnd) and S8 (antenna/ritXitScan) — those eight panels no
   // longer render on `desktop-v2` at all, so an entry for them would be
   // exactly the stale-ledger drift the N1a check below now enforces.
+  // `memory` graduated the same way with MOR-2425 (Memory lane, phase B2):
+  // its zone is real on `desktop-v2` now, so it too dropped out of this map.
   const SURVIVING_PANEL_REASONS: Record<string, string> = {
     band: 'S10 row 10 (PERMANENT for the broadcast half): BandSelector hosts the LW/MW + SWL '
       + 'tabs and 16 presets that are deliberately not facts and have no other production host. '
@@ -1792,9 +1798,6 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
     'desktop-vfo-ops': 'S10 row 7 (split row) is already gated on `semanticDeck`; the section '
       + 'itself is PERMANENT because of the band tabs above (row 10).',
     'desktop-workspace': 'S10 row 9 — PERMANENT. Workspace preferences are not a radio fact.',
-    memory: 'IN THE VOCABULARY, UNDECLARED (MOR-2425, Memory lane phase B1). `memory` joined '
-      + 'SEMANTIC_SURFACE_NAMES, but no desktop-v2 zone declares it and no semantic surface mounts '
-      + 'it yet, so the legacy panels are still the only hosts.',
     // Not in the inventory above under the default fixture, but reachable and
     // decided, so recorded here rather than discovered later:
     tx: 'R9 — the ONE key/unkey authority. It follows the semantic DECK via `hideTxPanel` '

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -54,6 +54,7 @@
     getPendingFrequencyHz,
     getPendingFilterSelection, getPendingNbOn, getPendingNrOn, getPendingPreampLevel,
     getSystemHandlers, getDataModeArmed,
+    deriveMemoryPanelProps, getMemoryHandlers,
   } from '$lib/runtime/adapters/panel-adapters';
   import { toRitXitProps } from '$lib/runtime/props/panel-props';
   import type { SemanticSurfaceName } from '../../presentation/layouts/contract';
@@ -125,6 +126,7 @@
   import CwKeyerInstrumentHost, {
     type CwKeyerInstrumentHandles,
   } from '../../semantic/CwKeyerInstrumentHost.svelte';
+  import MemorySurface from '../../semantic/MemorySurface.svelte';
   import ScopeControlsSurface, {
     type ScopeChoiceField, type ScopeToggleField,
   } from '../../semantic/ScopeControlsSurface.svelte';
@@ -459,6 +461,15 @@
    * keeps legacy servers compatible; `null` is the adapter's fail-closed
    * result for present-but-unusable metadata. */
   let ritDomain = $derived(toRitXitProps(runtime.state, runtime.caps).ritDomain);
+  /**
+   * MOR-2425 (Memory lane, phase B2). Memory channels are not in the
+   * MOR-1262 RadioViewModel vocabulary (the radio cannot report their
+   * contents), so `memorySurface` below reads `deriveMemoryPanelProps()` /
+   * `getMemoryHandlers()` directly — the SAME panel-adapters singleton the
+   * legacy `MemoryPanel.svelte` wires to, not a second instance.
+   */
+  let memoryFacts = $derived(deriveMemoryPanelProps());
+  const memoryHandlers = getMemoryHandlers();
   /**
    * MOR-1310 (slice 9B). The CW intent vocabulary, composed from the SHIPPED
    * `makeCwPanelHandlers` rather than forked. MOR-1606 wires its existing
@@ -2033,6 +2044,26 @@
   {/snippet}
 
   <!--
+    MOR-2425 (Memory lane, phase B2). Unlike every surface above, `memory`
+    carries no MOR-1262 RadioViewModel group — the radio cannot report
+    memory-channel contents at all (`MemorySurface.svelte`'s own header) —
+    so there is no `view?.memory` to structurally gate on, and the surface
+    mounts unconditionally, exactly as the legacy `MemoryPanel` always has.
+    `facts`/`onRecall`/`onStore`/`onClear` route through the SAME
+    `deriveMemoryPanelProps()` / `getMemoryHandlers()` singleton the legacy
+    panel uses (declared above); `onRename` is left unwired, same as the
+    legacy panel — nothing in `panel-commands.ts` owns a rename intent.
+  -->
+  {#snippet memorySurface()}
+    <MemorySurface
+      facts={memoryFacts}
+      onRecall={memoryHandlers.onRecall}
+      onStore={memoryHandlers.onStore}
+      onClear={memoryHandlers.onClear}
+    />
+  {/snippet}
+
+  <!--
     MOR-1312 (vocabulary slice 12B). Same structural gate and same reasoning
     as `txAuxSurface`/`metersSurface` above: the surface mounts only when the
     view model actually carries the MOR-1301 `scopeDisplay` group, so a radio
@@ -2167,6 +2198,9 @@
     {#snippet body()}{@render cwKeyerSurface(showKeyerSpeed, showKeyerSpeed)}{/snippet}
     {@render zoned('cwKeyer', view?.cwKeyer !== undefined, body, allowBare)}
   {/snippet}
+  {#snippet hostedMemory(allowBare = allowBareSurfaces)}
+    {@render zoned('memory', true, memorySurface, allowBare)}
+  {/snippet}
   {#snippet hostedScopeDisplay(allowBare = allowBareSurfaces)}
     {@render zoned('scopeDisplay', view?.scopeDisplay !== undefined, scopeDisplaySurface, allowBare)}
   {/snippet}
@@ -2213,6 +2247,7 @@
       ritXitInstruments,
       cwKeyerInstruments,
       cwKeyer: hostedCwKeyer,
+      memory: hostedMemory,
       scopeDisplay: hostedScopeDisplay,
       scopeControls: hostedScopeControls,
       txFaultRecovery,

--- a/frontend/src/components-v2/wiring/__tests__/semantic-memory-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-memory-wiring.component.test.ts
@@ -14,10 +14,9 @@
  *   (a) desktop-v2 mounts exactly one semantic Memory surface, inside the
  *       declared `memory` zone, with zero legacy `MemoryPanel` twins.
  *   (b) recall dispatches the real `panel-commands.ts` intent, per channel.
- *   (c) store is refused, end to end, when the adapter reports
- *       `vfoIdentityKnown: false` — the WRONG-VFO doctrine
- *       `MemorySurface.svelte`'s header documents, proven through the REAL
- *       adapter rather than a unit-test fixture.
+ *   (c) when the REAL adapter reports `vfoIdentityKnown: false`, the store
+ *       affordance is disabled and a forced click dispatches nothing (the
+ *       handler-level guard itself is pinned in `MemorySurface.test.ts`).
  *   (d) the surface unmounts on a layout that declares no `memory` zone, and
  *       remounts exactly once switching back.
  *
@@ -172,11 +171,7 @@ const liveCaps = (): Capabilities => ({
  * A single-receiver `ab`-scheme radio with `vfoReadback: 'selected_unselected'`
  * and NO `main.activeSlot` observation — the one shape
  * `relativeVfoIdentityUnknown()` reports true for (`panel-props.ts`), which
- * is what `MemorySurface.svelte`'s `facts.vfoIdentityKnown` gate reads. Only
- * the FACTS path (`deriveMemoryPanelProps`, reading the mocked `runtime`)
- * needs this shape; the command-authority store is left untouched from
- * `beforeEach`'s reset, since the surface's own guard must refuse the click
- * before any command authority is even consulted.
+ * is what `MemorySurface.svelte`'s `facts.vfoIdentityKnown` gate reads.
  */
 function relativeIdentityUnknownState(): ServerState {
   return { active: 'MAIN', main: { freqHz: 7_100_000, mode: 'LSB' }, fieldStatus: {} } as unknown as ServerState;
@@ -202,11 +197,9 @@ function useState(state: ServerState, caps: Capabilities): void {
 }
 
 /**
- * Sets ONLY the runtime-mock facts (`deriveMemoryPanelProps` reads
- * `runtime.state`/`runtime.caps`), leaving the command-authority store as
- * given — used by the store-refusal test below to prove the refusal is a
- * handler-level guard in `MemorySurface.svelte` ahead of the command
- * authority, not merely an artifact of an empty store.
+ * Sets the runtime-mock facts (`deriveMemoryPanelProps` reads
+ * `runtime.state`/`runtime.caps`). The mocked `subscribeControlAuthority`
+ * pushes the same state into the command-authority store on subscribe.
  */
 function useFacts(state: ServerState, caps: Capabilities): void {
   h.state = state;
@@ -286,14 +279,6 @@ describe('recall dispatches the real memory-to-vfo intent, per channel', () => {
 /* ── (c) STORE refused under the WRONG-VFO doctrine ────────────── */
 
 describe('store is refused end to end when vfoIdentityKnown is false', () => {
-  // The command-authority store is set to a FULLY VALID state — the same
-  // fixture the recall tests prove dispatches successfully — while only the
-  // runtime-mock FACTS report identity-unknown. If the refusal were merely
-  // an artifact of an empty/invalid store, this store would let the click
-  // through; it does not, which is what isolates the refusal to
-  // `MemorySurface.svelte`'s own `if (!facts.vfoIdentityKnown) return;`
-  // guard (the WRONG-VFO doctrine its header documents) rather than to
-  // `panel-commands.ts`'s command authority.
   it('never dispatches a command, even bypassing the disabled store button', () => {
     useState(liveState(), liveCaps());
     useFacts(relativeIdentityUnknownState(), relativeIdentityUnknownCaps());

--- a/frontend/src/components-v2/wiring/__tests__/semantic-memory-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-memory-wiring.component.test.ts
@@ -1,0 +1,343 @@
+/**
+ * MOR-2425 (Memory lane, phase B2) — the semantic Memory surface wired into
+ * `SemanticRadioSurfaces` and mounted on the `desktop-v2` zone.
+ *
+ * Unlike every other family in this file's siblings, `memory` carries no
+ * MOR-1262 RadioViewModel group: the radio cannot report memory-channel
+ * contents at all (`MemorySurface.svelte`'s own header), so the surface
+ * mounts unconditionally and `facts`/handlers come from
+ * `deriveMemoryPanelProps()` / `getMemoryHandlers()` — the SAME
+ * panel-adapters singleton the legacy `MemoryPanel.svelte` already uses, not
+ * a second instance.
+ *
+ * This file proves what only the composed tree can prove:
+ *   (a) desktop-v2 mounts exactly one semantic Memory surface, inside the
+ *       declared `memory` zone, with zero legacy `MemoryPanel` twins.
+ *   (b) recall dispatches the real `panel-commands.ts` intent, per channel.
+ *   (c) store is refused, end to end, when the adapter reports
+ *       `vfoIdentityKnown: false` — the WRONG-VFO doctrine
+ *       `MemorySurface.svelte`'s header documents, proven through the REAL
+ *       adapter rather than a unit-test fixture.
+ *   (d) the surface unmounts on a layout that declares no `memory` zone, and
+ *       remounts exactly once switching back.
+ *
+ * Isolated pool by name (`*.component.test.ts`), per the MOR-1272 doctrine.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import type { CommandDeliveryEvent, ControlSessionTransition } from '$lib/transport/ws-client';
+import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
+import type { RxAudioTargetSnapshot } from '$lib/stores/audio.svelte';
+
+const h = vi.hoisted(() => ({
+  state: null as unknown,
+  caps: null as unknown,
+  authoritySubscribers: new Set<(next: {
+    state: unknown; caps: unknown; session: ControlSessionTransition;
+    rxAudioTarget: RxAudioTargetSnapshot;
+  }) => void>(),
+  audio: { muted: false, rxEnabled: true, volume: 42 },
+  audioConnected: true,
+  rxEnabled: true,
+  txController: null as ManagedAppTxController | null,
+  session: { state: 'connected' as ControlSessionTransition['state'], epoch: 1 },
+  sessionSubscriber: undefined as ((event: ControlSessionTransition) => void) | undefined,
+  delivery: undefined as ((event: CommandDeliveryEvent) => void) | undefined,
+  transition: undefined as ((event: ControlSessionTransition) => void) | undefined,
+}));
+
+vi.mock('$lib/transport/ws-client', () => ({
+  sendCommand: vi.fn(() => true),
+  getControlSession: () => h.session,
+  onCommandDelivery: vi.fn((handler: (event: CommandDeliveryEvent) => void) => {
+    h.delivery = handler;
+    return () => { if (h.delivery === handler) h.delivery = undefined; };
+  }),
+  onControlSessionTransition: vi.fn((handler: (event: ControlSessionTransition) => void) => {
+    h.transition = handler;
+    return () => { if (h.transition === handler) h.transition = undefined; };
+  }),
+}));
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: {
+    get rxEnabled() { return h.rxEnabled; },
+    startRx: vi.fn(), stopRx: vi.fn(), setRxVolume: vi.fn(), setAudioConfig: vi.fn(),
+    onTxAudioDied: () => () => {},
+  },
+}));
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    onTxAudioDied: () => () => {},
+    get state() { return h.state; },
+    get caps() { return h.caps; },
+    get controlSession() { return h.session; },
+    subscribeControlSession(handler: (event: ControlSessionTransition) => void) {
+      h.sessionSubscriber = handler;
+      return () => { if (h.sessionSubscriber === handler) h.sessionSubscriber = undefined; };
+    },
+    subscribeControlAuthority(handler: (typeof h.authoritySubscribers extends Set<infer T> ? T : never)) {
+      h.authoritySubscribers.add(handler);
+      handler({
+        state: h.state, caps: h.caps, session: h.session,
+        rxAudioTarget: Object.freeze({ muted: h.audio.muted, rxEnabled: h.audio.rxEnabled }),
+      });
+      return () => { h.authoritySubscribers.delete(handler); };
+    },
+    get audio() { return h.audio; },
+    get connectionAudio() { return h.audioConnected; },
+    get rxEnabled() { return h.rxEnabled; },
+    setVolume: vi.fn(), setMuted: vi.fn(), setRxLive: vi.fn(), setRxVolume: vi.fn(),
+    get defaultScopeStatus() {
+      return {
+        source: null, available: false, resourceSelected: false, demand: 0,
+        lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+      };
+    },
+    get scope() { return { hardwareScopeConnected: false }; },
+  },
+}));
+vi.mock('$lib/runtime', async () => ({
+  runtime: (await import('$lib/runtime/frontend-runtime')).runtime,
+}));
+vi.mock('$lib/runtime/tx-controller/managed-app-host', () => ({
+  getManagedAppTxController: () => {
+    if (!h.txController) throw new Error('managed TX harness is not installed');
+    return h.txController;
+  },
+}));
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: 'LAN' }),
+  getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+}));
+
+import { sendCommand } from '$lib/transport/ws-client';
+import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
+import { setCapabilities } from '$lib/stores/capabilities.svelte';
+import { persistMemoryChannels } from '../../../semantic/memory-channels';
+import HostedRadioLayoutFixture from '../../layout/__tests__/fixtures/HostedRadioLayoutFixture.svelte';
+import { desktopV2Layout, sdrTestLayout } from '../../../presentation/layouts/declarations';
+import { readWorkspace } from '../../../presentation/workspace/contract';
+import { resolveSurfacePlan, SURFACE_PLAN_CONTEXT_KEY } from '../../../presentation/workspace/resolution';
+import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
+
+/**
+ * A dual-receiver radio with a fully observed MAIN receiver — the shape
+ * `currentA03cContext()`/`knownA03cReceiver()` (`panel-commands.ts`) and
+ * `relativeVfoIdentityUnknown()` (`panel-props.ts`) both need to answer
+ * "identity known, MAIN readable" for both the facts and the command
+ * authority. `main`/`connection`/`txTarget` follow `isValidServerState`'s
+ * real contract (`$lib/stores/radio.svelte.ts`) — the REAL `setRadioState`
+ * is used here, unlike `memory-command-authority.isolated.test.ts`, which
+ * mocks the store and so does not need it.
+ */
+const fresh = {
+  storePath: 'x', observed: true, freshness: 'fresh', availability: 'available',
+  lastObservedMonotonic: 10,
+} as const;
+const slot = (freqHz: number, mode: string) => ({ freqHz, mode, filterNum: 1, dataMode: 0 });
+function liveState(): ServerState {
+  const paths = ['active'];
+  for (const rx of ['main', 'sub']) {
+    paths.push(`${rx}.freqHz`, `${rx}.mode`, `${rx}.filter`, `${rx}.activeSlot`);
+    for (const v of ['vfoA', 'vfoB']) paths.push(`${rx}.${v}.freqHz`, `${rx}.${v}.mode`, `${rx}.${v}.filterNum`);
+  }
+  const receiver = (hz: number) => ({
+    ...slot(hz, 'USB'), vfoA: slot(hz, 'USB'), vfoB: slot(hz + 50_000, 'USB'), activeSlot: 'A',
+    filter: 1, sMeter: 0, att: 0, preamp: 0, nb: false, nr: false, afLevel: 0, rfGain: 0, squelch: 0,
+  });
+  return {
+    revision: 1, stateRevision: 1, freshnessRevision: 1, observationSeq: 1,
+    updatedAt: '2026-09-07T00:00:00Z', tunerStatus: 0,
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    stateContractVersion: 1, providerGeneration: 0,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14_074_000 },
+    main: receiver(14_074_000), sub: receiver(14_100_000),
+    connection: { rigConnected: true, radioReady: true, controlConnected: true },
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+const liveCaps = (): Capabilities => ({
+  model: 'fixture', scope: false, audio: false, tx: true, stateContractVersion: 1, providerGeneration: 0,
+  capabilities: ['dual_rx'], receivers: 2, vfoScheme: 'main_sub', freqRanges: [],
+  modes: ['USB'], filters: ['FIL1'],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false }, txBands: [], scopeSource: null, audioFftAvailable: false,
+} as unknown as Capabilities);
+
+/**
+ * A single-receiver `ab`-scheme radio with `vfoReadback: 'selected_unselected'`
+ * and NO `main.activeSlot` observation — the one shape
+ * `relativeVfoIdentityUnknown()` reports true for (`panel-props.ts`), which
+ * is what `MemorySurface.svelte`'s `facts.vfoIdentityKnown` gate reads. Only
+ * the FACTS path (`deriveMemoryPanelProps`, reading the mocked `runtime`)
+ * needs this shape; the command-authority store is left untouched from
+ * `beforeEach`'s reset, since the surface's own guard must refuse the click
+ * before any command authority is even consulted.
+ */
+function relativeIdentityUnknownState(): ServerState {
+  return { active: 'MAIN', main: { freqHz: 7_100_000, mode: 'LSB' }, fieldStatus: {} } as unknown as ServerState;
+}
+const relativeIdentityUnknownCaps = (): Capabilities => ({
+  model: 'fixture', scope: false, audio: false, tx: true,
+  capabilities: [], receivers: 1, vfoScheme: 'ab', vfoReadback: 'selected_unselected', freqRanges: [],
+  modes: ['LSB'], filters: [],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false }, txBands: [], scopeSource: null, audioFftAvailable: false,
+} as unknown as Capabilities);
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null = null;
+let txHarness: ManagedAppTxHarness;
+
+function useState(state: ServerState, caps: Capabilities): void {
+  h.state = state;
+  h.caps = caps;
+  resetRadioState();
+  setRadioState(state);
+  setCapabilities(caps);
+}
+
+/**
+ * Sets ONLY the runtime-mock facts (`deriveMemoryPanelProps` reads
+ * `runtime.state`/`runtime.caps`), leaving the command-authority store as
+ * given — used by the store-refusal test below to prove the refusal is a
+ * handler-level guard in `MemorySurface.svelte` ahead of the command
+ * authority, not merely an artifact of an empty store.
+ */
+function useFacts(state: ServerState, caps: Capabilities): void {
+  h.state = state;
+  h.caps = caps;
+}
+
+/** Mounts the REAL `RadioLayout` behind a reactive `skinId`, with a resolved
+ *  `SurfacePlan` in context so `zoneOwning()` can answer for real — same
+ *  shape as `semantic-cw-keyer-wiring.component.test.ts`'s `renderHosted`. */
+function renderHosted() {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  const props = proxy({ skinId: 'desktop-v2' as 'desktop-v2' | 'sdr-test' });
+  const context = new Map<unknown, unknown>([[SURFACE_PLAN_CONTEXT_KEY, () =>
+    resolveSurfacePlan(props.skinId === 'desktop-v2' ? desktopV2Layout : sdrTestLayout,
+      readWorkspace({ version: 1 }).workspace)]]);
+  component = mount(HostedRadioLayoutFixture, { target, props, context });
+  flushSync();
+  return props;
+}
+
+const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+const qAll = (sel: string) => target.querySelectorAll(sel);
+const commands = () => vi.mocked(sendCommand).mock.calls.map(([name, params]) => ({ name, params }));
+const press = (node: HTMLElement) => node.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+beforeEach(() => {
+  txHarness = new ManagedAppTxHarness();
+  h.txController = txHarness.controller;
+  h.session = { state: 'connected', epoch: 1 };
+  h.sessionSubscriber = undefined;
+  vi.mocked(sendCommand).mockClear();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+  localStorage.clear();
+  expect(h.sessionSubscriber).toBeUndefined();
+  expect(h.authoritySubscribers.size).toBe(0);
+});
+
+/* ── (a) MOUNTING — desktop-v2 zone, zero legacy twins ─────────── */
+
+describe('the memory surface mounts on the declared desktop-v2 zone', () => {
+  it('renders exactly one semantic Memory surface inside the memory zone, and zero legacy panels', () => {
+    useState(liveState(), liveCaps());
+    renderHosted();
+    const host = q('[data-zone-id="memory"]');
+    expect(host).not.toBeNull();
+    expect(host!.querySelector('[data-testid="memory-surface"]')).not.toBeNull();
+    expect(qAll('[data-testid="memory-surface"]')).toHaveLength(1);
+    expect(qAll('[data-panel-id="memory"]')).toHaveLength(0);
+  });
+});
+
+/* ── (b) RECALL — the real command-authority intent, per channel ── */
+
+describe('recall dispatches the real memory-to-vfo intent, per channel', () => {
+  it.each([5, 9])('channel %d: recalling it sends set_memory_mode + memory_to_vfo exactly once', (ch) => {
+    useState(liveState(), liveCaps());
+    persistMemoryChannels(new Map([[ch, { freq: 14_074_000, mode: 'USB', name: '' }]]));
+    renderHosted();
+    const recall = q<HTMLElement>(`[data-testid="memory-channel-${ch}-recall"]`);
+    expect(recall).not.toBeNull();
+    press(recall!);
+    flushSync();
+    expect(commands()).toEqual([
+      { name: 'set_memory_mode', params: { channel: ch } },
+      { name: 'memory_to_vfo', params: { channel: ch } },
+    ]);
+  });
+});
+
+/* ── (c) STORE refused under the WRONG-VFO doctrine ────────────── */
+
+describe('store is refused end to end when vfoIdentityKnown is false', () => {
+  // The command-authority store is set to a FULLY VALID state — the same
+  // fixture the recall tests prove dispatches successfully — while only the
+  // runtime-mock FACTS report identity-unknown. If the refusal were merely
+  // an artifact of an empty/invalid store, this store would let the click
+  // through; it does not, which is what isolates the refusal to
+  // `MemorySurface.svelte`'s own `if (!facts.vfoIdentityKnown) return;`
+  // guard (the WRONG-VFO doctrine its header documents) rather than to
+  // `panel-commands.ts`'s command authority.
+  it('never dispatches a command, even bypassing the disabled store button', () => {
+    useState(liveState(), liveCaps());
+    useFacts(relativeIdentityUnknownState(), relativeIdentityUnknownCaps());
+    renderHosted();
+    const toggle = q<HTMLElement>('[data-testid="memory-store-toggle"]');
+    expect(toggle).not.toBeNull();
+    expect(toggle!.hasAttribute('disabled')).toBe(true);
+    // Bypass `disabled` with a real bubbling click, same as the phase A
+    // surface unit test's `forceClick` precedent: the refusal must be a
+    // handler-level guard, not merely an attribute.
+    press(toggle!);
+    flushSync();
+    const confirm = q<HTMLElement>('[data-testid="memory-store-confirm"]');
+    expect(confirm, 'store bar opened despite the disabled toggle').not.toBeNull();
+    press(confirm!);
+    flushSync();
+    expect(commands()).toEqual([]);
+  });
+});
+
+/* ── (d) MOUNT LIFECYCLE across a layout that declares no memory zone ── */
+
+describe('the surface unmounts on a layout that declares no memory zone, and remounts once', () => {
+  // `sdrTestLayout` declares no `memory` zone (only `desktop-v2` does), so
+  // `declared.has('memory')` is false there and the MOR-1364 suppression
+  // channel's own rule applies: the legacy twin is NOT suppressed on a
+  // layout that never declared the zone (the same rule every other
+  // MOR-1364 family follows — e.g. `cwKeyer`'s legacy panel reappears on an
+  // undeclaring layout too). The legacy `MemoryPanel` reappearing here is
+  // therefore the CORRECT behaviour, not a residual double-presentation.
+  it('desktop-v2 -> sdr-test -> desktop-v2', () => {
+    useState(liveState(), liveCaps());
+    const props = renderHosted();
+    expect(qAll('[data-testid="memory-surface"]')).toHaveLength(1);
+    expect(qAll('[data-panel-id="memory"]')).toHaveLength(0);
+
+    props.skinId = 'sdr-test';
+    flushSync();
+    expect(qAll('[data-testid="memory-surface"]')).toHaveLength(0);
+    expect(qAll('[data-panel-id="memory"]')).toHaveLength(1);
+
+    props.skinId = 'desktop-v2';
+    flushSync();
+    expect(qAll('[data-testid="memory-surface"]')).toHaveLength(1);
+    expect(qAll('[data-panel-id="memory"]')).toHaveLength(0);
+  });
+});

--- a/frontend/src/components-v2/wiring/__tests__/semantic-memory-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-memory-wiring.component.test.ts
@@ -169,7 +169,7 @@ const liveCaps = (): Capabilities => ({
 
 /**
  * A single-receiver `ab`-scheme radio with `vfoReadback: 'selected_unselected'`
- * and NO `main.activeSlot` observation — the one shape
+ * and NO `main.activeSlot` observation — one of the shapes
  * `relativeVfoIdentityUnknown()` reports true for (`panel-props.ts`), which
  * is what `MemorySurface.svelte`'s `facts.vfoIdentityKnown` gate reads.
  */
@@ -198,8 +198,7 @@ function useState(state: ServerState, caps: Capabilities): void {
 
 /**
  * Sets the runtime-mock facts (`deriveMemoryPanelProps` reads
- * `runtime.state`/`runtime.caps`). The mocked `subscribeControlAuthority`
- * pushes the same state into the command-authority store on subscribe.
+ * `runtime.state`/`runtime.caps`).
  */
 function useFacts(state: ServerState, caps: Capabilities): void {
   h.state = state;

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -86,6 +86,11 @@ vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   getPendingFrequencyHz: () => null,
   getPendingFilterSelection: () => null, getPendingNbOn: () => null,
   getPendingNrOn: () => null, getPendingPreampLevel: () => null,
+  // MOR-2425 (Memory lane, phase B2) — `SemanticRadioSurfaces.svelte` now
+  // imports these unconditionally. This file does not exercise memory at
+  // all, so the stubs only need to satisfy the import.
+  deriveMemoryPanelProps: () => ({ activeFreqHz: Number.NaN, activeMode: '---', vfoIdentityKnown: false }),
+  getMemoryHandlers: () => ({ onRecall: () => false, onStore: () => false, onClear: () => false }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/instrument-composition.ts
+++ b/frontend/src/components-v2/wiring/instrument-composition.ts
@@ -47,6 +47,7 @@ export interface InstrumentComposition {
   readonly ritXitInstruments: RitXitScanInstrumentHandles;
   readonly cwKeyerInstruments: CwKeyerInstrumentHandles;
   readonly cwKeyer: Snippet<[allowBare?: boolean, showKeyerSpeed?: boolean]>;
+  readonly memory: Snippet<[allowBare?: boolean]>;
   readonly scopeDisplay: Snippet<[allowBare?: boolean]>;
   readonly scopeControls: Snippet<[allowBare?: boolean]>;
   readonly txFaultRecovery: Snippet;

--- a/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
@@ -47,7 +47,7 @@ describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
   it('declares receiver-deck:[vfo], rx-tx:[rxTx], tx-aux:[txAux], meters:[meters], '
     + 'scope-display:[scopeDisplay], filter:[filter], rf-front-end:[rfFrontEnd], '
     + 'band:[band], antenna:[antenna], rit-xit-scan:[ritXitScan], rx-audio:[rxAudio], '
-    + 'dsp:[dsp], cw-keyer:[cwKeyer] and scope-controls:[scopeControls]', () => {
+    + 'dsp:[dsp], cw-keyer:[cwKeyer], memory:[memory] and scope-controls:[scopeControls]', () => {
     expect(desktopV2Layout.zones).toEqual([
       { id: 'receiver-deck', surfaces: ['vfo'] },
       { id: 'rx-tx', surfaces: ['rxTx'] },
@@ -74,6 +74,10 @@ describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
       { id: 'rx-audio', surfaces: ['rxAudio'] },
       { id: 'dsp', surfaces: ['dsp'] },
       { id: 'cw-keyer', surfaces: ['cwKeyer'] },
+      // MOR-2425 (Memory lane, phase B2): memory becomes zone-owned too,
+      // closing the ledger entry `zone-ownership-coverage.test.ts` opened in
+      // phase B1. No RadioViewModel group backs it — it mounts unconditionally.
+      { id: 'memory', surfaces: ['memory'] },
       // MOR-1370 (S6b-2): scopeControls becomes zone-owned, the LAST surface
       // in the MOR-1262 vocabulary to graduate. Not required.
       { id: 'scope-controls', surfaces: ['scopeControls'] },
@@ -98,7 +102,7 @@ describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
   // is per-zone rather than per-manifest-first-zone.
   it('its zones flatten to the surfaces the shell suppresses legacy twins for', () => {
     expect([...declaredSurfaces(getLayout('desktop-v2'))].sort())
-      .toEqual(['antenna', 'band', 'cwKeyer', 'dsp', 'filter', 'meters', 'rfFrontEnd', 'ritXitScan', 'rxAudio', 'rxTx', 'scopeControls', 'scopeDisplay', 'txAux', 'vfo']);
+      .toEqual(['antenna', 'band', 'cwKeyer', 'dsp', 'filter', 'memory', 'meters', 'rfFrontEnd', 'ritXitScan', 'rxAudio', 'rxTx', 'scopeControls', 'scopeDisplay', 'txAux', 'vfo']);
   });
 });
 

--- a/frontend/src/presentation/layouts/__tests__/zone-ownership-coverage.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/zone-ownership-coverage.test.ts
@@ -24,9 +24,9 @@
  * MOR-1317 rework tail itself excused — which emptied `RECORDED_REASONS`
  * below for that program: every MOR-1317-era `SEMANTIC_SURFACE_NAMES` member
  * was zone-owned on `desktop-v2`, with the partition pin holding on zero
- * excused entries. MOR-2425 (Memory lane, phase B1) reopens the ledger with
- * one entry: `memory` joins the vocabulary here with no `desktop-v2` zone,
- * excused below until its own follow-up join declares one.
+ * excused entries. MOR-2425 (Memory lane, phase B1) reopened the ledger with
+ * one entry for `memory`; phase B2 (this join) declares its `desktop-v2`
+ * zone, so `RECORDED_REASONS` below is empty again.
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -43,19 +43,13 @@ const OWNED = declaredSurfaces(desktopV2Layout);
  * this map only by gaining a `desktop-v2` zone in the same commit.
  *
  * `filter`, `rfFrontEnd` (S7), `band`, `antenna`, `ritXitScan` (S8),
- * `rxAudio`, `dsp`, `cwKeyer` (S9) and `scopeControls` (S6b-2) all graduated
- * to real zones on `desktopV2Layout` under the MOR-1317 rework tail — `OWNED`
- * covers every one of them. `memory` (MOR-2425, Memory lane phase B1) is the
- * one live entry below: admitted to `SEMANTIC_SURFACE_NAMES` with no
- * `desktop-v2` zone yet, it is excused here until its own follow-up join
- * declares one.
+ * `rxAudio`, `dsp`, `cwKeyer` (S9), `scopeControls` (S6b-2) and `memory`
+ * (MOR-2425, Memory lane phase B2) all graduated to real zones on
+ * `desktopV2Layout` — `OWNED` covers every one of them, so THE LEDGER IS
+ * EMPTY AGAIN: every `SEMANTIC_SURFACE_NAMES` member is zone-owned on
+ * `desktop-v2`, and the partition pin below holds on zero excused entries.
  */
-const RECORDED_REASONS: Partial<Record<SemanticSurfaceName, string>> = {
-  memory:
-    'MOR-2425 (Memory lane, phase B1) admits `memory` to the vocabulary ' +
-    'without declaring a desktop-v2 zone; the zone and its mount land in ' +
-    'the phase B2 follow-up join.',
-};
+const RECORDED_REASONS: Partial<Record<SemanticSurfaceName, string>> = {};
 
 describe('MOR-1317 — every semantic surface has a desktop-v2 decision', () => {
   /**

--- a/frontend/src/presentation/layouts/desktop-declarations.ts
+++ b/frontend/src/presentation/layouts/desktop-declarations.ts
@@ -108,6 +108,19 @@ const DESKTOP_V2_ZONES = [
   { id: 'rx-audio', surfaces: ['rxAudio'] },
   { id: 'dsp', surfaces: ['dsp'] },
   { id: 'cw-keyer', surfaces: ['cwKeyer'] },
+  // MOR-2425 (Memory lane, phase B2): memory becomes zone-OWNED here too,
+  // closing the ledger entry `zone-ownership-coverage.test.ts` opened in
+  // phase B1. Unlike its siblings above, `memory` has no MOR-1262
+  // RadioViewModel group to self-gate on — the radio itself cannot report
+  // memory-channel contents (see `MemorySurface.svelte`'s header), so the
+  // surface mounts unconditionally, matching the legacy `MemoryPanel`'s own
+  // unconditional render. Declaring this zone activates the MOR-1364
+  // suppression channel for both sidebars' legacy `MemoryPanel` mount.
+  //
+  // Not `required`: the surface has no evidence gate to decline, so there is
+  // nothing for `requiredSemanticSurfaces` to force-restore here, same as
+  // every other non-vfo/rxTx zone in this manifest.
+  { id: 'memory', surfaces: ['memory'] },
   // MOR-1370 (S6b-2): scopeControls becomes zone-OWNED here — the LAST
   // surface in the whole MOR-1262 vocabulary to graduate. Declaring it
   // activates the MOR-1369 (S6b-1) suppression channel: `RadioLayout.svelte`

--- a/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
@@ -288,8 +288,9 @@ describe('MOR-1082 — the single-composition order comes from the same plan', (
     // MOR-1336 (S4) tx-aux zone, MOR-1341 (S5) meters zone, MOR-1365 (S6a)
     // scope-display zone, the MOR-1366 (S7) filter/rf-front-end zones, the
     // three MOR-1367 (S8) zones, the MOR-1368 (S9) rx-audio/dsp/cw-keyer
-    // zones and the MOR-1370 (S6b-2) scope-controls zone — flattening never
-    // drops a later zone.
+    // zones, the MOR-2425 (Memory lane, phase B2) memory zone and the
+    // MOR-1370 (S6b-2) scope-controls zone — flattening never drops a later
+    // zone.
     //
     // §1.5 / MOR-1339 discipline: this list GROWS, but `singleOrder`'s `{#each}`
     // in `SemanticRadioSurfaces.svelte` gains NO branch for any of these
@@ -298,7 +299,7 @@ describe('MOR-1082 — the single-composition order comes from the same plan', (
     // `components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts`
     // is the counterpart that would catch a double mount.
     expect(compositionSurfaces(plan(desktopV2Layout), FALLBACK))
-      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'scopeDisplay', 'filter', 'rfFrontEnd', 'band', 'antenna', 'ritXitScan', 'rxAudio', 'dsp', 'cwKeyer', 'scopeControls']);
+      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'scopeDisplay', 'filter', 'rfFrontEnd', 'band', 'antenna', 'ritXitScan', 'rxAudio', 'dsp', 'cwKeyer', 'memory', 'scopeControls']);
     // A within-zone reorder reaches the flattened composition — on `mobile`,
     // which still declares both surfaces in one zone (MOR-2231 split
     // sdr-test's).

--- a/frontend/src/presentation/workspace/contract.ts
+++ b/frontend/src/presentation/workspace/contract.ts
@@ -61,7 +61,7 @@ export type WorkspaceThemeId = (typeof WORKSPACE_THEME_IDS)[number];
  *  registered layout manifest declares". `main` left with MOR-2231, which
  *  split sdr-test's only zone into `receiver-deck` + `rx-tx`; no other
  *  manifest declared it. */
-export const WORKSPACE_ZONE_IDS = ['receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column', 'tx-aux', 'meters', 'scope-display', 'filter', 'rf-front-end', 'band', 'antenna', 'rit-xit-scan', 'rx-audio', 'dsp', 'cw-keyer', 'scope-controls', 'peer-columns'] as const;
+export const WORKSPACE_ZONE_IDS = ['receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column', 'tx-aux', 'meters', 'scope-display', 'filter', 'rf-front-end', 'band', 'antenna', 'rit-xit-scan', 'rx-audio', 'dsp', 'cw-keyer', 'memory', 'scope-controls', 'peer-columns'] as const;
 export type WorkspaceZoneId = (typeof WORKSPACE_ZONE_IDS)[number];
 
 /** Decision 7: command-bus intent names (`set_compressor`), never module paths. */

--- a/frontend/src/semantic/MemorySurface.svelte
+++ b/frontend/src/semantic/MemorySurface.svelte
@@ -28,10 +28,6 @@
   stored" would be dishonest. The active-VFO readout below is gated on
   `facts.vfoIdentityKnown` FIRST, never on `Number.isFinite` alone, and the
   store affordance is refused (no callback fires) under the same gate.
-
-  NOT YET WIRED (MOR-2425 phase B). No zone mounts this component, and no
-  `memory` entry exists in `SEMANTIC_SURFACE_NAMES` yet — see the phase A
-  handoff report for why that specific step did not land in this change.
 -->
 <script module lang="ts">
   import { MAX_MEMORY_CHANNELS, loadMemoryChannels, persistMemoryChannels } from './memory-channels';


### PR DESCRIPTION
10 code + 6 test files = 16 files — file-count exception granted by the coordinator (line total 475 stays under the hard ceiling; the sixteenth file is `MemorySurface.svelte`, whose header still claimed the surface was unwired and the vocabulary lacked `memory` — both false after #3351 and this change, deleted in the second commit): the zone declaration, the `WorkspaceZoneId` member, the `InstrumentComposition.memory` slot, the `SemanticRadioSurfaces` mount plus its fixture-build stub, the `RadioLayout` render site, the two sidebar suppression gates, and the ledger entry all fail or silently duplicate MEMORY if any one of them lands without the rest.

Soft threshold (6 files / 600 lines) is also crossed; this is reported, not waived, as one unit of work: every file above implements or exercises the single MOR-2425 phase-B2 change — routing the `memory` surface through its own zone instead of the two hard-coded sidebar panels — and none of them is independently reviewable or revertable from the others.

## Summary

- `presentation/layouts/desktop-declarations.ts` — adds `{ id: 'memory', surfaces: ['memory'] }` to `DESKTOP_V2_ZONES`.
- `presentation/workspace/contract.ts` — adds `'memory'` to `WORKSPACE_ZONE_IDS`.
- `components-v2/wiring/instrument-composition.ts` — adds `readonly memory: Snippet<[allowBare?: boolean]>;` to `InstrumentComposition`.
- `components-v2/wiring/SemanticRadioSurfaces.svelte` — mounts `MemorySurface.svelte` via a `zoned('memory', ...)` snippet, reading `deriveMemoryPanelProps()`/`getMemoryHandlers()` from the existing `$lib/runtime/adapters/panel-adapters` singleton (the same one `MemoryPanel.svelte` already calls) rather than adding a second handler instance to `bindSemanticSurfaceHandlers()`, which is pinned exact-shape by an isolated test outside this lease.
- `components-v2/layout/RadioLayout.svelte` — renders `{@render instruments.memory()}` inside the existing `desktop-v2`-only branch.
- `components-v2/layout/LeftSidebar.svelte` / `RightSidebar.svelte` — add `&& !declared.has('memory')` to the legacy `MemoryPanel` render guard, same shape as the existing `rfFrontEnd` suppression.
- `presentation/layouts/__tests__/zone-ownership-coverage.test.ts` — the `memory` entry is removed from `RECORDED_REASONS` (the ledger), now empty.
- `frontend/fixtures/stubs/panel-adapters.ts` — adds `deriveMemoryPanelProps`/`getMemoryHandlers` stub exports in this file's existing minimal/inert convention (the same shape `getBreakInDelayControlFeedback` and friends use), so the offline fixture-capture build resolves the two new imports `SemanticRadioSurfaces.svelte` now requires unconditionally.

**Deliberate deviation from the literal brief wording:** under `sdr-test`, which declares no `memory` zone, the legacy `MemoryPanel` correctly reappears — same behavior as every other MOR-1364-family surface moved to a layout that never declared its zone. `semantic-memory-wiring.component.test.ts`'s unmount/remount test asserts this true behavior instead of the brief's "no legacy panel appears" phrasing, which does not match how zone suppression actually works.

## Witnesses and mutations (from the prior builder's report, re-verified unchanged)

1. Drop the `RightSidebar.svelte` suppression gate (`&& !declared.has('memory')` removed) → 5 tests failed: this file's own "zero legacy panels" mount test and its unmount/remount test (both now see the reappeared legacy panel), plus three in `semantic-desktop-migration.component.test.ts` ("leaves the rest of the layout intact", "renders exactly the panel inventory... post-S9", "every legacy panel still on screen is a recorded decision").
2. Drop the `memory` zone from `DESKTOP_V2_ZONES` → 1 test failed: `zone-ownership-coverage.test.ts`'s "partitions SEMANTIC_SURFACE_NAMES into zone-owned and recorded-reason, exactly" (`memory` in neither `OWNED` nor `RECORDED_REASONS`).
3. Wire `onRecall` to a constant channel (`onRecall={(ch) => memoryHandlers.onRecall(1)}`) → both `it.each([5, 9])` rows in `semantic-memory-wiring.component.test.ts` failed independently (channel 5's row and channel 9's row each received `memory_to_vfo {channel: 1}`).

All three restored byte-identically; `git diff` on each touched file was empty afterward.

## Census (`git diff origin/main...HEAD --stat`)

```
 frontend/fixtures/stubs/panel-adapters.ts          |  23 ++
 .../src/components-v2/layout/LeftSidebar.svelte    |   2 +-
 .../src/components-v2/layout/RadioLayout.svelte    |   1 +
 .../src/components-v2/layout/RightSidebar.svelte   |   2 +-
 .../fixtures/HostedRadioLayoutFixture.svelte       |   2 +-
 .../semantic-desktop-migration.component.test.ts   |  19 +-
 .../wiring/SemanticRadioSurfaces.svelte            |  35 +++
 .../semantic-memory-wiring.component.test.ts       | 343 +++++++++++++++++++++
 ...semantic-vfo-indicator-wiring.component.test.ts |   5 +
 .../components-v2/wiring/instrument-composition.ts |   1 +
 .../__tests__/desktop-v2-registration.test.ts      |   8 +-
 .../__tests__/zone-ownership-coverage.test.ts      |  24 +-
 .../presentation/layouts/desktop-declarations.ts   |  13 +
 .../__tests__/preferences-adoption.test.ts         |   7 +-
 frontend/src/presentation/workspace/contract.ts    |   2 +-
 16 files changed, 439 insertions(+), 36 deletions(-) (at `7862e5f22`; the second and third commits delete the store-refusal test's guard-isolation claim — the test witnesses the disabled affordance and that nothing is dispatched; the guard itself is pinned in `MemorySurface.test.ts` — and the stale surface header; the third commit removes a docstring sentence about the mocked authority subscription that measurement refuted, and corrects "the one shape" to one of the two shapes `relativeVfoIdentityUnknown` reports true for)
```

## Verification

- `node frontend/fixtures/capture.mjs`: 65 captures → `fixtures-baselines`, 0 invalid.
- `semantic-memory-wiring.component.test.ts` + `zone-ownership-coverage.test.ts` + `presentation/workspace/__tests__/contract.test.ts` + `semantic-desktop-migration.component.test.ts`: 229/229 passed.
- Grep union of test files naming Memory/SemanticRadioSurfaces/RadioLayout/LeftSidebar/RightSidebar/HostedRadioLayoutFixture/WorkspaceSettingsPanel, plus `semantic-controls.component.svelte.test.ts` added explicitly (named by the TITLES coverage it carries, not caught by the grep pattern): 98 files, 2692/2692 tests passed in one run.
- `npm run check`: `COMPLETED 4834 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`.
- `npx eslint` on the 15 changed paths: 0 errors (`frontend/fixtures/stubs/panel-adapters.ts` falls outside every `files` glob in `eslint.config.js`, same as any other file under `fixtures/`, so it reports only an out-of-scope warning, no lint rule ran against it).
- `git diff --cached --check`: exit 0.
- `origin/main` unchanged from this branch's parent commit (`ec0bc4583`) at merge time — no upstream merge was needed.

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

