### PR TITLE
fix: release the startup gate for every skipped Yaesu read, not only the first per label

### DIFF
--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -378,6 +378,7 @@ class YaesuObservationAdapter:
                     except (Exception, asyncio.CancelledError):
                         logger.warning("Yaesu PTT error callback failed", exc_info=True)
 
+            read_error: Exception | None = None
             try:
                 reading = await self.radio.read_transmit_state()
             except asyncio.CancelledError:
@@ -389,17 +390,24 @@ class YaesuObservationAdapter:
                 KeyError,
                 CatCommandRejected,
             ) as exc:
-                self._log_field_skip(
-                    "ptt",
-                    "Skipping field %s — PTT read failed: %s",
-                    exc,
-                    paths=(_PTT,),
-                )
+                read_error = exc
                 reading = TxStateReading(None, failure="read-error")
             except Exception:
                 publish_ptt_error()
                 raise
             if reading.failure is not None:
+                # ``read-error`` is a field the radio cannot answer, whether it
+                # raised here or ``read_transmit_state`` absorbed it into the
+                # reading; ``timeout``/``transport`` re-raise below instead.
+                if reading.failure == "read-error":
+                    self._log_field_skip(
+                        "ptt",
+                        "Skipping field %s — PTT read failed: %s",
+                        read_error
+                        if read_error is not None
+                        else ValueError("read_transmit_state reported read-error"),
+                        paths=(_PTT,),
+                    )
                 publish_ptt_error()
                 if reading.failure == "timeout":
                     raise CatTimeoutError("PTT read failed: timeout")
@@ -598,6 +606,7 @@ class YaesuObservationAdapter:
                 "power_level",
                 "Skipping field %s — invalid power metadata: %s",
                 ValueError(f"max_watts must be a positive number, got {max_watts!r}"),
+                paths=(_POWER_LEVEL,),
             )
             return None
         if max_watts <= 0:
@@ -605,6 +614,7 @@ class YaesuObservationAdapter:
                 "power_level",
                 "Skipping field %s — invalid power metadata: %s",
                 ValueError(f"max_watts must be > 0, got {max_watts!r}"),
+                paths=(_POWER_LEVEL,),
             )
             return None
         if isinstance(watts, bool) or not isinstance(watts, (int, float)):
@@ -612,6 +622,7 @@ class YaesuObservationAdapter:
                 "power_level",
                 "Skipping field %s — invalid CAT value: %s",
                 ValueError(f"watts must be numeric, got {watts!r}"),
+                paths=(_POWER_LEVEL,),
             )
             return None
         return float(watts) / float(max_watts)
@@ -989,9 +1000,12 @@ class YaesuObservationAdapter:
                         domain=self.radio.profile.ctcss_tones_centihz,
                     )
                 except ValueError as exc:
