### PR TITLE
fix: read the FTX-1 sub S-meter despite the echoed main side digit

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -856,7 +856,10 @@ set_ptt        = { cat = { write = "TX{state};" } }
 
 # ── Meters ──
 get_s_meter    = { cat = { read = "SM0;", parse = "SM0{raw:03d};" } }
-get_s_meter_sub = { cat = { read = "SM1;", parse = "SM1{raw:03d};" } }
+# The radio answers the SUB query with the side digit echoed as 0; the value
+# is the SUB's. Pinned by test_ftx1_radio.py::
+# test_sub_s_meter_accepts_the_echoed_main_side_digit.
+get_s_meter_sub = { cat = { read = "SM1;", parse = "SM{receiver}{raw:03d};" } }
 get_meter      = { cat = { read = "RM{type};", parse = "RM{type}{main:03d}{sub:03d};" } }
 
 # ── Audio / RF Controls ──

--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -1307,10 +1307,9 @@ class YaesuObservationAdapter:
         ``CatCommandRejected`` (a ``?;`` reject = unsupported command on this
         radio) is caught while the base/timeout propagates.
 
-        MOR-561: a permanently unsupported field (e.g. the FTX-1 answering the
-        SUB ``SM1;`` query with a main-form ``SM0000;`` frame) fails identically
-        every poll cycle, several times a second. The FIRST failure for a given
-        field warns; every repeat is demoted to DEBUG so the log is not flooded.
+        MOR-561: a permanently unsupported field fails identically every poll
+        cycle, several times a second. The FIRST failure for a given field
+        warns; every repeat is demoted to DEBUG so the log is not flooded.
         """
         try:
             return True, await read

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -218,8 +218,7 @@ class YaesuCatRadio:
         # MOR-561: poll-lane fields whose field-level CAT failure has already
         # been warned about once. Persists across poll cycles (the observation
         # adapter is rebuilt every cycle, the radio is not), so a permanently
-        # unsupported field — e.g. the FTX-1 answering ``SM1;`` with a main-form
-        # ``SM0000;`` — warns once and then demotes repeats to DEBUG.
+        # unsupported field warns once and then demotes repeats to DEBUG.
         self._poll_warned_fields: set[str] = set()
 
         # Compile response parsers once at init time (keyed by command name).

--- a/src/rigplane/core/radio_state.py
+++ b/src/rigplane/core/radio_state.py
@@ -236,7 +236,8 @@ class YaesuStateExtension:
     consumers (e.g. a Yaesu-specific panel).
 
     Fields:
-        rx_func_mode: ``FR`` command — 0=dual RX off, 1=single RX.
+        rx_func_mode: ``FR`` command — 0=Dual receive, 1=Single receive
+            (FTX-1 CAT manual, edition 2508-C, FR FUNCTION RX).
         tx_func_mode: ``FT`` command — 0=MAIN TX, 1=SUB TX.
 
     ``None`` for any field means "not yet polled / unknown".

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -548,6 +548,31 @@ async def test_get_s_meter_sub(connected_radio):
 
 
 @pytest.mark.asyncio
+async def test_sub_s_meter_accepts_the_echoed_main_side_digit(connected_radio):
+    """Recorded FTX-1 frame pair: ``SM1;`` -> ``SM0052;`` and ``SM0;`` -> ``SM0000;``.
+
+    The radio echoes P1 as ``0`` for the SUB query while the value is the
+    SUB's, so the SUB read attributes the value to the side it queried.
+    """
+    frames = {"SM0;": "SM0000", "SM1;": "SM0052"}
+    connected_radio._transport.query = AsyncMock(side_effect=lambda cmd: frames[cmd])
+
+    assert await connected_radio.get_s_meter(receiver=1) == 52
+    assert await connected_radio.get_s_meter(receiver=0) == 0
+    assert connected_radio.radio_state.sub.s_meter == 52
+    assert connected_radio.radio_state.main.s_meter == 0
+
+
+@pytest.mark.asyncio
+async def test_main_s_meter_rejects_a_sub_side_digit(connected_radio):
+    """The MAIN read stays strict: an ``SM1`` frame is not a MAIN reading."""
+    connected_radio._transport.query = AsyncMock(return_value="SM1052")
+
+    with pytest.raises(CatParseError):
+        await connected_radio.get_s_meter(receiver=0)
+
+
+@pytest.mark.asyncio
 async def test_get_s_meter_zero(connected_radio):
     connected_radio._transport.query = AsyncMock(return_value="SM0000")
     raw = await connected_radio.get_s_meter()

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -2045,14 +2045,15 @@ async def test_read_if_shift_and_narrow_are_pure_reads() -> None:
 async def test_rx_meters_emit_main_when_sub_s_meter_raises_parse_error() -> None:
     """MOR-473: a malformed SUB ``SM1;`` answer must not drop the MAIN meter.
 
