### PR TITLE
fix: let the startup gate release a path the Yaesu adapter has given up on

### DIFF
--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -9,6 +9,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, TypeVar
 
+from rigplane.core.acquisition_scheduler import AcquisitionScheduler
 from rigplane.core.observation_adapter import ProviderObservationAdapter
 from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
 from rigplane.core.state_pipeline_contracts import FieldPath, Observation
@@ -509,7 +510,9 @@ class YaesuObservationAdapter:
         adapter = self._adapter()
         observations: list[Observation] = []
         if self._has_runtime_capability("meters") and self._can_poll(_MAIN_S_METER):
-            ok, raw = await self._safe_read("main.s_meter", self.radio.read_s_meter(0))
+            ok, raw = await self._safe_read(
+                "main.s_meter", self.radio.read_s_meter(0), path=_MAIN_S_METER
+            )
             if ok and raw is not None:
                 raw = smooth_s_meter(0, raw) if smooth_s_meter is not None else raw
                 value, quality = self._calibrate_s_meter(raw)
@@ -526,7 +529,9 @@ class YaesuObservationAdapter:
             and self._has_runtime_capability("dual_rx")
             and self._can_poll(_SUB_S_METER)
         ):
-            ok, raw = await self._safe_read("sub.s_meter", self.radio.read_s_meter(1))
+            ok, raw = await self._safe_read(
+                "sub.s_meter", self.radio.read_s_meter(1), path=_SUB_S_METER
+            )
             if ok and raw is not None:
                 raw = smooth_s_meter(1, raw) if smooth_s_meter is not None else raw
                 value, quality = self._calibrate_s_meter(raw)
@@ -1209,7 +1214,11 @@ class YaesuObservationAdapter:
         return tuple(observations)
 
     async def _safe_read(
-        self, label: str, read: Awaitable[_T]
+        self,
+        label: str,
+        read: Awaitable[_T],
+        *,
+        path: FieldPath | None = None,
     ) -> tuple[bool, _T | None]:
         """Await one field read, tolerating FIELD-level CAT failures (MOR-473).
 
@@ -1237,22 +1246,36 @@ class YaesuObservationAdapter:
             # ValueError covers _read_meter / int() malformed-frame failures;
             # CatParse/FormatError subclass ValueError but are listed for clarity.
             self._log_field_skip(
-                label, "Skipping field %s — malformed CAT response: %s", exc
+                label, "Skipping field %s — malformed CAT response: %s", exc, path=path
             )
             return False, None
         except CatCommandRejected as exc:
             # ``?;`` reject = command unsupported on this radio -> skip the field.
             self._log_field_skip(
-                label, "Skipping field %s — command rejected (?;): %s", exc
+                label, "Skipping field %s — command rejected (?;): %s", exc, path=path
             )
             return False, None
 
-    def _log_field_skip(self, label: str, message: str, exc: Exception) -> None:
+    def _log_field_skip(
+        self,
+        label: str,
+        message: str,
+        exc: Exception,
+        *,
+        path: FieldPath | None = None,
+    ) -> None:
         """Warn once per field, then demote repeats to DEBUG (MOR-561).
 
         The warned-field set lives on the radio (persistent across poll cycles)
         rather than the adapter (rebuilt every cycle). A non-``set`` attribute —
         e.g. a ``MagicMock`` test double — falls back to always-warn.
