### PR TITLE
feat: read back every field a command sets, through one path

### DIFF
--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -261,8 +261,8 @@ command_response_observable = [
     # ``_availability_for`` (acquisition_scheduler.py) rejects any
     # ``ensure_fresh`` request for a path with no declared capability
     # (UNKNOWN availability), so their armed confirm could not even reach
-    # the post-write-readback table added here (``_POST_WRITE_READBACK_FIELDS``
-    # in radio_poller.py) without this. MOR-2425: also given a non-polling
+    # the post-write readback (``RadioPoller._request_post_write_readback``)
+    # without this. MOR-2425: also given a non-polling
     # field_policies entry below so prime_unobserved() can reach them, per
     # R36b.
     "receiver.main.active.freq_mode.filter_num",

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -306,9 +306,7 @@ class CommandService:
 
         Those misses are no-ops, logged rather than swallowed so that a silent
         miss cannot read as coverage. The divergence is older than this method
-        and is tracked in MOR-1897; until it is closed this does NOT subsume
-        the web poller's per-command readback table, which builds the
-        canonical paths itself.
+        and is tracked in MOR-1897.
         """
         service = self._state_model_service
         target = intent.target
@@ -1112,10 +1110,11 @@ def expected_observations_for_command(
 ) -> tuple[FieldPath, ...]:
     """Return the field paths a write named *name* is expected to change.
 
-    The single derivation shared by every ingress: ``CommandIntent``s get it
-    at construction (:func:`command_intent_from_request`), legacy ``Command``
-    dataclasses get it from ``runtime/_poller_types.py: LEGACY_COMMAND_NAMES``
-    naming the same command.
+    Answers for command names without a ``CommandDescriptor``; a
+    descriptor-backed intent carries its target from ``CommandDescriptor.target``
+    (bound in ``core/command_dispatch.py``) and this derivation returns ``()``
+    for it. Legacy ``Command`` dataclasses reach it through
+    ``runtime/_poller_types.py: LEGACY_COMMAND_NAMES``.
     """
 
     return _command_expected_observations(name, params, _command_target(name, params))

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -43,8 +43,8 @@ logger = logging.getLogger(__name__)
 # it. ``ensure_fresh`` can only express that as an age no prior observation
 # can satisfy, so the request is never short-circuited by a FRESH pre-write
 # value. Same value and same reasoning as the freshness pipeline's own
-# reconciliation path and as the web poller's own per-command table
-# (``_POST_WRITE_READBACK_MAX_AGE``, MOR-1484).
+# reconciliation path and as ``_POST_WRITE_READBACK_MAX_AGE`` in
+# ``web/radio_poller.py`` (MOR-1484).
 _WRITE_CONFIRMATION_MAX_AGE = 1e-9
 
 __all__ = [
@@ -56,6 +56,8 @@ __all__ = [
     "PendingOverlay",
     "command_intent_from_request",
     "command_response_observation",
+    "expected_observations_for_command",
+    "observable_field_path",
 ]
 
 _UNSET = object()
@@ -1086,13 +1088,41 @@ def _is_yaesu_cat_readback(source: SourceMetadata) -> bool:
     )
 
 
-def _yaesu_receiver_alias(path: FieldPath) -> FieldPath:
+def observable_field_path(path: FieldPath) -> FieldPath:
+    """Return the spelling acquisition and the state model actually use.
+
+    A :class:`CommandIntent` target names its receiver by ingress index
+    (``"0"``/``"1"``) and leaves ``freq_mode`` slot-less. Profiles
+    (``rigs/*.toml``) and ``runtime/_civ_rx.py``'s observations use
+    ``"main"``/``"sub"`` and the relative ``active`` slot, so an
+    ``ensure_fresh`` for the intent's own spelling would name a path no
+    profile declares. Paths already in the second spelling pass through.
+    """
+
     if path.scope.value != "receiver" or path.receiver_id not in {"0", "1"}:
         return path
     receiver = "main" if path.receiver_id == "0" else "sub"
     if path.family.value == "freq_mode" and path.slot is None:
         return FieldPath.active(receiver, path.family.value, path.name)
     return FieldPath.receiver(receiver, path.family.value, path.name)
+
+
+def expected_observations_for_command(
+    name: str, params: Mapping[str, Any]
+) -> tuple[FieldPath, ...]:
+    """Return the field paths a write named *name* is expected to change.
+
+    The single derivation shared by every ingress: ``CommandIntent``s get it
+    at construction (:func:`command_intent_from_request`), legacy ``Command``
+    dataclasses get it from ``runtime/_poller_types.py: LEGACY_COMMAND_NAMES``
+    naming the same command.
+    """
+
+    return _command_expected_observations(name, params, _command_target(name, params))
+
+
+def _yaesu_receiver_alias(path: FieldPath) -> FieldPath:
+    return observable_field_path(path)
 
 
 def _external_rigctld_main_alias(path: FieldPath) -> FieldPath:
@@ -1298,6 +1328,38 @@ def _command_target(name: str, params: Mapping[str, Any]) -> FieldPath | None:
         return FieldPath.receiver(receiver, "operator_controls", "pbt_inner")
     if name == "set_pbt_outer":
         return FieldPath.receiver(receiver, "operator_controls", "pbt_outer")
+    if name == "set_nr_level":
+        return FieldPath.receiver(receiver, "operator_controls", "nr_level")
+    if name == "set_nb_level":
+        return FieldPath.receiver(receiver, "operator_controls", "nb_level")
+    if name == "set_notch_filter":
+        return FieldPath.receiver(receiver, "operator_controls", "notch_filter")
+    if name == "set_manual_notch_width":
+        return FieldPath.receiver(receiver, "operator_controls", "manual_notch_width")
+    if name == "set_auto_notch":
+        return FieldPath.receiver(receiver, "operator_toggles", "auto_notch")
+    if name == "set_manual_notch":
+        return FieldPath.receiver(receiver, "operator_toggles", "manual_notch")
+    if name == "set_twin_peak":
+        return FieldPath.receiver(receiver, "operator_toggles", "twin_peak_filter")
+    if name == "set_agc_time_constant":
+        return FieldPath.receiver(receiver, "operator_controls", "agc_time_constant")
+    if name == "set_filter_shape":
+        return FieldPath.receiver(receiver, "operator_controls", "filter_shape")
+    if name == "set_data_mode":
+        return FieldPath.receiver(receiver, "freq_mode", "data_mode")
+    if name == "set_tone_freq":
+        return FieldPath.receiver(receiver, "operator_controls", "tone_freq")
+    if name == "set_tsql_freq":
+        return FieldPath.receiver(receiver, "operator_controls", "tsql_freq")
+    if name == "set_rit_frequency":
+        return FieldPath.global_("operator_controls", "rit_freq")
+    if name == "set_rit_status":
+        return FieldPath.global_("tx_state", "rit_on")
+    if name == "set_rit_tx_status":
+        return FieldPath.global_("tx_state", "rit_tx")
+    if name == "set_break_in_delay":
+        return FieldPath.global_("operator_controls", "break_in_delay")
     if name == "set_powerstat":
         return FieldPath.global_("tx_state", "power_on")
     if name in ("set_rf_power", "set_power"):

--- a/src/rigplane/runtime/_poller_types.py
+++ b/src/rigplane/runtime/_poller_types.py
@@ -24,6 +24,7 @@ __all__ = [
     "Command",
     "CommandQueue",
     "CommandQueueEntry",
+    "LEGACY_COMMAND_NAMES",
     "execute_positive_tx_queue_entry",
     "validate_command_queue_entry_currency",
     "canonicalize_level_command",
@@ -1000,6 +1001,51 @@ def canonicalize_level_command(
         command_id=command_id,
         session_id=session_id,
     )
+
+
+# The canonical command name each legacy dataclass is the enqueued form of.
+# It is the only thing a legacy command declares about its own read-after-
+# write: the field paths come from ``core/command_service.py:
+# _command_target``, the same derivation ``CommandIntent`` uses.
+# ``web/radio_poller.py: RadioPoller._request_post_write_readback`` is the
+# consumer.
+#
+# A ``Set*`` dispatch arm absent from here gets no readback;
+# ``tests/test_post_write_readback_one_path.py`` enumerates the arms and
+# fails on any that is neither listed here nor classified there.
+LEGACY_COMMAND_NAMES: dict[type, str] = {
+    SetFreq: "set_freq",
+    SetMode: "set_mode",
+    SetFilter: "set_filter",
+    SetFilterWidth: "set_filter_width",
+    SetFilterShape: "set_filter_shape",
+    SetDataMode: "set_data_mode",
+    SetAttenuator: "set_att",
+    SetPreamp: "set_preamp",
+    SetNB: "set_nb",
+    SetNR: "set_nr",
+    SetNBLevel: "set_nb_level",
+    SetNRLevel: "set_nr_level",
+    SetAutoNotch: "set_auto_notch",
+    SetManualNotch: "set_manual_notch",
+    SetManualNotchWidth: "set_manual_notch_width",
+    SetNotchFilter: "set_notch_filter",
+    SetTwinPeak: "set_twin_peak",
+    SetAgcTimeConstant: "set_agc_time_constant",
+    SetDigiSel: "set_digisel",
+    SetIpPlus: "set_ip_plus",
+    SetPbtInner: "set_pbt_inner",
+    SetPbtOuter: "set_pbt_outer",
+    SetToneFreq: "set_tone_freq",
+    SetTsqlFreq: "set_tsql_freq",
+    SetRitFrequency: "set_rit_frequency",
+    SetRitStatus: "set_rit_status",
+    SetRitTxStatus: "set_rit_tx_status",
+    SetBreakInDelay: "set_break_in_delay",
+    SetPower: "set_rf_power",
+    SetPowerstat: "set_powerstat",
+    SetSplit: "set_split",
+}
 
 
 # ------------------------------------------------------------------

--- a/src/rigplane/runtime/_poller_types.py
+++ b/src/rigplane/runtime/_poller_types.py
@@ -1006,7 +1006,8 @@ def canonicalize_level_command(
 # The canonical command name each legacy dataclass is the enqueued form of.
 # It is the only thing a legacy command declares about its own read-after-
 # write: the field paths come from ``core/command_service.py:
-# _command_target``, the same derivation ``CommandIntent`` uses.
+# expected_observations_for_command`` (descriptor-backed names such as
+# ``set_att`` carry their target from ``CommandDescriptor.target`` instead).
 # ``web/radio_poller.py: RadioPoller._request_post_write_readback`` is the
 # consumer.
 #

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -33,7 +33,6 @@ import asyncio
 import logging
 import time
 from collections.abc import Iterator
-from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, cast
 
 from ..exceptions import CommandError
@@ -77,6 +76,8 @@ from ..commands.command_map import CommandMap
 from ..commands.commander import Priority
 from ..core.command_service import (
     CommandService,
+    expected_observations_for_command,
+    observable_field_path,
 )
 from ..core.acquisition_drain import AcquisitionDrain
 from ..core.command_dispatch import ManagedWriteAdmission, execute_command_intent
@@ -338,6 +339,7 @@ def _should_restart_rx(mode: str) -> bool:
 # ------------------------------------------------------------------
 
 from .._poller_types import (  # noqa: E402
+    LEGACY_COMMAND_NAMES,
     Command,
     CommandQueue,
     CommandQueueEntry,
@@ -486,94 +488,6 @@ def _post_write_receiver_id(cmd: Any) -> str:
 
     return "sub" if getattr(cmd, "receiver", 0) == 1 else "main"
 
-
-_POST_WRITE_READBACK_FIELDS: dict[type, Callable[[Any], tuple[FieldPath, ...]]] = {
-    SetFreq: lambda cmd: (
-        FieldPath.active(_post_write_receiver_id(cmd), "freq_mode", "freq_hz"),
-    ),
-    SetMode: lambda cmd: (
-        FieldPath.active(_post_write_receiver_id(cmd), "freq_mode", "mode"),
-    ),
-    # MOR-1484 review R1: att/preamp carry the #2452 armed affordance, whose
-    # ONLY confirming path back to the StateStore is this cadence poll --
-    # ``PendingOverlay`` has no web consumer and the CI-V own-frame/transceive
-    # echo this profile relies on for other fields does not reliably cover
-    # these two (see the "read-after-write via overlays + ... observation"
-    # comments on the ``SetAttenuator``/``SetPreamp`` case arms below, which
-    # describe the mechanism but not its actual reach on this profile). This
-    # PR ALSO slows att/preamp's cadence tier from 1.5s to 3.0s
-    # (rigs/ic7300.toml) to fund the freq/mode/rf_gain/squelch tightening
-    # above -- without this entry that give-back alone would widen the
-    # armed-affordance confirm window past the 3000ms ACK_CONFIRM_GRACE for a
-    # slice of clicks (grace expires, armed clears, the button shows the
-    # stale value until the next cadence tick -- the MOR-1478 stale-flash
-    # symptom, reintroduced on a new affordance). Table entries here make the
-    # 1.5s->3.0s give-back free for the operator's own write: confirmation no
-    # longer depends on the slowed cadence tier at all.
-    SetAttenuator: lambda cmd: (
-        FieldPath.receiver(_post_write_receiver_id(cmd), "operator_controls", "att"),
-    ),
-    SetPreamp: lambda cmd: (
-        FieldPath.receiver(_post_write_receiver_id(cmd), "operator_controls", "preamp"),
-    ),
-    # MOR-1546: filter-select and DATA-mode carry the #2452 armed affordance.
-    # Both were ALREADY confirmed incidentally: ``mode``'s own 1.0s cadence
-    # poll (CI-V 0x26 selected/unselected mode readback,
-    # [state_acquisition.field_policies] in rigs/ic7300.toml) returns
-    # ``(mode, data_mode, filter)`` in one frame, and ``_civ_rx.py``'s cmd
-    # 0x26 observation branch already emits ``data_mode``/``filter_num``
-    # observations alongside ``mode`` from that same answer -- so armed was
-    # already clearing via a genuine observation within that cadence's
-    # worst case (~1.0s), comfortably inside the 3000ms ACK_CONFIRM_GRACE.
-    # What was actually missing:
-    #  (1) a DEDICATED event-driven confirm at write time, so the
-    #      operator's own click doesn't have to wait out even the 1.0s
-    #      cadence tick before confirming -- the same class of latency win
-    #      freq/mode/rf_gain/squelch/att/preamp already get from this table;
-    #  (2) an acquisition CAPABILITY declaration for these two paths
-    #      (rigs/ic7300.toml) -- without one, ``ensure_fresh`` rejects the
-    #      path as UNAVAILABLE before it ever reaches the executor, so
-    #      these table entries alone would still be unreachable.
-    # Neither entry funds or is funded by a cadence give-back -- there is no
-    # new cadence here, zero standing budget added either way.
-    #
-    # filter_num has no dedicated CI-V read; it rides the SAME 0x26
-    # selected/unselected mode readback ``SetMode`` above already requests,
-    # as the filter byte in that response (``query_for_path`` in
-    # ``acquisition_scheduler.py``, ``_civ_rx.py``'s cmd 0x26 observation
-    # branch) -- requesting the ``filter_num`` path here still costs exactly
-    # one 0x26 query, identical to what a `mode` post-write readback would
-    # send. This entry fires unconditionally for every ``SetFilter``,
-    # including on a backend without ``CAP_FILTER_WIDTH`` (whose ``case
-    # SetFilter`` arm above never calls ``radio.set_filter`` at all) --
-    # harmless, one extra 0x26 query per click on a filterless backend, not
-    # a wire write.
-    SetFilter: lambda cmd: (
-        FieldPath.active(_post_write_receiver_id(cmd), "freq_mode", "filter_num"),
-    ),
-    # data_mode DOES have its own dedicated read (CI-V 0x1A 0x06,
-    # ``get_data_mode`` in every profile's ``[commands]`` table), so it gets
-    # its own one-query readback rather than piggybacking on ``mode``.
-    SetDataMode: lambda cmd: (
-        FieldPath.active(_post_write_receiver_id(cmd), "freq_mode", "data_mode"),
-    ),
-    SetFilterWidth: lambda cmd: (
-        FieldPath.active(_post_write_receiver_id(cmd), "freq_mode", "filter_width"),
-    ),
-    SetToneFreq: lambda cmd: (
-        FieldPath.receiver(
-            _post_write_receiver_id(cmd), "operator_controls", "tone_freq"
-        ),
-    ),
-    SetTsqlFreq: lambda cmd: (
-        FieldPath.receiver(
-            _post_write_receiver_id(cmd), "operator_controls", "tsql_freq"
-        ),
-    ),
-    SetBreakInDelay: lambda cmd: (
-        FieldPath.global_("operator_controls", "break_in_delay"),
-    ),
-}
 
 # ``ensure_fresh``'s ``max_age`` asks "how old may the CURRENT StateStore
 # observation be and still count as fresh". A write always invalidates
@@ -1473,21 +1387,29 @@ class RadioPoller:
             logger.debug("radio-poller: %s reconfirm failed", label, exc_info=True)
 
     def _request_post_write_readback(self, cmd: Command) -> None:
+        """Read back whatever the dispatched command just set (MOR-1484).
+
+        One derivation for both dispatch shapes: a ``CommandIntent`` carries
+        its ``expected_observations``, a legacy ``Command`` dataclass names
+        the command it is (``LEGACY_COMMAND_NAMES``) and the same
+        ``core/command_service.py`` derivation answers for it. The result is
+        rewritten by ``observable_field_path`` into the spelling profiles
+        declare before it reaches the scheduler.
+        """
+
         scheduler = self._acquisition_scheduler
         if scheduler is None:
             return
         if isinstance(cmd, CommandIntent):
-            paths = tuple(
-                replace(path, receiver_id="sub" if path.receiver_id == "1" else "main")
-                if path.receiver_id in ("0", "1")
-                else path
-                for path in cmd.expected_observations
-            )
+            expected = cmd.expected_observations
         else:
-            build_paths = _POST_WRITE_READBACK_FIELDS.get(type(cmd))
-            if build_paths is None:
+            name = LEGACY_COMMAND_NAMES.get(type(cmd))
+            if name is None:
                 return
-            paths = build_paths(cmd)
+            expected = expected_observations_for_command(
+                name, {"receiver": getattr(cmd, "receiver", 0)}
+            )
+        paths = tuple(observable_field_path(path) for path in expected)
         if type(cmd) is SetMode and CAP_FILTER_WIDTH in self._caps:
             filter_width = FieldPath.active(
                 _post_write_receiver_id(cmd), "freq_mode", "filter_width"
@@ -2337,9 +2259,6 @@ class RadioPoller:
                 # Hz↔index translation, profile-aware bounds + cmd29 wrapping
                 # are owned by the backend (P2-04). Issue #1101.
                 await radio.set_filter_width(width, receiver=rx)
-                # filter_width read-after-write now flows through CommandService
-                # pending overlays + the 0x1A 0x03 StateStore observation emitted
-                # by ``_civ_rx.py`` (MOR-437); no legacy RadioState mirror needed.
                 if self._on_state_event:
                     self._on_state_event(
                         "filter_width_changed", {"width": width, "receiver": rx}
@@ -2514,16 +2433,12 @@ class RadioPoller:
                 self._ensure_receiver_supported(rx, operation="set_nb")
                 if CAP_NB in self._caps:
                     await radio.set_nb(on, receiver=rx)
-                # nb read-after-write now flows through CommandService pending
-                # overlays + the 0x16 0x22 StateStore observation (MOR-437).
                 if self._on_state_event:
                     self._on_state_event("nb_changed", {"on": on, "receiver": rx})
             case SetNR(on=on, receiver=rx):
                 self._ensure_receiver_supported(rx, operation="set_nr")
                 if CAP_NR in self._caps:
                     await radio.set_nr(on, receiver=rx)
-                # nr read-after-write now flows through CommandService pending
-                # overlays + the 0x16 0x40 StateStore observation (MOR-437).
                 if self._on_state_event:
                     self._on_state_event("nr_changed", {"on": on, "receiver": rx})
             case SetDigiSel(on=on, receiver=rx):
@@ -2542,8 +2457,6 @@ class RadioPoller:
                 self._ensure_receiver_supported(rx, operation="set_attenuator")
                 if CAP_ATTENUATOR in self._caps:
                     await radio.set_attenuator_level(db, receiver=rx)
-                # att read-after-write now flows through CommandService pending
-                # overlays + the 0x11 StateStore observation (MOR-437).
                 if self._on_state_event:
                     self._on_state_event(
                         "attenuator_changed", {"db": db, "receiver": rx}
@@ -2552,8 +2465,6 @@ class RadioPoller:
                 self._ensure_receiver_supported(rx, operation="set_preamp")
                 if CAP_PREAMP in self._caps:
                     await radio.set_preamp(level, receiver=rx)
-                # preamp read-after-write now flows through CommandService pending
-                # overlays + the 0x16 0x02 StateStore observation (MOR-437).
                 if self._on_state_event:
                     self._on_state_event(
                         "preamp_changed", {"level": level, "receiver": rx}
@@ -2596,25 +2507,16 @@ class RadioPoller:
                         "if_shift_changed", {"offset": offset, "receiver": rx}
                     )
             case SetNRLevel(level=level, receiver=rx):
-                # nr_level read-after-write via overlays + 0x14 0x06 observation.
                 await _r.set_nr_level(level, receiver=rx)
             case SetNBLevel(level=level, receiver=rx):
-                # nb_level read-after-write via overlays + 0x14 0x12 observation.
                 await _r.set_nb_level(level, receiver=rx)
             case SetAutoNotch(on=on, receiver=rx):
-                # auto_notch read-after-write via overlays + 0x16 0x41 observation.
                 await _r.set_auto_notch(on, receiver=rx)
             case SetManualNotch(on=on, receiver=rx):
-                # manual_notch read-after-write via overlays + 0x16 0x48 observation.
                 await _r.set_manual_notch(on, receiver=rx)
             case SetNotchFilter(level=level, receiver=rx):
-                # notch_filter read-after-write via overlays + 0x14 0x0D
-                # observation (receiver-scoped since MOR-1548); the legacy
-                # global-scalar mirror write is gone with it.
                 await _r.set_notch_filter(level, receiver=rx)
             case SetAgcTimeConstant(value=value, receiver=rx):
-                # agc_time_constant read-after-write via overlays + 0x1A 0x04
-                # StateStore observation (MOR-437).
                 await _r.set_agc_time_constant(value, receiver=rx)
             case SetCwPitch(value=value):
                 await _r.set_cw_pitch(value)
@@ -2727,25 +2629,19 @@ class RadioPoller:
                 if not 0 <= mode <= 3:
                     raise CommandError(f"set_data_mode mode must be 0-3, got {mode}")
                 await radio.set_data_mode(mode, receiver=rx)
-                # data_mode read-after-write via overlays + 0x1A 0x06 observation.
                 if self._on_state_event:
                     self._on_state_event(
                         "data_mode_changed", {"mode": mode, "receiver": rx}
                     )
             case SetMicGain(level=level):
-                # mic_gain read-after-write via overlays + 0x14 0x0B observation.
                 await _r.set_mic_gain(level)
             case SetVox(on=on):
-                # vox_on read-after-write via overlays + 0x16 0x46 observation.
                 await _r.set_vox(on)
             case SetCompressorLevel(level=level):
-                # compressor_level read-after-write via overlays + 0x14 0x0E obs.
                 await _r.set_compressor_level(level)
             case SetMonitor(on=on):
-                # monitor_on read-after-write via overlays + 0x16 0x45 observation.
                 await _r.set_monitor(on)
             case SetMonitorGain(level=level):
-                # monitor_gain read-after-write via overlays + 0x14 0x15 observation.
                 await _r.set_monitor_gain(level)
             case SetDialLock(on=on):
                 await _r.set_dial_lock(on)
@@ -2765,7 +2661,6 @@ class RadioPoller:
                     agc_sent = await self._send_cmd(
                         "set_agc", bytes([mode]), receiver=rx
                     )
-                # agc read-after-write via overlays + 0x16 0x12 observation.
                 if agc_sent and self._on_state_event:
                     self._on_state_event("agc_changed", {"mode": mode, "receiver": rx})
             case SetRitStatus(on=on):
@@ -2788,8 +2683,6 @@ class RadioPoller:
                     self._on_state_event("rit_freq_changed", {"hz": freq})
             case SetSplit(on=on):
                 await _r.set_split(on)
-                # split read-after-write via overlays + 0x0F StateStore
-                # observation (MOR-437).
                 if self._on_state_event:
                     self._on_state_event("split_changed", {"on": on})
             case SetBand(band=band):
@@ -2840,7 +2733,6 @@ class RadioPoller:
                             command_service=command_service,
                             provider_generation=provider_generation,
                         )
-                        # Update local state immediately (don't wait for transceive echo)
                         if self._radio_state:
                             target = self._radio_state.main
                             if target:
@@ -3225,8 +3117,6 @@ class RadioPoller:
             case SetTunerStatus(value=value):
                 if CAP_TUNER in self._caps:
                     await radio.set_tuner_status(value)
-                    # tuner_status read-after-write via overlays + 0x1C 0x01
-                    # StateStore observation (MOR-437).
                     self._emit("tuner_changed", {"value": value})
             case SetAntenna1(on=on):
                 # IC-7610: 0x12 0x00 selects ANT1, data byte encodes RX-ANT OFF/ON.

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1389,12 +1389,11 @@ class RadioPoller:
     def _request_post_write_readback(self, cmd: Command) -> None:
         """Read back whatever the dispatched command just set (MOR-1484).
 
-        One derivation for both dispatch shapes: a ``CommandIntent`` carries
-        its ``expected_observations``, a legacy ``Command`` dataclass names
-        the command it is (``LEGACY_COMMAND_NAMES``) and the same
-        ``core/command_service.py`` derivation answers for it. The result is
-        rewritten by ``observable_field_path`` into the spelling profiles
-        declare before it reaches the scheduler.
+        A ``CommandIntent`` carries its ``expected_observations``; a legacy
+        ``Command`` dataclass names the command it is (``LEGACY_COMMAND_NAMES``)
+        and ``core/command_service.py: expected_observations_for_command``
+        answers for it. The result is rewritten by ``observable_field_path``
+        into the spelling profiles declare before it reaches the scheduler.
         """
 
         scheduler = self._acquisition_scheduler

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -2935,7 +2935,7 @@ def test_ic7300_real_profile_filter_num_and_data_mode_have_capability() -> None:
     """MOR-1546: without a declared acquisition capability, ``ensure_fresh``
     rejects the path as UNAVAILABLE before it ever reaches the executor
     (``AcquisitionScheduler._availability_for``) -- so the post-write
-    readback table entries alone are not sufficient, the profile must also
+    readback alone is not sufficient, the profile must also
     declare these two fields. Both are command_response_observable-only
     (event-driven), not ``polling_only``.
 

--- a/tests/test_post_write_readback_one_path.py
+++ b/tests/test_post_write_readback_one_path.py
@@ -447,7 +447,7 @@ _TABLE_SUCCESSION: tuple[tuple[Any, tuple[str, ...]], ...] = (
 async def test_readback_paths_the_deleted_table_used_are_unchanged(
     command: Any, paths: tuple[str, ...]
 ) -> None:
-    """The slot-bearing spellings ``_POST_WRITE_READBACK_FIELDS`` used survive.
+    """The slot-bearing spellings the deleted read-back table used survive.
 
     ``_command_target`` returns slot-less ``receiver.<n>.freq_mode.<name>``;
     the declared, observable path is ``receiver.<id>.active.freq_mode.<name>``.

--- a/tests/test_post_write_readback_one_path.py
+++ b/tests/test_post_write_readback_one_path.py
@@ -1,0 +1,581 @@
+"""Every dispatched set command reads back the field it sets, through one path.
+
+Owner ruling R39/R42 (MOR-2425): a command that changes something on the
+radio is followed by a read of that same thing. The mechanism is
+``CommandIntent.expected_observations`` -- derived once, in
+``core/command_service.py``, from ``_command_target`` -- and fired by
+``web/radio_poller.py: RadioPoller._request_post_write_readback`` as a
+``USER``-priority ``ensure_fresh``. Legacy ``Command`` dataclasses reach it
+by declaring which canonical command name they are
+(``runtime/_poller_types.py: LEGACY_COMMAND_NAMES``); they no longer carry
+their own field table.
+"""
+
+from __future__ import annotations
+
+import ast
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rigplane.capabilities import (
+    CAP_FILTER_SHAPE,
+    CAP_NOTCH,
+)
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionPriority,
+    AcquisitionScheduler,
+)
+from rigplane.core.command_service import expected_observations_for_command
+from rigplane.core.state_pipeline_contracts import CommandIntent, FieldPath
+from rigplane.profiles import resolve_radio_profile
+from rigplane.radio_state import RadioState
+from rigplane.runtime._poller_types import LEGACY_COMMAND_NAMES
+from rigplane.web.handlers import ControlHandler
+from rigplane.web.radio_poller import (
+    CommandQueue,
+    RadioPoller,
+    SetAgcTimeConstant,
+    SetAutoNotch,
+    SetDataMode,
+    SetFilterShape,
+    SetFreq,
+    SetManualNotch,
+    SetManualNotchWidth,
+    SetMode,
+    SetNBLevel,
+    SetNotchFilter,
+    SetNRLevel,
+    SetPbtInner,
+    SetPbtOuter,
+    SetRitFrequency,
+    SetRitStatus,
+    SetRitTxStatus,
+    SetToneFreq,
+    SetTsqlFreq,
+    SetTwinPeak,
+)
+
+pytestmark = pytest.mark.usefixtures("observed_rx_dispatch_premise")
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "rigplane"
+
+
+# ---------------------------------------------------------------------------
+# Arm enumeration: every ``case Set*`` arm is classified, exactly once
+# ---------------------------------------------------------------------------
+
+# Arms whose write has no field in the state model: nothing to read back.
+# Established by ``test_no_observable_field_arms_name_no_state_model_field``
+# below, which greps the declared field specs rather than trusting this list.
+_NO_OBSERVABLE_FIELD: dict[str, str] = {
+    # Clock/calendar writes.
+    "SetSystemDate": "system_date",
+    "SetSystemTime": "system_time",
+    "SetUtcOffset": "utc_offset",
+    # CI-V link configuration, not radio state.
+    "SetCivTransceive": "civ_transceive",
+    # Band-stack recall acts through freq/mode; it has no field of its own.
+    "SetBand": "band",
+    "SetBsr": "bsr",
+    "SetMemoryContents": "memory_contents",
+    "SetMemoryMode": "memory_mode",
+    # Panel-shortcut preferences.
+    "SetQuickSplit": "quick_split",
+    "SetQuickDualWatch": "quick_dual_watch",
+    "SetXfcStatus": "xfc_status",
+}
+
+# Arms this PR leaves uncovered. PR-1 ships the mechanism plus the RX
+# audio/DSP family; every other family keeps whatever it had. This list is
+# what PR-1b owes.
+_PENDING_LATER_PR: frozenset[str] = frozenset(
+    {
+        # Confirmed instead by RadioPoller._confirm_global_operator_write
+        # (direct getter, apply-if-match). Folding that into this path is
+        # PR-3.
+        "SetCwPitch",
+        "SetKeySpeed",
+        "SetBreakIn",
+        # Scope display settings.
+        "SetScopeCenterType",
+        "SetScopeDual",
+        "SetScopeDuringTx",
+        "SetScopeEdge",
+        "SetScopeFixedEdge",
+        "SetScopeHold",
+        "SetScopeMode",
+        "SetScopeRbw",
+        "SetScopeRef",
+        "SetScopeSpan",
+        "SetScopeSpeed",
+        "SetScopeVbw",
+        # TX audio / modulation family.
+        "SetAcc1ModLevel",
+        "SetUsbModLevel",
+        "SetLanModLevel",
+        "SetDataOffModInput",
+        "SetData1ModInput",
+        "SetData2ModInput",
+        "SetData3ModInput",
+        "SetMicGain",
+        "SetMonitor",
+        "SetMonitorGain",
+        "SetAfMute",
+        "SetCompressor",
+        "SetCompressorLevel",
+        "SetSsbTxBandwidth",
+        "SetDriveGain",
+        "SetVox",
+        "SetVoxGain",
+        "SetVoxDelay",
+        "SetAntiVoxGain",
+        # Antenna family: the antenna names are descriptor-backed, so their
+        # target lives on ``CommandDescriptor.target`` and needs bound
+        # params this lookup does not have.
+        "SetAntenna1",
+        "SetAntenna2",
+        "SetRxAntenna",
+        "SetRxAntennaAnt1",
+        "SetRxAntennaAnt2",
+        "SetCivOutputAnt",
+        "SetTunerStatus",
+        # Remaining RX controls whose state-model field this PR did not
+        # establish.
+        "SetAgc",
+        "SetApf",
+        "SetAudioPeakFilter",
+        "SetIfShift",
+        "SetDigiselShift",
+        "SetNbDepth",
+        "SetNbWidth",
+        "SetRepeaterTone",
+        "SetRepeaterTsql",
+        # Global/panel settings that DO carry a state-model field
+        # (``global.tx_state.dial_lock`` and friends) but whose
+        # ``_command_target`` entry this PR did not add.
+        "SetDialLock",
+        "SetTuningStep",
+        "SetRefAdjust",
+        "SetDashRatio",
+        "SetMainSubTracking",
+        "SetDualWatch",
+    }
+)
+
+
+def _set_command_arms() -> frozenset[str]:
+    """Every ``case Set*`` arm in ``RadioPoller._execute``'s ``match cmd:``."""
+    source = (_SRC / "web" / "radio_poller.py").read_text()
+    tree = ast.parse(source)
+    arms: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Match):
+            continue
+        for case in node.cases:
+            pattern = case.pattern
+            cls = None
+            if isinstance(pattern, ast.MatchClass) and isinstance(
+                pattern.cls, ast.Name
+            ):
+                cls = pattern.cls.id
+            if cls is not None and cls.startswith("Set"):
+                arms.add(cls)
+    return frozenset(arms)
+
+
+def _web_ingress_names() -> dict[str, set[str]]:
+    """Legacy dataclass name -> the ``set_*`` names that enqueue it.
+
+    Parsed from ``web/handlers/control.py``'s ``_enqueue_rc_*`` group
+    handlers. Those handlers are not the file's only construction site for
+    a legacy dataclass (``_ro_set_tuner_status`` builds one inline), so a
+    dataclass missing from this mapping is not proof it is never enqueued.
+    """
+    source = (_SRC / "web" / "handlers" / "control.py").read_text()
+    tree = ast.parse(source)
+    handler = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "ControlHandler"
+    )
+    mapping: dict[str, set[str]] = {}
+    for fn in handler.body:
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not fn.name.startswith("_enqueue_rc_"):
+            continue
+        for node in ast.walk(fn):
+            if not isinstance(node, ast.match_case):
+                continue
+            names: list[str] = []
+
+            def collect(pattern: ast.pattern, into: list[str] = names) -> None:
+                if isinstance(pattern, ast.MatchValue) and isinstance(
+                    pattern.value, ast.Constant
+                ):
+                    into.append(str(pattern.value.value))
+                elif isinstance(pattern, ast.MatchOr):
+                    for alternative in pattern.patterns:
+                        collect(alternative, into)
+
+            collect(node.pattern)
+            if not names:
+                continue
+            for call in ast.walk(node):
+                if not isinstance(call, ast.Call):
+                    continue
+                if not isinstance(call.func, ast.Attribute):
+                    continue
+                if call.func.attr not in ("put", "put_ordered"):
+                    continue
+                if not call.args:
+                    continue
+                built = call.args[0]
+                if isinstance(built, ast.Call) and isinstance(built.func, ast.Name):
+                    mapping.setdefault(built.func.id, set()).update(names)
+    return mapping
+
+
+def test_every_set_command_arm_is_classified() -> None:
+    arms = _set_command_arms()
+    covered = {cls.__name__ for cls in LEGACY_COMMAND_NAMES}
+    no_field = frozenset(_NO_OBSERVABLE_FIELD)
+    classified = covered | no_field | _PENDING_LATER_PR
+
+    assert arms - classified == set(), (
+        "new Set* dispatch arm with no readback classification: add it to "
+        "LEGACY_COMMAND_NAMES, or to _NO_OBSERVABLE_FIELD / _PENDING_LATER_PR "
+        "here with a reason"
+    )
+    assert classified - arms == set(), (
+        "classification names a dispatch arm that is gone"
+    )
+    assert covered & no_field == set()
+    assert covered & _PENDING_LATER_PR == set()
+    assert no_field & _PENDING_LATER_PR == set()
+
+
+def test_no_observable_field_arms_name_no_state_model_field() -> None:
+    """The "nothing to read back" claim, checked against the declared specs.
+
+    ``core/state_pipeline_contracts.py`` is where every readable field is
+    declared; a name that appears there as a quoted field name is readable
+    and does not belong in ``_NO_OBSERVABLE_FIELD``.
+    """
+    declared = (_SRC / "core" / "state_pipeline_contracts.py").read_text()
+    readable = [
+        f"{arm} -> {field}"
+        for arm, field in _NO_OBSERVABLE_FIELD.items()
+        if f'"{field}"' in declared
+    ]
+    assert readable == []
+
+
+def test_every_covered_command_resolves_to_at_least_one_field_path() -> None:
+    for command_type, name in LEGACY_COMMAND_NAMES.items():
+        paths = expected_observations_for_command(name, {"receiver": 0})
+        assert paths, f"{command_type.__name__} -> {name!r} resolves to no field path"
+
+
+def test_legacy_command_names_match_the_web_ingress() -> None:
+    """The declared name is one the web ingress actually dispatches as.
+
+    Keeps ``LEGACY_COMMAND_NAMES`` from drifting away from
+    ``control.py``'s ``_enqueue_rc_*`` handlers, which is where the
+    dataclass is built.
+    """
+    ingress = _web_ingress_names()
+    unreachable = {"SetAttenuator"}  # descriptor-backed name; see the PR body
+    for command_type, name in LEGACY_COMMAND_NAMES.items():
+        if command_type.__name__ in unreachable:
+            continue
+        assert command_type.__name__ in ingress, (
+            f"{command_type.__name__} is not enqueued by any _enqueue_rc_* arm"
+        )
+        assert name in ingress[command_type.__name__], (
+            f"{command_type.__name__} declares {name!r} but control.py dispatches "
+            f"it as {sorted(ingress[command_type.__name__])}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Behaviour: one USER-priority readback of the right path, per dispatch
+# ---------------------------------------------------------------------------
+
+
+_SETTERS: tuple[str, ...] = (
+    "set_freq",
+    "set_mode",
+    "set_data_mode",
+    "set_tone_freq",
+    "set_tsql_freq",
+    "set_nr_level",
+    "set_nb_level",
+    "set_notch_filter",
+    "set_manual_notch_width",
+    "set_auto_notch",
+    "set_manual_notch",
+    "set_agc_time_constant",
+    "set_filter_shape",
+    "set_twin_peak_filter",
+    "set_pbt_inner",
+    "set_pbt_outer",
+    "set_rit_frequency",
+    "set_rit_status",
+    "set_rit_tx_status",
+)
+
+
+def test_mocked_setters_exist_on_the_real_backend() -> None:
+    """A renamed backend setter must not survive as a silent mock attribute."""
+    from rigplane.runtime.radio import IcomRadio
+
+    missing = [name for name in _SETTERS if not hasattr(IcomRadio, name)]
+    assert missing == []
+
+
+def _poller(model: str = "IC-7300") -> tuple[RadioPoller, AcquisitionScheduler]:
+    profile = resolve_radio_profile(model=model)
+    assert profile.state_acquisition is not None
+    radio = MagicMock()
+    radio.profile = profile
+    radio.model = profile.model
+    radio.capabilities = {CAP_NOTCH, CAP_FILTER_SHAPE}
+    radio._radio_state = SimpleNamespace(active="MAIN")
+    for setter in _SETTERS:
+        setattr(radio, setter, AsyncMock())
+    scheduler = AcquisitionScheduler(profile=profile.state_acquisition)
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+    return poller, scheduler
+
+
+def _readback_paths(scheduler: AcquisitionScheduler) -> set[FieldPath]:
+    return {
+        path
+        for request in scheduler.pending_requests()
+        if request.reason == "post_write_readback"
+        for path in request.paths
+    }
+
+
+def _readback_priorities(scheduler: AcquisitionScheduler) -> set[AcquisitionPriority]:
+    return {
+        request.priority
+        for request in scheduler.pending_requests()
+        if request.reason == "post_write_readback"
+    }
+
+
+_RX_FAMILY: tuple[tuple[Any, str], ...] = (
+    (SetNRLevel(level=5, receiver=0), "receiver.main.operator_controls.nr_level"),
+    (SetNBLevel(level=5, receiver=0), "receiver.main.operator_controls.nb_level"),
+    (
+        SetNotchFilter(level=5, receiver=0),
+        "receiver.main.operator_controls.notch_filter",
+    ),
+    (
+        SetManualNotchWidth(value=1, receiver=0),
+        "receiver.main.operator_controls.manual_notch_width",
+    ),
+    (SetAutoNotch(on=True, receiver=0), "receiver.main.operator_toggles.auto_notch"),
+    (
+        SetManualNotch(on=True, receiver=0),
+        "receiver.main.operator_toggles.manual_notch",
+    ),
+    (
+        SetAgcTimeConstant(value=3, receiver=0),
+        "receiver.main.operator_controls.agc_time_constant",
+    ),
+    (
+        SetFilterShape(shape=1, receiver=0),
+        "receiver.main.operator_controls.filter_shape",
+    ),
+    (
+        SetTwinPeak(on=True, receiver=0),
+        "receiver.main.operator_toggles.twin_peak_filter",
+    ),
+    (SetPbtInner(level=128, receiver=0), "receiver.main.operator_controls.pbt_inner"),
+    (SetPbtOuter(level=128, receiver=0), "receiver.main.operator_controls.pbt_outer"),
+    (SetRitFrequency(freq=100), "global.operator_controls.rit_freq"),
+    (SetRitStatus(on=True), "global.tx_state.rit_on"),
+    (SetRitTxStatus(on=True), "global.tx_state.rit_tx"),
+)
+
+
+@pytest.mark.parametrize(
+    ("command", "path"), _RX_FAMILY, ids=[type(c).__name__ for c, _ in _RX_FAMILY]
+)
+@pytest.mark.asyncio
+async def test_rx_family_dispatch_requests_exactly_one_user_readback(
+    command: Any, path: str
+) -> None:
+    poller, scheduler = _poller()
+
+    await poller._execute(command)  # noqa: SLF001
+
+    assert _readback_paths(scheduler) == {FieldPath.parse(path)}
+    assert _readback_priorities(scheduler) == {AcquisitionPriority.USER}
+
+
+_TABLE_SUCCESSION: tuple[tuple[Any, tuple[str, ...]], ...] = (
+    (SetFreq(freq=14_000_000, receiver=0), ("receiver.main.active.freq_mode.freq_hz",)),
+    (SetMode(mode="USB", receiver=0), ("receiver.main.active.freq_mode.mode",)),
+    (SetDataMode(mode=1, receiver=0), ("receiver.main.active.freq_mode.data_mode",)),
+    (
+        SetToneFreq(freq_hz=8850, receiver=0),
+        ("receiver.main.operator_controls.tone_freq",),
+    ),
+    (
+        SetTsqlFreq(freq_hz=8850, receiver=0),
+        ("receiver.main.operator_controls.tsql_freq",),
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("command", "paths"),
+    _TABLE_SUCCESSION,
+    ids=[type(c).__name__ for c, _ in _TABLE_SUCCESSION],
+)
+@pytest.mark.asyncio
+async def test_readback_paths_the_deleted_table_used_are_unchanged(
+    command: Any, paths: tuple[str, ...]
+) -> None:
+    """The slot-bearing spellings ``_POST_WRITE_READBACK_FIELDS`` used survive.
+
+    ``_command_target`` returns slot-less ``receiver.<n>.freq_mode.<name>``;
+    the declared, observable path is ``receiver.<id>.active.freq_mode.<name>``.
+    ``observable_field_path`` is what reconciles them.
+    """
+    poller, scheduler = _poller()
+
+    await poller._execute(command)  # noqa: SLF001
+
+    assert _readback_paths(scheduler) >= {FieldPath.parse(path) for path in paths}
+
+
+@pytest.mark.asyncio
+async def test_sub_receiver_write_reads_back_the_sub_path() -> None:
+    poller, scheduler = _poller(model="IC-7610")
+
+    await poller._execute(SetNRLevel(level=5, receiver=1))  # noqa: SLF001
+
+    assert _readback_paths(scheduler) == {
+        FieldPath.parse("receiver.sub.operator_controls.nr_level")
+    }
+
+
+@pytest.mark.asyncio
+async def test_rigctld_set_level_and_the_web_slider_read_back_the_same_field() -> None:
+    """The nr_level asymmetry the census recorded is closed.
+
+    rigctld builds a ``CommandIntent`` for ``set_level``; the web slider
+    enqueues the legacy ``SetNRLevel``. Both now request the same path.
+    """
+    intent_poller, intent_scheduler = _poller()
+    legacy_poller, legacy_scheduler = _poller()
+    intent = CommandIntent(
+        id="rigctld-1",
+        name="set_level",
+        params={"level_name": "NR", "value": 5, "receiver": 0},
+        source="rigctld",
+        target=FieldPath.receiver("0", "operator_controls", "nr_level"),
+        expected_observations=(
+            FieldPath.receiver("0", "operator_controls", "nr_level"),
+        ),
+    )
+
+    intent_poller._request_post_write_readback(intent)  # noqa: SLF001
+    await legacy_poller._execute(SetNRLevel(level=5, receiver=0))  # noqa: SLF001
+
+    assert _readback_paths(intent_scheduler) == _readback_paths(legacy_scheduler)
+    assert _readback_paths(legacy_scheduler) == {
+        FieldPath.parse("receiver.main.operator_controls.nr_level")
+    }
+
+
+# ---------------------------------------------------------------------------
+# One readback per FLUSHED command, not per pointer event
+# ---------------------------------------------------------------------------
+
+
+class _QueueRecorder:
+    def __init__(self) -> None:
+        self.items: list[Any] = []
+
+    def put(self, item: Any, **_: Any) -> None:
+        self.items.append(item)
+
+
+@pytest.mark.asyncio
+async def test_coalesced_slider_burst_produces_one_dispatch_and_one_readback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ten superseded frames -> one enqueued command -> one readback.
+
+    Drives the real ``ControlChannel`` coalescer (``_coalesce_command`` /
+    ``_flush_coalesced_command``) and then runs whatever it actually
+    enqueued through the real poller and scheduler. ``_cmd_last`` is seeded
+    so that every frame of the burst, the first included, lands inside one
+    pacing window -- the mid-drag case.
+    """
+    ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
+    queue = _QueueRecorder()
+    handler = ControlHandler(
+        ws,
+        SimpleNamespace(
+            connected=True,
+            capabilities={"nr"},
+            profile=resolve_radio_profile(model="IC-7300"),
+        ),
+        "9.9.9",
+        "IC-7300",
+        server=SimpleNamespace(command_queue=queue),
+    )
+    handler._cmd_last["set_nr_level:0"] = time.monotonic()  # noqa: SLF001
+
+    for index in range(10):
+        await handler._handle_command(  # noqa: SLF001
+            {
+                "id": str(index),
+                "name": "set_nr_level",
+                "params": {"level": index, "receiver": 0},
+            }
+        )
+    for task in list(handler._cmd_flush_tasks.values()):  # noqa: SLF001
+        await task
+
+    assert [type(item) for item in queue.items] == [SetNRLevel]
+    assert queue.items[0].level == 9
+
+    poller, scheduler = _poller()
+    # ``pending_requests()`` alone cannot count readbacks: the scheduler
+    # groups repeat requests for one path into a single pending entry, so
+    # two dispatches of the same command also read as one. Count the calls
+    # into the real implementation instead of replacing it.
+    calls: list[tuple[FieldPath, ...]] = []
+    real_ensure_fresh = AcquisitionScheduler.ensure_fresh
+
+    def counting_ensure_fresh(
+        self: AcquisitionScheduler, paths: Any, **kwargs: Any
+    ) -> Any:
+        if kwargs.get("reason") == "post_write_readback":
+            calls.append(tuple(paths))
+        return real_ensure_fresh(self, paths, **kwargs)
+
+    monkeypatch.setattr(AcquisitionScheduler, "ensure_fresh", counting_ensure_fresh)
+    for item in queue.items:
+        await poller._execute(item)  # noqa: SLF001
+
+    assert calls == [(FieldPath.parse("receiver.main.operator_controls.nr_level"),)]
+    assert [
+        request
+        for request in scheduler.pending_requests()
+        if request.reason == "post_write_readback"
+    ]

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -85,6 +85,7 @@ from rigplane.web.radio_poller import (
     SetIpPlus,
     SetKeySpeed,
     SetMode,
+    SetMicGain,
     SetNB,
     SetNR,
     SetPbtInner,
@@ -1791,16 +1792,17 @@ async def test_execute_failed_set_mode_keeps_width_unknown_and_skips_readback() 
 
 @pytest.mark.asyncio
 async def test_execute_unmapped_write_does_not_queue_a_readback() -> None:
-    """A write command with no entry in ``_POST_WRITE_READBACK_FIELDS`` (e.g.
-    ``SetPower``) must be a silent no-op for this mechanism -- it must not
+    """A write command absent from ``LEGACY_COMMAND_NAMES`` (e.g.
+    ``SetMicGain``) must be a silent no-op for this mechanism -- it must not
     queue any acquisition request."""
     radio = _make_radio(active="MAIN")
-    path = FieldPath.global_("operator_controls", "power_level")
+    radio.set_mic_gain = AsyncMock()
+    path = FieldPath.global_("operator_controls", "mic_gain")
     scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
     radio._acquisition_scheduler = scheduler
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
 
-    await poller._execute(SetPower(200))  # noqa: SLF001
+    await poller._execute(SetMicGain(200))  # noqa: SLF001
 
     assert scheduler.pending_requests() == ()
 


### PR DESCRIPTION
Owner ruling R39/R42: a command that changes something on the radio is followed by a poll of that same thing and a `RadioState` update, and the same mechanism applies to every slider and knob.

**Census facts this rests on** (`origin/main` at `50f56bd2`). `RadioPoller._request_post_write_readback` fires `ensure_fresh(..., max_age=1e-9, priority=USER)` after every dispatched command, but its coverage came from two disagreeing sources: `CommandIntent.expected_observations` (default `(target,)`, from `core/command_service.py: _command_target`) for the intent path, and a 10-entry `_POST_WRITE_READBACK_FIELDS` table in `web/radio_poller.py` for legacy `Command` dataclasses — 85 of the 98 `case Set*` dispatch arms got neither. The web UI's own NR slider dispatched the legacy `SetNRLevel` (no readback) while rigctld's `set_level` built a `CommandIntent` for the same field (readback) — one field, two guarantees. Burst coalescing is already generic and server-side (`web/handlers/control.py: ControlChannel._coalesce_command`, key `name:receiver[:target]`, `_CMD_MIN_INTERVAL = 0.05`, last-value-wins), so a readback attached to each *dispatched* command is already bounded at one per 50 ms per key; this PR does not touch it.

**Mechanism chosen, and why.** `expected_observations` becomes the only input. A legacy dataclass now declares one thing — which canonical command name it is (`runtime/_poller_types.py: LEGACY_COMMAND_NAMES`, next to the existing `canonicalize_level_command`, which already maps three level dataclasses to their command name) — and `core/command_service.py: expected_observations_for_command` answers for both dispatch shapes from `_command_target`, the same derivation rigctld uses. The alternative, re-deriving a `type → FieldPath` table keyed by name, would have rebuilt the thing being deleted, and the two sources had in fact already diverged: `_POST_WRITE_READBACK_FIELDS` spelled freq/mode/filter/data-mode with `FieldPath.active(...)` (the spelling `rigs/*.toml` declares), `_command_target` returns slot-less `receiver.<n>.freq_mode.<name>`. That reconciliation is `observable_field_path`, promoted from `_yaesu_receiver_alias` — byte-identical logic that already existed privately in the same module, which now delegates to it.

**Coverage.** 31 of the 98 `Set*` arms now resolve to a field path. 15 of them needed no new derivation at all — `_command_target` on `main` already answered for `set_freq`, `set_mode`, `set_filter`, `set_filter_width`, `set_att`, `set_preamp`, `set_nb`, `set_nr`, `set_digisel`, `set_ip_plus`, `set_pbt_inner`, `set_pbt_outer`, `set_rf_power`, `set_powerstat`, `set_split`, and only the legacy dispatch path could not reach it. The other 16 are new `_command_target` entries: the RX audio/DSP family (`set_nr_level`, `set_nb_level`, `set_notch_filter`, `set_manual_notch_width`, `set_auto_notch`, `set_manual_notch`, `set_agc_time_constant`, `set_filter_shape`, `set_twin_peak`, `set_rit_frequency`, `set_rit_status`, `set_rit_tx_status`) plus `set_data_mode`, `set_tone_freq`, `set_tsql_freq` and `set_break_in_delay`, which the deleted table covered and `_command_target` did not. All 10 of the deleted table's entries stay covered; five of them are pinned path-for-path by `test_readback_paths_the_deleted_table_used_are_unchanged`. Adding a `_command_target` entry also gives that command's `CommandIntent` a target on every ingress, not just this readback — the pending-overlay path sees it too.

**What PR-1b still owes**, taken from the enumeration test's own list: 11 arms have no field in the state model at all (`SetSystemDate/Time`, `SetUtcOffset`, `SetCivTransceive`, `SetBand`, `SetBsr`, `SetMemoryContents/Mode`, `SetQuickSplit`, `SetQuickDualWatch`, `SetXfcStatus`) and are pinned as such by a test that greps the declared field specs. 56 remain uncovered with a field or a descriptor: the CW trio (`SetCwPitch`, `SetKeySpeed`, `SetBreakIn`, still on `_confirm_global_operator_write` — PR-3), the 12 scope-display settings, the TX-audio/modulation family, the antenna/tuner names (descriptor-backed, so their target lives on `CommandDescriptor.target` and needs bound params this lookup does not have), the remaining RX controls (`SetAgc`, `SetApf`, `SetAudioPeakFilter`, `SetIfShift`, `SetDigiselShift`, `SetNbDepth`, `SetNbWidth`, `SetRepeaterTone/Tsql`), and six global panel settings that do carry a field (`SetDialLock`, `SetTuningStep`, `SetRefAdjust`, `SetDashRatio`, `SetMainSubTracking`, `SetDualWatch`).

**Deletions.** `_POST_WRITE_READBACK_FIELDS` and its comment paragraphs, including the att/preamp one about "the mechanism but not its actual reach"; 20 read-after-write comment blocks (fifteen worded `read-after-write via overlays + 0xNN observation`, five worded `read-after-write now flows through CommandService pending overlays + the 0xNN StateStore observation`) on the dispatch arms; the `don't wait for transceive echo` line. rigplane never enables CI-V transceive (`backends/_icom_serial_base.py: connect()`), setters are `_send_fire_and_forget`, and the FB/FA ack is not decoded into an observation, so those comments named a confirmation the code does not receive. `_confirm_global_operator_write` is untouched. Two dated plan documents (`docs/plans/2026-08-14-*.md`) still name `_POST_WRITE_READBACK_FIELDS`; they record the state at their own date and were left alone. Two live in-tree references (an `ic7300.toml` comment and a scheduler test docstring) named the table by symbol and were rewritten to name the mechanism, which is why the PR touches seven files; a `command_service.py` docstring that still described the table as live was deleted, and three comments that called this derivation the single one for every ingress were narrowed (descriptor-backed intents carry their target from `CommandDescriptor.target`).

**Mutations run.** (1) Removing `SetNRLevel`/`SetNBLevel`/`SetNotchFilter` from `LEGACY_COMMAND_NAMES` → 7 failures: the enumeration test, their three family cases, the sub-receiver case, the rigctld/web symmetry case and the burst test. (2) Adding a `case SetBrandNewKnob(...)` arm → the enumeration test names it. (3) Pinning `observable_field_path`'s receiver to `"main"` → the sub-receiver case fails on `receiver.sub...` vs `receiver.main...`. (4) Making `_flush_coalesced_command` dispatch without popping → the burst test's dispatch-count assertion fails. (5) Calling `_request_post_write_readback` twice per dispatch → the burst test's `ensure_fresh` call-count assertion fails. That fifth mutation exists because `pending_requests()` alone could not have caught it: the scheduler groups repeat requests for one path into a single pending entry, so the burst test counts calls into the real implementation instead.

**Guardrails.** 7 files, 866 changed lines (723 + 143) at this head — over the soft threshold on both counts, under the hard ceiling. 264 of those lines are source; 591 are tests, of which the new file's two classification tables account for the 67 arms this PR leaves uncovered. The mechanism swap and the enumeration cannot be split: deleting the table without the enumeration would leave no record of which arms lost or kept coverage.

**Gates**, all at this head: `pytest` over the 68 test files matching `radio_poller|_request_post_write_readback|expected_observations|_coalesce_command|command_service` (the new file among them) — 4211 passed, 2 skipped (measured at ba054663; the two later commits are prose-only, AST-identical); `ruff check src/ tests/` clean; `ruff format --check src/ tests/` clean; `lint-imports` 5 contracts kept, 0 broken; `mypy --strict src/rigplane/web` clean.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

