### PR TITLE
Confirm CW keyer and scope writes through the one read-back path

### DIFF
--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -1398,14 +1398,41 @@ def _command_target(name: str, params: Mapping[str, Any]) -> FieldPath | None:
         return FieldPath.global_("operator_controls", "anti_vox_gain")
     if name == "set_vox_delay":
         return FieldPath.global_("operator_controls", "vox_delay")
-    # Scope-display settings are NOT resolved here (MOR-2425 PR-1b review,
-    # B1): a scope write is already confirmed by
-    # ``web/radio_poller.py: RadioPoller._reconfirm_scope_field``, called
-    # inline from the same ``case Set*`` arm that dispatches the write.
-    # Adding a target here would fire a second, scheduler-queued
-    # ``ensure_fresh`` for the same field -- a USER-priority query into the
-    # scope waveform stream ``_reconfirm_scope_field``'s own docstring says
-    # stays clear. Folding the two paths into one is PR-3's job.
+    # CW keyer (MOR-2425 PR-3): folded off
+    # ``web/radio_poller.py: RadioPoller._confirm_global_operator_write``,
+    # which is deleted. All three are declared
+    # ``command_response_observable`` on IC-7300.
+    if name == "set_cw_pitch":
+        return FieldPath.global_("operator_controls", "cw_pitch")
+    if name == "set_key_speed":
+        return FieldPath.global_("operator_controls", "key_speed")
+    if name == "set_break_in":
+        return FieldPath.global_("operator_controls", "break_in")
+    # Scope-display settings (MOR-2425 PR-3): ten of the twelve leaves folded
+    # off the inline ``RadioPoller._reconfirm_scope_field``. ``rbw`` and
+    # ``fixed_edge`` are NOT resolved here and keep that helper -- see the
+    # reasons recorded against them in
+    # ``tests/test_post_write_readback_one_path.py: _PENDING_LATER_PR``.
+    if name == "set_scope_during_tx":
+        return FieldPath.scope_control("display", "during_tx")
+    if name == "set_scope_center_type":
+        return FieldPath.scope_control("display", "center_type")
+    if name == "set_scope_edge":
+        return FieldPath.scope_control("display", "edge")
+    if name == "set_scope_vbw":
+        return FieldPath.scope_control("display", "vbw_narrow")
+    if name == "set_scope_dual":
+        return FieldPath.scope_control("display", "dual")
+    if name == "set_scope_mode":
+        return FieldPath.scope_control("display", "mode")
+    if name == "set_scope_span":
+        return FieldPath.scope_control("display", "span")
+    if name == "set_scope_speed":
+        return FieldPath.scope_control("display", "speed")
+    if name == "set_scope_ref":
+        return FieldPath.scope_control("display", "ref_db")
+    if name == "set_scope_hold":
+        return FieldPath.scope_control("display", "hold")
     if name == "set_rit_frequency":
         return FieldPath.global_("operator_controls", "rit_freq")
     if name == "set_rit_status":

--- a/src/rigplane/runtime/_poller_types.py
+++ b/src/rigplane/runtime/_poller_types.py
@@ -1058,6 +1058,21 @@ LEGACY_COMMAND_NAMES: dict[type, str] = {
     SetVoxGain: "set_vox_gain",
     SetAntiVoxGain: "set_anti_vox_gain",
     SetVoxDelay: "set_vox_delay",
+    # MOR-2425 PR-3: the CW keyer trio and the ten scope-display leaves
+    # folded off the two bespoke confirms in ``web/radio_poller.py``.
+    SetCwPitch: "set_cw_pitch",
+    SetKeySpeed: "set_key_speed",
+    SetBreakIn: "set_break_in",
+    SetScopeDuringTx: "set_scope_during_tx",
+    SetScopeCenterType: "set_scope_center_type",
+    SetScopeEdge: "set_scope_edge",
+    SetScopeVbw: "set_scope_vbw",
+    SetScopeDual: "set_scope_dual",
+    SetScopeMode: "set_scope_mode",
+    SetScopeSpan: "set_scope_span",
+    SetScopeSpeed: "set_scope_speed",
+    SetScopeRef: "set_scope_ref",
+    SetScopeHold: "set_scope_hold",
 }
 
 

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -218,7 +218,6 @@ logger = logging.getLogger(__name__)
 
 _GAP: float = 0.012
 _GAP_SERIAL: float = 0.050  # serial CI-V needs more breathing room
-_SEND_TIMEOUT: float = 1.0
 _FAST_INTERVAL: float = 0.025  # meters — wfview queue interval for LAN (25ms)
 _FAST_INTERVAL_SERIAL: float = 0.100  # serial: 10 polls/sec for responsive meters
 _PTT_PATH = FieldPath.global_("tx_state", "ptt")
@@ -1373,9 +1372,9 @@ class RadioPoller:
         ``_fetch_scope_controls``: a dropped response on a busy scope stream
         must not stall the command queue.
 
-        MOR-2425 PR-3 moved the ten scope leaves that ``ensure_fresh`` can
-        reach onto ``_request_post_write_readback``. The three callers left
-        are the ones it cannot; each says why at its own call site.
+        Ten scope leaves moved onto ``_request_post_write_readback``; the
+        three callers left could not be folded, and each says why at its
+        own call site.
         """
         try:
             await asyncio.wait_for(getter(), timeout=self._SCOPE_GETTER_TIMEOUT)

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -34,7 +34,7 @@ import dataclasses
 import logging
 import time
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 from ..exceptions import CommandError
 from ..exceptions import ConnectionError as RadioConnectionError
@@ -1362,10 +1362,7 @@ class RadioPoller:
     async def _reconfirm_scope_field(self, label: str, getter: Any) -> None:
         """Force a fresh confirmed observation for one scope-control leaf.
 
-        Scope-control fields are fetched once, at ``EnableScope`` time
-        (``_fetch_scope_controls`` above) and never touched again by the main
-        poll loop — by design, to avoid interfering with the high-rate scope
-        waveform stream. A ``Set*`` write only mutates the optimistic
+        A ``Set*`` write only mutates the optimistic
         ``RadioState.scope_controls`` mirror below; without a follow-up GET,
         the StateStore's confirmed observation for that leaf is never
         refreshed, so the public snapshot keeps re-applying the STALE
@@ -1375,6 +1372,10 @@ class RadioPoller:
         ``_SCOPE_GETTER_TIMEOUT`` for the same reason as
         ``_fetch_scope_controls``: a dropped response on a busy scope stream
         must not stall the command queue.