+
+        ``path`` names the declared field the skipped read would have produced.
+        Where it is given, the warning also releases that path from the startup
+        gate (``AcquisitionScheduler.abandon_startup_path``), so a field whose
+        answer never parses cannot hold that gate open. Pinned by
+        ``tests/test_yaesu_cat_observation_adapter.py::
+        test_first_sub_s_meter_skip_releases_the_path_from_the_startup_gate``.
         """
         warned = getattr(self.radio, "_poll_warned_fields", None)
         if isinstance(warned, set):
@@ -1260,6 +1283,12 @@ class YaesuObservationAdapter:
                 logger.debug(message, label, exc)
                 return
             warned.add(label)
+        if path is not None:
+            scheduler = getattr(self.radio, "_acquisition_scheduler", None)
+            if isinstance(scheduler, AcquisitionScheduler):
+                scheduler.abandon_startup_path(
+                    path, reason=f"yaesu field read skipped: {label}"
+                )
         logger.warning(message, label, exc)
 
     def _adapter(self) -> ProviderObservationAdapter:

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -346,6 +346,7 @@ class AcquisitionScheduler:
     """Minimal priority/dedupe queue for backend-neutral acquisition reads."""
 
     __slots__ = (
+        "_abandoned_startup_paths",
         "_clock",
         "_cadence_by_key",
         "_claims_by_request_id",
@@ -381,6 +382,7 @@ class AcquisitionScheduler:
         ] = {}
         self._failed_request_count = 0
         self._failure_count_by_reason: dict[str, int] = {}
+        self._abandoned_startup_paths: set[FieldPath] = set()
         self._next_id = 1
         # Round-robin starting offset into field_policies for
         # prime_unobserved (MOR-1501, A1 from #2415 review): see that
@@ -878,6 +880,24 @@ class AcquisitionScheduler:
             return True
         return False
 
+    def abandon_startup_path(self, path: FieldPath, *, reason: str) -> None:
+        """Drop one path from :meth:`unobserved_startup_paths` for good.
+
+        For a backend that has given up on a declared field. The first call
+        for a path logs it by name, with ``reason``, at WARNING; repeats are
+        silent. Pinned by ``tests/test_acquisition_scheduler.py::
+        test_abandon_startup_path_warns_once_naming_the_path_and_reason``.
+        """
+
+        if path in self._abandoned_startup_paths:
+            return
+        self._abandoned_startup_paths.add(path)
+        logger.warning(
+            "acquisition: abandoning startup path %s (%s)",
+            path,
+            reason,
+        )
+
     def unobserved_startup_paths(
         self,
         observed_paths: Iterable[FieldPath],
@@ -890,6 +910,8 @@ class AcquisitionScheduler:
         (:attr:`AcquisitionPolicy.tx_only`), never from a list kept here;
         :meth:`due_requests` gates those cadence groups on ``tx_active``, so
         a caller that waited on them would be waiting for a transmission.
+        Paths passed to :meth:`abandon_startup_path` are filtered out the
+        same way.
 
         Unlike :meth:`has_unobserved_policy_fields`, this does not exclude
         cadence-owned paths: a path :meth:`due_requests` will poll is still
@@ -904,7 +926,9 @@ class AcquisitionScheduler:
                 (
                     path
                     for path in domain
-                    if path not in observed and not profile.policy_for(path).tx_only
+                    if path not in observed
+                    and path not in self._abandoned_startup_paths
+                    and not profile.policy_for(path).tx_only
                 ),
                 key=str,
             )

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -660,8 +660,7 @@ class WebConfig:
     discovery_port: int = 8470  # UDP port for discovery
     read_only: bool = False  # reject PTT and other transmit commands
     emit_startup_event: bool = False  # emit JSON runtime startup event to stdout
-    # Hold the listener closed until every declared, non-tx_only field has
-    # been observed once (see web_startup._await_initial_state_acquisition).
+    # Hold the listener closed (see web_startup._await_initial_state_acquisition).
     # The CLI sets it; embedders and tests that drive start() without a
     # backend filling the store leave it off.
     await_initial_state: bool = False

--- a/src/rigplane/web/web_startup.py
+++ b/src/rigplane/web/web_startup.py
@@ -163,9 +163,7 @@ async def _await_initial_state_acquisition(
 ) -> None:
     """Block until every declared, non-``tx_only`` field has been observed.
 
