### PR TITLE
feat(MOR-2425): keep stale readings available instead of greying controls

### DIFF
--- a/frontend/src/components-v2/panels/__tests__/CwPanel.feedback-wiring.component.svelte.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/CwPanel.feedback-wiring.component.svelte.test.ts
@@ -130,6 +130,36 @@ describe('fallback CwPanel ControlFeedback wiring (MOR-1754)', () => {
     vi.useRealTimers();
   });
 
+  it('keeps a stale-but-observed CW Pitch available with its last value, then greys out on disconnect (MOR-2425/R29)', () => {
+    vi.useFakeTimers(); handlers.onCwPitchChange.mockClear();
+    render();
+    const pitch = target.querySelector<HTMLElement>('[aria-label="CW Pitch"]')!;
+    canonical.state = {
+      ...connectedState(),
+      fieldStatus: { ...connectedState().fieldStatus, cwPitch: { ...fresh(), freshness: 'stale' as const } },
+    };
+    flushSync();
+    // Session stays connected; only the ONE field goes stale. The owner
+    // ruling (R29) says a control greys out only on a real disconnect or
+    // structural absence — a stale-but-observed reading keeps the control
+    // enabled with its last value, never a vacuous placeholder.
+    expect(pitch.getAttribute('aria-disabled')).toBe('false');
+    expect(pitch.getAttribute('aria-valuenow')).toBe('600');
+    expect(vcValue('CW Pitch')).toBe('600 Hz');
+    pitch.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    vi.advanceTimersByTime(50);
+    expect(handlers.onCwPitchChange).toHaveBeenCalledExactlyOnceWith(605);
+
+    // A real disconnect still greys the control out — session disconnected
+    // ALONE, canonical state/caps left populated, isolates this from the
+    // `state === null` gate `projectControlFeedback` already enforces
+    // independently (a real WS close clears both together; this proves the
+    // session term itself still gates, not just the redundant null check).
+    canonical.session = { state: 'disconnected', epoch: 1 }; flushSync();
+    expect(pitch.getAttribute('aria-disabled')).toBe('true');
+    vi.useRealTimers();
+  });
+
   it('keeps normalized input local until one native change commits it', () => {
     handlers.onBreakInDelayChange.mockClear(); const r = render();
     Object.defineProperty(r.input(), 'valueAsNumber', { configurable: true, value: 111.4 });

--- a/frontend/src/components-v2/panels/__tests__/TxPanel.feedback-wiring.component.svelte.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/TxPanel.feedback-wiring.component.svelte.test.ts
@@ -327,7 +327,7 @@ describe('TxPanel v3 command-feedback wiring', () => {
       ]));
   });
 
