### PR TITLE
fix: keep on-demand fields fresh until the next observation

### DIFF
--- a/rigs/_schema.md
+++ b/rigs/_schema.md
@@ -221,8 +221,16 @@ Each field path uses the canonical `FieldPath` strings from
 Optional per-field policy overrides. Supported keys are `cadence_seconds`,
 `freshness_ttl_seconds`, `reconciliation_priority`, `external_cat_pause`,
 `adaptive_decay`, `adaptive_decay_idle_multiplier`,
-`adaptive_decay_max_cadence_seconds`, and `meter_coalescing_window_seconds`.
+`adaptive_decay_max_cadence_seconds`, `meter_coalescing_window_seconds`, and
+`tx_only` (the set the loader accepts is `_ACQUISITION_POLICY_KEYS` in
+`rig_loader.py`; anything else is rejected).
 Field-specific `meter_coalescing_window_seconds` is valid only for meter paths.
+
+An omitted key inherits the profile-level default rather than clearing it, so
+`freshness_ttl_seconds` also accepts the string `"never"` to mean "this field
+has no expiry". Use it for a path whose capability is not in `polling_only`:
+nothing re-reads such a field on a cadence, so any TTL would age it to stale
+once and leave it there.
 
 Example:
 

--- a/rigs/_schema.md
+++ b/rigs/_schema.md
@@ -192,7 +192,7 @@ these fields directly.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `provider` | string | no | Lowercase provider identifier such as `"icom_civ"`, `"yaesu_cat"`, `"xiegu_civ"`, or `"external_rigctld"`. Defaults to `"profile"`. |
-| `default_cadence_seconds` | float | no | Conservative default polling cadence for supported fields. Defaults to `5.0`. |
+| `default_cadence_seconds` | float or `"never"` | no | Conservative default polling cadence for supported fields. Defaults to `5.0`. `"never"` resolves to no cadence. |
 | `default_freshness_ttl_seconds` | float or `"never"` | no | TTL before a value should be considered stale. Must be greater than or equal to cadence. Defaults to `15.0`. `"never"` resolves to no expiry. |
 | `default_reconciliation_priority` | string | no | `"unsolicited"`, `"command_response"`, `"poll"`, or `"last_observation"`. Defaults to `"poll"`. |
 | `adaptive_decay` | bool | no | Whether a scheduler may widen cadence while idle. Defaults to `false`. |
@@ -230,12 +230,9 @@ An omitted key inherits the profile-level default rather than clearing it, so
 `freshness_ttl_seconds` also accepts the string `"never"` to mean "this field
 has no expiry". Use it only for a path whose loaded capability cannot be
 polled — in neither `polling_only` nor `stream_like_meters` (either one makes
-`can_poll` true; the loader itself rejects nothing, so a streaming meter given
-`"never"` would simply stop ageing). Only providers that build observations
-through `ProviderObservationAdapter` (`yaesu_cat`, `external_rigctld`) read
-this TTL into each observation; the Icom and Xiegu CI-V ingress takes each
-observation's `max_age` from `runtime/_civ_rx.py` instead. The section-level
-`default_freshness_ttl_seconds` accepts the same token.
+`can_poll` true, and the loader does not reject that combination). The
+section-level `default_freshness_ttl_seconds` and both `cadence_seconds` keys
+accept the same token.
 
 Example:
 

--- a/rigs/_schema.md
+++ b/rigs/_schema.md
@@ -193,7 +193,7 @@ these fields directly.
 |-------|------|----------|-------------|
 | `provider` | string | no | Lowercase provider identifier such as `"icom_civ"`, `"yaesu_cat"`, `"xiegu_civ"`, or `"external_rigctld"`. Defaults to `"profile"`. |
 | `default_cadence_seconds` | float | no | Conservative default polling cadence for supported fields. Defaults to `5.0`. |
-| `default_freshness_ttl_seconds` | float | no | TTL before a value should be considered stale. Must be greater than or equal to cadence. Defaults to `15.0`. |
+| `default_freshness_ttl_seconds` | float or `"never"` | no | TTL before a value should be considered stale. Must be greater than or equal to cadence. Defaults to `15.0`. `"never"` resolves to no expiry. |
 | `default_reconciliation_priority` | string | no | `"unsolicited"`, `"command_response"`, `"poll"`, or `"last_observation"`. Defaults to `"poll"`. |
 | `adaptive_decay` | bool | no | Whether a scheduler may widen cadence while idle. Defaults to `false`. |
 | `adaptive_decay_idle_multiplier` | float | no | Multiplier for idle cadence when adaptive decay is enabled. Must be greater than `1.0` when enabled. |