-    The wait is indefinite by design: there is no serve-anyway timeout, and a
-    field the radio answers with NG stays outstanding because the store has
-    no negative state.
+    The wait is indefinite by design: there is no serve-anyway timeout.
 
     ``sweep`` re-primes the scheduler while the gate is open. It is set only
     on the branch that builds a :class:`RadioPoller`, because that is the

--- a/src/rigplane/web/web_startup.py
+++ b/src/rigplane/web/web_startup.py
@@ -161,7 +161,7 @@ async def _await_initial_state_acquisition(
     *,
     sweep: bool,
 ) -> None:
-    """Block until every declared, non-``tx_only`` field has been observed.
+    """Block until ``AcquisitionScheduler.unobserved_startup_paths`` is empty.
 
     The wait is indefinite by design: there is no serve-anyway timeout.
 

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 import time
 from collections.abc import Iterable, Iterator
 from dataclasses import replace
@@ -3764,3 +3765,74 @@ def test_freshness_service_without_a_radio_still_ticks() -> None:
     service = StateFreshnessService(store=store)
 
     assert service.tick(now=100.0) is not None
+
+
+# ---------------------------------------------------------------------------
+# Startup-gate abandonment
+# ---------------------------------------------------------------------------
+
+_MAIN_S_METER = FieldPath.receiver("main", "meters", "s_meter")
+_SUB_S_METER = FieldPath.receiver("sub", "meters", "s_meter")
+
+
+def _abandon_scheduler() -> AcquisitionScheduler:
+    """Two declared, non-``tx_only`` meter paths — the FTX-1 pair's shape."""
+
+    return AcquisitionScheduler(
+        profile=RadioAcquisitionProfile(
+            provider="test_provider",
+            capabilities=(
+                FieldCapability(path=_MAIN_S_METER, polling=True),
+                FieldCapability(path=_SUB_S_METER, polling=True),
+            ),
+            field_policies={
+                _MAIN_S_METER: AcquisitionPolicy(
+                    cadence_seconds=0.2, freshness_ttl_seconds=0.8
+                ),
+                _SUB_S_METER: AcquisitionPolicy(
+                    cadence_seconds=0.2, freshness_ttl_seconds=0.8
+                ),
+            },
+        )
+    )
+
+
+def test_abandoned_startup_path_leaves_the_unobserved_set() -> None:
+    scheduler = _abandon_scheduler()
+    assert scheduler.unobserved_startup_paths(()) == (_MAIN_S_METER, _SUB_S_METER)
+
+    scheduler.abandon_startup_path(_SUB_S_METER, reason="malformed CAT response")
+
+    assert scheduler.unobserved_startup_paths(()) == (_MAIN_S_METER,)
+    assert scheduler.initial_acquisition_complete(()) is False
+    assert scheduler.initial_acquisition_complete((_MAIN_S_METER,)) is True
+
+
+def test_abandoning_an_observed_path_does_not_change_the_unobserved_set() -> None:
+    scheduler = _abandon_scheduler()
+    observed = (_SUB_S_METER,)
+    before = scheduler.unobserved_startup_paths(observed)
+
+    scheduler.abandon_startup_path(_SUB_S_METER, reason="malformed CAT response")
+
+    assert before == (_MAIN_S_METER,)
+    assert scheduler.unobserved_startup_paths(observed) == before
+
+
+def test_abandon_startup_path_warns_once_naming_the_path_and_reason(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    scheduler = _abandon_scheduler()
+
+    with caplog.at_level(logging.WARNING, logger="rigplane.core.acquisition_scheduler"):
+        scheduler.abandon_startup_path(_SUB_S_METER, reason="malformed CAT response")
+        scheduler.abandon_startup_path(_SUB_S_METER, reason="malformed CAT response")
+
+    warnings = [
+        record for record in caplog.records if record.levelno == logging.WARNING
+    ]
+    assert len(warnings) == 1
+    assert str(_SUB_S_METER) in warnings[0].getMessage()
+    assert "malformed CAT response" in warnings[0].getMessage()
+    # Idempotent: the repeat leaves the filtered set as the first call left it.
+    assert scheduler.unobserved_startup_paths(()) == (_MAIN_S_METER,)

--- a/tests/test_startup_state_gate.py
+++ b/tests/test_startup_state_gate.py
@@ -638,3 +638,129 @@ async def test_web_ui_banner_prints_only_after_the_server_reports_started(
     assert rc == 0
     assert "Web UI:" not in before_start[0]
     assert "Web UI:" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# A declared field the backend gives up on
+# ---------------------------------------------------------------------------
+
+SUB_S_METER = FieldPath.receiver("sub", "meters", "s_meter")
+
+
+def _dual_meter_profile() -> RadioAcquisitionProfile:
+    """Two declared, non-``tx_only`` meter paths — the FTX-1 pair's shape."""
+
+    return RadioAcquisitionProfile(
+        provider="yaesu_cat",
+        capabilities=(
+            FieldCapability(path=S_METER, polling=True, stream_like=True),
+            FieldCapability(path=SUB_S_METER, polling=True, stream_like=True),
+        ),
+        field_policies={
+            S_METER: AcquisitionPolicy(cadence_seconds=0.2, freshness_ttl_seconds=0.8),
+            SUB_S_METER: AcquisitionPolicy(
+                cadence_seconds=0.2, freshness_ttl_seconds=0.8
+            ),
+        },
+    )
+
+
+class _YaesuAdapterPoller:
+    """Drives the real Yaesu adapter on a loop, like ``YaesuCatPoller``."""
+
+    def __init__(
+        self, callback: Callable[[Sequence[Observation]], None], radio: object
+    ):
+        self._callback = callback
+        self._radio = radio
+
+    async def start(self) -> None:
+        from rigplane.backends.yaesu_cat.observations import YaesuObservationAdapter
+
+        while True:
+            adapter = YaesuObservationAdapter(
+                self._radio,  # type: ignore[arg-type]
+                profile=self._radio._acquisition_scheduler._profile,  # type: ignore[attr-defined]
+            )
+            self._callback(await adapter.poll_rx_meters())
+            await asyncio.sleep(0.001)
+
+    async def stop(self) -> None:
+        return None
+
+    def bind_provider_generation(self, *, capture: object, advance: object) -> None:
+        return None
+
+
+class _MalformedSubMeterRadio:
+    """Answers the MAIN meter and returns an unparseable SUB meter frame."""
+
+    backend_id = "yaesu_cat"
+    model = "FAKE-OBS"
+    capabilities = {"meters", "dual_rx"}
+    connected = control_connected = radio_ready = True
+
+    def __init__(self) -> None:
+        self.radio_state = RadioState()
+        self._state_store = StateStore()
+        self._acquisition_scheduler = AcquisitionScheduler(
+            profile=_dual_meter_profile()
+        )
+        self._poll_warned_fields: set[str] = set()
+        self._INITIAL_STATE_GAP_SERIAL = 0.005
+
+    @property
+    def state_store(self) -> StateStore:
+        return self._state_store
+
+    def supports_command(self, _command: str) -> bool:
+        return False
+
+    async def read_s_meter(self, receiver: int = 0) -> int:
+        from rigplane.backends.yaesu_cat.parser import CatParseError
+
+        if receiver == 0:
+            return 120
+        raise CatParseError(
+            "SM1{raw:03d};", "SM0000;", "Response does not match pattern"
+        )
+
+    def create_observation_poller(
+        self, *, callback: Callable[[Sequence[Observation]], None], **_kwargs: object
+    ) -> object:
+        return _YaesuAdapterPoller(callback, self)
+
+
+@pytest.mark.asyncio
+async def test_gate_completes_when_the_backend_abandons_a_declared_path(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The bind happens even though one declared field never answers usably.
+
+    ``SUB_S_METER`` is polled every cycle and every answer is unparseable, so
+    no observation for it can ever reach the store. Without the backend
+    telling the scheduler to release it, this gate never returns.
+    """
+    radio = _MalformedSubMeterRadio()
+    server = WebServer(radio, _gated_config())
+    scheduler = radio._acquisition_scheduler
+    assert set(scheduler.unobserved_startup_paths(())) == {S_METER, SUB_S_METER}
+    binds: list[str] = []
+
+    async def _bind(*_args: object, **_kwargs: object) -> _FakeAsyncServer:
+        binds.append("bind")
+        return _FakeAsyncServer()
+
+    with caplog.at_level(logging.WARNING, logger="rigplane.core.acquisition_scheduler"):
+        with patch("rigplane.web.web_startup.asyncio.start_server", new=_bind):
+            await asyncio.wait_for(server.start(), timeout=10.0)
+            await server.stop()
+
+    assert binds == ["bind"]
+    assert scheduler.unobserved_startup_paths(_observed_paths(server, scheduler)) == ()
+    abandoned = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.WARNING and str(SUB_S_METER) in record.getMessage()
+    ]
+    assert len(abandoned) == 1

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -10,7 +10,9 @@ from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
+from rigplane.core.acquisition_scheduler import AcquisitionScheduler
 from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
+from rigplane.core.state_pipeline_contracts import FieldPath
 from rigplane.core.tx_observation import OBSERVED_PTT_PATH, ObservedPtt, TxStateReading
 from rigplane.core.tx_target import KnownTxTarget, TxReceiver, UnknownTxTarget
 from rigplane.core.types import BreakInMode
@@ -2242,3 +2244,61 @@ async def test_sub_s_meter_parse_warning_logged_once_then_suppressed(
 
 def _raise(exc: Exception) -> object:
     raise exc
+
+
+class _AbandonRecordingScheduler(AcquisitionScheduler):
+    """Real scheduler that records every ``abandon_startup_path`` call."""
+
+    def __init__(self, profile: RadioAcquisitionProfile) -> None:
+        super().__init__(profile=profile)
+        self.abandoned: list[tuple[FieldPath, str]] = []
+
+    def abandon_startup_path(self, path: FieldPath, *, reason: str) -> None:
+        self.abandoned.append((path, reason))
+        super().abandon_startup_path(path, reason=reason)
+
+
+@pytest.mark.asyncio
+async def test_first_sub_s_meter_skip_releases_the_path_from_the_startup_gate() -> None:
+    """The skipped field must not leave the startup gate waiting for it.
+
+    Same frame as ``test_sub_s_meter_parse_warning_logged_once_then_suppressed``:
+    the FTX-1 answers the sub ``SM1;`` query in main form every cycle, so no
+    ``receiver.sub.meters.s_meter`` observation ever arrives. The first skip
+    tells the scheduler; the repeats that demote to DEBUG do not tell it again.
+    """
+    profile = _profile_state_acquisition()
+    scheduler = _AbandonRecordingScheduler(profile)
+    sub_path = FieldPath.receiver("sub", "meters", "s_meter")
+    assert sub_path in scheduler.unobserved_startup_paths(())
+
+    radio = _make_radio()
+    radio._poll_warned_fields = set()
+    radio._acquisition_scheduler = scheduler
+    radio.read_s_meter = AsyncMock(
+        side_effect=lambda receiver=0: (
+            120
+            if receiver == 0
+            else _raise(
+                CatParseError(
+                    "SM1{raw:03d};",
+                    "SM0000;",
+                    "Response does not match pattern",
+                )
+            )
+        )
+    )
+
+    for _ in range(3):
+        await YaesuObservationAdapter(
+            radio,
+            profile=profile,
+            clock=_clock,
+        ).poll_rx_meters()
+
+    assert [path for path, _ in scheduler.abandoned] == [sub_path]
+    assert sub_path not in scheduler.unobserved_startup_paths(())
+    # The MAIN meter, whose answer parses, is not abandoned.
+    assert FieldPath.receiver(
+        "main", "meters", "s_meter"
+    ) in scheduler.unobserved_startup_paths(())


### PR DESCRIPTION
## What

`AcquisitionScheduler` gains `abandon_startup_path(path, *, reason)`, backed by
a new set declared in `__slots__`.
`AcquisitionScheduler.unobserved_startup_paths` filters those paths out exactly
the way it already filters the profile's `tx_only` ones. The first call for a
path logs it by name, with the caller's reason, at WARNING; repeats are silent.

`YaesuObservationAdapter._safe_read` and `._log_field_skip`
(`src/rigplane/backends/yaesu_cat/observations.py`) take an optional
`path: FieldPath | None`. When it is given, the branch that emits the
once-per-field WARNING also calls `abandon_startup_path` on the scheduler
attached to the radio, reached the way `runtime/_civ_rx.py:
CivRuntime._record_scheduler_result_for_observation` reaches it —
`getattr(radio, "_acquisition_scheduler", None)` plus an `isinstance` guard.
`YaesuObservationAdapter.poll_rx_meters` passes `path=` for its two S-meter
reads.

No deadline is added. A field that has simply not answered yet, or that times
out, still keeps the gate open: `_safe_read` catches only field-level
parse/reject failures and re-raises transport errors, and
`AcquisitionScheduler.record_acquisition_failure` is untouched.
`test_never_answered_path_is_reprimed_once_per_reprime_interval` and
`test_outstanding_paths_are_logged_then_warned_when_nothing_arrives` pass
unchanged.

The Icom branch and `rigs/ftx1.toml` are untouched.

## Why

On a real FTX-1 `rigplane web` never binds. `web/web_startup.py:
_await_initial_state_acquisition` waits until
`AcquisitionScheduler.unobserved_startup_paths` is empty, and before this
change the only way a path left that set was a store observation (plus the
static `tx_only` exclusion). The FTX-1 answers the sub S-meter query `SM1;`
with a main-form `SM0000;` frame every poll cycle;
`YaesuObservationAdapter._safe_read` turns that into a silently skipped field
(MOR-561) and told nobody, so `receiver.sub.meters.s_meter` stayed outstanding
forever and the listener was never bound.

`_await_initial_state_acquisition`'s docstring claimed "a field the radio
answers with NG stays outstanding because the store has no negative state",
which this change falsifies for the Yaesu reject/parse case; that clause is
deleted. The "no serve-anyway timeout" sentence stays, and is still true.

## Guardrails

7 files / 334 changed lines — over the 6-file soft threshold, under both hard
ceilings. One unit of work: the scheduler cannot release a path nothing tells
it to release, and the adapter's call has nothing to call without the
scheduler method, so the two source files and their two test files land
together. `web/web_startup.py` is a three-line docstring deletion of the
sentence this change makes false.

## Census

`git diff --numstat origin/main...HEAD` at the pushed head:

```
35	6	src/rigplane/backends/yaesu_cat/observations.py
25	1	src/rigplane/core/acquisition_scheduler.py
1	2	src/rigplane/web/server.py
2	4	src/rigplane/web/web_startup.py
72	0	tests/test_acquisition_scheduler.py
126	0	tests/test_startup_state_gate.py
60	0	tests/test_yaesu_cat_observation_adapter.py
```

7 files, 321+/13- = 334 changed lines at cfeaadfa. The seventh file, `web/server.py`, carries only the deletion of a comment clause the change made false ("until every declared, non-tx_only field has been observed once"), found by the review's class sweep; the gate docstring's summary line in `web_startup.py` was narrowed for the same reason.

## Tests

`uv run pytest tests/test_acquisition_scheduler.py tests/test_startup_state_gate.py tests/test_yaesu_cat_observation_adapter.py -q -p no:cacheprovider`

```
204 passed in 2.60s
```

No `tests/test_web_startup*.py` exists (`ls tests/ | grep -c web_startup` → 0).

Other gates, each run in the worktree at this head:

```
uv run ruff check src/ tests/         -> All checks passed!
uv run ruff format --check src/ tests/-> 742 files already formatted
uv run mypy --strict src/rigplane/web -> Success: no issues found in 27 source files
uv run lint-imports                   -> Contracts: 5 kept, 0 broken.
```

New tests:

* `test_abandoned_startup_path_leaves_the_unobserved_set`,
  `test_abandoning_an_observed_path_does_not_change_the_unobserved_set`,
  `test_abandon_startup_path_warns_once_naming_the_path_and_reason`
  (`tests/test_acquisition_scheduler.py`);
* `test_first_sub_s_meter_skip_releases_the_path_from_the_startup_gate`
  (`tests/test_yaesu_cat_observation_adapter.py`) — the same
  `SM1;`→`SM0000;` frame as the MOR-561 test, three poll cycles, asserting
  the scheduler is told once and the path leaves the unobserved set;
* `test_gate_completes_when_the_backend_abandons_a_declared_path`
  (`tests/test_startup_state_gate.py`) — a synthetic two-meter profile
  matching the FTX-1 pair's declaration (`rigs/ftx1.toml`,
  `[state_acquisition.field_policies."receiver.{main,sub}.meters.s_meter"]`:
  cadence 0.2 s, TTL 0.8 s, no `tx_only`), driven through the real
  `YaesuObservationAdapter` behind `WebServer.start`, asserting the bind
  happens, the outstanding set empties, and the WARNING names the path.

## Mutations

(i) Filter term `and path not in self._abandoned_startup_paths` removed from
`AcquisitionScheduler.unobserved_startup_paths`:

```
FAILED tests/test_acquisition_scheduler.py::test_abandoned_startup_path_leaves_the_unobserved_set
FAILED tests/test_acquisition_scheduler.py::test_abandon_startup_path_warns_once_naming_the_path_and_reason
FAILED tests/test_startup_state_gate.py::test_gate_completes_when_the_backend_abandons_a_declared_path
FAILED tests/test_yaesu_cat_observation_adapter.py::test_first_sub_s_meter_skip_releases_the_path_from_the_startup_gate
4 failed, 200 passed in 12.92s
```

The gate test failed with `TimeoutError` out of its `asyncio.wait_for`, i.e.
the deadlock itself.
`test_abandoning_an_observed_path_does_not_change_the_unobserved_set` survived,
correctly — it asserts a no-op.

(ii) The `abandon_startup_path` call removed from
`YaesuObservationAdapter._log_field_skip`:

```
FAILED tests/test_startup_state_gate.py::test_gate_completes_when_the_backend_abandons_a_declared_path
FAILED tests/test_yaesu_cat_observation_adapter.py::test_first_sub_s_meter_skip_releases_the_path_from_the_startup_gate
2 failed, 202 passed in 12.79s
```

(iii) Behaviour-preserving refactor — the filter rewritten as a set difference
(`domain - observed - self._abandoned_startup_paths`, then the `tx_only` test):

```
204 passed in 2.84s
```

Tree restored after each; `git diff` before the final run showed only the
intended change.

## Left unfixed, reported

`_safe_read` has 47 call sites in
`src/rigplane/backends/yaesu_cat/observations.py`
(`grep -c "await self._safe_read("`). This change threads `path=` through 2 of
them, both in `poll_rx_meters`. The other 45 still skip silently and can still
hold the gate open if their answers stop parsing. They are not threaded here
because the mapping is not mechanical and needs per-site judgement: some labels
do not name one declared path (`"tx_target.freq"` is a sub-read feeding a
`global.tx_state.tx_target` observation that is emitted either way), and
`_log_field_skip` also has four call sites outside `_safe_read`
(three in `_normalize_power_level`, plus the PTT read-failure branch) whose
failure is profile metadata rather than a wire answer. Doing all 47 correctly
is a separate change.

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

