### PR TITLE
feat: let a field policy declare when the field exists

### DIFF
--- a/rigs/_schema.md
+++ b/rigs/_schema.md
@@ -221,10 +221,37 @@ Each field path uses the canonical `FieldPath` strings from
 Optional per-field policy overrides. Supported keys are `cadence_seconds`,
 `freshness_ttl_seconds`, `reconciliation_priority`, `external_cat_pause`,
 `adaptive_decay`, `adaptive_decay_idle_multiplier`,
-`adaptive_decay_max_cadence_seconds`, `meter_coalescing_window_seconds`, and
-`tx_only` (the set the loader accepts is `_ACQUISITION_POLICY_KEYS` in
-`rig_loader.py`; anything else is rejected).
+`adaptive_decay_max_cadence_seconds`, `meter_coalescing_window_seconds`,
+`tx_only`, and `available_when` (the set the loader accepts is
+`_ACQUISITION_POLICY_KEYS` in `rig_loader.py`; anything else is rejected).
 Field-specific `meter_coalescing_window_seconds` is valid only for meter paths.
+
+`available_when` declares the conditions under which the field exists on the
+radio at all — a mode, band or state in which the rig has no such function.
+It is a list of clauses, all of which must hold. Each clause names a `field`
+(a canonical `FieldPath` string) and exactly one comparison against that
+field's value, in one of three shapes:
+
+| Shape | Spelling | Holds when the source field's value |
+|-------|----------|-------------------------------------|
+| membership | `in = [...]`, `not_in = [...]` | is (is not) one of the listed values |
+| bound | `min = <number>`, `max = <number>` | is at or above (at or below) the bound |
+| equality | `equals = <value>` | equals this value |
+
+An unknown key, no comparison, more than one comparison, a `field` that does
+not parse, a non-list `in`/`not_in`, or a non-numeric `min`/`max` is a load
+error naming the policy path and the clause
+(`rig_loader.py: _parse_available_when`). Nothing acts on the parsed clauses
+yet: they reach
+`state_acquisition_policy.py: AcquisitionPolicy.available_when` and stop
+there.
+
+```toml
+[state_acquisition.field_policies."receiver.main.operator_controls.manual_notch_freq"]
+available_when = [
+    { field = "receiver.main.active.freq_mode.mode", not_in = ["FM", "FM-N", "DATA-FM"] },
+]
+```
 
 An omitted key inherits the profile-level default rather than clearing it, so
 `freshness_ttl_seconds` also accepts the string `"never"` to mean "this field

--- a/rigs/_schema.md
+++ b/rigs/_schema.md
@@ -249,7 +249,7 @@ there.
 ```toml
 [state_acquisition.field_policies."receiver.main.operator_controls.manual_notch_freq"]
 available_when = [
-    { field = "receiver.main.active.freq_mode.mode", not_in = ["FM", "FM-N", "DATA-FM"] },
+    { field = "receiver.main.active.freq_mode.mode", not_in = ["FM", "FM-N", "DATA-FM", "DATA-FM-N"] },
 ]
 ```
 

--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -248,9 +248,16 @@ freshness_ttl_seconds = 2.0
 cadence_seconds = 1.0
 freshness_ttl_seconds = 2.0
 
+# Bench probe 2026-09-08: `RA0;` was refused (`?;`) with MAIN on 461.550 MHz
+# FM. `RA` has a fixed P1 and no SUB form, so band and mode could not be
+# separated in that session; the 60 MHz edge below is provisional until MAIN
+# is retuned to HF and the read repeated.
 [state_acquisition.field_policies."receiver.main.operator_controls.att"]
 cadence_seconds = 1.0
 freshness_ttl_seconds = 2.0
+available_when = [
+    { field = "receiver.main.active.freq_mode.freq_hz", max = 60000000 },
+]
 
 [state_acquisition.field_policies."receiver.main.operator_controls.preamp"]
 cadence_seconds = 1.0
@@ -302,9 +309,15 @@ freshness_ttl_seconds = 2.0
 cadence_seconds = 1.0
 freshness_ttl_seconds = 2.0
 