-                    logger.warning(
-                        "Skipping CTCSS observations for invalid profile domain: %s",
+                    self._log_field_skip(
+                        "ctcss_tone_index",
+                        "Skipping field %s — CTCSS index outside the profile "
+                        "domain: %s",
                         exc,
+                        paths=(_MAIN_TONE_FREQ, _MAIN_TSQL_FREQ),
                     )
                     tone_centihz = None
                 if tone_centihz is not None:
@@ -1350,14 +1364,11 @@ class YaesuObservationAdapter:
         ``paths`` names the declared fields the skipped read would have
         produced; see ``AcquisitionScheduler.abandon_startup_path`` and
         ``tests/test_yaesu_cat_observation_adapter.py::
-        test_skipped_read_abandons_every_declared_path_it_feeds``.
+        test_skipped_read_abandons_every_declared_path_it_feeds``. They are
+        abandoned on every skip, not only the first for a ``label``, because the
+        warned-field set rate-limits the log alone
+        (``test_every_sub_s_meter_skip_releases_the_path_from_the_startup_gate``).
         """
-        warned = getattr(self.radio, "_poll_warned_fields", None)
-        if isinstance(warned, set):
-            if label in warned:
-                logger.debug(message, label, exc)
-                return
-            warned.add(label)
         if paths:
             scheduler = getattr(self.radio, "_acquisition_scheduler", None)
             if isinstance(scheduler, AcquisitionScheduler):
@@ -1365,6 +1376,12 @@ class YaesuObservationAdapter:
                     scheduler.abandon_startup_path(
                         path, reason=f"yaesu field read skipped: {label}"
                     )
+        warned = getattr(self.radio, "_poll_warned_fields", None)
+        if isinstance(warned, set):
+            if label in warned:
+                logger.debug(message, label, exc)
+                return
+            warned.add(label)
         logger.warning(message, label, exc)
 
     def _adapter(self) -> ProviderObservationAdapter:

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -22,7 +22,11 @@ from rigplane.radio_state import RadioState
 from rigplane.backends.yaesu_cat.observations import YaesuObservationAdapter
 from rigplane.backends.yaesu_cat.parser import CatParseError
 from rigplane.backends.yaesu_cat.radio import RadioConnectionError, YaesuCatRadio
-from rigplane.backends.yaesu_cat.transport import CatCommandRejected, CatTransportError
+from rigplane.backends.yaesu_cat.transport import (
+    CatCommandRejected,
+    CatTimeoutError,
+    CatTransportError,
+)
 
 
 def _clock() -> float:
@@ -2259,13 +2263,16 @@ class _AbandonRecordingScheduler(AcquisitionScheduler):
 
 
 @pytest.mark.asyncio
-async def test_first_sub_s_meter_skip_releases_the_path_from_the_startup_gate() -> None:
+async def test_every_sub_s_meter_skip_releases_the_path_from_the_startup_gate(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """The skipped field must not leave the startup gate waiting for it.
 
     Same frame as ``test_sub_s_meter_parse_warning_logged_once_then_suppressed``:
     the sub ``SM1;`` answer fails to parse every cycle, so no
-    ``receiver.sub.meters.s_meter`` observation ever arrives. The first skip
-    tells the scheduler; the repeats that demote to DEBUG do not tell it again.
+    ``receiver.sub.meters.s_meter`` observation ever arrives. Every skip tells
+    the scheduler, including the repeats the field log demotes to DEBUG; the
+    scheduler's own warning for the path still fires once.
     """
     profile = _profile_state_acquisition()
     scheduler = _AbandonRecordingScheduler(profile)
@@ -2289,19 +2296,25 @@ async def test_first_sub_s_meter_skip_releases_the_path_from_the_startup_gate() 
         )
     )
 
-    for _ in range(3):
-        await YaesuObservationAdapter(
-            radio,
-            profile=profile,
-            clock=_clock,
-        ).poll_rx_meters()
+    with caplog.at_level("WARNING"):
+        for _ in range(3):
+            await YaesuObservationAdapter(
+                radio,
+                profile=profile,
+                clock=_clock,
+            ).poll_rx_meters()
 
-    assert [path for path, _ in scheduler.abandoned] == [sub_path]
+    assert [path for path, _ in scheduler.abandoned] == [sub_path] * 3
     assert sub_path not in scheduler.unobserved_startup_paths(())
     # The MAIN meter, whose answer parses, is not abandoned.
     assert FieldPath.receiver(
         "main", "meters", "s_meter"
     ) in scheduler.unobserved_startup_paths(())
+    messages = [record.getMessage() for record in caplog.records]
+    skips = [text for text in messages if text.startswith("Skipping field")]
+    assert len(skips) == 1
+    assert "sub.s_meter" in skips[0]
+    assert len([text for text in messages if "abandoning startup path" in text]) == 1
 
 
 @pytest.mark.asyncio
@@ -2754,3 +2767,216 @@ async def test_tx_target_frequency_read_abandons_nothing() -> None:
     assert len(emitted) == 1
     assert isinstance(emitted[0], KnownTxTarget)
     assert emitted[0].frequency_hz is None
+
+
+_POWER_LEVEL_PATH = FieldPath.global_("operator_controls", "power_level")
+
+# (id, radio.profile stand-in, read_power answer)
+_POWER_LEVEL_FAULTS: tuple[tuple[str, object, tuple[int, object]], ...] = (
+    ("max-watts-not-a-number", SimpleNamespace(max_watts=None), (2, 55)),
+    ("max-watts-not-positive", SimpleNamespace(max_watts=0), (2, 55)),
+    ("watts-not-numeric", SimpleNamespace(max_watts=100), (2, "55")),
+)
+
+
+@pytest.mark.parametrize(
+    ("radio_profile", "power"),
+    [row[1:] for row in _POWER_LEVEL_FAULTS],
+    ids=[row[0] for row in _POWER_LEVEL_FAULTS],
+)
+@pytest.mark.asyncio
+async def test_power_level_normalisation_fault_abandons_the_declared_path(
+    radio_profile: object, power: tuple[int, object]
+) -> None:
+    """Each normalisation fault drops the field, so each must release its path.
+
+    ``_normalize_power_level`` returning ``None`` means no
+    ``global.operator_controls.power_level`` observation is appended, and the
+    ``PC`` read itself succeeded, so nothing else will release it.
+    """
+    profile = _profile_state_acquisition()
+    scheduler = _AbandonRecordingScheduler(profile)
+    radio = _gate_radio()
+    radio._acquisition_scheduler = scheduler
+    radio.profile = radio_profile
+    radio.read_power = AsyncMock(return_value=power)
+
+    observations = await YaesuObservationAdapter(
+        radio, profile=profile, clock=_clock
+    ).poll_tx_controls()
+
+    assert [path for path, _ in scheduler.abandoned] == [_POWER_LEVEL_PATH]
+    assert _POWER_LEVEL_PATH not in scheduler.unobserved_startup_paths(())
+    assert _POWER_LEVEL_PATH not in {item.path for item in observations}
+
+
+@pytest.mark.asyncio
+async def test_power_level_metadata_fault_does_not_disarm_the_read_failure() -> None:
+    """The two ``power_level`` skip sites share one warned-field label.
+
+    A normalisation fault on the first cycle marks the label warned; the ``PC``
+    read failing on a later cycle must still release the path.
+    """
+    profile = _profile_state_acquisition()
+    scheduler = _AbandonRecordingScheduler(profile)
+    radio = _gate_radio()
+    radio._acquisition_scheduler = scheduler
+    radio.profile = SimpleNamespace(max_watts=None)
+    adapter = YaesuObservationAdapter(radio, profile=profile, clock=_clock)
+
+    await adapter.poll_tx_controls()
+    _break_read(radio, "read_power", None)
+    await adapter.poll_tx_controls()
+
+    assert [path for path, _ in scheduler.abandoned] == [_POWER_LEVEL_PATH] * 2
+    assert _POWER_LEVEL_PATH not in scheduler.unobserved_startup_paths(())
+
+
+@pytest.mark.asyncio
+async def test_ctcss_index_outside_the_profile_domain_abandons_both_tone_paths(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A well-formed ``CN`` answer can still name a tone the profile lacks.
+
+    The FTX-1 resolves a 50-entry tone domain (asserted below), so index 50
+    parses but has no centihertz value; neither tone path can be emitted and
+    the ``CN`` read itself succeeded, so nothing else will release them.
+    """
+    profile = _profile_state_acquisition()
+    scheduler = _AbandonRecordingScheduler(profile)
+    radio = _gate_radio()
+    radio._acquisition_scheduler = scheduler
+    assert len(radio.profile.ctcss_tones_centihz) == 50
+    radio.read_ctcss_tone_index = AsyncMock(return_value=50)
+
+    tone = FieldPath.receiver("main", "operator_controls", "tone_freq")
+    tsql = FieldPath.receiver("main", "operator_controls", "tsql_freq")
+    with caplog.at_level("WARNING"):
+        observations = await YaesuObservationAdapter(
+            radio, profile=profile, clock=_clock
+        ).poll_slow_controls()
+
+    assert sorted(str(path) for path, _ in scheduler.abandoned) == sorted(
+        [str(tone), str(tsql)]
+    )
+    assert {item.path for item in observations} & {tone, tsql} == set()
+    assert tone not in scheduler.unobserved_startup_paths(())
+    assert tsql not in scheduler.unobserved_startup_paths(())
+    messages = [record.getMessage() for record in caplog.records]
+    assert len([text for text in messages if "CTCSS" in text]) == 1
+
+
+@pytest.mark.asyncio
+async def test_ptt_read_error_reading_abandons_the_gated_ptt_path() -> None:
+    """``read_transmit_state`` absorbs reject/parse faults into ``read-error``.
+
+    That reading publishes only ``global.tx_state.observed_ptt``, which the
+    FTX-1 gate does not hold; the gated ``global.tx_state.ptt`` gets no
+    observation and must be released instead.
+    """
+    profile = _profile_state_acquisition()
+    scheduler = _AbandonRecordingScheduler(profile)
+    radio = _gate_radio()
+    radio._acquisition_scheduler = scheduler
+    radio.read_transmit_state = AsyncMock(
+        return_value=TxStateReading(None, failure="read-error")
+    )
+
+    observations = await YaesuObservationAdapter(
+        radio, profile=profile, clock=_clock
+    ).poll_medium()
+
+    ptt = FieldPath.global_("tx_state", "ptt")
+    assert [path for path, _ in scheduler.abandoned] == [ptt]
+    assert ptt not in scheduler.unobserved_startup_paths(())
+    emitted = {item.path for item in observations}
+    assert OBSERVED_PTT_PATH in emitted
+    assert ptt not in emitted
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure", "expected"),
+    [("timeout", CatTimeoutError), ("transport", CatTransportError)],
+)
+async def test_ptt_transport_failures_raise_without_abandoning(
+    failure: str, expected: type[Exception]
+) -> None:
+    """A dead link is not a field the backend has given up on.
+
+    ``timeout`` and ``transport`` re-raise so the poller reconnects; the path
+    stays in the gate for the next connection to answer.
+    """
+    profile = _profile_state_acquisition()
+    scheduler = _AbandonRecordingScheduler(profile)
+    radio = _gate_radio()
+    radio._acquisition_scheduler = scheduler
+    radio.read_transmit_state = AsyncMock(
+        return_value=TxStateReading(None, failure=failure)
+    )
+
+    with pytest.raises(expected):
+        await YaesuObservationAdapter(
+            radio, profile=profile, clock=_clock
+        ).poll_medium()
+
+    assert scheduler.abandoned == []
+    assert FieldPath.global_("tx_state", "ptt") in scheduler.unobserved_startup_paths(
+        ()
+    )
+
+
+class _AllReadsFail:
+    """Delegate to ``radio`` but answer every CAT read with a bad frame."""
+
+    def __init__(self, radio: MagicMock) -> None:
+        self._radio = radio
+
+    def __getattr__(self, name: str) -> object:
+        attribute = getattr(self._radio, name)
+        if not isinstance(attribute, AsyncMock):
+            return attribute
+
+        async def _fail(*args: object, **kwargs: object) -> object:
+            raise CatParseError("XX{p};", "??;", "Response does not match pattern")
+
+        return _fail
+
+
+def _gated_startup_paths(profile: RadioAcquisitionProfile) -> set[FieldPath]:
+    """The domain of ``AcquisitionScheduler.unobserved_startup_paths``."""
+    domain = set(profile.pollable_paths()) | set(profile.field_policies)
+    return {path for path in domain if not profile.policy_for(path).tx_only}
+
+
+@pytest.mark.asyncio
+async def test_every_gated_path_is_released_when_every_read_fails() -> None:
+    """No gated field may be reachable only through an unannotated skip.
+
+    Every read answers with an unparseable frame, so every skip site in the
+    adapter runs; the paths the scheduler is then still waiting for are the
+    ones no site names. Only ``global.tx_state.tx_target`` may remain: its
+    observation is appended whether or not its sub-read parses.
+    """
+    profile = _profile_state_acquisition()
+    scheduler = _AbandonRecordingScheduler(profile)
+    radio = _gate_radio()
+    radio._acquisition_scheduler = scheduler
+    adapter = YaesuObservationAdapter(
+        _AllReadsFail(radio), profile=profile, clock=_clock
+    )
+
+    for poll in (
+        "poll_medium",
+        "poll_rx_meters",
+        "poll_tx_meters",
+        "poll_slow_controls",
+        "poll_tx_controls",
+    ):
+        await getattr(adapter, poll)()
+
+    tx_target = FieldPath.global_("tx_state", "tx_target")
+    gated = _gated_startup_paths(profile)
+    assert tx_target in gated
+    assert gated - {tx_target} <= {path for path, _ in scheduler.abandoned}
+    assert scheduler.unobserved_startup_paths(()) == (tx_target,)


