### PR TITLE
fix: abandon every declared path a skipped Yaesu read feeds

### DIFF
--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -1349,9 +1349,7 @@ class YaesuObservationAdapter:
         e.g. a ``MagicMock`` test double — falls back to always-warn.
 
         ``paths`` names the declared fields the skipped read would have
-        produced. Each is released from the startup gate
-        (``AcquisitionScheduler.abandon_startup_path``), so a field whose
-        answer never parses cannot hold that gate open. Pinned by
+        produced; see ``AcquisitionScheduler.abandon_startup_path`` and
         ``tests/test_yaesu_cat_observation_adapter.py::
         test_skipped_read_abandons_every_declared_path_it_feeds``.
         """

--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -322,7 +322,9 @@ class YaesuObservationAdapter:
         adapter = self._adapter()
         observations: list[Observation] = []
         if self._can_poll(_MAIN_FREQ):
-            ok, value = await self._safe_read("main.freq", self.radio.read_freq(0))
+            ok, value = await self._safe_read(
+                "main.freq", self.radio.read_freq(0), paths=(_MAIN_FREQ,)
+            )
             if ok:
                 observations.append(
                     adapter.observation(_MAIN_FREQ, value, native_id="read_freq")
@@ -332,20 +334,26 @@ class YaesuObservationAdapter:
         # issuing a redundant CAT mode query on the hot poll path (MOR-507).
         main_mode: str | None = None
         if self._can_poll(_MAIN_MODE):
-            ok, result = await self._safe_read("main.mode", self.radio.read_mode(0))
+            ok, result = await self._safe_read(
+                "main.mode", self.radio.read_mode(0), paths=(_MAIN_MODE,)
+            )
             if ok and result is not None:
                 main_mode = result[0]
                 observations.append(
                     adapter.observation(_MAIN_MODE, result[0], native_id="read_mode")
                 )
         if self._has_runtime_capability("dual_rx") and self._can_poll(_SUB_FREQ):
-            ok, value = await self._safe_read("sub.freq", self.radio.read_freq(1))
+            ok, value = await self._safe_read(
+                "sub.freq", self.radio.read_freq(1), paths=(_SUB_FREQ,)
+            )
             if ok:
                 observations.append(
                     adapter.observation(_SUB_FREQ, value, native_id="read_freq")
                 )
         if self._has_runtime_capability("dual_rx") and self._can_poll(_SUB_MODE):
-            ok, result = await self._safe_read("sub.mode", self.radio.read_mode(1))
+            ok, result = await self._safe_read(
+                "sub.mode", self.radio.read_mode(1), paths=(_SUB_MODE,)
+            )
             if ok and result is not None:
                 observations.append(
                     adapter.observation(_SUB_MODE, result[0], native_id="read_mode")
@@ -382,7 +390,10 @@ class YaesuObservationAdapter:
                 CatCommandRejected,
             ) as exc:
                 self._log_field_skip(
-                    "ptt", "Skipping field %s — PTT read failed: %s", exc
+                    "ptt",
+                    "Skipping field %s — PTT read failed: %s",
+                    exc,
+                    paths=(_PTT,),
                 )
                 reading = TxStateReading(None, failure="read-error")
             except Exception:
@@ -426,7 +437,9 @@ class YaesuObservationAdapter:
             _MAIN_FILTER_WIDTH
         ):
             ok, value = await self._safe_read(
-                "main.filter_width", self.radio.read_filter_width(0, mode=main_mode)
+                "main.filter_width",
+                self.radio.read_filter_width(0, mode=main_mode),
+                paths=(_MAIN_FILTER_WIDTH,),
             )
             if ok:
                 observations.append(
@@ -511,7 +524,7 @@ class YaesuObservationAdapter:
         observations: list[Observation] = []
         if self._has_runtime_capability("meters") and self._can_poll(_MAIN_S_METER):
             ok, raw = await self._safe_read(
-                "main.s_meter", self.radio.read_s_meter(0), path=_MAIN_S_METER
+                "main.s_meter", self.radio.read_s_meter(0), paths=(_MAIN_S_METER,)
             )
             if ok and raw is not None:
                 raw = smooth_s_meter(0, raw) if smooth_s_meter is not None else raw
@@ -530,7 +543,7 @@ class YaesuObservationAdapter:
             and self._can_poll(_SUB_S_METER)
         ):
             ok, raw = await self._safe_read(
-                "sub.s_meter", self.radio.read_s_meter(1), path=_SUB_S_METER
+                "sub.s_meter", self.radio.read_s_meter(1), paths=(_SUB_S_METER,)
             )
             if ok and raw is not None:
                 raw = smooth_s_meter(1, raw) if smooth_s_meter is not None else raw
@@ -609,7 +622,9 @@ class YaesuObservationAdapter:
         # ALC is a stream-like TX meter (MOR-448), emitted in the same lane and
         # under the same meter freshness/coalescing policy as power/swr.
         if self._has_runtime_capability("meters") and self._can_poll(_ALC_METER):
-            ok, raw = await self._safe_read("alc", self.radio.read_alc_meter())
+            ok, raw = await self._safe_read(
+                "alc", self.radio.read_alc_meter(), paths=(_ALC_METER,)
+            )
             if ok and raw is not None:
                 value, quality = self._calibrate_meter(raw, "alc")
                 observations.append(
@@ -621,7 +636,9 @@ class YaesuObservationAdapter:
                     )
                 )
         if self._has_runtime_capability("meters") and self._can_poll(_POWER_METER):
-            ok, raw = await self._safe_read("power", self.radio.read_power_meter())
+            ok, raw = await self._safe_read(
+                "power", self.radio.read_power_meter(), paths=(_POWER_METER,)
+            )
             if ok and raw is not None:
                 value, quality = self._calibrate_meter(raw, "power")
                 observations.append(
@@ -633,7 +650,9 @@ class YaesuObservationAdapter:
                     )
                 )
         if self._has_runtime_capability("meters") and self._can_poll(_SWR_METER):
-            ok, raw = await self._safe_read("swr", self.radio.read_swr_meter())
+            ok, raw = await self._safe_read(
+                "swr", self.radio.read_swr_meter(), paths=(_SWR_METER,)
+            )
             if ok and raw is not None:
                 value, quality = self._calibrate_meter(raw, "swr")
                 observations.append(
@@ -647,7 +666,9 @@ class YaesuObservationAdapter:
         # COMP is the cross-vendor PA meter (MOR-460), emitted in the same lane
         # and under the same meter freshness/coalescing policy as alc/power/swr.
         if self._has_runtime_capability("meters") and self._can_poll(_COMP_METER):
-            ok, raw = await self._safe_read("comp", self.radio.read_comp_meter())
+            ok, raw = await self._safe_read(
+                "comp", self.radio.read_comp_meter(), paths=(_COMP_METER,)
+            )
             if ok and raw is not None:
                 value, quality = self._calibrate_meter(raw, "comp")
                 observations.append(
@@ -665,7 +686,7 @@ class YaesuObservationAdapter:
         observations: list[Observation] = []
         if self._has_runtime_capability("af_level") and self._can_poll(_MAIN_AF):
             ok, value = await self._safe_read(
-                "main.af_level", self.radio.read_af_level(0)
+                "main.af_level", self.radio.read_af_level(0), paths=(_MAIN_AF,)
             )
             if ok:
                 observations.append(
@@ -677,7 +698,7 @@ class YaesuObservationAdapter:
                 )
         if self._has_runtime_capability("rf_gain") and self._can_poll(_MAIN_RF):
             ok, value = await self._safe_read(
-                "main.rf_gain", self.radio.read_rf_gain(0)
+                "main.rf_gain", self.radio.read_rf_gain(0), paths=(_MAIN_RF,)
             )
             if ok:
                 observations.append(
@@ -689,7 +710,7 @@ class YaesuObservationAdapter:
                 )
         if self._has_runtime_capability("squelch") and self._can_poll(_MAIN_SQL):
             ok, value = await self._safe_read(
-                "main.squelch", self.radio.read_squelch(0)
+                "main.squelch", self.radio.read_squelch(0), paths=(_MAIN_SQL,)
             )
             if ok:
                 observations.append(
@@ -705,7 +726,7 @@ class YaesuObservationAdapter:
             and self._can_poll(_SUB_AF)
         ):
             ok, value = await self._safe_read(
-                "sub.af_level", self.radio.read_af_level(1)
+                "sub.af_level", self.radio.read_af_level(1), paths=(_SUB_AF,)
             )
             if ok:
                 observations.append(
@@ -720,7 +741,9 @@ class YaesuObservationAdapter:
             and self._has_runtime_capability("rf_gain")
             and self._can_poll(_SUB_RF)
         ):
-            ok, value = await self._safe_read("sub.rf_gain", self.radio.read_rf_gain(1))
+            ok, value = await self._safe_read(
+                "sub.rf_gain", self.radio.read_rf_gain(1), paths=(_SUB_RF,)
+            )
             if ok:
                 observations.append(
                     adapter.observation(
@@ -734,7 +757,9 @@ class YaesuObservationAdapter:
             and self._has_runtime_capability("squelch")
             and self._can_poll(_SUB_SQL)
         ):
-            ok, value = await self._safe_read("sub.squelch", self.radio.read_squelch(1))
+            ok, value = await self._safe_read(
+                "sub.squelch", self.radio.read_squelch(1), paths=(_SUB_SQL,)
+            )
             if ok:
                 observations.append(
                     adapter.observation(
@@ -751,7 +776,9 @@ class YaesuObservationAdapter:
         # receives the coerced ``int(on_off)`` (0/1) — no scaling beyond the
         # bool→int match (cross-vendor calibration is MOR-453).
         if self._has_runtime_capability("attenuator") and self._can_poll(_MAIN_ATT):
-            ok, value = await self._safe_read("main.att", self.radio.read_attenuator(0))
+            ok, value = await self._safe_read(
+                "main.att", self.radio.read_attenuator(0), paths=(_MAIN_ATT,)
+            )
             if ok and value is not None:
                 observations.append(
                     adapter.observation(
@@ -759,13 +786,17 @@ class YaesuObservationAdapter:
                     )
                 )
         if self._has_runtime_capability("preamp") and self._can_poll(_MAIN_PREAMP):
-            ok, value = await self._safe_read("main.preamp", self.radio.read_preamp(0))
+            ok, value = await self._safe_read(
+                "main.preamp", self.radio.read_preamp(0), paths=(_MAIN_PREAMP,)
+            )
             if ok:
                 observations.append(
                     adapter.observation(_MAIN_PREAMP, value, native_id="read_preamp")
                 )
         if self._can_poll(_MAIN_AGC):
-            ok, value = await self._safe_read("main.agc", self.radio.read_agc(0))
+            ok, value = await self._safe_read(
+                "main.agc", self.radio.read_agc(0), paths=(_MAIN_AGC,)
+            )
             if ok:
                 observations.append(
                     adapter.observation(_MAIN_AGC, value, native_id="read_agc")
@@ -777,7 +808,7 @@ class YaesuObservationAdapter:
         # "always — lightweight query" treatment, like AGC.
         if self._has_runtime_capability("if_shift") and self._can_poll(_MAIN_IF_SHIFT):
             ok, value = await self._safe_read(
-                "main.if_shift", self.radio.read_if_shift(0)
+                "main.if_shift", self.radio.read_if_shift(0), paths=(_MAIN_IF_SHIFT,)
             )
             if ok:
                 observations.append(
@@ -786,7 +817,9 @@ class YaesuObservationAdapter:
                     )
                 )
         if self._can_poll(_MAIN_NARROW):
-            ok, value = await self._safe_read("main.narrow", self.radio.read_narrow(0))
+            ok, value = await self._safe_read(
+                "main.narrow", self.radio.read_narrow(0), paths=(_MAIN_NARROW,)
+            )
             if ok:
                 observations.append(
                     adapter.observation(_MAIN_NARROW, value, native_id="read_narrow")
@@ -800,7 +833,9 @@ class YaesuObservationAdapter:
         # exactly as the legacy poller derives them; no second query.
         if self._has_runtime_capability("nb"):
             ok, nb_level = await self._safe_read(
-                "main.nb_level", self.radio.read_nb_level(0)
+                "main.nb_level",
+                self.radio.read_nb_level(0),
+                paths=(_MAIN_NB_LEVEL, _MAIN_NB),
             )
             if ok and nb_level is not None:
                 if self._can_poll(_MAIN_NB_LEVEL):
@@ -821,7 +856,9 @@ class YaesuObservationAdapter:
                     )
         if self._has_runtime_capability("nr"):
             ok, nr_level = await self._safe_read(
-                "main.nr_level", self.radio.read_nr_level(0)
+                "main.nr_level",
+                self.radio.read_nr_level(0),
+                paths=(_MAIN_NR_LEVEL, _MAIN_NR),
             )
             if ok and nr_level is not None:
                 if self._can_poll(_MAIN_NR_LEVEL):
@@ -842,7 +879,9 @@ class YaesuObservationAdapter:
                     )
         if self._has_runtime_capability("notch") and self._can_poll(_MAIN_AUTO_NOTCH):
             ok, value = await self._safe_read(
-                "main.auto_notch", self.radio.read_auto_notch(0)
+                "main.auto_notch",
+                self.radio.read_auto_notch(0),
+                paths=(_MAIN_AUTO_NOTCH,),
             )
             if ok:
                 observations.append(
@@ -852,7 +891,9 @@ class YaesuObservationAdapter:
                 )
         if self._has_runtime_capability("notch") and self._can_poll(_MAIN_MANUAL_NOTCH):
             ok, value = await self._safe_read(
-                "main.manual_notch", self.radio.read_manual_notch(0)
+                "main.manual_notch",
+                self.radio.read_manual_notch(0),
+                paths=(_MAIN_MANUAL_NOTCH,),
             )
             if ok:
                 observations.append(
@@ -864,7 +905,9 @@ class YaesuObservationAdapter:
             _MAIN_MANUAL_NOTCH_FREQ
         ):
             ok, value = await self._safe_read(
-                "main.manual_notch_freq", self.radio.read_manual_notch_freq(0)
+                "main.manual_notch_freq",
+                self.radio.read_manual_notch_freq(0),
+                paths=(_MAIN_MANUAL_NOTCH_FREQ,),
             )
             if ok:
                 observations.append(
@@ -894,7 +937,9 @@ class YaesuObservationAdapter:
         # here.
         if self._has_runtime_capability("sql_type"):
             ok, sql_type = await self._safe_read(
-                "main.sql_type", self.radio.read_sql_type(0)
+                "main.sql_type",
+                self.radio.read_sql_type(0),
+                paths=(_MAIN_REPEATER_TONE, _MAIN_REPEATER_TSQL),
             )
             if ok and sql_type is not None:
                 if self._can_poll(_MAIN_REPEATER_TONE):
@@ -933,7 +978,9 @@ class YaesuObservationAdapter:
         # NO neutral DCS path is emitted.
         if self._has_runtime_capability("sql_type"):
             ok, tone_index = await self._safe_read(
-                "main.ctcss_tone_index", self.radio.read_ctcss_tone_index(0)
+                "main.ctcss_tone_index",
+                self.radio.read_ctcss_tone_index(0),
+                paths=(_MAIN_TONE_FREQ, _MAIN_TSQL_FREQ),
             )
             if ok and tone_index is not None:
                 try:
@@ -976,6 +1023,7 @@ class YaesuObservationAdapter:
                     ok, shift_code = await self._safe_read(
                         f"{label}.repeater_shift",
                         self.radio.read_repeater_shift(receiver),
+                        paths=(path,),
                     )
                     if ok and shift_code is not None:
                         observations.append(
@@ -991,7 +1039,9 @@ class YaesuObservationAdapter:
         # ``VS`` index (0=MAIN, 1=SUB) is coerced to the neutral
         # ``global.slow_state.active`` ``"MAIN"``/``"SUB"`` str.
         if self._can_poll(_ACTIVE):
-            ok, index = await self._safe_read("active", self.radio.read_vfo_select())
+            ok, index = await self._safe_read(
+                "active", self.radio.read_vfo_select(), paths=(_ACTIVE,)
+            )
             if ok and index is not None:
                 observations.append(
                     adapter.observation(
@@ -1005,7 +1055,9 @@ class YaesuObservationAdapter:
         # key_speed/cw_pitch/break_in). Emitted in the slow-control lane beside
         # ``slow_state.active``, the only other global slow_state observation.
         if self._has_runtime_capability("cw") and self._can_poll(_CW_SPOT):
-            ok, value = await self._safe_read("cw_spot", self.radio.read_cw_spot())
+            ok, value = await self._safe_read(
+                "cw_spot", self.radio.read_cw_spot(), paths=(_CW_SPOT,)
+            )
             if ok:
                 observations.append(
                     adapter.observation(
@@ -1032,7 +1084,9 @@ class YaesuObservationAdapter:
         adapter = self._adapter()
         observations: list[Observation] = []
         if self._has_runtime_capability("tx") and self._can_poll(_POWER_LEVEL):
-            ok, result = await self._safe_read("power_level", self.radio.read_power())
+            ok, result = await self._safe_read(
+                "power_level", self.radio.read_power(), paths=(_POWER_LEVEL,)
+            )
             if ok and result is not None:
                 normalized = self._normalize_power_level(result[1])
                 if normalized is not None:
@@ -1044,7 +1098,9 @@ class YaesuObservationAdapter:
                         )
                     )
         if self._can_poll(_MIC_GAIN):
-            ok, value = await self._safe_read("mic_gain", self.radio.read_mic_gain())
+            ok, value = await self._safe_read(
+                "mic_gain", self.radio.read_mic_gain(), paths=(_MIC_GAIN,)
+            )
             if ok:
                 observations.append(
                     adapter.observation(_MIC_GAIN, value, native_id="read_mic_gain")
@@ -1053,7 +1109,7 @@ class YaesuObservationAdapter:
             _COMPRESSOR_ON
         ):
             ok, value = await self._safe_read(
-                "compressor_on", self.radio.read_processor()
+                "compressor_on", self.radio.read_processor(), paths=(_COMPRESSOR_ON,)
             )
             if ok:
                 observations.append(
@@ -1065,7 +1121,9 @@ class YaesuObservationAdapter:
             _COMPRESSOR_LEVEL
         ):
             ok, value = await self._safe_read(
-                "compressor_level", self.radio.read_processor_level()
+                "compressor_level",
+                self.radio.read_processor_level(),
+                paths=(_COMPRESSOR_LEVEL,),
             )
             if ok:
                 observations.append(
@@ -1074,7 +1132,9 @@ class YaesuObservationAdapter:
                     )
                 )
         if self._has_runtime_capability("vox") and self._can_poll(_VOX_ON):
-            ok, value = await self._safe_read("vox", self.radio.read_vox())
+            ok, value = await self._safe_read(
+                "vox", self.radio.read_vox(), paths=(_VOX_ON,)
+            )
             if ok:
                 observations.append(
                     adapter.observation(_VOX_ON, value, native_id="read_vox")
@@ -1083,7 +1143,9 @@ class YaesuObservationAdapter:
         # ``split`` runtime capability, mirroring the legacy poller's
         # ``"split" in caps`` gate.
         if self._has_runtime_capability("split") and self._can_poll(_SPLIT):
-            ok, value = await self._safe_read("split", self.radio.read_split())
+            ok, value = await self._safe_read(
+                "split", self.radio.read_split(), paths=(_SPLIT,)
+            )
             if ok:
                 observations.append(
                     adapter.observation(_SPLIT, value, native_id="read_split")
@@ -1095,7 +1157,9 @@ class YaesuObservationAdapter:
         has_rit = self._has_runtime_capability("rit")
         has_xit = self._has_runtime_capability("xit")
         if has_rit or has_xit:
-            ok, clar = await self._safe_read("clarifier", self.radio.read_clarifier(0))
+            ok, clar = await self._safe_read(
+                "clarifier", self.radio.read_clarifier(0), paths=(_RIT_ON, _RIT_TX)
+            )
             if ok and clar is not None:
                 rx_clar, tx_clar = clar
                 if has_rit and self._can_poll(_RIT_ON):
@@ -1116,7 +1180,9 @@ class YaesuObservationAdapter:
                     )
             if self._can_poll(_RIT_FREQ):
                 ok, freq = await self._safe_read(
-                    "clarifier_freq", self.radio.read_clarifier_freq(0)
+                    "clarifier_freq",
+                    self.radio.read_clarifier_freq(0),
+                    paths=(_RIT_FREQ,),
                 )
                 if ok:
                     observations.append(
@@ -1130,7 +1196,9 @@ class YaesuObservationAdapter:
         # gated on the ``tuner`` runtime capability, mirroring the legacy
         # poller's ``"tuner" in caps`` gate; the generic getter normalizes AC.
         if self._has_runtime_capability("tuner") and self._can_poll(_TUNER):
-            ok, value = await self._safe_read("tuner", self.radio.get_tuner_status())
+            ok, value = await self._safe_read(
+                "tuner", self.radio.get_tuner_status(), paths=(_TUNER,)
+            )
             if ok and value is not None:
                 observations.append(
                     adapter.observation(
@@ -1143,7 +1211,9 @@ class YaesuObservationAdapter:
         # ``dial_lock`` runtime capability, mirroring the legacy poller's
         # ``"dial_lock" in caps`` gate.
         if self._has_runtime_capability("dial_lock") and self._can_poll(_DIAL_LOCK):
-            ok, value = await self._safe_read("dial_lock", self.radio.read_lock())
+            ok, value = await self._safe_read(
+                "dial_lock", self.radio.read_lock(), paths=(_DIAL_LOCK,)
+            )
             if ok:
                 observations.append(
                     adapter.observation(
@@ -1165,7 +1235,7 @@ class YaesuObservationAdapter:
         if self._has_runtime_capability("cw"):
             if self._can_poll(_KEY_SPEED):
                 ok, value = await self._safe_read(
-                    "key_speed", self.radio.read_keyer_speed()
+                    "key_speed", self.radio.read_keyer_speed(), paths=(_KEY_SPEED,)
                 )
                 if ok and value is not None:
                     observations.append(
@@ -1177,7 +1247,7 @@ class YaesuObservationAdapter:
                     )
             if self._can_poll(_CW_PITCH):
                 ok, value = await self._safe_read(
-                    "cw_pitch", self.radio.read_cw_pitch()
+                    "cw_pitch", self.radio.read_cw_pitch(), paths=(_CW_PITCH,)
                 )
                 if ok and value is not None:
                     observations.append(
@@ -1189,7 +1259,7 @@ class YaesuObservationAdapter:
                     )
             if self._can_poll(_BREAK_IN):
                 ok, value = await self._safe_read(
-                    "break_in", self.radio.read_break_in()
+                    "break_in", self.radio.read_break_in(), paths=(_BREAK_IN,)
                 )
                 if ok and value is not None:
                     observations.append(
@@ -1201,7 +1271,9 @@ class YaesuObservationAdapter:
                     )
             if self._can_poll(_BREAK_IN_DELAY):
                 ok, value = await self._safe_read(
-                    "break_in_delay", self.radio.read_break_in_delay()
+                    "break_in_delay",
+                    self.radio.read_break_in_delay(),
+                    paths=(_BREAK_IN_DELAY,),
                 )
                 if ok and value is not None:
                     observations.append(
@@ -1218,7 +1290,7 @@ class YaesuObservationAdapter:
         label: str,
         read: Awaitable[_T],
         *,
-        path: FieldPath | None = None,
+        paths: tuple[FieldPath, ...] = (),
     ) -> tuple[bool, _T | None]:
         """Await one field read, tolerating FIELD-level CAT failures (MOR-473).
 
