### PR TITLE
fix: confirm descriptor-backed commands on the field's read-back, whatever value it carries

### DIFF
--- a/frontend/src/__tests__/control-feedback-presentation.test.ts
+++ b/frontend/src/__tests__/control-feedback-presentation.test.ts
@@ -41,7 +41,7 @@ describe('pure ControlFeedback presentation contract (MOR-1711)', () => {
 
   it.each(PHASES)('maps phase %s deterministically', (phase) => {
     const result = projectControlFeedbackPresentation(
-      feedback<number>(phase, { target: 2400, requestedTarget: 2400 }), EMPTY, String,
+      feedback<number>(phase, { confirmed: 2400, target: 2400, requestedTarget: 2400 }), EMPTY, String,
     );
     expect(result.attributes).toEqual({
       'data-command-phase': phase, 'aria-busy': BUSY.has(phase) ? 'true' : 'false',
@@ -56,7 +56,9 @@ describe('pure ControlFeedback presentation contract (MOR-1711)', () => {
   it.each(['confirmed', 'failed', 'timed-out', 'cancelled', 'superseded'] as const)(
     'maps terminal outcome %s without a busy ARIA state', (phase) => {
       const result = projectControlFeedbackPresentation(
-        feedback<number>(phase, { requestedTarget: 1800, outcome: { phase, error: 'bounded' } }),
+        feedback<number>(phase, {
+          confirmed: 1800, requestedTarget: 1800, outcome: { phase, error: 'bounded' },
+        }),
         EMPTY, (value) => `${value} Hz`,
       );
       expect(result.attributes['aria-busy']).toBe('false');
@@ -109,6 +111,21 @@ describe('pure ControlFeedback presentation contract (MOR-1711)', () => {
     );
     expect(idle.currentStatus).toBeNull();
     expect(idle.politeAnnouncement).toBeNull();
+  });
+
+  it('names the observed value once confirmed, the requested value when nothing was observed', () => {
+    const confirmed = projectControlFeedbackPresentation(
+      feedback<number>('confirmed', { confirmed: 64, requestedTarget: 111 }), EMPTY, String,
+    );
+    expect(confirmed.targetDescription).toBe('64');
+    expect(confirmed.currentStatus).toBe('Confirmed: 64');
+    expect(confirmed.politeAnnouncement?.message).toBe('Confirmed: 64');
+
+    const failed = projectControlFeedbackPresentation(
+      feedback<number>('failed', { confirmed: 64, requestedTarget: 111 }), EMPTY, String,
+    );
+    expect(failed.currentStatus).toBe('Failed: 111');
+    expect(failed.politeAnnouncement?.message).toBe('Failed: 111');
   });
 
   it('derives toggle and choice ARIA only from confirmed truth', () => {

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
@@ -445,16 +445,16 @@ describe('DspPanel v3 DSP scalar source integration (MOR-2423)', () => {
     assertModalFeedback(t, 'failed', 'new');
   });
 
-  it('requires the exact same-field observation to be newer than ACK', () => {
+  it('requires the same-field observation to be newer than ACK', () => {
     const command = beginCommand({
       id: 'exact-nb-level', name: 'set_nb_level', params: { level: 129, receiver: 0 },
       originalEpoch: 1, timeoutMs: 5_000,
     });
     acknowledgeCommand(command.id, command.originalEpoch, 1);
 
-    const wrongValue = qualifiedState(2);
-    wrongValue.main!.nbLevel = 130;
-    runtimeState.state = wrongValue;
+    const staleWrong = qualifiedState(1);
+    staleWrong.main!.nbLevel = 130;
+    runtimeState.state = staleWrong;
     runtimeState.notify();
     expect(getDspControlFeedback('nbLevel').phase).toBe('awaiting-confirmation');
 
@@ -464,9 +464,9 @@ describe('DspPanel v3 DSP scalar source integration (MOR-2423)', () => {
     runtimeState.notify();
     expect(getDspControlFeedback('nbLevel').phase).toBe('awaiting-confirmation');
 
-    const freshExact = qualifiedState(2);
-    freshExact.main!.nbLevel = 129;
-    runtimeState.state = freshExact;
+    const freshWrong = qualifiedState(2);
+    freshWrong.main!.nbLevel = 130;
+    runtimeState.state = freshWrong;
     runtimeState.notify();
     expect(getDspControlFeedback('nbLevel').phase).toBe('confirmed');
   });

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
@@ -369,7 +369,7 @@ describe('DspPanel v3 DSP scalar source integration (MOR-2423)', () => {
     vi.useRealTimers();
   });
 
-  it('uses the real descriptors for submitted, ACK, exact fresh confirmation, and authority replacement', () => {
+  it('uses the real descriptors for submitted, ACK, fresh confirmation, and authority replacement', () => {
     const commands = lanes.map(([field, name, params]) => beginCommand({
       id: `dsp-${field}`, name, params, originalEpoch: 1, timeoutMs: 5_000,
     }));

--- a/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
@@ -344,7 +344,9 @@ function advanceDelay(value: number, marker: number): void {
   flushSync();
 }
 
-function advanceCw(cwPitch: number, keySpeed: number, marker: number): void {
+function advanceCw(
+  cwPitch: number, keySpeed: number, marker: number, speedMarker = marker,
+): void {
   const state = liveState({
     cwPitch, keySpeed, revision: marker, stateRevision: marker,
     freshnessRevision: marker, observationSeq: marker,
@@ -354,7 +356,7 @@ function advanceCw(cwPitch: number, keySpeed: number, marker: number): void {
     cwPitch: { ...fresh, freshness: 'fresh' as const, availability: 'available' as const,
       lastObservedMonotonic: marker },
     keySpeed: { ...fresh, freshness: 'fresh' as const, availability: 'available' as const,
-      lastObservedMonotonic: marker },
+      lastObservedMonotonic: speedMarker },
   };
   h.state = state;
   setRadioState(state);
@@ -498,7 +500,7 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
     expect(cwInput('pitchHz').dataset.commandPhase).toBe('awaiting-confirmation');
     expect(cwInput('keyerSpeed').dataset.commandPhase).toBe('awaiting-confirmation');
 
-    advanceCw(725, 24, 11);
+    advanceCw(725, 24, 11, 10);
     expect(cwInput('pitchHz').dataset.commandPhase).toBe('confirmed');
     expect(cwValue('pitchHz')).toBe('725');
     expect(cwInput('keyerSpeed').dataset.commandPhase).toBe('awaiting-confirmation');
@@ -636,7 +638,7 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
     expect(txHarness.trace()).toEqual([]);
   });
 
-  it('projects acknowledgement and only newer matching radio truth as confirmed', () => {
+  it('projects acknowledgement and the first newer radio truth as confirmed, whatever value it carries', () => {
     render();
     const commandId = submitDelay(111);
     deliver(commandId, 'ack');
@@ -644,10 +646,8 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
     expect(delayInput().value).toBe('111');
 
     advanceDelay(64, 11);
-    expect(delayInput().dataset.commandPhase).toBe('awaiting-confirmation');
-    advanceDelay(111, 12);
     expect(delayInput().dataset.commandPhase).toBe('confirmed');
-    expect(delayInput().value).toBe('111');
+    expect(delayInput().value).toBe('64');
     expect(delayInput().getAttribute('aria-busy')).toBe('false');
     const live = q<HTMLElement>('[data-control-feedback-status]');
     expect(live?.getAttribute('aria-live')).toBe('polite');

--- a/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
@@ -651,7 +651,7 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
     expect(delayInput().getAttribute('aria-busy')).toBe('false');
     const live = q<HTMLElement>('[data-control-feedback-status]');
     expect(live?.getAttribute('aria-live')).toBe('polite');
-    expect(live?.textContent).toContain('111');
+    expect(live?.textContent).toContain('64');
   });
 
   it('restores canonical truth after transport failure and timeout', () => {

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -1248,7 +1248,7 @@ describe('the composed TX/VOX controls consume the real feedback lifecycle', () 
     },
   );
 
-  it('keeps ACK pending through unrelated and mismatched readback, then confirms a held exact truth', () => {
+  it('confirms ACK on the first same-field readback past the boundary, whatever value it carries', () => {
     const descriptor = TX_AUX_COMMAND_DESCRIPTORS.micGain;
     const command = beginCommand({
       id: 'mic-feedback', name: descriptor.intentName, params: { level: 200 }, originalEpoch: 7,
@@ -1271,8 +1271,8 @@ describe('the composed TX/VOX controls consume the real feedback lifecycle', () 
     } as unknown as ServerState);
     pushRadioState(observed(1, 199, 'fresh'));
     pushSession({ state: 'connected', epoch: 7 });
-    expect(input().dataset.commandPhase).toBe('awaiting-confirmation');
-    // MOR-2425/R40: a HELD readback past the ACK boundary that matches confirms.
+    expect(input().dataset.commandPhase).toBe('confirmed');
+    expect(input().getAttribute('aria-valuenow')).toBe('199');
     pushRadioState(observed(2, 200, 'stale'));
     pushSession({ state: 'connected', epoch: 7 });
     expect(input().getAttribute('aria-disabled')).toBe('false');

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -734,7 +734,7 @@ describe('Break-in Delay ControlFeedback projection (MOR-1744)', () => {
     expect(getBreakInDelayControlFeedback()).toMatchObject({ phase: 'idle', confirmed: 52 });
   });
 
-  it('confirms only from matching fresh canonical truth newer than the ACK boundary', async () => {
+  it('confirms from the first fresh canonical truth newer than the ACK boundary, whatever value it carries', async () => {
     vi.useFakeTimers(); vi.doUnmock('$lib/stores/commands.svelte'); vi.resetModules();
     const store = await import('$lib/stores/commands.svelte');
     const { getBreakInDelayControlFeedback: getLiveFeedback } = await import('../panel-adapters');
@@ -749,10 +749,13 @@ describe('Break-in Delay ControlFeedback projection (MOR-1744)', () => {
     expect(getLiveFeedback()).toMatchObject({ phase: 'awaiting-confirmation', target: 64 });
     emitAcceptedState(delayState({ breakInDelay: 64 }));
     expect(store.getCommandLifecycle(record.id, 7)?.status).toBe('acknowledged');
-    emitAcceptedState(delayState({ breakInDelay: 48, fieldStatus: { breakInDelay: {
+    runtimeState.state = delayState({ breakInDelay: 48, fieldStatus: { breakInDelay: {
       observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5,
-    } } }));
-    expect(store.getCommandLifecycle(record.id, 7)?.status).toBe('acknowledged');
+    } } }); emitAcceptedState(runtimeState.state);
+    expect(store.getCommandLifecycle(record.id, 7)?.status).toBe('confirmed');
+    expect(getLiveFeedback()).toMatchObject({
+      phase: 'confirmed', confirmed: 48, target: null, outcome: { phase: 'confirmed' },
+    });
     runtimeState.state = delayState({ breakInDelay: 64, fieldStatus: { breakInDelay: {
       observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 6,
     } } }); emitAcceptedState(runtimeState.state);

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1519-mode-armed.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1519-mode-armed.isolated.test.ts
@@ -7,10 +7,9 @@
  * over the SAME `latestPendingParam` decision table the four MOR-1441 leg-2
  * accessors already use (`mor1441-pending-discrete.isolated.test.ts`) — not
  * a second source of truth — so it inherits that table's honesty rules
- * verbatim: pending survives the transport ack until a confirming
- * post-ack observation (or the shared grace backstop), a re-click re-arms
- * at the freshest target, and a terminal failure clears `armed` immediately
- * (it must never present a failed command as still in flight).
+ * verbatim: a re-click re-arms at the freshest target, and a terminal
+ * failure clears `armed` immediately (it must never present a failed
+ * command as still in flight).
  *
  * `getModeArmed` differs from the leg-2 accessors only in HOW it picks the
  * receiver: no `receiver` param — `ModePanel` renders a single grid for the
@@ -97,15 +96,12 @@ describe('getModeArmed (MOR-1519)', () => {
     },
   );
 
-  // A transport ack is not a confirming observation — armed survives ack
-  // until the radio's OWN observed mode confirms the target.
   it('stays armed for an acknowledged command when the confirmed mode has not caught up', () => {
     runtimeState.state = { active: 'MAIN', main: { mode: 'USB' }, sub: {} };
     state.commands = [cmd({ status: 'acknowledged', params: { mode: 'CW', receiver: 0 } })];
     expect(getModeArmed()).toEqual({ armed: true, value: 'CW' });
   });
 
-  // Confirming observation clears armed — pending is display-only.
   it('clears armed once the confirmed mode matches the target', () => {
     runtimeState.state = { active: 'MAIN', main: { mode: 'CW' }, sub: {} };
     state.commands = [cmd({ status: 'acknowledged', params: { mode: 'CW', receiver: 0 } })];

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1536-armed-adoption.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1536-armed-adoption.isolated.test.ts
@@ -10,9 +10,8 @@
  * comment in `panel-adapters.ts`). Every accessor here is a thin,
  * no-receiver-arg `ArmedFact`-shaped projection over the exact same
  * primitive `getModeArmed` uses — no re-derivation, same honesty rules
- * (pending survives ack until a confirming post-ack observation or the
- * shared grace backstop, a re-click re-arms at the freshest target, a
- * terminal failure clears armed immediately).
+ * (a re-click re-arms at the freshest target, a terminal failure clears
+ * armed immediately).
  *
  * RIT/XIT/scan/antenna are NOT covered here: their handlers
  * (`makeRitXitHandlers`/`makeScanHandlers`/`makeAntennaHandlers`,

--- a/frontend/src/lib/runtime/adapters/__tests__/tx-aux-command-feedback.component.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/tx-aux-command-feedback.component.test.ts
@@ -115,7 +115,9 @@ describe('mounted raw TX/VOX feedback recovery', () => {
 
     expect(setRadioState(radioState(3, 2, 127, 2))).toBe(true);
     flushSync();
-    expect(probe.dataset.phase).toBe('awaiting-confirmation');
+    expect(probe.dataset).toMatchObject({
+      phase: 'confirmed', confirmed: '127', target: '', outcome: 'confirmed',
+    });
     expect(setRadioState(radioState(3, 3, 128, 3))).toBe(true);
     flushSync();
     expect(probe.dataset).toMatchObject({

--- a/frontend/src/lib/runtime/adapters/__tests__/tx-aux-command-feedback.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/tx-aux-command-feedback.isolated.test.ts
@@ -124,7 +124,7 @@ describe('imperative qualified raw TX/VOX command feedback', () => {
     expect(h.sessionReads).toBe(0);
   });
 
-  it('keeps ACK awaiting across active-receiver, other-field and mismatch observations, then confirms a held exact one', () => {
+  it('keeps ACK awaiting across active-receiver and other-field observations, then confirms on the first newer same-field readback', () => {
     h.state = state({ micGain: 100 });
     const command = begin('micGain', 128, 'mic');
     expect(getTxAuxControlFeedback('micGain', connected).phase).toBe('submitted');
@@ -141,11 +141,11 @@ describe('imperative qualified raw TX/VOX command feedback', () => {
     expect(getTxAuxControlFeedback('micGain', connected).scope.receiver).toBe(0);
 
     emitState(state({ micGain: 127, fieldStatus: { ...state().fieldStatus, micGain: fresh(2) } }));
-    expect(getCommandLifecycle(command.id, 7)?.status).toBe('acknowledged');
+    expect(getCommandLifecycle(command.id, 7)?.status).toBe('confirmed');
+    expect(getTxAuxControlFeedback('micGain', connected)).toMatchObject({
+      confirmed: 127, target: null, requestedTarget: 128, phase: 'confirmed',
+    });
 
-    // MOR-2425/R40: marker 3 is newer than the ACK boundary and the value
-    // matches, so this HELD observation confirms — it is a genuinely newer
-    // reading, only an older one than the TTL calls fresh.
     emitState(state({
       micGain: 128,
       fieldStatus: { ...state().fieldStatus, micGain: { ...fresh(3), freshness: 'stale' } },

--- a/frontend/src/lib/stores/__tests__/commands.test.ts
+++ b/frontend/src/lib/stores/__tests__/commands.test.ts
@@ -394,7 +394,7 @@ describe('command lifecycle store', () => {
       expect(store.isCommandLifecycleSuperseded(sqlMain)).toBe(false);
     });
 
-    it('confirms only from exact scoped truth after a finite advancing ACK marker', () => {
+    it('confirms on the first same-field observation past the ACK marker, whatever value it carries', () => {
       const snapshot = (
         rfGain: number, marker: number, freshness: 'fresh' | 'stale' = 'fresh',
       ): ServerState => ({

--- a/frontend/src/lib/stores/__tests__/commands.test.ts
+++ b/frontend/src/lib/stores/__tests__/commands.test.ts
@@ -418,10 +418,32 @@ describe('command lifecycle store', () => {
       emitState(snapshot(128 / 255, 4));
       expect(current().status).toBe('acknowledged');
       emitState(snapshot(0.5, 5));
-      expect(current().status).toBe('acknowledged');
-      // MOR-2425/R40: marker 6 is newer than the ACK boundary and matches.
+      expect(current().status).toBe('confirmed');
       emitState(snapshot(128 / 255, 6, 'stale'));
       expect(current().status).toBe('confirmed');
+    });
+
+    it('keeps a clamped read-back confirmed instead of letting the deadline expire', () => {
+      const snapshot = (rfGain: number, marker: number): ServerState => ({
+        providerGeneration: 3, main: { rfGain }, sub: {},
+        fieldStatus: { 'main.rfGain': {
+          storePath: 'fixture', observed: true, freshness: 'fresh',
+          availability: 'available', lastObservedMonotonic: marker,
+        } },
+      } as unknown as ServerState);
+      emitState(snapshot(128 / 255, 4));
+      const command = store.beginCommand({
+        id: 'rf-clamped', name: 'set_rf_gain', params: { level: 128, receiver: 0 },
+        originalEpoch: 7, timeoutMs: 25,
+      });
+      store.acknowledgeCommand(command.id, 7, 7);
+      const status = () => store.getCommandLifecycle(command.id, 7)?.status;
+      expect(status()).toBe('acknowledged');
+
+      emitState(snapshot(0.5, 5));
+      expect(status()).toBe('confirmed');
+      vi.advanceTimersByTime(25);
+      expect(status()).toBe('confirmed');
     });
   });
 
@@ -473,7 +495,7 @@ describe('command lifecycle store', () => {
     it.each([
       ['set_cw_pitch', 'cwPitch', 'value', 640, 650],
       ['set_key_speed', 'keySpeed', 'speed', 27, 28],
-    ] as const)('confirms %s only after a newer matching exact field observation', (
+    ] as const)('confirms %s from the first newer exact field observation, whatever value it carries', (
       name, field, param, target, mismatch,
     ) => {
       const observed = (value: number, marker: number, freshness: 'fresh' | 'stale' = 'fresh') => ({
@@ -491,7 +513,7 @@ describe('command lifecycle store', () => {
       expect(status()).toBe('acknowledged');
       emitState(observed(target, 4));
       emitState(observed(mismatch, 5));
-      // MOR-2425/R40: marker 6 is newer than the ACK boundary and matches.
+      expect(status()).toBe('confirmed');
       emitState(observed(target, 6, 'stale'));
       expect(status()).toBe('confirmed');
     });
@@ -560,7 +582,7 @@ describe('command lifecycle store', () => {
       expect(store.isCommandLifecycleSuperseded(drive)).toBe(false);
     });
 
-    it.each(registrations)('confirms %s only from a newer matching exact raw observation', (
+    it.each(registrations)('confirms %s from the first newer exact raw observation, whatever value it carries', (
       field, intentName, _control, target,
     ) => {
       const observed = (
@@ -580,7 +602,7 @@ describe('command lifecycle store', () => {
       expect(status()).toBe('acknowledged');
       emitState(observed(target, 4));
       emitState(observed(target - 1, 5));
-      // MOR-2425/R40: marker 6 is newer than the ACK boundary and matches.
+      expect(status()).toBe('confirmed');
       emitState(observed(target, 6, 'stale'));
       expect(status()).toBe('confirmed');
     });
@@ -670,7 +692,7 @@ describe('command lifecycle store', () => {
       ['set_agc_time_constant', 'sub.agcTimeConstant', 'value', 900, 899, 1],
       ['set_nb_width', 'nbWidth', 'level', 64, 63, null],
       ['set_nb_depth', 'nbDepth', 'level', 9, 8, null],
-    ] as const)('confirms %s only from a newer matching exact field observation', (
+    ] as const)('confirms %s from the first newer exact field observation, whatever value it carries', (
       name, path, param, target, mismatch, receiver,
     ) => {
       const observed = (value: number, marker: number, freshness: 'fresh' | 'stale' = 'fresh') => ({
@@ -690,7 +712,7 @@ describe('command lifecycle store', () => {
       expect(status()).toBe('acknowledged');
       emitState(observed(target, 4));
       emitState(observed(mismatch, 5));
-      // MOR-2425/R40: marker 6 is newer than the ACK boundary and matches.
+      expect(status()).toBe('confirmed');
       emitState(observed(target, 6, 'stale'));
       expect(status()).toBe('confirmed');
     });
@@ -749,11 +771,11 @@ describe('command lifecycle store', () => {
         providerGeneration: 3, active: 'MAIN', nbWidth: 20, nbDepth: 4,
         main: { nbLevel: 40, nrLevel: 136 }, sub: { nbLevel: 30, nrLevel: 128 },
         fieldStatus: {
-          nbWidth: { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 },
-          nbDepth: { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 },
+          nbWidth: { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
+          nbDepth: { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
           'main.nbLevel': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 },
           'sub.nbLevel': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
-          'main.nrLevel': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 },
+          'main.nrLevel': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
           'sub.nrLevel': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
         },
       } as unknown as ServerState);
@@ -806,7 +828,7 @@ describe('command lifecycle store', () => {
       ['pbtInner', 'set_pbt_inner', 'value', 131, 130],
       ['pbtOuter', 'set_pbt_outer', 'value', 131, 130],
       ['ifShift', 'set_if_shift', 'offset', 500, 480],
-    ] as const)('confirms %s only from a newer matching exact raw field observation', (
+    ] as const)('confirms %s from the first newer exact raw field observation, whatever value it carries', (
       field, name, param, target, mismatch,
     ) => {
       const observed = (value: number, marker: number, freshness: 'fresh' | 'stale' = 'fresh') => ({
@@ -825,7 +847,7 @@ describe('command lifecycle store', () => {
       expect(status()).toBe('acknowledged');
       emitState(observed(target, 4));
       emitState(observed(mismatch, 5));
-      // MOR-2425/R40: marker 6 is newer than the ACK boundary and matches.
+      expect(status()).toBe('confirmed');
       emitState(observed(target, 6, 'stale'));
       expect(status()).toBe('confirmed');
     });

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -550,7 +550,7 @@ function reconcileStateBackedCommands(state: ServerState | null): void {
       command.ackFieldObservationTimes = { ...boundaries, [path]: marker };
       continue;
     }
-    if (marker > boundary && descriptor.matches(confirmed, target)) {
+    if (marker > boundary) {
       transition(command.id, command.originalEpoch, 'confirmed', command.eventEpoch ?? command.originalEpoch);
     }
   }

--- a/frontend/src/primitives/control-feedback/control-feedback-presentation.ts
+++ b/frontend/src/primitives/control-feedback/control-feedback-presentation.ts
@@ -55,8 +55,10 @@ export function projectControlFeedbackPresentation<T>(
   previous: Readonly<ControlFeedbackPresentationState>,
   describeTarget: (target: T) => string,
 ): Readonly<ControlFeedbackPresentation> {
-  const target = feedback.target ?? feedback.requestedTarget;
-  const targetDescription = target === null ? null : describeTarget(target);
+  const described = feedback.phase === 'confirmed'
+    ? feedback.confirmed
+    : feedback.target ?? feedback.requestedTarget;
+  const targetDescription = described === null ? null : describeTarget(described);
   const statusMessage = targetDescription === null
     ? PHASE_TEXT[feedback.phase]
     : `${PHASE_TEXT[feedback.phase]}: ${targetDescription}`;


### PR DESCRIPTION
File-count exception granted by the coordinating session under the owner's
2026-09-03 delegation: the extra files are the four test files the predicate
change reddened in CI and the announcement fix the review required;
2 code + 10 test files = 12 files.

## What

`commands.svelte.ts: reconcileStateBackedCommands` ended a descriptor-backed
command as `confirmed` only when the post-ack observation both advanced the
commanded field's marker **and** carried the commanded value. Its terminal
predicate is now `marker > boundary` alone: the record ends `confirmed` on the
commanded field's first post-ack observation, whatever value that observation
carries.

## Why

Owner doctrine (2026-09-08): after the user's own action a field shows PENDING;
the core reads that field back at user priority right after the command; when
the read-back arrives the field shows what the radio reports, whatever the
value; if nothing arrives, pending ends at the bound.

Under the old predicate, a radio that clamped to a different value left the
record `acknowledged` for the full `DEFAULT_TIMEOUT_MS` window and then flipped
to `timed-out` — while the readout had already been showing the radio's value
since the read-back landed, because `panel-adapters.ts: projectControlFeedback`
computes `confirmed` from live state independently of command status. The chip
therefore kept asserting an in-flight command toward a target the radio had
observably declined, and ended on a failure phase for a command that had in
fact been answered.

PR #3374 applied the same rule to the display lane
(`panel-adapters.ts: latestPendingParam`). This is the lifecycle lane, using
the boundary and clock that lane already captures — `transition`'s
acknowledged branch writes `command.ackFieldObservationTimes` from
`fieldStatus[path].lastObservedMonotonic` for both lanes.

`StateBackedCommandDescriptor.matches` and the descriptors' `matches`
implementations are untouched; removing them is a separate follow-up.

## Guardrails

12 files · 157 changed lines — past the 10-file hard ceiling, under the
1000-line one, and over the 6-file soft threshold. The file-count exception is
the first line of this body. One unit of work: a one-line predicate change,
the announcement fix that change made necessary, and the tests that pin both.

## Census

`git diff --numstat origin/main...HEAD` at the pushed head:

```
19	2	frontend/src/__tests__/control-feedback-presentation.test.ts
8	8	frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
8	8	frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
3	3	frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
7	4	frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
3	7	frontend/src/lib/runtime/adapters/__tests__/mor1519-mode-armed.isolated.test.ts
2	3	frontend/src/lib/runtime/adapters/__tests__/mor1536-armed-adoption.isolated.test.ts
3	1	frontend/src/lib/runtime/adapters/__tests__/tx-aux-command-feedback.component.test.ts
5	5	frontend/src/lib/runtime/adapters/__tests__/tx-aux-command-feedback.isolated.test.ts
36	14	frontend/src/lib/stores/__tests__/commands.test.ts
1	1	frontend/src/lib/stores/commands.svelte.ts
4	2	frontend/src/primitives/control-feedback/control-feedback-presentation.ts
```

12 files, 99+/58- = 157 changed lines.

A follow-up commit moves four further rows onto the read-back rule —
`DspPanel.component.test.ts: requires the same-field observation to be newer
than ACK`, `semantic-tx-aux-wiring.component.test.ts: confirms ACK on the
first same-field readback past the boundary, whatever value it carries`,
`tx-aux-command-feedback.component.test.ts: reactively recovers one persistent
derived consumer across lifecycle and authority replacement` and
`tx-aux-command-feedback.isolated.test.ts: keeps ACK awaiting across
active-receiver and other-field observations, then confirms on the first newer
same-field readback` — and mutation (i), re-run on those four files, reddens
exactly those four rows.

## Changes beyond the one-line predicate

Two test repairs were **not** anticipated and are worth a reviewer's attention.

**1. `commands.test.ts: does not confirm receiver or global DSP commands from
the wrong field path`** — this test was expected to be untouched. It went red.
Only one of its four commands (`sub-level`) was a genuine wrong-field-path
row; `global-width`, `main-nr` and `global-depth` each had their **own**
commanded field's marker advance from 4 to 5 in the second push, and stayed
`acknowledged` purely because of the value gate. The test's title attributed
to field-path scoping an outcome three of its rows got from
`descriptor.matches`. The fixture now holds those three fields' markers at 4
and advances only `main.nbLevel`, which no command in the fixture watches, so
all four rows test what the title claims. The test stays green under mutation
(i), as it should.

**2. `semantic-cw-keyer-wiring.component.test.ts`** — two rows went red.
- `projects independent native CW feedback from intent through confirmation
  and failure`: its `advanceCw` helper advanced the `cwPitch` and `keySpeed`
  markers together, so the speed lane confirmed alongside the pitch lane and
  could no longer take the `response-error` path the test's own title covers.
  `advanceCw` now takes an optional per-field `speedMarker` so the speed lane
  genuinely has no read-back; the failure-path coverage is preserved.
- `projects acknowledgement and only newer matching radio truth as confirmed`:
  retitled, and the assertion after the clamped read-back (64 against a
  requested 111) is now `confirmed` with the input showing the radio's 64.
  The trailing second push (111 at a newer marker) was dropped — see below.

## Observations recorded, not changed

- **A second push after the record goes terminal does not refresh this
  surface's readout in the component harness.** After the record confirms at
  the clamped 64, pushing 111 at a newer marker leaves the rendered input at
  `64` although `runtime.state.breakInDelay` is `111`, established by
  instrumenting the test and reading both values at that point. The harness
  mocks `runtime.state` as a plain getter (the file's own comment notes the
  mocks split the runtime seam from the radio store, which production
  unifies), so this surface re-derives on a command-lifecycle change rather
  than on the state push. The old assertion passed only because the lifecycle
  transition happened to land on that same push. I could not establish from
  this harness whether production has the same staleness, so the step was
  dropped rather than re-asserted, and nothing was changed to address it.

## Review fixes

**B1 — the confirmed announcement named the requested value.**
`control-feedback-presentation.ts: projectControlFeedbackPresentation` derived
its status text from `feedback.target ?? feedback.requestedTarget`.
`projectControlFeedback` sets `target: null` on a terminal phase, so a
confirmed read-back announced `requestedTarget`. In
`semantic-cw-keyer-wiring.component.test.ts`, with the radio reporting 64
against a requested 111, `[data-control-feedback-status]` read
`Confirmed: 111` while the same row's readout assertion showed 64. The
`confirmed` phase now describes `feedback.confirmed`, so that
live region reads `Confirmed: 64`; `failed`, `timed-out`, `cancelled` and
`superseded` keep naming the requested value, which is the only value their
transition was about. `control-feedback-presentation.test.ts` gains a row
pinning both directions, and the cw-keyer row asserts the observed 64.

**B2 — stale titles.** `commands.test.ts: confirms only from exact scoped
truth after a finite advancing ACK marker` kept its name after its body moved
onto the read-back rule; it is now `confirms on the first same-field
observation past the ACK marker, whatever value it carries`. The class sweep
found one more title claiming the removed value-exactness rule in a file this
PR already changed — `DspPanel.component.test.ts`, `exact fresh confirmation`
→ `fresh confirmation`. Two further members are left unfixed to hold the file
count at 12, and are reported to the coordinating session:
`TxPanel.feedback-wiring.component.svelte.test.ts: keeps ACK awaiting, exposes
terminal error, and confirms only exact fresh readback` and
`dsp-command-feedback.isolated.test.ts: keeps a raw NR alias busy until exact
confirmation while all display slots equal 8`.

**Mutations at this head.** Reverting B1's branch to
`feedback.target ?? feedback.requestedTarget` reddens exactly two rows —
`control-feedback-presentation.test.ts: names the observed value once
confirmed, the requested value when nothing was observed` (`expected '111' to
be '64'`) and the cw-keyer row (`expected 'Confirmed: 111' to contain '64'`).
Over-applying it instead (`confirmed ?? target ?? requestedTarget` for every
phase) reddens the same new row on its `failed` half (`expected 'Failed: 64'
to be 'Failed: 111'`). The tree was restored after both.

**Gates on the review-fix head.** `control-feedback-presentation.test.ts`,
`semantic-cw-keyer-wiring.component.test.ts`, `commands.test.ts`,
`DspPanel.component.test.ts`, `TxPanel.feedback-wiring.component.svelte.test.ts`
and `dsp-command-feedback.isolated.test.ts` together: `Tests 224 passed (224)`.
`grep -rl` over `frontend/src` for `projectControlFeedbackPresentation` or
`[data-control-feedback-status]` names 16 test files; all 16 were run, the 14
of them not named above as one batch: `Tests 669 passed (669)`. `npm run lint`
clean; `npm run check` `4841 FILES 0 ERRORS 0 WARNINGS`.

## Tests

Baseline at `origin/main`, the two behaviour files: `Tests 135 passed (135)`.

Test-first, with the tests updated and the production predicate still the old
one: `Tests 22 failed | 114 passed (136)`.

After the predicate change, each named and gate file run individually:

```
commands.test.ts                                    Tests 85 passed (85)
filter-width-command-lifecycle.isolated.test.ts     Tests 51 passed (51)
filter-width-command-lifecycle.component.test.ts    Tests  4 passed (4)
control-feedback-presentation.test.ts               Tests 20 passed (20)
CwPanel.feedback-wiring.component.svelte.test.ts    Tests 18 passed (18)
semantic-cw-keyer-wiring.component.test.ts          Tests 34 passed (34)
CwKeyerInstrumentHost.isolated.test.ts              Tests 13 passed (13)
mor1519-mode-armed.isolated.test.ts                 Tests 12 passed (12)
mor1536-armed-adoption.isolated.test.ts             Tests 78 passed (78)
```

The five files after `filter-width-command-lifecycle.isolated.test.ts` are the
descriptor-lane mounts: `filter-width-command-lifecycle.component.test.ts`
plus every test file importing `projectControlFeedback`, enumerated with
`grep -rln projectControlFeedback frontend/src`.

Gates: `npm run lint` clean; `npm run check` `4841 FILES 0 ERRORS 0 WARNINGS`;
`npm run i18n:check` `OK (3 locale file(s) checked, 279 source keys)`;
`npm run build` `built in 5.19s`.

## Mutations

**(i) Restore `&& descriptor.matches(confirmed, target)`.** Measured at
48859c0c, before the fix cycle: 23 tests redden across three files:

```
commands.test.ts                                 Tests 21 failed | 64 passed (85)
filter-width-command-lifecycle.isolated.test.ts  Tests  1 failed | 50 passed (51)
semantic-cw-keyer-wiring.component.test.ts       Tests  1 failed | 33 passed (34)
```

The 21 in `commands.test.ts` are the rf-gain row, the new clamped-deadline
regression row, and the 19 parametrised rows across the CW, TX/VOX, DSP and
PBT/IF-shift families. `does not confirm receiver or global DSP commands from
the wrong field path` stays green under this mutation, as intended — it pins
field-path scoping, not the value gate.

Measured again at eeffdd4d on the four files the fix cycle moved: the same
mutation reddens exactly those four rows and nothing else, so at eeffdd4d it
reddens 27 rows across seven files (independent review measured the same
27 across the nine test files changed at that head).

**(ii) Behaviour-preserving refactor** (hoist the comparison into a
`readBackArrived` local): all three files stay green — 85, 51 and 34 passed.

The tree was restored after both mutations; `git diff` on
`commands.svelte.ts` at the pushed head is the single predicate line.

## New regression coverage

`commands.test.ts: keeps a clamped read-back confirmed instead of letting the
deadline expire` — a `set_rf_gain` command with a 25 ms `timeoutMs` override
is acknowledged, a fresh mismatched observation arrives, and the record is
`confirmed` both immediately and after the timers advance past the deadline.
Under mutation (i) it reddens twice over: `acknowledged` right after the push,
then `timed-out` once the deadline elapses.

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)