### PR DESCRIPTION
## What and why

`acquisition_scheduler.py: AcquisitionScheduler.unobserved_startup_paths` holds
the startup gate open for every declared FTX-1 field until it is observed or
passed to `AcquisitionScheduler.abandon_startup_path`. The Yaesu adapter reaches
that release through `observations.py: YaesuObservationAdapter._log_field_skip`,
and four routes into it did not carry the fact — so a field the backend had
permanently given up on could wedge startup forever.

## The four defects and how each is closed

1. **Abandon rode on the log rate limiter.** In `_log_field_skip` the abandon
   block sat after the once-per-label `if label in warned: … return`, so only
   the *first* skip for a label reached the scheduler. The label store,
   `radio.py: YaesuCatRadio.__init__`'s `_poll_warned_fields`, is also written
   by `radio.py: YaesuCatRadio._warn_ptt_unrecognised` (`grep -rn
   _poll_warned_fields src/` — one reader in the adapter, one writer pair in
   `radio.py`), so an unrelated warning could disarm a release. The abandon loop
   now runs before the warned-label return. No new set: `abandon_startup_path`
   already dedups by path and warns once per path, so the log rate limiter and
   the abandon fact are simply decoupled.
2. **Label collision on `power_level`.** The three direct
   `_log_field_skip("power_level", …)` calls in
   `YaesuObservationAdapter._normalize_power_level` passed no paths, while the
   `_safe_read("power_level", …)` site in
   `YaesuObservationAdapter.poll_tx_controls` passed
   `global.operator_controls.power_level`. All three now pass the same
   `paths=(_POWER_LEVEL,)`. On the shipped profile these branches are
   unreachable (`rigs/ftx1.toml` sets `max_watts = 100` and the `PC` template
   parses an int), so this closes the class rather than a live fault.