@@ -228,9 +228,14 @@ Field-specific `meter_coalescing_window_seconds` is valid only for meter paths.
 
 An omitted key inherits the profile-level default rather than clearing it, so
 `freshness_ttl_seconds` also accepts the string `"never"` to mean "this field
-has no expiry". Use it for a path whose capability is not in `polling_only`:
-nothing re-reads such a field on a cadence, so any TTL would age it to stale
-once and leave it there.
+has no expiry". Use it only for a path whose loaded capability cannot be
+polled — in neither `polling_only` nor `stream_like_meters` (either one makes
+`can_poll` true; the loader itself rejects nothing, so a streaming meter given
+`"never"` would simply stop ageing). Only providers that build observations
+through `ProviderObservationAdapter` (`yaesu_cat`, `external_rigctld`) read
+this TTL into each observation; the Icom and Xiegu CI-V ingress takes each
+observation's `max_age` from `runtime/_civ_rx.py` instead. The section-level
+`default_freshness_ttl_seconds` accepts the same token.
 
 Example:
 

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -535,18 +535,22 @@ adaptive_decay = false
 # lands its first observation — worst case a few re-derive windows if the
 # scheduler's 5-path-per-call burst cap (prime_unobserved's
 # _PRIME_UNOBSERVED_BURST_LIMIT) paces this whole group across multiple