@@ -1246,13 +1318,19 @@ class YaesuObservationAdapter:
             # ValueError covers _read_meter / int() malformed-frame failures;
             # CatParse/FormatError subclass ValueError but are listed for clarity.
             self._log_field_skip(
-                label, "Skipping field %s — malformed CAT response: %s", exc, path=path
+                label,
+                "Skipping field %s — malformed CAT response: %s",
+                exc,
+                paths=paths,
             )
             return False, None
         except CatCommandRejected as exc:
             # ``?;`` reject = command unsupported on this radio -> skip the field.
             self._log_field_skip(
-                label, "Skipping field %s — command rejected (?;): %s", exc, path=path
+                label,
+                "Skipping field %s — command rejected (?;): %s",
+                exc,
+                paths=paths,
             )
             return False, None
 
@@ -1262,7 +1340,7 @@ class YaesuObservationAdapter:
         message: str,
         exc: Exception,
         *,
-        path: FieldPath | None = None,
+        paths: tuple[FieldPath, ...] = (),
     ) -> None:
         """Warn once per field, then demote repeats to DEBUG (MOR-561).
 
@@ -1270,12 +1348,12 @@ class YaesuObservationAdapter:
         rather than the adapter (rebuilt every cycle). A non-``set`` attribute —
         e.g. a ``MagicMock`` test double — falls back to always-warn.
 
-        ``path`` names the declared field the skipped read would have produced.
-        Where it is given, the warning also releases that path from the startup
-        gate (``AcquisitionScheduler.abandon_startup_path``), so a field whose
+        ``paths`` names the declared fields the skipped read would have
+        produced. Each is released from the startup gate
+        (``AcquisitionScheduler.abandon_startup_path``), so a field whose
         answer never parses cannot hold that gate open. Pinned by
         ``tests/test_yaesu_cat_observation_adapter.py::
-        test_first_sub_s_meter_skip_releases_the_path_from_the_startup_gate``.
+        test_skipped_read_abandons_every_declared_path_it_feeds``.
         """
         warned = getattr(self.radio, "_poll_warned_fields", None)
         if isinstance(warned, set):