3. **CTCSS index outside the tone domain.** In
   `YaesuObservationAdapter.poll_slow_controls` the `CN` read succeeds for any
   index 000–999, but `radio.py: _ctcss_index_to_centihz` raises for an index
   past the profile's resolved domain — 50 entries for the FTX-1 (asserted in
   the test). `tone_centihz` became `None`, neither
   `receiver.main.operator_controls.tone_freq` nor `.tsql_freq` was emitted, and
   nothing was abandoned. That `except ValueError` now routes through
   `_log_field_skip` under the label `ctcss_tone_index` with both paths,
   replacing the bare `logger.warning` (one warning, not two).
4. **PTT read-error route.** `radio.py: YaesuCatRadio.read_transmit_state`
   absorbs `CatCommandRejected` and `CatParseError` into
   `TxStateReading(failure="read-error")` and only re-raises for `timeout` /
   `transport`, so those two never reached `poll_medium`'s `except` branch. The
   `read-error` route ran `publish_ptt_error()`, which emits
   `global.tx_state.observed_ptt` — not gated — leaving gated
   `global.tx_state.ptt` unobserved and unabandoned. `poll_medium` now logs the
   skip for `failure == "read-error"` on both entries into that state (raised
   here, or absorbed by the reading), keeping the single existing warning by
   moving it out of the `except` clause. `timeout` / `transport` still re-raise
   and abandon nothing.

