### PR TITLE
fix: render no filter-width slider where the profile declares fixed widths

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -1219,6 +1219,14 @@ describe('MOR-2374 shared DATA and filter configuration', () => {
     ], fixed: resolved.fixed, minHz: resolved.minHz, maxHz: resolved.maxHz, stepHz: resolved.stepHz,
     segments: resolved.segments, table: resolved.table } : null);
   });
+  it('projects fixed = true for a defaults-only fixed configuration', () => {
+    const c = dataCaps({ filterConfig: { FM: { defaults: [15000, 10000, 7000], fixed: true } } });
+    const s = state(); s.main.mode = 'FM'; s.main.dataMode = 0;
+    const projected = toRadioViewModel(s, c)!.modeFilter!.activeFilterConfiguration!;
+    expect(projected.fixed).toBe(true);
+    expect(projected.table).toEqual([]);
+    expect(projected.minHz).toBeNull();
+  });
   it('copies nested configuration and never fills missing defaults from current width', () => {
     const c = dataCaps({ filterConfig: { USB: structuredClone(config) } });
     const s = state(); s.main.filterWidth = 999;

--- a/frontend/src/semantic/FilterSurface.svelte
+++ b/frontend/src/semantic/FilterSurface.svelte
@@ -108,6 +108,7 @@
 
   let modeFilter = $derived(view.modeFilter);
   let filterPassband = $derived(view.filterPassband);
+  let fixedWidth = $derived(modeFilter?.activeFilterConfiguration?.fixed === true);
 
   function filterWidthInput(): Readonly<ContinuousScalarInput> {
     const field = modeFilter?.filterWidth;
@@ -213,16 +214,18 @@
       {#if modeFilter.filterWidth.availability.structural}
         <label class="filter-level" data-testid="filter-width" data-disabled-reason={reasonOf(modeFilter.filterWidth)}>
           <span class="filter-level-name">Width</span>
-          <input
-            type="range"
-            {...feedbackIntegratedRange}
-            min={numberOf(modeFilter.filterWidthMin, 50)} max={numberOf(modeFilter.filterWidthMax, 9999)} step={50}
-            value={filterWidthView.displayed ?? numberOf(modeFilter.filterWidth, 0)}
-            disabled={!filterWidthView.editable}
-            data-command-phase={filterWidthView.phase ?? undefined}
-            aria-busy={filterWidthView.busy}
-            oninput={(event) => filterWidthLease?.nativeInput(event.currentTarget.valueAsNumber)}
-          />
+          {#if !fixedWidth}
+            <input
+              type="range"
+              {...feedbackIntegratedRange}
+              min={numberOf(modeFilter.filterWidthMin, 50)} max={numberOf(modeFilter.filterWidthMax, 9999)} step={50}
+              value={filterWidthView.displayed ?? numberOf(modeFilter.filterWidth, 0)}
+              disabled={!filterWidthView.editable}
+              data-command-phase={filterWidthView.phase ?? undefined}
+              aria-busy={filterWidthView.busy}
+              oninput={(event) => filterWidthLease?.nativeInput(event.currentTarget.valueAsNumber)}
+            />
+          {/if}
           <output>{textOf(modeFilter.filterWidth)}</output>
           {#if filterWidthAnnouncement !== null}
             {#key filterWidthAnnouncement.eventKey}

--- a/frontend/src/semantic/__tests__/FilterSurface.test.ts
+++ b/frontend/src/semantic/__tests__/FilterSurface.test.ts
@@ -20,7 +20,8 @@ import FilterInstrumentHostFixture from './fixtures/FilterInstrumentHostFixture.
 import { topologyFixtures, withFilterPassband, withModeFilter } from '../fixtures/topologies';
 import { FILTER_SHAPES, type FilterInstrumentHandles } from '../filter-instruments';
 import type {
-  Availability, FilterPassbandViewModel, ModeFilterViewModel, RadioViewModel,
+  ActiveFilterConfiguration, Availability, FilterPassbandViewModel, ModeFilterViewModel,
+  RadioViewModel,
 } from '../radio-view-model';
 import type { CommandScalarFeedback } from '../../primitives/scalar/continuous-scalar.svelte';
 
@@ -977,6 +978,53 @@ describe('filterWidth and its bounds carry independent availability', () => {
     withSurface(view, (s) => {
       expect(s.input('filter-width')!.min).toBe('50');
       expect(s.input('filter-width')!.max).toBe('9999');
+    });
+  });
+});
+
+// ── 6b. a fixed-width mode gets no width slider ─────────────────────────────
+
+describe('a fixed-width configuration hides the width slider', () => {
+  const configured = (fixed: boolean): RadioViewModel => {
+    const view = base();
+    const activeFilterConfiguration: ActiveFilterConfiguration = {
+      slots: [15000, 10000, 7000].map((factoryWidthHz, i) =>
+        ({ filter: i + 1, label: `FIL${i + 1}`, factoryWidthHz })),
+      fixed, minHz: null, maxHz: null, stepHz: null, segments: [], table: [],
+    };
+    return { ...view, modeFilter: { ...view.modeFilter!, activeFilterConfiguration } };
+  };
+
+  it('renders no width range input and keeps the width readout', () => {
+    withSurface(configured(true), (s) => {
+      expect(s.group('filter-width')).not.toBeNull();
+      expect(s.input('filter-width')).toBeNull();
+      expect(s.output('filter-width')!.textContent).toBe('2400');
+      expect(s.group('filter-width')!.querySelector('.filter-level-name')!.textContent).toBe('Width');
+    });
+  });
+
+  it('leaves every other filter control untouched', () => {
+    withSurface(configured(true), (s) => {
+      for (const testId of ['filter-mode', 'filter-select', 'filter-shape', 'filter-data-mode']) {
+        expect(s.group(testId)).not.toBeNull();
+      }
+      for (const field of ['ifShift', 'pbtInner', 'pbtOuter']) {
+        expect(s.group(`filter-${field}`)).not.toBeNull();
+        expect(s.input(`filter-${field}`)).not.toBeNull();
+      }
+      expect(s.group('filter-pbt-reset')).not.toBeNull();
+    });
+  });
+
+  it('renders the width range input for a non-fixed configuration', () => {
+    withSurface(configured(false), (s) => {
+      const input = s.input('filter-width')!;
+      expect(input.type).toBe('range');
+      expect(input.min).toBe('50');
+      expect(input.max).toBe('3600');
+      expect(input.disabled).toBe(false);
+      expect(s.output('filter-width')!.textContent).toBe('2400');
     });
   });
 });


### PR DESCRIPTION
## What

`FilterSurface.svelte` renders the filter-width `<input type="range">` whenever
`modeFilter.filterWidth.availability.structural` is true. It never read
`activeFilterConfiguration`. This commit gates that input on the `fixed` flag
the adapter already projects; the width readout (`<output>`) and every other
filter control are unchanged.

## Why

Some modes have no continuous filter width on the radio at all. In
`rigs/ic7300.toml`, `[filters.width.FM]` declares `fixed = true` with
`defaults = [15000, 10000, 7000]` and no `segments`, `table`, `min_hz` or
`max_hz`. In `rigs/ftx1.toml`, `[filters.width.AM]` and `[filters.width.FM]`
each declare `fixed = true` with a one-entry `table`. For IC-7300 FM the
surface was offering a 50–9999 Hz slider.

The boolean was already available: `radio-view-model.ts`'s
`ActiveFilterConfiguration.fixed`, computed in
`radio-view-model-adapter.ts`'s `deriveModeFilter` via
`copyFilterConfiguration`. It is reachable from the surface's existing `view`
prop as `view.modeFilter.activeFilterConfiguration`, so nothing needed
threading and no new store, subscription or abstraction was added.

## Tests

Test-first. `FilterSurface.test.ts` gains a `describe` with three cases:

- fixed configuration renders no width range input, keeps the width readout
  and the "Width" label;
- fixed configuration leaves mode, filter choice, shape, DATA, all three
  passband rows and the PBT reset button present, with their inputs intact;
- non-fixed configuration renders the range input as before (`type=range`,
  `min=50`, `max=3600`, enabled).

`radio-view-model-adapter.test.ts` gains one isolated row for the IC-7300 FM
shape (a `defaults`-only, `fixed: true` entry) asserting
`activeFilterConfiguration.fixed === true`. Grepped first: no existing row
asserted `fixed === true`. That row passed before the surface fix, confirming
the defect was in the surface only.

Before the fix: `1 failed | 250 passed (251)` across the two files.
After the fix: `251 passed (251)`.

**Mutation.** Removing the `{#if !fixedWidth}` guard from
`FilterSurface.svelte` and running the new `describe`: `1 failed | 2 passed`.
The killed case is "renders no width range input and keeps the width readout".
The non-fixed case passed, as it must. The "leaves every other filter control
untouched" case also passed under the mutation — it is a companion assertion
that nothing else moved, not a killer. The tree was restored before the final
run and `git diff` shows only the intended change.

Also run, as collateral checks on files that mount `FilterSurface`:
`semantic-tx-aux-wiring`, `semantic-discrete-pending-wiring`,
`freshness-invisibility`, `semantic-vfo-indicator-wiring`, `disabled-reason`,
`filter-declarability` — `6 passed (149 tests)`.

## Fixtures and visual baselines

No baseline needs re-pinning. `filterConfig` appears nowhere under
`frontend/fixtures/`, `frontend/tests/` or `frontend/component-kit-api/`, so
`resolveFilterModeConfig` returns `null` for every harness scene and
`activeFilterConfiguration` is `null` throughout; the only receiver modes in
`frontend/fixtures/catalog.ts` are USB and CW. No capture or visual-baseline
scene renders `FilterSurface` in a fixed mode.

## Gates

- `npx vitest run` on the two named files — 251 passed
- `npm run lint` — clean
- `npm run i18n:check` — OK (3 locale files, 279 source keys)
- `npm run check` — 4841 files, 0 errors, 0 warnings
- `npm run build` — built

## Census

`git diff --numstat origin/main...HEAD`, re-derived at the pushed head:
**3 files, 70+/11- = 81 changed lines.** Under both the soft threshold and the
hard ceiling.

Internal-identifier self-check — empty.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