-# calls. cadence_seconds is pinned equal to freshness_ttl_seconds purely so
-# diagnostics don't show a misleadingly fast number — it is otherwise inert
-# here because these capabilities carry polling=False.
+# calls. These capabilities carry polling=False, so due_requests never
+# reaches them (_poll_cadence_groups skips any capability whose can_poll is
+# false) and freshness_ttl_seconds is "never": nothing re-reads them on a
+# cadence, so an expiry would flip each one to STALE once after its single
+# observation and leave it there on a healthy, idle link. cadence_seconds is
+# still load-bearing — with no TTL, prime_unobserved passes it as the prime
+# read's max_age.
 [state_acquisition.field_policies."global.tx_state.vox_on"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.tx_state.monitor_on"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
@@ -554,13 +558,13 @@ adaptive_decay = false
 # VOX/MON toggles above.
 [state_acquisition.field_policies."global.operator_controls.vox_delay"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.main.active.freq_mode.filter_width"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
@@ -569,136 +573,135 @@ adaptive_decay = false
 # never primed.
 [state_acquisition.field_policies."receiver.main.active.freq_mode.filter_num"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.main.active.freq_mode.data_mode"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.main.operator_controls.filter_shape"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.main.operator_controls.pbt_inner"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.main.operator_controls.pbt_outer"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.main.operator_controls.nr_level"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.main.operator_controls.nb_level"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.main.operator_toggles.auto_notch"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.main.operator_toggles.manual_notch"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.main.operator_controls.notch_filter"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.main.operator_controls.manual_notch_width"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.main.operator_controls.agc_time_constant"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.operator_controls.rit_freq"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.tx_state.rit_on"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.tx_state.rit_tx"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.operator_controls.break_in"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.operator_controls.break_in_delay"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.operator_controls.key_speed"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.operator_controls.cw_pitch"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.main.operator_toggles.twin_peak_filter"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 # MOR-2234 group B: tone/TSQL frequency join the same non-polling
-# command_response membership as the CW keyer setpoints above, and copy
-# their 25.0s cadence/TTL pair verbatim.
+# command_response membership as the CW keyer setpoints above.
 [state_acquisition.field_policies."receiver.main.operator_controls.tone_freq"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.main.operator_controls.tsql_freq"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -537,9 +537,9 @@ adaptive_decay = false
 # _PRIME_UNOBSERVED_BURST_LIMIT) paces this whole group across multiple
 # calls. These capabilities carry polling=False, so due_requests never
 # reaches them (_poll_cadence_groups skips any capability whose can_poll is
-# false) and freshness_ttl_seconds is "never": nothing re-reads them on a
-# cadence, so an expiry would flip each one to STALE once after its single
-# observation and leave it there on a healthy, idle link. cadence_seconds is
+# false) and freshness_ttl_seconds is "never": no cadence read refreshes
+# them, and the CI-V ingress takes each observation's max_age from
+# runtime/_civ_rx.py rather than from this key. cadence_seconds is
 # still load-bearing — with no TTL, prime_unobserved passes it as the prime
 # read's max_age.
 [state_acquisition.field_policies."global.tx_state.vox_on"]

--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -188,7 +188,7 @@ external_cat_pause = "pause_polling"
 # iterates field_policies), so it could never be observed at startup.
 [state_acquisition.field_policies."receiver.main.active.freq_mode.filter_width"]
 cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
+freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -1646,13 +1646,16 @@ class StateFreshnessService:
 
     #: Fast re-derivation spacing used WHILE at least one explicit
     #: ``field_policies`` field remains unobserved (MOR-1501, verifier-
-    #: prescribed on #2421's review). The flat 30s interval below left a
-    #: real IC-7300 connect with a ~120s populate tail for its 23 non-polling
-    #: policy fields: ``ceil(23 / _PRIME_UNOBSERVED_BURST_LIMIT) == 5`` waves
-    #: at 30s apart, even though each field's true CI-V round-trip cost is
-    #: ~1.1s. At 5s spacing the same 5 waves complete in ~20-25s — the burst
-    #: cap (unchanged, still the lane-protection knob) is what still bounds
-    #: each wave's size, this constant only bounds how long a capped-out
+    #: prescribed on #2421's review). :meth:`prime_unobserved` queues at
+    #: most ``_PRIME_UNOBSERVED_BURST_LIMIT`` (5) new paths per call, and
+    #: ``rigs/ic7300.toml`` leaves 26 of its 60 ``field_policies`` paths
+    #: unskipped by that method's cadence-owned test (``sum(1 for path,
+    #: policy in field_policies.items() if not (capability_for(path).can_poll
+    #: and policy.cadence_seconds is not None))``), so queueing them all
+    #: takes at least ``ceil(26 / 5) == 6`` calls — the sixth lands ~150s in
+    #: at the 30s interval below, ~25s in at this one. The burst cap
+    #: (unchanged, still the lane-protection knob) is what still bounds each
+    #: wave's size, this constant only bounds how long a capped-out
     #: straggler waits between waves. See
     #: :meth:`_reprime_unobserved_if_due` for the dead-link write-rate
     #: consequence of shortening this interval.
@@ -1781,8 +1784,9 @@ class StateFreshnessService:
         backs off to the slower :data:`PRIME_REDERIVE_INTERVAL_SECONDS` the
         moment that set empties — cheap either way (one ``store.snapshot()``
         plus a loop over ``field_policies``), so paying it more often while
-        fields are still missing is a fine trade against the ~120s populate
-        tail the flat 30s interval produced.
+        fields are still missing is a fine trade against the populate tail
+        the flat 30s interval produced (see
+        :data:`PRIME_ADAPTIVE_INTERVAL_SECONDS` for that arithmetic).
 
         Dead-link write-rate honesty (R3 lesson from MOR-1490's own review,
         applies again here): a capped-out straggler left short of the burst

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -1406,6 +1406,13 @@ def _strict_policy_float(
     return float(value)
 
 
+#: TOML has no null literal, and an omitted acquisition-policy key inherits
+#: the profile default rather than clearing it, so a seconds-valued key
+#: spells "no value here" with this token. It resolves to ``None``, which
+#: ``StateStore.mark_stale_due`` skips instead of ageing.
+_POLICY_SECONDS_NEVER = "never"
+
+
 def _policy_seconds(
     filename: str,
     prefix: str,
@@ -1423,6 +1430,8 @@ def _policy_seconds(
     else:
         value = fallback
     key_label = label if label is not None else key
+    if value == _POLICY_SECONDS_NEVER:
+        return None
     return (
         None
         if value is None

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -1407,8 +1407,9 @@ def _strict_policy_float(
 
 
 #: TOML has no null literal, and an omitted acquisition-policy key inherits
-#: the profile default rather than clearing it, so a seconds-valued key
-#: spells "no value here" with this token. It resolves to ``None``, which
+#: the profile default rather than clearing it, so ``cadence_seconds`` and
+#: ``freshness_ttl_seconds`` (the two keys ``_policy_seconds`` parses) spell
+#: "no value here" with this token. It resolves to ``None``, which
 #: ``StateStore.mark_stale_due`` skips instead of ageing.
 _POLICY_SECONDS_NEVER = "never"
 

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -106,8 +106,11 @@ _OBSERVATION_MAX_AGE_SECONDS: dict[tuple[str, str, str], float] = {
     # MOR-2234 follow-up: declaring these observable in ``rigs/ic7300.toml``
     # left them with no entry here, so ``_observation`` gave them
     # ``max_age=None`` and ``state_store.py: StateStore.mark_stale_due``
-    # never aged them. The TTL is that profile's declared
-    # ``freshness_ttl_seconds``, pinned by
+    # never aged them. These two values are this table's own, independent of
+    # what any profile declares for the same paths: ``_observation`` takes
+    # every CI-V observation's ``max_age`` from this (scope, family, name)
+    # lookup — the ``tx_target`` branch there is the sole exception — and
+    # nothing in this module reads ``field_policies``. Pinned by
     # ``test_tone_and_tsql_freq_observations_can_go_stale``.
     ("receiver", "operator_controls", "tone_freq"): 25.0,
     ("receiver", "operator_controls", "tsql_freq"): 25.0,

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -2921,20 +2921,18 @@ def test_tone_and_tsql_freq_observations_can_go_stale(
     process, whatever the front panel did afterwards.
 
     Fail-without: the observation carries ``max_age=None`` and the field is
-    still ``FRESH`` past the TTL ``rigs/ic7300.toml`` declares for it.
+    still ``FRESH`` past that table's TTL.
     """
+
+    from rigplane.runtime._civ_rx import _OBSERVATION_MAX_AGE_SECONDS
 
     radio._profile = resolve_radio_profile(model="IC-7300")  # noqa: SLF001
     stored = FieldPath.receiver("0", "operator_controls", name)
-    # The TTL is not a literal here: it is read from the IC-7300 profile,
-    # which is what declared this path observable (e0558fea).
-    declared_ttl = (
-        resolve_radio_profile(model="IC-7300")
-        .state_acquisition.field_policies[
-            FieldPath.receiver("main", "operator_controls", name)
-        ]
-        .freshness_ttl_seconds
-    )
+    # The TTL is not a literal here: it is read from the table that supplies
+    # it. That table is keyed by (scope, family, name) and does not consult
+    # the profile, so ``rigs/ic7300.toml``'s field_policies entry for the
+    # same path is not what lands on the observation.
+    declared_ttl = _OBSERVATION_MAX_AGE_SECONDS[("receiver", "operator_controls", name)]
 
     observed_at = 500.0
     with patch("rigplane.runtime._civ_rx.time.monotonic", return_value=observed_at):

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -1024,9 +1024,7 @@ def test_non_polling_field_policies_declare_no_freshness_expiry() -> None:
 
     ``AcquisitionScheduler._poll_cadence_groups`` skips every capability
     whose ``can_poll`` is false, so no cadence read ever refreshes such a
-    field; a finite ``freshness_ttl_seconds`` on one can therefore only flip
-    it to ``STALE`` once and leave it there on a healthy, idle link. The
-    profile spells "no expiry" as ``freshness_ttl_seconds = "never"``, which
+    field. The profile spells "no expiry" as ``freshness_ttl_seconds = "never"``, which
     the loader resolves to ``None`` — the value
     ``StateStore.mark_stale_due`` skips instead of ageing.
     """
@@ -1056,8 +1054,11 @@ def test_non_polling_field_policies_declare_no_freshness_expiry() -> None:
 def test_ic7300_on_demand_field_stays_fresh_while_polled_field_expires() -> None:
     """Only the cadence-polled field ages out; the on-demand one does not.
 
-    Drives the profile-policy chain end to end for the IC-7300 profile:
-    ``ProviderObservationAdapter`` reads each path's ``max_age`` from its
+    Drives the profile-policy chain end to end over the IC-7300 profile's
+    policies through ``ProviderObservationAdapter`` — the adapter the
+    ``yaesu_cat`` and ``rigctld_client`` providers use; the Icom CI-V ingress
+    takes ``max_age`` from ``runtime/_civ_rx.py`` instead, so this is not the
+    IC-7300 wire path. ``ProviderObservationAdapter`` reads each path's ``max_age`` from its
     ``field_policies`` entry, ``StateStore`` keeps it on the entry, and
     ``StateFreshnessService.tick`` is what ages it. ``filter_width`` rides a
     ``polling=False`` capability, so no cadence read refreshes it;

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -1055,10 +1055,10 @@ def test_ic7300_on_demand_field_stays_fresh_while_polled_field_expires() -> None
     """Only the cadence-polled field ages out; the on-demand one does not.
 
     Drives the profile-policy chain end to end over the IC-7300 profile's
-    policies through ``ProviderObservationAdapter`` — the adapter the
-    ``yaesu_cat`` and ``rigctld_client`` providers use; the Icom CI-V ingress
-    takes ``max_age`` from ``runtime/_civ_rx.py`` instead, so this is not the
-    IC-7300 wire path. ``ProviderObservationAdapter`` reads each path's ``max_age`` from its
+    policies through ``ProviderObservationAdapter`` (the adapter the Yaesu
+    CAT and rigctld-client backends build observations with); the IC-7300
+    CI-V ingress is not under test here.
+    ``ProviderObservationAdapter`` reads each path's ``max_age`` from its
     ``field_policies`` entry, ``StateStore`` keeps it on the entry, and
     ``StateFreshnessService.tick`` is what ages it. ``filter_width`` rides a
     ``polling=False`` capability, so no cadence read refreshes it;

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -9,6 +9,11 @@ from typing import Any, cast
 
 import pytest
 
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionScheduler,
+    StateFreshnessService,
+)
+from rigplane.core.observation_adapter import ProviderObservationAdapter
 from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
     AdaptiveDecayPolicy,
@@ -18,6 +23,7 @@ from rigplane.core.state_acquisition_policy import (
     RadioAcquisitionProfile,
 )
 from rigplane.core.state_pipeline_contracts import FieldPath
+from rigplane.core.state_store import FreshnessState, StateStore
 from rigplane.profiles import get_radio_profile
 from rigplane.rig_loader import RigLoadError, discover_rigs, load_rig
 from _acquisition_query_helpers import (
@@ -1011,3 +1017,147 @@ def test_ic7300_activation_does_not_change_ftx1_acquisition_contract() -> None:
     assert acquisition.capability_for(sub_shift).can_poll is True
     assert acquisition.policy_for(sub_shift).cadence_seconds == 30.0
     assert acquisition.policy_for(sub_shift).freshness_ttl_seconds == 120.0
+
+
+def test_non_polling_field_policies_declare_no_freshness_expiry() -> None:
+    """A field nothing re-reads on a cadence must not expire on its own.
+
+    ``AcquisitionScheduler._poll_cadence_groups`` skips every capability
+    whose ``can_poll`` is false, so no cadence read ever refreshes such a
+    field; a finite ``freshness_ttl_seconds`` on one can therefore only flip
+    it to ``STALE`` once and leave it there on a healthy, idle link. The
+    profile spells "no expiry" as ``freshness_ttl_seconds = "never"``, which
+    the loader resolves to ``None`` — the value
+    ``StateStore.mark_stale_due`` skips instead of ageing.
+    """
+
+    failures: list[str] = []
+    for model, rig in discover_rigs(RIGS_DIR).items():
+        acquisition = rig.to_profile().state_acquisition
+        if acquisition is None:
+            continue
+        for path, policy in sorted(
+            acquisition.field_policies.items(), key=lambda item: str(item[0])
+        ):
+            if acquisition.capability_for(path).can_poll:
+                continue
+            if policy.freshness_ttl_seconds is None:
+                continue
+            failures.append(
+                f"{model}: {path} freshness_ttl_seconds={policy.freshness_ttl_seconds}"
+            )
+
+    assert not failures, (
+        "field_policies entry on a non-polling capability with a finite "
+        f"freshness_ttl_seconds (nothing will ever refresh it): {failures}"
+    )
+
+
+def test_ic7300_on_demand_field_stays_fresh_while_polled_field_expires() -> None:
+    """Only the cadence-polled field ages out; the on-demand one does not.
+
+    Drives the profile-policy chain end to end for the IC-7300 profile:
+    ``ProviderObservationAdapter`` reads each path's ``max_age`` from its
+    ``field_policies`` entry, ``StateStore`` keeps it on the entry, and
+    ``StateFreshnessService.tick`` is what ages it. ``filter_width`` rides a
+    ``polling=False`` capability, so no cadence read refreshes it;
+    ``freq_hz`` is cadence-polled and must still expire, so the decay
+    mechanism is not disabled wholesale.
+    """
+
+    profile = get_radio_profile("IC-7300")
+    acquisition = profile.state_acquisition
+    assert acquisition is not None
+    on_demand = FieldPath.active("main", "freq_mode", "filter_width")
+    polled = FieldPath.active("main", "freq_mode", "freq_hz")
+    assert acquisition.capability_for(on_demand).can_poll is False
+    assert acquisition.capability_for(polled).can_poll is True
+    polled_ttl = acquisition.policy_for(polled).freshness_ttl_seconds
+    assert polled_ttl is not None and polled_ttl < 60.0
+
+    observed_at = 1_000.0
+    adapter = ProviderObservationAdapter(
+        profile=acquisition,
+        source="poll_response",
+        clock=lambda: observed_at,
+    )
+    store = StateStore()
+    store.apply(adapter.observation(on_demand, 2_400))
+    store.apply(adapter.observation(polled, 14_074_000))
+    service = StateFreshnessService(store=store)
+
+    delta = service.tick(now=observed_at + 60.0)
+
+    stale_paths = {
+        request.path
+        for request in delta.reconciliation_requests
+        if request.reason == "stale"
+    }
+    assert polled in stale_paths
+    assert on_demand not in stale_paths
+    freshness = {field.path: field.freshness for field in store.snapshot().fields}
+    assert freshness[polled] is FreshnessState.STALE
+    assert freshness[on_demand] is FreshnessState.FRESH
+
+
+def test_loader_parses_never_as_absent_freshness_ttl(tmp_path: Path) -> None:
+    """``"never"`` is the TOML spelling of a ``None`` seconds value.
+
+    TOML has no null literal, and an omitted key inherits the profile
+    default rather than clearing it, so a policy that must carry no expiry
+    needs an explicit token.
+    """
+
+    toml = _minimal_state_acquisition_toml(
+        """
+        [state_acquisition]
+        provider = "icom_civ"
+        default_cadence_seconds = 2.0
+        default_freshness_ttl_seconds = 8.0
+
+        [state_acquisition.capabilities]
+        polling_only = ["global.meters.power"]
+        command_response_observable = ["global.tx_state.vox_on"]
+
+        [state_acquisition.field_policies."global.tx_state.vox_on"]
+        cadence_seconds = 25.0
+        freshness_ttl_seconds = "never"
+        reconciliation_priority = "command_response"
+        """
+    )
+
+    acquisition = load_rig(_write_toml(tmp_path, toml)).to_profile().state_acquisition
+    vox_on = FieldPath.global_("tx_state", "vox_on")
+    power = FieldPath.global_("meters", "power")
+
+    assert acquisition is not None
+    assert acquisition.policy_for(vox_on).freshness_ttl_seconds is None
+    assert acquisition.policy_for(vox_on).cadence_seconds == 25.0
+    # A path with no override still inherits the numeric profile default.
+    assert acquisition.policy_for(power).freshness_ttl_seconds == 8.0
+
+
+def test_ic7300_on_demand_field_primes_with_its_cadence_as_max_age() -> None:
+    """A no-expiry entry's ``cadence_seconds`` becomes the prime's max_age.
+
+    ``AcquisitionScheduler.prime_unobserved`` falls back to
+    ``policy.cadence_seconds`` for the prime read's ``max_age`` whenever
+    ``freshness_ttl_seconds`` is ``None``, so ``cadence_seconds`` is
+    load-bearing on these entries even though nothing polls them.
+    """
+
+    acquisition = get_radio_profile("IC-7300").state_acquisition
+    assert acquisition is not None
+    on_demand = FieldPath.active("main", "freq_mode", "filter_width")
+    assert acquisition.policy_for(on_demand).freshness_ttl_seconds is None
+
+    scheduler = AcquisitionScheduler(profile=acquisition)
+    request_by_path: dict[FieldPath, Any] = {}
+    for _ in range(len(acquisition.field_policies)):
+        for request in scheduler.prime_unobserved(observed_paths=()):
+            for path in request.paths:
+                request_by_path[path] = request
+
+    assert request_by_path[on_demand].max_age == (
+        acquisition.policy_for(on_demand).cadence_seconds
+    )


### PR DESCRIPTION
Owner ruling R41: a field the user never touches has no reason to look stale on a healthy link, so a field nothing re-reads on a cadence must stay FRESH until its next observation.

## What changed, per rig

- `rigs/ic7300.toml` — the 26 `field_policies` entries on `polling=False` capabilities (`vox_on, monitor_on, vox_delay, filter_width, filter_num, data_mode, filter_shape, pbt_inner, pbt_outer, nr_level, nb_level, auto_notch, manual_notch, notch_filter, manual_notch_width, agc_time_constant, rit_freq, rit_on, rit_tx, break_in, break_in_delay, key_speed, cw_pitch, twin_peak_filter, tone_freq, tsql_freq`) go from `freshness_ttl_seconds = 25.0` to `"never"`. `cadence_seconds` is untouched.
- `rigs/x6200.toml` — same shape, 1 entry: `receiver.main.active.freq_mode.filter_width`. Found by sweeping every `rigs/*.toml` through the loader for `capability_for(path).can_poll == False` and a finite `freshness_ttl_seconds`; that sweep is now `test_non_polling_field_policies_declare_no_freshness_expiry`, whose failure list at the base commit was exactly these 27 entries.
- `rigs/ftx1.toml`, `ic705`, `ic7610`, `ic9700`, `x6100`, `tx500` — nothing. FTX-1 (48 field policies) and IC-7610 (87) have zero entries of this shape; `ic705`/`ic9700`/`x6100` declare no `field_policies`; `tx500` has no `[state_acquisition]` block.
- `tx_only` meters (4 on IC-7300, 4 on FTX-1) deliberately untouched — see "Not fixed" below.

## Mechanism

`StateStore.mark_stale_due` already skips any entry whose `max_age` is `None`, and `AcquisitionPolicy.freshness_ttl_seconds` is already `float | None`, so "no expiry" needed no new concept. What was missing was a way to *say* it in TOML: there is no null literal, and an omitted policy key inherits the profile default rather than clearing it. The code change is therefore two lines in `rig_loader.py: _policy_seconds` — a seconds-valued key may be the string `"never"`, which resolves to `None`. No new abstraction; documented in `rigs/_schema.md`.

`cadence_seconds` stays on these entries because it becomes load-bearing once the TTL is gone: `AcquisitionScheduler.prime_unobserved` falls back to `policy.cadence_seconds` for the prime read's `max_age` when `freshness_ttl_seconds` is `None`, so the startup prime still asks for the same 25.0s it asked for before. Pinned by `test_ic7300_on_demand_field_primes_with_its_cadence_as_max_age`.

## Red/green and mutations

Three tests written first, all red at the base commit:
- `test_non_polling_field_policies_declare_no_freshness_expiry` — listed all 27 entries.
- `test_ic7300_on_demand_field_stays_fresh_while_polled_field_expires` — real profile, real `ProviderObservationAdapter`, real `StateStore`, real `StateFreshnessService.tick(now=...)`, no mocks: `filter_width` was in the emitted `reason="stale"` set.
- `test_loader_parses_never_as_absent_freshness_ttl` — `RigLoadError: freshness_ttl_seconds must be a number`.

Mutations run against the finished tree (each reverted, `git diff` verified clean afterwards):
1. `filter_width` TTL back to `25.0` → killed both profile tests.
2. `freq_hz` (cadence-polled) TTL to `"never"` → killed the behavioural test's precondition and an unrelated existing profile assertion.
3. `mark_stale_due`'s age comparison forced to `continue` (decay disabled wholesale) → killed at the behavioural test's outcome assertion `polled in stale_paths`, i.e. it does not pass vacuously.
4. `_policy_seconds` returning `fallback` instead of `None` for the token → killed the loader test plus 10 others.
5. `prime_unobserved`'s cadence fallback removed → killed `..._primes_with_its_cadence_as_max_age` (`1e-09 != 25.0`).

Mutation 5's sibling — deleting `cadence_seconds` from one entry — does *not* kill that test (both sides of the assertion move together); the test pins the code fallback, not the profile value, and its docstring says only that.

## Prose corrected

- `rigs/ic7300.toml`: the "cadence pinned equal to freshness_ttl_seconds purely so diagnostics don't show a misleading number" rationale is gone (deleted, not softened — it stopped being re-establishable once the TTL went), replaced by what `_poll_cadence_groups` and `prime_unobserved` actually do. The MOR-2234 comment's "copy their 25.0s cadence/TTL pair verbatim" clause is deleted.
- `acquisition_scheduler.py: PRIME_ADAPTIVE_INTERVAL_SECONDS`: "23 non-polling policy fields" was stale. Measured 26 with `prime_unobserved`'s own predicate — `sum(1 for path, policy in field_policies.items() if not (capability_for(path).can_poll and policy.cadence_seconds is not None))` over `rigs/ic7300.toml` — and the derived `ceil(23/5) == 5` waves becomes `ceil(26/5) == 6`. The "~120s populate tail measured on a real connect" and "~1.1s CI-V round-trip" figures are deleted rather than restated: I could not re-establish either, and the wave arithmetic that replaces them is checkable from the constants.
- `runtime/_civ_rx.py`: the `_OBSERVATION_MAX_AGE_SECONDS` comment claimed the tone/TSQL TTLs are "that profile's declared `freshness_ttl_seconds`". That is false — see below.
- `rigs/_schema.md`: the field-policy key list omitted `tx_only`; corrected against `_ACQUISITION_POLICY_KEYS`.

## Not fixed — reported instead

**This change does not alter IC-7300 or X6200 runtime behaviour.** `ProviderObservationAdapter` (the only thing that reads `freshness_ttl_seconds` onto an observation) is used by `backends/rigctld_client` and `backends/yaesu_cat` only. Every Icom CI-V observation's `max_age` comes from `runtime/_civ_rx.py: _OBSERVATION_MAX_AGE_SECONDS`, a hardcoded `(scope, family, name)` table that never consults `field_policies` (`grep -c field_policies src/rigplane/runtime/_civ_rx.py` → 0). Of the 26 IC-7300 paths above, 19 — including `filter_width` itself — have no entry in that table and so already carried `max_age=None`; the other 7 expire from the table, not the profile:

| path | table TTL |
|---|---|
| `global.operator_controls.rit_freq` | 10.0 |
| `global.tx_state.rit_on` | 10.0 |
| `global.tx_state.rit_tx` | 10.0 |
| `receiver.main.operator_controls.pbt_inner` | 10.0 |
| `receiver.main.operator_controls.pbt_outer` | 10.0 |
| `receiver.main.operator_controls.tone_freq` | 25.0 |
| `receiver.main.operator_controls.tsql_freq` | 25.0 |

Those 7 are left unfixed because the table is keyed rig-blind and 5 of the 7 (RIT ×3, PBT ×2) are cadence-polled on IC-7610 (also CI-V; tone_freq/tsql_freq are not — that radio marks those commands absent), so deleting the RIT/PBT entries would disable expiry where it is correct; making the lookup rig-aware is a mechanism consolidation with cross-rig blast radius that this ruling does not scope. This PR only corrects the now-false comment there and repairs `test_tone_and_tsql_freq_observations_can_go_stale`, which derived its expected TTL from the profile and broke once the profile stopped declaring one — it now reads the TTL from the table that actually supplies it.

`tx_only` meters: `dispatchable_requests` already withholds their stale hints while PTT is false, but `mark_stale_due` still flips them STALE 1–2s after de-key on both IC-7300 and FTX-1. Left alone — post-PTT staleness is a separate question from idle expiry.

Frontend (verify only, no change): `set_filter_width` is a state-backed descriptor over public path `main.filterWidth` (`_snapshot_field_public_paths` confirms the mapping), and `commands.svelte.ts: reconcileStateBackedCommands` admits a pending marker only when `field.freshness === 'fresh'` — so on the paths where a field now stays fresh, the marker is admitted. That gate is pinned by the parametrised "confirms %s only from a newer fresh exact field observation" cases in `frontend/src/lib/stores/__tests__/commands.test.ts`, which feed a `freshness: 'stale'` state and assert non-admission; I did not find `set_filter_width` among those parametrised cases. No frontend file is touched, so no vitest run was needed.

## Size

8 files, +229/−54 = 283 changed lines, measured at this head (`git diff --stat HEAD~1`). Over the 6-file soft threshold, under the hard ceiling. It is one unit of work: the loader token, the two profiles that use it, the schema line that documents it, its tests, and the two prose sites the change itself falsified.

## Gates

- `uv run pytest` over the 69 test files matching `field_policies|freshness_ttl|mark_stale_due|StateFreshnessService|ic7300` — 5317 passed, 154 skipped, 0 failed. (The full suite is CI's; this PR's `quick` run is the record.)
- `uv run ruff check src/ tests/` — All checks passed
- `uv run ruff format --check src/ tests/` — 740 files already formatted
- `uv run lint-imports` — 5 kept, 0 broken
- `uv run mypy --strict src/rigplane/web` — Success, no issues in 27 source files

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

