### PR TITLE
feat(MOR-2425): seat the filter shape and DATA instruments independently

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -348,6 +348,8 @@
   <div class="filter-finite-grid" data-testid="filter-finite-grid">
     <div class="filter-finite-seat" data-field="mode">{@render filterInstruments.mode()}</div>
     <div class="filter-finite-seat" data-field="filter">{@render filterInstruments.filter()}</div>
+    <div class="filter-finite-seat" data-field="shape">{@render filterInstruments.shape()}</div>
+    <div class="filter-finite-seat" data-field="dataMode">{@render filterInstruments.dataMode()}</div>
   </div>
 {/snippet}
 

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -789,7 +789,10 @@
       || !Number.isSafeInteger(stateGeneration) || stateGeneration! < 0
       || stateGeneration !== capsGeneration) return null;
     const model = toRadioViewModel(state, caps);
-    if (model?.modeFilter === undefined) return null;
+    // MOR-2425 F1-C2: widened from `model?.modeFilter === undefined` alone so
+    // a passband-only radio (Filter Shape/DATA, no mode/filter group) still
+    // gets a valid Filter authority — the same lane now serves both groups.
+    if (model?.modeFilter === undefined && model?.filterPassband === undefined) return null;
     return Object.freeze({
       sessionEpoch: session.epoch,
       providerGeneration: stateGeneration as number,
@@ -1499,9 +1502,11 @@
   {#snippet children(rfFrontEndInstruments)}
   {#snippet vfoInstrumentComposition(vfoOperations: VfoOperationHandles)}
   <FilterInstrumentHost
-    {...filterFiniteRendererSelection} {view} {pendingFilter}
+    {...filterFiniteRendererSelection} {view} {pendingFilter} {pendingDataMode}
     onModeChange={filterIntents.onModeChange}
     onFilterChange={filterIntents.onFilterChange}
+    onFilterShapeChange={filterIntents.onFilterShapeChange}
+    onDataModeChange={filterIntents.onDataModeChange}
   >
   {#snippet children(filterInstruments)}
   <BandInstrumentHost
@@ -1885,11 +1890,8 @@
     {#if view?.modeFilter || view?.filterPassband}
       <FilterSurface
         {view} handles={filterInstruments} {finiteLayout}
-        {pendingDataMode}
         {filterWidthFeedback}
-        onDataModeChange={filterIntents.onDataModeChange}
         onFilterWidthChange={filterIntents.onFilterWidthChange}
-        onFilterShapeChange={filterIntents.onFilterShapeChange}
         onIfShiftChange={filterIntents.onIfShiftChange}
         onPbtInnerChange={filterIntents.onPbtInnerChange}
         onPbtOuterChange={filterIntents.onPbtOuterChange}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -768,10 +768,10 @@ describe('hosted Filter Mode/Filter/Shape/DATA ownership', () => {
     expect(q('[data-testid="external-Mode"]')?.getAttribute('data-reading')).toBe('USB');
     for (const id of residual) expect(target.querySelectorAll(`[data-testid="${id}"]`)).toHaveLength(1);
     retainedInvocations.get('Mode')?.('CW'); retainedInvocations.get('Filter')?.(2);
-    retainedInvocations.get('Filter shape')?.(0); retainedInvocations.get('DATA mode')?.(1);
+    retainedInvocations.get('Filter shape')?.(1); retainedInvocations.get('DATA mode')?.(1);
     expect(h.modeChange).toHaveBeenCalledExactlyOnceWith('CW');
     expect(h.filterChange).toHaveBeenCalledExactlyOnceWith(2);
-    expect(h.filterShapeChange).toHaveBeenCalledExactlyOnceWith(0);
+    expect(h.filterShapeChange).toHaveBeenCalledExactlyOnceWith(1);
     expect(h.dataModeChange).toHaveBeenCalledExactlyOnceWith(1);
     const standardMode = retainedInvocations.get('Mode')!;
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -41,6 +41,8 @@ const h = vi.hoisted(() => ({
   monLevel: vi.fn(),
   modeChange: vi.fn(),
   filterChange: vi.fn(),
+  filterShapeChange: vi.fn(),
+  dataModeChange: vi.fn(),
   split: vi.fn(),
   dualWatch: vi.fn(),
   mainReceiver: vi.fn(),
@@ -65,6 +67,28 @@ const h = vi.hoisted(() => ({
 vi.mock('../../../component-kits/activation', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../component-kits/activation')>();
   return { ...actual, getSelectedFiniteControlAppearance: () => h.selectedFiniteAppearance };
+});
+
+/** MOR-2425 F1-C2 — the `createContinuousScalar` capture wrapper
+ *  `semantic-dsp-wiring.component.test.ts`'s `dspBindings()` recipe
+ *  establishes, transplanted for `createChoiceRendererSeat`: every finite
+ *  seat this file mounts (Mode/Filter/Filter shape/DATA mode included, plus
+ *  every other family's choice seats) is recorded by its OWN label so the
+ *  Filter shape/DATA persistence witness below can name the host-owned seat
+ *  OBJECT — a DOM testid is re-created by the layout switch on both sides
+ *  and proves nothing about whether the underlying seat survived it. */
+const finiteSeats = vi.hoisted(() => ({ seats: [] as Array<{ label: string; seat: unknown }> }));
+vi.mock('../../../primitives/control-instruments/control-instrument-renderer.svelte', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../../../primitives/control-instruments/control-instrument-renderer.svelte')>();
+  return {
+    ...actual,
+    createChoiceRendererSeat: (...args: Parameters<typeof actual.createChoiceRendererSeat>) => {
+      const seat = actual.createChoiceRendererSeat(...args);
+      finiteSeats.seats.push({ label: args[0]().label, seat });
+      return seat;
+    },
+  };
 });
 
 vi.mock('$lib/runtime', () => ({
@@ -180,10 +204,10 @@ vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
     // intent vocabulary; `makeModeHandlers` is composed at both call sites
     // (rxAudio's MOD-input remedy and filterIntents), so the stub carries both.
     makeModeHandlers: () => ({
-      onModInputChange: h.noop, onModeChange: h.modeChange, onDataModeChange: h.noop,
+      onModInputChange: h.noop, onModeChange: h.modeChange, onDataModeChange: h.dataModeChange,
     }),
     makeFilterHandlers: () => ({
-      onFilterChange: h.filterChange, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
+      onFilterChange: h.filterChange, onFilterWidthChange: h.noop, onFilterShapeChange: h.filterShapeChange,
       onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
     }),
     // MOR-1305 — the wiring now also composes the dsp intent vocabulary. This
@@ -418,6 +442,7 @@ beforeEach(() => {
   h.sessionSubscriber = null;
   h.selectedFiniteAppearance = undefined;
   resetRetainedInvocations();
+  finiteSeats.seats.length = 0;
   for (const value of Object.values(h)) {
     if (typeof value === 'function' && 'mockReset' in value) (value as ReturnType<typeof vi.fn>).mockReset();
   }
@@ -726,25 +751,28 @@ describe('selected finite TX auxiliary authority lifetime', () => {
   });
 });
 
-describe('hosted Filter Mode and Filter ownership', () => {
-  const residual = [
-    'filter-width', 'filter-shape', 'filter-ifShift',
-    'filter-pbtInner', 'filter-pbtOuter', 'filter-data-mode',
-  ] as const;
+describe('hosted Filter Mode/Filter/Shape/DATA ownership', () => {
+  const residual = ['filter-width', 'filter-ifShift', 'filter-pbtInner', 'filter-pbtOuter'] as const;
+  const externalLabels = ['Mode', 'Filter', 'Filter shape', 'DATA mode'] as const;
 
   it('places named Standard and grouped SDR seats once while residual owners stay single', () => {
     h.state = filterState(); h.caps = filterCaps(); h.selectedFiniteAppearance = finiteAppearance;
     const layout = renderHostedLayout('desktop-v2');
     const subscribers = [...h.authoritySubscribers];
     const grid = q('[data-testid="filter-finite-grid"]')!;
-    expect([...grid.children].map(node => node.getAttribute('data-field'))).toEqual(['mode', 'filter']);
-    expect(target.querySelectorAll('[data-testid="external-Mode"]')).toHaveLength(1);
-    expect(target.querySelectorAll('[data-testid="external-Filter"]')).toHaveLength(1);
+    expect([...grid.children].map(node => node.getAttribute('data-field')))
+      .toEqual(['mode', 'filter', 'shape', 'dataMode']);
+    for (const label of externalLabels) {
+      expect(target.querySelectorAll(`[data-testid="external-${label}"]`)).toHaveLength(1);
+    }
     expect(q('[data-testid="external-Mode"]')?.getAttribute('data-reading')).toBe('USB');
     for (const id of residual) expect(target.querySelectorAll(`[data-testid="${id}"]`)).toHaveLength(1);
     retainedInvocations.get('Mode')?.('CW'); retainedInvocations.get('Filter')?.(2);
+    retainedInvocations.get('Filter shape')?.(0); retainedInvocations.get('DATA mode')?.(1);
     expect(h.modeChange).toHaveBeenCalledExactlyOnceWith('CW');
     expect(h.filterChange).toHaveBeenCalledExactlyOnceWith(2);
+    expect(h.filterShapeChange).toHaveBeenCalledExactlyOnceWith(0);
+    expect(h.dataModeChange).toHaveBeenCalledExactlyOnceWith(1);
     const standardMode = retainedInvocations.get('Mode')!;
 
     publishAuthority(); flushSync();
@@ -753,8 +781,9 @@ describe('hosted Filter Mode and Filter ownership', () => {
     layout.skinId = 'sdr-test'; flushSync();
 
     expect(q('[data-testid="filter-finite-grid"]')).toBeNull();
-    expect(target.querySelectorAll('[data-testid="external-Mode"]')).toHaveLength(1);
-    expect(target.querySelectorAll('[data-testid="external-Filter"]')).toHaveLength(1);
+    for (const label of externalLabels) {
+      expect(target.querySelectorAll(`[data-testid="external-${label}"]`)).toHaveLength(1);
+    }
     for (const id of residual) expect(target.querySelectorAll(`[data-testid="${id}"]`)).toHaveLength(1);
     expect([...h.authoritySubscribers]).toEqual(subscribers);
     const sdrMode = retainedInvocations.get('Mode')!;
@@ -768,8 +797,7 @@ describe('hosted Filter Mode and Filter ownership', () => {
     h.session = { state: 'disconnected', epoch: 7 };
     renderHostedDesktop();
 
-    expect(q('[data-testid="external-Mode"]')).toBeNull();
-    expect(q('[data-testid="external-Filter"]')).toBeNull();
+    for (const label of externalLabels) expect(q(`[data-testid="external-${label}"]`)).toBeNull();
     expect(q('[data-testid="filter-mode"]')).toBeNull();
     expect(q('[data-testid="filter-select"]')).toBeNull();
     for (const id of residual) expect(target.querySelectorAll(`[data-testid="${id}"]`)).toHaveLength(1);
@@ -806,6 +834,82 @@ describe('hosted Filter Mode and Filter ownership', () => {
       retainedA1('FM'); expect(h.modeChange).toHaveBeenCalledTimes(1);
     },
   );
+
+  /**
+   * MOR-2425 F1-C2 — the weakest witness: request DATA in Standard, switch
+   * to SDR BEFORE any echo updates the confirmed reading, and prove — in
+   * this order — (i) the SAME host-owned DATA-mode seat object survives the
+   * switch (`finiteSeats`, the `createChoiceRendererSeat` capture wrapper
+   * above — a DOM testid alone is re-created by the layout swap on both
+   * sides and proves nothing), (ii) the fresh SDR invocation still commands
+   * exactly once, (iii) the unconfirmed reading is unaffected by the switch
+   * itself, and only then (iv) the stale pre-switch invocation is inert.
+   * Counting `filter-data-mode`/`external-DATA mode` occurrences before and
+   * after the switch (the vacuous form) would pass unchanged even if the
+   * host were torn down and rebuilt, since the grouped SDR surface renders
+   * its own DATA seat regardless of which host produced it.
+   */
+  it('keeps the DATA-mode seat, commands once, and detaches the stale Standard invocation across Standard→SDR', () => {
+    h.state = filterState(); h.caps = filterCaps(); h.selectedFiniteAppearance = finiteAppearance;
+    const layout = renderHostedLayout('desktop-v2');
+    const dataSeatsBefore = finiteSeats.seats.filter(entry => entry.label === 'DATA mode');
+    expect(dataSeatsBefore).toHaveLength(1);
+    const dataSeat = dataSeatsBefore[0].seat;
+    const staleStandardData = retainedInvocations.get('DATA mode')!;
+    const beforeReading = q('[data-testid="external-DATA mode"]')?.getAttribute('data-reading');
+
+    layout.skinId = 'sdr-test'; flushSync();
+
+    // (i) Identity, positively: the SAME host-owned seat, not rebuilt.
+    const dataSeatsAfter = finiteSeats.seats.filter(entry => entry.label === 'DATA mode');
+    expect(dataSeatsAfter).toHaveLength(1);
+    expect(dataSeatsAfter[0].seat).toBe(dataSeat);
+
+    // (ii) A fresh, CURRENT invocation exists for the grouped SDR placement
+    // and commands exactly once.
+    const freshSdrData = retainedInvocations.get('DATA mode')!;
+    expect(freshSdrData).not.toBe(staleStandardData);
+    freshSdrData(1);
+    expect(h.dataModeChange).toHaveBeenCalledExactlyOnceWith(1);
+
+    // (iii) The unconfirmed reading is unaffected by the switch itself —
+    // only the click above changes anything downstream.
+    expect(q('[data-testid="external-DATA mode"]')?.getAttribute('data-reading')).toBe(beforeReading);
+
+    // (iv) Only now: the stale pre-switch invocation is DETACHED.
+    staleStandardData(1);
+    expect(h.dataModeChange).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * MOR-2425 F1-C2 — `filterFiniteAuthority`'s group-presence gate widened
+ * from `model?.modeFilter === undefined` alone to `modeFilter === undefined
+ * && filterPassband === undefined`, so a passband-only radio (Shape/DATA
+ * capability, no mode/filter group at all) still gets a valid Filter
+ * authority context. Left at the old gate, authority stays null forever for
+ * such a radio, so a Filter finite seat's `createChoiceRendererSeat` lease
+ * captures a null context and starts permanently revoked (`createSeat`'s
+ * `attachRenderer`, `control-instrument-renderer.svelte.ts`) — the external
+ * renderer's `view` is `undefined` and nothing with `data-testid="external-
+ * DATA mode"` ever renders, even though the field itself is structurally
+ * present.
+ */
+describe('MOR-2425 F1-C2 — Filter authority admits a passband-only radio', () => {
+  function passbandOnlyCaps(): Capabilities {
+    return {
+      ...liveCaps(true), modes: [], filters: [],
+      capabilities: [...liveCaps(true).capabilities, 'data_mode'],
+      dataModeCount: 1,
+    } as unknown as Capabilities;
+  }
+
+  it('renders the DATA-mode seat for a radio with no modeFilter group at all', () => {
+    h.state = liveState(true); h.caps = passbandOnlyCaps(); h.selectedFiniteAppearance = finiteAppearance;
+    renderHostedDesktop();
+    expect(q('[data-testid="filter-finite-grid"]')).not.toBeNull();
+    expect(q('[data-testid="external-DATA mode"]')).not.toBeNull();
+  });
 });
 
 // ── 1. The structural gate: absent group ⇒ no surface, no element drift ────

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts
@@ -524,7 +524,7 @@ describe('ifShiftControlStructural — the presentation-only IF-shift control ga
 
 /**
  * `filterShapeControlStructural` (MOR-1502) — a SEPARATE, presentation-only
- * flag `FilterSurface.svelte` uses to decide whether to show the SHARP/SOFT
+ * flag `FilterInstrumentHost.svelte` uses to decide whether to show the SHARP/SOFT
  * shape ROW, deliberately independent of `filterShape.availability.
  * structural` above (which is `hasFilters` alone — see the "per-field
  * structural gates" block — because `scope-adapter.ts` still needs the

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -658,7 +658,7 @@ function deriveFilterPassband(
     // an honest derived `filterShape` READING for any consumer of the raw
     // fact (`scope-adapter.ts` reads `filterPassband.filterShape` directly).
     // This flag answers a DIFFERENT question — does the radio have a REAL
-    // `filter_shape` COMMAND of its own — for `FilterSurface.svelte` to
+    // `filter_shape` COMMAND of its own — for `FilterInstrumentHost.svelte` to
     // decide whether to show the SHARP/SOFT shape CONTROL at all. The FTX-1
     // (filters, no filter_shape) has no such command; showing the control
     // permanently disabled is a dead control, not a usable one (the owner's

--- a/frontend/src/semantic/FilterInstrumentHost.svelte
+++ b/frontend/src/semantic/FilterInstrumentHost.svelte
@@ -6,14 +6,19 @@
   import {
     createChoiceRendererSeat, type FiniteControlAppearance, type FiniteRendererContext,
   } from '../primitives/control-instruments/control-instrument-renderer.svelte';
-  import type { FilterFiniteChoiceValue, FilterInstrumentHandles } from './filter-instruments';
+  import {
+    FILTER_SHAPES, type FilterFiniteChoiceValue, type FilterInstrumentHandles,
+  } from './filter-instruments';
   import type { RadioViewModel } from './radio-view-model';
 
   interface ExistingProps {
     view: RadioViewModel | null;
     pendingFilter?: number | null;
+    pendingDataMode?: number | null;
     onModeChange?: (mode: string) => void;
     onFilterChange?: (filter: number) => void;
+    onFilterShapeChange?: (shape: number) => void;
+    onDataModeChange?: (mode: number) => void;
     children: Snippet<[FilterInstrumentHandles]>;
   }
   type RendererSelection = { finiteAppearance?: undefined; rendererContext?: undefined } | {
@@ -23,18 +28,23 @@
   type Props = ExistingProps & RendererSelection;
 
   let {
-    view, pendingFilter = null, onModeChange, onFilterChange,
+    view, pendingFilter = null, pendingDataMode = null,
+    onModeChange, onFilterChange, onFilterShapeChange, onDataModeChange,
     finiteAppearance, rendererContext, children,
   }: Props = $props();
 
   let modeFilter = $derived(view?.modeFilter);
+  let filterPassband = $derived(view?.filterPassband);
   const pendingId = $props.id();
+  const pendingDataModeId = `${pendingId}-data-mode`;
   const usable = (field: { availability: { structural: boolean; operational: boolean };
     reading: { status: string } } | undefined): boolean => field !== undefined
       && field.availability.structural && field.availability.operational
       && field.reading.status === 'known';
   const reason = (field: Parameters<typeof usable>[0]) =>
     usable(field) ? undefined : 'field-not-observed';
+  const textOf = (field: { reading: { status: 'known'; value: unknown } | { status: 'unknown' } }) =>
+    field.reading.status === 'known' ? String(field.reading.value) : '?';
   const requested = <T,>(target: T | null) => target === null
     ? undefined : { kind: 'requested-target' as const, target };
 
@@ -47,6 +57,16 @@
     choices: (modeFilter?.filterChoices ?? []).map((_choice, index) => index + 1),
     invoke: (value) => onFilterChange?.(value),
   }));
+  const shapeBehavior = bindChoiceInstrument(() => ({
+    field: filterPassband?.filterShape, choices: FILTER_SHAPES.map(([value]) => value),
+    invoke: (value) => onFilterShapeChange?.(value),
+  }));
+  const dataBehavior = bindChoiceInstrument(() => ({
+    field: filterPassband?.dataMode,
+    choices: filterPassband?.dataModeChoices.map(choice => choice.value) ?? [],
+    blocked: (filterPassband?.dataModeChoices.length ?? 0) < 2,
+    invoke: (value) => onDataModeChange?.(value),
+  }));
 
   const modeSeat = createChoiceRendererSeat<FilterFiniteChoiceValue>(() => ({
     context: rendererContext ?? null, field: modeFilter?.currentMode, label: 'Mode',
@@ -58,7 +78,22 @@
     options: (modeFilter?.filterChoices ?? []).map((label, index) => ({ value: index + 1, label })),
     requested: requested(pendingFilter), invoke: value => onFilterChange?.(value as number),
   }), { selectionRequiresAvailability: true });
-  onDestroy(() => { modeSeat.destroy(); filterSeat.destroy(); });
+  const shapeSeat = createChoiceRendererSeat<FilterFiniteChoiceValue>(() => ({
+    context: rendererContext ?? null, field: filterPassband?.filterShape, label: 'Filter shape',
+    options: FILTER_SHAPES.map(([value, label]) => ({ value, label })),
+    invoke: value => onFilterShapeChange?.(value as number),
+  }), { selectionRequiresAvailability: true });
+  const dataSeat = createChoiceRendererSeat<FilterFiniteChoiceValue>(() => ({
+    context: rendererContext ?? null, field: filterPassband?.dataMode, label: 'DATA mode',
+    options: (filterPassband?.dataModeChoices ?? []).map(choice => ({
+      value: choice.value, label: choice.label ?? (choice.value === 0 ? 'OFF' : `D${choice.value}`),
+    })),
+    blocked: (filterPassband?.dataModeChoices.length ?? 0) < 2,
+    requested: requested(pendingDataMode), invoke: value => onDataModeChange?.(value as number),
+  }), { selectionRequiresAvailability: true });
+  onDestroy(() => {
+    modeSeat.destroy(); filterSeat.destroy(); shapeSeat.destroy(); dataSeat.destroy();
+  });
 </script>
 
 {#snippet external(seat: typeof modeSeat)}
@@ -93,11 +128,43 @@
     {/if}
   {/if}
 {/snippet}
+{#snippet shape()}
+  {#if filterPassband?.filterShapeControlStructural}
+    {#if finiteAppearance}{@render external(shapeSeat)}{:else}
+      <div class="filter-choice-group" data-testid="filter-shape" data-disabled-reason={reason(filterPassband.filterShape)}>
+        {#each FILTER_SHAPES as [value, label] (value)}<button type="button" class="filter-choice"
+          data-testid={`filter-shape-${value}`} aria-pressed={shapeBehavior.available && shapeBehavior.isSelected(value)}
+          disabled={!shapeBehavior.available} onclick={() => shapeBehavior.invoke(value)}>{label}</button>{/each}
+      </div>
+    {/if}
+  {/if}
+{/snippet}
+{#snippet dataMode()}
+  {#if filterPassband?.dataMode.availability.structural}
+    {#if finiteAppearance}{@render external(dataSeat)}{:else}
+      <div class={filterPassband.dataModeChoices.length > 1 ? 'filter-choice-group' : 'filter-readout'} data-testid="filter-data-mode"
+        role="group" aria-label={t('core.mobile.sheet.dataMode')} data-disabled-reason={reason(filterPassband.dataMode)}
+        data-data-mode-status={pendingDataMode !== null ? 'pending' : usable(filterPassband.dataMode) ? 'confirmed' : filterPassband.dataMode.reading.status === 'known' ? 'retained' : 'unknown'}
+        aria-describedby={pendingDataMode !== null ? pendingDataModeId : undefined}>
+        <span class="filter-level-name">{filterPassband.dataModeChoices.length > 1 ? t('core.mobile.sheet.dataMode') : 'DATA'}</span>
+        <output>{textOf(filterPassband.dataMode)}</output>
+        {#if filterPassband.dataModeChoices.length > 1}
+          {#each filterPassband.dataModeChoices as choice (choice.value)}<button type="button" class="filter-choice"
+            data-testid={`filter-data-mode-${choice.value}`} aria-pressed={dataBehavior.available && dataBehavior.isSelected(choice.value)}
+            data-pending={pendingDataMode === choice.value} disabled={!dataBehavior.available}
+            onclick={() => dataBehavior.invoke(choice.value)}>{choice.label ?? (choice.value === 0 ? 'OFF' : `D${choice.value}`)}</button>{/each}
+        {/if}
+        {#if pendingDataMode !== null}<span id={pendingDataModeId} class="sr-only">{t('core.modePanel.dataMode.pendingAnnouncement')}</span>{/if}
+      </div>
+    {/if}
+  {/if}
+{/snippet}
 
-{@render children({ mode, filter })}
+{@render children({ mode, filter, shape, dataMode })}
 
 <style>
-  .filter-choice-group { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; }
+  .filter-choice-group, .filter-readout { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; }
+  .filter-level-name { min-width: 8ch; }
   .filter-choice[aria-pressed='true'] { font-weight: 700; }
   .filter-choice:disabled { cursor: not-allowed; }
   .filter-choice[data-pending='true'] { font-style: italic; opacity: 0.75; }

--- a/frontend/src/semantic/FilterSurface.svelte
+++ b/frontend/src/semantic/FilterSurface.svelte
@@ -15,8 +15,7 @@
       nothing; a present-but-unobserved field renders disabled, with reason
       `field-not-observed`, never a guessed value or a fabricated selection
       (a control never claims a choice is active unless its OWN reading says
-      so — an unknown `filterShape` on a radio that HAS filters shows neither
-      button pressed, matching v2's fail-open default nowhere).
+      so).
   (3) `filterWidthMin`/`filterWidthMax` are read through their OWN field —
       each one carries its OWN operational flag (the adapter gates them on
       `modeObserved`, `filterWidth` on its own `widthObserved`); this file
@@ -33,15 +32,6 @@
   MOR-1494 fixed. `ifShiftControlStructural` answers the narrower question
   this row needs: does the radio have a REAL `if_shift` command. See
   `radio-view-model.ts`'s `FilterPassbandViewModel` doc comment.
-
-  MOR-1502 applies the SAME split to the `filter-shape` ROW: it gates on
-  `filterPassband.filterShapeControlStructural`, NOT on
-  `filterPassband.filterShape.availability.structural`. The latter stays
-  `true` for any radio with a declared filter catalog at all (the FTX-1 has
-  filters but no `filter_shape` command — showing SHARP/SOFT permanently
-  disabled is the same "shown dead" defect). `filterShapeControlStructural`
-  answers whether the radio has a REAL `filter_shape` command; see
-  `FilterPassbandViewModel.filterShapeControlStructural`'s doc comment.
 
   PENDING AFFORDANCE (MOR-1441 leg 2). The host-owned Filter handle carries
   the pending target separately from confirmed truth.

--- a/frontend/src/semantic/FilterSurface.svelte
+++ b/frontend/src/semantic/FilterSurface.svelte
@@ -3,9 +3,8 @@
 
   Presentation only. Places the host-owned mode and filter handles beside
   the MOR-1280 `modeFilter` width, then renders the MOR-1284
-  `filterPassband` group (filter shape, IF-shift, PBT inner/outer, DATA
-  submode) — the same two groups the v2 `FilterPanel` reads together
-  (`panel-props.ts`'s `deriveFilterProps`).
+  `filterPassband` group — the same two groups the v2 `FilterPanel` reads
+  together (`panel-props.ts`'s `deriveFilterProps`).
 
   Doctrine, same as `TxAuxSurface`/`MetersSurface`:
   (1) Facts only — every value and every min/max bound is READ from the
@@ -45,8 +44,7 @@
   `FilterPassbandViewModel.filterShapeControlStructural`'s doc comment.
 
   PENDING AFFORDANCE (MOR-1441 leg 2). The host-owned Filter handle carries
-  the pending target separately from confirmed truth. DATA remains local and
-  keeps the same separation below.
+  the pending target separately from confirmed truth.
 -->
 <script module lang="ts">
   import type { DisplayObservedField, TxAuxField } from './radio-view-model';

--- a/frontend/src/semantic/FilterSurface.svelte
+++ b/frontend/src/semantic/FilterSurface.svelte
@@ -51,9 +51,6 @@
 <script module lang="ts">
   import type { DisplayObservedField, TxAuxField } from './radio-view-model';
 
-  /** Fixed filter-shape choice set (SHARP/SOFT) — same two options
-   *  `FilterPanel`'s shape buttons offer, `[value, label]`. */
-  export const FILTER_SHAPES = [[0, 'SHARP'], [1, 'SOFT']] as const;
   /** `[field, label, min, max, step]` in RAW Hz, same ranges `FilterPanel`'s
    *  IF-shift/PBT sliders have always used. */
   export const FILTER_PASSBAND_LEVELS = [
@@ -89,7 +86,6 @@
 <script lang="ts">
   import { onDestroy, untrack } from 'svelte';
   import { t } from '$lib/i18n';
-  import { bindChoiceInstrument } from '../primitives/control-instruments/control-instrument-behavior';
   import {
     createContinuousScalar, nativeRangeContinuousScalarPolicy,
     type CommandScalarFeedback, type ContinuousScalarInput,
@@ -102,24 +98,19 @@
     view: RadioViewModel;
     handles: FilterInstrumentHandles;
     finiteLayout?: FilterFiniteLayout;
-    pendingDataMode?: number | null;
     filterWidthFeedback?: Readonly<CommandScalarFeedback>;
-    onDataModeChange?: (mode: number) => void;
     onFilterWidthChange?: (width: number) => void;
-    onFilterShapeChange?: (shape: number) => void;
     onIfShiftChange?: (value: number) => void;
     onPbtInnerChange?: (value: number) => void;
     onPbtOuterChange?: (value: number) => void;
     onPbtReset?: () => void;
   }
   let {
-    view, handles, finiteLayout, pendingDataMode = null, filterWidthFeedback,
-    onDataModeChange, onFilterWidthChange,
-    onFilterShapeChange, onIfShiftChange, onPbtInnerChange, onPbtOuterChange, onPbtReset,
+    view, handles, finiteLayout, filterWidthFeedback,
+    onFilterWidthChange, onIfShiftChange, onPbtInnerChange, onPbtOuterChange, onPbtReset,
   }: Props = $props();
 
   const pendingFilterId = $props.id();
-  const pendingDataModeId = `${pendingFilterId}-data-mode`;
   const feedbackIntegratedRange = { 'feedback-policy': 'feedback-integrated' } as const;
 
   let modeFilter = $derived(view.modeFilter);
@@ -205,20 +196,6 @@
     );
   });
   onDestroy(() => filterWidthScalar.destroy());
-  function shapeInstrument() {
-    return bindChoiceInstrument(() => ({
-      field: filterPassband?.filterShape, choices: FILTER_SHAPES.map(([value]) => value),
-      invoke: (value) => onFilterShapeChange?.(value),
-    }));
-  }
-  function dataModeInstrument() {
-    return bindChoiceInstrument(() => ({
-      field: filterPassband?.dataMode,
-      choices: filterPassband?.dataModeChoices.map(choice => choice.value) ?? [],
-      blocked: (filterPassband?.dataModeChoices.length ?? 0) < 2,
-      invoke: (value) => onDataModeChange?.(value),
-    }));
-  }
   /** One guarded entry point for all three passband sliders — each still
    *  reads and disables on its OWN field's availability (see the file
    *  header, rule 3), this only routes the already-checked value onward. */
@@ -233,11 +210,13 @@
 
 {#if modeFilter || filterPassband}
   <section class="filter-surface" data-testid="filter-surface" aria-label="Mode and filter controls">
+    {#if finiteLayout}
+      {@render finiteLayout(handles)}
+    {:else if modeFilter}
+      {@render handles.mode()}
+      {@render handles.filter()}
+    {/if}
     {#if modeFilter}
-      {#if finiteLayout}{@render finiteLayout(handles)}{:else}
-        {@render handles.mode()}
-        {@render handles.filter()}
-      {/if}
       {#if modeFilter.filterWidth.availability.structural}
         <label class="filter-level" data-testid="filter-width" data-disabled-reason={reasonOf(modeFilter.filterWidth)}>
           <span class="filter-level-name">Width</span>
@@ -275,21 +254,8 @@
           />
         {/key}
       {/snippet}
-      {#if filterPassband.filterShapeControlStructural}
-        {@const behavior = shapeInstrument()}
-        <div
-          class="filter-choice-group" data-testid="filter-shape"
-          data-disabled-reason={reasonOf(filterPassband.filterShape)}
-        >
-          {#each FILTER_SHAPES as [value, label] (value)}
-            <button
-              type="button" class="filter-choice" data-testid={`filter-shape-${value}`}
-              aria-pressed={behavior.available && behavior.isSelected(value)}
-              disabled={!behavior.available}
-              onclick={() => behavior.invoke(value)}
-            >{label}</button>
-          {/each}
-        </div>
+      {#if !finiteLayout}
+        {@render handles.shape()}
       {/if}
       {#each FILTER_PASSBAND_LEVELS as [field, label, min, max, step] (field)}
         {#if field === 'ifShift' ? filterPassband.ifShiftControlStructural : filterPassband[field].availability.structural}
@@ -337,32 +303,8 @@
           onclick={() => onPbtReset?.()}
         >Reset</button>
       {/if}
-      {#if filterPassband.dataMode.availability.structural}
-        {@const behavior = dataModeInstrument()}
-        <div
-          class={filterPassband.dataModeChoices.length > 1 ? 'filter-choice-group' : 'filter-readout'} data-testid="filter-data-mode"
-          role="group" aria-label={t('core.mobile.sheet.dataMode')}
-          data-disabled-reason={reasonOf(filterPassband.dataMode)}
-          data-data-mode-status={pendingDataMode !== null ? 'pending' : presentationOf(filterPassband.dataMode)}
-          aria-describedby={pendingDataMode !== null ? pendingDataModeId : undefined}
-        >
-          <span class="filter-level-name">{filterPassband.dataModeChoices.length > 1 ? t('core.mobile.sheet.dataMode') : 'DATA'}</span>
-          <output>{textOf(filterPassband.dataMode)}</output>
-          {#if filterPassband.dataModeChoices.length > 1}
-            {#each filterPassband.dataModeChoices as choice (choice.value)}
-              <button
-                type="button" class="filter-choice" data-testid={`filter-data-mode-${choice.value}`}
-                aria-pressed={behavior.available && behavior.isSelected(choice.value)}
-                data-pending={pendingDataMode === choice.value}
-                disabled={!behavior.available}
-                onclick={() => behavior.invoke(choice.value)}
-              >{choice.label ?? (choice.value === 0 ? 'OFF' : `D${choice.value}`)}</button>
-            {/each}
-          {/if}
-          {#if pendingDataMode !== null}
-            <span id={pendingDataModeId} class="sr-only">{t('core.modePanel.dataMode.pendingAnnouncement')}</span>
-          {/if}
-        </div>
+      {#if !finiteLayout}
+        {@render handles.dataMode()}
       {/if}
     {/if}
   </section>
@@ -371,22 +313,14 @@
 <style>
   /* Structure only — a design language owns colour (MOR-977, forced-colors). */
   .filter-surface { display: flex; flex-direction: column; gap: 0.25rem; }
-  .filter-choice-group { display: flex; flex-wrap: wrap; gap: 0.5rem; }
-  .filter-level, .filter-readout { display: flex; align-items: baseline; gap: 0.5rem; }
+  .filter-level { display: flex; align-items: baseline; gap: 0.5rem; }
   .filter-level-name { min-width: 8ch; }
   .pbt-slot { display: inline-flex; align-items: center; width: 8rem; height: 1.5rem; }
   .pbt-slot input { width: 100%; margin-inline: 0; }
   .pbt-unknown { width: 100%; text-align: center; }
   .pbt-value { min-width: 6ch; font-variant-numeric: tabular-nums; }
   .pbt-cue { width: 1ch; }
-  .filter-choice[aria-pressed='true'] { font-weight: 700; }
-  .filter-choice:disabled { cursor: not-allowed; }
   .pbt-reset-button { align-self: flex-start; }
-  /* MOR-1441 leg 2 — a pending (unconfirmed) target never renders identically
-     to confirmed truth. Structural (italic + reduced opacity), never a
-     color-only tell — same doctrine `.freq[data-freq-status='pending']`
-     (leg 1) established. */
-  .filter-choice[data-pending='true'] { font-style: italic; opacity: 0.75; }
   .sr-only {
     position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
     overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;

--- a/frontend/src/semantic/__tests__/FilterInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/FilterInstrumentHost.isolated.test.ts
@@ -9,7 +9,7 @@ import FiniteControlRendererFixture, {
 } from '../../primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte';
 import type { FilterFiniteChoiceValue } from '../filter-instruments';
 import { topologyFixtures, withFilterPassband, withModeFilter } from '../fixtures/topologies';
-import type { ModeFilterViewModel, RadioViewModel } from '../radio-view-model';
+import type { FilterPassbandViewModel, ModeFilterViewModel, RadioViewModel } from '../radio-view-model';
 import FilterInstrumentHostFixture from './fixtures/FilterInstrumentHostFixture.svelte';
 
 const base = (): RadioViewModel => withFilterPassband(withModeFilter(topologyFixtures['1/single']));
@@ -25,58 +25,68 @@ beforeEach(() => {
 });
 afterEach(() => target.remove());
 
-function modeReading(
-  view: RadioViewModel, name: 'currentMode' | 'currentFilter',
-  reading: { status: 'unknown' } | { status: 'known'; value: string | number },
-  operational = true,
+function reading(
+  view: RadioViewModel, group: 'modeFilter' | 'filterPassband', name: string,
+  next: { status: 'unknown' } | { status: 'known'; value: string | number }, operational = true,
 ): RadioViewModel {
-  const modeFilter = view.modeFilter!;
-  return { ...view, modeFilter: { ...modeFilter, [name]: {
-    ...modeFilter[name], availability: { ...modeFilter[name].availability, operational }, reading,
-  } } as ModeFilterViewModel };
+  const current = view[group] as unknown as Record<string, unknown>;
+  const field = current[name] as { availability: { structural: boolean; operational: boolean } };
+  return { ...view, [group]: { ...current, [name]: {
+    ...field, availability: { ...field.availability, operational }, reading: next,
+  } } } as RadioViewModel;
 }
 
-describe('FilterInstrumentHost Mode and Filter ownership', () => {
-  it('renders exact native choices in grouped and independent layouts with pending separate from truth', () => {
+describe('FilterInstrumentHost finite ownership', () => {
+  it('renders exact native choices in grouped and independent arrangements with pending separate from truth', () => {
     const onModeChange = vi.fn(), onFilterChange = vi.fn();
+    const onFilterShapeChange = vi.fn(), onDataModeChange = vi.fn();
     const props = proxy({ view: base(), presentation: 'grouped' as 'grouped' | 'independent',
-      pendingFilter: 2, onModeChange, onFilterChange });
+      pendingFilter: 2, pendingDataMode: 1,
+      onModeChange, onFilterChange, onFilterShapeChange, onDataModeChange });
     const component = mount(FilterInstrumentHostFixture, { target, props }); flushSync();
+    expect(target.querySelectorAll('[data-testid="grouped-filter-composition"] button')).toHaveLength(12);
     const labels = (id: string) => [...target.querySelectorAll(`[data-testid="${id}"] button`)]
       .map(button => button.textContent);
-    expect(target.querySelectorAll('[data-testid="grouped-filter-composition"] button')).toHaveLength(8);
     expect(labels('filter-mode')).toEqual(['USB', 'LSB', 'CW', 'RTTY', 'FM']);
     expect(labels('filter-select')).toEqual(['FIL1', 'FIL2', 'FIL3']);
+    expect(labels('filter-shape')).toEqual(['SHARP', 'SOFT']);
+    expect(labels('filter-data-mode')).toEqual(['OFF', 'D1']);
     expect(target.querySelector('[data-testid="filter-mode-USB"]')?.getAttribute('aria-pressed')).toBe('true');
     expect(target.querySelector('[data-testid="filter-select-1"]')?.getAttribute('aria-pressed')).toBe('true');
     expect((target.querySelector('[data-testid="filter-select-2"]') as HTMLElement).dataset.pending).toBe('true');
+    expect(target.querySelector('[data-testid="filter-data-mode-0"]')?.getAttribute('aria-pressed')).toBe('true');
+    expect((target.querySelector('[data-testid="filter-data-mode-1"]') as HTMLElement).dataset.pending).toBe('true');
+    expect(target.querySelector('[data-testid="filter-mode"]')?.getAttribute('aria-describedby')).toBeNull();
+    expect(target.querySelector('[data-testid="filter-shape"]')?.getAttribute('aria-describedby')).toBeNull();
     expect(target.querySelector('[data-testid="filter-select"]')?.getAttribute('aria-describedby')).not.toBeNull();
-    (target.querySelector('[data-testid="filter-mode-LSB"]') as HTMLButtonElement).click();
-    (target.querySelector('[data-testid="filter-select-2"]') as HTMLButtonElement).click();
+    expect(target.querySelector('[data-testid="filter-data-mode"]')?.getAttribute('aria-describedby')).not.toBeNull();
+    for (const id of ['filter-mode-LSB', 'filter-select-2', 'filter-shape-0', 'filter-data-mode-1'])
+      (target.querySelector(`[data-testid="${id}"]`) as HTMLButtonElement).click();
     expect(onModeChange).toHaveBeenCalledExactlyOnceWith('LSB');
     expect(onFilterChange).toHaveBeenCalledExactlyOnceWith(2);
+    expect(onFilterShapeChange).toHaveBeenCalledExactlyOnceWith(0);
+    expect(onDataModeChange).toHaveBeenCalledExactlyOnceWith(1);
     props.presentation = 'independent'; flushSync();
     expect(target.querySelector('[data-testid="grouped-filter-composition"]')).toBeNull();
-    expect(target.querySelectorAll('[data-testid="independent-filter-composition"] button')).toHaveLength(8);
-    expect(target.querySelectorAll('[data-slot="mode"]')).toHaveLength(1);
-    expect(target.querySelectorAll('[data-slot="filter"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-testid="independent-filter-composition"] button')).toHaveLength(12);
     unmount(component);
   });
 
-  it('keeps external options, raw readings and callbacks current', () => {
-    const firstMode = vi.fn(), nextMode = vi.fn(), onFilterChange = vi.fn();
-    const props = proxy({
-      view: modeReading(base(), 'currentFilter', { status: 'known', value: 99 }),
-      presentation: 'independent' as const, finiteAppearance: appearance,
-      rendererContext: createFiniteRendererContext(), onModeChange: firstMode, onFilterChange,
-    });
+  it('keeps external options and callbacks current without coercing DATA2 or unknown truth', () => {
+    const firstMode = vi.fn(), nextMode = vi.fn(), onDataModeChange = vi.fn();
+    let view = reading(base(), 'filterPassband', 'dataMode', { status: 'known', value: 2 });
+    view = reading(view, 'filterPassband', 'filterShape', { status: 'unknown' });
+    const props = proxy({ view, presentation: 'independent' as const, finiteAppearance: appearance,
+      rendererContext: createFiniteRendererContext(), onModeChange: firstMode, onDataModeChange });
     const component = mount(FilterInstrumentHostFixture, { target, props }); flushSync();
-    const filter = target.querySelector('[data-testid="external-Filter"]')!;
-    expect(filter.getAttribute('data-reading')).toBe('99');
-    expect(filter.querySelector('[aria-checked="true"]')).toBeNull();
-    expect([...filter.querySelectorAll('button')].map(button => button.textContent)).toEqual(['FIL1', 'FIL2', 'FIL3']);
-    (filter.querySelector('[data-testid="external-Filter-2"]') as HTMLButtonElement).click();
-    expect(onFilterChange).toHaveBeenCalledExactlyOnceWith(2);
+    const data = target.querySelector('[data-testid="external-DATA mode"]')!;
+    expect(data.getAttribute('data-reading')).toBe('2');
+    expect(data.querySelector('[aria-checked="true"]')).toBeNull();
+    expect([...data.querySelectorAll('button')].map(button => button.textContent)).toEqual(['OFF', 'D1']);
+    (data.querySelector('[data-testid="external-DATA mode-0"]') as HTMLButtonElement).click();
+    (data.querySelector('[data-testid="external-DATA mode-1"]') as HTMLButtonElement).click();
+    expect(onDataModeChange.mock.calls).toEqual([[0], [1]]);
+    expect(target.querySelector('[data-testid="external-Filter shape"]')?.querySelectorAll('button:disabled')).toHaveLength(2);
 
     props.view = { ...props.view, modeFilter: { ...props.view.modeFilter!,
       currentMode: { ...props.view.modeFilter!.currentMode, reading: { status: 'known', value: 'AM' } },
@@ -86,6 +96,10 @@ describe('FilterInstrumentHost Mode and Filter ownership', () => {
     expect([...mode.querySelectorAll('button')].map(button => button.textContent)).toEqual(['AM', 'FM']);
     (mode.querySelector('[data-testid="external-Mode-AM"]') as HTMLButtonElement).click();
     expect(firstMode).not.toHaveBeenCalled(); expect(nextMode).toHaveBeenCalledExactlyOnceWith('AM');
+    props.view = { ...props.view, filterPassband: { ...props.view.filterPassband!,
+      dataModeChoices: [{ value: 0, label: null }],
+    } as FilterPassbandViewModel }; flushSync();
+    expect((target.querySelector('[data-testid="external-DATA mode-0"]') as HTMLButtonElement).disabled).toBe(true);
     unmount(component);
   });
 
@@ -107,41 +121,76 @@ describe('FilterInstrumentHost Mode and Filter ownership', () => {
     unmount(component); activeA2(3); expect(onFilterChange).toHaveBeenCalledTimes(1);
   });
 
-  it('uses exact structural gates and retains unavailable readings without selected truth', () => {
-    const callbacks = { onModeChange: vi.fn(), onFilterChange: vi.fn() };
-    const absentBase = base();
-    const absent = { ...absentBase, modeFilter: { ...absentBase.modeFilter!,
-      currentMode: { ...absentBase.modeFilter!.currentMode,
-        availability: { structural: false, operational: true } },
-      currentFilter: { ...absentBase.modeFilter!.currentFilter,
-        availability: { structural: false, operational: true } },
-    } };
-    const props = proxy({ view: absent, presentation: 'independent' as const, ...callbacks });
-    let component = mount(FilterInstrumentHostFixture, { target, props }); flushSync();
+  it('uses each exact structural gate and keeps present unavailable fields inert', () => {
+    const unavailable = { structural: false, operational: true };
+    let view = base();
+    view = { ...view, modeFilter: { ...view.modeFilter!, currentMode: { ...view.modeFilter!.currentMode,
+      availability: unavailable }, currentFilter: { ...view.modeFilter!.currentFilter, availability: unavailable } },
+      filterPassband: { ...view.filterPassband!, filterShapeControlStructural: false,
+        dataMode: { ...view.filterPassband!.dataMode, availability: unavailable } } };
+    const props = proxy({ view, presentation: 'independent' as const });
+    const component = mount(FilterInstrumentHostFixture, { target, props }); flushSync();
     expect(target.querySelectorAll('[data-testid^="filter-"]')).toHaveLength(0);
-    unmount(component);
 
-    let retained = modeReading(base(), 'currentMode', { status: 'known', value: 'USB' }, false);
-    retained = modeReading(retained, 'currentFilter', { status: 'known', value: 1 }, false);
-    props.view = retained;
-    component = mount(FilterInstrumentHostFixture, { target, props }); flushSync();
-    for (const id of ['filter-mode-USB', 'filter-select-1']) {
-      const button = target.querySelector(`[data-testid="${id}"]`) as HTMLButtonElement;
-      expect(button.disabled).toBe(true); expect(button.getAttribute('aria-pressed')).toBe('false'); button.click();
+    const shapeFactAbsent = base();
+    props.view = { ...shapeFactAbsent, filterPassband: { ...shapeFactAbsent.filterPassband!,
+      filterShape: { ...shapeFactAbsent.filterPassband!.filterShape,
+        availability: { structural: false, operational: true } } } }; flushSync();
+    expect(target.querySelector('[data-testid="filter-shape"]')).not.toBeNull();
+    expect(target.querySelectorAll('[data-testid="filter-shape"] button:not(:disabled)')).toHaveLength(0);
+
+    view = reading(base(), 'modeFilter', 'currentMode', { status: 'unknown' });
+    view = reading(view, 'modeFilter', 'currentFilter', { status: 'known', value: 1 }, false);
+    view = reading(view, 'filterPassband', 'filterShape', { status: 'unknown' });
+    view = reading(view, 'filterPassband', 'dataMode', { status: 'known', value: 0 }, false);
+    props.view = view; flushSync();
+    const groups = ['filter-mode', 'filter-select', 'filter-shape', 'filter-data-mode'];
+    for (const id of groups) {
+      const group = target.querySelector(`[data-testid="${id}"]`)!;
+      expect(group.getAttribute('data-disabled-reason')).toBe('field-not-observed');
+      expect(group.querySelectorAll('button:not(:disabled)')).toHaveLength(0);
     }
-    expect(callbacks.onModeChange).not.toHaveBeenCalled(); expect(callbacks.onFilterChange).not.toHaveBeenCalled();
+    unmount(component);
+  });
+
+  it('retains all four known readings without selected truth while unavailable', () => {
+    const onModeChange = vi.fn(), onFilterChange = vi.fn();
+    const onFilterShapeChange = vi.fn(), onDataModeChange = vi.fn();
+    const callbacks = { onModeChange, onFilterChange, onFilterShapeChange, onDataModeChange };
+    let view = reading(base(), 'modeFilter', 'currentMode', { status: 'known', value: 'USB' }, false);
+    view = reading(view, 'modeFilter', 'currentFilter', { status: 'known', value: 1 }, false);
+    view = reading(view, 'filterPassband', 'filterShape', { status: 'known', value: 1 }, false);
+    view = reading(view, 'filterPassband', 'dataMode', { status: 'known', value: 0 }, false);
+    const props = proxy({ view, presentation: 'independent' as const, ...callbacks });
+    let component = mount(FilterInstrumentHostFixture, { target, props }); flushSync();
+
+    for (const id of ['filter-mode-USB', 'filter-select-1', 'filter-shape-1', 'filter-data-mode-0']) {
+      const button = target.querySelector(`[data-testid="${id}"]`) as HTMLButtonElement;
+      expect(button.disabled).toBe(true);
+      expect(button.getAttribute('aria-pressed')).toBe('false');
+      button.click();
+    }
+    expect(target.querySelector('[data-testid="filter-data-mode"] output')?.textContent).toBe('0');
+    for (const callback of Object.values(callbacks)) expect(callback).not.toHaveBeenCalled();
     unmount(component);
 
-    Object.assign(props, { finiteAppearance: appearance, rendererContext: createFiniteRendererContext() });
+    Object.assign(props, { finiteAppearance: appearance,
+      rendererContext: createFiniteRendererContext() });
     component = mount(FilterInstrumentHostFixture, { target, props }); flushSync();
-    for (const [label, exact] of [['Mode', 'USB'], ['Filter', '1']] as const) {
+    const retained = [['Mode', 'USB'], ['Filter', '1'], ['Filter shape', '1'], ['DATA mode', '0']] as const;
+    for (const [label, exactReading] of retained) {
       const group = target.querySelector(`[data-testid="external-${label}"]`)!;
-      expect(group.getAttribute('data-reading')).toBe(exact);
+      expect(group.getAttribute('data-reading')).toBe(exactReading);
       expect(group.querySelector('[aria-checked="true"]')).toBeNull();
       expect(group.querySelectorAll('button:disabled')).toHaveLength(group.querySelectorAll('button').length);
     }
     retainedInvocations.get('Mode')?.('USB'); retainedInvocations.get('Filter')?.(1);
-    expect(callbacks.onModeChange).not.toHaveBeenCalled(); expect(callbacks.onFilterChange).not.toHaveBeenCalled();
+    retainedInvocations.get('Filter shape')?.(1); retainedInvocations.get('DATA mode')?.(0);
+    for (const callback of Object.values(callbacks)) expect(callback).not.toHaveBeenCalled();
+
+    props.view = base(); flushSync();
+    for (const label of ['Mode', 'Filter', 'Filter shape', 'DATA mode'])
+      expect(target.querySelector(`[data-testid="external-${label}"] [aria-checked="true"]`)).not.toBeNull();
     unmount(component);
   });
 });

--- a/frontend/src/semantic/__tests__/FilterInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/FilterInstrumentHost.isolated.test.ts
@@ -60,11 +60,11 @@ describe('FilterInstrumentHost finite ownership', () => {
     expect(target.querySelector('[data-testid="filter-shape"]')?.getAttribute('aria-describedby')).toBeNull();
     expect(target.querySelector('[data-testid="filter-select"]')?.getAttribute('aria-describedby')).not.toBeNull();
     expect(target.querySelector('[data-testid="filter-data-mode"]')?.getAttribute('aria-describedby')).not.toBeNull();
-    for (const id of ['filter-mode-LSB', 'filter-select-2', 'filter-shape-0', 'filter-data-mode-1'])
+    for (const id of ['filter-mode-LSB', 'filter-select-2', 'filter-shape-1', 'filter-data-mode-1'])
       (target.querySelector(`[data-testid="${id}"]`) as HTMLButtonElement).click();
     expect(onModeChange).toHaveBeenCalledExactlyOnceWith('LSB');
     expect(onFilterChange).toHaveBeenCalledExactlyOnceWith(2);
-    expect(onFilterShapeChange).toHaveBeenCalledExactlyOnceWith(0);
+    expect(onFilterShapeChange).toHaveBeenCalledExactlyOnceWith(1);
     expect(onDataModeChange).toHaveBeenCalledExactlyOnceWith(1);
     props.presentation = 'independent'; flushSync();
     expect(target.querySelector('[data-testid="grouped-filter-composition"]')).toBeNull();

--- a/frontend/src/semantic/__tests__/FilterSurface.test.ts
+++ b/frontend/src/semantic/__tests__/FilterSurface.test.ts
@@ -14,11 +14,11 @@ import { createRawSnippet, flushSync, mount, unmount } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import { getLocale, setLocale } from '$lib/i18n';
 import FilterSurface, {
-  FILTER_PASSBAND_LEVELS, FILTER_SHAPES, type FilterPassbandLevelField,
+  FILTER_PASSBAND_LEVELS, type FilterPassbandLevelField,
 } from '../FilterSurface.svelte';
 import FilterInstrumentHostFixture from './fixtures/FilterInstrumentHostFixture.svelte';
 import { topologyFixtures, withFilterPassband, withModeFilter } from '../fixtures/topologies';
-import type { FilterInstrumentHandles } from '../filter-instruments';
+import { FILTER_SHAPES, type FilterInstrumentHandles } from '../filter-instruments';
 import type {
   Availability, FilterPassbandViewModel, ModeFilterViewModel, RadioViewModel,
 } from '../radio-view-model';
@@ -1180,6 +1180,8 @@ describe('explicit PBT display (MOR-1692)', () => {
 const pbtStubHandles: FilterInstrumentHandles = {
   mode: createRawSnippet(() => ({ render: () => '<span></span>' })),
   filter: createRawSnippet(() => ({ render: () => '<span></span>' })),
+  shape: createRawSnippet(() => ({ render: () => '<span></span>' })),
+  dataMode: createRawSnippet(() => ({ render: () => '<span></span>' })),
 };
 function renderPbtOnly(view: RadioViewModel, onPbtReset?: () => void) {
   const component = mount(FilterSurface, {

--- a/frontend/src/semantic/__tests__/fixtures/FilterInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/FilterInstrumentHostFixture.svelte
@@ -37,21 +37,24 @@
 {#snippet independent(handles: FilterInstrumentHandles)}
   <div data-slot="mode">{@render handles.mode()}</div>
   <div data-slot="filter">{@render handles.filter()}</div>
+  <div data-slot="shape">{@render handles.shape()}</div>
+  <div data-slot="data-mode">{@render handles.dataMode()}</div>
 {/snippet}
 
-<FilterInstrumentHost {view} {pendingFilter} {onModeChange} {onFilterChange} {...selection}>
+<FilterInstrumentHost {view} {pendingFilter} {pendingDataMode} {onModeChange} {onFilterChange}
+  {onFilterShapeChange} {onDataModeChange} {...selection}>
   {#snippet children(handles: FilterInstrumentHandles)}
     {#if renderSurface && view !== null}
       <FilterSurface
         {view} {handles} finiteLayout={presentation === 'independent' ? independent : undefined}
-        {pendingDataMode} {filterWidthFeedback} {onDataModeChange} {onFilterWidthChange}
-        {onFilterShapeChange} {onIfShiftChange} {onPbtInnerChange} {onPbtOuterChange}
+        {filterWidthFeedback} {onFilterWidthChange}
+        {onIfShiftChange} {onPbtInnerChange} {onPbtOuterChange}
       />
     {:else}
       {#key presentation}
         <section data-testid={`${presentation}-filter-composition`}>
           {#if presentation === 'grouped'}
-            {@render handles.mode()}{@render handles.filter()}
+            {@render handles.mode()}{@render handles.filter()}{@render handles.shape()}{@render handles.dataMode()}
           {:else}
             {@render independent(handles)}
           {/if}

--- a/frontend/src/semantic/filter-instruments.ts
+++ b/frontend/src/semantic/filter-instruments.ts
@@ -2,9 +2,16 @@ import type { Snippet } from 'svelte';
 
 export type FilterFiniteChoiceValue = string | number;
 
+/** Fixed filter-shape choice set (SHARP/SOFT) — the one definition, moved
+ *  here from `FilterSurface.svelte`'s `<script module>` (MOR-2425 F1-C2) now
+ *  that `FilterInstrumentHost` owns the shape seat too. */
+export const FILTER_SHAPES = [[0, 'SHARP'], [1, 'SOFT']] as const;
+
 export interface FilterInstrumentHandles {
   readonly mode: Snippet;
   readonly filter: Snippet;
+  readonly shape: Snippet;
+  readonly dataMode: Snippet;
 }
 
 export type FilterFiniteLayout = Snippet<[FilterInstrumentHandles]>;

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -389,7 +389,7 @@ export interface FilterPassbandViewModel {
    * The FTX-1 has none — showing its SHARP/SOFT shape CONTROL permanently
    * disabled is a dead control (same class of defect `ifShiftControlStructural`
    * fixed, MOR-1494 ruling: hide capability-absent controls, don't show them
-   * dead). `FilterSurface.svelte` gates the filter-shape ROW on this flag,
+   * dead). `FilterInstrumentHost.svelte` gates the filter-shape ROW on this flag,
    * and ONLY this flag — never on `filterShape.availability.structural`,
    * which stays reserved for consumers of the derived fact itself (see
    * `deriveFilterPassband`'s doc comment). A plain boolean, not


### PR DESCRIPTION
7 code + 5 test files = 12 files (file-count exception granted by the coordinating session under the owner's 2026-09-03 delegation: the three files beyond the nine reviewed carry only one-word corrections to doc comments that the shape-gate relocation had falsified).

One unit of work: this is the already-released F1-C2 lane — it extends the exact same host, handle record, layout callback, and authority lane that F1-C1 (mode+filter) shipped, completing the split accepted in `filter-c1-family-preparation-release.md`/`filter-finite-live-split-refinement.md`; splitting it further would separate one seat-pair addition from the record/gate change it depends on. 12 files crosses the 6-file soft threshold and, by two, the 10-file hard ceiling (exception above).

## Summary

`FilterInstrumentHost`/`FilterInstrumentHandles` gain `shape` and `dataMode` seats, ported as hunks from the reviewed private branch `5095b95e` (never cherry-picked) — the shape/DATA halves of a four-seat host whose mode/filter half already shipped and whose renderer correction (`selectionRequiresAvailability`) is already on `main`. `FILTER_SHAPES` moves to `filter-instruments.ts` so one definition remains. `FilterSurface` drops its local shape/DATA owners and renders the host snippets in the same position, gated the same way `mode`/`filter` already were (native inline when no `finiteLayout`, delegated to the layout callback otherwise) — this also fixes a latent gap: previously the `finiteLayout` dispatch was nested inside `{#if modeFilter}`, so a passband-only radio's named layout was never invoked at all. `SemanticRadioSurfaces` forwards the two new callbacks to the host and widens `filterFiniteAuthority`'s group-presence gate from `modeFilter === undefined` to `modeFilter === undefined && filterPassband === undefined`, admitting passband-only radios without a new subscription or context family. `RadioLayout`'s Standard `filterFiniteLayout` gains two more named seats beside mode/filter; SDR is unchanged (grouped order unaffected).

## Witnesses

- `FilterInstrumentHost.isolated.test.ts` (ported from `5095b95e`, adapted): grouped/independent native choices with shape+DATA now in the 12-button count; external renderer parity; null/detached/A-B-A/teardown revocation; structural gates per field; retained-known-unavailable with no selected truth; **DATA2 case** — offered `[0,1]`, canonical reading `2` → no option pressed, DATA1 never claimed.
- `semantic-tx-aux-wiring.component.test.ts`: named Standard grid now `['mode','filter','shape','dataMode']`; **weakest witness** — mount Standard, capture the DATA-mode seat via a `createChoiceRendererSeat` capture wrapper (the same recipe `semantic-dsp-wiring.component.test.ts`'s `dspBindings()` and `semantic-rf-front-end-wiring.component.test.ts`'s `rfPair` establish), switch to SDR, and prove in order: (i) the SAME seat object survives (not a DOM-testid count — the vacuous form), (ii) the fresh SDR invocation commands exactly once, (iii) the unconfirmed reading is unaffected by the switch itself, (iv) only then the stale Standard invocation is inert. A second new case proves the widened authority gate: a passband-only radio (no `modeFilter` at all) still renders `external-DATA mode` under Standard — with the old gate, authority stays null forever and the seat's lease starts permanently revoked.
- `FilterInstrumentHost.isolated.test.ts` type check: `FilterSurface.test.ts`'s `pbtStubHandles` object literal is a `FilterInstrumentHandles` with only `mode`/`filter` — widening the record makes it a compile error, a free witness that the record actually widened (fixed by adding `shape`/`dataMode` stub snippets there).

## Test-fix round 1 (independent review BLOCKED, then addressed)

Round-1 review (`pr3359-filter-shape-data-verifier-report-r1.md`) found the shape-seat witness at `semantic-tx-aux-wiring.component.test.ts:771/774` invoked and asserted value `0` — `FILTER_SHAPES[0][0]` — so a `shapeSeat` hard-wired to a constant `0` passed undetected; reproduced both ways (mutate `shapeSeat`'s `invoke` to a constant on a `git archive` extract → 1 failed/78 passed; restore → 79 passed). Fixed by moving that witness to value `1`. `FilterInstrumentHost.isolated.test.ts`'s inline-path shape click (line ~63) carried the same value-0 weakness and is now aligned to value `1` as well. Two false header sentences in `FilterSurface.svelte` were also deleted: "DATA remains local and keeps the same separation below" (DATA's local ownership was removed by this PR) and the line-6 enumeration listing "filter shape … DATA submode" among fields this file renders directly (they are now rendered via the host's snippets, not locally).

## Mutations (mandatory, restored byte-identically)

- (a) `{#key surfacePlan()}` wrapped around the `<FilterInstrumentHost>` mount in `SemanticRadioSurfaces.svelte` → **both** the "places named Standard and grouped SDR seats" test and the new DATA persistence witness failed (host rebuilt: authority subscriber set changed, DATA seat object identity changed). Restored; `git diff --stat` matches pre-mutation (12 +7/-5).
- (b) shape's `bindChoiceInstrument` wired to a constant (`invoke: (_value) => onFilterShapeChange?.(0)`) — this run mutated the inline path only; `createChoiceRendererSeat`'s `invoke` (the external/appearance-renderer seat) was a separate, unmutated path, and round-1 review's own reproduction on that seat is what exposed B1 above. Caught by `FilterSurface.test.ts`'s "emits onFilterShapeChange with the clicked shape value" (clicks value `1`: failed with `[0]` instead of `[1]`) and, after the round-1 fix, also by `FilterInstrumentHost.isolated.test.ts`'s own inline-path click and by the wiring test's `shapeSeat` witness, both now on value `1`. Restored; diff matches pre-mutation.
- (c) DATA seat's `field` overridden to always report reading `1` when known → both `FilterInstrumentHost.isolated.test.ts`'s DATA2 case and its "retains all four known readings" case failed (`expected '1' to be '2'` / `'0'`). Restored; diff matches pre-mutation.
- (d) `filterFiniteAuthority`'s gate reverted to `modeFilter === undefined` alone → the new "renders the DATA-mode seat for a radio with no modeFilter group at all" case failed (`expected null not to be null`) — the only case that exercises the widened half of the gate. Restored; diff matches pre-mutation (12 +7/-5).

## Census

```
 frontend/src/components-v2/layout/RadioLayout.svelte                        |   2 +
 frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte              |  12 +-
 .../components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts | 132 +++++++++++++++++++++----
 frontend/src/semantic/FilterInstrumentHost.svelte                           |  77 ++++++++++++++--
 frontend/src/semantic/FilterSurface.svelte                                  | 100 ++++-------------------
 frontend/src/semantic/__tests__/FilterInstrumentHost.isolated.test.ts       | 155 ++++++++++++++++++++++------------
 frontend/src/semantic/__tests__/FilterSurface.test.ts                       |   6 +-
 frontend/src/semantic/__tests__/fixtures/FilterInstrumentHostFixture.svelte |  11 +-
 frontend/src/semantic/filter-instruments.ts                                 |   7 +
 9 files changed, 335 insertions(+), 167 deletions(-)
```
9 files (lease exactly; no 10th) = 502 A+D, within the released F1-C2 execution budget of 525 (forecast 289–439; 63 lines above the upper forecast, attributable to the wiring test's added identity/gate-widening cases and their capture-wrapper scaffolding, plus the round-1 test-fix cycle).

## Verification

- Initial implementation (`87e67157e`): `npx vitest run` on the wiring test, `FilterInstrumentHost.isolated.test.ts`, `FilterSurface.test.ts`, `RadioLayout.isolated.test.ts`: all pass. Grep union of every test file naming Filter/SemanticRadioSurfaces/RadioLayout (141 files) run together: 141 passed, 4333 tests passed. `npm run check`: 4836 files, 0 errors, 0 warnings. `eslint` on the 9 changed files: clean. `git diff --check`: clean. `node frontend/fixtures/capture.mjs`: 65/65 captures pass, 0 invalid. Not re-run at the current head.
- Test-fix round 1 (this head, `9222f4c30`): `npx vitest run` on the wiring test, `FilterInstrumentHost.isolated.test.ts`, `FilterSurface.test.ts`: 3 files, 175/175 pass. `npm run check`: 4836 files, 0 errors, 0 warnings. `npx eslint src --max-warnings=0`: clean. `git diff --check`: clean.

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)