-    The live FTX-1 can answer ``SM1;`` with a non-SM1 frame (no dual-RX), which
-    raises ``CatParseError`` from the SUB s-meter read. The fast lane must skip
-    that single field and still emit the MAIN s-meter.
+    A ``CatParseError`` from the SUB s-meter read must skip that single field
+    and still emit the MAIN s-meter.
     """
     radio = _make_radio()
     radio.read_s_meter = AsyncMock(
         side_effect=lambda receiver=0: (
-            120 if receiver == 0 else _raise(CatParseError("SM1{...};", "SM0000;", "x"))
+            120
+            if receiver == 0
+            else _raise(CatParseError("SM{receiver}{raw:03d};", "SM?;", "x"))
         )
     )
     adapter = YaesuObservationAdapter(
@@ -2183,10 +2184,9 @@ async def test_happy_path_slow_poll_unchanged_when_all_reads_succeed() -> None:
 async def test_sub_s_meter_parse_warning_logged_once_then_suppressed(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """MOR-561: the FTX-1 answers ``SM1;`` (sub) with a main-form ``SM0000;``.
+    """MOR-561: a SUB ``SM1;`` answer that never parses must not flood the log.
 
-    That well-formed-but-wrong-form frame raises ``CatParseError`` every poll
-    cycle. The poller queries it several times per second, so a per-cycle
+    The poller queries the field several times per second, so a per-cycle
     WARNING floods the log. The first occurrence must WARN once; every repeat
     for the same field must demote to DEBUG (no repeated WARNING).
     """
