### PR TITLE
feat(MOR-2425): keep stale fields available in the shared field-status primitive

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -24,7 +24,8 @@
   const vfoContext = bindVfoTunerContext();
 
   // MOR-429: gate per-receiver indicators on fieldStatus availability so an
-  // unobserved/stale/default value is never presented as a confirmed reading.
+  // unobserved/default value is never presented as a confirmed reading (a stale
+  // observed value stays available — owner ruling R29, 2026-09-07).
   // The cockpit's VFO A strip always renders MAIN, VFO B always SUB, so each
   // token gates on its own receiver path (e.g. `main.agc` / `sub.agc`).
   function rxAvailable(rxKey: 'main' | 'sub', field: string): boolean {
@@ -204,7 +205,7 @@
   // Per-receiver token builder — gates every indicator on fieldStatus
   // availability (MOR-429). Unavailable fields are suppressed entirely rather
   // than shown as confirmed defaults; AGC in particular no longer emits
-  // `active: true` when `${rxKey}.agc` is missing/stale.
+  // `active: true` when `${rxKey}.agc` is missing.
   function vfoTokens(rxKey: 'main' | 'sub'): IndToken[] {
     const rxState = radioState?.[rxKey];
     return [

--- a/frontend/src/components-v2/panels/lcd/AmberScope.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberScope.svelte
@@ -78,7 +78,8 @@
   let activeRxKey = $derived<'main' | 'sub'>(radioState?.active === 'SUB' ? 'sub' : 'main');
 
   // MOR-429: gate active-receiver indicators on fieldStatus availability so an
-  // unobserved/stale/default value is never presented as a confirmed reading.
+  // unobserved/default value is never presented as a confirmed reading (a stale
+  // observed value stays available — owner ruling R29, 2026-09-07).
   function rxAvailable(field: string): boolean {
     return isFieldAvailable(radioState, `${activeRxKey}.${field}`);
   }

--- a/frontend/src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts
@@ -244,7 +244,7 @@ describe('Amber TX and inline RIT availability (MOR-1586 review)', () => {
     ['RIT', 'ritOn', false, true, 'RIT', [mountCockpit, mountScope]],
   ] as const;
 
-  it.each(tokenCases)('%s distinguishes fresh off/on from missing/stale', (
+  it.each(tokenCases)('%s distinguishes fresh off/on from missing, and presents its last state when stale (R29)', (
     _name, field, offValue, onValue, label, mounts,
   ) => {
     for (const mountPanel of mounts) {
@@ -257,28 +257,37 @@ describe('Amber TX and inline RIT availability (MOR-1586 review)', () => {
       expect(on).toBeDefined();
       expect(on?.classList.contains('active')).toBe(true);
       expect(indicator(mountPanel(stateFor(field, onValue, missing)), label)).toBeUndefined();
-      expect(indicator(mountPanel(stateFor(field, onValue, stale)), label)).toBeUndefined();
+
+      const staleOn = indicator(mountPanel(stateFor(field, onValue, stale)), label);
+      expect(staleOn).toBeDefined();
+      expect(staleOn?.classList.contains('active')).toBe(true);
     }
   });
 
-  it('distinguishes ATU from TUNE and never fabricates a PROC level', () => {
+  it('distinguishes ATU from TUNE and never fabricates a PROC level for a missing reading; a stale one keeps its last level (R29)', () => {
     const tuning = indicator(mountCockpit(stateFor('tunerStatus', 2, fresh)), 'TUNE');
     expect(tuning?.classList.contains('active')).toBe(true);
-    for (const status of [missing, stale]) {
-      expect(indicator(mountCockpit(stateFor('tunerStatus', 2, status)), 'TUNE')).toBeUndefined();
-      expect(indicator(mountCockpit(stateFor('compressorLevel', 7, status)), 'PROC')).toBeDefined();
-      expect(indicator(mountScope(stateFor('compressorLevel', 7, status)), 'PROC')).toBeDefined();
-      expect(indicator(mountCockpit(stateFor('compressorLevel', 7, status)), 'PROC 7')).toBeUndefined();
-      expect(indicator(mountScope(stateFor('compressorLevel', 7, status)), 'PROC 7')).toBeUndefined();
-    }
+
+    expect(indicator(mountCockpit(stateFor('tunerStatus', 2, missing)), 'TUNE')).toBeUndefined();
+    expect(indicator(mountCockpit(stateFor('compressorLevel', 7, missing)), 'PROC')).toBeDefined();
+    expect(indicator(mountScope(stateFor('compressorLevel', 7, missing)), 'PROC')).toBeDefined();
+    expect(indicator(mountCockpit(stateFor('compressorLevel', 7, missing)), 'PROC 7')).toBeUndefined();
+    expect(indicator(mountScope(stateFor('compressorLevel', 7, missing)), 'PROC 7')).toBeUndefined();
+
+    const staleTuning = indicator(mountCockpit(stateFor('tunerStatus', 2, stale)), 'TUNE');
+    expect(staleTuning?.classList.contains('active')).toBe(true);
+    expect(indicator(mountCockpit(stateFor('compressorLevel', 7, stale)), 'PROC')).toBeUndefined();
+    expect(indicator(mountScope(stateFor('compressorLevel', 7, stale)), 'PROC')).toBeUndefined();
+    expect(indicator(mountCockpit(stateFor('compressorLevel', 7, stale)), 'PROC 7')).toBeDefined();
+    expect(indicator(mountScope(stateFor('compressorLevel', 7, stale)), 'PROC 7')).toBeDefined();
   });
 
-  it('shows inline XIT only for fresh XIT-on and hides missing/stale XIT', () => {
+  it('shows inline XIT for fresh or stale XIT-on (R29) and hides only a missing XIT', () => {
     for (const status of [fresh, missing, stale]) {
       const state = stateFor('ritTx', true, status) as any;
       state.ritOn = false;
       const label = mountCockpit(state).querySelector('.rit-label')?.textContent;
-      expect(label).toBe(status === fresh ? 'XIT' : undefined);
+      expect(label).toBe(status === missing ? undefined : 'XIT');
     }
   });
 
@@ -290,12 +299,12 @@ describe('Amber TX and inline RIT availability (MOR-1586 review)', () => {
     expect(mountCockpit(state).querySelector('.rit-label')).toBeNull();
   });
 
-  it('does not let stale RIT steal inline XIT label priority', () => {
+  it('gives a stale-but-observed RIT-on the same label priority as a fresh one (R29)', () => {
     const state = stateFor('ritTx', true, fresh) as any;
     state.ritOn = true;
     state.fieldStatus.ritOn = stale;
 
-    expect(mountCockpit(state).querySelector('.rit-label')?.textContent).toBe('XIT');
+    expect(mountCockpit(state).querySelector('.rit-label')?.textContent).toBe('RIT');
   });
 });
 

--- a/frontend/src/components-v2/panels/lcd/__tests__/lcd-availability.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/lcd-availability.isolated.test.ts
@@ -185,7 +185,7 @@ describe('AmberScope availability gating (MOR-429)', () => {
     expect(agcChip(target)).toBeUndefined();
   });
 
-  it('suppresses the AGC indicator when agc is stale', () => {
+  it('presents the AGC indicator with its last value when agc is stale (R29)', () => {
     const state = {
       active: 'MAIN',
       main: baseReceiver(),
@@ -201,6 +201,8 @@ describe('AmberScope availability gating (MOR-429)', () => {
     } as unknown as ServerState;
 
     const target = mountScope(state);
-    expect(agcChip(target)).toBeUndefined();
+    const chip = agcChip(target);
+    expect(chip).toBeDefined();
+    expect(chip?.classList.contains('active')).toBe(true);
   });
 });

--- a/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
@@ -703,16 +703,16 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
 
     // R29: a stale-but-observed field no longer fails the control closed —
     // `projectControlFeedback` presents the last value with phase 'idle',
-    // never a blanked 'unavailable' placeholder. `disabled` stays `true`
-    // here regardless: `CwKeyerSurface`'s own `usable(cw.breakInDelay)` gate
-    // reads `field.availability.operational` from the SEPARATE, unfixed
-    // `field-status.ts: getFieldAvailability` chokepoint (still 'stale' !==
-    // 'available' there) — a second doctrine site the census flagged and
-    // this PR defers (see PR body's field-status follow-up paragraph), not
-    // a regression introduced here.
+    // never a blanked 'unavailable' placeholder. `disabled` now flips to
+    // `false` too: MOR-2425's follow-up PR fixes `field-status.ts:
+    // getFieldAvailability`, the second doctrine site #3357 (the commit that
+    // wrote this test) named and deliberately deferred — `CwKeyerSurface`'s
+    // `usable(cw.breakInDelay)` gate reads THAT primitive, confirmed by the
+    // flipped `STALE_FIELDS` row for `breakInDelay` in
+    // `cw-keyer-adapter.test.ts`.
     unmount(component!); component = null;
     useState(delayState(72, 12, { freshness: 'stale' })); render();
-    expect(delayInput().disabled).toBe(true);
+    expect(delayInput().disabled).toBe(false);
     expect(delayInput().dataset.commandPhase).toBe('idle');
     expect(delayInput().value).toBe('72');
     expect(delayInput().hasAttribute('aria-valuenow')).toBe(true);

--- a/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
@@ -499,7 +499,7 @@ describe('MOR-2425: RESUME buttons reach the real command bus (replacing the cyc
   // required a KNOWN reading to compute its next value): none of the four
   // explicit buttons reads `scanResumeMode.reading` at all, so all four must
   // still reach the wire even when the radio has never reported it.
-  it('fires even while scanResumeMode is unobserved (stale/unavailable, not merely absent)', () => {
+  it('fires and shows its last value while scanResumeMode is stale-but-observed (MOR-2425/R29)', () => {
     const state = liveState();
     useState({
       ...state,
@@ -509,7 +509,9 @@ describe('MOR-2425: RESUME buttons reach the real command bus (replacing the cyc
       },
     } as ServerState);
     render();
-    expect(el('scan-resume-value')!.textContent?.trim()).toBe('—');
+    // A stale-but-observed reading still carries its last value (R29) —
+    // `liveState()`'s raw `scanResumeMode` is 1.
+    expect(el('scan-resume-value')!.textContent?.trim()).toBe('1');
     el('scan-resume-0xd1')!.click();
     flushSync();
     expect(sendCommand).toHaveBeenCalledExactlyOnceWith('scan_set_resume', { mode: 0xD1 });

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
@@ -677,13 +677,16 @@ describe('SDR hosted semantic scope controls (MOR-2358)', () => {
     if (mode === null) expect((el('scope-mode-0') as HTMLButtonElement).disabled).toBe(true);
   });
 
-  it.each(['stale', 'unobserved'] as const)('keeps a supported %s leaf disabled and rejects a synthetic click', (status) => {
+  it.each(['stale', 'unobserved'] as const)('keeps a supported %s leaf disabled only when unobserved (R29); a stale click dispatches its last value, an unobserved one is rejected', (status) => {
     const source = liveState();
     source.fieldStatus!['scopeControls.hold'] = { ...fresh, observed: status !== 'unobserved', freshness: status === 'stale' ? 'stale' : 'unknown', availability: status === 'stale' ? 'stale' : 'missing' };
     useState(source); hosted();
     const hold = el('scope-hold') as HTMLButtonElement;
-    expect(hold.closest('[data-testid="scope-toolbar-host"]')).not.toBeNull(); expect(hold.disabled).toBe(true);
-    hold.dispatchEvent(new MouseEvent('click', { bubbles: true })); flushSync(); expect(sendCommand).not.toHaveBeenCalled();
+    expect(hold.closest('[data-testid="scope-toolbar-host"]')).not.toBeNull();
+    expect(hold.disabled).toBe(status === 'unobserved');
+    hold.dispatchEvent(new MouseEvent('click', { bubbles: true })); flushSync();
+    if (status === 'unobserved') expect(sendCommand).not.toHaveBeenCalled();
+    else expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_scope_hold', { on: true });
   });
 
   it('removes unsupported receiver leaves while keeping the supported surface hosted', () => {

--- a/frontend/src/lib/runtime/adapters/__tests__/band-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/band-adapter.test.ts
@@ -273,11 +273,6 @@ describe('currentBandTx fails closed (MOR-1294)', () => {
       hfCaps,
     ],
     [
-      'the frequency reading is stale',
-      () => bareState({ fieldStatus: { ...bareState().fieldStatus, 'main.freqHz': stale } }),
-      hfCaps,
-    ],
-    [
       'the frequency lies outside every band of the plan',
       () => bareState({ main: { ...bareState().main, freqHz: 9000000 } }),
       hfCaps,
@@ -323,13 +318,18 @@ describe('currentBandTx fails closed (MOR-1294)', () => {
     expect(view.band!.currentBandTx).toBe('denied');
   });
 
-  it('degrades a stale frequency to an unknown band while keeping structural availability true', () => {
+  // MOR-2425/R29: a stale-but-observed frequency still carries its last
+  // value and is `available`, so this row moved out of CLOSED_CASES above —
+  // it now permits TX at that last-known, in-band frequency, same as the
+  // fresh case at the top of this describe block.
+  it('allows the current band and its TX permit from a stale-but-observed frequency', () => {
     const view = model(bareState({
       fieldStatus: { ...bareState().fieldStatus, 'main.freqHz': stale },
     }), hfCaps);
     expect(view.band!.currentBand).toEqual({
-      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+      reading: { status: 'known', value: '20m' }, availability: { structural: true, operational: true },
     });
+    expect(view.band!.currentBandTx).toBe('allowed');
   });
 
   it('degrades a malformed raw frequency (wrong JS type) to unknown rather than coercing', () => {

--- a/frontend/src/lib/runtime/adapters/__tests__/cw-keyer-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/cw-keyer-adapter.test.ts
@@ -186,22 +186,26 @@ describe('cwKeyer per-field derivation (MOR-1296)', () => {
     expect(cw.apf.availability.operational).toBe(true);
   });
 
+  // MOR-2425/R29: a stale-but-observed field carries its last decoded value
+  // and is `available`, not degraded to unknown — the fourth column is that
+  // decoded view value (`breakIn` decodes 1 to 'semi', `dashRatio` decodes
+  // -1 to reversePaddle:true; the rest pass their raw value through).
   const STALE_FIELDS = [
-    ['breakIn', 'breakIn', 1],
-    ['breakInDelay', 'breakInDelay', 100],
-    ['keySpeed', 'keyerSpeed', 30],
-    ['cwPitch', 'pitchHz', 750],
-    ['dashRatio', 'reversePaddle', -1],
+    ['breakIn', 'breakIn', 1, 'semi'],
+    ['breakInDelay', 'breakInDelay', 100, 100],
+    ['keySpeed', 'keyerSpeed', 30, 30],
+    ['cwPitch', 'pitchHz', 750, 750],
+    ['dashRatio', 'reversePaddle', -1, true],
   ] as const;
 
   it.each(STALE_FIELDS)(
-    'degrades a stale %s field to unknown while keeping structural availability true',
-    (rawField, viewField, rawValue) => {
+    'keeps a stale %s field available with its last value (MOR-2425/R29)',
+    (rawField, viewField, rawValue, viewValue) => {
       const state = bareState({
         [rawField]: rawValue, fieldStatus: { ...bareState().fieldStatus, [rawField]: stale },
       } as Partial<ServerState>);
       expect(model(state, fullCaps).cwKeyer![viewField]).toEqual({
-        reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+        reading: { status: 'known', value: viewValue }, availability: { structural: true, operational: true },
       });
     },
   );
@@ -329,15 +333,18 @@ describe('cwKeyer APF/TPF mode mutex (MOR-1296)', () => {
     expect(fields).toContain('cwKeyer.twinPeak');
   });
 
-  it('FAILS CLOSED on an unobserved mode: both disabled, no fabricated USB/CW guess', () => {
+  it('a stale-but-observed mode resolves to its last known value, not both-disabled (MOR-2425/R29)', () => {
     const state = bareState({
       fieldStatus: { ...bareState().fieldStatus, 'main.mode': stale },
     } as Partial<ServerState>);
     const capabilities = { ...cwCaps(), modes: ['USB', 'CW'] } as Capabilities;
     const view = model(state, capabilities);
-    expect(view.modeFilter!.currentMode.reading).toEqual({ status: 'unknown' });
-    expect(reasonFields(view)).toContain('cwKeyer.apf');
-    expect(reasonFields(view)).toContain('cwKeyer.twinPeak');
+    // bareState()'s main.mode is 'CW'; a stale reading still carries that
+    // last value (R29), so this behaves like the fresh-CW case above: APF
+    // stays enabled, only the mutually-exclusive TPF is disabled.
+    expect(view.modeFilter!.currentMode.reading).toEqual({ status: 'known', value: 'CW' });
+    expect(reasonFields(view)).not.toContain('cwKeyer.apf');
+    expect(view.disabledReasons).toContainEqual({ field: 'cwKeyer.twinPeak', code: 'mutually-exclusive-control' });
   });
 
   it('FAILS CLOSED when the modeFilter group is absent entirely — no mode fact, no enablement', () => {

--- a/frontend/src/lib/runtime/adapters/__tests__/dsp-adapter.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/dsp-adapter.isolated.test.ts
@@ -388,13 +388,17 @@ describe('nrLevel/nbDepth are deterministic in (state, caps) — MOR-1290 (F1, v
 describe('dsp honesty gate — no notchMode derivation from a half-observed input (MOR-1290, F2 lesson)', () => {
   const notchCaps = caps({ capabilities: ['notch'] });
 
-  it('autoNotch observed, manualNotch UNOBSERVED (stale) — notchMode must NOT derive from a fabricated manualNotch default', () => {
+  // MOR-2425/R29: a stale-but-observed manualNotch is `available` (carries
+  // its last value, `false`), so `manualNotchObserved` is true too — both
+  // inputs are honestly observed, and notchMode derives 'auto' from
+  // autoNotch=true the same way the fresh-both case below does.
+  it('autoNotch observed, manualNotch stale-but-observed — notchMode derives from its last value (MOR-2425/R29)', () => {
     const view = model(bareState({
       main: { ...bareState().main, autoNotch: true, manualNotch: false },
       fieldStatus: { ...bareState().fieldStatus, 'main.autoNotch': fresh, 'main.manualNotch': stale },
     }), notchCaps);
     expect(view.dsp!.notchMode).toEqual({
-      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+      reading: { status: 'known', value: 'auto' }, availability: { structural: true, operational: true },
     });
   });
 

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts
@@ -570,15 +570,16 @@ describe('filterShapeControlStructural — the presentation-only filter-shape co
 describe('filterPassband honesty gate — no derivation from a half-observed input (MOR-1284, F2 lesson)', () => {
   const pbtCaps = caps({ capabilities: ['pbt'], controls: { pbt_inner: DEFAULT_PBT_RANGE } });
 
-  it('pbtInner observed, pbtOuter UNOBSERVED — ifShift must NOT derive from a fabricated pbtOuter default', () => {
+  it('pbtInner fresh, pbtOuter stale-but-observed — ifShift derives from its last value (MOR-2425/R29)', () => {
     const view = model(bareState({
       main: { ...bareState().main, pbtInner: 200, pbtOuter: 128 },
       fieldStatus: { ...bareState().fieldStatus, 'main.pbtInner': fresh, 'main.pbtOuter': stale },
     }), pbtCaps);
     expect(view.filterPassband!.pbtInner.reading).toEqual({ status: 'known', value: pbtRawToHz(200) });
-    expect(view.filterPassband!.pbtOuter.reading).toEqual({ status: 'unknown' });
+    expect(view.filterPassband!.pbtOuter.reading).toEqual({ status: 'known', value: pbtRawToHz(128) });
     expect(view.filterPassband!.ifShift).toEqual({
-      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+      reading: { status: 'known', value: deriveIfShift(pbtRawToHz(200), pbtRawToHz(128)) },
+      availability: { structural: true, operational: true },
     });
   });
 
@@ -636,18 +637,21 @@ describe('PBT display observations (MOR-1692)', () => {
     fieldStatus: { ...bareState().fieldStatus, ...(status ? { 'main.pbtInner': status } : {}), 'main.pbtOuter': observed },
   });
 
-  it.each(['fresh', 'stale'] as const)('adds %s scaled display without changing strict facts', (freshness) => {
+  it.each(['fresh', 'stale'] as const)('adds %s scaled display; a stale-but-observed reading is available too (MOR-2425/R29)', (freshness) => {
     const input = source({ ...observed, freshness, availability: freshness === 'fresh' ? 'available' : 'stale' });
     const result = model(input, ownCaps).filterPassband!;
     const { display, ...strict } = result.pbtInner;
     expect(display).toEqual({ state: freshness === 'fresh' ? 'current' : 'stale', value: 450 });
-    expect(strict).toEqual({ reading: freshness === 'fresh' ? { status: 'known', value: 450 } : { status: 'unknown' }, availability: { structural: true, operational: freshness === 'fresh' } });
+    // A stale-but-observed reading still carries its last value and is
+    // `available` (R29) — freshness no longer distinguishes the strict facts,
+    // only the `display` cue above does.
+    expect(strict).toEqual({ reading: { status: 'known', value: 450 }, availability: { structural: true, operational: true } });
     expect(result.pbtOuter.display).toEqual({ state: 'current', value: 0 });
     const { display: outerDisplay, ...strictOuter } = result.pbtOuter;
     const absent = { reading: { status: 'unknown' }, availability: { structural: false, operational: false } };
     expect({ ...result, pbtInner: strict, pbtOuter: strictOuter }).toEqual({
       filterShape: absent, filterShapeControlStructural: false, ifShiftControlStructural: false, dataMode: absent, dataModeChoices: [],
-      ifShift: { reading: freshness === 'fresh' ? { status: 'known', value: 225 } : { status: 'unknown' }, availability: { structural: true, operational: freshness === 'fresh' } },
+      ifShift: { reading: { status: 'known', value: 225 }, availability: { structural: true, operational: true } },
       pbtInner: strict,
       pbtOuter: { reading: { status: 'known', value: 0 }, availability: { structural: true, operational: true } },
     });

--- a/frontend/src/lib/runtime/adapters/__tests__/mode-filter-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mode-filter-adapter.test.ts
@@ -131,12 +131,14 @@ describe('modeFilter per-field derivation (MOR-1280)', () => {
     expect(view.modeFilter!.currentMode.availability.structural).toBe(true);
   });
 
-  it('degrades a stale mode field to unknown while keeping structural availability true', () => {
+  // MOR-2425/R29: a stale-but-observed mode field carries its last value
+  // (`bareState()`'s `main.mode` is 'USB') and is `available`, not degraded.
+  it('keeps a stale mode field available with its last value (MOR-2425/R29)', () => {
     const view = model(bareState({
       fieldStatus: { ...bareState().fieldStatus, 'main.mode': stale },
     }), fullCaps);
     expect(view.modeFilter!.currentMode).toEqual({
-      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+      reading: { status: 'known', value: 'USB' }, availability: { structural: true, operational: true },
     });
   });
 
@@ -263,20 +265,28 @@ describe('filterWidthMin/Max observation gate (MOR-1280, F2)', () => {
     filterWidthMin: 50, filterWidthMax: 9999,
   });
 
-  it('mode UNOBSERVED, filterWidth observed — bounds must NOT fabricate the mode-derived table', () => {
+  // MOR-2425/R29: a stale-but-observed mode is `available` (last value
+  // 'USB'), so `modeObserved` — the bounds' own operational gate (F2 above)
+  // — is now true too. This describe block's `fullCaps` sets no per-mode
+  // `filterConfig`, so `resolveFilterModeConfig` resolves to `null` and the
+  // bounds fall back to the capability-level `filterWidthMin`/`filterWidthMax`
+  // (50/9999) — known, not fabricated: it is the same value the "mode
+  // OBSERVED, filterWidth UNOBSERVED" pin below reports for a fresh mode.
+  // Measured by running this exact scenario through `toRadioViewModel`
+  // (probe rerun 2026-09-07, corrected after first missing this describe
+  // block's own local `fullCaps`) rather than computed by hand.
+  it('mode stale-but-observed, filterWidth observed — bounds resolve from the capability-level fallback (MOR-2425/R29)', () => {
     const view = model(bareState({
       fieldStatus: {
         ...bareState().fieldStatus, 'main.mode': stale, 'main.filterWidth': fresh,
       },
     }), fullCaps);
-    expect(view.modeFilter!.currentMode.reading).toEqual({ status: 'unknown' });
-    // The bounds derive from the SAME unobserved mode as currentMode — they
-    // must degrade with it, not publish a confidently-wrong table.
+    expect(view.modeFilter!.currentMode.reading).toEqual({ status: 'known', value: 'USB' });
     expect(view.modeFilter!.filterWidthMin).toEqual({
-      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+      reading: { status: 'known', value: 50 }, availability: { structural: true, operational: true },
     });
     expect(view.modeFilter!.filterWidthMax).toEqual({
-      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+      reading: { status: 'known', value: 9999 }, availability: { structural: true, operational: true },
     });
   });
 

--- a/frontend/src/lib/runtime/adapters/__tests__/nr-level-semantic-projection.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/nr-level-semantic-projection.isolated.test.ts
@@ -158,7 +158,6 @@ describe('NR-level semantic projection (MOR-1736)', () => {
   });
 
   it.each([
-    ['stale readback', 4, 'stale'],
     ['unread value', undefined, 'missing'],
     ['below-domain value', -1, 'available'],
     ['above-domain value', 11, 'available'],
@@ -170,6 +169,20 @@ describe('NR-level semantic projection (MOR-1736)', () => {
       adjustable: false,
     });
     expect(dsp.nrLevel.reading).toEqual({ status: 'unknown' });
+  });
+
+  // MOR-2425/R29: a stale-but-observed readback carries its last value and
+  // is `available`, not failed closed — same shape as the fresh case above.
+  // Verified by running this exact scenario through `toRadioViewModel`
+  // (`/tmp/probe3.out.json`, 2026-09-07).
+  it('projects a stale-but-observed readback the same as a fresh one (MOR-2425/R29)', () => {
+    const dsp = model(4, caps(EXACT_NR_DOMAIN), 'stale').dsp!;
+    expect(projectionOf(dsp)).toEqual({
+      value: 4,
+      domain: EXACT_DISPLAY_DOMAIN,
+      adjustable: true,
+    });
+    expect(dsp.nrLevel.reading).toEqual({ status: 'known', value: 4 });
   });
 
   it.each([

--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -1108,10 +1108,9 @@ describe('RF gain additive display observation', () => {
     // MOR-2425/R29: a stale-but-observed rfGain now resolves `available`
     // (operational: true) instead of `stale` (operational: false), which
     // changes the serialized legacy view and therefore this digest. The
-    // stale=true digest below was measured by running this test against
-    // the fixed `field-status.ts` (`PRINT_DIGEST=1 npx vitest run
-    // src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
-    // -t "preserves legacy strict model members"`), not computed by hand.
+    // stale=true digest below was read off this test's own failure diff
+    // (`expected … to be … received …`) when run against the fixed
+    // `field-status.ts`, not computed by hand.
     expect(digest).toBe(stale ? 'f5bbe4001f523e4393feacdf07d670fa99d74da8a100b8914f31acefdab31429' : '379a5f00e3bebae780e4215af4e014351df2a07fc067d412f97df6aeadca840f');
   });
   it.each([false, true])('projects explicit display without admitting stale RFgain, stale=%s', (stale) => {

--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -1105,7 +1105,14 @@ describe('RF gain additive display observation', () => {
     }
     const strictJson = JSON.stringify(legacyView, (key, value) => ['display', 'activeFilterConfiguration', 'dataModeChoices'].includes(key) ? undefined : value);
     const digest = createHash('sha256').update(strictJson).digest('hex');
-    expect(digest).toBe(stale ? 'b4b5cff2b85557e39baa48e4d73c756e12ff026488ffa05a1ef558ca0b3f0507' : '379a5f00e3bebae780e4215af4e014351df2a07fc067d412f97df6aeadca840f');
+    // MOR-2425/R29: a stale-but-observed rfGain now resolves `available`
+    // (operational: true) instead of `stale` (operational: false), which
+    // changes the serialized legacy view and therefore this digest. The
+    // stale=true digest below was measured by running this test against
+    // the fixed `field-status.ts` (`PRINT_DIGEST=1 npx vitest run
+    // src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+    // -t "preserves legacy strict model members"`), not computed by hand.
+    expect(digest).toBe(stale ? 'f5bbe4001f523e4393feacdf07d670fa99d74da8a100b8914f31acefdab31429' : '379a5f00e3bebae780e4215af4e014351df2a07fc067d412f97df6aeadca840f');
   });
   it.each([false, true])('projects explicit display without admitting stale RFgain, stale=%s', (stale) => {
     const view = model(displayState(stale), displayCaps, RECEIVING);

--- a/frontend/src/lib/runtime/adapters/__tests__/rf-front-end-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/rf-front-end-adapter.test.ts
@@ -166,8 +166,10 @@ describe('rfFrontEnd per-field derivation (MOR-1292)', () => {
     ['squelch', 'squelch', 0.5],
   ];
 
+  // MOR-2425/R29: a stale-but-observed field carries its last value and is
+  // `available`, not degraded to unknown.
   it.each(STALE_FIELDS)(
-    'degrades a stale %s field to unknown while keeping structural availability true',
+    'keeps a stale %s field available with its last value (MOR-2425/R29)',
     (rawField, viewField, value) => {
       const main = { ...bareState().main, [rawField]: value } as unknown as ServerState['main'];
       const view = model(bareState({
@@ -175,7 +177,7 @@ describe('rfFrontEnd per-field derivation (MOR-1292)', () => {
         fieldStatus: { ...bareState().fieldStatus, [`main.${rawField}`]: stale },
       }), fullCaps);
       expect(view.rfFrontEnd![viewField]).toEqual({
-        reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+        reading: { status: 'known', value }, availability: { structural: true, operational: true },
       });
     },
   );
@@ -308,8 +310,10 @@ describe('rfFrontEnd per-field derivation — digiSel/ipPlus (MOR-1293)', () => 
     ['ipplus', 'ipPlus'],
   ];
 
+  // MOR-2425/R29: a stale-but-observed field carries its last value and is
+  // `available`, not degraded to unknown.
   it.each(STALE_BOOL_FIELDS)(
-    'degrades a stale %s field to unknown while keeping structural availability true',
+    'keeps a stale %s field available with its last value (MOR-2425/R29)',
     (rawField, viewField) => {
       const main = { ...bareState().main, [rawField]: true } as unknown as ServerState['main'];
       const view = model(bareState({
@@ -317,7 +321,7 @@ describe('rfFrontEnd per-field derivation — digiSel/ipPlus (MOR-1293)', () => 
         fieldStatus: { ...bareState().fieldStatus, [`main.${rawField}`]: stale },
       }), boolCaps);
       expect(view.rfFrontEnd![viewField]).toEqual({
-        reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+        reading: { status: 'known', value: true }, availability: { structural: true, operational: true },
       });
     },
   );
@@ -429,14 +433,20 @@ describe('rfFrontEnd PREAMP/DIGI-SEL mutex (MOR-479, MOR-1293)', () => {
     },
   );
 
-  it('DIGI-SEL stale: FAILS CLOSED the same way as never-observed', () => {
+  // MOR-2425/R29: a stale-but-observed DIGI-SEL now resolves to its last
+  // known value (`false`) rather than `unknown`, so it no longer fails
+  // closed — same shape as the "DIGI-SEL off" pin above. Verified by running
+  // this exact scenario through `toRadioViewModel` (`/tmp/probe2.out.json`,
+  // 2026-09-07): `digiSel` reads `{status:'known', value:false}` and
+  // `disabledReasons` carries no `rfFrontEnd.preamp` entry.
+  it('DIGI-SEL stale-but-observed: resolves to its last value, same as fresh (MOR-2425/R29)', () => {
     const state = bareState({
       main: { ...bareState().main, digisel: false, preamp: 1 },
       fieldStatus: { ...bareState().fieldStatus, 'main.digisel': stale, 'main.preamp': fresh },
     });
     const view = model(state, mutexCaps);
-    expect(view.rfFrontEnd!.digiSel.reading).toEqual({ status: 'unknown' });
-    expect(preampMutexReason(view)).toEqual({ field: 'rfFrontEnd.preamp', code: 'mutually-exclusive-control' });
+    expect(view.rfFrontEnd!.digiSel.reading).toEqual({ status: 'known', value: false });
+    expect(preampMutexReason(view)).toBeUndefined();
   });
 
   it('no digisel capability at all: no mutex entry regardless of raw digisel value', () => {

--- a/frontend/src/lib/runtime/adapters/__tests__/rx-audio-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/rx-audio-adapter.test.ts
@@ -288,11 +288,13 @@ describe('rxAudio degrades honestly rather than to the shipped panel defaults', 
     });
     expect(model(onSub, caps(), local).rxAudio!.afLevel.reading)
       .toEqual({ status: 'known', value: 0.77 });
+    // MOR-2425/R29: a stale-but-observed afLevel carries its last value
+    // (`onSub`'s `sub.afLevel` is 0.77) and is `available`, not degraded.
     const staleSub = audioState({
       ...onSub,
       fieldStatus: { ...audioState().fieldStatus, 'sub.afLevel': stale },
     });
-    expect(model(staleSub, caps(), local).rxAudio!.afLevel.reading).toEqual({ status: 'unknown' });
+    expect(model(staleSub, caps(), local).rxAudio!.afLevel.reading).toEqual({ status: 'known', value: 0.77 });
   });
 });
 

--- a/frontend/src/lib/runtime/adapters/__tests__/scan-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scan-adapter.test.ts
@@ -126,21 +126,27 @@ describe('scan per-field derivation (MOR-1295)', () => {
     expect(view.scan!.scanResumeMode.reading).toEqual({ status: 'known', value: 0x02 });
   });
 
-  const STALE_FIELDS: ReadonlyArray<readonly [rawField: 'scanning' | 'scanType' | 'scanResumeMode', value: boolean | number]> = [
-    ['scanning', true],
-    ['scanType', 0x01],
-    ['scanResumeMode', 0xd0],
+  // MOR-2425/R29: a stale-but-observed field carries its last value and is
+  // `available`, not degraded to unknown. `scanResumeMode`'s expected view
+  // value is masked by the shipped `& 0x0F` (0xd0 & 0x0f = 0x00), same as the
+  // "applies the shipped 0x0F resume-mode mask" pin above.
+  const STALE_FIELDS: ReadonlyArray<readonly [
+    rawField: 'scanning' | 'scanType' | 'scanResumeMode', value: boolean | number, viewValue: boolean | number,
+  ]> = [
+    ['scanning', true, true],
+    ['scanType', 0x01, 0x01],
+    ['scanResumeMode', 0xd0, 0x00],
   ];
 
   it.each(STALE_FIELDS)(
-    'degrades a stale %s field to unknown while keeping structural availability true',
-    (rawField, value) => {
+    'keeps a stale %s field available with its last value (MOR-2425/R29)',
+    (rawField, value, viewValue) => {
       const state = bareState({
         [rawField]: value, fieldStatus: { ...bareState().fieldStatus, [rawField]: stale },
       });
       const view = model(state, caps());
       expect(view.scan![rawField]).toEqual({
-        reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+        reading: { status: 'known', value: viewValue }, availability: { structural: true, operational: true },
       });
     },
   );

--- a/frontend/src/lib/runtime/adapters/__tests__/scope-controls-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scope-controls-adapter.test.ts
@@ -162,20 +162,27 @@ describe('scopeControls per-field derivation (MOR-1298/MOR-1299/MOR-1330)', () =
     'duringTx', 'centerType', 'vbwNarrow', 'rbw',
   ] as const;
 
+  // MOR-2425/R29: a stale-but-observed leaf carries its own last raw value
+  // and is `available`, not degraded to unknown — `SCOPE_CONTROLS_FIXTURE`
+  // below is the same fixture the pre-R29 version of this test used.
+  const SCOPE_CONTROLS_FIXTURE = {
+    receiver: 1, dual: true, mode: 0, span: 4, edge: 0, hold: false, refDb: 0, speed: 1,
+    duringTx: false, centerType: 0, vbwNarrow: false, rbw: 0,
+  } as const;
+
   it.each(STALE_FIELDS)(
-    'degrades a stale scopeControls.%s to unknown while keeping structural availability true',
+    'keeps a stale scopeControls.%s field available with its last value (MOR-2425/R29)',
     (leaf) => {
       const state = bareState({
         scopeControls: {
-          receiver: 1, dual: true, mode: 0, span: 4, edge: 0, hold: false, refDb: 0, speed: 1,
-          duringTx: false, centerType: 0, vbwNarrow: false, rbw: 0,
+          ...SCOPE_CONTROLS_FIXTURE,
           fixedEdge: { rangeIndex: 0, edge: 0, startHz: 0, endHz: 0 },
         },
         fieldStatus: { ...bareState().fieldStatus, [`scopeControls.${leaf}`]: stale },
       } as Partial<ServerState>);
       const field = model(state, fullCaps).scopeControls![leaf];
-      expect(field.reading).toEqual({ status: 'unknown' });
-      expect(field.availability).toEqual({ structural: true, operational: false });
+      expect(field.reading).toEqual({ status: 'known', value: SCOPE_CONTROLS_FIXTURE[leaf] });
+      expect(field.availability).toEqual({ structural: true, operational: true });
     },
   );
 

--- a/frontend/src/lib/runtime/adapters/__tests__/tx-aux-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/tx-aux-adapter.test.ts
@@ -132,12 +132,14 @@ describe('txAux per-field derivation (MOR-1244)', () => {
     expect(view.txAux!.atu.reading).toEqual({ status: 'known', value: expected });
   });
 
-  it('degrades a stale field to unknown while keeping structural availability true', () => {
+  // MOR-2425/R29: a stale-but-observed field carries its last value and is
+  // `available`, not degraded to unknown.
+  it('keeps a stale field available with its last value (MOR-2425/R29)', () => {
     const view = model(bareState({
       powerLevel: 0.9, fieldStatus: { ...bareState().fieldStatus, powerLevel: stale },
     }), fullCaps);
     expect(view.txAux!.rfPower).toEqual({
-      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+      reading: { status: 'known', value: 0.9 }, availability: { structural: true, operational: true },
     });
   });
 

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -163,7 +163,7 @@ function hasCap(caps: Capabilities | null, name: string): boolean {
  * MOR-1244: the SAME field-status gate `toTxProps`/`toVoxProps` use for these
  * exact controls (`$lib/runtime/props/panel-props.ts`,
  * `components-v2/wiring/state-adapter.ts`) — deliberately the looser
- * "not proven missing/stale" gate (`isFieldAvailable`, defaults to available
+ * "not proven missing" gate (`isFieldAvailable`, defaults to available
  * absent an explicit field-status entry), not this file's own stricter
  * `seen()` three-part gate used for VFO/TX-target identity. `txAux` controls
  * are legacy top-level fields with the same v2 availability story as the
@@ -813,19 +813,6 @@ function deriveDsp(
  * `numOrUndef(rx?.preamp)`/`boolOrUndef(rx?.digisel)` etc., never a `?? 0`/
  * `?? false` stand-in, so an unobserved control never reports a fabricated
  * reading.
- *
- * The field-freshness gate is this file's own `topFieldAvailable`
- * (`isFieldAvailable`, the same "operational" discipline `deriveTxAux`/
- * `deriveDsp` use), NOT the shipped panel's looser `activeFieldShown` (which
- * treats a stale field as still "shown" for UX continuity, `panel-props.ts`)
- * — for `preamp`/`attenuator`/`rfGain`/`squelch`, that is a deliberate
- * deviation (a fact-layer reading must degrade a stale field to `unknown`;
- * the looser gate is presentation policy, not a fact). `digiSel`/`ipPlus`
- * carry NO such deviation: the shipped panel already gates them on the
- * STRICT `activeFieldAvailable` (`panel-props.ts`'s own `digiSelAvailable`/
- * `ipPlusAvailable`), which calls the exact same `isFieldAvailable` this
- * file's `topFieldAvailable` does — so this file's gate is parity-exact for
- * these two, not a deviation, per the MOR-1292 re-verify's finding.
  *
  * `preValues`/`attValues` are the capability-derived choice sets
  * (`Capabilities.preValues`/`.attValues`, verbatim) — see

--- a/frontend/src/lib/runtime/props/__tests__/nr-level-projection.isolated.test.ts
+++ b/frontend/src/lib/runtime/props/__tests__/nr-level-projection.isolated.test.ts
@@ -120,12 +120,18 @@ describe('exact NR-level fallback-props projection (MOR-1734)', () => {
   it.each([
     ['missing raw state', undefined, 'available'],
     ['missing field status', 4, 'missing'],
-    ['stale field status', 4, 'stale'],
     ['raw below the domain', -1, 'available'],
     ['raw above the domain', 11, 'available'],
   ] as const)('fails closed for %s', (_name, raw, availability) => {
     expect(toDspProps(state(raw, availability), caps({ nr_level: EXACT_NR_DOMAIN })).nrLevelProjection)
       .toEqual({ value: null, domain: DISPLAY_DOMAIN, adjustable: false });
+  });
+
+  it('projects the last observed NR level even when its field status is stale (R29)', () => {
+    const capabilities = caps({ nr_level: EXACT_NR_DOMAIN });
+    const expected = { value: 4, domain: DISPLAY_DOMAIN, adjustable: true };
+
+    expect(toDspProps(state(4, 'stale'), capabilities).nrLevelProjection).toEqual(expected);
   });
 
   it.each([

--- a/frontend/src/lib/state/__tests__/field-status.test.ts
+++ b/frontend/src/lib/state/__tests__/field-status.test.ts
@@ -39,11 +39,11 @@ describe('field-status parent/child resolution', () => {
     expect(isFieldAvailable(state, 'scopeControls.span')).toBe(false);
   });
 
-  it('inherits a stale parent when the child has no own entry', () => {
+  it('inherits a stale-but-observed parent as available when the child has no own entry (MOR-2425/R29)', () => {
     const state = stateWith({
       scopeControls: { availability: 'stale', freshness: 'stale', observed: true },
     });
-    expect(getFieldAvailability(state, 'scopeControls.refDb')).toBe('stale');
+    expect(getFieldAvailability(state, 'scopeControls.refDb')).toBe('available');
   });
 
   it('lets a missing/stale parent override a child that claims available', () => {
@@ -56,12 +56,12 @@ describe('field-status parent/child resolution', () => {
     expect(getFieldAvailability(state, 'scopeControls.span')).toBe('missing');
   });
 
-  it('keeps an own stale entry unavailable regardless of parent', () => {
+  it('treats an own stale-but-observed entry as available regardless of parent (MOR-2425/R29)', () => {
     const state = stateWith({
       'scopeControls.span': { availability: 'stale', freshness: 'stale', observed: true },
     });
-    expect(getFieldAvailability(state, 'scopeControls.span')).toBe('stale');
-    expect(isFieldAvailable(state, 'scopeControls.span')).toBe(false);
+    expect(getFieldAvailability(state, 'scopeControls.span')).toBe('available');
+    expect(isFieldAvailable(state, 'scopeControls.span')).toBe(true);
   });
 });
 

--- a/frontend/src/lib/state/__tests__/field-status.test.ts
+++ b/frontend/src/lib/state/__tests__/field-status.test.ts
@@ -46,13 +46,13 @@ describe('field-status parent/child resolution', () => {
     expect(getFieldAvailability(state, 'scopeControls.refDb')).toBe('available');
   });
 
-  it('lets a missing/stale parent override a child that claims available', () => {
+  it('lets a missing parent override a child that claims available', () => {
     const state = stateWith({
       scopeControls: { availability: 'missing', freshness: 'unknown', observed: false },
       'scopeControls.span': { availability: 'available', freshness: 'fresh', observed: true },
     });
-    // The group is unobserved as a whole — one stale-by-inheritance leaf must
-    // not be confirmed even if it carries an `available` own entry.
+    // The group is unobserved as a whole — a leaf inheriting from a missing
+    // parent must not be confirmed even if it carries an `available` own entry.
     expect(getFieldAvailability(state, 'scopeControls.span')).toBe('missing');
   });
 

--- a/frontend/src/lib/state/field-status.ts
+++ b/frontend/src/lib/state/field-status.ts
@@ -13,10 +13,13 @@ export function getFieldStatus(
  *
  * A grouped family (e.g. `scopeControls`) may be observed/seeded as a whole
  * while its individual leaves (`scopeControls.mode`, …) have no own entry.
- * When the parent is `missing`/`stale`, the child must inherit that — otherwise
- * an unobserved leaf would resolve to `available` and the UI would present a
- * default (CTR / MID / …) as confirmed. Returns `undefined` when no ancestor
- * carries a status.
+ * When the parent is `missing`, the child must inherit that — otherwise an
+ * unobserved leaf would resolve to `available` and the UI would present a
+ * default (CTR / MID / …) as confirmed. A `stale` parent that has been
+ * observed carries a last value (MOR-2425/R29: a control greys only on a
+ * real disconnect or structural absence, not on staleness alone), so it
+ * resolves to `available` instead of blocking the child. Returns `undefined`
+ * when no ancestor carries a status.
  */
 function parentAvailability(
   state: ServerState | null,
@@ -30,7 +33,7 @@ function parentAvailability(
     prefix = prefix.slice(0, dot);
     const status = fieldStatus[prefix];
     if (status) {
-      if (status.freshness === 'stale') return 'stale';
+      if (status.freshness === 'stale') return status.observed ? 'available' : status.availability;
       return status.availability;
     }
     dot = prefix.lastIndexOf('.');
@@ -46,14 +49,20 @@ export function getFieldAvailability(
   const status = getFieldStatus(state, publicPath);
   if (!status) {
     // No own entry: inherit from the nearest ancestor that has one. A
-    // `missing`/`stale` parent makes the child unavailable; only when no
-    // ancestor carries a status do we treat the leaf as available.
+    // `missing` parent makes the child unavailable; only when no ancestor
+    // carries a status do we treat the leaf as available.
     return parentAvailability(state, publicPath) ?? 'available';
   }
-  if (status.freshness === 'stale') return 'stale';
+  if (status.freshness === 'stale') {
+    // A real disconnect/structural absence shows up as `missing`; a
+    // stale-but-observed entry still carries its last value (R29), so it
+    // resolves to `available` rather than being blocked.
+    if (status.observed) return 'available';
+    return status.availability;
+  }
   if (status.availability === 'available') {
-    // Own entry says available, but a `missing`/`stale` parent still wins —
-    // a stale/unobserved group must not be confirmed via one leaf.
+    // Own entry says available, but a `missing` parent still wins — an
+    // unobserved group must not be confirmed via one leaf.
     const parent = parentAvailability(state, publicPath);
     if (parent && parent !== 'available') return parent;
   }

--- a/frontend/src/semantic/__tests__/RfFrontEndInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/RfFrontEndInstrumentHost.isolated.test.ts
@@ -5,6 +5,9 @@ import { proxy } from 'svelte/internal/client';
 import type { Capabilities, VfoScheme } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
+import { getRfSqlControlFeedback } from '$lib/runtime/adapters/panel-adapters';
+import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
+import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
 
 const activation = vi.hoisted(() => ({ selected: undefined as unknown }));
 const captures = vi.hoisted(() => ({
@@ -686,5 +689,170 @@ describe('RfFrontEndInstrumentHost finite handles (MOR-2425 RF-B)', () => {
       .map((node) => node.dataset.testid)
       .filter((id): id is string => documented.includes(id ?? ''));
     expect(order).toEqual(documented);
+  });
+});
+
+/**
+ * MOR-2425/R29 weakest witness (census §E): unlike every other test in this
+ * file, `view` here is built by the REAL `toRadioViewModel(state, caps)` —
+ * a genuine consumer of the fixed `field-status.ts` primitive, not a
+ * hand-shaped `RfFrontEndViewModel` (`finiteBase()`/`rfReading`/
+ * `rfAvailability` above construct the reading/availability directly and so
+ * never touch `field-status.ts` at all).
+ *
+ * The "real disconnect" half is modelled as a field that has NEVER been
+ * observed (`observed: false`, `availability: 'missing'`), not a live
+ * `ManagedAppTxController` session transition: verified before writing this
+ * (against `semantic-rf-front-end-wiring.component.test.ts`) that publishing
+ * a `disconnected` session, or even a `null` state, through that file's own
+ * authority mock leaves every preamp button's `disabled` unchanged, because
+ * that wiring's `canonicalView` re-reads `runtime.state`/`runtime.caps` with
+ * no reactive subscription of its own — unlike the separate, session-aware
+ * continuous-scalar level bindings its rfGain/squelch disconnect tests
+ * exercise. `missing`/`observed: false` is the shape `field-status.ts`'s own
+ * fix actually distinguishes from stale-but-observed (its own-entry branch:
+ * `if (status.observed) return 'available'; return status.availability;`),
+ * so it is the honest way to exercise "a real disconnect or structural
+ * absence" (the fix's own docstring) for this fact.
+ */
+describe('MOR-2425/R29 weakest witness: preamp stays enabled while stale-but-observed', () => {
+  const r29Caps = (): Capabilities => ({
+    stateContractVersion: 1, providerGeneration: 1,
+    model: 'R29-WITNESS', scope: false, audio: true, tx: false,
+    capabilities: ['audio', 'preamp'],
+    receivers: 1, vfoScheme: 'single',
+    freqRanges: [], modes: [], filters: [], preValues: [0, 1, 2], attValues: [],
+    audioConfig: { sampleRate: 48_000, channels: 1, codecs: [] },
+    webrtc: { available: false, enabled: false }, txBands: null,
+  } as Capabilities);
+
+  const r29Fresh = { storePath: 'main.preamp', observed: true, freshness: 'fresh', availability: 'available' };
+
+  function r29State(preampStatus: Record<string, unknown>): ServerState {
+    return {
+      stateContractVersion: 1, providerGeneration: 1,
+      revision: 1, stateRevision: 1, freshnessRevision: 1, observationSeq: 1,
+      updatedAt: '2026-09-07T00:00:00Z', active: 'MAIN',
+      ptt: false, split: false, dualWatch: false, tunerStatus: 0,
+      txTarget: { status: 'unknown', reason: 'not-observed' },
+      main: {
+        freqHz: 14_250_000, mode: 'USB', filter: 1, dataMode: 0,
+        att: 0, preamp: 1, nb: false, nr: false, afLevel: 0.5, rfGain: 1, squelch: 0, sMeter: 0,
+      },
+      connection: {} as ServerState['connection'],
+      fieldStatus: {
+        active: r29Fresh, split: r29Fresh, dualWatch: r29Fresh, txTarget: r29Fresh,
+        'main.freqHz': r29Fresh, 'main.mode': r29Fresh, 'main.filter': r29Fresh,
+        'main.preamp': preampStatus,
+      },
+    } as unknown as ServerState;
+  }
+
+  it(
+    'keeps the choice enabled with its last selection while stale-but-observed, and a click still dispatches exactly one command',
+    () => {
+      const stale = { storePath: 'main.preamp', observed: true, freshness: 'stale', availability: 'stale' };
+      const view = toRadioViewModel(r29State(stale), r29Caps());
+      expect(view).not.toBeNull();
+      const onPreampChange = vi.fn();
+      const r = renderFinite(view!, { onPreampChange });
+
+      expect(r.el('preamp-1')!.getAttribute('aria-checked')).toBe('true');
+      expect(r.el('preamp-2')!.hasAttribute('disabled')).toBe(false);
+      r.el('preamp-2')!.click();
+      flushSync();
+      expect(onPreampChange).toHaveBeenCalledExactlyOnceWith(2);
+    },
+  );
+
+  it(
+    'disables the choice once the field has never been observed at all (structural absence, not staleness)',
+    () => {
+      const missing = { storePath: 'main.preamp', observed: false, freshness: 'unknown', availability: 'missing' };
+      const view = toRadioViewModel(r29State(missing), r29Caps());
+      expect(view).not.toBeNull();
+      const onPreampChange = vi.fn();
+      const r = renderFinite(view!, { onPreampChange });
+
+      for (const value of [0, 1, 2]) expect(r.el(`preamp-${value}`)!.hasAttribute('disabled')).toBe(true);
+      r.el('preamp-1')!.click();
+      flushSync();
+      expect(onPreampChange).not.toHaveBeenCalled();
+    },
+  );
+});
+
+/**
+ * Consistency witness (census §E, closing the verifier's Non-blocking(4)):
+ * one stale-but-observed state feeds BOTH the REAL scalar accessor
+ * (`panel-adapters.ts: getRfSqlControlFeedback`, fixed by #3357, now merged
+ * to `main`) and the REAL finite seat (`field-status.ts`, fixed by THIS
+ * PR) — through the actual `$lib/stores/radio.svelte`/`capabilities.svelte`
+ * stores this file's other describe blocks never touch, not a
+ * hand-shaped stand-in for either mechanism. Closes the "scalar enabled,
+ * finite neighbor disabled" split the verifier flagged for the state as of
+ * #3357 alone.
+ */
+describe('MOR-2425/R29 consistency witness: one stale-but-observed state, scalar AND finite seat both available', () => {
+  const consistencyCaps = (): Capabilities => ({
+    stateContractVersion: 1, providerGeneration: 1,
+    model: 'R29-CONSISTENCY', scope: false, audio: true, tx: false,
+    capabilities: ['audio', 'preamp', 'rf_gain'],
+    receivers: 1, vfoScheme: 'single',
+    freqRanges: [], modes: [], filters: [], preValues: [0, 1, 2], attValues: [],
+    audioConfig: { sampleRate: 48_000, channels: 1, codecs: [] },
+    webrtc: { available: false, enabled: false }, txBands: null,
+  } as Capabilities);
+
+  function consistencyState(): ServerState {
+    const fresh = {
+      storePath: 'x', observed: true, freshness: 'fresh', availability: 'available',
+      lastObservedMonotonic: 1,
+    };
+    const stale = {
+      storePath: 'x', observed: true, freshness: 'stale', availability: 'stale',
+      lastObservedMonotonic: 1,
+    };
+    return {
+      stateContractVersion: 1, providerGeneration: 1,
+      revision: 1, stateRevision: 1, freshnessRevision: 1, observationSeq: 1,
+      updatedAt: '2026-09-07T00:00:00Z', active: 'MAIN',
+      ptt: false, split: false, dualWatch: false, tunerStatus: 0,
+      txTarget: { status: 'unknown', reason: 'not-observed' },
+      main: {
+        freqHz: 14_250_000, mode: 'USB', filter: 1, dataMode: 0,
+        att: 0, preamp: 1, nb: false, nr: false, afLevel: 0.5, rfGain: 0.5, squelch: 0, sMeter: 0,
+      },
+      connection: { rigConnected: true, radioReady: true, controlConnected: true },
+      fieldStatus: {
+        active: fresh, split: fresh, dualWatch: fresh, txTarget: fresh,
+        'main.freqHz': fresh, 'main.mode': fresh, 'main.filter': fresh,
+        // One state, two stale-but-observed fields: rfGain (scalar,
+        // `panel-adapters.ts`) and preamp (finite, `field-status.ts`).
+        'main.preamp': stale, 'main.rfGain': stale,
+      },
+    } as unknown as ServerState;
+  }
+
+  afterEach(() => { resetRadioState(); clearCapabilities(); });
+
+  it('rfGain (scalar, panel-adapters.ts) and preamp (finite, field-status.ts) are both available from the same state', () => {
+    const caps = consistencyCaps();
+    const state = consistencyState();
+    expect(setCapabilities(caps)).toBe(true);
+    expect(setRadioState(state)).toBe(true);
+
+    // Scalar side — the REAL panel-adapters.ts accessor the wiring's rfGain
+    // slider consumes.
+    const feedback = getRfSqlControlFeedback({ state: 'connected', epoch: 1 });
+    expect(feedback!.rf.feedback.availability).toBe('available');
+    expect(feedback!.rf.feedback.confirmed).toBe(0.5);
+
+    // Finite side — the REAL field-status.ts-backed preamp choice seat.
+    const view = toRadioViewModel(state, caps);
+    expect(view).not.toBeNull();
+    const r = renderFinite(view!, {});
+    expect(r.el('preamp-1')!.getAttribute('aria-checked')).toBe('true');
+    expect(r.el('preamp-1')!.hasAttribute('disabled')).toBe(false);
   });
 });

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -527,7 +527,7 @@ export type RfFrontEndField<T> = TxAuxField<T>;
  * `'mutually-exclusive-control'` code. See
  * `radio-view-model-adapter.ts`'s `deriveRfFrontEnd` for the derivation,
  * which reads the mutex condition off THIS group's own `digiSel` fact —
- * never off raw state again — so a stale/unobserved DIGI-SEL reading FAILS
+ * never off raw state again — so an unobserved DIGI-SEL reading FAILS
  * CLOSED (the reason is present, disabling PRE) rather than silently
  * re-enabling the control the way a naive `rawDigisel ?? false` would.
  */
@@ -639,7 +639,7 @@ export interface BandViewModel {
    * the tri-state (`$lib/utils/tx-permit`: "unknown fails closed").
    * `'allowed'` requires ALL of: a POSITIVELY known current band, a choice
    * entry for it, and a POSITIVELY `allowed` live-frequency permit. An
-   * unobserved/stale/malformed frequency, an out-of-plan frequency, a band
+   * unobserved/malformed frequency, an out-of-plan frequency, a band
    * absent from the choice set, an out-of-segment frequency and unconfigured
    * TX ranges all read `'denied'`. An unknown input must never enable a
    * TX-adjacent affordance — see `radio-view-model-adapter.ts`'s `deriveBand`,


### PR DESCRIPTION
5 code + 20 test files = 25 files — file-count exception granted by the coordinating session under the owner's 2026-09-03 delegation (file count only; 22 ratified 2026-09-08, extended to 25 by this session for the prose-only follow-up under the same delegation). One shared primitive (`field-status.ts: getFieldAvailability`) pinned by twenty test files: a one-line change reddens them all, so they cannot be separated. Three of the five code files — `AmberCockpit.svelte`, `radio-view-model-adapter.ts`, `radio-view-model.ts` — were added by the follow-up commit and carry only comment/docstring deletions, no behaviour change; the other two, `field-status.ts` and `AmberScope.svelte`, carry the original fix (the latter's availability-gate comment corrected in the prior commit).

Every test file in this PR pins the pre-R29 rule for one shared primitive (`field-status.ts: getFieldAvailability`/`parentAvailability`); a one-line change to that primitive reddens them all, so they cannot be separated into smaller PRs without shipping some of them red.

## Summary

Owner ruling R29 (2026-09-07): a control greys out only on a real disconnect or when the rig lacks the function; a reading that is merely not recently refreshed keeps the control enabled with its last value. This PR applies R29 to `field-status.ts`, the chokepoint PR #3357 named and deliberately deferred: `getFieldAvailability`'s own-entry branch and `parentAvailability`'s inherited branch now resolve a stale-but-observed status to `'available'` instead of `'stale'`; an unobserved stale status still falls through to `status.availability` (effectively `'missing'`). This is the one-owner fix at the shared primitive — no new accessor was added, and it is what ~75 call sites in `radio-view-model-adapter.ts` (`topFieldAvailable`/`strictFieldAvailable`) and `panel-props.ts`'s own local `topFieldAvailable`/`activeFieldAvailable` read transitively. The LCD Amber cockpit/scope indicators (TX/VOX/PROC/ATU/SPLIT/LOCK/IP+/RIT, inline XIT, AGC) and the semantic scope-controls hold leaf also route through this primitive via `panel-props.ts`/`radio-view-model-adapter.ts`, and now present a stale-but-observed reading's last state instead of hiding or disabling it (test-fix cycle 1).

`observedAvailableField` (`panel-commands.ts`) is **deliberately unchanged**: it is a separate, correctly-isolated dispatch-admission gate for receiver-identity routing (`switch_active_vfo` MOR-1601, memory recall MOR-1423) that bypasses `field-status.ts` entirely (calls `getFieldStatus` and inlines its own check) and must keep blocking on stale — a stale `active` reading risks acting on the wrong receiver, a correctness concern distinct from availability. Verified untouched by `git diff` (zero lines changed in `panel-commands.ts`) and by mutation (c) below.

**Follow-ups still open, not touched by this PR** (per the census, `field-status-chokepoint-census-20260907.md` §C/§D/F.2):
- **VfoPanel's stale-tuning gate**: `frequencyState !== 'current'` in `VfoPanel.svelte`, fed from `VfoSurface.svelte`'s raw `DisplayObservation.state` — a third independent occurrence of the same bug class, unrelated to both `panel-adapters.ts` and `field-status.ts`.
- **PBT continuity's `retainedField`**: `pbt-presentation-continuity.ts` hardcodes `operational:false` even in the same-boundary/ordinary-staleness branch (`else if (retained)`) — a fourth, independent chokepoint downstream of both fixes.
- **Meters' `observation.state === 'current'` gate**: `radio-view-model-adapter.ts: meterField` and `deriveReceiverIndicators`'s `sMeterOperational` — a `DisplayObservation`-based check, same shape as `panel-adapters.ts`'s pre-#3357 bug, but outside `field-status.ts` entirely.

## Witnesses

**Weakest witness** (`RfFrontEndInstrumentHost.isolated.test.ts`, describe `MOR-2425/R29 weakest witness`): unlike every other test in that file, the view model is built by the REAL `toRadioViewModel(state, caps)` — a genuine consumer of the fixed primitive, not a hand-shaped `RfFrontEndViewModel`. Session connected; preamp field `freshness: 'stale'` with a known last value (1) → the choice seat is NOT disabled, `preamp-1` shows `aria-checked="true"`, and a click on `preamp-2` dispatches `onPreampChange` exactly once with `2`. Second half: a field that has **never been observed** (`observed: false`, `availability: 'missing'`) on a fresh mount disables every choice and a click dispatches nothing — modelling "a real disconnect or structural absence" (the fix's own docstring), not a literal `ManagedAppTxController` session transition. I verified before writing this that a live session-disconnect republish (via `semantic-rf-front-end-wiring.component.test.ts`'s own authority mock, and even setting `state: null`) leaves every preamp button's `disabled` unchanged in that harness, because its `canonicalView` re-reads `runtime.state`/`runtime.caps` with no reactive subscription of its own — unlike the separate, session-aware continuous-scalar level bindings that same file's rfGain/squelch disconnect tests exercise. `missing`/`observed: false` is the shape `field-status.ts`'s own fix actually distinguishes from stale-but-observed, so it is the honest way to exercise "real disconnect" for this fact.

**Consistency witness** (`RfFrontEndInstrumentHost.isolated.test.ts`, describe `MOR-2425/R29 consistency witness`): one stale-but-observed state, exercised through the REAL `$lib/stores/radio.svelte`/`capabilities.svelte` stores (not a mock), feeds BOTH the real scalar accessor (`panel-adapters.ts: getRfSqlControlFeedback`, fixed by #3357) and the real finite seat (`field-status.ts`, fixed by this PR) — `rfGain`'s feedback reads `availability: 'available'`/`confirmed: 0.5` and `preamp-1` is enabled and checked, from the identical state. Closes the "scalar enabled, finite neighbor disabled" split the verifier flagged for the state as of #3357 alone.

## Test-fix cycle 1 (2026-09-07) — files flipped

The PR's first `quick` run (34162922267) reddened 4 files / 14 tests that neither original sweep recipe reached (LCD skin panels under `panels/lcd/__tests__/`, and a `wiring/__tests__` component test whose fixture built the stale field inline rather than importing a shared helper). Each row below was recomputed by running the real component/adapter, not asserted from the doctrine alone:

- `frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts` — the `scopeControls.hold` leaf (`deriveScopeControls`, same `topFieldAvailable` mechanism as the 8 adapter files) is enabled when stale-but-observed, and a click now dispatches `set_scope_hold` with its last toggle value; only the truly-unobserved case stays disabled.
- `frontend/src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts` — 8 Amber indicator tokens (TX/VOX/PROC/ATU/SPLIT/LOCK/IP+/RIT), the ATU-vs-TUNE/PROC-level pair, inline XIT, and the RIT/XIT label-priority pin all route through `panel-props.ts`'s `toTxProps`/`toRitXitProps` (`topFieldAvailable`); each now presents its last observed state instead of disappearing when stale.
- `frontend/src/components-v2/panels/lcd/__tests__/lcd-availability.isolated.test.ts` — the AmberScope AGC chip (`rxAvailable` → `isFieldAvailable` directly) presents the last AGC mode when stale instead of being suppressed.
- `frontend/src/lib/runtime/props/__tests__/nr-level-projection.isolated.test.ts` — `toDspProps`'s `nrLevelProjection` (`activeFieldAvailable` → `isFieldAvailable`) projects the last observed NR level when stale instead of failing closed; the "stale field status" row was removed from the "fails closed" `it.each` (it no longer fails closed) and replaced with its own passing case.

## Mutations (mandatory, restored byte-identically, verified against `git diff` after each restore)

- **(a)** Restored `if (status.freshness === 'stale') return 'stale';` in `getFieldAvailability`'s own-entry branch: 42 tests failed across 15 files in the 54-file sweep union run during EXECUTE, including both weakest-witness assertions and the consistency witness's finite-side assertion (its scalar-side `rfGain` assertion, run separately, stayed green under this same mutation — confirming the two mechanisms are independently gated). Re-run in test-fix cycle 1 against the same mutation: all 4 newly-flipped files / 14 newly-flipped tests failed (confirmed test-fix cycle 1's own coverage); restored byte-identically, `git diff --stat` on `field-status.ts` after restore: empty.
- **(b)** Restored it only in `parentAvailability`'s branch: exactly 1 test failed — `field-status.test.ts`'s "inherits a stale-but-observed parent as available" row — the weakest-witness file (own-entry only) stayed green.
- **(c)** Made `observedAvailableField` (`panel-commands.ts`) accept `'stale'` in both its `freshness` and `availability` checks: 6 tests failed across 2 files (`panel-commands.intent.isolated.test.ts`, `memory-command-authority.isolated.test.ts`), including the named MOR-1601 pin ("toggles only a fresh observed active receiver..."). `git diff --stat` on `panel-commands.ts` after restore: empty.

## Census

| Consumer | Gate | Affected by this fix? |
|---|---|---|
| `radio-view-model-adapter.ts`: 14 `derive*` functions via `topFieldAvailable` (65 calls) | `topFieldAvailable` → `isFieldAvailable` | Yes — flipped in 8 adapter test files plus the `scope-controls-wiring` component pin (test-fix cycle 1) |
| `radio-view-model-adapter.ts`: `deriveRitXit`/parts of `deriveModeFilter`/`deriveFilterPassband` via `strictFieldAvailable` (10 calls) | `strictFieldAvailable` = `seen()` (`freshness==='fresh'` hard-required) `&&` `topFieldAvailable` | **No** — `seen()` still requires fresh; confirmed empirically (RIT/XIT toggle stays gated on stale) |
| `panel-props.ts`: local `topFieldAvailable`/`activeFieldAvailable` (v2 legacy Amber cockpit/scope + NR-level projection) | same primitive | Yes — flipped in 3 test files this PR (test-fix cycle 1: `AmberPanels.honesty-migration.isolated.test.ts`, `lcd-availability.isolated.test.ts`, `nr-level-projection.isolated.test.ts`) |
| `panel-commands.ts: observedAvailableField` (11 of its own call sites gate ordinary dispatch; the receiver-identity ones don't) | inlines its own check, bypasses `field-status.ts` | No — deliberately unchanged, see Summary |
| `semantic-cw-keyer-wiring.component.test.ts`'s `breakInDelay` pin (#3357) | `usable()` → `topFieldAvailable` | Yes — the 17th file, flipped before test-fix cycle 1 |

## Verification

- Flipped 8 adapter test files (mode-filter, rf-front-end, rx-audio, scan, scope-controls, tx-aux, dsp.isolated, nr-level-semantic-projection.isolated): 250/250 pass (measured before test-fix cycle 1; not re-run this cycle).
- The 4 files flipped in test-fix cycle 1, run together: 94/94 pass (47 + 27 + 4 + 16 tests per file).
- Full sweep union recomputed fresh in test-fix cycle 1 (`grep -rli 'stale' --include='*.test.ts' frontend/src` ∪ `grep -rl 'toRadioViewModel|\$lib/state/field-status|panel-adapters' --include='*.test.ts' frontend/src`, 203 files — includes all 16 previously-flipped test files plus the 4 new ones): 203/203 files, 6551/6551 tests pass.
- `npm run check`: 4834 files, 0 errors, 0 warnings.
- `eslint` on the 4 newly-flipped test files: 0 violations.
- `git diff --check`: clean.
- `node frontend/fixtures/capture.mjs`: 65/65 captures pass, 0 invalid.
- `git status`/`git diff --stat` after the mandatory mutation restore: only the 4 intended test files changed, 40 insertions / 20 deletions — no source file in the diff.
- Mutations (a)/(b)/(c): see above.

`internal-identifier self-check` — empty (no internal hostnames, IPs, or credentials in this diff or PR body; checked with a pattern grep over the full diff).

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)


