### PR TITLE
feat: poll the panel-knob fields every 5 s and write the cadence classes down

### DIFF
--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -528,10 +528,13 @@ direction is documented in the [v3 architecture decision](../plans/2026-07-25-ui
 `_FAST_INTERVAL` (LAN) and `_FAST_INTERVAL_SERIAL` (serial) in
 `web/radio_poller.py: RadioPoller` are how often the poller loop wakes, not
 how often any field is read: a pass dispatches whatever the acquisition
-scheduler already has queued. What puts a request there is the field's own
-`cadence_seconds` in `rigs/*.toml` (`[state_acquisition.field_policies]`,
-falling back to that profile's `default_cadence_seconds`), emitted by
-`core/acquisition_scheduler.py: StateFreshnessService.tick`.
+scheduler already has queued. What puts a cadence request there is the
+field's own `cadence_seconds` in `rigs/*.toml`
+(`[state_acquisition.field_policies]`, falling back to that profile's
+`default_cadence_seconds`), emitted by
+`core/acquisition_scheduler.py: StateFreshnessService.tick`
+(`AcquisitionScheduler.ensure_fresh` and `.prime_unobserved` also enqueue
+requests, outside this cadence).
 
 ### State polling and conditional requests
 

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -525,10 +525,13 @@ direction is documented in the [v3 architecture decision](../plans/2026-07-25-ui
 
 ### Backend CI-V poll cadence (state freshness)
 
-Poll interval is backend-specific:
-
-- LAN backends: `25ms` fast cycle (`_FAST_INTERVAL`)
-- serial backends: `100ms` fast cycle (`_FAST_INTERVAL_SERIAL`)
+`_FAST_INTERVAL` (LAN) and `_FAST_INTERVAL_SERIAL` (serial) in
+`web/radio_poller.py: RadioPoller` are how often the poller loop wakes, not
+how often any field is read: a pass dispatches whatever the acquisition
+scheduler already has queued. What puts a request there is the field's own
+`cadence_seconds` in `rigs/*.toml` (`[state_acquisition.field_policies]`,
+falling back to that profile's `default_cadence_seconds`), emitted by
+`core/acquisition_scheduler.py: StateFreshnessService.tick`.
 
 ### State polling and conditional requests
 

--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -202,147 +202,167 @@ adaptive_decay = false
 meter_coalescing_window_seconds = 0.2
 tx_only = true
 
+# --- Slow-control tier ------------------------------------------------------
+# MOR-2425 (owner ruling, 2026-09-07): 30.0s/120.0s -> 1.0s/2.0s. These
+# numbers are bookkeeping, not wire traffic. On the web path FTX-1 implements
+# ObservationPollable, so web_startup.start_web_server builds
+# backends/yaesu_cat/poller.py: YaesuCatPoller for it and never the
+# RadioPoller that carries the web's only AcquisitionDrain. On the rigctld
+# path a drain IS built, but no executor for it: this profile's provider
+# ("yaesu_cat") is outside core/acquisition_scheduler.py's
+# _CIV_ACQUISITION_PROVIDERS and the Yaesu backend supplies none, so
+# AcquisitionDrain.run_once takes its executor-missing branch and sends no
+# frame. What these keys do drive is StateStore.mark_stale_due via
+# StateFreshnessService, and 120.0s let a field be labelled STALE for up to
+# two minutes after a value the poller re-reads far more often than that.
+# 1.0s is YaesuCatPoller._SLOW_INTERVAL, the interval of the group
+# (YaesuCatPoller._poll_slow) that re-reads this tier; the TTL is twice
+# that. Pinned by
+# tests/test_yaesu_cat_poller.py::
+# test_slow_group_interval_matches_the_profile_slow_control_cadence and
+# tests/test_web_server_coverage.py::
+# test_observation_pollable_web_path_builds_no_radio_poller.
 [state_acquisition.field_policies."receiver.main.operator_controls.af_level"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.main.operator_controls.rf_gain"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.main.operator_controls.squelch"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.sub.operator_controls.af_level"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.sub.operator_controls.rf_gain"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.sub.operator_controls.squelch"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.main.operator_controls.att"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.main.operator_controls.preamp"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.main.operator_controls.agc"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 # IF-shift / narrow / filter_width DSP controls (MOR-445). filter_width is a
 # slow-changing control (not a meter), so it uses the slow-control cadence
 # even though it is emitted in the freq/mode lane.
 [state_acquisition.field_policies."receiver.main.operator_controls.if_shift"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.main.operator_toggles.narrow"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.main.active.freq_mode.filter_width"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 # NB/NR levels + derived toggles, auto/manual notch DSP controls (MOR-444).
 # Slow-changing operator controls, MAIN-only (no per-receiver CAT command). The
 # ``nb``/``nr`` toggles are derived from the level read in the same poll cycle.
 [state_acquisition.field_policies."receiver.main.operator_controls.nb_level"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.main.operator_toggles.nb"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.main.operator_controls.nr_level"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.main.operator_toggles.nr"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.main.operator_toggles.auto_notch"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.main.operator_toggles.manual_notch"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.main.operator_controls.manual_notch_freq"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."global.operator_controls.power_level"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."global.operator_controls.mic_gain"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."global.tx_state.compressor_on"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."global.operator_controls.compressor_level"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."global.tx_state.vox_on"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 # Split + active-slot controls (MOR-446). Slow-changing operator state: split
 # (global tx_state bool, CAT ``ST``) and the active receiver/VFO field (global
 # slow_state, CAT ``VS`` → neutral "MAIN"/"SUB"). Both use the slow-control
 # cadence, matching the other global TX/operator setpoints above.
 [state_acquisition.field_policies."global.tx_state.split"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."global.slow_state.active"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 # Clarifier RIT/XIT controls (MOR-454). Slow-changing global operator/TX state:
 # rit_on/rit_tx (global tx_state bools, CAT ``CF000``) and rit_freq (global
 # operator-control signed Hz offset, CAT ``CF001``). All use the slow-control
 # cadence, matching the other global TX/operator setpoints above.
 [state_acquisition.field_policies."global.tx_state.rit_on"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."global.tx_state.rit_tx"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."global.operator_controls.rit_freq"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 # Tuner + dial-lock controls (MOR-455). Slow-changing global operator/TX state:
 # tuner_status (global operator-control antenna-tuner int, CAT ``AC``) and
 # dial_lock (global tx_state bool, CAT ``LK``). Both use the slow-control
 # cadence, matching the other global TX/operator setpoints above.
 [state_acquisition.field_policies."global.operator_controls.tuner_status"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."global.tx_state.dial_lock"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 # CW keyer family (MOR-456). Slow-changing global operator/slow controls:
 # key_speed (keyer WPM, CAT ``KS``), cw_pitch (sidetone Hz, CAT ``KP``),
@@ -350,24 +370,24 @@ freshness_ttl_seconds = 120.0
 # ``SD``), and cw_spot (global slow_state bool, CAT ``CS``). All use the
 # slow-control cadence, matching the other global TX/operator setpoints above.
 [state_acquisition.field_policies."global.operator_controls.key_speed"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."global.operator_controls.cw_pitch"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."global.operator_controls.break_in"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."global.operator_controls.break_in_delay"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."global.slow_state.cw_spot"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 # Tone / CTCSS squelch-type (MOR-457, corrected MOR-2130). The MAIN-only CAT
 # ``CT`` "SQL TYPE" read (FTX-1_CAT_OM_ENG_2508-C) is mapped onto the neutral
@@ -375,12 +395,12 @@ freshness_ttl_seconds = 120.0
 # ENC+DEC, "TSQL"). Slow-changing per-receiver operator toggles, so they use
 # the slow-control cadence, matching the other receiver DSP toggles above.
 [state_acquisition.field_policies."receiver.main.operator_toggles.repeater_tone"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.main.operator_toggles.repeater_tsql"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 # CTCSS tone frequency (MOR-458). The MAIN-only CAT ``CN`` "CTCSS TONE
 # FREQUENCY" read (FTX-1_CAT_OM_ENG_2508-C) maps a 0-49 tone-chart index → Hz →
@@ -390,25 +410,25 @@ freshness_ttl_seconds = 120.0
 # controls, so they use the slow-control cadence like the other receiver DSP
 # controls above.
 [state_acquisition.field_policies."receiver.main.operator_controls.tone_freq"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.main.operator_controls.tsql_freq"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 # Repeater shift DIRECTION (MOR-2111/MOR-2160). The CAT ``OS`` "OFFSET
 # (REPEATER SHIFT)" read (FTX-1_CAT_OM_ENG_2508-C) uses P1=0 for MAIN and P1=1
 # for SUB and reports P2 (0=Simplex, 1=Plus Shift, 2=Minus Shift, 3=ARS)
 # directly onto each neutral repeater_shift path. Both are slow-changing
-# per-receiver controls with the same 30-second cadence and 120-second TTL.
+# per-receiver controls on the same slow-control tier.
 [state_acquisition.field_policies."receiver.main.operator_controls.repeater_shift"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [state_acquisition.field_policies."receiver.sub.operator_controls.repeater_shift"]
-cadence_seconds = 30.0
-freshness_ttl_seconds = 120.0
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 [ctcss]
 table = "standard_50"

--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -213,8 +213,10 @@ tx_only = true
 # _CIV_ACQUISITION_PROVIDERS and the Yaesu backend supplies none, so
 # AcquisitionDrain.run_once takes its executor-missing branch and sends no
 # frame. What these keys do drive is StateStore.mark_stale_due via
-# StateFreshnessService, and 120.0s let a field be labelled STALE for up to
-# two minutes after a value the poller re-reads far more often than that.
+# StateFreshnessService: a field stays FRESH until now minus its last
+# observation exceeds freshness_ttl_seconds, so on a healthy link -- the
+# poller re-reading far more often than 120.0s -- it is never STALE; if the
+# link ever truly stops, the STALE verdict arrives up to two minutes late.
 # 1.0s is YaesuCatPoller._SLOW_INTERVAL, the interval of the group
 # (YaesuCatPoller._poll_slow) that re-reads this tier; the TTL is twice
 # that. Pinned by

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -170,6 +170,25 @@ polling_only = [
     "global.operator_controls.monitor_gain",
     "global.operator_controls.vox_gain",
     "global.operator_controls.anti_vox_gain",
+    # MOR-2425 (owner ruling, 2026-09-07): the ten panel knobs. As
+    # command_response-only membership they were never re-read after their
+    # first observation, so a front-panel turn reached the web only when a
+    # command happened to touch the same field. Their cadence is 5.0s below
+    # -- the one threshold the owner set for a panel change appearing in the
+    # web -- and the 2.5 q/s that funds it comes from the S-meter moving
+    # 0.2s -> 0.4s (see its field_policies entry below and the serial-budget
+    # assertion in tests/test_state_acquisition_policy.py::
+    # test_ic7300_profile_enrolls_exact_supported_observation_rows).
+    "receiver.main.active.freq_mode.filter_width",
+    "receiver.main.operator_controls.pbt_inner",
+    "receiver.main.operator_controls.pbt_outer",
+    "receiver.main.operator_controls.nr_level",
+    "receiver.main.operator_controls.nb_level",
+    "receiver.main.operator_controls.notch_filter",
+    "receiver.main.operator_controls.manual_notch_width",
+    "receiver.main.operator_toggles.auto_notch",
+    "receiver.main.operator_toggles.manual_notch",
+    "global.operator_controls.rit_freq",
     # MOR-1485: TX/PA meters (0x15 0x11-0x16). ``[commands]`` already declares
     # get_power_meter/get_swr/get_alc/get_comp_meter/get_vd_meter/get_id_meter
     # below. The acquisition scheduler resolves those canonical getter names
@@ -179,8 +198,9 @@ polling_only = [
     # these paths, so rigctld's own one-shot reads (proven healthy —
     # ``_OBSERVABLE_CMD15_FIELDS``, ``_civ_rx.py``) were the only thing that
     # ever populated them, and the always-polling web panel never saw a live
-    # value. Not stream_like_meters (that class is pinned to <=0.25s/<=2.0s
-    # by test_known_profiles_stream_like_meters_use_fast_non_decaying_policies
+    # value. Not stream_like_meters (that class is pinned to a fast cadence
+    # and a <=2.0s TTL by
+    # test_known_profiles_stream_like_meters_use_fast_non_decaying_policies
     # for every profile including this one) — plain polling_only instead,
     # with cadence chosen for THIS profile's serial budget below.
     "global.meters.power",
@@ -242,9 +262,9 @@ command_response_observable = [
     # ``ensure_fresh`` request for a path with no declared capability
     # (UNKNOWN availability), so their armed confirm could not even reach
     # the post-write-readback table added here (``_POST_WRITE_READBACK_FIELDS``
-    # in radio_poller.py) without this. MOR-2425: also given a field_policies
-    # entry below (same shape as ``filter_width``) so prime_unobserved() can
-    # reach them, per R36b.
+    # in radio_poller.py) without this. MOR-2425: also given a non-polling
+    # field_policies entry below so prime_unobserved() can reach them, per
+    # R36b.
     "receiver.main.active.freq_mode.filter_num",
     "receiver.main.active.freq_mode.data_mode",
     "receiver.main.operator_controls.filter_shape",
@@ -305,8 +325,15 @@ supported_controls = [
     "global.tx_state.split",
 ]
 
+# MOR-2425 (owner ruling, 2026-09-07): 0.2s -> 0.4s. The S-meter was the
+# single largest share of this profile's RX-state demand (5.0 of 19.833 q/s);
+# halving its rate gives back 2.5 q/s, which is what pays for the ten
+# panel-knob fields now polled at 5.0s below. freshness_ttl_seconds stays
+# 2.0s: the <=2.0s bound on a streaming meter's TTL is about detecting a
+# stopped stream promptly (MOR-334), not about the cadence, and 0.4s still
+# leaves the TTL five sample intervals of headroom.
 [state_acquisition.field_policies."receiver.main.meters.s_meter"]
-cadence_seconds = 0.2
+cadence_seconds = 0.4
 freshness_ttl_seconds = 2.0
 adaptive_decay = false
 meter_coalescing_window_seconds = 0.2
@@ -473,7 +500,8 @@ adaptive_decay = false
 # 1.5s-or-faster tier for everything else that matters live; it only ever
 # fires during a TX segment, transiently adding 4 fields / 1.0s = 4.0 q/s on
 # top of this profile's RX-state demand (see vd/id below; 19.967 q/s when
-# this was written, 19.833 q/s after the MOR-1484 and MOR-1983 cadence changes)
+# this was written, 19.333 q/s after the MOR-1484, MOR-1983 and MOR-2425
+# cadence changes)
 # for as long as the key is down -- an accepted, TX-scoped tradeoff, not a
 # steady-state regression of the MOR-1484 serial medians.
 [state_acquisition.field_policies."global.meters.power"]
@@ -512,8 +540,9 @@ tx_only = true
 # (2 fields / 60.0s = 0.033 q/s, 19.933 -> 19.967 q/s) while still refreshing
 # a slowly-varying supply rail/current reading roughly once a minute --
 # "live", just not fast. (These 19.933/19.967 figures predate the MOR-1484
-# cadence tightening above/below this block -- see that block's comment for
-# the current total, 19.833 q/s.)
+# cadence tightening above/below this block -- see the serial-budget
+# assertion in tests/test_state_acquisition_policy.py for the current total,
+# 19.333 q/s.)
 [state_acquisition.field_policies."global.meters.vd"]
 cadence_seconds = 60.0
 freshness_ttl_seconds = 90.0
@@ -522,6 +551,68 @@ adaptive_decay = false
 [state_acquisition.field_policies."global.meters.id"]
 cadence_seconds = 60.0
 freshness_ttl_seconds = 90.0
+adaptive_decay = false
+
+# MOR-2425 (owner ruling, 2026-09-07): the ten panel knobs, cadence-polled.
+# Class rule, not a per-rig number: a field the operator reaches by turning a
+# knob must reach the web within 5.0s, and freshness_ttl_seconds is twice the
+# cadence -- the ratio this profile's own default carries (1.5/3.0), as do
+# its 1.0/2.0, 3.0/6.0 and 30.0/60.0 tiers. These paths ARE in
+# [state_acquisition.capabilities].polling_only above, so due_requests()
+# reaches them and no reconciliation_priority override is needed: the file
+# default ("poll") now matches how they are actually acquired. Their cost,
+# 10 x 1/5.0 = 2.0 q/s, is funded by the S-meter's 0.2s -> 0.4s (-2.5 q/s);
+# both sides are pinned by the serial-budget assertion in
+# tests/test_state_acquisition_policy.py::
+# test_ic7300_profile_enrolls_exact_supported_observation_rows.
+[state_acquisition.field_policies."receiver.main.active.freq_mode.filter_width"]
+cadence_seconds = 5.0
+freshness_ttl_seconds = 10.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.pbt_inner"]
+cadence_seconds = 5.0
+freshness_ttl_seconds = 10.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.pbt_outer"]
+cadence_seconds = 5.0
+freshness_ttl_seconds = 10.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.nr_level"]
+cadence_seconds = 5.0
+freshness_ttl_seconds = 10.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.nb_level"]
+cadence_seconds = 5.0
+freshness_ttl_seconds = 10.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.notch_filter"]
+cadence_seconds = 5.0
+freshness_ttl_seconds = 10.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.manual_notch_width"]
+cadence_seconds = 5.0
+freshness_ttl_seconds = 10.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_toggles.auto_notch"]
+cadence_seconds = 5.0
+freshness_ttl_seconds = 10.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_toggles.manual_notch"]
+cadence_seconds = 5.0
+freshness_ttl_seconds = 10.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.operator_controls.rit_freq"]
+cadence_seconds = 5.0
+freshness_ttl_seconds = 10.0
 adaptive_decay = false
 
 # MOR-1483/1491/1492/1493 (field-policy membership wave): non-polling
@@ -562,15 +653,8 @@ freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
-[state_acquisition.field_policies."receiver.main.active.freq_mode.filter_width"]
-cadence_seconds = 25.0
-freshness_ttl_seconds = "never"
-reconciliation_priority = "command_response"
-adaptive_decay = false
-
-# Same event-driven-only shape as filter_width above: prime_unobserved()
-# iterates field_policies only, so without this entry these two paths are
-# never primed.
+# prime_unobserved() iterates field_policies only, so without an entry here
+# these two paths are never primed.
 [state_acquisition.field_policies."receiver.main.active.freq_mode.filter_num"]
 cadence_seconds = 25.0
 freshness_ttl_seconds = "never"
@@ -589,61 +673,7 @@ freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
-[state_acquisition.field_policies."receiver.main.operator_controls.pbt_inner"]
-cadence_seconds = 25.0
-freshness_ttl_seconds = "never"
-reconciliation_priority = "command_response"
-adaptive_decay = false
-
-[state_acquisition.field_policies."receiver.main.operator_controls.pbt_outer"]
-cadence_seconds = 25.0
-freshness_ttl_seconds = "never"
-reconciliation_priority = "command_response"
-adaptive_decay = false
-
-[state_acquisition.field_policies."receiver.main.operator_controls.nr_level"]
-cadence_seconds = 25.0
-freshness_ttl_seconds = "never"
-reconciliation_priority = "command_response"
-adaptive_decay = false
-
-[state_acquisition.field_policies."receiver.main.operator_controls.nb_level"]
-cadence_seconds = 25.0
-freshness_ttl_seconds = "never"
-reconciliation_priority = "command_response"
-adaptive_decay = false
-
-[state_acquisition.field_policies."receiver.main.operator_toggles.auto_notch"]
-cadence_seconds = 25.0
-freshness_ttl_seconds = "never"
-reconciliation_priority = "command_response"
-adaptive_decay = false
-
-[state_acquisition.field_policies."receiver.main.operator_toggles.manual_notch"]
-cadence_seconds = 25.0
-freshness_ttl_seconds = "never"
-reconciliation_priority = "command_response"
-adaptive_decay = false
-
-[state_acquisition.field_policies."receiver.main.operator_controls.notch_filter"]
-cadence_seconds = 25.0
-freshness_ttl_seconds = "never"
-reconciliation_priority = "command_response"
-adaptive_decay = false
-
-[state_acquisition.field_policies."receiver.main.operator_controls.manual_notch_width"]
-cadence_seconds = 25.0
-freshness_ttl_seconds = "never"
-reconciliation_priority = "command_response"
-adaptive_decay = false
-
 [state_acquisition.field_policies."receiver.main.operator_controls.agc_time_constant"]
-cadence_seconds = 25.0
-freshness_ttl_seconds = "never"
-reconciliation_priority = "command_response"
-adaptive_decay = false
-
-[state_acquisition.field_policies."global.operator_controls.rit_freq"]
 cadence_seconds = 25.0
 freshness_ttl_seconds = "never"
 reconciliation_priority = "command_response"

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -740,9 +740,8 @@ class AcquisitionScheduler:
         **Cadence-owned paths are skipped entirely**, not just deduped
         against an in-flight request (MOR-1490 review R3): a
         ``field_policies`` override doesn't imply the field is
-        *unpolled* — on the shipped IC-7300 profile all six overrides
-        (``s_meter``, ``ptt``, and the four 15s-cadence gain fields) sit on
-        capabilities with ``polling=True``. Priming one of those anyway
+        *unpolled* — on the shipped IC-7300 profile 44 of its 60 overrides
+        sit on capabilities with ``polling=True``. Priming one of those anyway
         queues a request under the exact same
         ``_AcquisitionRequestKey`` that :meth:`due_requests`'s
         ``_due_poll_groups`` groups by, and that method skips a whole
@@ -755,12 +754,13 @@ class AcquisitionScheduler:
         policy carries a ``cadence_seconds`` is therefore left to
         :meth:`due_requests` entirely; this method never touches it,
         regardless of whether it happens to also carry a ``field_policies``
-        entry. On the shipped IC-7300 profile ``prime_unobserved`` now
-        actively primes the non-polling ``command_response`` field-policy
-        membership added by MOR-1483/1491/1492/1493 (VOX/MON toggles,
-        filter/PBT facts, DSP level facts, RIT/XIT and CW keyer facts) —
-        this mechanism was previously wired but exercised by nothing on any
-        shipped profile.
+        entry. On the shipped IC-7300 profile ``prime_unobserved`` actively
+        primes that profile's remaining non-polling ``command_response``
+        field-policy membership — the menu settings (VOX/MON toggles and VOX
+        delay, filter select/DATA mode/filter shape, AGC time constant,
+        RIT/XIT enables, CW keyer setpoints, twin-peak filter, tone/TSQL
+        frequency). The panel knobs that were also in this group until
+        MOR-2425 are cadence-polled now, so this method skips them.
 
         Two further guards keep one call from flooding the transport:
 
@@ -1688,12 +1688,12 @@ class StateFreshnessService:
     #: ``field_policies`` field remains unobserved (MOR-1501, verifier-
     #: prescribed on #2421's review). :meth:`prime_unobserved` queues at
     #: most ``_PRIME_UNOBSERVED_BURST_LIMIT`` (5) new paths per call, and
-    #: ``rigs/ic7300.toml`` leaves 26 of its 60 ``field_policies`` paths
+    #: ``rigs/ic7300.toml`` leaves 16 of its 60 ``field_policies`` paths
     #: unskipped by that method's cadence-owned test (``sum(1 for path,
     #: policy in field_policies.items() if not (capability_for(path).can_poll
     #: and policy.cadence_seconds is not None))``), so queueing them all
-    #: takes at least ``ceil(26 / 5) == 6`` calls — the sixth lands ~150s in
-    #: at the 30s interval below, ~25s in at this one. The burst cap
+    #: takes at least ``ceil(16 / 5) == 4`` calls — the fourth lands ~90s in
+    #: at the 30s interval below, ~15s in at this one. The burst cap
     #: (unchanged, still the lane-protection knob) is what still bounds each
     #: wave's size, this constant only bounds how long a capped-out
     #: straggler waits between waves. See

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -2203,12 +2203,15 @@ def test_state_freshness_service_ic7300_non_polling_populate_completes_within_25
     # MOR-2234 adds tone_freq/tsql_freq, taking the count from 22 to 24.
     # MOR-2425 adds filter_num/data_mode (R36b: previously declared
     # command_response_observable with no field_policies entry, so they could
-    # never be primed), taking the count from 24 to 26 -- measured by running
-    # this test's own simulation below, which still lands its slowest field at
-    # 25.0s (see the assertion at the end of this test).
+    # never be primed), taking the count from 24 to 26, and then moves the ten
+    # panel knobs onto a 5.0s cadence (R46), which drops them out of this
+    # non-polling set and takes the count from 26 to 16. ``nb_level`` is one
+    # of the ten: it keeps its field_policies entry but is now cadence-polled,
+    # so it is asserted for membership in field_policies only.
     assert apf_path not in acquisition.field_policies
     assert nb_level_path in acquisition.field_policies
-    assert len(non_polling_paths) == 26
+    assert nb_level_path not in non_polling_paths
+    assert len(non_polling_paths) == 16
 
     clock = FreshnessClock(start=2000.0)
     store = StateStore(freshness_clock=clock)
@@ -2934,14 +2937,14 @@ def test_ic7300_real_profile_filter_num_and_data_mode_have_capability() -> None:
     (``AcquisitionScheduler._availability_for``) -- so the post-write
     readback table entries alone are not sufficient, the profile must also
     declare these two fields. Both are command_response_observable-only
-    (event-driven, like ``filter_width``), not ``polling_only``.
+    (event-driven), not ``polling_only``.
 
     A command_response_observable field with no ``field_policies`` entry is
     never primed by ``AcquisitionScheduler.prime_unobserved`` (it only
-    iterates ``field_policies``). Both fields now carry the same event-driven ``field_policies`` shape as
-    ``filter_width`` -- not ``polling_only``, so ``due_requests`` still never
-    touches them and the standing serial budget accounted for at the bottom
-    of ``rigs/ic7300.toml`` is unaffected.
+    iterates ``field_policies``). Both fields carry the on-demand
+    ``field_policies`` shape ``vox_on`` carries -- not ``polling_only``, so
+    ``due_requests`` still never touches them and the standing serial budget
+    accounted for at the bottom of ``rigs/ic7300.toml`` is unaffected.
     """
     profile = get_radio_profile("IC-7300")
     acquisition = profile.state_acquisition
@@ -2949,7 +2952,7 @@ def test_ic7300_real_profile_filter_num_and_data_mode_have_capability() -> None:
 
     filter_num = FieldPath.active("main", "freq_mode", "filter_num")
     data_mode = FieldPath.active("main", "freq_mode", "data_mode")
-    filter_width = FieldPath.active("main", "freq_mode", "filter_width")
+    on_demand = FieldPath.global_("tx_state", "vox_on")
 
     filter_cap = acquisition.capability_for(filter_num)
     data_mode_cap = acquisition.capability_for(data_mode)
@@ -2958,16 +2961,15 @@ def test_ic7300_real_profile_filter_num_and_data_mode_have_capability() -> None:
     assert data_mode_cap.command_response_observable is True
     assert data_mode_cap.polling is False
 
-    # Event-driven only, primable, same field_policies shape as filter_width.
-    filter_width_policy = acquisition.policy_for(filter_width)
+    # Event-driven only, primable, same field_policies shape as vox_on.
+    on_demand_policy = acquisition.policy_for(on_demand)
     for path in (filter_num, data_mode):
         assert path in acquisition.field_policies
         policy = acquisition.policy_for(path)
-        assert policy.cadence_seconds == filter_width_policy.cadence_seconds
-        assert policy.freshness_ttl_seconds == filter_width_policy.freshness_ttl_seconds
+        assert policy.cadence_seconds == on_demand_policy.cadence_seconds
+        assert policy.freshness_ttl_seconds == on_demand_policy.freshness_ttl_seconds
         assert (
-            policy.reconciliation_priority
-            == filter_width_policy.reconciliation_priority
+            policy.reconciliation_priority == on_demand_policy.reconciliation_priority
         )
         assert policy.adaptive_decay.enabled is False
 

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -6583,13 +6583,15 @@ def test_scan_facts_seed_labelled_command_response_not_poll_response() -> None:
 # ---------------------------------------------------------------------------
 
 #: ``(command, sub, data)`` of every frame one IC-7300 drain cycle emits.
-#: MOR-2425: re-recorded after ic7300.toml gained field_policies entries for
-#: filter_num/data_mode (R36b, so prime_unobserved() can reach them) --
-#: filter_num now falls inside this cycle's 5-field prime burst (0x26/None,
-#: the get_selected_mode selector read) where filter_shape's 0x16/0x56 read
-#: used to, since filter_num sits earlier in field_policies declaration
-#: order. filter_shape and data_mode still populate, just on a later burst
-#: this one-tick test doesn't drive. No frame count changed (still 42).
+#: MOR-2425: re-recorded after the ten panel knobs moved from
+#: command_response-only membership onto a 5.0s cadence (owner ruling,
+#: 2026-09-07). 42 -> 52 frames, one cadence read per newly-polled field:
+#: 0x1A 03 filter_width, 0x14 07/08 PBT inner/outer, 0x14 06 NR level,
+#: 0x14 12 NB level, 0x14 0D notch position, 0x16 57 notch width,
+#: 0x16 41/48 auto/manual notch, 0x21 00 RIT offset. The prime burst is
+#: still 5 paths (_PRIME_UNOBSERVED_BURST_LIMIT); filter_width left the
+#: never-observed set it is drawn from, so data_mode (0x1A 06) takes its
+#: slot in this one-tick cycle.
 _IC7300_DRAIN_CYCLE_FRAMES: tuple[tuple[int, int | None, bytes], ...] = (
     (0x1C, 0x00, b""),
     (0x25, None, b"\x00"),
@@ -6597,19 +6599,29 @@ _IC7300_DRAIN_CYCLE_FRAMES: tuple[tuple[int, int | None, bytes], ...] = (
     (0x15, 0x02, b""),
     (0x14, 0x02, b""),
     (0x14, 0x03, b""),
+    (0x0F, None, b""),
     (0x14, 0x01, b""),
     (0x16, 0x12, b""),
     (0x16, 0x22, b""),
     (0x16, 0x40, b""),
     (0x25, None, b"\x01"),
     (0x26, None, b"\x01"),
-    (0x0F, None, b""),
     (0x11, None, b""),
     (0x16, 0x02, b""),
     (0x14, 0x0E, b""),
     (0x14, 0x0A, b""),
     (0x1C, 0x01, b""),
     (0x16, 0x44, b""),
+    (0x1A, 0x03, b""),
+    (0x16, 0x57, b""),
+    (0x14, 0x12, b""),
+    (0x14, 0x0D, b""),
+    (0x14, 0x06, b""),
+    (0x14, 0x07, b""),
+    (0x14, 0x08, b""),
+    (0x16, 0x41, b""),
+    (0x16, 0x48, b""),
+    (0x21, 0x00, b""),
     (0x14, 0x17, b""),
     (0x14, 0x0B, b""),
     (0x14, 0x15, b""),
@@ -6617,8 +6629,8 @@ _IC7300_DRAIN_CYCLE_FRAMES: tuple[tuple[int, int | None, bytes], ...] = (
     (0x16, 0x45, b""),
     (0x16, 0x46, b""),
     (0x1A, 0x05, b"\x01\x91"),
+    (0x1A, 0x06, b""),
     (0x26, None, b"\x00"),
-    (0x1A, 0x03, b""),
     (0x27, 0x1C, b""),
     (0x27, 0x13, b""),
     (0x27, 0x1B, b""),

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -104,6 +104,38 @@ _ON_DEMAND_FIELD_NAMES = frozenset(
     }
 )
 
+#: Classified paths with no own ``field_policies`` entry, so
+#: ``test_field_policies_obey_their_cadence_class_not_their_rig`` cannot see
+#: them (it walks ``field_policies.items()``, not ``capabilities``): each
+#: inherits the profile's ``default_cadence_seconds`` instead, and that
+#: inherited cadence exceeds the path's class bound. Reproduced by
+#: ``_inherited_default_out_of_class`` below, which walks every profile's
+#: ``capabilities`` and keeps only paths where that comparison fails.
+_INHERITED_DEFAULT_OUT_OF_CLASS: dict[str, tuple[FieldPath, ...]] = {
+    "X6200": (
+        # inherits default 2.0s; live bound is 1.0s
+        FieldPath.active("main", "freq_mode", "freq_hz"),
+    ),
+    "IC-7610": (
+        # inherits default 2.0s; live bound is 1.0s
+        FieldPath.active("main", "freq_mode", "mode"),
+        FieldPath.active("sub", "freq_mode", "mode"),
+    ),
+    "IC-7300": (
+        # inherits default 1.5s; live bound is 1.0s
+        FieldPath.unselected("main", "freq_mode", "freq_hz"),
+        FieldPath.unselected("main", "freq_mode", "mode"),
+    ),
+    "FTX-1": (
+        # inherits default 2.0s; live bound is 1.0s
+        FieldPath.global_("tx_state", "ptt"),
+        FieldPath.active("main", "freq_mode", "freq_hz"),
+        FieldPath.active("main", "freq_mode", "mode"),
+        FieldPath.active("sub", "freq_mode", "freq_hz"),
+        FieldPath.active("sub", "freq_mode", "mode"),
+    ),
+}
+
 #: The ten panel knobs the owner's ruling named, on the one rig it named.
 _IC7300_PANEL_KNOB_PATHS = (
     FieldPath.active("main", "freq_mode", "filter_width"),
@@ -682,7 +714,7 @@ def _cadence_class(
 
 
 def test_field_policies_obey_their_cadence_class_not_their_rig() -> None:
-    """One bound per class, applied to every profile that declares policies.
+    """One bound per class, applied to every path with its own field_policies entry.
 
     Owner ruling (2026-09-07): a field's cadence follows what the field is,
     not which radio it sits on. Each class constant above is the longest the
@@ -691,12 +723,18 @@ def test_field_policies_obey_their_cadence_class_not_their_rig() -> None:
     one in this repo is IC-7300's 20 q/s serial ceiling, asserted in
     ``test_ic7300_profile_enrolls_exact_supported_observation_rows``).
 
-    A profile that declares no ``field_policies`` at all makes no per-field
-    cadence claim -- every path inherits one default -- so it is skipped, and
-    the set of profiles actually exercised is pinned below so this cannot go
-    vacuous. A classified path whose capability is not pollable is the
-    on-demand shape instead: nothing re-reads it on a cadence, so it must
-    carry no expiry.
+    This gate only checks a path that carries its own ``field_policies``
+    entry, because it walks ``field_policies.items()``. A classified path
+    that instead inherits the profile's ``default_cadence_seconds`` is
+    invisible to it -- see ``_INHERITED_DEFAULT_OUT_OF_CLASS`` and
+    ``test_inherited_default_cadence_out_of_class_paths_are_exactly_named``
+    below for the ten such paths that are out of class today. A profile that
+    declares no ``field_policies`` at all makes no per-field cadence claim --
+    every path inherits one default -- so it is skipped; ``checked ==
+    {...}`` below pins which profiles were walked, not that every classified
+    path on each one carries its own entry. A classified path whose
+    capability is not pollable is the on-demand shape instead: nothing
+    re-reads it on a cadence, so it must carry no expiry.
     """
 
     checked: set[str] = set()
@@ -730,6 +768,50 @@ def test_field_policies_obey_their_cadence_class_not_their_rig() -> None:
 
     assert not failures, f"field_policies entries outside their class: {failures}"
     assert checked == {"FTX-1", "IC-7300", "IC-7610", "X6200"}
+
+
+def _inherited_default_out_of_class() -> dict[str, tuple[FieldPath, ...]]:
+    """Classified paths the gate above cannot see, that are out of class.
+
+    Walks every profile's ``capabilities`` (not ``field_policies``, which is
+    what the gate above walks) and keeps a path only if it (a) has no own
+    ``field_policies`` entry, so its effective cadence is the profile's
+    inherited ``default_cadence_seconds``, and (b) that inherited cadence
+    exceeds its class bound.
+    """
+
+    found: dict[str, list[FieldPath]] = {}
+    for model, rig in sorted(discover_rigs(RIGS_DIR).items()):
+        acquisition = rig.to_profile().state_acquisition
+        if acquisition is None or not acquisition.field_policies:
+            continue
+        for capability in sorted(acquisition.capabilities, key=lambda c: str(c.path)):
+            path = capability.path
+            if path in acquisition.field_policies:
+                continue
+            classified = _cadence_class(path, capability)
+            if classified is None:
+                continue
+            _class_name, bound = classified
+            cadence = acquisition.policy_for(path).cadence_seconds
+            if cadence is not None and cadence <= bound:
+                continue
+            found.setdefault(model, []).append(path)
+    return {model: tuple(paths) for model, paths in found.items()}
+
+
+def test_inherited_default_cadence_out_of_class_paths_are_exactly_named() -> None:
+    """The paths the cadence-class gate cannot see must be exactly the named ten.
+
+    ``test_field_policies_obey_their_cadence_class_not_their_rig`` only
+    checks a path with its own ``field_policies`` entry. This test covers
+    the gap: it re-derives ``_INHERITED_DEFAULT_OUT_OF_CLASS`` from the
+    profiles themselves, so fixing one of the ten (or introducing a new
+    inherited-default violation) changes the derived set and this assertion
+    goes red, naming what changed.
+    """
+
+    assert _inherited_default_out_of_class() == _INHERITED_DEFAULT_OUT_OF_CLASS
 
 
 def test_ic7300_panel_knob_fields_are_polled_at_the_panel_class_cadence() -> None:

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -22,7 +22,7 @@ from rigplane.core.state_acquisition_policy import (
     MeterCoalescingPolicy,
     RadioAcquisitionProfile,
 )
-from rigplane.core.state_pipeline_contracts import FieldPath
+from rigplane.core.state_pipeline_contracts import FieldPath, FieldScope
 from rigplane.core.state_store import FreshnessState, StateStore
 from rigplane.profiles import get_radio_profile
 from rigplane.rig_loader import RigLoadError, discover_rigs, load_rig
@@ -48,6 +48,101 @@ _UNPRIMABLE_COMMAND_RESPONSE_EXEMPTIONS: dict[str, frozenset[FieldPath]] = {
         }
     ),
 }
+
+
+# --- Cadence classes -------------------------------------------------------
+# Longest a class of field may lag the front panel, in seconds. Membership is
+# by field name (or, for stream meters, by the profile's own ``stream_like``
+# flag) so the same bound applies on every rig.
+
+#: Continuously-moving readings the profile declares ``stream_like``. 0.4s is
+#: IC-7300's cadence after the S-meter gave 2.5 q/s back to fund the panel
+#: tier below; every other profile declares 0.2s or 0.25s.
+_STREAM_METER_MAX_CADENCE_SECONDS = 0.4
+#: Facts that move while the operator tunes or keys.
+_LIVE_MAX_CADENCE_SECONDS = 1.0
+#: Everything the operator reaches by turning a knob or opening a menu. 5.0s
+#: is the owner's single threshold for a panel change reaching the web.
+_OPERATOR_SET_MAX_CADENCE_SECONDS = 5.0
+
+_LIVE_FIELD_NAMES = frozenset({"freq_hz", "mode", "ptt"})
+_PANEL_ADJUSTABLE_FIELD_NAMES = frozenset(
+    {
+        "auto_notch",
+        "filter_width",
+        "if_shift",
+        "manual_notch",
+        "manual_notch_freq",
+        "manual_notch_width",
+        "nb_level",
+        "notch_filter",
+        "nr_level",
+        "pbt_inner",
+        "pbt_outer",
+        "rit_freq",
+        "split",
+    }
+)
+_ON_DEMAND_FIELD_NAMES = frozenset(
+    {
+        "agc_time_constant",
+        "break_in",
+        "break_in_delay",
+        "cw_pitch",
+        "data_mode",
+        "filter_num",
+        "filter_shape",
+        "key_speed",
+        "monitor_on",
+        "rit_on",
+        "rit_tx",
+        "tone_freq",
+        "tsql_freq",
+        "twin_peak_filter",
+        "vox_delay",
+        "vox_on",
+    }
+)
+
+#: The ten panel knobs the owner's ruling named, on the one rig it named.
+_IC7300_PANEL_KNOB_PATHS = (
+    FieldPath.active("main", "freq_mode", "filter_width"),
+    FieldPath.global_("operator_controls", "rit_freq"),
+    FieldPath.receiver("main", "operator_controls", "manual_notch_width"),
+    FieldPath.receiver("main", "operator_controls", "nb_level"),
+    FieldPath.receiver("main", "operator_controls", "notch_filter"),
+    FieldPath.receiver("main", "operator_controls", "nr_level"),
+    FieldPath.receiver("main", "operator_controls", "pbt_inner"),
+    FieldPath.receiver("main", "operator_controls", "pbt_outer"),
+    FieldPath.receiver("main", "operator_toggles", "auto_notch"),
+    FieldPath.receiver("main", "operator_toggles", "manual_notch"),
+)
+_IC7300_PANEL_KNOB_CADENCE_SECONDS = 5.0
+#: Twice the cadence, the ratio the IC-7300 profile default carries
+#: (1.5/3.0), as do its 1.0/2.0, 3.0/6.0 and 30.0/60.0 tiers.
+_IC7300_PANEL_KNOB_TTL_SECONDS = 10.0
+
+#: The menu settings that stay on-demand: reached by
+#: ``AcquisitionScheduler.prime_unobserved`` and refreshed by their own
+#: command response, never by a cadence read.
+_IC7300_ON_DEMAND_PATHS = (
+    FieldPath.active("main", "freq_mode", "data_mode"),
+    FieldPath.active("main", "freq_mode", "filter_num"),
+    FieldPath.global_("operator_controls", "break_in"),
+    FieldPath.global_("operator_controls", "break_in_delay"),
+    FieldPath.global_("operator_controls", "cw_pitch"),
+    FieldPath.global_("operator_controls", "key_speed"),
+    FieldPath.global_("operator_controls", "vox_delay"),
+    FieldPath.global_("tx_state", "monitor_on"),
+    FieldPath.global_("tx_state", "rit_on"),
+    FieldPath.global_("tx_state", "rit_tx"),
+    FieldPath.global_("tx_state", "vox_on"),
+    FieldPath.receiver("main", "operator_controls", "agc_time_constant"),
+    FieldPath.receiver("main", "operator_controls", "filter_shape"),
+    FieldPath.receiver("main", "operator_controls", "tone_freq"),
+    FieldPath.receiver("main", "operator_controls", "tsql_freq"),
+    FieldPath.receiver("main", "operator_toggles", "twin_peak_filter"),
+)
 
 
 def _write_toml(tmp_path: Path, content: str, name: str = "test.toml") -> Path:
@@ -545,7 +640,7 @@ def test_known_profiles_stream_like_meters_use_fast_non_decaying_policies() -> N
         for capability in stream_like:
             policy = acquisition.policy_for(capability.path)
             assert policy.cadence_seconds is not None
-            assert policy.cadence_seconds <= 0.25
+            assert policy.cadence_seconds <= _STREAM_METER_MAX_CADENCE_SECONDS
             assert policy.freshness_ttl_seconds is not None
             # MOR-334 (s_meter stuck-low): a streaming meter's freshness TTL must
             # EXCEED its own cadence so the field stays FRESH between live
@@ -564,6 +659,117 @@ def test_known_profiles_stream_like_meters_use_fast_non_decaying_policies() -> N
             )
 
 
+def _cadence_class(
+    path: FieldPath,
+    capability: FieldCapability,
+) -> tuple[str, float] | None:
+    """Name the cadence class a path belongs to, or ``None`` if unclassified."""
+
+    if capability.stream_like:
+        return ("stream meter", _STREAM_METER_MAX_CADENCE_SECONDS)
+    if path.scope is FieldScope.SCOPE_CONTROLS:
+        # The spectrum-scope display settings share several names with radio
+        # state (``mode``, ``span``, ``speed``) and are not what any class
+        # below is about. No ruling covers them; they stay unclassified.
+        return None
+    if path.name in _LIVE_FIELD_NAMES:
+        return ("live", _LIVE_MAX_CADENCE_SECONDS)
+    if path.name in _PANEL_ADJUSTABLE_FIELD_NAMES:
+        return ("panel-adjustable", _OPERATOR_SET_MAX_CADENCE_SECONDS)
+    if path.name in _ON_DEMAND_FIELD_NAMES:
+        return ("on-demand", _OPERATOR_SET_MAX_CADENCE_SECONDS)
+    return None
+
+
+def test_field_policies_obey_their_cadence_class_not_their_rig() -> None:
+    """One bound per class, applied to every profile that declares policies.
+
+    Owner ruling (2026-09-07): a field's cadence follows what the field is,
+    not which radio it sits on. Each class constant above is the longest the
+    web may lag a front-panel change for the fields in it; a profile may poll
+    faster, and going slower needs a measured budget for that link (the only
+    one in this repo is IC-7300's 20 q/s serial ceiling, asserted in
+    ``test_ic7300_profile_enrolls_exact_supported_observation_rows``).
+
+    A profile that declares no ``field_policies`` at all makes no per-field
+    cadence claim -- every path inherits one default -- so it is skipped, and
+    the set of profiles actually exercised is pinned below so this cannot go
+    vacuous. A classified path whose capability is not pollable is the
+    on-demand shape instead: nothing re-reads it on a cadence, so it must
+    carry no expiry.
+    """
+
+    checked: set[str] = set()
+    failures: list[str] = []
+    for model, rig in sorted(discover_rigs(RIGS_DIR).items()):
+        acquisition = rig.to_profile().state_acquisition
+        if acquisition is None or not acquisition.field_policies:
+            continue
+        checked.add(model)
+        for path, policy in sorted(
+            acquisition.field_policies.items(), key=lambda item: str(item[0])
+        ):
+            capability = acquisition.capability_for(path)
+            classified = _cadence_class(path, capability)
+            if classified is None:
+                continue
+            class_name, bound = classified
+            if not capability.can_poll:
+                if policy.freshness_ttl_seconds is not None:
+                    failures.append(
+                        f"{model}: {path} ({class_name}) is not pollable yet "
+                        f"expires after {policy.freshness_ttl_seconds}s"
+                    )
+                continue
+            cadence = policy.cadence_seconds
+            if cadence is None or cadence > bound:
+                failures.append(
+                    f"{model}: {path} ({class_name}) cadence={cadence}s "
+                    f"exceeds the class bound of {bound}s"
+                )
+
+    assert not failures, f"field_policies entries outside their class: {failures}"
+    assert checked == {"FTX-1", "IC-7300", "IC-7610", "X6200"}
+
+
+def test_ic7300_panel_knob_fields_are_polled_at_the_panel_class_cadence() -> None:
+    """The ten knobs the ruling named must be cadence-polled, not on-demand.
+
+    Left non-polling they sit in ``command_response_observable`` only, which
+    ``AcquisitionScheduler._poll_cadence_groups`` skips -- a front-panel
+    change would never reach the web until a command happened to touch the
+    field, which is the case the 5.0s bound exists to close.
+    """
+
+    acquisition = get_radio_profile("IC-7300").state_acquisition
+    assert acquisition is not None
+
+    for path in _IC7300_PANEL_KNOB_PATHS:
+        capability = acquisition.capability_for(path)
+        assert capability.can_poll is True, f"{path} is not cadence-polled"
+        policy = acquisition.policy_for(path)
+        assert policy.cadence_seconds == _IC7300_PANEL_KNOB_CADENCE_SECONDS, path
+        assert policy.freshness_ttl_seconds == _IC7300_PANEL_KNOB_TTL_SECONDS, path
+
+
+def test_ic7300_on_demand_fields_keep_the_never_ttl() -> None:
+    """The menu settings stay on-demand: no cadence read, so no expiry."""
+
+    acquisition = get_radio_profile("IC-7300").state_acquisition
+    assert acquisition is not None
+
+    for path in _IC7300_ON_DEMAND_PATHS:
+        assert acquisition.capability_for(path).can_poll is False, path
+        assert acquisition.policy_for(path).freshness_ttl_seconds is None, path
+
+    never_ttl = {
+        path
+        for path, policy in acquisition.field_policies.items()
+        if policy.freshness_ttl_seconds is None
+    }
+    assert never_ttl == set(_IC7300_ON_DEMAND_PATHS)
+
+
 def test_ftx1_profile_declares_slow_control_policies_for_polling_adapter() -> None:
     ftx1 = get_radio_profile("FTX-1")
     assert ftx1.state_acquisition is not None
@@ -575,8 +781,8 @@ def test_ftx1_profile_declares_slow_control_policies_for_polling_adapter() -> No
     assert ftx1.state_acquisition.capability_for(af_level).can_poll is True
     assert ftx1.state_acquisition.capability_for(squelch).can_poll is True
     assert ftx1.state_acquisition.capability_for(ptt).can_poll is True
-    assert ftx1.state_acquisition.policy_for(af_level).freshness_ttl_seconds == 120.0
-    assert ftx1.state_acquisition.policy_for(af_level).cadence_seconds == 30.0
+    assert ftx1.state_acquisition.policy_for(af_level).freshness_ttl_seconds == 2.0
+    assert ftx1.state_acquisition.policy_for(af_level).cadence_seconds == 1.0
 
 
 def test_ftx1_tx_meters_are_declared_tx_only() -> None:
@@ -623,6 +829,11 @@ def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
         FieldPath.global_("tx_state", "ptt"),
         FieldPath.global_("operator_controls", "tuner_status"),
         FieldPath.global_("tx_state", "split"),
+        # MOR-2425 (owner ruling, 2026-09-07): the ten panel knobs, moved off
+        # command_response-only membership onto a 5.0s cadence -- see
+        # _IC7300_PANEL_KNOB_PATHS and
+        # test_ic7300_panel_knob_fields_are_polled_at_the_panel_class_cadence.
+        *_IC7300_PANEL_KNOB_PATHS,
         # MOR-1452: documented-readable 0x14 sub-commands (mic/monitor/VOX/
         # anti-VOX gain, docs/validation/cat-audits/ic7300.md) added to the
         # slow poll tier so the TX-aux panel stops showing a permanent "?".
@@ -754,7 +965,7 @@ def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
         for path in acquisition.pollable_paths()
         if acquisition.policy_for(path).tx_only
     )
-    # MOR-1484 baseline: pre-MOR-1484 total was 19.967 q/s. This PR moves
+    # MOR-1484 baseline: pre-MOR-1484 total was 19.967 q/s. MOR-1484 moved
     # freq_hz(active)/mode(active)/rf_gain/squelch (4 fields) from the 1.5s
     # default tier to a dedicated 1.0s tier (+2.667 -> +4.0 = +1.333 q/s) and
     # mic/monitor/VOX/anti-VOX gain (4 fields) from 15.0s to 10.0s (+0.267 ->
@@ -762,16 +973,21 @@ def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
     # (tuner_status, power_level, compressor_on/level, att, preamp; 6 fields)
     # back from 1.5s to 3.0s (-4.0 -> -2.0 = -2.0 q/s). Net:
     # 19.967 + 1.333 + 0.133 - 2.0 = 19.433 q/s before the twelve 30s scope
-    # reads declared by MOR-1983 add 0.4 q/s. The resulting 19.833 q/s stays
-    # below the 20 q/s ceiling.
-    assert rx_state_demand_hz == pytest.approx(19.833, abs=0.001)
+    # reads declared by MOR-1983 add 0.4 q/s, for 19.833 q/s.
+    #
+    # MOR-2425 (owner ruling, 2026-09-07) enrols the ten panel knobs at 5.0s
+    # (10 x 1/5.0 = +2.0 q/s) and funds them by halving the S-meter's rate,
+    # 0.2s -> 0.4s (5.0 -> 2.5 = -2.5 q/s). Net:
+    # 19.833 + 2.0 - 2.5 = 19.333 q/s, still below the 20 q/s ceiling and
+    # 0.5 q/s further below it than before.
+    assert rx_state_demand_hz == pytest.approx(19.333, abs=0.001)
     assert rx_state_demand_hz < serial_ceiling_hz
     # Po/SWR/ALC/COMP: 4 fields / 1.0s = 4.0 q/s, ONLY while tx_only gating
     # lets them through (PTT observed true) — a transient TX-window cost, not
     # a steady-state one. Untouched by MOR-1484.
     assert tx_only_demand_hz == pytest.approx(4.0, abs=0.001)
     total_during_tx_hz = rx_state_demand_hz + tx_only_demand_hz
-    assert total_during_tx_hz == pytest.approx(23.833, abs=0.001)
+    assert total_during_tx_hz == pytest.approx(23.333, abs=0.001)
 
     assert (
         acquisition.capability_for(
@@ -1015,8 +1231,8 @@ def test_ic7300_activation_does_not_change_ftx1_acquisition_contract() -> None:
 
     sub_shift = FieldPath.receiver("sub", "operator_controls", "repeater_shift")
     assert acquisition.capability_for(sub_shift).can_poll is True
-    assert acquisition.policy_for(sub_shift).cadence_seconds == 30.0
-    assert acquisition.policy_for(sub_shift).freshness_ttl_seconds == 120.0
+    assert acquisition.policy_for(sub_shift).cadence_seconds == 1.0
+    assert acquisition.policy_for(sub_shift).freshness_ttl_seconds == 2.0
 
 
 def test_non_polling_field_policies_declare_no_freshness_expiry() -> None:
@@ -1060,7 +1276,7 @@ def test_ic7300_on_demand_field_stays_fresh_while_polled_field_expires() -> None
     CI-V ingress is not under test here.
     ``ProviderObservationAdapter`` reads each path's ``max_age`` from its
     ``field_policies`` entry, ``StateStore`` keeps it on the entry, and
-    ``StateFreshnessService.tick`` is what ages it. ``filter_width`` rides a
+    ``StateFreshnessService.tick`` is what ages it. ``cw_pitch`` rides a
     ``polling=False`` capability, so no cadence read refreshes it;
     ``freq_hz`` is cadence-polled and must still expire, so the decay
     mechanism is not disabled wholesale.
@@ -1069,7 +1285,7 @@ def test_ic7300_on_demand_field_stays_fresh_while_polled_field_expires() -> None
     profile = get_radio_profile("IC-7300")
     acquisition = profile.state_acquisition
     assert acquisition is not None
-    on_demand = FieldPath.active("main", "freq_mode", "filter_width")
+    on_demand = FieldPath.global_("operator_controls", "cw_pitch")
     polled = FieldPath.active("main", "freq_mode", "freq_hz")
     assert acquisition.capability_for(on_demand).can_poll is False
     assert acquisition.capability_for(polled).can_poll is True
@@ -1149,7 +1365,7 @@ def test_ic7300_on_demand_field_primes_with_its_cadence_as_max_age() -> None:
 
     acquisition = get_radio_profile("IC-7300").state_acquisition
     assert acquisition is not None
-    on_demand = FieldPath.active("main", "freq_mode", "filter_width")
+    on_demand = FieldPath.global_("operator_controls", "cw_pitch")
     assert acquisition.policy_for(on_demand).freshness_ttl_seconds is None
 
     scheduler = AcquisitionScheduler(profile=acquisition)

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -109,8 +109,12 @@ _ON_DEMAND_FIELD_NAMES = frozenset(
 #: them (it walks ``field_policies.items()``, not ``capabilities``): each
 #: inherits the profile's ``default_cadence_seconds`` instead, and that
 #: inherited cadence exceeds the path's class bound. Reproduced by
-#: ``_inherited_default_out_of_class`` below, which walks every profile's
-#: ``capabilities`` and keeps only paths where that comparison fails.
+#: ``_inherited_default_out_of_class`` below, which walks the
+#: ``capabilities`` of every profile that declares ``field_policies`` and
+#: keeps only paths where that comparison fails. Profiles declaring no
+#: ``field_policies`` (IC-705, IC-9700, X6100) are outside this list: the
+#: same walk without that skip finds 28 more such paths there (12, 12, 4),
+#: which no test bounds.
 _INHERITED_DEFAULT_OUT_OF_CLASS: dict[str, tuple[FieldPath, ...]] = {
     "X6200": (
         # inherits default 2.0s; live bound is 1.0s
@@ -773,8 +777,10 @@ def test_field_policies_obey_their_cadence_class_not_their_rig() -> None:
 def _inherited_default_out_of_class() -> dict[str, tuple[FieldPath, ...]]:
     """Classified paths the gate above cannot see, that are out of class.
 
-    Walks every profile's ``capabilities`` (not ``field_policies``, which is
-    what the gate above walks) and keeps a path only if it (a) has no own
+    Walks the ``capabilities`` (not ``field_policies``, which is what the
+    gate above walks) of every profile that declares ``field_policies`` —
+    profiles declaring none are skipped, as the gate skips them — and keeps a
+    path only if it (a) has no own
     ``field_policies`` entry, so its effective cadence is the profile's
     inherited ``default_cadence_seconds``, and (b) that inherited cadence
     exceeds its class bound.
@@ -801,14 +807,16 @@ def _inherited_default_out_of_class() -> dict[str, tuple[FieldPath, ...]]:
 
 
 def test_inherited_default_cadence_out_of_class_paths_are_exactly_named() -> None:
-    """The paths the cadence-class gate cannot see must be exactly the named ten.
+    """On the profiles the gate walks, the paths it cannot see are exactly the named ten.
 
     ``test_field_policies_obey_their_cadence_class_not_their_rig`` only
     checks a path with its own ``field_policies`` entry. This test covers
     the gap: it re-derives ``_INHERITED_DEFAULT_OUT_OF_CLASS`` from the
-    profiles themselves, so fixing one of the ten (or introducing a new
-    inherited-default violation) changes the derived set and this assertion
-    goes red, naming what changed.
+    profiles that declare ``field_policies``, so fixing one of the ten (or
+    introducing a new inherited-default violation on one of those profiles)
+    changes the derived set and this assertion goes red, naming what
+    changed. A profile with no ``field_policies`` is not walked, so a
+    violation introduced there is not caught here.
     """
 
     assert _inherited_default_out_of_class() == _INHERITED_DEFAULT_OUT_OF_CLASS

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -442,6 +442,41 @@ async def test_start_routes_observation_pollable_radio_through_observation_store
 
 
 @pytest.mark.asyncio
+async def test_observation_pollable_web_path_builds_no_radio_poller() -> None:
+    """An ObservationPollable radio's web path carries no AcquisitionDrain.
+
+    ``RadioPoller`` is the only web-side builder of an ``AcquisitionDrain``,
+    and ``start_web_server`` builds it only on its trailing Icom CI-V branch.
+    An ``ObservationPollable`` radio (FTX-1 via ``YaesuCatRadio``) takes the
+    observation-poller branch instead, so the ``AcquisitionScheduler`` is
+    never drained for it and the ``cadence_seconds`` values in
+    ``rigs/ftx1.toml`` cannot reach the CAT link -- they drive
+    ``StateStore.mark_stale_due`` bookkeeping and nothing else.
+    """
+    radio = _ObservationStatePollableRadio()
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0, discovery=False))
+
+    with (
+        patch(
+            "rigplane.web.web_startup.asyncio.start_server",
+            new=AsyncMock(return_value=_FakeAsyncServer()),
+        ),
+        patch(
+            "rigplane.web.web_startup.RadioPoller",
+            side_effect=AssertionError(
+                "an ObservationPollable radio must not get a RadioPoller"
+            ),
+        ),
+    ):
+        await srv.start()
+        await asyncio.sleep(0)
+        await srv.stop()
+
+    assert srv._radio_poller is None  # noqa: SLF001
+    assert radio.observation_poller is not None
+
+
+@pytest.mark.asyncio
 async def test_web_fallback_observation_store_advances_before_attach_and_detach() -> (
     None
 ):

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -609,13 +609,13 @@ async def test_medium_poll_emits_frequency_mode_and_ptt_observations() -> None:
     assert {item.source.transport for item in observations} == {"serial"}
     assert all(item.timestamp_monotonic == 123.456 for item in observations)
     # freq/mode/ptt use the default 8.0s freshness TTL; filter_width carries
-    # its own slow-control TTL (120.0s) from the per-field policy, even though
+    # its own slow-control TTL (2.0s) from the per-field policy, even though
     # it shares the freq/mode lane (MOR-445).
     by_path = {str(item.path): item for item in observations}
     assert by_path["global.tx_state.ptt"].max_age == 8.0
     assert by_path["global.tx_state.tx_target"].max_age == 8.0
     assert by_path["receiver.main.active.freq_mode.freq_hz"].max_age == 8.0
-    assert by_path["receiver.main.active.freq_mode.filter_width"].max_age == 120.0
+    assert by_path["receiver.main.active.freq_mode.filter_width"].max_age == 2.0
     assert all(item.source.capability_id == str(item.path) for item in observations)
 
 
@@ -853,7 +853,7 @@ async def test_slow_poll_emits_declared_control_observations_only() -> None:
         ("global.slow_state.cw_spot", True),
     ]
     assert all(item.source.source == "yaesu_poll_response" for item in observations)
-    assert all(item.max_age == 120.0 for item in observations)
+    assert all(item.max_age == 2.0 for item in observations)
     assert radio.read_vfo_select.await_count == 1
     radio.get_vfo_select.assert_not_awaited()
     assert radio.read_cw_spot.await_count == 1
@@ -1133,7 +1133,7 @@ async def test_tx_controls_poll_emits_global_setpoints() -> None:
         ("global.operator_controls.break_in_delay", 300),
     ]
     assert all(item.source.source == "yaesu_poll_response" for item in observations)
-    assert all(item.max_age == 120.0 for item in observations)
+    assert all(item.max_age == 2.0 for item in observations)
     # Power emits the watt SETPOINT (read_power), never the RM5 meter.
     radio.read_power.assert_awaited_once()
     radio.read_mic_gain.assert_awaited_once()

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -3991,3 +3991,23 @@ async def test_execute_command_set_power_raw_255_unit_rejected() -> None:
         await poller._execute_command(SetPower(level=200))  # default unit='raw_255'
 
     radio.set_power.assert_not_awaited()
+
+
+def test_slow_group_interval_matches_the_profile_slow_control_cadence() -> None:
+    """The FTX-1 profile's slow tier must name the interval that re-reads it.
+
+    ``YaesuCatPoller`` is what actually polls an FTX-1: the AGC, gain, notch,
+    RIT, tuner, keyer and tone paths all ride ``_SLOW_INTERVAL``. The profile's
+    ``cadence_seconds`` for those paths never reaches the CAT link (the
+    ``AcquisitionScheduler`` is not drained on this backend), so the only thing
+    keeping the declared number honest is this equality.
+    """
+    from rigplane.backends.yaesu_cat.poller import _SLOW_INTERVAL
+    from rigplane.profiles import get_radio_profile
+
+    assert _SLOW_INTERVAL == 1.0
+
+    acquisition = get_radio_profile("FTX-1").state_acquisition
+    assert acquisition is not None
+    slow_control = FieldPath.receiver("main", "operator_controls", "af_level")
+    assert acquisition.policy_for(slow_control).cadence_seconds == _SLOW_INTERVAL


### PR DESCRIPTION
10 code + 0 regenerated baselines = 10 files (file-count exception granted by the coordinating session under the owner's 2026-09-03 delegation: the tenth file carries three docstring numbers this change falsified); 865 changed lines (649 + 216) at 82d4ab15f, over the soft threshold on both counts and under the 1000-line ceiling. One unit of work: the same cadence decision applied to the two profiles it touches, plus every test, golden and comment that pinned the old numbers; splitting the IC-7300 change from its ledger pin or the FTX-1 bookkeeping from its wire-tier pins would leave a red or a vacuous half.

## The rulings

The owner ruled that a field's cadence follows what the field is, not which
radio it sits on — a per-rig deviation needs a measured bus budget — and that
5 s is the one threshold for a front-panel change appearing in the web. He then
chose to fund a 5 s tier for the ten IC-7300 panel knobs by halving the S-meter
rate rather than by cutting anything else.

## IC-7300 ledger

The ten panel knobs (`filter_width`, `pbt_inner/outer`, `rit_freq`,
`auto_notch`, `manual_notch`, `notch_filter`, `manual_notch_width`, `nr_level`,
`nb_level`) were `command_response_observable` with `polling=False`: never
re-read after their first observation. They now sit in `polling_only` at
`cadence_seconds = 5.0` / `freshness_ttl_seconds = 10.0`.

    19.833 (before)
      + 10 x 1/5.0   = +2.0   the ten panel knobs
      - (1/0.2-1/0.4) = -2.5   S-meter 0.2s -> 0.4s
    = 19.333 q/s RX-state demand, against the 20 q/s serial ceiling
      (_SERIAL_DEFAULT_CIV_MIN_INTERVAL_MS = 50.0)

`tx_only_demand_hz` is unchanged at 4.0; total during TX 23.833 -> 23.333. The
figure is computed from the profile inside
`test_ic7300_profile_enrolls_exact_supported_observation_rows`, not written in
by hand. The S-meter TTL stays 2.0 s: the `<= 2.0` bound on a streaming meter's
TTL is about detecting a stopped stream (MOR-334), not about the cadence, and
0.4 s still leaves five sample intervals of headroom — the TTL was not scaled
with the cadence.

## Per rig

- **IC-7300**: the ten knobs polled at 5.0 s; S-meter 0.2 -> 0.4 s. The
  `"never"` TTL now appears on exactly the sixteen menu-setting fields, pinned
  as a set.
- **FTX-1**: the 42 slow-tier fields go 30.0/120.0 -> 1.0/2.0. No wire
  behaviour changes. On the web path FTX-1 takes `start_web_server`'s
  `ObservationPollable` branch and never gets the `RadioPoller` that carries
  the web's only `AcquisitionDrain`; on the rigctld path a drain is built but
  no executor for it (`yaesu_cat` is outside `_CIV_ACQUISITION_PROVIDERS` and
  the Yaesu backend supplies none), so `AcquisitionDrain.run_once` takes its
  executor-missing branch and sends no frame. 1.0 s is
  `YaesuCatPoller._SLOW_INTERVAL`, the group that actually re-reads this tier.
  Both claims are pinned by new tests.
- **IC-7610, IC-705, IC-9700, X6200, X6100**: unchanged. No measured bus
  budget exists for any of them, so there is no evidence on which to move a
  number.

## Cadence classes

Written once, as named constants in `tests/test_state_acquisition_policy.py`,
applied to every profile that declares `field_policies` (FTX-1, IC-7300,
IC-7610, X6200 — the exercised set is asserted so the test cannot go vacuous):

| class | bound | membership |
|---|---|---|
| stream meter | 0.4 s | the profile's own `stream_like` flag |
| live | 1.0 s | `freq_hz`, `mode`, `ptt` |
| panel-adjustable | 5.0 s | 13 field names |
| on-demand | 5.0 s when polled | 16 field names |

A classified path that is not pollable must instead carry the on-demand shape
(no TTL), which is how X6200's `filter_width` passes — that profile documents
that the radio cannot round-trip `0x1A 0x03`.

Two classification calls worth flagging, both made because the alternative was
a bound I have no evidence to relax: `split` is panel-adjustable, not live
(IC-7610 declares it at 1.5 s); and the stream-meter bound is one number, 0.4 s,
not a serial/LAN pair, because `RadioAcquisitionProfile` carries no transport
discriminator. That single bound loosens the previous flat `<= 0.25` in
`test_known_profiles_stream_like_meters_use_fast_non_decaying_policies`; the
other profiles' TOML values (0.2 / 0.25) are unchanged.

Violations found and deliberately not fixed: IC-7300's `mic_gain`,
`monitor_gain`, `vox_gain`, `anti_vox_gain` sit at 10.0 s — twice the panel
bound, outside the ten the ruling named, and funded at 10.0 s by MOR-1484's
bench probe; they are left unclassified. `vd`/`id` (60 s) and the scope-display
controls (30 s) are likewise unclassified — no ruling covers them. IC-705,
IC-9700 and X6100 declare no `field_policies` at all: every field including the
S-meter runs at their profile default of 2.0 s. They make no per-field claim,
so the test skips them. Invisible to the gate rather than merely unfixed: the
gate checks only paths carrying their own `field_policies` entry, so ten
classified live-class paths that inherit a profile default above the 1.0 s
bound are not checked — FTX-1 `global.tx_state.ptt` and main/sub active
`freq_hz`/`mode` (2.0 s default), IC-7300 unselected `freq_hz`/`mode` (1.5 s),
IC-7610 main/sub active `mode` (2.0 s), X6200 main active `freq_hz` (2.0 s).
They are named in `_INHERITED_DEFAULT_OUT_OF_CLASS` and pinned by a test that
re-derives the set from the profiles that declare `field_policies`, so fixing
or adding one there is visible. That disclosure covers only those four
profiles: IC-705, IC-9700 and X6100 declare no `field_policies`, are skipped
by the gate and by the pin alike, and the same walk without that skip finds
28 further out-of-class inherited-default classified paths there (12, 12, 4 —
including, on each of IC-705 and IC-9700, the six global stream meters plus the S-meter at 2.0 s against the 0.4 s bound)
that no test bounds.

## Mutations run

| mutation | result |
|---|---|
| S-meter back to 0.2 s | ledger pin fails: 21.833 vs 19.333 |
| `pbt_inner` left non-polling | class pin fails, naming it: "receiver.main.operator_controls.pbt_inner is not cadence-polled" |
| FTX-1 slow tier back to 30 s | class test names 18 paths; the `_SLOW_INTERVAL` pin fails 30.0 != 1.0 |
| `web_startup` builds a `RadioPoller` on the `ObservationPollable` branch | the no-drain pin fails |

The tree was restored from copies after each and `git diff` re-checked.

## Sweep

`docs/guide/web-ui.md` presented `_FAST_INTERVAL_SERIAL` (100 ms) as the poll
cadence; it is the poller loop's wake tick. Corrected, cited by symbol.
`acquisition_scheduler.py` carried three counts my change falsifies —
"26 of its 60 field_policies paths" (now 16, `ceil(16/5) == 4`), "all six
overrides ... polling=True" (44 of 60, measured), and a list of what
`prime_unobserved` primes that included the now-polled knobs. All three
re-measured against the profile at this head.

## Not established

On the rigctld path with an FTX-1 (a drain but no executor), the
`acquisition_executor_missing` diagnostic re-arms one cadence after each
failure, so with the slow tier at 1 s it fires about once a second instead of
once per 30 s. It writes to `StateDiagnosticsRecorder`, which is disabled by
default and never logs; with diagnostics explicitly enabled, a bounded
in-memory ring buffer fills faster. No log-rate change. Not measured end to
end, and no test covers it.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)


