### PR TITLE
fix: take a CI-V observation's max_age from the profile policy

### DIFF
--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -543,14 +543,19 @@ tx_only = true
 # cadence tightening above/below this block -- see the serial-budget
 # assertion in tests/test_state_acquisition_policy.py for the current total,
 # 19.333 q/s.)
+# MOR-2425: freshness_ttl_seconds is what a CI-V observation of these two is
+# now stamped with (runtime/_civ_rx.py: _observation_max_age), so it is the
+# window a reading actually gets. 90.0 was 1.5x the cadence; 120.0 is the 2x
+# this profile's default policy (1.5/3.0) and its 1.0/2.0, 3.0/6.0, 5.0/10.0
+# and 30.0/60.0 tiers already carry.
 [state_acquisition.field_policies."global.meters.vd"]
 cadence_seconds = 60.0
-freshness_ttl_seconds = 90.0
+freshness_ttl_seconds = 120.0
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.meters.id"]
 cadence_seconds = 60.0
-freshness_ttl_seconds = 90.0
+freshness_ttl_seconds = 120.0
 adaptive_decay = false
 
 # MOR-2425 (owner ruling, 2026-09-07): the ten panel knobs, cadence-polled.
@@ -629,10 +634,8 @@ adaptive_decay = false
 # calls. These capabilities carry polling=False, so due_requests never
 # reaches them (_poll_cadence_groups skips any capability whose can_poll is
 # false) and freshness_ttl_seconds is "never": no cadence read refreshes
-# them, and the CI-V ingress takes each observation's max_age from
-# runtime/_civ_rx.py rather than from this key. cadence_seconds is
-# still load-bearing — with no TTL, prime_unobserved passes it as the prime
-# read's max_age.
+# them. cadence_seconds is still load-bearing — with no TTL,
+# prime_unobserved passes it as the prime read's max_age.
 [state_acquisition.field_policies."global.tx_state.vox_on"]
 cadence_seconds = 25.0
 freshness_ttl_seconds = "never"

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -85,6 +85,9 @@ _SCOPE_BACKLOG_SHED_THRESHOLD = 256
 _SCOPE_BACKLOG_KEEP_LATEST = 64
 _RAW_RECEIVED_FRAME_BYTES_LIMIT = 256
 