+# Bench probe 2026-09-08: `BP01;` answered `BP01F35;` with MAIN in FM while
+# `BP11;` answered `BP11150;` with SUB in USB, in the same session -- the
+# manual-notch frequency has no decimal answer in FM.
 [state_acquisition.field_policies."receiver.main.operator_controls.manual_notch_freq"]
 cadence_seconds = 1.0
 freshness_ttl_seconds = 2.0
+available_when = [
+    { field = "receiver.main.active.freq_mode.mode", not_in = ["FM", "FM-N", "DATA-FM"] },
+]
 
 [state_acquisition.field_policies."global.operator_controls.power_level"]
 cadence_seconds = 1.0

--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -311,12 +311,15 @@ freshness_ttl_seconds = 2.0
 
 # Bench probe 2026-09-08: `BP01;` answered `BP01F35;` with MAIN in FM while
 # `BP11;` answered `BP11150;` with SUB in USB, in the same session -- the
-# manual-notch frequency has no decimal answer in FM.
+# manual-notch frequency has no decimal answer in FM. FM-N, DATA-FM and
+# DATA-FM-N are the mode codec's three other reachable FM-family modes
+# (`radio._code_to_mode` codes 4/B/A/F in src/rigplane/backends/yaesu_cat) --
+# declared absent by family, not yet probed individually.
 [state_acquisition.field_policies."receiver.main.operator_controls.manual_notch_freq"]
 cadence_seconds = 1.0
 freshness_ttl_seconds = 2.0
 available_when = [
-    { field = "receiver.main.active.freq_mode.mode", not_in = ["FM", "FM-N", "DATA-FM"] },
+    { field = "receiver.main.active.freq_mode.mode", not_in = ["FM", "FM-N", "DATA-FM", "DATA-FM-N"] },
 ]
 
 [state_acquisition.field_policies."global.operator_controls.power_level"]

--- a/src/rigplane/core/state_acquisition_policy.py
+++ b/src/rigplane/core/state_acquisition_policy.py
@@ -16,6 +16,8 @@ from rigplane.core.state_pipeline_contracts import FieldFamily, FieldPath
 __all__ = [
     "AcquisitionPolicy",
     "AdaptiveDecayPolicy",
+    "AvailabilityClause",
+    "AvailabilityOperator",
     "ExternalCatPauseBehavior",
     "FieldAvailability",
     "FieldCapability",
@@ -216,6 +218,70 @@ class MeterCoalescingPolicy:
         )
 
 