**Why the adapter, not the radio, for (4):** `read_transmit_state`'s contract is
deliberately that transport outcomes return a `failure` tag while connection
preconditions raise — the poller and the managed TX actuator both depend on
`read-error` being a value rather than an exception. The gate is not part of
that contract: `_acquisition_scheduler` is attached by `web`/`rigctld` and read
by the adapter, and `abandon_startup_path` has exactly one production caller,
`_log_field_skip`. Making the radio raise again would change a shared reading
contract to fix a gate concern that lives one layer up; passing the existing
`read-error` value through the adapter's own skip route changes nothing about
what `publish_ptt_error` emits.

## Census

`git diff --numstat origin/main...HEAD` at the pushed head:

```
32	15	src/rigplane/backends/yaesu_cat/observations.py
237	11	tests/test_yaesu_cat_observation_adapter.py
```

**2 files, 269+/26- = 295 changed lines.** Under the 6-file / 600-line soft
threshold.

## Tests

All in `tests/test_yaesu_cat_observation_adapter.py`. No gate-level witness was
needed, so `tests/test_startup_state_gate.py` is untouched.

- `test_every_sub_s_meter_skip_releases_the_path_from_the_startup_gate` —
  rewritten from `test_first_sub_s_meter_skip_…`, whose assertion and docstring
  pinned the defect (1) behaviour. Three cycles of the same unparseable `SM1;`
  answer now record three abandons; exactly one `Skipping field` warning and
  exactly one `abandoning startup path` warning are logged.