-  it('fails each malformed or stale authority lane closed, then follows fresh truth', () => {
+  it('fails each malformed or genuinely-unresolved lane closed, keeps a stale lane available, then follows fresh truth', () => {
     render();
     openSettings();
     canonical.state = {
@@ -341,10 +341,15 @@ describe('TxPanel v3 command-feedback wiring', () => {
       },
     } as unknown as ServerState;
     flushSync();
-    for (const field of FIELDS) {
+    for (const field of ['micGain', 'compressorLevel', 'monitorGain'] as const) {
       expect(slider(field).getAttribute('aria-disabled')).toBe('true');
       expect(value(field)).toBe('—');
     }
+    // MOR-2425/R29: driveGain is stale, not malformed/unresolved — it stays
+    // available with its last observed value, unlike its three siblings.
+    expect(slider('driveGain').getAttribute('aria-disabled')).toBe('false');
+    expect(slider('driveGain').getAttribute('aria-valuenow')).toBe(String(VALUES.driveGain));
+    expect(value('driveGain')).toBe(`${Math.round(VALUES.driveGain / 2.55)}%`);
 
     canonical.state = {
       ...connectedState(), micGain: 41, driveGain: 81, compressorLevel: 121, monitorGain: 161,

--- a/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
@@ -693,7 +693,7 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
     expect(sendCommand).toHaveBeenCalledTimes(2);
   });
 
-  it('presents out-of-band truth and fails closed for stale or malformed truth', () => {
+  it('presents out-of-band truth, keeps a stale reading honest, and fails closed for malformed truth', () => {
     render();
     unmount(component!); component = null;
     useState(delayState(72, 11)); render();
@@ -701,13 +701,35 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
     expect(delayInput().value).toBe('72');
     expect(sendCommand).not.toHaveBeenCalled();
 
+    // R29: a stale-but-observed field no longer fails the control closed —
+    // `projectControlFeedback` presents the last value with phase 'idle',
+    // never a blanked 'unavailable' placeholder. `disabled` stays `true`
+    // here regardless: `CwKeyerSurface`'s own `usable(cw.breakInDelay)` gate
+    // reads `field.availability.operational` from the SEPARATE, unfixed
+    // `field-status.ts: getFieldAvailability` chokepoint (still 'stale' !==
+    // 'available' there) — a second doctrine site the census flagged and
+    // this PR defers (see PR body's field-status follow-up paragraph), not
+    // a regression introduced here.
     unmount(component!); component = null;
     useState(delayState(72, 12, { freshness: 'stale' })); render();
     expect(delayInput().disabled).toBe(true);
+    expect(delayInput().dataset.commandPhase).toBe('idle');
+    expect(delayInput().value).toBe('72');
+    expect(delayInput().hasAttribute('aria-valuenow')).toBe(true);
+    expect(delayInput().getAttribute('aria-valuenow')).toBe('72');
+    expect(delayInput().getAttribute('aria-valuetext')).toBe('Confirmed 72');
+    expect(el('breakInDelay-value')!.textContent).toContain('72');
+
+    // A REAL disconnect (`state === null`, `projectControlFeedback`'s own
+    // gate, orthogonal to freshness) still greys the control out from this
+    // stale-but-presented starting point.
+    unmount(component!); component = null;
+    h.state = null;
+    h.session = { state: 'disconnected', epoch: 2 };
+    render();
+    expect(delayInput().disabled).toBe(true);
     expect(delayInput().dataset.commandPhase).toBe('unavailable');
-    expect(delayInput().hasAttribute('aria-valuenow')).toBe(false);
-    expect(delayInput().getAttribute('aria-valuetext')).toBe('Break-in delay unavailable');
-    expect(el('breakInDelay-value')!.textContent).toContain('— unavailable');
+    h.session = { state: 'connected', epoch: 1 };
 
     unmount(component!); component = null;
     useState(delayState(256, 13)); render();

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -1174,10 +1174,16 @@ describe('the composed TX/VOX controls consume the real feedback lifecycle', () 
     pushRadioState(observed(1, 199, 'fresh'));
     pushSession({ state: 'connected', epoch: 7 });
     expect(input().dataset.commandPhase).toBe('awaiting-confirmation');
+    // R29: a stale readback no longer fails the control closed, even one
+    // that happens to match the requested target exactly — availability and
+    // confirmation are separate axes. `reconcileStateBackedCommands`
+    // (`commands.svelte.ts`) still requires `freshness === 'fresh'` before
+    // marking a command confirmed (untouched by this PR), so the lifecycle
+    // stays 'acknowledged' and the control stays in 'awaiting-confirmation'.
     pushRadioState(observed(2, 200, 'stale'));
     pushSession({ state: 'connected', epoch: 7 });
-    expect(input().dataset.commandPhase).toBe('unavailable');
-    expect(input().getAttribute('aria-disabled')).toBe('true');
+    expect(input().dataset.commandPhase).toBe('awaiting-confirmation');
+    expect(input().getAttribute('aria-disabled')).toBe('false');
     expect(getCommandLifecycles()[0]?.status).toBe('acknowledged');
     pushRadioState(observed(3, 200, 'fresh'));
     expect(getCommandLifecycles()[0]?.status).toBe('confirmed');

--- a/frontend/src/lib/runtime/adapters/__tests__/cw-level-command-feedback.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/cw-level-command-feedback.isolated.test.ts
@@ -101,13 +101,13 @@ describe('qualified global CW command feedback', () => {
     });
   });
 
-  it('qualifies pitch and speed independently from exact top-level current evidence', () => {
+  it('qualifies pitch and speed independently, keeping a stale-but-observed pitch available (MOR-2425/R29)', () => {
     h.state = state({ fieldStatus: {
       cwPitch: { ...fresh(), freshness: 'stale' }, keySpeed: fresh(),
     } });
     h.caps = caps();
     expect(getCwPitchControlFeedback(connected)).toMatchObject({
-      availability: 'unavailable', confirmed: null,
+      availability: 'available', confirmed: 640,
     });
     expect(getKeySpeedControlFeedback(connected)).toMatchObject({
       availability: 'available', confirmed: 27,

--- a/frontend/src/lib/runtime/adapters/__tests__/dsp-command-feedback.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/dsp-command-feedback.isolated.test.ts
@@ -169,11 +169,14 @@ describe('qualified raw DSP command feedback', () => {
     expect(getDspControlFeedback('nbLevel', connected)).toMatchObject({ target: 100, requestedTarget: 100 });
     expect(getDspControlFeedback('notchFilter', connected)).toMatchObject({ target: -100, confirmed: -80 });
 
+    // R29 (MOR-2425): a stale-but-observed nbLevel field stays available with
+    // its last confirmed value and its own in-flight lifecycle, independent
+    // of notchFilter's.
     h.state = state({
       fieldStatus: { ...state().fieldStatus, 'main.nbLevel': { ...fresh(), freshness: 'stale' } },
     });
     expect(getDspControlFeedback('nbLevel', connected)).toMatchObject({
-      phase: 'unavailable', confirmed: null, target: null, outcome: null,
+      phase: 'submitted', confirmed: 60, target: 100, outcome: null,
     });
     expect(getDspControlFeedback('notchFilter', connected)).toMatchObject({
       phase: 'submitted', confirmed: -80, target: -100,
@@ -224,7 +227,7 @@ describe('qualified raw DSP command feedback', () => {
     expect(getDspControlFeedback('notchFilter', connected).availability).toBe('available');
   });
 
-  it('fails closed for ambiguous and missing or stale transformed observations', () => {
+  it('fails closed for ambiguous or missing observations, but keeps a stale one available (MOR-2425/R29)', () => {
     h.state = state(); h.caps = caps(); h.indicatorCount = 2;
     expect(getDspControlFeedback('nrLevel', connected).availability).toBe('unavailable');
     h.indicatorCount = 1;
@@ -235,7 +238,9 @@ describe('qualified raw DSP command feedback', () => {
     h.state = state({
       fieldStatus: { ...state().fieldStatus, nbDepth: { ...fresh(), freshness: 'stale' } },
     });
-    expect(getDspControlFeedback('nbDepth', connected).availability).toBe('unavailable');
+    expect(getDspControlFeedback('nbDepth', connected)).toMatchObject({
+      availability: 'available', confirmed: VALUES.nbDepth,
+    });
   });
 
   it('drops old provider and session lifecycles after authority replacement', () => {

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -182,8 +182,6 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
   it.each([
     ['missing status', undefined],
     ['unobserved status', { observed: false, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 }],
-    ['stale status', { observed: true, freshness: 'stale', availability: 'available', lastObservedMonotonic: 5 }],
-    ['unavailable status', { observed: true, freshness: 'fresh', availability: 'stale', lastObservedMonotonic: 5 }],
     ['missing marker', { observed: true, freshness: 'fresh', availability: 'available' }],
     ['non-finite marker', { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: Number.NaN }],
   ])('makes the full projection unavailable from %s evidence', (_case, fieldStatus) => {
@@ -191,6 +189,21 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     lifecycle.commands = [command({ status: 'acknowledged', ackFieldObservationTimes: { 'main.filterWidth': 4 } })];
     expect(getFilterWidthCommandLifecycle()).toMatchObject({
       confirmed: null, target: null, phase: 'unavailable', busy: false, outcome: null,
+    });
+  });
+  it.each([
+    // R29 (MOR-2425): a field that is observed and carries a value stays
+    // available whichever of the two wire signals (`freshness`/`availability`)
+    // records the staleness — the server always sets them together
+    // (`_freshness_availability`, `src/rigplane/web/runtime_helpers.py`), but
+    // this predicate does not require them to agree to accept 'stale'.
+    ['stale status', { observed: true, freshness: 'stale', availability: 'available', lastObservedMonotonic: 5 }],
+    ['stale availability', { observed: true, freshness: 'fresh', availability: 'stale', lastObservedMonotonic: 5 }],
+  ])('keeps the full projection available with the last value from %s evidence', (_case, fieldStatus) => {
+    runtimeState.state = state({ main: { filterWidth: 3000 }, fieldStatus: { 'main.filterWidth': fieldStatus } });
+    lifecycle.commands = [command({ status: 'acknowledged', ackFieldObservationTimes: { 'main.filterWidth': 4 } })];
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({
+      confirmed: 3000, target: 3000, phase: 'acknowledged', busy: true, outcome: null,
     });
   });
   it('does not let a legacy record without an ACK field boundary confirm', () => {
@@ -667,9 +680,6 @@ describe('Break-in Delay ControlFeedback projection (MOR-1744)', () => {
     ['missing value', delayState({ breakInDelay: undefined })],
     ['non-integer value', delayState({ breakInDelay: 32.5 })],
     ['missing field status', delayState({ fieldStatus: {} })],
-    ['stale field', delayState({ fieldStatus: { breakInDelay: {
-      observed: true, freshness: 'stale', availability: 'available', lastObservedMonotonic: 5,
-    } } })],
     ['unavailable field', delayState({ fieldStatus: { breakInDelay: {
       observed: true, freshness: 'fresh', availability: 'unavailable', lastObservedMonotonic: 5,
     } } })],
@@ -678,6 +688,16 @@ describe('Break-in Delay ControlFeedback projection (MOR-1744)', () => {
     expect(getBreakInDelayControlFeedback()).toMatchObject({
       confirmed: null, target: null, phase: 'unavailable', busy: false,
       availability: 'unavailable',
+    });
+  });
+
+  it('keeps a stale-but-observed field available with its last value (MOR-2425/R29)', () => {
+    runtimeState.state = delayState({ fieldStatus: { breakInDelay: {
+      observed: true, freshness: 'stale', availability: 'available', lastObservedMonotonic: 5,
+    } } });
+    lifecycle.commands = [delayCommand()];
+    expect(getBreakInDelayControlFeedback()).toMatchObject({
+      confirmed: 32, target: 64, phase: 'submitted', busy: true, availability: 'available',
     });
   });
 

--- a/frontend/src/lib/runtime/adapters/__tests__/rf-sql-command-feedback.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/rf-sql-command-feedback.isolated.test.ts
@@ -166,7 +166,6 @@ describe('qualified RF/SQL command feedback', () => {
 
   it.each([
     ['negative leaf marker', { 'main.rfGain': fresh(-1), 'main.squelch': fresh() }],
-    ['stale present parent', { main: { ...fresh(), freshness: 'stale' as const }, 'main.rfGain': fresh(), 'main.squelch': fresh() }],
     ['missing present parent', { main: { ...fresh(), observed: false }, 'main.rfGain': fresh(), 'main.squelch': fresh() }],
   ])('masks RF when evidence has a %s', (_name, fieldStatus) => {
     h.state = state({ fieldStatus }); h.caps = caps();
@@ -175,6 +174,18 @@ describe('qualified RF/SQL command feedback', () => {
     expect(pair.sql.feedback).toMatchObject(_name === 'negative leaf marker'
       ? { availability: 'available', confirmed: 0.2 }
       : { availability: 'unavailable', confirmed: null });
+  });
+
+  it('keeps both lanes available through a stale present parent (MOR-2425/R29)', () => {
+    h.state = state({
+      fieldStatus: {
+        main: { ...fresh(), freshness: 'stale' as const }, 'main.rfGain': fresh(), 'main.squelch': fresh(),
+      },
+    });
+    h.caps = caps();
+    const pair = getRfSqlControlFeedback(connected)!;
+    expect(pair.rf.feedback).toMatchObject({ availability: 'available', confirmed: 0.5 });
+    expect(pair.sql.feedback).toMatchObject({ availability: 'available', confirmed: 0.2 });
   });
 
   it('preserves the accepted absent-ancestor skip', () => {

--- a/frontend/src/lib/runtime/adapters/__tests__/tx-aux-command-feedback.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/tx-aux-command-feedback.isolated.test.ts
@@ -193,7 +193,6 @@ describe('imperative qualified raw TX/VOX command feedback', () => {
 
   it.each([
     ['not observed', { ...fresh(), observed: false }, VALUES.micGain],
-    ['stale', { ...fresh(), freshness: 'stale' as const }, VALUES.micGain],
     ['unavailable', { ...fresh(), availability: 'unavailable' as const }, VALUES.micGain],
     ['missing marker', { ...fresh(), lastObservedMonotonic: undefined }, VALUES.micGain],
     ['fractional truth', fresh(), 120.5],
@@ -206,6 +205,16 @@ describe('imperative qualified raw TX/VOX command feedback', () => {
     expect(getTxAuxControlFeedback('micGain', connected)).toMatchObject({
       availability: 'unavailable', confirmed: null, target: null,
       requestedTarget: null, phase: 'unavailable', outcome: null,
+    });
+  });
+
+  it('keeps a stale-but-observed field available with its canonical truth (MOR-2425/R29)', () => {
+    h.state = state({
+      micGain: VALUES.micGain,
+      fieldStatus: { ...state().fieldStatus, micGain: { ...fresh(), freshness: 'stale' as const } },
+    });
+    expect(getTxAuxControlFeedback('micGain', connected)).toMatchObject({
+      availability: 'available', confirmed: VALUES.micGain, phase: 'idle',
     });
   });
 

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -54,6 +54,7 @@ import {
 import { currentControlSessionEpoch } from '../commands/radio-intents';
 import type { ServerState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
+import type { DisplayObservation } from '../../../semantic/radio-view-model';
 import { qualifyDisplayObservation, qualifyRadioDisplayObservation } from './display-observation';
 import {
   controlRangeFromCapsOrDefault, nbDepthRawToDisplay, projectNrLevel,
@@ -332,8 +333,15 @@ export function projectControlFeedback<T>(
   if (state === null) return empty('unavailable', null);
   const field = state.fieldStatus?.[descriptor.fieldPath(scope)];
   const confirmed = descriptor.confirmed(state, scope);
-  if (confirmed === null || field?.observed !== true || field.freshness !== 'fresh'
-    || field.availability !== 'available' || typeof field.lastObservedMonotonic !== 'number'
+  // R29(1): a field that has been observed and carries a value stays
+  // available even once it goes stale — only a field the server has never
+  // resolved (`availability: 'missing'`, or any other non-evidentiary
+  // value) gates the control unavailable. Freshness alone is deliberately
+  // not consulted here: `availability` already folds it in 1:1 on the wire
+  // (`_freshness_availability`, `src/rigplane/web/runtime_helpers.py`).
+  if (confirmed === null || field?.observed !== true
+    || (field.availability !== 'available' && field.availability !== 'stale')
+    || typeof field.lastObservedMonotonic !== 'number'
     || !Number.isFinite(field.lastObservedMonotonic)) return empty('unavailable', null);
 
   let latest: CommandLifecycle | null = null;
@@ -401,6 +409,20 @@ export function getFilterWidthControlFeedback(): Readonly<ControlFeedback<number
 type GlobalCwControl = 'cw-pitch' | 'keyer-speed';
 type GlobalCwField = 'cwPitch' | 'keySpeed';
 
+/**
+ * R29(1): a `'stale'` `DisplayObservation` still carries a real last-observed
+ * value (`display-observation.ts: qualifyEvidence`) — only `'unknown'`/
+ * `'unsupported'` mean the field was never resolved. Used by every accessor
+ * below that qualifies a `DisplayObservation` before trusting
+ * `projectControlFeedback`'s result. A type predicate (not a plain boolean
+ * over `.state`) so callers keep type-narrowed access to `.value`.
+ */
+function hasUsableObservation<T extends number | string | boolean>(
+  observation: DisplayObservation<T>,
+): observation is Extract<DisplayObservation<T>, { state: 'current' | 'stale' }> {
+  return observation.state === 'current' || observation.state === 'stale';
+}
+
 function unavailableControlFeedback(
   feedback: Readonly<ControlFeedback<number>>,
 ): Readonly<ControlFeedback<number>> {
@@ -435,7 +457,7 @@ function getGlobalCwControlFeedback(
       value: state?.[field],
     });
     return session.state === 'connected' && epoch >= 0
-      && observation.state === 'current' && Number.isSafeInteger(observation.value)
+      && hasUsableObservation(observation) && Number.isSafeInteger(observation.value)
       ? feedback : unavailableControlFeedback(feedback);
   } catch {
     return unavailableControlFeedback(feedback);
@@ -495,7 +517,7 @@ export function getTxAuxControlFeedback(
       state, caps, path: field, structural, value: state?.[field],
     });
     return session.state === 'connected' && epoch >= 0
-      && observation.state === 'current' && Number.isSafeInteger(observation.value)
+      && hasUsableObservation(observation) && Number.isSafeInteger(observation.value)
       ? feedback : unavailableControlFeedback(feedback);
   } catch {
     return unavailableControlFeedback(feedback);
@@ -552,7 +574,7 @@ export function getDspControlFeedback(
         state, caps, path: field, structural: caps?.controls?.nb_depth != null,
         value: state?.[field],
       });
-      return observation.state === 'current' && Number.isSafeInteger(observation.value)
+      return hasUsableObservation(observation) && Number.isSafeInteger(observation.value)
         ? feedback : unavailableControlFeedback(feedback);
     }
     const receiverId = activeReceiver;
@@ -564,7 +586,7 @@ export function getDspControlFeedback(
       structural: tags.includes(DSP_FEEDBACK_CAPABILITIES[field]),
       value: receiverState?.[field],
     });
-    return observation.state === 'current' && Number.isSafeInteger(observation.value)
+    return hasUsableObservation(observation) && Number.isSafeInteger(observation.value)
       ? feedback : unavailableControlFeedback(feedback);
   } catch {
     return unavailableControlFeedback(feedback);
@@ -661,7 +683,7 @@ export function getRfSqlControlFeedback(
       state, caps, receiver, path: `${base}.${leaf}`, structural,
       value: receiverState?.[leaf],
     });
-    const qualified = observation.state === 'current' ? feedback : Object.freeze({
+    const qualified = hasUsableObservation(observation) ? feedback : Object.freeze({
       ...feedback,
       confirmed: null, target: null, requestedTarget: null,
       phase: 'unavailable' as const, busy: false, availability: 'unavailable' as const,


### PR DESCRIPTION
1 code + 9 test files = 10 files

Hard ceiling (10 files/1000 lines): 10 files, 184 changed lines — at the file ceiling, not over it. One unit of work across two rounds: a single predicate change (`projectControlFeedback`'s field-level gate) plus every call path that wraps it, and the test files pinning each of those call paths at two layers — the isolated per-accessor unit tests (round 1) and the v3 semantic-surface wiring tests that exercise the identical call paths through the composed `SemanticRadioSurfaces` tree (round 2, added because round 1's grep — scoped to import names — could not see them; see Witnesses below). Splitting the doctrine change from any of its test flips would leave part of the suite red on its own.

## Summary

Owner ruling R29 (2026-09-07): `availability: 'unavailable'` / a disabled control only when runtime state is null, session not connected, epoch < 0, structural absence (capability/field unsupported), or the value is genuinely unknown (never observed / no value). A field whose `freshness === 'stale'` but which HAS a last observed value is AVAILABLE with that value. Staleness stays visible as data (`freshness`/`DisplayObservation.state: 'stale'`) so a renderer MAY mark it — no visual mark is added in this PR. Availability and confirmation are separate axes: this PR only widens `projectControlFeedback`'s AVAILABILITY gate; `commands.svelte.ts: reconcileStateBackedCommands`'s own, untouched `field.freshness !== 'fresh'` gate still requires a FRESH exact match before marking a pending command CONFIRMED, so a stale echo that happens to equal the requested target keeps a command `'awaiting-confirmation'`, never `'confirmed'` (verified by mutation (i) below).

`projectControlFeedback` (`frontend/src/lib/runtime/adapters/panel-adapters.ts`) no longer requires `field.freshness === 'fresh'`, and widens its `field.availability` check from `!== 'available'` to accept `'stale'` too — a field is now gated unavailable only when `observed !== true`, `confirmed === null`, availability is neither `'available'` nor `'stale'`, or `lastObservedMonotonic` is missing/non-finite. The four `qualifyDisplayObservation`/`qualifyRadioDisplayObservation`-wrapped accessors (`getGlobalCwControlFeedback` → CW pitch/speed, `getTxAuxControlFeedback`, `getDspControlFeedback` ×2 branches, `getRfSqlControlFeedback`) accept `DisplayObservation.state === 'stale'` alongside `'current'` via a new type-predicate helper `hasUsableObservation` (a plain boolean-over-`.state` broke `.value` narrowing under `svelte-check --tsconfig ./tsconfig.app.json`, which is why this is a predicate over the whole observation, not its `.state` field). Session/epoch/capability/disconnect terms are untouched.

**Deviation from the census's exact enumeration, reported (sweep, same mechanism):** the census's `filter-width-command-lifecycle.isolated.test.ts:189` list named only the `'stale status'` row (`freshness:'stale', availability:'available'`) as needing to flip. Reading `src/rigplane/web/runtime_helpers.py: _freshness_availability` shows the server derives `availability` from `freshness` 1:1 (`FRESH→available`, `STALE→stale`, `UNKNOWN→missing`) — there is no wire state where `freshness` and `availability` disagree. The row's own sibling, `'unavailable status'` (`freshness:'fresh', availability:'stale'`), used the literal `'stale'` as its "not available" probe value for the availability clause specifically — a choice that made sense under the old doctrine (`'stale'` was "not available") but is now legitimate too, since `FieldAvailability` only has three members and `'missing'` was already the probe for the sibling "unobserved" rows. I flipped this row too (renamed `'stale status'`/`'stale availability'`) since leaving it in the "stays unavailable" bucket would pin the OLD doctrine for a value that is now, correctly, available. Filed as a deviation here rather than silently absorbed.

## Item 3 (field-status.ts / radio-view-model-adapter.ts) — NOT done, deferred

Item 3 asked to fix `field-status.ts: getFieldAvailability` (the second chokepoint the census identified, feeding mode/filter dropdowns and PBT/IF-shift sliders via `radio-view-model-adapter.ts: deriveModeFilter`/`deriveFilterPassband`). I implemented it (a narrowly-scoped new accessor `isFieldAvailableOrStale`, wired only into those two named `derive*` functions, leaving the shared `getFieldAvailability`/`isFieldAvailable`/`topFieldAvailable`/`strictFieldAvailable` untouched for every other caller) and it worked — `npm run check`/eslint/the flipped tests all passed. But `topFieldAvailable`/`strictFieldAvailable` turned out to have 76 call sites across `radio-view-model-adapter.ts`, not the ~5 the census named, and rewiring even just `deriveModeFilter` necessarily flips `cw-keyer-adapter.test.ts`'s `deriveCwKeyerReasons`-driven mutex pin (it reads `deriveModeFilter`'s own output downstream). Implementing item 3 at all — field-status.ts + radio-view-model-adapter.ts + cw-keyer-adapter.test.ts — is 3 more files on top of this PR's base, well past the hard ceiling. I reverted item 3 in full (`git checkout -- frontend/src/lib/state/field-status.ts frontend/src/lib/state/__tests__/field-status.test.ts frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts frontend/src/lib/runtime/adapters/__tests__/cw-keyer-adapter.test.ts`) rather than self-grant the hard-ceiling exception, which CLAUDE.md reserves to the owner or a delegated coordinator. Recommend a follow-up PR for item 3 alone, using the `isFieldAvailableOrStale`-scoped-to-two-functions approach already proven to work here (not committed).

This deferral is why round 2's two new pins show a genuinely mixed state, not a bug: `CwKeyerSurface`'s `breakInDelay` control still renders `disabled` for a stale reading, because `usable(cw.breakInDelay)` reads `field.availability.operational` from the SAME deferred `field-status.ts` chokepoint — a second, independent gate this PR does not touch. See Witnesses below.

## Witnesses + mutations (verbatim)

**Weakest witness (round 1)**: `frontend/src/components-v2/panels/__tests__/CwPanel.feedback-wiring.component.svelte.test.ts`, new test `'keeps a stale-but-observed CW Pitch available with its last value, then greys out on disconnect (MOR-2425/R29)'`. Mounts the real `CwPanel.svelte` against the real `getCwPitchControlFeedback`; session connected, `cwPitch` field goes `freshness:'stale'` with `lastObservedMonotonic` set and value `600` unchanged: asserts `aria-disabled === 'false'`, `aria-valuenow === '600'`, the displayed value is exactly `'600 Hz'` (not a placeholder), then dispatches an `ArrowRight` keydown and asserts `onCwPitchChange` was called exactly once with `605`. Then disconnects the session ALONE (state/caps left populated, isolating the session term from `projectControlFeedback`'s own independent `state === null` gate) and asserts `aria-disabled === 'true'`.

**Round 2 — the two flipped v3 wiring pins (quick run 34157201187 on head `73033306` red, both still pinning the pre-R29 doctrine):**
- `frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts` — `'presents out-of-band truth, keeps a stale reading honest, and fails closed for malformed truth'` (break-in delay via `getBreakInDelayControlFeedback`, mounted inside the real `SemanticRadioSurfaces` → `CwKeyerSurface` tree). A stale-but-observed field now presents `phase: 'idle'`, value `'72'`, `aria-valuenow: '72'`, `aria-valuetext: 'Confirmed 72'` — never the old blanked `'unavailable'` placeholder. `disabled` stays `true` for this specific control, per the item-3 deferral above (a real, pre-existing gap, not introduced here). Added a disconnect leg (`runtime.state = null`) proving the control still fails closed independent of freshness, matching the standard the CwPanel/TxPanel witnesses set. The malformed-truth row (out-of-domain value `256`) is unchanged: still fails closed.
- `frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts` — `'keeps ACK pending through unrelated, mismatched and stale readback, then confirms fresh exact truth'` (mic gain via `getTxAuxControlFeedback`). An acknowledged command now stays `'awaiting-confirmation'` (not `'unavailable'`) through a stale exact-match readback, `aria-disabled` flips to `'false'`, and — this is the confirmation-collapse check — the command lifecycle itself stays `'acknowledged'` (not `'confirmed'`), proving `reconcileStateBackedCommands`'s own freshness gate, not `projectControlFeedback`, decides confirmation. A sibling test in the same file (`'fails closed and recovers in place across provider and session replacement'`) already covers this control's disconnect leg.

Round 1 mutations run, each restored byte-identically before the next (confirmed via `git diff` after each restore):
- **(a) Restore the freshness term** — reinserted `field.freshness !== 'fresh'` into `projectControlFeedback`'s OR-chain (alongside the new availability term, not replacing it). Result: killed the witness's stale-available assertion AND every flipped isolated pin (`cw-level-command-feedback`, `dsp-command-feedback` ×2, `tx-aux-command-feedback`, `filter-width-command-lifecycle`'s `'stale status'` row, `CwPanel`/`TxPanel` witnesses) — 8 failures. Did NOT kill `filter-width`'s `'stale availability'` row (`freshness:'fresh'`), correctly, since that row tests the availability term, not freshness. Restored; `git diff` clean.
- **(c) Drop the disconnect term** — removed `session.state === 'connected' &&` from `getGlobalCwControlFeedback`'s return. Result: killed `cw-level-command-feedback.isolated.test.ts`'s `'disconnected'` authority-matrix row immediately. Did NOT kill the witness's own disconnect assertion on the FIRST attempt, because the witness originally nulled `canonical.state` at the same time as disconnecting the session — `projectControlFeedback`'s independent `state === null` check papered over the dropped term. Fixed the witness to disconnect the session alone (state/caps left populated); re-ran the mutation and it now correctly kills the witness's disconnect assertion too. Restored; `git diff` clean.
- **(b) Make `getFieldAvailability` return `'stale'` again** — not applicable: item 3 (the only code this mutation targets) is deferred, not shipped in this PR (see above).

Round 2 mutations run (mandatory per the test-fix dispatch), each restored byte-identically (`git diff` clean after — confirmed no leftover mutation in either `panel-adapters.ts` or `commands.svelte.ts`):
- **(i) Let a stale exact echo confirm** — dropped `field.freshness !== 'fresh'` from `commands.svelte.ts: reconcileStateBackedCommands`'s own gate (the confirmation side, not `projectControlFeedback`). Result: killed the TX-aux pending pin — `dataset.commandPhase` became `'confirmed'` instead of the required `'awaiting-confirmation'` on the stale-but-matching readback. This is the confirmation-collapse mutation the dispatch required; it confirms confirmation and availability are independently guarded.
- **(ii) Restore the freshness term in `panel-adapters.ts: projectControlFeedback`'s availability gate** — reinserted `field.freshness !== 'fresh'`. Result: killed BOTH the CW-keyer stale pin (`dataset.commandPhase` became `'unavailable'` instead of `'idle'`) and the mounted `CwPanel.feedback-wiring` witness's stale-available assertion (`aria-disabled` became `'true'` instead of `'false'`).

**Sweep performed (round 2, per dispatch, two passes):**
1. Every `*.component.test.ts`/`*.svelte.test.ts` matching `'stale'` (22 files, loose pattern; includes the 2 round-1 witnesses and the 2 round-2 flips already covered above). Of the other 18: 6 (`MobileRadioLayout`, `semantic-lcd-display-frame-wiring`, `SpectrumPanel`, `rx-tx-surface`, `state-vocabulary`, `tx-meter-telemetry`) don't actually co-occur `'stale'` with an availability/freshness-shaped assertion — the match is incidental. 3 (`CenterstageDisplay`, `DominantUnifiedDisplay`, `LcdRfPanadapter`) use `freshness:'stale'` on an audio/hardware scope-frame fixture, a different domain (frame recency, not `ServerState.fieldStatus`) — confirmed by inspection; `LcdRfPanadapter` additionally re-run standalone (23/23 pass). The remaining 9 — `DspPanel.nr-level`, `semantic-antenna-wiring`, `semantic-discrete-pending-wiring`, `semantic-meters-wiring`, `semantic-pbt-continuity`, `semantic-ritxit-scan-wiring`, `semantic-scope-controls-wiring`, `semantic-scope-projection`, `semantic-vfo-indicator-wiring` — genuinely gate on stale field-availability, and were run together (221 tests, all pass) unmodified: each routes through the deferred `field-status.ts: getFieldAvailability` chokepoint (item 3, above), so none needed to flip.
2. The verifier's broader `*.test.ts` variant, `grep -rln "freshness: 'stale'" frontend/src --include="*.test.ts" | xargs grep -ln "unavailable\|aria-disabled"` — 20 files at this head (the literal-string form misses `semantic-tx-aux-wiring.component.test.ts` itself, which passes `freshness` as a shorthand property from a parameterized fixture rather than the literal text `freshness: 'stale'` — direct evidence of the same import/text-scoping limitation the verifier flagged, now on a string literal instead of an import name). Of the 20: 5 are round-1's already-flipped isolated files, 2 are round-1's mounted witnesses, 1 (`semantic-cw-keyer-wiring`) is the other round-2 flip, 1 (`field-status.test.ts`) is the documented item-3 deferral, and 4 (`semantic-antenna-wiring`, `semantic-discrete-pending-wiring`, `semantic-ritxit-scan-wiring`, `semantic-vfo-indicator-wiring`) are already covered by pass 1 above. The remaining 7 — `band-adapter.test.ts`, `cw-keyer-adapter.test.ts`, `filter-passband-adapter.isolated.test.ts`, `radio-view-model-adapter.test.ts`, `memory-command-authority.isolated.test.ts`, `panel-commands.intent.isolated.test.ts`, `LcdRfPanadapter.component.test.ts` — were run together (447 tests, all pass) unmodified, confirming none regressed. I did not trace each one's exact gating mechanism to confirm it is field-status.ts's chokepoint specifically (three of the seven — `filter-passband-adapter`, `memory-command-authority`, `panel-commands.intent` — do reference `topFieldAvailable`/`isFieldAvailable`/`strictFieldAvailable` by name; `band-adapter`, `cw-keyer-adapter`, `radio-view-model-adapter` do not reference those names directly in the test file, so their reason for staying green is not established here); `LcdRfPanadapter`'s `'unavailable'` match is an unrelated assertion (receiver-identity, not the file's `freshness:'stale'` hardware-frame fixture).

No file in either pass needed to flip beyond the two already flipped, so no 11th file was required.

## Census (from `availability-doctrine-lane-census-20260907.md` §A, this PR's coverage)

| Pin | Outcome |
|---|---|
| `cw-level-command-feedback.isolated.test.ts` (pitch/speed independent) | Flipped — available |
| `tx-aux-command-feedback.isolated.test.ts` (`'stale'` row) | Moved out of the `it.each` "rejects" block into its own flipped test |
| `dsp-command-feedback.isolated.test.ts` ×2 (`nbLevel` lifecycle-independence, `nbDepth` ambiguous/stale) | Both flipped — available |
| `rf-sql-command-feedback.isolated.test.ts` (`'stale present parent'`) | Moved out of the `it.each` "masks RF" block into its own flipped test — both lanes available |
| `filter-width-command-lifecycle.isolated.test.ts` (width `'stale status'` + `'stale availability'`, break-in-delay `'stale field'`) | All three flipped — `'stale availability'` is the reported deviation above |
| `semantic-cw-keyer-wiring.component.test.ts` (break-in delay, `'presents out-of-band truth...'`) | **Round 2** — flipped; phase/value now honest for stale, `disabled` correctly stays `true` (item-3 chokepoint, not this PR) |
| `semantic-tx-aux-wiring.component.test.ts` (mic gain, `'keeps ACK pending...'`) | **Round 2** — flipped; stale readback no longer forces `'unavailable'`; confirmation still independently gated |
| `field-status.test.ts` (`getFieldAvailability`'s own/inherited stale entries) | **Not touched** — item 3 deferred |
| Disconnect/structural pins (all authority/capability `it.each` blocks, both rounds) | Untouched, green |
| `semantic-vfo-indicator-wiring.component.test.ts` (VfoPanel `frequencyState !== 'current'`) | Out of scope (task item 6), untouched; confirmed still green |

## Verification

- `npx vitest run` on the four target files (`CwPanel.feedback-wiring`, `TxPanel.feedback-wiring`, `semantic-cw-keyer-wiring`, `semantic-tx-aux-wiring`): 140/140 pass.
- Grep union `field-status|panel-adapters|display-observation|ControlFeedback` across `frontend/src --include="*.test.ts"`: 87 files, 2411/2411 pass (round 1 was 85/2300; the two new comments referencing `field-status.ts`/`reconcileStateBackedCommands` in the round-2 test files add 2 files to this grep's match set).
- `npm run check` (svelte-check + both tsc project configs): 4833 files, 0 errors, 0 warnings.
- `npx eslint` on all 10 changed files: clean.
- `git diff --check`: clean (no whitespace errors).
- `node frontend/fixtures/capture.mjs`: 65/65 captures pass, 0 invalid, including `connection-loss-stale--reference--desktop`; no baseline drift.
- Public-boundary self-check: no telemetry, no Pro-boundary crossing, no `local-extensions/` touched.

## Follow-ups (not touched, reported per task item 6 and item 3 above)

- Item 3: `field-status.ts: getFieldAvailability`/`isFieldAvailable` and their `radio-view-model-adapter.ts: deriveModeFilter`/`deriveFilterPassband` consumers (mode/filter dropdowns, PBT/IF-shift sliders, and `CwKeyerSurface`'s `usable()`-gated break-in delay `disabled` state) — deferred, see above; recommend the scoped `isFieldAvailableOrStale` approach already validated here (not committed).
- `VfoPanel.svelte`'s `frequencyState !== 'current'` tuning gate — out of scope (task item 6).
- `pbt-presentation-continuity.ts: retainedField` setting `operational:false` — out of scope (task item 6); this is also why fixing item 3's PBT/IF-shift leaves alone would not fully change `FilterSurface.svelte`'s rendered behavior without this second, separately out-of-scope mechanism.
- The bad-link chip — separate PR in flight (task item 6).

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