+class AvailabilityOperator(StrEnum):
+    """Comparison an availability clause applies to its source field."""
+
+    IN = "in"
+    NOT_IN = "not_in"
+    MIN = "min"
+    MAX = "max"
+    EQUALS = "equals"
+
+
+_SEQUENCE_AVAILABILITY_OPERATORS = frozenset(
+    {AvailabilityOperator.IN, AvailabilityOperator.NOT_IN}
+)
+_NUMERIC_AVAILABILITY_OPERATORS = frozenset(
+    {AvailabilityOperator.MIN, AvailabilityOperator.MAX}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AvailabilityClause:
+    """One condition on another field's current value."""
+
+    field: FieldPath
+    operator: AvailabilityOperator | str
+    value: Any
+
+    def __post_init__(self) -> None:
+        operator = AvailabilityOperator(str(self.operator))
+        value = self.value
+        if operator in _SEQUENCE_AVAILABILITY_OPERATORS:
+            if isinstance(value, str) or not isinstance(value, Sequence):
+                raise ValueError(f"{operator.value} must be a sequence of values")
+            value = tuple(value)
+        elif operator in _NUMERIC_AVAILABILITY_OPERATORS:
+            value = _strict_float(value, label=operator.value)
+        object.__setattr__(self, "operator", operator)
+        object.__setattr__(self, "value", value)
+
+    def to_dict(self) -> dict[str, Any]:
+        operator = AvailabilityOperator(str(self.operator))
+        return {
+            "field": str(self.field),
+            "operator": operator.value,
+            "value": (
+                list(self.value)
+                if operator in _SEQUENCE_AVAILABILITY_OPERATORS
+                else self.value
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> AvailabilityClause:
+        _reject_unknown_keys(
+            value,
+            allowed=frozenset({"field", "operator", "value"}),
+            label="availability clause",
+        )
+        return cls(
+            field=FieldPath.parse(str(value["field"])),
+            operator=AvailabilityOperator(str(value["operator"])),
+            value=value["value"],
+        )
+
+
 @dataclass(frozen=True, slots=True)
 class AcquisitionPolicy:
     """Scheduler-facing policy for acquiring one or more fields."""
@@ -235,6 +301,9 @@ class AcquisitionPolicy:
     #: triggered read is never blocked by this flag). Inert when
     #: ``cadence_seconds`` is ``None`` (nothing left for it to gate).
     tx_only: bool = False
+    #: Declared conditions, all of which must hold, for this field to exist
+    #: on the radio in its current mode, band or state.
+    available_when: tuple[AvailabilityClause, ...] = ()
 
     def __post_init__(self) -> None:
         cadence = _optional_positive_float(
@@ -264,6 +333,11 @@ class AcquisitionPolicy:
             "tx_only",
             _strict_bool(self.tx_only, label="tx_only"),
         )
+        clauses = tuple(self.available_when)
+        for clause in clauses:
+            if not isinstance(clause, AvailabilityClause):
+                raise ValueError("available_when must hold AvailabilityClause entries")
+        object.__setattr__(self, "available_when", clauses)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -282,6 +356,7 @@ class AcquisitionPolicy:
                 else self.meter_coalescing.to_dict()
             ),
             "txOnly": self.tx_only,
+            "availableWhen": [clause.to_dict() for clause in self.available_when],
         }
 
     @classmethod
@@ -297,6 +372,7 @@ class AcquisitionPolicy:
                     "externalCatPause",
                     "meterCoalescing",
                     "txOnly",
+                    "availableWhen",
                 }
             ),
             label="acquisition policy",
@@ -333,6 +409,10 @@ class AcquisitionPolicy:
                 value.get("meterCoalescing")
             ),
             tx_only=bool(value.get("txOnly", False)),
+            available_when=tuple(
+                AvailabilityClause.from_dict(clause)
+                for clause in value.get("availableWhen", ())
+            ),
         )
 
 

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -17,6 +17,7 @@ from rigplane.core.capabilities import KNOWN_CAPABILITIES
 from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
     AdaptiveDecayPolicy,
+    AvailabilityClause,
     ExternalCatPauseBehavior,
     FieldAvailability,
     FieldCapability,
@@ -1451,8 +1452,59 @@ _ACQUISITION_POLICY_KEYS = frozenset(
         "external_cat_pause",
         "meter_coalescing_window_seconds",
         "tx_only",
+        "available_when",
     }
 )
