### PR TITLE
fix: end the pending marker on the commanded field's read-back

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/semantic-discrete-pending-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-discrete-pending-wiring.component.test.ts
@@ -76,6 +76,21 @@ const fresh = {
 };
 
 /**
+ * One field's own observation marker advanced — `lastObservedMonotonic`
+ * (`runtime_helpers.py: _observed_field_status`), the per-field "the radio
+ * answered for THIS field" signal. Every fixture below starts from
+ * `fresh`'s marker of 1, so any value above it is a post-ack re-read of
+ * that one field.
+ */
+function observedAgain(base: ServerState, path: string, marker: number): ServerState {
+  return {
+    ...base,
+    observationSeq: marker, freshnessRevision: marker,
+    fieldStatus: { ...base.fieldStatus, [path]: { ...fresh, lastObservedMonotonic: marker } },
+  } as unknown as ServerState;
+}
+
+/**
  * Single-receiver (IC-7300/FTX-1-shaped) fixture — the live-bench topology
  * the MOR-1488 symptom was reported against — with filter, preamp and nb/nr
  * all evidenced, so `FilterSurface`/`RfFrontEndSurface`/`DspSurface` all
@@ -127,32 +142,21 @@ function liveState(): ServerState {
  */
 function nbConfirmedState(): ServerState {
   const base = liveState();
-  return {
+  return observedAgain({
     ...base,
-    revision: 2, stateRevision: 2, freshnessRevision: 2, observationSeq: 2,
+    revision: 2, stateRevision: 2,
     main: { ...base.main, nb: true },
-  } as unknown as ServerState;
+  } as unknown as ServerState, 'main.nb', 2);
 }
 
 /**
- * A non-transitioning observation (MOR-1488 review R2, F2 test-theatre
- * fix; reused for review R3): `liveState()` with `main.nb` left at `false`
- * (unchanged) but `observationSeq`/`freshnessRevision` advanced past the
- * fixture's initial value — `stateRevision`/`revision` deliberately stay
- * put. This is "the radio was freshly re-polled (or an unrelated field's
- * meter poll landed) and nb is still off": no field value moved, so
- * `core.state_store._apply_one` would never bump `stateRevision` for a
- * push like this (it only bumps on `semantic_changed`), but `observationSeq`
- * bumps unconditionally, on every applied observation.
- *
- * Dual role by test: whether this push CONFIRMS or MISMATCHES depends only
- * on what the in-flight command's own target is at each call site — this
- * fixture always reports `nb: false`.
- *   - R2's double-toggle test targets OFF (`false`): this push MATCHES and
- *     is the genuine confirming observation that settles the record.
- *   - R3's tests target ON (`true`, a single click): this push MISMATCHES
- *     — proving a mismatched post-ack push must NOT retire the record (R3's
- *     asymmetric settle), only a matching one or the grace backstop can.
+ * A push that observed something OTHER than `main.nb`: `liveState()` with
+ * `main.nb` left at `false` and every field's own `lastObservedMonotonic`
+ * left at the fixture's initial value, while `observationSeq`/
+ * `freshnessRevision` advance. `core.state_store._apply_one` bumps
+ * `observationSeq` on every applied observation but only touches the
+ * observed field's own marker, so this is the shape of an unrelated meter
+ * poll landing while the commanded field has not been re-read yet.
  */
 function nbReobservedState(): ServerState {
   const base = liveState();
@@ -170,17 +174,17 @@ function nbReobservedState(): ServerState {
  */
 function freqConfirmedState(freqHz: number): ServerState {
   const base = liveState();
-  return {
+  return observedAgain({
     ...base,
-    revision: 2, stateRevision: 2, freshnessRevision: 2, observationSeq: 2,
+    revision: 2, stateRevision: 2,
     main: { ...base.main, freqHz },
-  } as unknown as ServerState;
+  } as unknown as ServerState, 'main.freqHz', 2);
 }
 
 /**
  * Leg-1 sibling of `nbReobservedState`: a post-ack push that advances
- * `observationSeq` (an unrelated meter poll) without confirming `freqHz` —
- * `main.freqHz` stays at the ORIGINAL `liveState()` value.
+ * `observationSeq` (an unrelated meter poll) while `main.freqHz` is neither
+ * re-observed (its own marker stays put) nor changed.
  */
 function freqReobservedState(seq = 2): ServerState {
   const base = liveState();
@@ -268,9 +272,9 @@ describe('discrete pending markers reach the mounted DOM over the real wiring pa
     flushSync();
     expect(on.dataset.pending).toBe('true');
     const receiver = active === 'MAIN' ? 'main' : 'sub';
-    expect(setRadioState({ ...state, revision: 2, stateRevision: 2, freshnessRevision: 2, observationSeq: 2,
+    expect(setRadioState(observedAgain({ ...state, revision: 2, stateRevision: 2,
       [receiver]: { ...state[receiver], dataMode: 1 },
-    })).toBe(true);
+    } as unknown as ServerState, `${receiver}.dataMode`, 2))).toBe(true);
     flushSync();
     expect(on.dataset.pending).toBe('false');
     expect(off.getAttribute('aria-pressed')).toBe('false');
@@ -445,13 +449,12 @@ describe('discrete pending markers reach the mounted DOM over the real wiring pa
   });
 
   /**
-   * MOR-1478 (leg-1 parity with the leg-2 R3 finding above): a post-ack
-   * push that advances `observationSeq` without confirming `freqHz` (an
-   * unrelated meter poll landing before the commanded field's own
-   * round-robin slot) must not clear the marker — that would collapse the
-   * pending window right back to the reported symptom.
+   * A post-ack push that observed a DIFFERENT field (an unrelated meter
+   * poll landing before the commanded field's own read-back) must not clear
+   * the marker — that would collapse the pending window right back to the
+   * MOR-1478 symptom.
    */
-  it('does not clear the VFO frequency marker on a post-ack push that advances observationSeq without confirming the target (MOR-1478)', () => {
+  it('does not clear the VFO frequency marker on a post-ack push that observed another field (MOR-1478)', () => {
     render();
     const freqEl = () => target.querySelector('[data-vfo-receiver="MAIN"] [data-freq-status]') as HTMLElement | null;
 
@@ -465,12 +468,37 @@ describe('discrete pending markers reach the mounted DOM over the real wiring pa
     flushSync();
     expect(freqEl()?.dataset.freqStatus).toBe('pending');
 
-    // A post-ack push arrives (observationSeq advances) but `main.freqHz`
-    // is still the pre-spin value — NOT the commanded target.
-    expect(setRadioState(freqReobservedState())).toBe(true);
+    expect(setRadioState(observedAgain(liveState(), 'main.mode', 2))).toBe(true);
     flushSync();
 
     expect(freqEl()?.dataset.freqStatus).toBe('pending');
+  });
+
+  /**
+   * The read-back the core issues at USER priority for the commanded field
+   * ends the marker on arrival, whatever it reports. Here
+   * `main.freqHz` is re-observed still holding the pre-spin value (the
+   * radio refused the tune) — the marker must end anyway, because the field
+   * now shows what the radio reports.
+   */
+  it('clears the VFO frequency marker when main.freqHz is re-observed after the ack still holding the old value', () => {
+    render();
+    const freqEl = () => target.querySelector('[data-vfo-receiver="MAIN"] [data-freq-status]') as HTMLElement | null;
+
+    dispatchRadioIntent({ name: 'set_freq', params: { freq: 14260000, receiver: 0 } });
+    flushSync();
+    const command = getCommandLifecycles().find(
+      (candidate) => candidate.name === 'set_freq' && candidate.status === 'pending',
+    );
+    expect(command).toBeDefined();
+    acknowledgeCommand(command!.id, command!.originalEpoch, command!.originalEpoch);
+    flushSync();
+    expect(freqEl()?.dataset.freqStatus).toBe('pending');
+
+    expect(setRadioState(observedAgain(liveState(), 'main.freqHz', 2))).toBe(true);
+    flushSync();
+
+    expect(freqEl()?.dataset.freqStatus).toBe('confirmed');
   });
 
   /**
@@ -506,7 +534,7 @@ describe('discrete pending markers reach the mounted DOM over the real wiring pa
       expect(freqEl()?.dataset.freqStatus).toBe('pending');
 
       vi.advanceTimersByTime(501); // now past 3000ms
-      // Still non-confirming (`main.freqHz` stays at the pre-spin value) —
+      // `main.freqHz` was never re-observed (its own marker never moves) —
       // only the elapsed grace window retires it. (seq advances again so the
       // second push is accepted by the store.)
       expect(setRadioState(freqReobservedState(3))).toBe(true);
@@ -552,9 +580,7 @@ describe('discrete pending markers reach the mounted DOM over the real wiring pa
    * confirmed"). This drives the command to 'acknowledged' directly
    * (`acknowledgeCommand`, the same primitive `radio-intents.ts`'s
    * `onCommandDelivery` ack handler calls) WITHOUT changing the confirmed
-   * radio state, and requires the marker to survive that ack — only a
-   * `setRadioState` observation that actually confirms the target
-   * (`main.nb === true`) may clear it.
+   * radio state, and requires the marker to survive that ack.
    */
   it('keeps the NB marker pending across a transport ack until a confirming state observation arrives (MOR-1488)', () => {
     render();
@@ -589,13 +615,11 @@ describe('discrete pending markers reach the mounted DOM over the real wiring pa
    * plain "does the target match the current confirmed reading" comparison
    * (the pre-R2 implementation) would clear the marker the instant OFF
    * acks, even though nothing has actually been re-observed since either
-   * click. This proves the sequence guard blocks exactly that, and that the
-   * FIRST genuine post-ack push (even one that only reconfirms the
-   * already-correct value, never advancing `stateRevision`) is what
-   * actually settles it — the counters `nbConfirmedState()`'s sibling
-   * `nbReobservedState()` bumps are not decorative.
+   * click. This proves that coincidence alone does not settle it, and that
+   * the field's OWN post-ack re-read does — even one that only reconfirms
+   * the already-correct value and never advances `stateRevision`.
    */
-  it('does not clear the marker from a stale pre-ack snapshot on a fast double-toggle, only on the next real push (MOR-1488 review R2, closes F2)', () => {
+  it('does not clear the marker from a stale pre-ack snapshot on a fast double-toggle, only on the field\'s own re-read (MOR-1488 review R2, closes F2)', () => {
     render();
     expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('confirmed');
 
@@ -616,28 +640,21 @@ describe('discrete pending markers reach the mounted DOM over the real wiring pa
     // must NOT clear from that coincidence alone.
     expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('pending');
 
-    // The first real post-ack push, even a non-transitioning reconfirmation.
-    expect(setRadioState(nbReobservedState())).toBe(true);
+    // The field's own post-ack re-read, even a non-transitioning one.
+    expect(setRadioState(observedAgain(liveState(), 'main.nb', 2))).toBe(true);
     flushSync();
 
     expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('confirmed');
   });
 
   /**
-   * MOR-1488 review R3: `observationSeq` bumps on EVERY applied field
-   * observation, not just a re-read of THIS command's field — a 25ms meter
-   * poll advances it exactly as much as the commanded field's own confirming
-   * re-read would, but that confirming re-read is a full poll round-robin
-   * away (~1.3s worst case), not the very next push. R2 settled the record
-   * on the first post-ack push regardless of match, which fired on the next
-   * unrelated meter poll (~50ms after ack) — collapsing the pending window
-   * right back to a few frames, the original bench symptom. `nbReobservedState()`
-   * (defined above, `main.nb` still `false`) doubles here as a stand-in for
-   * exactly that unrelated meter-poll push: it advances `observationSeq` but
-   * does not confirm THIS command's target (`true`). It must not clear the
-   * marker.
+   * `observationSeq` bumps on EVERY applied field observation, not just a
+   * re-read of THIS command's field — a 25ms meter poll advances it exactly
+   * as much as the commanded field's own read-back would. Only the field's
+   * own `lastObservedMonotonic` separates the two, so a push that observed
+   * some other field must leave the marker pending.
    */
-  it('does not clear the marker on a post-ack push that advances observationSeq without confirming the target (MOR-1488 review R3)', () => {
+  it('does not clear the marker on a post-ack push that observed another field (MOR-1488 review R3)', () => {
     render();
     q<HTMLButtonElement>('[data-testid="dsp-nbActive"]')!.click();
     flushSync();
@@ -651,14 +668,36 @@ describe('discrete pending markers reach the mounted DOM over the real wiring pa
     flushSync();
     expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('pending');
 
-    // A post-ack push arrives (observationSeq advances) but `main.nb` is
-    // still `false` — NOT the commanded `true`. Not evidence of failure,
-    // just an observation that has not reached this field's round-robin
-    // slot yet.
-    expect(setRadioState(nbReobservedState())).toBe(true);
+    expect(setRadioState(observedAgain(liveState(), 'main.freqHz', 2))).toBe(true);
     flushSync();
 
     expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('pending');
+  });
+
+  /**
+   * The commanded field's own post-ack observation ends the marker
+   * whatever it reports. `main.nb` is re-observed still `false`
+   * while the click commanded `true` — the radio refused, or has not
+   * applied it — and the operator is shown what the radio reports rather
+   * than a marker that outlives the answer.
+   */
+  it('clears the marker when main.nb is re-observed after the ack still holding the old value', () => {
+    render();
+    q<HTMLButtonElement>('[data-testid="dsp-nbActive"]')!.click();
+    flushSync();
+
+    const command = getCommandLifecycles().find(
+      (candidate) => candidate.name === 'set_nb' && candidate.status === 'pending',
+    );
+    expect(command).toBeDefined();
+    acknowledgeCommand(command!.id, command!.originalEpoch, command!.originalEpoch);
+    flushSync();
+    expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('pending');
+
+    expect(setRadioState(observedAgain(liveState(), 'main.nb', 2))).toBe(true);
+    flushSync();
+
+    expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('confirmed');
   });
 
   /**
@@ -684,9 +723,8 @@ describe('discrete pending markers reach the mounted DOM over the real wiring pa
       expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('pending');
 
       vi.advanceTimersByTime(3_001);
-      // Still non-confirming (`main.nb` stays `false`, target is `true`) —
-      // the sequence guard alone would leave this pending forever; only the
-      // elapsed grace window retires it.
+      // `main.nb` was never re-observed (its own marker never moves), so
+      // only the elapsed grace window retires the marker.
       expect(setRadioState(nbReobservedState())).toBe(true);
       flushSync();
 

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1441-pending-discrete.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1441-pending-discrete.isolated.test.ts
@@ -10,10 +10,10 @@
  * rule (MOR-1488): a terminal-without-further-meaning command (failed,
  * cancelled, timed-out) must never be read as still pending, but a merely
  * `'acknowledged'` one (the transport ack) stays pending until the radio's
- * OWN observed state confirms the target — an ack proves only that the
- * radio received the command, typically milliseconds before the next state
- * poll actually echoes it back, and presenting that ack as confirmation is
- * the exact live-bench fabrication MOR-1488 fixes.
+ * OWN observed state answers for the commanded field — an ack proves only
+ * that the radio received the command, typically milliseconds before the
+ * next state poll actually echoes it back, and presenting that ack as
+ * confirmation is the exact live-bench fabrication MOR-1488 fixes.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -22,11 +22,16 @@ type FakeCommand = {
   status: string;
   createdAt: number;
   params: Record<string, unknown>;
+  updatedAt?: number;
+  ackFieldObservationTimes?: Record<string, number>;
 };
 type FakeReceiverState = Record<string, unknown>;
+type FakeFieldStatus = Record<string, { lastObservedMonotonic?: number }>;
 
 const state: { commands: FakeCommand[] } = { commands: [] };
-const runtimeState: { state: { main: FakeReceiverState; sub: FakeReceiverState } | null } = { state: null };
+const runtimeState: {
+  state: { main: FakeReceiverState; sub: FakeReceiverState; fieldStatus?: FakeFieldStatus } | null;
+} = { state: null };
 
 vi.mock('$lib/stores/commands.svelte', () => ({
   getCommandLifecycles: () => state.commands,
@@ -127,6 +132,43 @@ describe.each(CASES)('$label (MOR-1441 leg 2, MOR-1488)', (
   it('ignores an acknowledged command once the confirmed state matches the target', () => {
     runtimeState.state = { main: { [confirmedField]: value }, sub: {} };
     state.commands = [cmd({ name: intentName, status: 'acknowledged', params: { [paramKey]: value, receiver: 0 } })];
+    expect(accessor(0)).toBeNull();
+  });
+
+  /**
+   * After the write the core re-reads the commanded field at USER
+   * priority, so that field's own observation is what ends the marker —
+   * whatever value it carries. The per-field marker is
+   * `lastObservedMonotonic` (`runtime_helpers.py: _observed_field_status`),
+   * captured at ack into `ackFieldObservationTimes`
+   * (`commands.svelte.ts: transition`).
+   */
+  const fieldPath = `main.${confirmedField}`;
+  const acked = (over: Partial<FakeCommand> = {}): FakeCommand => cmd({
+    name: intentName, status: 'acknowledged', params: { [paramKey]: value, receiver: 0 },
+    ackFieldObservationTimes: { [fieldPath]: 4 }, ...over,
+  });
+
+  it('ends the marker when the commanded field is re-observed after the ack reporting a value other than the target', () => {
+    runtimeState.state = { main: { [confirmedField]: otherValue }, sub: {},
+      fieldStatus: { [fieldPath]: { lastObservedMonotonic: 5 } } };
+    state.commands = [acked()];
+    expect(accessor(0)).toBeNull();
+  });
+
+  it('stays pending when only another field is observed after the ack', () => {
+    runtimeState.state = { main: { [confirmedField]: otherValue }, sub: {},
+      fieldStatus: { [fieldPath]: { lastObservedMonotonic: 4 }, 'main.sMeter': { lastObservedMonotonic: 9 } } };
+    state.commands = [acked()];
+    expect(accessor(0)).toBe(value);
+  });
+
+  it('stays pending while the commanded field is never re-observed, until the grace backstop retires it', () => {
+    runtimeState.state = { main: { [confirmedField]: otherValue }, sub: {},
+      fieldStatus: { [fieldPath]: { lastObservedMonotonic: 4 } } };
+    state.commands = [acked({ updatedAt: Date.now() })];
+    expect(accessor(0)).toBe(value);
+    state.commands = [acked({ updatedAt: Date.now() - 3_001 })];
     expect(accessor(0)).toBeNull();
   });
 

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -264,8 +264,7 @@ export function getActiveFrequencyHz(): number | null {
  * current for the ~500ms until the next poll actually caught up — the
  * reported symptom. Routed through `latestPendingParam` (below) — the same
  * decision table leg 2's four discrete accessors use — so a command now
- * stays pending through ack until the radio's own observed state confirms
- * `freqHz`, or the shared `ACK_CONFIRM_GRACE_MS` backstop elapses.
+ * stays pending through ack.
  */
 export function getPendingFrequencyHz(receiver: 0 | 1): number | null {
   const value = latestPendingParam('set_freq', 'freq', receiver, 'freqHz');
@@ -1010,9 +1009,9 @@ function confirmedReceiverState(receiver: 0 | 1): ServerState['main'] | undefine
 /**
  * Grace backstop (MOR-1488 review R2, timing revised R3) — retire an
  * acknowledged-pending command this long after its ack even with no
- * confirming observation. Covers the never-confirms-at-all classes the
- * sequence guard below cannot, because none of them ever produce a
- * confirming post-ack push to guard against: (1) MOR-1445 post-ack
+ * observation of the commanded field. Covers the never-answered-at-all
+ * classes the observation rule below cannot, because none of them ever
+ * produce a post-ack read-back to end on: (1) MOR-1445 post-ack
  * execution failure — the server acks `ok:true` at enqueue time, and a
  * later failure reaches only a session notification (`server.py`
  * `commandExecutionFailed`) that `ws-client.ts`'s `_emitCommandResult`
@@ -1025,25 +1024,11 @@ function confirmedReceiverState(receiver: 0 | 1): ServerState['main'] | undefine
  * `latestPendingParam` (the next state push, or any other `$derived`
  * recompute), not the instant the clock crosses the threshold.
  *
- * 2000ms (R3, was 1500ms): review R3 found the commanded field's own
- * confirming re-read is a full poll round-robin away, not the next state
- * push — `_state_queries.py` schedules per-field reads across the
- * round-robin and `radio_poller.py:529-531` cycles roughly 25 queries at
- * ~25ms apiece, so worst case is ~1.3s for one full rotation. 1500ms left
- * too little margin: a command acked just after its field's slot in the
- * rotation could retire on the grace backstop moments before the actual
- * confirming readback arrives. 2000ms budgets a full rotation (≈1.3s) plus
- * headroom for scheduling jitter, matching the sequence guard below's
- * "mismatch is not evidence of failure, only of not-yet-observed" doctrine.
- *
- * 3000ms (MOR-1478): leg 2's ~1.3s round-robin is not the binding
- * constraint once leg 1 shares this table — `tuning-accumulator.ts:6,44`
- * records the observed `set_freq` confirm round trip at 0.5–2s on live
- * hardware, so a 2000ms budget expires exactly at the documented worst
- * case and drops the readout back to the stale pre-spin value for the
- * remainder — the MOR-1478 symptom itself. 3000ms keeps ~50% headroom
- * over the slowest documented confirm, matching the margin leg 2's own
- * 2000ms held over its 1.3s rotation.
+ * 3000ms (MOR-1478): `tuning-accumulator.ts:6,44` records the observed
+ * `set_freq` confirm round trip at 0.5–2s on live hardware, so a shorter
+ * budget expires inside the documented worst case and drops the readout
+ * back to the stale pre-spin value for the remainder — the MOR-1478
+ * symptom itself.
  */
 const ACK_CONFIRM_GRACE_MS = 3_000;
 
@@ -1063,52 +1048,24 @@ const ACK_CONFIRM_GRACE_MS = 3_000;
  * window to something imperceptible live, presenting an unconfirmed value
  * as confirmed.
  *
- * MOR-1488 review R2 (sequence guard, closes F2): matching the CURRENT
- * confirmed snapshot at ack time is not enough on its own — that snapshot
- * can predate the command entirely. A fast double-toggle (confirmed
- * nb:false → click ON → click OFF before either is observed) acks the OFF
- * command while the receiver state still reflects the value from BEFORE
- * both clicks; OFF's target (false) happens to equal that stale snapshot,
- * so a plain match would clear the marker immediately even though nothing
- * has actually been re-observed since. `command.ackObservationSeq`
- * (`commands.svelte.ts`, captured the instant a command reaches
- * 'acknowledged') fixes this: the command stays pending until the runtime's
- * current `observationSeq` (`$lib/stores/radio.svelte` — the one counter
- * that increments on every applied state push regardless of whether any
- * field's value actually changed; see `ackObservationSeq`'s own doc comment
- * for why `stateRevision` cannot serve this role) has advanced PAST the
- * ack-time value.
+ * An acknowledged record ends on the commanded field's own post-ack
+ * observation, whatever value that observation carries — the core
+ * re-reads the written field at USER priority after every write
+ * (`radio_poller.py: RadioPoller._request_post_write_readback`), and the
+ * server publishes that read's own `lastObservedMonotonic` per field
+ * (`runtime_helpers.py: _observed_field_status`). `ackFieldObservationTimes`
+ * (`commands.svelte.ts: transition`) captures that marker at ack; a marker
+ * strictly above it is the answer. Pinned by
+ * `semantic-discrete-pending-wiring.component.test.ts`'s "clears the marker
+ * when main.nb is re-observed after the ack still holding the old value"
+ * and "does not clear the marker on a post-ack push that observed another
+ * field".
  *
- * MOR-1488 review R3 (asymmetric settle, revises R2's "either way"):
- * `observationSeq` bumps on EVERY applied field observation — a 25ms meter
- * poll (`core.state_store._apply_one`) advances it exactly as much as a
- * genuine re-read of THIS command's field. But the commanded field's own
- * confirming re-read is scheduled a full poll round-robin away
- * (`_state_queries.py`, `radio_poller.py:529-531`, ~25 queries at ~25ms —
- * up to ~1.3s worst case), not on the very next push. R2 retired the
- * record on the first post-ack push regardless of match, which fires
- * ~50ms after ack (the next unrelated meter poll) — collapsing the
- * pending window back to a few frames, the exact symptom this PR set out
- * to fix. So as of R3: a post-ack push whose confirmed field MATCHES the
- * target is a real confirmation and clears the record (leg-1 "pending is
- * display-only, confirmed reading stays the group's sole selection source"
- * doctrine). A post-ack push that does NOT match is NOT evidence the value
- * failed to take — it is far more likely an unrelated field's observation
- * that simply hasn't reached this one's round-robin slot yet — so the
- * record stays pending and is left to the grace backstop above to bound.
- *
- * When no `ackObservationSeq` was captured (no radio state had ever been
- * observed at ack time — a real gap only in cold-start/test-double
- * scenarios) or the runtime currently has no observed state either, the
- * sequence guard has nothing to compare against and falls back to a direct
- * match against the current confirmed reading (the pre-R2 behavior).
- *
- * The match itself intentionally reads the receiver's plain schema value
- * (`confirmedReceiverState(receiver)?.[confirmedField]`), not `fieldStatus`
- * freshness — a field that has never been observed at all reads as
- * `undefined` here, which never `===`-matches a real target value, so an
- * unobserved field is correctly treated as "not yet confirmed" rather than
- * silently matching.
+ * Without both markers (no boundary captured, or the field carries none)
+ * there is no per-field evidence to read, and the record falls back to the
+ * older rule: the `ackObservationSeq` sequence guard, then a direct
+ * match against the current confirmed reading, bounded by the grace
+ * backstop above.
  */
 function latestPendingParam(
   intentName: string, paramKey: string, receiver: 0 | 1, confirmedField: keyof ServerState['main'],
@@ -1116,6 +1073,7 @@ function latestPendingParam(
   let latest: {
     createdAt: number; value: unknown; status: string;
     updatedAt: number; ackObservationSeq: number | undefined;
+    ackFieldObservationTimes: Readonly<Record<string, number>> | undefined;
   } | null = null;
   for (const command of getCommandLifecycles()) {
     if (command.name !== intentName) continue;
@@ -1132,6 +1090,7 @@ function latestPendingParam(
       latest = {
         createdAt: command.createdAt, value, status: command.status,
         updatedAt: command.updatedAt, ackObservationSeq: command.ackObservationSeq,
+        ackFieldObservationTimes: command.ackFieldObservationTimes,
       };
     }
   }
@@ -1142,24 +1101,23 @@ function latestPendingParam(
   if (!latest || (latest.status !== 'pending' && latest.status !== 'acknowledged')) return undefined;
   if (latest.status !== 'acknowledged') return latest.value;
 
-  // Grace backstop: fires regardless of what the sequence guard below would
-  // otherwise decide — see the constant's own doc comment.
+  // Grace backstop: bounds the no-answer case (NAK, or nothing at all).
   if (Date.now() - latest.updatedAt > ACK_CONFIRM_GRACE_MS) return undefined;
+
+  const fieldPath = `${receiver === 1 ? 'sub' : 'main'}.${String(confirmedField)}`;
+  const boundary = latest.ackFieldObservationTimes?.[fieldPath];
+  const observedAt = runtime.state?.fieldStatus?.[fieldPath]?.lastObservedMonotonic;
+  if (typeof boundary === 'number' && Number.isFinite(boundary)
+    && typeof observedAt === 'number' && Number.isFinite(observedAt)) {
+    return observedAt > boundary ? undefined : latest.value;
+  }
 
   const ackObservationSeq = latest.ackObservationSeq;
   const currentObservationSeq = runtime.state?.observationSeq;
   if (ackObservationSeq !== undefined && currentObservationSeq !== undefined
     && currentObservationSeq <= ackObservationSeq) {
-    // No push observed since ack yet — stay pending regardless of any
-    // coincidental match against the (necessarily stale) current snapshot.
     return latest.value;
   }
-  // Either the guard has no sequencing data to work with (fall back to a
-  // direct match, pre-R2 behavior) or a post-ack push has arrived: either
-  // way, only a MATCH settles the record (R3) — a mismatch here is not
-  // evidence the value failed to take (the commanded field's own
-  // confirming re-read is a full round-robin away, see doc comment above),
-  // so it stays pending for the grace backstop to bound instead.
   return confirmedReceiverState(receiver)?.[confirmedField] === latest.value ? undefined : latest.value;
 }
 
@@ -1205,9 +1163,8 @@ export function getPendingNrOn(receiver: 0 | 1): boolean | null {
  * documented on `latestPendingParam` and `ACK_CONFIRM_GRACE_MS` applies
  * unchanged:
  *  - `armed` goes true the instant a command dispatches (`status ===
- *    'pending'`) and stays true through the transport ack (`'acknowledged'`)
- *    until a confirming post-ack observation of the target value arrives, or
- *    `ACK_CONFIRM_GRACE_MS` elapses since ack with no confirmation.
+ *    'pending'`), stays true through the transport ack (`'acknowledged'`),
+ *    and goes false when `latestPendingParam` releases the record.
  *  - A re-click while armed re-arms at the new target: `latestPendingParam`'s
  *    freshest-`createdAt`-wins tie-break already handles this, no separate
  *    "already armed" state to fight.

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -1025,10 +1025,7 @@ function confirmedReceiverState(receiver: 0 | 1): ServerState['main'] | undefine
  * recompute), not the instant the clock crosses the threshold.
  *
  * 3000ms (MOR-1478): `tuning-accumulator.ts:6,44` records the observed
- * `set_freq` confirm round trip at 0.5–2s on live hardware, so a shorter
- * budget expires inside the documented worst case and drops the readout
- * back to the stale pre-spin value for the remainder — the MOR-1478
- * symptom itself.
+ * `set_freq` confirm round trip at 0.5–2s on live hardware.
  */
 const ACK_CONFIRM_GRACE_MS = 3_000;
 
@@ -1215,8 +1212,6 @@ export function getPendingNrOn(receiver: 0 | 1): boolean | null {
  * drift. Left as-is; do not refactor without a concrete reason.
  */
 export interface ArmedFact<T> {
-  /** True from command dispatch until a confirming observation (or grace
-   *  expiry) clears the pending record — see the contract above. */
   armed: boolean;
   /** The in-flight target while `armed`; `null` otherwise. Pending is
    *  display-only (leg-1 doctrine) — never read this as an arithmetic base

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -394,6 +394,27 @@ export const STATE_BACKED_COMMAND_DESCRIPTORS: ReadonlyMap<RadioIntentName, Stat
 export const getStateBackedCommandDescriptor = (intentName: string): StateBackedCommandDescriptor<unknown> | undefined =>
   (STATE_BACKED_COMMAND_DESCRIPTORS as ReadonlyMap<string, StateBackedCommandDescriptor<unknown>>).get(intentName);
 
+/**
+ * The `ServerState` receiver field each pending-marker intent is confirmed
+ * against — the same `confirmedField` `panel-adapters.ts`'s pending
+ * accessors pass to `latestPendingParam` for that intent. Used here only to
+ * capture that field's ack-time observation marker; an intent absent from
+ * this table simply captures no marker.
+ */
+const PENDING_CONFIRM_FIELDS: Readonly<Record<string, keyof ServerState['main']>> = Object.freeze({
+  set_freq: 'freqHz',
+  set_mode: 'mode',
+  set_filter: 'filter',
+  set_agc: 'agc',
+  set_preamp: 'preamp',
+  set_attenuator: 'att',
+  set_nb: 'nb',
+  set_nr: 'nr',
+  set_data_mode: 'dataMode',
+  set_auto_notch: 'autoNotch',
+  set_manual_notch: 'manualNotch',
+});
+
 const DEFAULT_TIMEOUT_MS = 5_000;
 /**
  * Terminal outcomes remain available for a five-second bounded presentation
@@ -481,13 +502,17 @@ function transition(
   if (status === 'acknowledged') {
     const radio = getRadioState(); command.ackObservationSeq = radio?.observationSeq;
     const observations: Record<string, number> = {};
+    const captureBoundary = (path: string | null | undefined): void => {
+      if (path === null || path === undefined) return;
+      const marker = radio?.fieldStatus?.[path]?.lastObservedMonotonic;
+      if (typeof marker === 'number' && Number.isFinite(marker)) observations[path] = marker;
+    };
     const descriptor = getStateBackedCommandDescriptor(command.name);
     const scope = descriptor?.scope(command);
-    const path = scope === null || scope === undefined ? null : descriptor?.fieldPath(scope);
-    if (path !== null && path !== undefined) {
-      const field = radio?.fieldStatus?.[path];
-      const marker = field?.lastObservedMonotonic;
-      if (typeof marker === 'number' && Number.isFinite(marker)) observations[path] = marker;
+    captureBoundary(scope === null || scope === undefined ? null : descriptor?.fieldPath(scope));
+    const pendingField = PENDING_CONFIRM_FIELDS[command.name];
+    if (pendingField !== undefined) {
+      captureBoundary(`${receiverScope(command) === 1 ? 'sub' : 'main'}.${pendingField}`);
     }
     command.ackFieldObservationTimes = observations;
     startLiveDeadline(command);


### PR DESCRIPTION
## What

`panel-adapters.ts: latestPendingParam` cleared an acknowledged command's
pending marker only when the receiver's confirmed value `===` the commanded
value. A read-back that reported a *different* value — the radio clamped the
request, or refused it — left the marker in flight until
`ACK_CONFIRM_GRACE_MS` (3000 ms) expired, and that expiry produced exactly
the same outward result as a real confirmation.

The marker now ends on the first observation of the commanded field that is
newer than the acknowledgement, whatever value that observation carries. The
evidence is the per-field marker the server already publishes:
`runtime_helpers.py: _observed_field_status` emits `lastObservedMonotonic`
for every field, and `commands.svelte.ts: transition` captures the commanded
field's marker into `ackFieldObservationTimes` at the moment the command
reaches `acknowledged`. `latestPendingParam` releases the record when the
field's current marker is strictly above that boundary.

Unchanged: the grace backstop still bounds the no-answer case (NAK, or
nothing at all); supersession, the terminal-record barrier and the
freshest-`createdAt`-wins selection are untouched.

## Why the `ackObservationSeq` guard stays

It is now the *fallback*, not a second parallel guard. When no per-field
evidence exists — no boundary was captured because the field carried no
marker at ack time, or the current state carries none — there is nothing to
compare, and the record falls back to the older rule: the `ackObservationSeq`
sequence guard, then a direct match against the current confirmed reading.
That fallback still needs the guard for the "no push since ack" gap it was
added for, so it is kept rather than deleted. The two are ordered, not
concurrent: the per-field comparison returns before the guard is reached
whenever both markers exist.

## Delta-path finding (asked before designing)

**Yes** — a field-status update where only `lastObservedMonotonic` moved is
delivered to the client. Three links, each read at `origin/main`:

1. `core/state_store.py: StateStore._apply_one` writes
   `last_observed_monotonic` from the observation and bumps
   `_observation_seq` unconditionally; only the ordering guard above it can
   skip an observation. `_state_revision` is the counter gated on a value
   change, and it is not what the delivery key or the field status depend on.
2. `web/server.py: WebServer._public_state_delivery_key` includes
   `snapshot.observation_seq`, so `_broadcast_state_update`'s
   "same key → return" gate does not suppress a re-observation of an
   unchanged value.
3. `web/_delta_encoder.py: DeltaEncoder.encode` compares top-level keys with
   `!=`. `fieldStatus` is one top-level key (`web/state_schema.py:
   PublicState.fieldStatus`), so a nested marker change puts the whole map
   into `changed`.

Link 3 run directly against the module:

```
$ python3 -c "
import importlib.util
spec = importlib.util.spec_from_file_location('de', 'src/rigplane/web/_delta_encoder.py')
m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
enc = m.DeltaEncoder()
before = {'main': {'nb': False}, 'fieldStatus': {'main.nb': {'observed': True, 'freshness': 'fresh', 'lastObservedMonotonic': 10.0}}}
after  = {'main': {'nb': False}, 'fieldStatus': {'main.nb': {'observed': True, 'freshness': 'fresh', 'lastObservedMonotonic': 11.0}}}
enc.encode(before, state_revision=1, observation_seq=1)
d = enc.encode(after, state_revision=1, observation_seq=2)
print('type=', d['type']); print('changed keys=', sorted(d['changed']))
print('fieldStatus delivered=', d['changed'].get('fieldStatus'))"
type= delta
changed keys= ['fieldStatus']
fieldStatus delivered= {'main.nb': {'observed': True, 'freshness': 'fresh', 'lastObservedMonotonic': 11.0}}
```

No backend change in this PR.

## Census

`git diff --numstat origin/main...HEAD` at the pushed head
(`34510c5542ce49401093f6e5f2dd61378036e873`):

```
108	70	frontend/src/components-v2/wiring/__tests__/semantic-discrete-pending-wiring.component.test.ts
47	5	frontend/src/lib/runtime/adapters/__tests__/mor1441-pending-discrete.isolated.test.ts
39	82	frontend/src/lib/runtime/adapters/panel-adapters.ts
30	5	frontend/src/lib/stores/commands.svelte.ts
```

**4 files, 224+/162- = 386 changed lines.** Under both guardrails.

## Tests

Test-first. Before the implementation, the four pinning files ran
`Test Files 2 failed | 2 passed (4)`, `Tests 6 failed | 130 passed (136)` —
the six new "clears on the field's own read-back" rows. After:

```
$ npx vitest run \
    src/lib/runtime/adapters/__tests__/mor1441-pending-discrete.isolated.test.ts \
    src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts \
    src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.component.test.ts \
    src/components-v2/wiring/__tests__/semantic-discrete-pending-wiring.component.test.ts
 Test Files  4 passed (4)
      Tests  136 passed (136)
```

Rows moved and added:

- `mor1441-pending-discrete.isolated.test.ts` — three rows per accessor
  (four accessors): the commanded field re-observed after the ack reporting a
  value other than the target **ends** the marker; only another field observed
  **stays** pending; never re-observed **stays** pending until the grace
  backstop retires it.
- `semantic-discrete-pending-wiring.component.test.ts` — the two rows that
  pinned "a post-ack push that does not confirm the target leaves the marker
  pending" now pin "a post-ack push that observed *another field* leaves it
  pending", and two new rows pin that `main.nb` / `main.freqHz` re-observed
  still holding the old value **clears** it. The confirming fixtures
  (`nbConfirmedState`, `freqConfirmedState`, the DATA click, the R2
  double-toggle settle) now advance the commanded field's own marker, which
  is what the production read-back does. The two grace-backstop rows are
  unchanged and now stand for "the field was never re-observed".

Also run green, as the adjacent consumers of the same decision table:
`DspPanel.component`, `DspPanel.isolated`, `FilterPanel.isolated`,
`ModePanel.isolated`, `RfFrontEnd.component`, `TxPanel.feedback-wiring`,
`mor1536-armed-adoption` (panels + adapters), `semantic-rf-front-end-wiring`,
`semantic-tx-aux-wiring`, `semantic-vfo-indicator-wiring`,
`mor1441-pending-frequency`, `mor1519-mode-armed`,
`pbt-if-shift-terminal-outcome-retention`, `tx-aux-command-feedback`
(component + isolated), `tuning-accumulator`, `stores/commands` —
`Test Files 18 passed (18)`, `Tests 612 passed (612)`.

## Mutations

1. **Restore the value-match rule** — `return observedAt > boundary && confirmed === target ? undefined : latest.value`.
   6 failed / 75 passed: the four `mor1441-pending-discrete` "ends the marker
   … reporting a value other than the target" rows plus both wiring "clears …
   still holding the old value" rows. This is the exact bug the change
   removes.
2. **Drop the newer-than-ack comparison** — clear whenever both markers
   exist (`return undefined`). 19 failed, including both "does not clear …
   observed another field" rows and all four "stays pending when only another
   field is observed after the ack" rows. Repeated as the tighter
   `observedAt >= boundary`: same 19.
3. **Remove the ack-time capture** — delete the `PENDING_CONFIRM_FIELDS`
   branch in `commands.svelte.ts: transition`. 2 failed: both wiring "clears
   … still holding the old value" rows, i.e. the store half of the change is
   load-bearing and pinned end-to-end over the real command store.

Tree restored before the final run; `git diff` shows only the intended
change.

## Gates

- `npx vitest run` over the four files — 136 passed, 0 failed
- `npm run lint` — clean
- `npm run i18n:check` — `OK (3 locale file(s) checked, 279 source keys)`
- `npm run check` — `4841 FILES 0 ERRORS 0 WARNINGS`
- `npm run build` — `built in 4.99s`

The full vitest run and the Python suite are left to CI.

## Known bounds

- The intent → confirmed-field mapping is now stated twice: once in
  `commands.svelte.ts: PENDING_CONFIRM_FIELDS` (capture) and once as the
  `confirmedField` argument at each `latestPendingParam` call site (read).
  A disagreement is fail-safe rather than fail-wrong — the boundary is stored
  under one key and looked up under another, no boundary is found, and the
  record falls back to the previous behaviour for that control. The
  agreement is pinned end-to-end over the real store for `set_nb`,
  `set_freq` and `set_data_mode` by
  `semantic-discrete-pending-wiring.component.test.ts`; the remaining eight
  intents in the table are not pinned that way.
- I did not establish, for every intent in that table, that the server emits
  a `fieldStatus` entry under the receiver-scoped path the capture computes.
  Where it does not, no boundary is captured and behaviour is unchanged.

## Seen, not changed

`filter-width-command-lifecycle.isolated.test.ts` and
`filter-width-command-lifecycle.component.test.ts` do not exercise
`latestPendingParam` at all — they pin the separate descriptor-backed
`projectControlFeedback` / `reconcileStateBackedCommands` path
(`set_filter_width`, `set_break_in_delay`, …), which still confirms only on a
value match (`StateBackedCommandDescriptor.matches`). Both files are run as
gates here and are unmodified. Whether that second path should adopt the same
read-back rule is a separate question this PR does not answer.

Internal-identifier self-check — empty.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