- `test_power_level_metadata_fault_does_not_disarm_the_read_failure` — a
  normalisation fault marks the shared label warned on cycle one; the `PC` read
  failing on cycle two still releases the path.
- `test_power_level_normalisation_fault_abandons_the_declared_path` — three
  rows, one per `_normalize_power_level` branch; each abandons the path and
  emits no `power_level` observation.
- `test_ctcss_index_outside_the_profile_domain_abandons_both_tone_paths` — index
  50 against the shipped 50-entry domain abandons both tone paths, emits
  neither, and logs one CTCSS warning.
- `test_ptt_read_error_reading_abandons_the_gated_ptt_path` — a
  `TxStateReading(failure="read-error")` abandons `global.tx_state.ptt` while
  `observed_ptt` is still emitted.
- `test_ptt_transport_failures_raise_without_abandoning` — `timeout` and
  `transport` re-raise and abandon nothing.
- `test_every_gated_path_is_released_when_every_read_fails` — the coverage
  witness. `_AllReadsFail` wraps the fixture radio so every CAT read raises;
  all five `poll_*` methods run; the gated set is recomputed from
  `rigs/ftx1.toml` exactly as `unobserved_startup_paths` does
  (`pollable_paths() | field_policies` minus `tx_only`) and asserted to be
  covered by the recorded abandons except `global.tx_state.tx_target`, whose
  observation is appended either way. The annotated set is established by
  driving the adapter, never by reading its source.

`uv run pytest tests/test_yaesu_cat_observation_adapter.py tests/test_yaesu_cat_poller.py tests/test_ftx1_radio.py tests/test_startup_state_gate.py tests/test_acquisition_scheduler.py tests/test_yaesu_web_projection.py tests/test_yaesu_managed_tx_actuator.py -q`

```
831 passed in 15.37s
```

The 48-row `test_skipped_read_abandons_every_declared_path_it_feeds` table and
the three tests relocated onto `SM?;` are among those, unchanged and green.