+#: Fallback freshness TTLs for CI-V observations, keyed ``(scope, family,
+#: name)`` — rig-blind, and read by ``_observation_max_age`` only for a path
+#: the loaded profile declares no ``field_policies`` entry for.
 _OBSERVATION_MAX_AGE_SECONDS: dict[tuple[str, str, str], float] = {
     ("receiver", "freq_mode", "freq_hz"): 5.0,
     ("receiver", "freq_mode", "mode"): 5.0,
@@ -106,12 +109,11 @@ _OBSERVATION_MAX_AGE_SECONDS: dict[tuple[str, str, str], float] = {
     # MOR-2234 follow-up: declaring these observable in ``rigs/ic7300.toml``
     # left them with no entry here, so ``_observation`` gave them
     # ``max_age=None`` and ``state_store.py: StateStore.mark_stale_due``
-    # never aged them. These two values are this table's own, independent of
-    # what any profile declares for the same paths: ``_observation`` takes
-    # every CI-V observation's ``max_age`` from this (scope, family, name)
-    # lookup — the ``tx_target`` branch there is the sole exception — and
-    # nothing in this module reads ``field_policies``. Pinned by
-    # ``test_tone_and_tsql_freq_observations_can_go_stale``.
+    # never aged them. IC-7300 no longer reaches these two rows — it declares
+    # a field policy for both — but ``rigs/ic705.toml`` and
+    # ``rigs/ic9700.toml`` bind ``get_tone_freq``/``get_tsql_freq`` with no
+    # ``field_policies`` table at all, and still do. Pinned by
+    # ``test_tone_and_tsql_freq_observations_fall_back_to_the_table``.
     ("receiver", "operator_controls", "tone_freq"): 25.0,
     ("receiver", "operator_controls", "tsql_freq"): 25.0,
     ("global", "slow_state", "active"): 5.0,
@@ -513,6 +515,33 @@ def _profile_path_for_observation(profile: Any, path: FieldPath) -> FieldPath:
         if capability.availability.value != "unknown":
             return candidate
     return path
+
+
+def _observation_max_age(profile: Any, path: FieldPath) -> float | None:
+    """Freshness TTL to stamp on one CI-V observation of ``path``.
+
+    The rig's own ``[state_acquisition.field_policies]`` entry wins where the
+    profile declares one — including ``freshness_ttl_seconds = "never"``,
+    which loads as ``None`` and leaves ``state_store.py:
+    StateStore.mark_stale_due`` unable to age the field at all. Everything
+    else falls back to :data:`_OBSERVATION_MAX_AGE_SECONDS`.
+
+    Only a *declared* policy counts, not ``policy_for``'s ``default_policy``
+    answer: a profile's default applies to every path in the rig, including
+    the ones no author considered when writing it.
+    """
+
+    acquisition = getattr(profile, "state_acquisition", None)
+    if acquisition is not None:
+        declared = acquisition.field_policies.get(
+            _profile_path_for_observation(acquisition, path)
+        )
+        if declared is not None:
+            ttl: float | None = declared.freshness_ttl_seconds
+            return ttl
+    return _OBSERVATION_MAX_AGE_SECONDS.get(
+        (path.scope.value, path.family.value, path.name)
+    )
 
 
 def _changeset_for_request_paths(
@@ -2779,9 +2808,7 @@ class CivRuntime:
         max_age_path = (
             FieldPath.global_("tx_state", "ptt") if path == OBSERVED_PTT_PATH else path
         )
-        max_age = _OBSERVATION_MAX_AGE_SECONDS.get(
-            (max_age_path.scope.value, max_age_path.family.value, max_age_path.name)
-        )
+        max_age = _observation_max_age(self._host._profile, max_age_path)
         if path == FieldPath.global_("tx_state", "tx_target"):
             # MOR-2223: single source shared with
             # ``RadioPoller._tx_target_max_age`` — see

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -2042,9 +2042,9 @@ def test_slow_state_toggle_observation_backed(
 
     field = radio._state_store.snapshot().field(store_path)
     assert field.value == expected
-    # Slow-state toggles never expire — no max_age, so the freshness service
-    # cannot mark them stale and re-gate the frontend ``missing`` (MOR-437).
-    assert field.max_age is None
+    # A slow-state toggle expires only where the fixture's own profile declares
+    # a TTL for it (MOR-437, MOR-2425).
+    assert field.max_age == _expected_observation_max_age(radio, store_path)
     assert field.freshness is FreshnessState.FRESH
 
 
@@ -2310,14 +2310,34 @@ def _public_value_control_expected(public_path: str, value: object) -> object:
     return value
 
 
-def _expected_value_control_max_age(store_path: str) -> float | None:
-    if store_path.endswith(".af_level") or store_path.endswith(".rf_gain"):
-        return 10.0
-    if store_path == "global.operator_controls.power_level":
-        return 30.0
-    if store_path.endswith(".tone_freq") or store_path.endswith(".tsql_freq"):
-        return 25.0
-    return None
+def _expected_observation_max_age(radio: IcomRadio, store_path: str) -> float | None:
+    """What ``_observation`` stamps: the profile's declared TTL, else the table.
+
+    Written out here rather than delegated to ``_civ_rx``'s own resolver: the
+    store spells receivers ``0``/``1`` and ``[state_acquisition.field_policies]``
+    spells them ``main``/``sub``, and that translation is the part worth
+    restating independently.
+    """
+
+    from rigplane.runtime._civ_rx import _OBSERVATION_MAX_AGE_SECONDS
+
+    path = FieldPath.parse(store_path)
+    spellings = [path]
+    if path.receiver_id in ("0", "1"):
+        spellings.append(
+            dataclasses.replace(
+                path, receiver_id="main" if path.receiver_id == "0" else "sub"
+            )
+        )
+    acquisition = radio._profile.state_acquisition  # noqa: SLF001
+    if acquisition is not None:
+        for candidate in spellings:
+            declared = acquisition.field_policies.get(candidate)
+            if declared is not None:
+                return declared.freshness_ttl_seconds
+    return _OBSERVATION_MAX_AGE_SECONDS.get(
+        (path.scope.value, path.family.value, path.name)
+    )
 
 
 def _use_ctcss_fixture_profile(radio: IcomRadio, store_path: str) -> None:
@@ -2346,7 +2366,7 @@ def test_value_control_observation_value(
 
     field = radio_with_state._state_store.snapshot().field(store_path)
     assert field.value == expected
-    assert field.max_age == _expected_value_control_max_age(store_path)
+    assert field.max_age == _expected_observation_max_age(radio_with_state, store_path)
     assert field.freshness is FreshnessState.FRESH
 
 
@@ -2848,13 +2868,14 @@ def test_meter_value_survives_freshness_window_between_live_arrivals(
 
     path = FieldPath.receiver("main", "meters", "s_meter")
     # Production cadence: fast nominal cadence, short coalescing window, and the
-    # freshness TTL the shipped IC-7610 CI-V path assigns to s_meter
-    # (``_OBSERVATION_MAX_AGE_SECONDS``). The observation carries that TTL into
-    # the store, so the test asserts against the real shipped value rather than a
-    # synthetic one.
-    from rigplane.runtime._civ_rx import _OBSERVATION_MAX_AGE_SECONDS
-
-    s_meter_ttl = _OBSERVATION_MAX_AGE_SECONDS[("receiver", "meters", "s_meter")]
+    # freshness TTL the shipped IC-7610 CI-V path assigns to s_meter — the
+    # ``field_policies`` entry in ``rigs/ic7610.toml``, which is the fixture
+    # radio's own profile. The observation carries that TTL into the store, so
+    # the test asserts against the real shipped value rather than a synthetic one.
+    ic7610_acquisition = resolve_radio_profile(model="IC-7610").state_acquisition
+    assert ic7610_acquisition is not None
+    s_meter_ttl = ic7610_acquisition.field_policies[path].freshness_ttl_seconds
+    assert s_meter_ttl is not None
     policy = AcquisitionPolicy(
         cadence_seconds=0.2,
         freshness_ttl_seconds=4.0,
@@ -2909,30 +2930,33 @@ def test_meter_value_survives_freshness_window_between_live_arrivals(
         (0x01, "tsql_freq"),
     ],
 )
-def test_tone_and_tsql_freq_observations_can_go_stale(
+def test_tone_and_tsql_freq_observations_fall_back_to_the_table(
     radio: IcomRadio, sub: int, name: str
 ) -> None:
-    """MOR-2234 follow-up: a declared-observable path still needs a TTL here.
+    """The table is what a path with no declared field policy still gets.
 
-    ``_observation`` reads ``max_age`` from ``_OBSERVATION_MAX_AGE_SECONDS``
-    with no default, and ``state_store.py: StateStore.mark_stale_due`` skips
-    any entry whose ``max_age`` is ``None``. With no table entry this path
-    was observed once and then reported ``FRESH`` for the lifetime of the
-    process, whatever the front panel did afterwards.
+    ``rigs/ic705.toml`` has no ``[state_acquisition.field_policies]`` table
+    at all, so these paths reach ``_observation``'s
+    ``_OBSERVATION_MAX_AGE_SECONDS`` fallback rather than a profile TTL —
+    and ``state_store.py: StateStore.mark_stale_due`` skips any entry whose
+    ``max_age`` is ``None``, so without the fallback the field would report
+    ``FRESH`` for the lifetime of the process.
 
-    Fail-without: the observation carries ``max_age=None`` and the field is
-    still ``FRESH`` past that table's TTL.
+    The profile default TTL is deliberately NOT the fallback: it is 8.0 s on
+    this profile, which the assertion below would reject.
     """
 
     from rigplane.runtime._civ_rx import _OBSERVATION_MAX_AGE_SECONDS
 
-    radio._profile = resolve_radio_profile(model="IC-7300")  # noqa: SLF001
+    profile = resolve_radio_profile(model="IC-705")
+    radio._profile = profile  # noqa: SLF001
+    assert profile.state_acquisition is not None
+    assert profile.state_acquisition.field_policies == {}
     stored = FieldPath.receiver("0", "operator_controls", name)
-    # The TTL is not a literal here: it is read from the table that supplies
-    # it. That table is keyed by (scope, family, name) and does not consult
-    # the profile, so ``rigs/ic7300.toml``'s field_policies entry for the
-    # same path is not what lands on the observation.
     declared_ttl = _OBSERVATION_MAX_AGE_SECONDS[("receiver", "operator_controls", name)]
+    assert (
+        declared_ttl != profile.state_acquisition.default_policy.freshness_ttl_seconds
+    )
 
     observed_at = 500.0
     with patch("rigplane.runtime._civ_rx.time.monotonic", return_value=observed_at):
@@ -2940,6 +2964,7 @@ def test_tone_and_tsql_freq_observations_can_go_stale(
             _make_frame(cmd=0x1B, sub=sub, data=_encode_tone_freq(8850), receiver=0x00)
         )
     assert radio._state_store.snapshot().field(str(stored)).value == 8850
+    assert radio._state_store.snapshot().field(str(stored)).max_age == declared_ttl
 
     # Inside the declared TTL the value is still the radio's truth.
     radio._state_store.mark_stale_due(now=observed_at + declared_ttl - 0.1)
@@ -2957,6 +2982,205 @@ def test_tone_and_tsql_freq_observations_can_go_stale(
     assert [(r.path, r.max_age) for r in delta.reconciliation_requests] == [
         (stored, declared_ttl)
     ]
+
+
+def test_s_meter_falls_back_to_the_table_on_a_profile_with_no_field_policies(
+    radio: IcomRadio,
+) -> None:
+    """Same fallback, for a streaming meter rather than an on-demand field.
+
+    ``rigs/ic705.toml``'s ``default_freshness_ttl_seconds`` is 8.0 s. If the
+    lookup answered from the default policy instead of the table, a stopped
+    S-meter would keep reporting FRESH four times longer than the shipped
+    2.0 s window MOR-334 settled on.
+    """
+
+    from rigplane.runtime._civ_rx import _OBSERVATION_MAX_AGE_SECONDS
+
+    radio._profile = resolve_radio_profile(model="IC-705")  # noqa: SLF001
+    stored = FieldPath.receiver("0", "meters", "s_meter")
+    table_ttl = _OBSERVATION_MAX_AGE_SECONDS[("receiver", "meters", "s_meter")]
+
+    with patch("rigplane.runtime._civ_rx.time.monotonic", return_value=700.0):
+        radio._civ_runtime._apply_state_store_observations(
+            _make_frame(cmd=0x15, sub=0x02, data=_bcd2(122))
+        )
+    assert radio._state_store.snapshot().field(str(stored)).max_age == table_ttl
+
+
+# Four IC-7300 fields under the owner's ruling R41: a field the operator has
+# not touched must not turn "stale" on a healthy link. ``pbt_inner`` and
+# ``filter_width`` are cadence-polled panel knobs (5.0 s), so they keep a
+# finite TTL of twice that; ``rit_on`` and ``tone_freq`` are on-demand and
+# ``rigs/ic7300.toml`` gives them ``freshness_ttl_seconds = "never"``.
+_R41_IC7300_EXPECTED_MAX_AGE = {
+    "receiver.0.operator_controls.pbt_inner": 10.0,
+    "receiver.0.active.freq_mode.filter_width": 10.0,
+    "global.tx_state.rit_on": None,
+    "receiver.0.operator_controls.tone_freq": None,
+}
+
+
+def test_ic7300_profile_supplies_the_civ_observation_max_age(
+    radio: IcomRadio,
+) -> None:
+    """R41: the CI-V ingress stamps the profile's TTL, not the table's.
+
+    ``rit_on`` and ``tone_freq`` took 10.0 s and 25.0 s from
+    ``_OBSERVATION_MAX_AGE_SECONDS`` before this: a finite TTL on two fields
+    no cadence read renews, so an idle link could retire them.
+    """
+
+    radio._profile = resolve_radio_profile(model="IC-7300")  # noqa: SLF001
+    observed_at = 500.0
+    frames = (
+        _make_frame(cmd=0x14, sub=0x07, data=_bcd2(128), receiver=0x00),
+        _make_frame(cmd=0x21, sub=0x01, data=b"\x01"),
+        _make_frame(cmd=0x1B, sub=0x00, data=_encode_tone_freq(8850), receiver=0x00),
+        _make_frame(cmd=0x1A, sub=0x03, data=_bcd2(31), receiver=0x00),
+    )
+    with patch("rigplane.runtime._civ_rx.time.monotonic", return_value=observed_at):
+        for frame in frames:
+            radio._civ_runtime._apply_state_store_observations(frame)
+
+    snapshot = radio._state_store.snapshot()
+    assert {
+        path: snapshot.field(path).max_age for path in _R41_IC7300_EXPECTED_MAX_AGE
+    } == _R41_IC7300_EXPECTED_MAX_AGE
+
+    # 60 s idle: nothing re-reads the two on-demand fields, and nothing may
+    # retire them either. (The two polled ones do decay here — no cadence read
+    # renewed them; ``..._polled_pbt_stays_fresh_across_its_own_cadence``
+    # covers the answered case.)
+    on_demand = [
+        path for path, ttl in _R41_IC7300_EXPECTED_MAX_AGE.items() if ttl is None
+    ]
+    delta = radio._state_store.mark_stale_due(now=observed_at + 60.0)
+    assert set(on_demand).isdisjoint(str(t.path) for t in delta.freshness)
+    for path in on_demand:
+        assert radio._state_store.snapshot().field(path).freshness is (
+            FreshnessState.FRESH
+        ), path
+
+
+def test_ic7300_polled_pbt_stays_fresh_across_its_own_cadence(
+    radio: IcomRadio,
+) -> None:
+    """``pbt_inner`` keeps a TTL because a cadence read renews it.
+
+    Its profile TTL (10.0 s) is twice its profile cadence (5.0 s), so a link
+    that answers every cadence read leaves the field FRESH throughout — the
+    field decays only when the reads stop.
+    """
+
+    profile = resolve_radio_profile(model="IC-7300")
+    radio._profile = profile  # noqa: SLF001
+    assert profile.state_acquisition is not None
+    policy = profile.state_acquisition.field_policies[
+        FieldPath.receiver("main", "operator_controls", "pbt_inner")
+    ]
+    assert policy.freshness_ttl_seconds == 2 * policy.cadence_seconds
+    stored = "receiver.0.operator_controls.pbt_inner"
+
+    start = 500.0
+    for step in range(13):  # 0 s .. 60 s at the profile's own 5.0 s cadence
+        now = start + step * policy.cadence_seconds
+        with patch("rigplane.runtime._civ_rx.time.monotonic", return_value=now):
+            radio._civ_runtime._apply_state_store_observations(
+                _make_frame(cmd=0x14, sub=0x07, data=_bcd2(128), receiver=0x00)
+            )
+        radio._state_store.mark_stale_due(now=now)
+        assert radio._state_store.snapshot().field(stored).freshness is (
+            FreshnessState.FRESH
+        )
+
+    # Stop answering and it does expire — the TTL is real, not disabled.
+    radio._state_store.mark_stale_due(
+        now=start + 12 * policy.cadence_seconds + policy.freshness_ttl_seconds + 0.1
+    )
+    assert radio._state_store.snapshot().field(stored).freshness is (
+        FreshnessState.STALE
+    )
+
+
+def test_ptt_observation_max_age_comes_from_the_ic7300_profile(
+    radio: IcomRadio,
+) -> None:
+    """``ptt`` is 1.0 s in both sources; pin which one now answers.
+
+    ``rigs/ic7300.toml`` declares 1.0 s against a 0.3 s cadence, so the
+    observed-PTT window still clears its own poll interval by more than 2x.
+    """
+
+    profile = resolve_radio_profile(model="IC-7300")
+    radio._profile = profile  # noqa: SLF001
+    assert profile.state_acquisition is not None
+    policy = profile.state_acquisition.field_policies[
+        FieldPath.global_("tx_state", "ptt")
+    ]
+    assert policy.freshness_ttl_seconds == 1.0
+    assert policy.cadence_seconds == 0.3
+    assert policy.freshness_ttl_seconds >= 2 * policy.cadence_seconds
+
+    with patch("rigplane.runtime._civ_rx.time.monotonic", return_value=800.0):
+        radio._civ_runtime._apply_state_store_observations(
+            _make_frame(cmd=0x1C, sub=0x00, data=b"\x00")
+        )
+    field = radio._state_store.snapshot().field("global.tx_state.ptt")
+    assert field.max_age == policy.freshness_ttl_seconds
+
+
+@pytest.mark.parametrize(
+    ("receiver", "stored"),
+    [
+        (0x00, "receiver.0.operator_controls.pbt_inner"),
+        (0x01, "receiver.1.operator_controls.pbt_inner"),
+    ],
+)
+def test_ic7610_pbt_takes_the_profile_ttl_including_the_sub_receiver(
+    radio: IcomRadio, receiver: int, stored: str
+) -> None:
+    """IC-7610's own, shorter, cadence-backed TTL — for both receivers.
+
+    ``rigs/ic7610.toml`` declares 5.0 s for ``receiver.main``/
+    ``receiver.sub`` while the table's entry for the same (scope, family,
+    name) is 10.0 s.  The profile spells the receiver ``main``/``sub`` and
+    the CI-V ingress spells it ``0``/``1``, so neither case lands without
+    ``_profile_path_for_observation``'s alias resolution.
+    """
+
+    from rigplane.runtime._civ_rx import _OBSERVATION_MAX_AGE_SECONDS
+
+    profile = resolve_radio_profile(model="IC-7610")
+    radio._profile = profile  # noqa: SLF001
+    assert profile.state_acquisition is not None
+    policy = profile.state_acquisition.field_policies[
+        FieldPath.receiver(
+            "main" if receiver == 0x00 else "sub", "operator_controls", "pbt_inner"
+        )
+    ]
+    assert policy.freshness_ttl_seconds == 5.0
+    table_ttl = _OBSERVATION_MAX_AGE_SECONDS[
+        ("receiver", "operator_controls", "pbt_inner")
+    ]
+    assert table_ttl == 10.0
+
+    observed_at = 900.0
+    with patch("rigplane.runtime._civ_rx.time.monotonic", return_value=observed_at):
+        radio._civ_runtime._apply_state_store_observations(
+            _make_frame(cmd=0x14, sub=0x07, data=_bcd2(128), receiver=receiver)
+        )
+    field = radio._state_store.snapshot().field(stored)
+    assert field.max_age == policy.freshness_ttl_seconds
+
+    # Expiry still works where it is cadence-backed, and on the profile's
+    # schedule rather than the table's.
+    radio._state_store.mark_stale_due(
+        now=observed_at + policy.freshness_ttl_seconds + 0.1
+    )
+    assert radio._state_store.snapshot().field(stored).freshness is (
+        FreshnessState.STALE
+    )
 
 
 def test_same_value_coalesced_meter_flush_completes_scheduler_request(
@@ -4255,9 +4479,10 @@ def test_scope_control_observation_backed(
         field = snapshot.field(store_path)
         assert field.value == value
         assert field.freshness is FreshnessState.FRESH
-        # Scope controls only change on user/poller action — no decay window,
-        # matching the slow-state toggle pattern (MOR-437).
-        assert field.max_age is None
+        # The fixture's IC-7610 profile declares 60.0 s against a 30.0 s
+        # scope-control cadence, so the decay window is the poller's rather
+        # than this module's fallback table (MOR-557, MOR-2425).
+        assert field.max_age == _expected_observation_max_age(radio, store_path)
 
 
 def test_scope_waterfall_data_emits_no_observations(radio: IcomRadio) -> None:

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -3103,10 +3103,12 @@ def test_ic7300_polled_pbt_stays_fresh_across_its_own_cadence(
     )
 
 
-def test_ptt_observation_max_age_comes_from_the_ic7300_profile(
+def test_ptt_observation_max_age_matches_the_ic7300_profile_declaration(
     radio: IcomRadio,
 ) -> None:
-    """``ptt`` is 1.0 s in both sources; pin which one now answers.
+    """``ptt`` is 1.0 s in both the profile and the table, so this test cannot
+    tell which source answered; ``test_ic7610_pbt_takes_the_profile_ttl_including_the_sub_receiver``
+    is what pins the source.
 
     ``rigs/ic7300.toml`` declares 1.0 s against a 0.3 s cadence, so the
     observed-PTT window still clears its own poll interval by more than 2x.

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -842,6 +842,25 @@ def test_ic7300_panel_knob_fields_are_polled_at_the_panel_class_cadence() -> Non
         assert policy.freshness_ttl_seconds == _IC7300_PANEL_KNOB_TTL_SECONDS, path
 
 
+def test_ic7300_supply_meter_ttls_clear_twice_their_cadence() -> None:
+    """MOR-2425: ``vd``/``id`` are what a CI-V observation is stamped with.
+
+    Since ``runtime/_civ_rx.py: _observation_max_age`` reads this key, the
+    declared TTL is the window a supply-rail reading actually gets. These two
+    were the only IC-7300 meters whose TTL sat below twice their cadence.
+    """
+
+    acquisition = get_radio_profile("IC-7300").state_acquisition
+    assert acquisition is not None
+
+    for name in ("vd", "id"):
+        path = FieldPath.global_("meters", name)
+        policy = acquisition.policy_for(path)
+        assert acquisition.capability_for(path).can_poll is True, path
+        assert policy.cadence_seconds == 60.0, path
+        assert policy.freshness_ttl_seconds == 2 * policy.cadence_seconds, path
+
+
 def test_ic7300_on_demand_fields_keep_the_never_ttl() -> None:
     """The menu settings stay on-demand: no cadence read, so no expiry."""
 


### PR DESCRIPTION
Owner ruling R41: a field the operator has not touched must not turn "stale" on a healthy link. On a live IC-7300 sampled every 5 s for 60 s idle with no client connected, `main.pbtInner`/`main.pbtOuter` were stale in 4/12 and 3/12 samples, `ritTx`/`ritFreq`/`ritOn` in 2/12 and 1/12 each, and `idMeter`/`vdMeter` (served `maxAge` 2.0 against a 60 s poll cadence) in 1/12 each.

## What was wrong

Every Icom/Xiegu CI-V observation took its `max_age` from `runtime/_civ_rx.py: _OBSERVATION_MAX_AGE_SECONDS` — a hard-coded, rig-blind `(scope, family, name)` table — and the profile's own `freshness_ttl_seconds` was never read (`global.tx_state.tx_target` was the sole exception, via `tx_target_max_age`). So `rigs/ic7300.toml` could declare `"never"` for a field nothing polls and the ingress would still stamp a finite TTL on it.

`runtime/_civ_rx.py: _observation_max_age` now takes the **declared** `[state_acquisition.field_policies]` entry where the profile has one — `"never"` included, which loads as `None` and leaves `StateStore.mark_stale_due` unable to age the field — and falls back to the table otherwise. Receiver spelling is bridged by the existing `_profile_path_for_observation` (store `0`/`1`, profile `main`/`sub`). The `tx_target` branch is unchanged.

Only a *declared* policy counts, not `policy_for`'s `default_policy` answer. Using `policy_for` would have made the table dead but given IC-705/IC-9700/X6100 — which declare no `field_policies` at all — their 8.0 s profile default for everything, including `global.tx_state.ptt` (1.0 s today) and the six streaming meters (2.0 s today).

## Enumeration: which source now supplies each table key

Method: for each of the 25 table keys, load every `rigs/*.toml` and list the CI-V profiles (`state_acquisition.provider` in `icom_civ`/`xiegu_civ`) that declare the path, separating an explicit `field_policies` entry from a capability-only declaration. FTX-1 (`yaesu_cat`) and TX-500 (Kenwood CAT, no backend, no `[state_acquisition]`) never enter `_civ_rx`.

| Table key | Profile now supplies it | Table still supplies it |
|---|---|---|
| `receiver.freq_mode.freq_hz` (5.0) | IC-7300 2.0, IC-7610 main+sub 2.0 | IC-705 ×2, IC-7300 unselected, IC-9700 ×2, X6100, X6200 |
| `receiver.freq_mode.mode` (5.0) | IC-7300 2.0, X6200 4.0 | IC-705 ×2, IC-7610 ×2, IC-9700 ×2, X6100 |
| `receiver.vfo.active_slot` (5.0) | — | every rig (no profile declares it) |
| `receiver.meters.s_meter` (2.0) | IC-7300 2.0, IC-7610 2.0, X6200 1.0 | IC-705, IC-9700, X6100 |
| `receiver.operator_toggles.nb` / `.nr` (10.0) | IC-7610 main+sub 3.0 | IC-705, IC-7300, IC-9700 |
| `receiver.operator_controls.af_level` (10.0) | IC-7610 main+sub 3.0 | IC-705, IC-7300, IC-9700 |
| `receiver.operator_controls.rf_gain` (10.0) | IC-7300 2.0, IC-7610 main+sub 3.0 | IC-705, IC-9700 |
| `receiver.operator_controls.pbt_inner` / `.pbt_outer` (10.0) | IC-7300 10.0, IC-7610 main+sub 5.0 | IC-705, IC-9700 (bind `get_pbt_inner`/`get_pbt_outer`, declare no policy) |
| `receiver.operator_controls.tone_freq` / `.tsql_freq` (25.0) | IC-7300 `never` | IC-705, IC-9700 (bind `get_tone_freq`/`get_tsql_freq`, declare no policy) |
| `global.slow_state.active` (5.0) | — | IC-7610 (capability only) |
| `global.tx_state.ptt` (1.0) | IC-7300 1.0, IC-7610 1.0 | IC-705, IC-9700 |
| `global.tx_state.rit_on` / `.rit_tx` (10.0) | IC-7300 `never` | IC-7610 (capability only) |
| `global.tx_state.power_on` (30.0) | — | FTX-1/X6100/X6200 declare it unsupported; no profile declares a policy |
| `global.operator_controls.rit_freq` (10.0) | IC-7300 10.0 | IC-7610 (capability only) |
| `global.operator_controls.power_level` (30.0) | IC-7300 6.0, IC-7610 5.0 | IC-705, IC-9700 |
| `global.meters.alc`/`power`/`swr`/`comp` (2.0) | IC-7300 2.0, IC-7610 2.0, X6200 `power` 1.0 | IC-705, IC-9700, and X6100/X6200 for the meters they declare without a policy |
| `global.meters.vd` / `.id` (2.0) | IC-7300 120.0, IC-7610 2.0 | IC-705, IC-9700 |

**Nothing was deleted from the table.** Every one of the 25 keys is still reachable on at least one shipped CI-V profile. The two candidates the earlier review scoped as removable — `tone_freq`/`tsql_freq` — are shadowed on IC-7300, but IC-705 and IC-9700 bind `get_tone_freq`/`get_tsql_freq` (`rigs/ic705.toml`, `rigs/ic9700.toml`) with no `field_policies` table at all, so those rows still answer for them. The same holds for `pbt_inner`/`pbt_outer`. The five RIT/PBT rows the review said must survive do survive: RIT ×3 through the table (IC-7610 declares no policy for them), PBT ×2 through IC-7610's own 5.0 s policy.

## Behavioural delta (measured, whole tree)

Comparing the table value against the declared TTL for every declared path on every CI-V profile: **121 paths change** — IC-7300 39, IC-7610 79, X6200 3; IC-705 / IC-9700 / X6100 zero, since they declare no field policies. Two properties hold across all 121:

- No field with `can_poll = False` gains a finite TTL. The only paths that *lose* expiry are IC-7300's four on-demand ones — `rit_on`, `rit_tx`, `tone_freq`, `tsql_freq` (10.0/10.0/25.0/25.0 → `never`). That is the R41 fix.
- Every newly-finite TTL sits on a cadence-polled field at ≥ 1.5x its cadence (most at 2x). The largest group is IC-7610's `operator_controls`/`operator_toggles` (`None` → 3.0/5.0 against 1.5/3.0 s cadences) and both rigs' twelve/thirteen scope-control fields (`None` → 60.0 against a 30.0 s cadence).

## Cadence check on `ptt`, `id`, `vd`

- `ptt`: IC-7300 and IC-7610 both declare 1.0 s against a 0.3 s cadence (3.3x) — same value the table gave, no profile change needed.
- `vd`/`id`: IC-7300 declared 90.0 s against a 60.0 s cadence (1.5x). Since this key is now the window a reading actually gets, `rigs/ic7300.toml` raises both to **120.0** — twice the cadence, the ratio the profile's default policy (1.5/3.0) and its 1.0/2.0, 3.0/6.0, 5.0/10.0 and 30.0/60.0 tiers already carry. This also removes the bench's `idMeter`/`vdMeter` flicker at its root: they were being stamped 2.0 s against a 60 s cadence.

### Same class, left unfixed

Sweeping every CI-V profile for a pollable declared policy with `freshness_ttl_seconds < 2 x cadence_seconds` finds **29** instances. Two are fixed here (`vd`, `id`). The other 27 are outside what this change's spec covers and are reported, not touched:

- IC-7300 ×4 — `mic_gain`, `monitor_gain`, `vox_gain`, `anti_vox_gain`, all 15.0/10.0 (1.5x).
- IC-7610 ×23 — every 5.0/3.0 pair (1.67x): nine `global.operator_controls` (`anti_vox_gain`, `break_in_delay`, `compressor_level`, `cw_pitch`, `key_speed`, `mic_gain`, `monitor_gain`, `power_level`, `vox_gain`) plus seven `operator_controls` on each of main and sub (`agc_time_constant`, `apf_type_level`, `nb_level`, `notch_filter`, `nr_level`, `pbt_inner`, `pbt_outer`).

## Prose deleted

`rigs/ic7300.toml`'s claim that "the CI-V ingress takes each observation's max_age from runtime/_civ_rx.py rather than from this key" is now false and is deleted. `_OBSERVATION_MAX_AGE_SECONDS`'s claim that its tone/TSQL values are "independent of what any profile declares" and that "nothing in this module reads field_policies" is likewise deleted; the rows keep the narrower rationale that IC-705/IC-9700 still reach them.

## Tests

Written first, all red before the implementation.

- `test_ic7300_profile_supplies_the_civ_observation_max_age` — real IC-7300 profile through the real ingress (`CivRuntime._apply_state_store_observations` with real 0x14/0x07, 0x21/0x01, 0x1B/0x00 and 0x1A/0x03 frames): `pbt_inner` and `filter_width` 10.0, `rit_on` and `tone_freq` `None`; at +60 s idle neither on-demand field is in `mark_stale_due`'s delta and both are still FRESH.
- `test_ic7300_polled_pbt_stays_fresh_across_its_own_cadence` — thirteen observations at the profile's own 5.0 s cadence over 60 s, FRESH throughout; STALE once the reads stop.
- `test_ptt_observation_max_age_matches_the_ic7300_profile_declaration` — 1.0 s from the profile, ≥ 2x its 0.3 s cadence.
- `test_ic7610_pbt_takes_the_profile_ttl_including_the_sub_receiver` — 5.0 s (not the table's 10.0) on both `receiver.0` and `receiver.1`, and it still expires at 5.0 s.
- `test_tone_and_tsql_freq_observations_fall_back_to_the_table` (rewritten from `..._can_go_stale`) and `test_s_meter_falls_back_to_the_table_on_a_profile_with_no_field_policies` — the IC-705 profile, which has no `field_policies`: 25.0 and 2.0 from the table, explicitly not the 8.0 s profile default.
- `test_ic7300_supply_meter_ttls_clear_twice_their_cadence` — pins the `vd`/`id` change.
- `test_value_control_observation_value`, `test_slow_state_toggle_observation_backed`, `test_scope_control_observation_backed` and `test_meter_value_survives_freshness_window_between_live_arrivals` now read their expected TTL from the profile that supplies it, and their comments no longer say these fields never expire.

## Mutations

| Mutation | Result |
|---|---|
| Delete the profile branch in `_observation_max_age` (table always) | 49 failed, incl. both IC-7610 PBT cases and the IC-7300 R41 test |
| Use `path` instead of `_profile_path_for_observation(acquisition, path)` | 22 failed, incl. **both** IC-7610 PBT cases — `receiver.0` misses `receiver.main` as surely as `receiver.1` misses `receiver.sub` |
| `ic7300.toml` `tone_freq` `"never"` → 25.0 | killed `test_ic7300_profile_supplies_the_civ_observation_max_age` + `test_ic7300_on_demand_fields_keep_the_never_ttl` (2 tests; measured by the reviewer two independent ways) |
| `ic7300.toml` `vd`/`id` 120.0 → 90.0, before the new pin | killed nothing across the 43-file gate set — the pin was added for exactly this and now kills it |

Honest negative: restoring a deleted table row would not fail anything, since the profile wins either way — which is part of why no row was deleted.

## Gates

- `uv run pytest` over the 43 files matching `_OBSERVATION_MAX_AGE_SECONDS|max_age|mark_stale_due|tx_target_max_age`, `-n auto --timeout=300 --timeout-method=thread` — **3192 passed, 2 skipped, 0 failed**. A wider 234-file sweep (`freshness|field_policies|IC-7300|IC-7610|golden|state_acquisition|maxAge`) ran green at 9807 passed / 197 skipped / 3 xfailed before the last prose-only edits. The full suite is CI's.
- `uv run ruff check src/ tests/` — All checks passed
- `uv run ruff format --check src/ tests/` — 741 files already formatted
- `uv run lint-imports` — 5 kept, 0 broken
- `uv run mypy --strict src/rigplane/web` — Success, 27 source files
- `git status` clean at the commit; the diff is 4 files, 325+/51− = 376 changed lines — under the 6-file / 600-line soft threshold.

## Could not establish

Whether the 60 s idle bench sampling predates the 5.0 s panel-knob cadence merged in #3367; the PBT and RIT staleness it recorded is consistent with either a 25 s or a 5 s cadence under the table's 10.0 s TTL, and the capture does not name its head.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