+
+#: Operator keys an ``available_when`` clause may carry; a clause must use
+#: exactly one of them alongside its ``field``.
+_AVAILABILITY_OPERATOR_KEYS = ("in", "not_in", "min", "max", "equals")
+_AVAILABILITY_CLAUSE_KEYS = frozenset({"field", *_AVAILABILITY_OPERATOR_KEYS})
+
+
+def _parse_available_when(
+    filename: str,
+    prefix: str,
+    value: Any,
+) -> tuple[AvailabilityClause, ...]:
+    if not isinstance(value, list):
+        raise RigLoadError(
+            f"{filename}: {prefix}.available_when must be a list of clauses"
+        )
+    clauses: list[AvailabilityClause] = []
+    for index, raw_clause in enumerate(value):
+        label = f"{prefix}.available_when[{index}]"
+        if not isinstance(raw_clause, dict):
+            raise RigLoadError(f"{filename}: {label} must be a table")
+        _reject_unknown_keys(filename, label, raw_clause, _AVAILABILITY_CLAUSE_KEYS)
+        if not isinstance(raw_clause.get("field"), str):
+            raise RigLoadError(f"{filename}: {label}.field must be a field path string")
+        try:
+            path = FieldPath.parse(raw_clause["field"])
+        except ValueError as exc:
+            raise RigLoadError(
+                f"{filename}: {label}.field is not a field path: {exc}"
+            ) from exc
+        present = [key for key in _AVAILABILITY_OPERATOR_KEYS if key in raw_clause]
+        if len(present) != 1:
+            raise RigLoadError(
+                f"{filename}: {label} must use exactly one of "
+                f"{list(_AVAILABILITY_OPERATOR_KEYS)}, got {present}"
+            )
+        operator = present[0]
+        operand = raw_clause[operator]
+        if operator in ("in", "not_in") and not isinstance(operand, list):
+            raise RigLoadError(f"{filename}: {label}.{operator} must be a list")
+        if operator in ("min", "max"):
+            operand = _strict_policy_float(filename, label, operator, operand)
+        try:
+            clauses.append(
+                AvailabilityClause(field=path, operator=operator, value=operand)
+            )
+        except ValueError as exc:
+            raise RigLoadError(f"{filename}: {label} invalid: {exc}") from exc
+    return tuple(clauses)
+
 
 _STATE_ACQUISITION_KEYS = frozenset(
     {
@@ -1493,6 +1545,11 @@ def _parse_acquisition_policy(
 ) -> AcquisitionPolicy:
     _reject_unknown_keys(filename, prefix, raw, _ACQUISITION_POLICY_KEYS)
     labels = key_labels or {}
+    available_when = (
+        _parse_available_when(filename, prefix, raw["available_when"])
+        if "available_when" in raw
+        else ()
+    )
     try:
         return AcquisitionPolicy(
             cadence_seconds=_policy_seconds(
@@ -1608,6 +1665,7 @@ def _parse_acquisition_policy(
                     defaults.tx_only if defaults is not None else False,
                 ),
             ),
+            available_when=available_when,
         )
     except (TypeError, ValueError) as exc:
         raise RigLoadError(

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -17,6 +17,7 @@ from rigplane.core.observation_adapter import ProviderObservationAdapter
 from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
     AdaptiveDecayPolicy,
+    AvailabilityClause,
     FieldAvailability,
     FieldCapability,
     MeterCoalescingPolicy,
@@ -1487,3 +1488,155 @@ def test_ic7300_on_demand_field_primes_with_its_cadence_as_max_age() -> None:
     assert request_by_path[on_demand].max_age == (
         acquisition.policy_for(on_demand).cadence_seconds
     )
+
+
+def _available_when_toml(value: str) -> str:
+    return _minimal_state_acquisition_toml(
+        f"""
+        [state_acquisition]
+        provider = "icom_civ"
+        default_cadence_seconds = 2.0
+        default_freshness_ttl_seconds = 8.0
+
+        [state_acquisition.capabilities]
+        polling_only = ["global.meters.power", "global.tx_state.vox_on"]
+
+        [state_acquisition.field_policies."global.meters.power"]
+        available_when = {value}
+        """
+    )
+
+
+def test_loader_parses_every_available_when_operator(tmp_path: Path) -> None:
+    """Each of the five clause operators reaches the parsed field policy."""
+
+    toml = _available_when_toml(
+        """[
+            { field = "receiver.main.active.freq_mode.mode", in = ["USB", "LSB"] },
+            { field = "receiver.main.active.freq_mode.mode", not_in = ["FM"] },
+            { field = "receiver.main.active.freq_mode.freq_hz", min = 1800000 },
+            { field = "receiver.main.active.freq_mode.freq_hz", max = 60000000 },
+            { field = "global.tx_state.split", equals = false },
+        ]"""
+    )
+
+    acquisition = load_rig(_write_toml(tmp_path, toml)).to_profile().state_acquisition
+    assert acquisition is not None
+    mode = FieldPath.active("main", "freq_mode", "mode")
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    split = FieldPath.global_("tx_state", "split")
+
+    assert acquisition.policy_for(
+        FieldPath.global_("meters", "power")
+    ).available_when == (
+        AvailabilityClause(field=mode, operator="in", value=("USB", "LSB")),
+        AvailabilityClause(field=mode, operator="not_in", value=("FM",)),
+        AvailabilityClause(field=freq, operator="min", value=1800000.0),
+        AvailabilityClause(field=freq, operator="max", value=60000000.0),
+        AvailabilityClause(field=split, operator="equals", value=False),
+    )
+    # A path with no override of its own does not inherit these clauses.
+    assert (
+        acquisition.policy_for(FieldPath.global_("tx_state", "vox_on")).available_when
+        == ()
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        ('"main only"', "must be a list of clauses"),
+        ('["main only"]', "must be a table"),
+        ('[{ field = "global.tx_state.split" }]', "exactly one"),
+        (
+            '[{ field = "global.tx_state.split", equals = true, min = 1 }]',
+            "exactly one",
+        ),
+        ('[{ field = "global.tx_state.split", nope = 1 }]', "unknown key"),
+        ("[{ equals = true }]", "field"),
+        ('[{ field = "global tx_state split", equals = true }]', "field"),
+        ('[{ field = "global.tx_state.split", in = "USB" }]', "must be a list"),
+        ('[{ field = "global.tx_state.split", not_in = "USB" }]', "must be a list"),
+        ('[{ field = "global.tx_state.split", min = "1" }]', "must be a number"),
+        ('[{ field = "global.tx_state.split", max = "1" }]', "must be a number"),
+    ],
+)
+def test_loader_rejects_malformed_available_when(
+    tmp_path: Path, value: str, message: str
+) -> None:
+    """Every malformed clause shape is a load error naming the policy path."""
+
+    with pytest.raises(RigLoadError) as excinfo:
+        load_rig(_write_toml(tmp_path, _available_when_toml(value)))
+
+    text = str(excinfo.value)
+    assert message in text
+    assert "field_policies.global.meters.power" in text
+
+
+def test_available_when_round_trips_through_to_dict() -> None:
+    policy = AcquisitionPolicy(
+        cadence_seconds=1.0,
+        freshness_ttl_seconds=2.0,
+        available_when=(
+            AvailabilityClause(
+                field=FieldPath.active("main", "freq_mode", "mode"),
+                operator="not_in",
+                value=("FM",),
+            ),
+        ),
+    )
+
+    payload = json.loads(json.dumps(policy.to_dict()))
+    assert payload["availableWhen"] == [
+        {
+            "field": "receiver.main.active.freq_mode.mode",
+            "operator": "not_in",
+            "value": ["FM"],
+        }
+    ]
+    assert AcquisitionPolicy.from_dict(payload) == policy
+    assert AcquisitionPolicy(cadence_seconds=1.0).available_when == ()
+
+
+def test_ftx1_declares_when_manual_notch_and_attenuator_exist() -> None:
+    """The two FTX-1 paths a 2026-09-08 bench probe found conditional."""
+
+    acquisition = get_radio_profile("FTX-1").state_acquisition
+    assert acquisition is not None
+
+    notch = FieldPath.receiver("main", "operator_controls", "manual_notch_freq")
+    assert acquisition.policy_for(notch).available_when == (
+        AvailabilityClause(
+            field=FieldPath.active("main", "freq_mode", "mode"),
+            operator="not_in",
+            value=("FM", "FM-N", "DATA-FM"),
+        ),
+    )
+
+    att = FieldPath.receiver("main", "operator_controls", "att")
+    assert acquisition.policy_for(att).available_when == (
+        AvailabilityClause(
+            field=FieldPath.active("main", "freq_mode", "freq_hz"),
+            operator="max",
+            value=60000000.0,
+        ),
+    )
+
+
+def test_available_when_is_declared_only_where_a_probe_established_it() -> None:
+    """Loading every shipped profile turns up exactly the two declarations."""
+
+    declared: set[tuple[str, str]] = set()
+    for model, rig in discover_rigs(RIGS_DIR).items():
+        acquisition = rig.to_profile().state_acquisition
+        if acquisition is None:
+            continue
+        for path, policy in acquisition.field_policies.items():
+            if policy.available_when:
+                declared.add((model, str(path)))
+
+    assert declared == {
+        ("FTX-1", "receiver.main.operator_controls.att"),
+        ("FTX-1", "receiver.main.operator_controls.manual_notch_freq"),
+    }

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -1610,7 +1610,7 @@ def test_ftx1_declares_when_manual_notch_and_attenuator_exist() -> None:
         AvailabilityClause(
             field=FieldPath.active("main", "freq_mode", "mode"),
             operator="not_in",
-            value=("FM", "FM-N", "DATA-FM"),
+            value=("FM", "FM-N", "DATA-FM", "DATA-FM-N"),
         ),
     )
 


### PR DESCRIPTION
## What

A rig profile can now declare that a field exists only under a condition on
another field's current value. A `[state_acquisition.field_policies."<path>"]`
block accepts an optional `available_when` list; every clause must hold. Each
clause names a `field` (a canonical `FieldPath` string) and exactly one of
`in = [...]`, `not_in = [...]`, `min = <number>`, `max = <number>`,
`equals = <value>`.

- `state_acquisition_policy.py: AvailabilityOperator` and
  `state_acquisition_policy.py: AvailabilityClause` — the frozen clause type,
  next to `AcquisitionPolicy.tx_only`.
- `state_acquisition_policy.py: AcquisitionPolicy.available_when` — the new
  field (default `()`), carried through `AcquisitionPolicy.to_dict` /
  `AcquisitionPolicy.from_dict` as `availableWhen`.
- `rig_loader.py: _parse_available_when` — validation. An unknown key, no
  operator, more than one operator, a `field` that does not parse, a non-list
  `in`/`not_in`, or a non-numeric `min`/`max` raises `RigLoadError` naming the
  policy path and the clause index. It is called from
  `rig_loader.py: _parse_acquisition_policy` before the `AcquisitionPolicy`
  construction, so its message is not re-wrapped by that function's generic
  `invalid acquisition policy` handler.
- `rigs/_schema.md` — the key, the three clause shapes, and one sentence saying
  nothing acts on the parsed clauses yet. **That sentence must be deleted by
  the PR that makes a consumer honour them.**

## Why

Mode- and band-dependent absence belongs in the profile, not the UI (owner
ruling R42), and a declared read the radio refuses is a defect (R48). Today the
only state-conditional exclusion a profile can express is `tx_only`, which is
static and resolved at load time; the two mode gates that exist live in the
frontend adapter. This PR adds the declaration only — the scheduler, the
startup gate, the pollers and the web layer are untouched and behave exactly as
before. A repo-wide grep for `available_when` / `availableWhen` /
`AvailabilityClause` / `AvailabilityOperator` over `*.py`, `*.ts`, `*.svelte`,
`grep -rlE "\bavailable_when\b|availableWhen|AvailabilityClause|AvailabilityOperator"` over `*.py`, `*.ts`, `*.svelte`, `*.toml`, `*.md` (excluding `.venv`, `node_modules`, `.git`) returns five files: `rigs/_schema.md`, `rigs/ftx1.toml`, `src/rigplane/core/state_acquisition_policy.py`, `src/rigplane/profiles/rig_loader.py`, `tests/test_state_acquisition_policy.py`; within `src/`, only the two modules this PR changes.

## The two FTX-1 declarations

Both come from a 2026-09-08 read-only bench session on the FTX-1, recorded in
the run's handoff notes. `receiver.main.operator_controls.manual_notch_freq`
gets `not_in = ["FM", "FM-N", "DATA-FM", "DATA-FM-N"]` on
`receiver.main.active.freq_mode.mode`: in that session `BP01;` answered
`BP01F35;` with MAIN in FM while `BP11;` answered `BP11150;` with SUB in USB,
so the manual-notch frequency has no decimal answer in FM; the spellings are
those in `rigs/ftx1.toml`'s `[modes].list`, cross-checked against the codec map
pinned by `tests/test_ftx1_radio.py`. The `not_in` list names all four modes
the mode codec's single-character `{mode}` group can reach in the FM family
(codes 4/B/A/F; `C4FM-DN`/`C4FM-VW` are multi-character codes that group can
never produce) rather than only the one mode the bench probed: under the
fail-fast rule, a mode left out of `not_in` reads as available and gets
queried anyway, which is the worse error than declaring an unprobed sibling
absent. Only FM was probed; FM-N, DATA-FM and DATA-FM-N are declared absent by
family and marked provisional in the TOML comment, the same treatment the
attenuator's 60 MHz edge below already gets. `receiver.main.operator_controls.att`
gets `max = 60000000` on `receiver.main.active.freq_mode.freq_hz`: `RA0;` was
refused (`?;`) with MAIN on 461.550 MHz FM, and because `RA` has a fixed P1 and
no SUB form, band and mode could not be separated in that session — the TOML
comment says the 60 MHz edge is provisional until MAIN is retuned to HF and the
read repeated. The seven `receiver.sub.*` paths are **not** declared: no
canonical, live-observed field for the FTX-1's dual-receive state exists today
(`FR` is read only in the legacy `poller.py: _poll_slow` body, and
`global.tx_state.dual_watch` is published only from `runtime/_civ_rx.py`, the
Icom path). A later PR must land the live `FR` observation before those clauses
can name a source field.

## `polling_only` vs `field_policies`

`RadioAcquisitionProfile.policy_for` returns the shared `default_policy` for
any path without its own `field_policies` entry, so a `polling_only` path
without such a block has **no policy object of its own** — attaching clauses
there would leak them onto every other undeclared path. `available_when` is
therefore accepted only inside a `field_policies` block. No FTX-1 path had to
move: both declared paths already carried a `field_policies` block, and their
cadences are unchanged.

## Guardrails

`git diff --numstat origin/main...HEAD`:

```
30	3	rigs/_schema.md
16	0	rigs/ftx1.toml
80	0	src/rigplane/core/state_acquisition_policy.py
58	0	src/rigplane/profiles/rig_loader.py
153	0	tests/test_state_acquisition_policy.py
```

5 files, 337+/3- = 340 changed lines — under both soft-threshold numbers.

## Tests and mutations

Test-first, all in `tests/test_state_acquisition_policy.py`:
`test_loader_parses_every_available_when_operator` (all five operators reach
the parsed policy; an undeclared path does not inherit them),
`test_loader_rejects_malformed_available_when` (11 parametrised malformed
shapes, each asserting the policy path is in the message),
`test_available_when_round_trips_through_to_dict`,
`test_ftx1_declares_when_manual_notch_and_attenuator_exist`, and
`test_available_when_is_declared_only_where_a_probe_established_it` (loads
every profile under `rigs/` and asserts the declarations are exactly the two
FTX-1 ones).

Mutations run and reverted:

1. `len(present) != 1` → `not present` in `rig_loader.py:
   _parse_available_when`: the two-operator case of
   `test_loader_rejects_malformed_available_when` failed (`DID NOT RAISE`);
   the other ten cases stayed green.
2. Same guard → `len(present) > 1`: the zero-operator case failed; the other
   ten stayed green.
3. Dropped `"DATA-FM"` from the FTX-1 notch clause in `rigs/ftx1.toml`:
   `test_ftx1_declares_when_manual_notch_and_attenuator_exist` failed on the
   clause value.
4. Changed the FTX-1 attenuator edge to `30000000`: the same test failed on
   the `max` value.

`git diff` after reverting shows only the intended change.

Local gates on the head: `uv run ruff check src/ tests/` — all checks passed;
`uv run ruff format --check src/ tests/` — 742 files already formatted;
`uv run mypy --strict src/rigplane/web` — no issues in 27 source files;
`uv run lint-imports` — 5 contracts kept, 0 broken;
`uv run pytest` over `tests/test_state_acquisition_policy.py`,
`tests/test_rig_loader.py`, the four `tests/test_ftx1_*.py`,
`tests/test_startup_state_gate.py` and `tests/test_acquisition_scheduler.py` —
967 passed, 1 skipped. The full suite is CI's to run.
`.github/scripts/check-doc-citations.sh` could not run locally (it needs bash 4+
associative arrays; the shell here is bash 3.2). `.github/workflows/doc-citation-gate.yml`
is path-scoped to `.github/scripts/check-doc-citations.sh` and to itself, and
this PR touches neither, so the gate does not run here; the two citations
added were checked by hand as file plus symbol, no line numbers.

Internal-identifier self-check — empty.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)