## Mutations

Each applied alone against `tests/test_yaesu_cat_observation_adapter.py`, the
file restored from a pristine copy in between; `git diff` at the pushed head
shows only the intended change.

**(i) restore the abandon-after-return ordering** in `_log_field_skip`:

```
FAILED tests/test_yaesu_cat_observation_adapter.py::test_every_sub_s_meter_skip_releases_the_path_from_the_startup_gate
FAILED tests/test_yaesu_cat_observation_adapter.py::test_power_level_metadata_fault_does_not_disarm_the_read_failure
2 failed, 138 passed in 1.45s
```

**(ii) drop `paths=` from one `_normalize_power_level` call** (the
`watts must be numeric` branch):

```
FAILED tests/test_yaesu_cat_observation_adapter.py::test_power_level_normalisation_fault_abandons_the_declared_path[watts-not-numeric]
1 failed, 139 passed in 1.46s
```

**(iii) restore the bare `logger.warning` CTCSS route:**

```
FAILED tests/test_yaesu_cat_observation_adapter.py::test_ctcss_index_outside_the_profile_domain_abandons_both_tone_paths
1 failed, 139 passed in 1.41s
```

**(iv) reinstate the PTT gap** — skip only when the exception was raised in
`poll_medium` (`and read_error is not None`), i.e. never for an absorbed
`read-error`:

```
FAILED tests/test_yaesu_cat_observation_adapter.py::test_ptt_read_error_reading_abandons_the_gated_ptt_path
1 failed, 139 passed in 1.35s
```

**(v) drop `paths=` from one `_safe_read` site** (`main.if_shift`):

```
FAILED tests/test_yaesu_cat_observation_adapter.py::test_skipped_read_abandons_every_declared_path_it_feeds[main.if_shift]
FAILED tests/test_yaesu_cat_observation_adapter.py::test_every_gated_path_is_released_when_every_read_fails
2 failed, 138 passed in 1.36s
```

**(vi) behaviour-preserving refactor** — hoist the scheduler lookup and reason
string out of the `if paths:` guard in `_log_field_skip`, and rewrite the
`read_error` ternary as an `or`:

```
154 passed in 1.85s
```
(`tests/test_yaesu_cat_observation_adapter.py` + `tests/test_startup_state_gate.py`;
the per-mutation figures above are the adapter file alone.)

## Gates

| Gate | Result |
|---|---|
| named test files | 831 passed (above) |
| `uv run ruff check src/ tests/` | All checks passed! |
| `uv run ruff format --check src/ tests/` | 742 files already formatted |
| `uv run mypy --strict src/rigplane/web` | Success: no issues found in 27 source files |
| `uv run lint-imports` | Contracts: 5 kept, 0 broken |

## Seen, in class, not changed

The class swept is "a skip or absorbed failure that leaves a declared FTX-1 path
unobservable without telling the scheduler". Enumerated by reading every
`_log_field_skip` call site and every `except`/`warning` branch that drops a
field in `src/rigplane/backends/yaesu_cat/observations.py`, and by
`grep -rn abandon_startup_path src/` (one production caller, `_log_field_skip`)
plus `grep -rn _poll_warned_fields src/` for the shared label store. All four
instances the audit and PR #3377 recorded are fixed here; the sweep found no
fifth site in this file.

Two adjacent facts, checked and left alone:

- `YaesuObservationAdapter._read_tx_target`'s `tx_target.freq` sub-read still
  passes no paths, and `global.tx_state.tx_target` is still appended either way
  — pinned by `test_tx_target_frequency_read_abandons_nothing` and now also by
  the coverage witness, which asserts it is the one gated path left holding.
- An abandoned path never expires: `AcquisitionScheduler` has no clear for
  `_abandoned_startup_paths` and is built once per server. Whether a path
  abandoned on one bad frame should reset on reconnect is a behavioural ruling
  for the owner, raised by the audit and untouched here.

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