+
+        MOR-2425 PR-3 moved the ten scope leaves that ``ensure_fresh`` can
+        reach onto ``_request_post_write_readback``. The three callers left
+        are the ones it cannot; each says why at its own call site.
         """
         try:
             await asyncio.wait_for(getter(), timeout=self._SCOPE_GETTER_TIMEOUT)
@@ -1473,46 +1474,6 @@ class RadioPoller:
             command_service.apply_observation(observation)
         else:
             self._state_store.apply(observation)
-
-    async def _confirm_global_operator_write(
-        self,
-        name: str,
-        expected: int,
-        getter: Callable[[], Awaitable[int]],
-        *,
-        command_id: str | None,
-        source: CommandSource,
-        session_id: str | None,
-        command_service: CommandService | None,
-        provider_generation: int,
-    ) -> None:
-        """Apply a global operator write only after a matching fresh readback."""
-
-        try:
-            confirmed = await asyncio.wait_for(getter(), timeout=_SEND_TIMEOUT)
-        except Exception:
-            logger.debug(
-                "radio-poller: %s post-write readback failed",
-                name,
-                exc_info=True,
-            )
-            return
-        if provider_generation != self._provider_generation():
-            logger.debug("radio-poller: discarded stale %s readback", name)
-            return
-        if confirmed != expected:
-            logger.warning("radio-poller: %s write readback mismatch", name)
-            return
-        self._apply_global_control_observation(
-            name,
-            confirmed,
-            command_id=command_id,
-            source=source,
-            session_id=session_id,
-            command_service=command_service,
-            provider_generation=provider_generation,
-        )
-        self._apply_compatibility_mirror(lambda state: setattr(state, name, confirmed))
 
     def _apply_global_command_echo_observation(
         self,
@@ -2525,42 +2486,25 @@ class RadioPoller:
                 await _r.set_notch_filter(level, receiver=rx)
             case SetAgcTimeConstant(value=value, receiver=rx):
                 await _r.set_agc_time_constant(value, receiver=rx)
+            # MOR-2425 PR-3: the readback is
+            # ``_request_post_write_readback``'s, like every other covered
+            # arm. These optimistic mirror writes are the only writers of the
+            # three ``RadioState`` attributes on this seat --
+            # ``runtime/_civ_rx.py`` publishes cw_pitch as a StateStore
+            # observation without mirroring it, and ``cw_auto_tune``
+            # (``web/handlers/control.py``) reads ``state.cw_pitch``.
             case SetCwPitch(value=value):
                 await _r.set_cw_pitch(value)
-                await self._confirm_global_operator_write(
-                    "cw_pitch",
-                    value,
-                    _r.get_cw_pitch,
-                    command_id=command_id,
-                    source=command_source,
-                    session_id=session_id,
-                    command_service=command_service,
-                    provider_generation=provider_generation,
-                )
+                if self._radio_state:
+                    self._radio_state.cw_pitch = value
             case SetKeySpeed(speed=speed):
                 await _r.set_key_speed(speed)
-                await self._confirm_global_operator_write(
-                    "key_speed",
-                    speed,
-                    _r.get_key_speed,
-                    command_id=command_id,
-                    source=command_source,
-                    session_id=session_id,
-                    command_service=command_service,
-                    provider_generation=provider_generation,
-                )
+                if self._radio_state:
+                    self._radio_state.key_speed = speed
             case SetBreakIn(mode=mode):
                 await _r.set_break_in(mode)
-                await self._confirm_global_operator_write(
-                    "break_in",
-                    mode,
-                    _r.get_break_in,
-                    command_id=command_id,
-                    source=command_source,
-                    session_id=session_id,
-                    command_service=command_service,
-                    provider_generation=provider_generation,
-                )
+                if self._radio_state:
+                    self._radio_state.break_in = mode
             case SetApf(mode=mode, receiver=rx):
                 self._ensure_receiver_supported(rx, operation="set_apf")
                 await _r.set_audio_peak_filter(mode, receiver=rx)
@@ -2978,6 +2922,16 @@ class RadioPoller:
                 # nothing, on a miss; the mirror/reconfirm/log below are
                 # gated on that return the same way the MOR-2004 SetAgc
                 # branch above gates its state event on ``agc_sent``.
+                #
+                # MOR-2425 PR-3 left this reconfirm inline for that reason:
+                # ``_request_post_write_readback`` runs after the whole
+                # ``match``, unconditionally, so a readback fired from there
+                # would also fire on the refusal branch. IC-7300 is such a
+                # profile -- its command map declares no
+                # ``set_scope_main_sub`` -- while its
+                # ``[state_acquisition.capabilities]`` does declare
+                # ``scope_controls.global.display.receiver``, so the read
+                # would be queued and sent.
                 self._ensure_receiver_supported(
                     receiver,
                     operation="switch_scope_receiver",
@@ -2999,17 +2953,11 @@ class RadioPoller:
                     await radio.set_scope_during_tx(on)
                     if self._radio_state:
                         self._radio_state.scope_controls.during_tx = on
-                    await self._reconfirm_scope_field(
-                        "get_scope_during_tx", radio.get_scope_during_tx
-                    )
             case SetScopeCenterType(center_type=center_type):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_center_type(center_type)
                     if self._radio_state:
                         self._radio_state.scope_controls.center_type = center_type
-                    await self._reconfirm_scope_field(
-                        "get_scope_center_type", radio.get_scope_center_type
-                    )
             case SetScopeFixedEdge(edge=edge, start_hz=start_hz, end_hz=end_hz):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_fixed_edge(
@@ -3029,6 +2977,12 @@ class RadioPoller:
                     # selector addresses ONE specific slot (MOR-662), so a
                     # bare re-read would default back to range 1/edge 1 and
                     # clobber the mirror with an unrelated slot's data.
+                    #
+                    # That is why MOR-2425 PR-3 did not fold this arm onto
+                    # ``_request_post_write_readback``: the shared acquisition
+                    # resolver (``runtime/_state_queries.py``) builds
+                    # ``get_scope_fixed_edge`` with its ``range_index=1,
+                    # edge=1`` defaults, i.e. the bare re-read above.
                     if self._radio_state:
                         written = self._radio_state.scope_controls.fixed_edge
                         await self._reconfirm_scope_field(
@@ -3046,70 +3000,53 @@ class RadioPoller:
                     await radio.set_scope_dual(dual)
                     if self._radio_state:
                         self._radio_state.scope_controls.dual = dual
-                    await self._reconfirm_scope_field(
-                        "get_scope_dual", radio.get_scope_dual
-                    )
             case SetScopeMode(mode=mode):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_mode(mode)
                     if self._radio_state:
                         self._radio_state.scope_controls.mode = mode
-                    await self._reconfirm_scope_field(
-                        "get_scope_mode", radio.get_scope_mode
-                    )
             case SetScopeSpan(span=span):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_span(span)
                     if self._radio_state:
                         self._radio_state.scope_controls.span = span
-                    await self._reconfirm_scope_field(
-                        "get_scope_span", radio.get_scope_span
-                    )
             case SetScopeSpeed(speed=speed):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_speed(speed)
                     if self._radio_state:
                         self._radio_state.scope_controls.speed = speed
-                    await self._reconfirm_scope_field(
-                        "get_scope_speed", radio.get_scope_speed
-                    )
             case SetScopeRef(ref=ref):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_ref(ref)
                     if self._radio_state:
                         self._radio_state.scope_controls.ref_db = float(ref)
-                    await self._reconfirm_scope_field(
-                        "get_scope_ref", radio.get_scope_ref
-                    )
             case SetScopeHold(on=on):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_hold(on)
                     if self._radio_state:
                         self._radio_state.scope_controls.hold = on
-                    await self._reconfirm_scope_field(
-                        "get_scope_hold", radio.get_scope_hold
-                    )
             case SetScopeEdge(edge=edge):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_edge(edge)
                     if self._radio_state:
                         self._radio_state.scope_controls.edge = edge
-                    await self._reconfirm_scope_field(
-                        "get_scope_edge", radio.get_scope_edge
-                    )
             case SetScopeVbw(narrow=narrow):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_vbw(narrow)
                     if self._radio_state:
                         self._radio_state.scope_controls.vbw_narrow = narrow
-                    await self._reconfirm_scope_field(
-                        "get_scope_vbw", radio.get_scope_vbw
-                    )
             case SetScopeRbw(rbw=rbw):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_rbw(rbw)
                     if self._radio_state:
                         self._radio_state.scope_controls.rbw = rbw
+                    # Not folded onto ``_request_post_write_readback``
+                    # (MOR-2425 PR-3): of the profiles in ``rigs/``, only
+                    # ic7610.toml declares
+                    # ``scope_controls.global.display.rbw`` in
+                    # ``[state_acquisition.capabilities]``, so on the
+                    # live-bench IC-7300 ``ensure_fresh`` would answer
+                    # UNAVAILABLE and queue nothing.
                     await self._reconfirm_scope_field(
                         "get_scope_rbw", radio.get_scope_rbw
                     )

--- a/tests/test_post_write_readback_one_path.py
+++ b/tests/test_post_write_readback_one_path.py
@@ -770,9 +770,7 @@ async def test_cw_pitch_readback_applies_the_value_the_radio_reports() -> None:
     the reported value.
 
     The lifecycle assertion below is a guard, not a discriminator: nothing
-    confirms ``SetCwPitch`` today either way (no confirmed or reconciled
-    event is emitted whether the radio reports the requested value or
-    another one).
+    confirms ``SetCwPitch`` today either way.
     """
     path = FieldPath.parse("global.operator_controls.cw_pitch")
     poller, scheduler = _poller(

--- a/tests/test_post_write_readback_one_path.py
+++ b/tests/test_post_write_readback_one_path.py
@@ -24,9 +24,12 @@ import pytest
 
 from rigplane.capabilities import (
     CAP_AGC,
+    CAP_BREAK_IN,
     CAP_COMPRESSOR,
+    CAP_CW,
     CAP_FILTER_SHAPE,
     CAP_NOTCH,
+    CAP_SCOPE,
     CAP_TUNER,
     CAP_VOX,
 )
@@ -34,8 +37,17 @@ from rigplane.core.acquisition_scheduler import (
     AcquisitionPriority,
     AcquisitionScheduler,
 )
-from rigplane.core.command_service import expected_observations_for_command
-from rigplane.core.state_pipeline_contracts import CommandIntent, FieldPath
+from rigplane.core.command_service import (
+    CommandExecutionResult,
+    CommandService,
+    expected_observations_for_command,
+)
+from rigplane.core.state_pipeline_contracts import (
+    CommandIntent,
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
 from rigplane.profiles import resolve_radio_profile
 from rigplane.radio_state import RadioState
 from rigplane.runtime._poller_types import LEGACY_COMMAND_NAMES
@@ -47,11 +59,14 @@ from rigplane.web.radio_poller import (
     SetAgcTimeConstant,
     SetAntiVoxGain,
     SetAutoNotch,
+    SetBreakIn,
     SetCompressor,
     SetCompressorLevel,
+    SetCwPitch,
     SetDataMode,
     SetFilterShape,
     SetFreq,
+    SetKeySpeed,
     SetManualNotch,
     SetManualNotchWidth,
     SetMicGain,
@@ -66,6 +81,16 @@ from rigplane.web.radio_poller import (
     SetRitFrequency,
     SetRitStatus,
     SetRitTxStatus,
+    SetScopeCenterType,
+    SetScopeDual,
+    SetScopeDuringTx,
+    SetScopeEdge,
+    SetScopeHold,
+    SetScopeMode,
+    SetScopeRef,
+    SetScopeSpan,
+    SetScopeSpeed,
+    SetScopeVbw,
     SetToneFreq,
     SetTsqlFreq,
     SetTunerStatus,
@@ -78,6 +103,12 @@ from rigplane.web.radio_poller import (
 pytestmark = pytest.mark.usefixtures("observed_rx_dispatch_premise")
 
 _SRC = Path(__file__).resolve().parents[1] / "src" / "rigplane"
+
+
+class _NoopCommandExecutor:
+    async def execute(self, intent: object) -> CommandExecutionResult:
+        del intent
+        return CommandExecutionResult()
 
 
 # ---------------------------------------------------------------------------
@@ -124,34 +155,27 @@ _NO_OBSERVABLE_FIELD: dict[str, str] = {
 # is covered by ``LEGACY_COMMAND_NAMES``.
 _PENDING_LATER_PR: frozenset[str] = frozenset(
     {
-        # Confirmed instead by RadioPoller._confirm_global_operator_write
-        # (direct getter, apply-if-match). Folding that into this path is
-        # PR-3.
-        "SetCwPitch",
-        "SetKeySpeed",
-        "SetBreakIn",
-        # Scope-display settings (review B1, MOR-2425 PR-1b): all twelve
-        # are confirmed instead by
-        # ``RadioPoller._reconfirm_scope_field``, called inline from the
-        # same ``case Set*`` arm that dispatches the write -- adding a
-        # target for these to ``_command_target`` made
-        # ``_request_post_write_readback`` fire a SECOND, scheduler-queued
-        # USER-priority ``ensure_fresh`` for the same field on every scope
-        # write, unbudgeted against the scope waveform stream
-        # ``_reconfirm_scope_field``'s own docstring says stays clear.
-        # Folding the two paths into one is PR-3's job.
+        # The two scope-display leaves MOR-2425 PR-3 could not fold into the
+        # one read-back path; the other ten, and the CW keyer trio, are
+        # covered below.
+        #
+        # rbw: ``rigs/ic7300.toml``'s ``[state_acquisition.capabilities]``
+        # declares twelve ``scope_controls.global.display.*`` leaves, and
+        # ``rbw`` is not one of them (of the profiles in ``rigs/``, only
+        # ``ic7610.toml`` declares it), so ``AcquisitionScheduler
+        # .ensure_fresh`` answers UNAVAILABLE and queues nothing on the
+        # live-bench profile.
+        #
+        # fixed_edge: the shared acquisition resolver (``runtime/
+        # _state_queries.py: acquisition_query_resolver_for_profile``) builds
+        # ``commands/scope.py: get_scope_fixed_edge`` with its
+        # ``range_index=1, edge=1`` defaults -- the slot-less re-read the
+        # ``SetScopeFixedEdge`` arm's own MOR-662 comment says comes back
+        # with an unrelated slot's data.
+        #
+        # Both arms keep their inline ``RadioPoller._reconfirm_scope_field``.
         "SetScopeRbw",
-        "SetScopeDuringTx",
-        "SetScopeCenterType",
-        "SetScopeEdge",
         "SetScopeFixedEdge",
-        "SetScopeVbw",
-        "SetScopeDual",
-        "SetScopeMode",
-        "SetScopeSpan",
-        "SetScopeSpeed",
-        "SetScopeRef",
-        "SetScopeHold",
         # TX audio / modulation family: mic_gain, monitor(_gain),
         # compressor(_level), vox(_gain/_delay/anti) are covered (see
         # below). These seven have a state-model field but no declared
@@ -399,11 +423,7 @@ _SETTERS: tuple[str, ...] = (
 
 
 # IC-7300-witnessed additions (MOR-2425 PR-1b): agc, tuner_status, and the
-# TX audio/modulation nine dispatch through ``IcomRadio``. Scope-display
-# setters are excluded -- their readback stays on
-# ``RadioPoller._reconfirm_scope_field`` (review B1); see
-# ``tests/test_radio_poller_coverage.py`` for scope-specific dispatch
-# coverage.
+# TX audio/modulation nine dispatch through ``IcomRadio``.
 _IC7300_SETTERS: tuple[str, ...] = (
     "set_agc",
     "set_tuner_status",
@@ -419,12 +439,44 @@ _IC7300_SETTERS: tuple[str, ...] = (
 )
 
 
+# MOR-2425 PR-3: the CW keyer trio and the ten scope-display leaves folded off
+# the two bespoke confirms (``RadioPoller._confirm_global_operator_write``,
+# deleted, and ``RadioPoller._reconfirm_scope_field``, kept only for
+# fixed_edge/rbw and the scope-receiver switch). Each entry pairs the arm's
+# setter with the getter the bespoke confirm used to await, so a witness can
+# assert the inline read is gone.
+_FOLDED_SETTER_GETTER: tuple[tuple[str, str], ...] = (
+    ("set_cw_pitch", "get_cw_pitch"),
+    ("set_key_speed", "get_key_speed"),
+    ("set_break_in", "get_break_in"),
+    ("set_scope_during_tx", "get_scope_during_tx"),
+    ("set_scope_center_type", "get_scope_center_type"),
+    ("set_scope_edge", "get_scope_edge"),
+    ("set_scope_vbw", "get_scope_vbw"),
+    ("set_scope_dual", "get_scope_dual"),
+    ("set_scope_mode", "get_scope_mode"),
+    ("set_scope_span", "get_scope_span"),
+    ("set_scope_speed", "get_scope_speed"),
+    ("set_scope_ref", "get_scope_ref"),
+    ("set_scope_hold", "get_scope_hold"),
+)
+_FOLDED_SETTERS: tuple[str, ...] = tuple(setter for setter, _ in _FOLDED_SETTER_GETTER)
+_FOLDED_GETTERS: tuple[str, ...] = tuple(getter for _, getter in _FOLDED_SETTER_GETTER)
+
+
 def test_mocked_setters_exist_on_the_real_backend() -> None:
-    """A renamed backend setter must not survive as a silent mock attribute."""
+    """A renamed backend method must not survive as a silent mock attribute."""
     from rigplane.runtime.radio import IcomRadio
 
     missing = [
-        name for name in (*_SETTERS, *_IC7300_SETTERS) if not hasattr(IcomRadio, name)
+        name
+        for name in (
+            *_SETTERS,
+            *_IC7300_SETTERS,
+            *_FOLDED_SETTERS,
+            *_FOLDED_GETTERS,
+        )
+        if not hasattr(IcomRadio, name)
     ]
     assert missing == []
 
@@ -433,6 +485,7 @@ def _poller(
     model: str = "IC-7300",
     *,
     setters: tuple[str, ...] = _SETTERS,
+    getters: tuple[str, ...] = (),
     capabilities: frozenset[str] = frozenset({CAP_NOTCH, CAP_FILTER_SHAPE}),
 ) -> tuple[RadioPoller, AcquisitionScheduler]:
     profile = resolve_radio_profile(model=model)
@@ -444,6 +497,12 @@ def _poller(
     radio._radio_state = SimpleNamespace(active="MAIN")
     for setter in setters:
         setattr(radio, setter, AsyncMock())
+    # Explicit AsyncMocks, not MagicMock's auto-attributes: an awaited
+    # MagicMock() result raises TypeError, which the deleted confirm helpers
+    # swallowed -- so a bare MagicMock getter would let a surviving inline
+    # read pass as "not called".
+    for getter in getters:
+        setattr(radio, getter, AsyncMock(return_value=0))
     scheduler = AcquisitionScheduler(profile=profile.state_acquisition)
     radio._acquisition_scheduler = scheduler
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
@@ -606,6 +665,154 @@ async def test_ic7300_family_dispatch_requests_exactly_one_user_readback(
 
     assert _readback_paths(scheduler) == {FieldPath.parse(path)}
     assert _readback_priorities(scheduler) == {AcquisitionPriority.USER}
+
+
+# ---------------------------------------------------------------------------
+# MOR-2425 PR-3: the two bespoke confirms, folded into the one path
+# ---------------------------------------------------------------------------
+
+
+_FOLDED_FAMILY: tuple[tuple[Any, str], ...] = (
+    (SetCwPitch(value=650), "global.operator_controls.cw_pitch"),
+    (SetKeySpeed(speed=24), "global.operator_controls.key_speed"),
+    (SetBreakIn(mode=1), "global.operator_controls.break_in"),
+    (SetScopeDuringTx(on=True), "scope_controls.global.display.during_tx"),
+    (
+        SetScopeCenterType(center_type=1),
+        "scope_controls.global.display.center_type",
+    ),
+    (SetScopeEdge(edge=2), "scope_controls.global.display.edge"),
+    (SetScopeVbw(narrow=True), "scope_controls.global.display.vbw_narrow"),
+    (SetScopeDual(dual=True), "scope_controls.global.display.dual"),
+    (SetScopeMode(mode=1), "scope_controls.global.display.mode"),
+    (SetScopeSpan(span=6), "scope_controls.global.display.span"),
+    (SetScopeSpeed(speed=2), "scope_controls.global.display.speed"),
+    (SetScopeRef(ref=5), "scope_controls.global.display.ref_db"),
+    (SetScopeHold(on=True), "scope_controls.global.display.hold"),
+)
+
+_FOLDED_CAPABILITIES = frozenset({CAP_CW, CAP_BREAK_IN, CAP_SCOPE})
+
+
+@pytest.mark.parametrize(
+    ("command", "path"),
+    _FOLDED_FAMILY,
+    ids=[type(c).__name__ for c, _ in _FOLDED_FAMILY],
+)
+@pytest.mark.asyncio
+async def test_folded_family_dispatch_requests_exactly_one_user_readback(
+    command: Any, path: str
+) -> None:
+    """One scheduler readback, the right path, USER -- and no inline GET.
+
+    The CW keyer trio used to await ``RadioPoller._confirm_global_operator_write``'s
+    direct backend getter and these ten scope leaves
+    ``RadioPoller._reconfirm_scope_field``'s. Both are gone from these arms:
+    the getters must not be awaited during ``_execute``.
+    """
+    poller, scheduler = _poller(
+        setters=_FOLDED_SETTERS,
+        getters=_FOLDED_GETTERS,
+        capabilities=_FOLDED_CAPABILITIES,
+    )
+
+    await poller._execute(command)  # noqa: SLF001
+
+    assert _readback_paths(scheduler) == {FieldPath.parse(path)}
+    assert _readback_priorities(scheduler) == {AcquisitionPriority.USER}
+    awaited = [
+        getter
+        for getter in _FOLDED_GETTERS
+        if getattr(poller._radio, getter).await_count  # noqa: SLF001
+    ]
+    assert awaited == []
+
+
+@pytest.mark.parametrize(
+    ("command", "path"),
+    _FOLDED_FAMILY,
+    ids=[type(c).__name__ for c, _ in _FOLDED_FAMILY],
+)
+@pytest.mark.asyncio
+async def test_folded_family_queues_the_written_path_exactly_once(
+    command: Any, path: str
+) -> None:
+    """The written path appears once across every queued request.
+
+    Guards the double-read the PR-1b review found: a second, scheduler-queued
+    ``ensure_fresh`` alongside an inline confirm for the same field.
+    """
+    poller, scheduler = _poller(
+        setters=_FOLDED_SETTERS,
+        getters=_FOLDED_GETTERS,
+        capabilities=_FOLDED_CAPABILITIES,
+    )
+
+    await poller._execute(command)  # noqa: SLF001
+
+    queued = [
+        queued_path
+        for request in scheduler.pending_requests()
+        for queued_path in request.paths
+    ]
+    assert queued == [FieldPath.parse(path)]
+
+
+@pytest.mark.asyncio
+async def test_cw_pitch_readback_applies_the_value_the_radio_reports() -> None:
+    """A mismatched readback now lands in the store.
+
+    ``_confirm_global_operator_write`` compared the readback against the
+    requested value and discarded anything else, so the store kept its
+    pre-write value. The generic path applies whatever the radio reports --
+    that is the assertion that discriminates here, and it fails if the
+    reported value is taken to be the requested one.
+
+    The lifecycle assertion below is a guard, not a discriminator: nothing
+    confirms ``SetCwPitch`` today either way, because ``set_cw_pitch``
+    carries its value under ``value`` while the field is named ``cw_pitch``,
+    so ``CommandService._record_intent_overlay`` finds no value for the path
+    and records no pending overlay.
+    """
+    path = FieldPath.parse("global.operator_controls.cw_pitch")
+    poller, scheduler = _poller(
+        setters=_FOLDED_SETTERS,
+        getters=_FOLDED_GETTERS,
+        capabilities=_FOLDED_CAPABILITIES,
+    )
+    store = poller._state_store  # noqa: SLF001
+    generation = store.begin_provider_generation()
+    store.apply(
+        Observation(
+            path=path,
+            value=600,
+            source=SourceMetadata(source="poll_response", provider="test"),
+            timestamp_monotonic=time.monotonic(),
+            provider_generation=generation,
+        )
+    )
+    command_service = CommandService(executor=_NoopCommandExecutor(), state_store=store)
+
+    await poller._execute(SetCwPitch(value=600))  # noqa: SLF001
+
+    assert _readback_paths(scheduler) == {path}
+    # The radio answers 650, not the 600 that was asked for.
+    command_service.apply_observation(
+        Observation(
+            path=path,
+            value=650,
+            source=SourceMetadata(source="poll_response", provider="test"),
+            timestamp_monotonic=time.monotonic(),
+            provider_generation=generation,
+        )
+    )
+
+    assert store.snapshot().field(path).value == 650
+    assert [
+        event.state
+        for event in command_service.lifecycle_events()
+        if event.state in ("confirmed", "reconciled")
+    ] == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_post_write_readback_one_path.py
+++ b/tests/test_post_write_readback_one_path.py
@@ -770,10 +770,9 @@ async def test_cw_pitch_readback_applies_the_value_the_radio_reports() -> None:
     the reported value.
 
     The lifecycle assertion below is a guard, not a discriminator: nothing
-    confirms ``SetCwPitch`` today either way, because ``set_cw_pitch`` has no
-    command descriptor (``command_dispatch.py: command_descriptor`` returns
-    ``None``), so no scoped ``CommandIntent`` -- and hence no pending
-    overlay -- is ever built for it.
+    confirms ``SetCwPitch`` today either way (no confirmed or reconciled
+    event is emitted whether the radio reports the requested value or
+    another one).
     """
     path = FieldPath.parse("global.operator_controls.cw_pitch")
     poller, scheduler = _poller(

--- a/tests/test_post_write_readback_one_path.py
+++ b/tests/test_post_write_readback_one_path.py
@@ -764,15 +764,16 @@ async def test_cw_pitch_readback_applies_the_value_the_radio_reports() -> None:
 
     ``_confirm_global_operator_write`` compared the readback against the
     requested value and discarded anything else, so the store kept its
-    pre-write value. The generic path applies whatever the radio reports --
-    that is the assertion that discriminates here, and it fails if the
-    reported value is taken to be the requested one.
+    pre-write value. The generic path applies whatever the radio reports.
+    The readback-path assertion is what discriminates a reinstated bespoke
+    confirm; the store-value assertion pins what the generic path does with
+    the reported value.
 
     The lifecycle assertion below is a guard, not a discriminator: nothing
-    confirms ``SetCwPitch`` today either way, because ``set_cw_pitch``
-    carries its value under ``value`` while the field is named ``cw_pitch``,
-    so ``CommandService._record_intent_overlay`` finds no value for the path
-    and records no pending overlay.
+    confirms ``SetCwPitch`` today either way, because ``set_cw_pitch`` has no
+    command descriptor (``command_dispatch.py: command_descriptor`` returns
+    ``None``), so no scoped ``CommandIntent`` -- and hence no pending
+    overlay -- is ever built for it.
     """
     path = FieldPath.parse("global.operator_controls.cw_pitch")
     poller, scheduler = _poller(

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -1525,7 +1525,7 @@ async def test_execute_failed_set_break_in_delay_does_not_queue_readback() -> No
 
 
 @pytest.mark.parametrize(
-    ("cmd", "field", "expected", "previous"),
+    ("cmd", "field", "written", "previous"),
     (
         (SetCwPitch(650), "cw_pitch", 650, 600),
         (SetKeySpeed(24), "key_speed", 24, 20),
@@ -1535,97 +1535,33 @@ async def test_execute_failed_set_break_in_delay_does_not_queue_readback() -> No
     ids=("cw-pitch", "key-speed", "break-in-semi", "break-in-full"),
 )
 @pytest.mark.asyncio
-async def test_cw_operator_write_requires_matching_radio_readback(
-    cmd: Any, field: str, expected: int, previous: int
+async def test_cw_operator_write_mirrors_and_leaves_no_inline_readback(
+    cmd: Any, field: str, written: int, previous: int
 ) -> None:
-    path = FieldPath.global_("operator_controls", field)
+    """MOR-2425 PR-3: the trio's readback moved to the scheduler path.
+
+    ``RadioPoller._confirm_global_operator_write`` — a direct getter whose
+    result was applied only when it equalled the requested value — is gone.
+    The arm keeps the optimistic ``RadioState`` mirror, which
+    ``web/handlers/control.py``'s ``cw_auto_tune`` reads; the confirmed value
+    now arrives as an ordinary observation.
+    """
     store = StateStore()
     store.begin_provider_generation()
     state = RadioState()
     setattr(state, field, previous)
     radio = _make_radio(model="IC-7300")
     setter = AsyncMock()
-    getter = AsyncMock(return_value=expected)
+    getter = AsyncMock(return_value=written)
     setattr(radio, f"set_{field}", setter)
     setattr(radio, f"get_{field}", getter)
     poller = RadioPoller(radio, CommandQueue(), radio_state=state, state_store=store)
 
     await poller._execute(cmd, command_id="cw-write-1")  # noqa: SLF001
 
-    setter.assert_awaited_once_with(expected)
-    getter.assert_awaited_once_with()
-    confirmed = store.snapshot().field(path)
-    assert (confirmed.value, confirmed.source.native_id) == (
-        expected,
-        f"{field}_readback",
-    )
-    assert getattr(state, field) == expected
-
-
-@pytest.mark.parametrize(
-    "outcome", ("failure", "timeout", "mismatch", "stale", "new-generation")
-)
-@pytest.mark.asyncio
-async def test_cw_operator_unconfirmed_write_preserves_radio_truth(
-    outcome: str,
-) -> None:
-    cmd, field, expected, previous = SetCwPitch(650), "cw_pitch", 650, 600
-    path = FieldPath.global_("operator_controls", field)
-    store = StateStore()
-    generation = store.begin_provider_generation()
-
-    def seed(value: int, provider_generation: int) -> None:
-        store.apply(
-            Observation(
-                path=path,
-                value=value,
-                source=SourceMetadata(source="poll_response", provider="test"),
-                timestamp_monotonic=time.monotonic(),
-                provider_generation=provider_generation,
-            )
-        )
-
-    seed(previous, generation)
-    before = store.snapshot().field(path)
-    state = RadioState()
-    setattr(state, field, previous)
-    radio = _make_radio(model="IC-7300")
-    setter = AsyncMock()
-
-    async def readback() -> int:
-        if outcome == "failure":
-            raise CommandError("readback failed")
-        if outcome == "timeout":
-            await asyncio.Event().wait()
-        if outcome == "mismatch":
-            return expected + 1
-        if outcome == "new-generation":
-            seed(previous, store.begin_provider_generation())
-        return expected
-
-    getter = AsyncMock(side_effect=readback)
-    setattr(radio, f"set_{field}", setter)
-    setattr(radio, f"get_{field}", getter)
-    poller = RadioPoller(radio, CommandQueue(), radio_state=state, state_store=store)
-    if outcome == "stale":
-        poller._provider_generation = MagicMock(  # type: ignore[method-assign] # noqa: SLF001
-            side_effect=(generation, generation + 1)
-        )
-
-    with patch("rigplane.web.radio_poller._SEND_TIMEOUT", 0.001):
-        await poller._execute(cmd)  # noqa: SLF001
-
-    setter.assert_awaited_once_with(expected)
-    getter.assert_awaited_once_with()
-    after = store.snapshot().field(path)
-    if outcome != "new-generation":
-        assert after == before
-    else:
-        assert (after.value, after.provider_generation) == (
-            previous,
-            store.provider_generation,
-        )
-    assert getattr(state, field) == previous
+    setter.assert_awaited_once_with(written)
+    getter.assert_not_awaited()
+    assert getattr(state, field) == written
 
 
 def test_ic7300_cw_operator_controls_have_paired_readback_routes() -> None:
@@ -3152,58 +3088,51 @@ async def test_execute_set_scope_rbw_updates_state() -> None:
     assert state.scope_controls.rbw == 2
 
 
+# MOR-1446/MOR-1524 gave these ten leaves an inline reconfirm GET so the
+# StateStore observation would refresh after a write; MOR-2425 PR-3 moved that
+# read onto ``RadioPoller._request_post_write_readback``'s scheduler path
+# (witnessed against the real IC-7300 profile in
+# ``tests/test_post_write_readback_one_path.py``). What this file still pins
+# is the arm itself: the setter is awaited, the optimistic
+# ``RadioState.scope_controls`` mirror is written, and no inline GET is left.
+_SCOPE_WRITE_ARMS: tuple[tuple[Any, str, str, Any], ...] = (
+    (SetScopeSpan(span=6), "scope_span", "span", 6),
+    (SetScopeSpeed(speed=2), "scope_speed", "speed", 2),
+    (SetScopeRef(ref=5), "scope_ref", "ref_db", 5.0),
+    (SetScopeMode(mode=1), "scope_mode", "mode", 1),
+    (SetScopeEdge(edge=3), "scope_edge", "edge", 3),
+    (SetScopeHold(on=True), "scope_hold", "hold", True),
+    (SetScopeDual(dual=True), "scope_dual", "dual", True),
+    (SetScopeDuringTx(on=True), "scope_during_tx", "during_tx", True),
+    (SetScopeCenterType(center_type=2), "scope_center_type", "center_type", 2),
+    (SetScopeVbw(narrow=True), "scope_vbw", "vbw_narrow", True),
+)
+
+
+@pytest.mark.parametrize(
+    ("command", "wire", "leaf", "expected"),
+    _SCOPE_WRITE_ARMS,
+    ids=[wire for _, wire, _, _ in _SCOPE_WRITE_ARMS],
+)
 @pytest.mark.asyncio
-async def test_execute_set_scope_span_updates_state_and_reconfirms() -> None:
-    """MOR-1446: a span write must re-GET so the StateStore observation for
-    ``scope_controls.span`` refreshes — otherwise the stale pre-write
-    observation (last confirmed at ``EnableScope`` time) keeps overwriting
-    the fresh optimistic value on every subsequent state snapshot, and the
-    frontend readout desyncs from the radio's real span (MOR-1446 leg 1)."""
+async def test_execute_scope_write_mirrors_and_leaves_no_inline_get(
+    command: Any, wire: str, leaf: str, expected: Any
+) -> None:
     radio = _make_radio()
     state = RadioState()
+    getter = AsyncMock(return_value=0)
+    setattr(radio, f"get_{wire}", getter)
     poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
 
-    await poller._execute(SetScopeSpan(span=6))  # noqa: SLF001
+    await poller._execute(command)  # noqa: SLF001
 
-    radio.set_scope_span.assert_awaited_once_with(6)
-    assert state.scope_controls.span == 6
-    radio.get_scope_span.assert_awaited_once_with()
+    getattr(radio, f"set_{wire}").assert_awaited_once()
+    assert getattr(state.scope_controls, leaf) == expected
+    getter.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_execute_set_scope_speed_updates_state_and_reconfirms() -> None:
-    """MOR-1446 leg 3: SPEED reads as inert without the reconfirm — the
-    dispatch reaches the radio, but the readout never advances past its
-    pre-write reading."""
-    radio = _make_radio()
-    state = RadioState()
-    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
-
-    await poller._execute(SetScopeSpeed(speed=2))  # noqa: SLF001
-
-    radio.set_scope_speed.assert_awaited_once_with(2)
-    assert state.scope_controls.speed == 2
-    radio.get_scope_speed.assert_awaited_once_with()
-
-
-@pytest.mark.asyncio
-async def test_execute_set_scope_ref_updates_state_and_reconfirms() -> None:
-    """MOR-1446 leg 2: REF stays stuck at 0 without the reconfirm — the radio
-    applies the level (waterfall visibly changes) but the readout keeps
-    replaying the stale pre-write observation."""
-    radio = _make_radio()
-    state = RadioState()
-    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
-
-    await poller._execute(SetScopeRef(ref=5))  # noqa: SLF001
-
-    radio.set_scope_ref.assert_awaited_once_with(5)
-    assert state.scope_controls.ref_db == 5.0
-    radio.get_scope_ref.assert_awaited_once_with()
-
-
-@pytest.mark.asyncio
-async def test_execute_set_scope_span_reconfirm_timeout_does_not_raise() -> None:
+async def test_execute_set_scope_rbw_reconfirm_timeout_does_not_raise() -> None:
     """A dropped confirm response (busy scope stream) must not fail the
     command — `_reconfirm_scope_field` bounds and swallows it exactly like
     `_fetch_scope_controls` already does for the same class of getter."""
@@ -3214,114 +3143,13 @@ async def test_execute_set_scope_span_reconfirm_timeout_does_not_raise() -> None
         await asyncio.sleep(10)
         return 0
 
-    radio.get_scope_span = _never_resolves
+    radio.get_scope_rbw = _never_resolves
     poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
 
-    await poller._execute(SetScopeSpan(span=6))  # noqa: SLF001
+    await poller._execute(SetScopeRbw(rbw=2))  # noqa: SLF001
 
-    radio.set_scope_span.assert_awaited_once_with(6)
-    assert state.scope_controls.span == 6
-
-
-@pytest.mark.asyncio
-async def test_execute_set_scope_mode_updates_state_and_reconfirms() -> None:
-    """MOR-1524: SetScopeMode must reconfirm exactly like SPAN/SPEED/REF
-    (MOR-1446) — without the GET the StateStore keeps replaying the stale
-    pre-write mode observation."""
-    radio = _make_radio()
-    state = RadioState()
-    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
-
-    await poller._execute(SetScopeMode(mode=1))  # noqa: SLF001
-
-    radio.set_scope_mode.assert_awaited_once_with(1)
-    assert state.scope_controls.mode == 1
-    radio.get_scope_mode.assert_awaited_once_with()
-
-
-@pytest.mark.asyncio
-async def test_execute_set_scope_edge_updates_state_and_reconfirms() -> None:
-    """MOR-1524: SetScopeEdge must reconfirm — same MOR-1446 desync class."""
-    radio = _make_radio()
-    state = RadioState()
-    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
-
-    await poller._execute(SetScopeEdge(edge=3))  # noqa: SLF001
-
-    radio.set_scope_edge.assert_awaited_once_with(3)
-    assert state.scope_controls.edge == 3
-    radio.get_scope_edge.assert_awaited_once_with()
-
-
-@pytest.mark.asyncio
-async def test_execute_set_scope_hold_updates_state_and_reconfirms() -> None:
-    """MOR-1524: SetScopeHold must reconfirm — same MOR-1446 desync class."""
-    radio = _make_radio()
-    state = RadioState()
-    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
-
-    await poller._execute(SetScopeHold(on=True))  # noqa: SLF001
-
-    radio.set_scope_hold.assert_awaited_once_with(True)
-    assert state.scope_controls.hold is True
-    radio.get_scope_hold.assert_awaited_once_with()
-
-
-@pytest.mark.asyncio
-async def test_execute_set_scope_dual_updates_state_and_reconfirms() -> None:
-    """MOR-1524: SetScopeDual must reconfirm — same MOR-1446 desync class."""
-    radio = _make_radio()
-    state = RadioState()
-    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
-
-    await poller._execute(SetScopeDual(dual=True))  # noqa: SLF001
-
-    radio.set_scope_dual.assert_awaited_once_with(True)
-    assert state.scope_controls.dual is True
-    radio.get_scope_dual.assert_awaited_once_with()
-
-
-@pytest.mark.asyncio
-async def test_execute_set_scope_during_tx_updates_state_and_reconfirms() -> None:
-    """MOR-1524: SetScopeDuringTx must reconfirm — same MOR-1446 desync class."""
-    radio = _make_radio()
-    state = RadioState()
-    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
-
-    await poller._execute(SetScopeDuringTx(on=True))  # noqa: SLF001
-
-    radio.set_scope_during_tx.assert_awaited_once_with(True)
-    assert state.scope_controls.during_tx is True
-    radio.get_scope_during_tx.assert_awaited_once_with()
-
-
-@pytest.mark.asyncio
-async def test_execute_set_scope_center_type_updates_state_and_reconfirms() -> None:
-    """MOR-1524: SetScopeCenterType must reconfirm — same MOR-1446 desync
-    class."""
-    radio = _make_radio()
-    state = RadioState()
-    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
-
-    await poller._execute(SetScopeCenterType(center_type=2))  # noqa: SLF001
-
-    radio.set_scope_center_type.assert_awaited_once_with(2)
-    assert state.scope_controls.center_type == 2
-    radio.get_scope_center_type.assert_awaited_once_with()
-
-
-@pytest.mark.asyncio
-async def test_execute_set_scope_vbw_updates_state_and_reconfirms() -> None:
-    """MOR-1524: SetScopeVbw must reconfirm — same MOR-1446 desync class."""
-    radio = _make_radio()
-    state = RadioState()
-    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
-
-    await poller._execute(SetScopeVbw(narrow=True))  # noqa: SLF001
-
-    radio.set_scope_vbw.assert_awaited_once_with(True)
-    assert state.scope_controls.vbw_narrow is True
-    radio.get_scope_vbw.assert_awaited_once_with()
+    radio.set_scope_rbw.assert_awaited_once_with(2)
+    assert state.scope_controls.rbw == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Owner ruling R39/R42: after every user command the core reads back the field it
set, through ONE path.

## The two bespoke confirms, and what changes

**(a) `RadioPoller._confirm_global_operator_write`** — `SetCwPitch`,
`SetKeySpeed`, `SetBreakIn`. It awaited the backend getter directly, applied the
result **only if it equalled the requested value**, and on
timeout/exception/mismatch/stale-generation logged at debug/warning and applied
nothing. Deleted; all three arms now resolve a target in
`core/command_service.py: _command_target` and reach
`RadioPoller._request_post_write_readback`'s `ensure_fresh(priority=USER)`.

**(b) `RadioPoller._reconfirm_scope_field`** — an inline awaited GET on each
`SetScope*` arm. Ten of the twelve arms are folded onto the same path; the
helper survives for the three callers that could not be (below).

**Behaviour change, stated plainly.** Apply-if-match is gone. The observation
that comes back applies whatever value the radio reports — the truth — and a
value that differs from the request shows up as a field that never matched the
request, not as a refusal. No refusal signal is added here; that is PR-2.

Pinned by `test_cw_pitch_readback_applies_the_value_the_radio_reports`: after
`SetCwPitch(600)` with the readback carrying 650, the store holds 650. Where
`_confirm_global_operator_write` left the store at its pre-write value. The
test's lifecycle assertion is a guard, not a discriminator, and its docstring
says so: nothing confirms `SetCwPitch` today either way.

## Three arms that could not be folded, with evidence

- **`SetScopeRbw`** — of the profiles in `rigs/`, only `ic7610.toml` declares
  `scope_controls.global.display.rbw` in `[state_acquisition.capabilities]`.
  Measured on the real IC-7300 profile: `AcquisitionScheduler.ensure_fresh`
  answers `unavailable` and queues nothing. (`ic7300.toml` also declares no
  `get_scope_rbw`/`set_scope_rbw` in `[commands]` — grepped both files.)
- **`SetScopeFixedEdge`** — the shared acquisition resolver
  (`runtime/_state_queries.py: acquisition_query_resolver_for_profile`) builds
  `commands/scope.py: get_scope_fixed_edge` with its `range_index=1, edge=1`
  defaults. Measured: the resolved query for that leaf on IC-7300 is
  `0x27 0x1E` with data `0101` — the slot-less bare re-read the arm's own
  MOR-662 comment says returns an unrelated slot's data. The arm's inline
  reconfirm re-reads the slot the SET just wrote.
- **`SwitchScopeReceiver`** (not a `Set*` arm, so not in the enumeration) — its
  write is gated on `_send_cmd("set_scope_main_sub", …)` returning True
  (MOR-2106), and `ic7300.toml` declares no `set_scope_main_sub` (grepped every
  `rigs/*.toml`: only ic705/ic7610/ic9700 do). `_request_post_write_readback`
  runs after the whole `match`, unconditionally, so folding this arm would read
  back a write the profile refused. Left inline, with that reason at the call
  site.

`SetNbDepth`/`SetNbWidth` carry inline write-through getters of a third shape
(apply whatever comes back, no match check). They stay pending and keep those
getters: `global.operator_controls.nb_depth`/`nb_width` are in neither
`[state_acquisition.capabilities]` list on `ic7300.toml`, and `ensure_fresh`
answers `unavailable` for both — measured on the real profile. Folding them
would have removed their only readback.

## The scope-stream question

`_reconfirm_scope_field`'s docstring claimed scope leaves are fetched once at
`EnableScope` time and never touched by the poll loop. That is false at this
head and the sentence is deleted: `ic7300.toml` lists twelve
`scope_controls.global.display.*` leaves under `polling_only` with a 30 s
cadence, and `AcquisitionScheduler.due_requests` on the real IC-7300 profile
returns all twelve (measured).

Does a USER-priority scheduler request interleave with the 0x27 waveform stream
differently from the inline GET? What I found:

- **Same one frame, same command/sub.** The resolver's query for each folded
  leaf is a single `0x27 <sub>` frame — `during_tx 0x1B`, `center_type 0x1C`,
  `edge 0x16`, `vbw_narrow 0x1D`, `dual 0x13`, `mode 0x14`, `span 0x15`,
  `speed 0x1A`, `ref_db 0x19`, `hold 0x17` — built from the same
  `_SCOPE_CONTROL_GETTERS` names the inline getters use.
- **Same inbound handling.** `runtime/_civ_rx.py: CivRuntime._route_civ_frame`
  short-circuits `0x27 sub==0x00` (waveform chunks) before anything else; a
  `0x27` reply with a non-zero sub reaches `_observations_from_frame` →
  `_scope_control_observations` either way. The reply path does not distinguish
  the two callers.
- **What actually changes is the outbound timing.** `ensure_fresh` is
  fire-and-queue (its own docstring: "nothing here awaits it"); the frame goes
  out on the next `AcquisitionDrain.run_once()` from `RadioPoller._send_query`.
  `_run` waits at most `_FAST_INTERVAL_SERIAL = 0.100` s between passes on a
  serial profile, and IC-7300 is serial (`profile.has_lan` is False). The inline
  GET went out immediately and blocked the command-queue drain for up to
  `_SCOPE_GETTER_TIMEOUT = 0.2` s.

So: no new mechanism, no extra frame, and the command queue no longer stalls on
a dropped scope reply.

**One difference worth a reviewer's attention, not fixed here.** For the
receiver-selectable scope subs the resolver prepends
`commands/scope.py: SCOPE_SELECTOR_MAIN` (`0x00`), while the inline getter used
`self._scope_controls().receiver`. On a dual-receiver profile with the scope on
SUB, the folded readback reads MAIN's leaf. This is not new — the 30 s cadence
already reads MAIN through the same resolver — and the
`scope_controls.global.display.*` paths carry no `receiver_id`, so the state
model has one slot for these regardless. IC-7300 is single-receiver
(`receiver_count == 1`), so the live bench is unaffected. I did not change it.

## Coverage before/after

Counting rule, unchanged: the enumeration test AST-parses every `case Set*` arm
in `RadioPoller._execute`'s `match cmd:`; each lands in exactly one of
`LEGACY_COMMAND_NAMES` (covered), `_NO_OBSERVABLE_FIELD`, `_PENDING_LATER_PR`,
asserted disjoint and exhaustive by
`test_every_set_command_arm_is_classified`. Re-derived at this head by importing
the test module and `LEGACY_COMMAND_NAMES`, not carried forward:

| | before (`a37afea4`) | after |
|---|---|---|
| total arms | 98 | 98 |
| covered | 42 | 55 (+13) |
| no field | 15 | 15 |
| pending | 41 | 28 (−13) |

98 = 55 + 15 + 28.

## Deletions

- `RadioPoller._confirm_global_operator_write` (40 lines) and its three call
  sites. No other caller — grepped `src/` and `tests/`.
- The `typing.Awaitable` import, now unused.
- The ten inline `_reconfirm_scope_field` calls.
- `_reconfirm_scope_field`'s "fetched once at `EnableScope` time and never
  touched again by the main poll loop" claim (false, see above). The helper
  itself is kept for its three remaining callers.
- `test_cw_operator_unconfirmed_write_preserves_radio_truth` — it pinned
  apply-if-match, the behaviour this PR removes.

## Mutations run

Applied one at a time; `git diff --stat` confirmed the tree matched pre-mutation
before the final suite run.

1. Reinstated the inline `_reconfirm_scope_field` on `SetScopeSpan` →
   `test_folded_family_dispatch_requests_exactly_one_user_readback[SetScopeSpan]`
   and `test_execute_scope_write_mirrors_and_leaves_no_inline_get[scope_span]`
   fail; 318 pass.
2. Removed `SetScopeSpan` from `LEGACY_COMMAND_NAMES` →
   `test_every_set_command_arm_is_classified` plus both `[SetScopeSpan]`
   witnesses fail; 317 pass.
3. Made the mismatch pin's readback carry the requested 600 instead of 650 →
   `test_cw_pitch_readback_applies_the_value_the_radio_reports` fails with
   `assert 600 == 650`. The store-value assertion is the discriminator; the
   lifecycle assertion is not, and the test says so.

The witness getters are explicit `AsyncMock`s, not `MagicMock` auto-attributes:
an awaited `MagicMock()` result raises `TypeError`, which both deleted confirm
helpers swallowed, so a bare `MagicMock` getter would let a surviving inline
read pass as "not called".

## Gates (local, at this head)

- `uv run pytest` over the 74 files matching
  `radio_poller|_request_post_write_readback|expected_observations|command_service|_poller_types|_confirm_global_operator_write|_reconfirm_scope_field`
  as one run — **4335 passed, 2 skipped**.
- `uv run ruff check src/ tests/` — clean.
- `uv run ruff format --check src/ tests/` — 742 files already formatted.
- `uv run lint-imports` — 5 contracts kept, 0 broken.
- `uv run mypy --strict src/rigplane/web` — no issues in 27 source files.

## Guardrails

`git diff --numstat origin/main...HEAD` at the pushed head: **5 files, 759
changed lines** (385 insertions + 374 deletions) — `command_service.py` 43,
`_poller_types.py` 15, `radio_poller.py` 148,
`test_post_write_readback_one_path.py` 275, `test_radio_poller_coverage.py` 278.
Under the 6-file soft threshold and the 10-file / 1000-line hard ceiling; over
the 600-line soft threshold.

Why this is one unit of work: deleting `_confirm_global_operator_write` and
folding the scope arms are the same edit seen from two sides — both remove a
bespoke confirm in favour of the one target table, and the enumeration test's
partition has to move in the same commit or it stops being exhaustive. 553 of
the 759 lines are tests, and 260 of those are deletions — 225 of them in
`test_radio_poller_coverage.py`, where the tests that pinned the old inline
reads had to go with them.

## Census

`readback-census-20260908.md` §B named the three confirmation mechanisms and
recorded that (2) — the CW trio's direct getter with silent discard on
mismatch/timeout — was the only one it could call verified, and that (1), the
scheduler path, never awaits the read. This PR moves (2) onto (1). The census's
`_POST_WRITE_READBACK_FIELDS` deletion happened in PR-1; the refusal signal it
also asked for is PR-2 and is not in this change.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