@@ -1283,12 +1361,13 @@ class YaesuObservationAdapter:
                 logger.debug(message, label, exc)
                 return
             warned.add(label)
-        if path is not None:
+        if paths:
             scheduler = getattr(self.radio, "_acquisition_scheduler", None)
             if isinstance(scheduler, AcquisitionScheduler):
-                scheduler.abandon_startup_path(
-                    path, reason=f"yaesu field read skipped: {label}"
-                )
+                for path in paths:
+                    scheduler.abandon_startup_path(
+                        path, reason=f"yaesu field read skipped: {label}"
+                    )
         logger.warning(message, label, exc)
 
     def _adapter(self) -> ProviderObservationAdapter:

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -2302,3 +2302,402 @@ async def test_first_sub_s_meter_skip_releases_the_path_from_the_startup_gate() 
     assert FieldPath.receiver(
         "main", "meters", "s_meter"
     ) in scheduler.unobserved_startup_paths(())
+
+
+def _gate_radio() -> MagicMock:
+    """``_make_radio`` plus the ``repeater_shift`` capability and its read."""
+    radio = _make_radio()
+    radio._poll_warned_fields = set()
+    radio.capabilities = radio.capabilities | {"repeater_shift"}
+    radio.read_repeater_shift = AsyncMock(side_effect=lambda receiver=0: receiver)
+    return radio
+
+
+def _break_read(radio: MagicMock, method: str, receiver: int | None) -> None:
+    """Make ``method`` answer with an unparseable frame.
+
+    ``receiver`` selects which call fails: ``None`` fails every call, an int
+    fails only the call whose first positional argument equals it, so a read
+    shared by MAIN and SUB can be broken on one side alone.
+    """
+    original = getattr(radio, method)
+
+    async def _answer(*args: object, **kwargs: object) -> object:
+        if receiver is None or (args and args[0] == receiver):
+            raise CatParseError("XX{p};", "??;", "Response does not match pattern")
+        return await original(*args, **kwargs)
+
+    setattr(radio, method, _answer)
+
+
+# (id, radio method, failing receiver, poll method, declared paths abandoned)
+_ABANDON_ROWS: tuple[tuple[str, str, int | None, str, tuple[str, ...]], ...] = (
+    (
+        "main.freq",
+        "read_freq",
+        0,
+        "poll_medium",
+        ("receiver.main.active.freq_mode.freq_hz",),
+    ),
+    (
+        "main.mode",
+        "read_mode",
+        0,
+        "poll_medium",
+        ("receiver.main.active.freq_mode.mode",),
+    ),
+    (
+        "sub.freq",
+        "read_freq",
+        1,
+        "poll_medium",
+        ("receiver.sub.active.freq_mode.freq_hz",),
+    ),
+    (
+        "sub.mode",
+        "read_mode",
+        1,
+        "poll_medium",
+        ("receiver.sub.active.freq_mode.mode",),
+    ),
+    ("ptt", "read_transmit_state", None, "poll_medium", ("global.tx_state.ptt",)),
+    (
+        "main.filter_width",
+        "read_filter_width",
+        0,
+        "poll_medium",
+        ("receiver.main.active.freq_mode.filter_width",),
+    ),
+    (
+        "main.s_meter",
+        "read_s_meter",
+        0,
+        "poll_rx_meters",
+        ("receiver.main.meters.s_meter",),
+    ),
+    (
+        "sub.s_meter",
+        "read_s_meter",
+        1,
+        "poll_rx_meters",
+        ("receiver.sub.meters.s_meter",),
+    ),
+    ("alc", "read_alc_meter", None, "poll_tx_meters", ("global.meters.alc",)),
+    ("power", "read_power_meter", None, "poll_tx_meters", ("global.meters.power",)),
+    ("swr", "read_swr_meter", None, "poll_tx_meters", ("global.meters.swr",)),
+    ("comp", "read_comp_meter", None, "poll_tx_meters", ("global.meters.comp",)),
+    (
+        "main.af_level",
+        "read_af_level",
+        0,
+        "poll_slow_controls",
+        ("receiver.main.operator_controls.af_level",),
+    ),
+    (
+        "main.rf_gain",
+        "read_rf_gain",
+        0,
+        "poll_slow_controls",
+        ("receiver.main.operator_controls.rf_gain",),
+    ),
+    (
+        "main.squelch",
+        "read_squelch",
+        0,
+        "poll_slow_controls",
+        ("receiver.main.operator_controls.squelch",),
+    ),
+    (
+        "sub.af_level",
+        "read_af_level",
+        1,
+        "poll_slow_controls",
+        ("receiver.sub.operator_controls.af_level",),
+    ),
+    (
+        "sub.rf_gain",
+        "read_rf_gain",
+        1,
+        "poll_slow_controls",
+        ("receiver.sub.operator_controls.rf_gain",),
+    ),
+    (
+        "sub.squelch",
+        "read_squelch",
+        1,
+        "poll_slow_controls",
+        ("receiver.sub.operator_controls.squelch",),
+    ),
+    (
+        "main.att",
+        "read_attenuator",
+        0,
+        "poll_slow_controls",
+        ("receiver.main.operator_controls.att",),
+    ),
+    (
+        "main.preamp",
+        "read_preamp",
+        0,
+        "poll_slow_controls",
+        ("receiver.main.operator_controls.preamp",),
+    ),
+    (
+        "main.agc",
+        "read_agc",
+        0,
+        "poll_slow_controls",
+        ("receiver.main.operator_controls.agc",),
+    ),
+    (
+        "main.if_shift",
+        "read_if_shift",
+        0,
+        "poll_slow_controls",
+        ("receiver.main.operator_controls.if_shift",),
+    ),
+    (
+        "main.narrow",
+        "read_narrow",
+        0,
+        "poll_slow_controls",
+        ("receiver.main.operator_toggles.narrow",),
+    ),
+    (
+        "main.nb_level",
+        "read_nb_level",
+        0,
+        "poll_slow_controls",
+        (
+            "receiver.main.operator_controls.nb_level",
+            "receiver.main.operator_toggles.nb",
+        ),
+    ),
+    (
+        "main.nr_level",
+        "read_nr_level",
+        0,
+        "poll_slow_controls",
+        (
+            "receiver.main.operator_controls.nr_level",
+            "receiver.main.operator_toggles.nr",
+        ),
+    ),
+    (
+        "main.auto_notch",
+        "read_auto_notch",
+        0,
+        "poll_slow_controls",
+        ("receiver.main.operator_toggles.auto_notch",),
+    ),
+    (
+        "main.manual_notch",
+        "read_manual_notch",
+        0,
+        "poll_slow_controls",
+        ("receiver.main.operator_toggles.manual_notch",),
+    ),
+    (
+        "main.manual_notch_freq",
+        "read_manual_notch_freq",
+        0,
+        "poll_slow_controls",
+        ("receiver.main.operator_controls.manual_notch_freq",),
+    ),
+    (
+        "main.sql_type",
+        "read_sql_type",
+        0,
+        "poll_slow_controls",
+        (
+            "receiver.main.operator_toggles.repeater_tone",
+            "receiver.main.operator_toggles.repeater_tsql",
+        ),
+    ),
+    (
+        "main.ctcss_tone_index",
+        "read_ctcss_tone_index",
+        0,
+        "poll_slow_controls",
+        (
+            "receiver.main.operator_controls.tone_freq",
+            "receiver.main.operator_controls.tsql_freq",
+        ),
+    ),
+    (
+        "main.repeater_shift",
+        "read_repeater_shift",
+        0,
+        "poll_slow_controls",
+        ("receiver.main.operator_controls.repeater_shift",),
+    ),
+    (
+        "sub.repeater_shift",
+        "read_repeater_shift",
+        1,
+        "poll_slow_controls",
+        ("receiver.sub.operator_controls.repeater_shift",),
+    ),
+    (
+        "active",
+        "read_vfo_select",
+        None,
+        "poll_slow_controls",
+        ("global.slow_state.active",),
+    ),
+    (
+        "cw_spot",
+        "read_cw_spot",
+        None,
+        "poll_slow_controls",
+        ("global.slow_state.cw_spot",),
+    ),
+    (
+        "power_level",
+        "read_power",
+        None,
+        "poll_tx_controls",
+        ("global.operator_controls.power_level",),
+    ),
+    (
+        "mic_gain",
+        "read_mic_gain",
+        None,
+        "poll_tx_controls",
+        ("global.operator_controls.mic_gain",),
+    ),
+    (
+        "compressor_on",
+        "read_processor",
+        None,
+        "poll_tx_controls",
+        ("global.tx_state.compressor_on",),
+    ),
+    (
+        "compressor_level",
+        "read_processor_level",
+        None,
+        "poll_tx_controls",
+        ("global.operator_controls.compressor_level",),
+    ),
+    ("vox", "read_vox", None, "poll_tx_controls", ("global.tx_state.vox_on",)),
+    ("split", "read_split", None, "poll_tx_controls", ("global.tx_state.split",)),
+    (
+        "clarifier",
+        "read_clarifier",
+        0,
+        "poll_tx_controls",
+        ("global.tx_state.rit_on", "global.tx_state.rit_tx"),
+    ),
+    (
+        "clarifier_freq",
+        "read_clarifier_freq",
+        0,
+        "poll_tx_controls",
+        ("global.operator_controls.rit_freq",),
+    ),
+    (
+        "tuner",
+        "get_tuner_status",
+        None,
+        "poll_tx_controls",
+        ("global.operator_controls.tuner_status",),
+    ),
+    (
+        "dial_lock",
+        "read_lock",
+        None,
+        "poll_tx_controls",
+        ("global.tx_state.dial_lock",),
+    ),
+    (
+        "key_speed",
+        "read_keyer_speed",
+        None,
+        "poll_tx_controls",
+        ("global.operator_controls.key_speed",),
+    ),
+    (
+        "cw_pitch",
+        "read_cw_pitch",
+        None,
+        "poll_tx_controls",
+        ("global.operator_controls.cw_pitch",),
+    ),
+    (
+        "break_in",
+        "read_break_in",
+        None,
+        "poll_tx_controls",
+        ("global.operator_controls.break_in",),
+    ),
+    (
+        "break_in_delay",
+        "read_break_in_delay",
+        None,
+        "poll_tx_controls",
+        ("global.operator_controls.break_in_delay",),
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("method", "receiver", "poll", "expected"),
+    [row[1:] for row in _ABANDON_ROWS],
+    ids=[row[0] for row in _ABANDON_ROWS],
+)
+@pytest.mark.asyncio
+async def test_skipped_read_abandons_every_declared_path_it_feeds(
+    method: str,
+    receiver: int | None,
+    poll: str,
+    expected: tuple[str, ...],
+) -> None:
+    """One unparseable read releases the declared paths it feeds, and no others.
+
+    A path the backend can never observe must not hold the startup gate open;
+    a path some other read still supplies must not be released with it.
+    """
+    profile = _profile_state_acquisition()
+    scheduler = _AbandonRecordingScheduler(profile)
+    radio = _gate_radio()
+    radio._acquisition_scheduler = scheduler
+    _break_read(radio, method, receiver)
+
+    adapter = YaesuObservationAdapter(radio, profile=profile, clock=_clock)
+    await getattr(adapter, poll)()
+
+    assert sorted(str(path) for path, _ in scheduler.abandoned) == sorted(expected)
+    for name in expected:
+        assert FieldPath.parse(name) not in scheduler.unobserved_startup_paths(())
+
+
+@pytest.mark.asyncio
+async def test_tx_target_frequency_read_abandons_nothing() -> None:
+    """The TX-target frequency is a sub-read of a field emitted either way.
+
+    ``global.tx_state.tx_target`` is appended whether or not that frequency
+    parses (the frequency degrades to ``None``), so a skip there releases no
+    path from the gate.
+    """
+    profile = _profile_state_acquisition()
+    scheduler = _AbandonRecordingScheduler(profile)
+    radio = _gate_radio()
+    radio._acquisition_scheduler = scheduler
+    radio.capabilities = radio.capabilities - {"dual_rx"}
+    radio.get_tx_func = AsyncMock(return_value=1)
+    _break_read(radio, "read_freq", 1)
+
+    observations = await YaesuObservationAdapter(
+        radio, profile=profile, clock=_clock
+    ).poll_medium()
+
+    assert scheduler.abandoned == []
+    emitted = [
+        item.value
+        for item in observations
+        if str(item.path) == "global.tx_state.tx_target"
+    ]
+    assert len(emitted) == 1
+    assert isinstance(emitted[0], KnownTxTarget)
+    assert emitted[0].frequency_hz is None


### PR DESCRIPTION
## What and why

The startup gate (`acquisition_scheduler.py: AcquisitionScheduler.unobserved_startup_paths`)
waits indefinitely for every declared field in the FTX-1 profile's gated set.
`AcquisitionScheduler.abandon_startup_path` exists so a backend can say it has
given up on a field, but in the Yaesu adapter only the two S-meter reads used
it: `observations.py: YaesuObservationAdapter.poll_rx_meters` passed `path=`,
and no other call site did. A permanently unparseable answer on any other
declared read therefore held the gate open forever.

Every `_safe_read` call in `backends/yaesu_cat/observations.py` now names the
declared `FieldPath`(s) its failure makes unobservable, and the direct
`_log_field_skip` call for `global.tx_state.ptt` in
`YaesuObservationAdapter.poll_medium` names that path. The one read whose
failure does not make any declared field unobservable — the TX-target
frequency sub-read in `YaesuObservationAdapter._read_tx_target`, whose
`global.tx_state.tx_target` observation is appended either way with
`frequency_hz` degraded to `None` — names nothing.

`YaesuObservationAdapter._safe_read` and `._log_field_skip` take
`paths: tuple[FieldPath, ...] = ()` in place of the single optional `path`,
because five reads each feed two declared paths (`main.nb_level`, `main.nr_level`, `main.sql_type`, `main.ctcss_tone_index`, `clarifier` — see the table). No new class
or registry; nothing about what is polled, when, or how failures are logged
changed.

## Site → path table

Derived by matching `_safe_read` call sites in the committed
`src/rigplane/backends/yaesu_cat/observations.py` against the FTX-1 gated set
computed from `rigs/ftx1.toml` via
`RadioAcquisitionProfile.pollable_paths() | field_policies`, minus the
`tx_only`-policy paths — i.e. the domain of
`AcquisitionScheduler.unobserved_startup_paths`. That set has **50** members.
The table has 47 `_safe_read` rows plus the direct PTT row; between them they
cover **49 of the 50** gated paths. The one not covered is
`global.tx_state.tx_target`, which `poll_medium` appends unconditionally and so
cannot wedge the gate.

| `_safe_read` label | declared FieldPath(s) it feeds | in FTX-1 gated set |
|---|---|---|
| `main.freq` | `receiver.main.active.freq_mode.freq_hz` | yes |
| `main.mode` | `receiver.main.active.freq_mode.mode` | yes |
| `sub.freq` | `receiver.sub.active.freq_mode.freq_hz` | yes |
| `sub.mode` | `receiver.sub.active.freq_mode.mode` | yes |
| `ptt` (direct `_log_field_skip`) | `global.tx_state.ptt` | yes |
| `main.filter_width` | `receiver.main.active.freq_mode.filter_width` | yes |
| `tx_target.freq` | **(none — passes no path)** | `global.tx_state.tx_target` is emitted regardless |
| `main.s_meter` | `receiver.main.meters.s_meter` | yes |
| `sub.s_meter` | `receiver.sub.meters.s_meter` | yes |
| `alc` | `global.meters.alc` | no (`tx_only`) |
| `power` | `global.meters.power` | no (`tx_only`) |
| `swr` | `global.meters.swr` | no (`tx_only`) |
| `comp` | `global.meters.comp` | no (`tx_only`) |
| `main.af_level` | `receiver.main.operator_controls.af_level` | yes |
| `main.rf_gain` | `receiver.main.operator_controls.rf_gain` | yes |
| `main.squelch` | `receiver.main.operator_controls.squelch` | yes |
| `sub.af_level` | `receiver.sub.operator_controls.af_level` | yes |
| `sub.rf_gain` | `receiver.sub.operator_controls.rf_gain` | yes |
| `sub.squelch` | `receiver.sub.operator_controls.squelch` | yes |
| `main.att` | `receiver.main.operator_controls.att` | yes |
| `main.preamp` | `receiver.main.operator_controls.preamp` | yes |
| `main.agc` | `receiver.main.operator_controls.agc` | yes |
| `main.if_shift` | `receiver.main.operator_controls.if_shift` | yes |
| `main.narrow` | `receiver.main.operator_toggles.narrow` | yes |
| `main.nb_level` | `receiver.main.operator_controls.nb_level`<br>`receiver.main.operator_toggles.nb` | yes (both) |
| `main.nr_level` | `receiver.main.operator_controls.nr_level`<br>`receiver.main.operator_toggles.nr` | yes (both) |
| `main.auto_notch` | `receiver.main.operator_toggles.auto_notch` | yes |
| `main.manual_notch` | `receiver.main.operator_toggles.manual_notch` | yes |
| `main.manual_notch_freq` | `receiver.main.operator_controls.manual_notch_freq` | yes |
| `main.sql_type` | `receiver.main.operator_toggles.repeater_tone`<br>`receiver.main.operator_toggles.repeater_tsql` | yes (both) |
| `main.ctcss_tone_index` | `receiver.main.operator_controls.tone_freq`<br>`receiver.main.operator_controls.tsql_freq` | yes (both) |
| `{label}.repeater_shift` (loop, MAIN and SUB) | `receiver.main.operator_controls.repeater_shift`<br>`receiver.sub.operator_controls.repeater_shift` | yes (both) |
| `active` | `global.slow_state.active` | yes |
| `cw_spot` | `global.slow_state.cw_spot` | yes |
| `power_level` | `global.operator_controls.power_level` | yes |
| `mic_gain` | `global.operator_controls.mic_gain` | yes |
| `compressor_on` | `global.tx_state.compressor_on` | yes |
| `compressor_level` | `global.operator_controls.compressor_level` | yes |
| `vox` | `global.tx_state.vox_on` | yes |
| `split` | `global.tx_state.split` | yes |
| `clarifier` | `global.tx_state.rit_on`<br>`global.tx_state.rit_tx` | yes (both) |
| `clarifier_freq` | `global.operator_controls.rit_freq` | yes |
| `tuner` | `global.operator_controls.tuner_status` | yes |
| `dial_lock` | `global.tx_state.dial_lock` | yes |
| `key_speed` | `global.operator_controls.key_speed` | yes |
| `cw_pitch` | `global.operator_controls.cw_pitch` | yes |
| `break_in` | `global.operator_controls.break_in` | yes |
| `break_in_delay` | `global.operator_controls.break_in_delay` | yes |

The four `tx_only` meter rows pass their paths too: whether a path is gated is
a property of the profile, not of the adapter, so the adapter reports the
skipped field and `unobserved_startup_paths` applies its own `tx_only` filter.

## Census

`git diff --numstat origin/main...HEAD` at the pushed head:

```
137	58	src/rigplane/backends/yaesu_cat/observations.py
399	0	tests/test_yaesu_cat_observation_adapter.py
```

**2 files, 535+/59- = 594 changed lines at d748ed73 (a docstring totality was deleted after review).** Under the 6-file / 600-line soft
threshold. One unit of work: a single mechanism (name the declared paths a
skipped read feeds) applied to every site in one file, plus its table-driven
test.

## Tests

New in `tests/test_yaesu_cat_observation_adapter.py`:

- `test_skipped_read_abandons_every_declared_path_it_feeds` — 48 parametrised
  rows, one per read site (46 `_safe_read` sites that feed a declared path,
  the two `repeater_shift` receivers being separate rows, plus the direct PTT
  skip). Each row makes exactly one read answer with an unparseable frame and
  asserts the recorded `abandon_startup_path` calls equal that read's declared
  paths and nothing else, and that those paths leave
  `unobserved_startup_paths`. Rows `main.s_meter` and `sub.s_meter` pin the
  previously unpinned S-meter plumbing; `main.nb_level`, `main.nr_level`,
  `main.sql_type`, `main.ctcss_tone_index` and `clarifier` are the multi-path
  rows.
- `test_tx_target_frequency_read_abandons_nothing` — the TX-target frequency
  sub-read fails, nothing is abandoned, and the `tx_target` observation is
  still emitted with `frequency_hz is None`.

`uv run pytest tests/test_yaesu_cat_observation_adapter.py tests/test_startup_state_gate.py tests/test_acquisition_scheduler.py -q`

```
253 passed in 2.80s
```

Adjacent Yaesu files (signature change):
`uv run pytest tests/test_yaesu_cat_poller.py tests/test_yaesu_web_projection.py tests/test_yaesu_managed_tx_actuator.py -q`

```
238 passed in 9.90s
```

Measured by checking out `origin/main`'s
`src/rigplane/backends/yaesu_cat/observations.py` under the committed test
file: `46 failed, 84 passed in 1.33s`. The two S-meter rows and the
`tx_target` test were the only new cases already green, matching the residual
the review measured.

## Mutations

Each mutation applied alone; the tree was restored from a pristine copy in
between and `git status` is clean at the pushed head.

**(i) drop `paths=` from one site** — `"main.agc", self.radio.read_agc(0), paths=(_MAIN_AGC,)`
→ `"main.agc", self.radio.read_agc(0)`:

```
FAILED tests/test_yaesu_cat_observation_adapter.py::test_skipped_read_abandons_every_declared_path_it_feeds[main.agc]
1 failed, 129 passed in 1.58s
```
with `assert [] == ['receiver.ma...controls.agc']`.

**(ii) a multi-path site passes only its first path** —
`paths=(_MAIN_NB_LEVEL, _MAIN_NB)` → `paths=(_MAIN_NB_LEVEL,)`:

```
FAILED tests/test_yaesu_cat_observation_adapter.py::test_skipped_read_abandons_every_declared_path_it_feeds[main.nb_level]
1 failed, 129 passed in 1.20s
```
with `assert ['receiver.ma...ols.nb_level'] == ['receiver.ma...r_toggles.nb']`.

**(iii) behaviour-preserving refactor** — hoist the scheduler lookup out of
the `if paths:` guard and the reason string out of the loop in
`_log_field_skip`:

```
144 passed in 1.60s   (tests/test_yaesu_cat_observation_adapter.py + tests/test_startup_state_gate.py: 130 + 14; the (i)/(ii) figures above are the adapter file alone)
```

## Gates

| Gate | Result |
|---|---|
| named test files | 253 passed + 238 passed (above) |
| `uv run ruff check src/ tests/` | All checks passed |
| `uv run ruff format --check src/ tests/` | 742 files already formatted |
| `uv run mypy --strict src/rigplane/web` | Success: no issues found in 27 source files |
| `uv run lint-imports` | Contracts: 5 kept, 0 broken |

## Seen, in class, not changed

Sweeping the same class — "a skip that leaves a declared path unobservable
without telling the scheduler" — turned up three more sites — three `_log_field_skip` calls, one bare
`logger.warning`, and one absorbed failure — all reachable through
`backends/yaesu_cat/observations.py`. `grep -rn abandon_startup_path src/` and
`grep -rl '_safe_read\|_log_field_skip' src/` show this file is the only caller
of the mechanism, so the class does not extend to other backends.

1. `YaesuObservationAdapter._normalize_power_level` — three direct
   `_log_field_skip("power_level", ...)` calls (invalid `max_watts` metadata,
   non-positive `max_watts`, non-numeric watts). When any fires,
   `global.operator_controls.power_level` is not emitted. None of the three
   branches is reachable on `rigs/ftx1.toml` (`max_watts = 100`; the `PC`
   parse `PC{head}{watts:03d};` yields an `int`). The label `"power_level"`
   is shared with the `_safe_read` site, so a metadata fault would disarm the
   abandon for that path through the once-per-label guard; adding paths to
   these three calls alone would not fix that. Left unfixed: the spec for this
   change scopes the direct-call fix to the PTT skip.
2. `YaesuObservationAdapter.poll_slow_controls`, CTCSS block — the `CN`
   parse `CN00{code:03d};` accepts 000–999 while `rigs/ftx1.toml` resolves a
   50-entry tone domain, so an index ≥ 50 from the radio makes the
   index-to-centihertz conversion raise and neither
   `receiver.main.operator_controls.tone_freq` nor `.tsql_freq` is emitted,
   with nothing abandoned, even though the `CN` read itself succeeded
   (independent review reproduced this against the shipped profile with the
   read returning 50). Left unfixed: it is not a `_safe_read` failure path.

3. `YaesuObservationAdapter.poll_medium`, PTT block — `YaesuCatRadio.read_transmit_state`
   absorbs `CatCommandRejected`/`CatParseError` into `TxStateReading(failure="read-error")`,
   so those never reach the `_log_field_skip("ptt", …, paths=(_PTT,))` branch. That route
   runs `publish_ptt_error()`, which emits `global.tx_state.observed_ptt` (not in the
   FTX-1 gated set) and leaves the gated `global.tx_state.ptt` unobserved and
   unabandoned (independent review measured the gated set: 50 members, `ptt` present,
   `observed_ptt` absent). Left unfixed: the fix belongs in `read_transmit_state`'s
   failure contract, not in this change's `_safe_read` sweep.

The CTCSS case is a live follow-up (an out-of-spec but well-formed CAT answer,
the same shape that motivated this change); the power-level case needs a
decision about whether a profile-metadata fault should abandon a path or fail
louder. Both are outside this change.

Checked and found clean: every one of the FTX-1's 50 gated paths is
`can_poll`, so none is reachable only through `field_policies`
(`policies - pollable` is empty).

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