@@ -2201,8 +2201,8 @@ async def test_sub_s_meter_parse_warning_logged_once_then_suppressed(
             if receiver == 0
             else _raise(
                 CatParseError(
-                    "SM1{raw:03d};",
-                    "SM0000;",
+                    "SM{receiver}{raw:03d};",
+                    "SM?;",
                     "Response does not match pattern",
                 )
             )
@@ -2263,7 +2263,7 @@ async def test_first_sub_s_meter_skip_releases_the_path_from_the_startup_gate() 
     """The skipped field must not leave the startup gate waiting for it.
 
     Same frame as ``test_sub_s_meter_parse_warning_logged_once_then_suppressed``:
-    the FTX-1 answers the sub ``SM1;`` query in main form every cycle, so no
+    the sub ``SM1;`` answer fails to parse every cycle, so no
     ``receiver.sub.meters.s_meter`` observation ever arrives. The first skip
     tells the scheduler; the repeats that demote to DEBUG do not tell it again.
     """
@@ -2281,8 +2281,8 @@ async def test_first_sub_s_meter_skip_releases_the_path_from_the_startup_gate() 
             if receiver == 0
             else _raise(
                 CatParseError(
-                    "SM1{raw:03d};",
-                    "SM0000;",
+                    "SM{receiver}{raw:03d};",
+                    "SM?;",
                     "Response does not match pattern",
                 )
             )
@@ -2302,6 +2302,59 @@ async def test_first_sub_s_meter_skip_releases_the_path_from_the_startup_gate() 
     assert FieldPath.receiver(
         "main", "meters", "s_meter"
     ) in scheduler.unobserved_startup_paths(())
+
+
+@pytest.mark.asyncio
+async def test_sub_s_meter_reads_through_the_profile_despite_the_echoed_side(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The recorded FTX-1 frames reach ``receiver.sub.meters.s_meter``.
+
+    Real ``YaesuCatRadio`` on the bundled ``ftx1`` profile, so the frames go
+    through the profile's own parse templates. Swapping which side carries the
+    signal swaps the two readings.
+    """
+
+    def _radio() -> YaesuCatRadio:
+        radio = YaesuCatRadio("/dev/null", audio_driver=MagicMock())
+        radio._transport._connected = True
+        return radio
+
+    async def _poll(radio: YaesuCatRadio, frames: dict[str, str]) -> dict[str, object]:
+        radio._transport.query = AsyncMock(side_effect=lambda cmd: frames[cmd])
+        observations = await YaesuObservationAdapter.from_radio(
+            radio, clock=_clock
+        ).poll_rx_meters()
+        return {str(item.path): item.value for item in observations}
+
+    radio = _radio()
+    scheduler = _AbandonRecordingScheduler(_profile_state_acquisition())
+    radio._acquisition_scheduler = scheduler
+
+    with caplog.at_level("DEBUG"):
+        signal_on_sub = await _poll(radio, {"SM0;": "SM0000", "SM1;": "SM0052"})
+    signal_on_main = await _poll(_radio(), {"SM0;": "SM0052", "SM1;": "SM0000"})
+
+    assert set(signal_on_sub) == {
+        "receiver.main.meters.s_meter",
+        "receiver.sub.meters.s_meter",
+    }
+    assert (
+        signal_on_sub["receiver.sub.meters.s_meter"]
+        != signal_on_sub["receiver.main.meters.s_meter"]
+    )
+    assert (
+        signal_on_sub["receiver.sub.meters.s_meter"]
+        == signal_on_main["receiver.main.meters.s_meter"]
+    )
+    assert (
+        signal_on_sub["receiver.main.meters.s_meter"]
+        == signal_on_main["receiver.sub.meters.s_meter"]
+    )
+    assert [
+        rec.getMessage() for rec in caplog.records if "s_meter" in rec.getMessage()
+    ] == []
+    assert scheduler.abandoned == []
 
 
 def _gate_radio() -> MagicMock:


### PR DESCRIPTION
## What

`rigs/ftx1.toml` `get_s_meter_sub` now parses its answer as `SM{receiver}{raw:03d};` instead of `SM1{raw:03d};`. `get_s_meter` (MAIN) is unchanged and stays strict. No code changed in the read path: `YaesuCatRadio.read_s_meter` already keys the side on the command it sends (`get_s_meter` vs `get_s_meter_sub`) and reads only `raw` from the parse result, and `_query` does no echo check, so widening the sub template is the whole fix. The `receiver` placeholder (`[01]`, int) already exists in `backends/yaesu_cat/parser.py` `_PLACEHOLDER_REGEX` and is already used by the profile's `get_repeater_shift`, so no codec change was needed either.

Three comments that the change makes false are corrected by deletion of the false clause: `backends/yaesu_cat/radio.py` (`YaesuCatRadio.__init__`, the `_poll_warned_fields` comment) and `backends/yaesu_cat/observations.py` (`YaesuObservationAdapter._safe_read` docstring) both cited "the FTX-1 answering `SM1;` with a main-form `SM0000;`" as the example of a permanently unsupported field; `core/radio_state.py` (`YaesuStateExtension` docstring) said `FR` `0=dual RX off, 1=single RX`, which is backwards.

## Why

Per the FTX-1 CAT manual, edition 2508-C (page 25, `SM S METER`), `SM P1;` reads the S-meter with P1 `0` = MAIN-side and `1` = SUB-side, and the documented answer is `SM P1 P2P2P2;`; page 17 (`FR FUNCTION RX`) gives P1 `00` = Dual receive, `01` = Single receive. On the live FTX-1 with dual receive on (`FR;` → `FR00;`), three read-only probes established that the radio echoes the side digit as `0` for the SUB query while the value is the SUB's: with an FT8 signal on MAIN only, `SM0;` answered 065–127 and `SM1;` answered `000` across 30 samples over 72 s; after the sides were swapped so the signal was on SUB only, `SM0;` answered `000` across 25 samples over 60 s while `SM1;` answered 040–065. The recorded frame pair used as the regression fixture is query `SM1;` → `SM0052;` alongside query `SM0;` → `SM0000;`. Because the sub template demanded the documented `SM1` form, every sub read raised `CatParseError`, `_safe_read` skipped the field, and the first skip abandoned `receiver.sub.meters.s_meter` for the startup gate — so the field was never shown.

## Census

`git diff --numstat origin/main...HEAD`: **6 files, 100+/20- = 120 changed lines**.

```
4	1	rigs/ftx1.toml
3	4	src/rigplane/backends/yaesu_cat/observations.py
1	2	src/rigplane/backends/yaesu_cat/radio.py
2	1	src/rigplane/core/radio_state.py
25	0	tests/test_ftx1_radio.py
65	12	tests/test_yaesu_cat_observation_adapter.py
```

## Tests

Added, test-first (the first and third were red before the profile change; the second is a guard against widening the MAIN template and passes on the old template too):

- `tests/test_ftx1_radio.py::test_sub_s_meter_accepts_the_echoed_main_side_digit` — the recorded frames through the real `rigs/ftx1.toml` profile and the real parser: `SM1;` → `SM0052;` yields SUB 52, `SM0;` → `SM0000;` yields MAIN 0.
- `tests/test_ftx1_radio.py::test_main_s_meter_rejects_a_sub_side_digit` — MAIN read of an `SM1052;` frame still raises `CatParseError`.
- `tests/test_yaesu_cat_observation_adapter.py::test_sub_s_meter_reads_through_the_profile_despite_the_echoed_side` — a real `YaesuCatRadio` on the bundled profile, driven through `YaesuObservationAdapter.poll_rx_meters`: both meter paths are emitted, swapping which side carries the signal swaps the two readings, no `s_meter` log record is produced, and the recording scheduler abandons nothing.

Moved onto a frame that is still genuinely malformed under the new template (verified directly: `CatCommandParser("SM{receiver}{raw:03d};")` rejects `SM?;`, `SM0;`, `SM00;` and `SM2052;`, and accepts `SM0052;` and `SM1052;`): `test_sub_s_meter_parse_warning_logged_once_then_suppressed`, `test_first_sub_s_meter_skip_releases_the_path_from_the_startup_gate`, and — same shape, found by sweeping the class — `test_rx_meters_emit_main_when_sub_s_meter_raises_parse_error`. Their docstring claims about what the radio answers were deleted rather than restated.

`_break_read` in `tests/test_yaesu_cat_observation_adapter.py` raises `CatParseError("XX{p};", "??;", …)` from the mock itself, so the `sub.s_meter` row of `_ABANDON_ROWS` is independent of the profile template and stays malformed; it was left unchanged.

## Mutations run

1. Sub template reverted to `SM1{raw:03d};` → `test_sub_s_meter_accepts_the_echoed_main_side_digit` and `test_sub_s_meter_reads_through_the_profile_despite_the_echoed_side` failed; 459 passed.
2. MAIN template made lenient (`get_s_meter` parse → `SM{receiver}{raw:03d};`), sub template intact → `test_main_s_meter_rejects_a_sub_side_digit` failed alone; 460 passed.
3. `_log_field_skip`'s `if paths:` forced false → `test_skipped_read_abandons_every_declared_path_it_feeds[sub.s_meter]` and `[main.s_meter]` both failed, confirming the `_ABANDON_ROWS` row still has teeth under the new template.

Tree restored after each; the pre-commit `git diff` showed only the intended change.

## Gates

- `uv run pytest tests/test_yaesu_cat_observation_adapter.py tests/test_ftx1_radio.py tests/test_yaesu_cat_parser.py tests/test_startup_state_gate.py tests/test_yaesu_cat_poller.py tests/test_ftx1_control_domains.py` — 707 passed, 0 failed.
- `uv run pytest tests/test_command_catalog_docs.py tests/test_yaesu_web_projection.py` — 44 passed, 0 failed.
- `uv run ruff check src/ tests/` — All checks passed.
- `uv run ruff format --check src/ tests/` — 742 files already formatted.
- `uv run mypy --strict src/rigplane/web` — Success: no issues found in 27 source files.
- `uv run lint-imports` — Contracts: 5 kept, 0 broken.

No full-suite run and no radio was touched.

## Seen but not changed

The same now-stale `SM1;` → `SM0000;` example appears in `docs/internals/radio-state-pipeline-validation.md` (five places) and `docs/CHANGELOG.md` (one, a released entry), and as cosmetic `CatParseError` constructor arguments on the synthetic `_MalformedSubMeterRadio` in `tests/test_startup_state_gate.py`. The class was enumerated with `grep -rn "SM0000\|SM1;\|SM1{" src/ docs/ rigs/ tests/ .github/`. Editing any of them is a separate change (a dated validation log and a released changelog entry), so they are reported here rather than widened into this fix; six files is the soft threshold, not a limit. `MOR-561` tags already present on the corrected comment lines were kept as-is.

A second class, left alone on evidence: five sibling SUB reads in `rigs/ftx1.toml` pin the side digit as a literal in their parse templates (`get_af_level_sub` `AG1{level:03d};`, `get_filter_width_sub` `SH1{code:03d};`, `get_mode_sub` `MD1{mode};`, `get_rf_gain_sub` `RG1{level:03d};`, `get_squelch_sub` `SQ1{level:03d};`). A read-only probe on the bench radio with dual receive on answered `AG1;`→`AG1000;`, `SH1;`→`SH1020;`, `MD1;`→`MD12;`, `RG1;`→`RG1255;`, `SQ1;`→`SQ1048;` while `SM1;`→`SM0048;` — every sibling echoes its side digit correctly and only `SM` does not, so those templates stay strict.

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

