### PR TITLE
fix: serve dual_rx from the profile instead of the swap-and-equalize protocol

### DIFF
--- a/docs/plans/2026-09-01-segmentline-peer-split.md
+++ b/docs/plans/2026-09-01-segmentline-peer-split.md
@@ -90,24 +90,13 @@ dual composition had no path for any of the four.
 `peer-split`'s `fallbackLayoutId` names `unified-instrument`. Retarget it to
 `lcd-cockpit`, where the persisted amber preference already routes.
 
-## 5. The second receiver before MOR-2144
+## 5. The second receiver
 
-`rigs/ftx1.toml` declares `dual_rx`; the web layer discards it because
-`YaesuCatRadio` does not satisfy `DualReceiverCapable`. Tracked as MOR-2144,
-not fixed here.
-
-The consequence is **not** that `peer-split` cannot render.
-`derivePresentationCapabilities` keeps both receivers structurally present and
-sets `operationalReceivers = ['MAIN']` with a `dual-rx-unavailable`
-diagnostic; `toRadioViewModel` emits a `receiver.SUB` /
-`capability-unavailable` disabled reason, and `isOperationalStrip` reads it
-back onto the strip. `radio-view-model-adapter.ts` records this as the
-intended behaviour: a structurally dual radio without the tag keeps SUB in
-`vfos`, "correct: MOR-977 renders it PRESENT".
-
-**Owner decision, 2026-09-01:** ship it that way. The SUB column renders
-present and marked not-operational, and becomes live when MOR-2144 lands with
-no change in this layout.
+**Owner ruling, 2026-09-08:** structural existence of the second receiver
+follows the rig profile — `runtime_helpers.py: runtime_capabilities` no longer
+discards a profile-declared `dual_rx` — while the swap and equalize actions
+stay gated by their own capability tags
+(`runtime_helpers.py: projected_vfo_capability_tags`).
 
 ## 6. Architecture placement
 

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -741,7 +741,7 @@ class ControlHandler:
             return
         caps = self._capabilities()
         # Also check profile capabilities (runtime_capabilities may strip
-        # protocol-gated tags like dual_rx even when the profile supports them).
+        # protocol-gated tags even when the profile supports them).
         raw_profile = getattr(self._radio, "profile", None)
         if isinstance(raw_profile, RadioProfile):
             if capability in raw_profile.capabilities:

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -577,8 +577,10 @@ def runtime_capabilities(radio: "Radio | None") -> set[str]:
             # frontend — drop the tag so the UI doesn't render dead
             # controls.
             caps.discard("audio")
-        if "dual_rx" in caps and not isinstance(radio, DualReceiverCapable):
-            caps.discard("dual_rx")
+        # ``dual_rx`` is deliberately not gated on ``DualReceiverCapable``:
+        # owner ruling, 2026-09-08. Structural existence of the second
+        # receiver follows the rig profile; the swap and equalize actions
+        # are gated separately, by ``projected_vfo_capability_tags``.
         if "repeater_shift" in caps and not isinstance(radio, RepeaterShiftCapable):
             caps.discard("repeater_shift")
         return caps

--- a/tests/test_mor1499_coalesce_keys.py
+++ b/tests/test_mor1499_coalesce_keys.py
@@ -175,9 +175,6 @@ async def test_set_filter_same_target_still_coalesces() -> None:
 async def test_set_nb_cross_receiver_both_reach_radio() -> None:
     ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
     queue = _QueueRecorder()
-    # Canonical dual-RX VFO methods (DualReceiverCapable) so the "dual_rx"
-    # capability tag isn't stripped by runtime_capabilities()'s isinstance
-    # check, and receiver=1 (SUB) passes _ensure_receiver_supported.
     radio = SimpleNamespace(
         connected=True,
         capabilities={"nb", "dual_rx"},

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -745,3 +745,75 @@ class TestCommandGuards:
         # Should not raise
         handler._ensure_capability("dual_rx", "set_dual_watch")
         handler._ensure_capability("dual_rx", "set_dual_watch")
+
+
+# ── Profile-declared second receiver (owner ruling, 2026-09-08) ─
+
+
+class TestProfileDeclaredSecondReceiver:
+    """A profile-declared ``dual_rx`` reaches the served surface.
+
+    Owner ruling, 2026-09-08: structural existence of the second receiver
+    follows the rig profile, not the swap-and-equalize protocol. The swap
+    and equalize *actions* keep their own gates, so a backend that declares
+    ``dual_rx`` without implementing the MAIN/SUB primitives serves the
+    receiver and refuses the actions.
+
+    The radio here is a real :class:`YaesuCatRadio` on the bundled ``ftx1``
+    profile — a ``MagicMock`` would satisfy every Protocol check trivially
+    and could not distinguish the two behaviours.
+    """
+
+    def test_runtime_capabilities_keeps_dual_rx_without_the_protocol(self) -> None:
+        from rigplane.radio_protocol import DualReceiverCapable
+        from rigplane.web.runtime_helpers import runtime_capabilities
+
+        radio = _yaesu()
+        assert "dual_rx" in radio.capabilities
+        assert not isinstance(radio, DualReceiverCapable)
+        assert "dual_rx" in runtime_capabilities(radio)
+
+    @pytest.mark.asyncio
+    async def test_info_reports_the_second_receiver(self) -> None:
+        radio = _yaesu()
+        srv = WebServer(radio)
+        writer = _FakeWriter()
+        await srv._serve_info(writer)  # noqa: SLF001
+        data = _parse_json_body(writer)
+        assert data["capabilities"]["hasDualReceiver"] is True
+        assert data["capabilities"]["maxReceivers"] == 2
+        assert "dual_rx" in data["capabilities"]["tags"]
+
+    @pytest.mark.asyncio
+    async def test_capabilities_endpoint_reports_the_second_receiver(self) -> None:
+        radio = _yaesu()
+        srv = WebServer(radio)
+        writer = _FakeWriter()
+        await srv._serve_capabilities(writer)  # noqa: SLF001
+        data = _parse_json_body(writer)
+        assert "dual_rx" in data["capabilities"]
+        assert data["receivers"] == 2
+
+    def test_swap_and_equalize_tags_absent_without_the_primitives(self) -> None:
+        from rigplane.web.runtime_helpers import projected_vfo_capability_tags
+
+        radio = _yaesu()
+        assert not hasattr(radio, "swap_main_sub")
+        assert not hasattr(radio, "equalize_main_sub")
+        assert projected_vfo_capability_tags(radio, None) == frozenset()
+
+    @pytest.mark.parametrize("name", ["vfo_swap", "vfo_equalize"])
+    def test_swap_and_equalize_commands_are_refused(self, name: str) -> None:
+        from rigplane.web.handlers import ControlHandler
+
+        radio = _yaesu()
+        handler = ControlHandler.__new__(ControlHandler)
+        handler._radio = radio
+        queue: list[object] = []
+
+        expected = f"command '{name}' is not supported by active profile"
+        with pytest.raises(ValueError, match=expected):
+            handler._enqueue_rc_frequency(  # noqa: SLF001
+                name, {}, SimpleNamespace(put=queue.append), radio
+            )
+        assert queue == []

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -552,8 +552,11 @@ def test_runtime_capabilities_fallback_recognises_usb_audio_only() -> None:
 def test_runtime_capabilities_filters_incompatible_tags() -> None:
     radio = _FakeRadio(caps={"scope", "audio", "dual_rx", "repeater_shift", "tx"})
     caps = runtime_capabilities(radio)
-    # No Protocols implemented -> scope/audio/dual_rx/repeater_shift dropped, tx preserved
-    assert caps == {"tx"}
+    # No Protocols implemented -> scope/audio/repeater_shift dropped; tx and
+    # dual_rx preserved. ``dual_rx`` is not gated on ``DualReceiverCapable``
+    # (owner ruling, 2026-09-08): the second receiver's structural existence
+    # follows the rig profile, not the swap-and-equalize protocol.
+    assert caps == {"tx", "dual_rx"}
 
 
 def test_runtime_capabilities_drops_repeater_shift_without_both_methods() -> None:


### PR DESCRIPTION
## What

`web/runtime_helpers.py: runtime_capabilities` no longer discards a
profile-declared `dual_rx` when the radio object fails
`isinstance(radio, DualReceiverCapable)`. The other three guarded tags
(`audio`, `repeater_shift`, `scope`) are untouched.

## Why

`DualReceiverCapable` (`core/radio_protocol.py`) requires `swap_main_sub`
and `equalize_main_sub` alongside the tracking pair. A backend can have a
real second receiver and no atomic MAIN/SUB swap primitive; it then lost
the tag, while `WebServer._serve_info`'s `maxReceivers` and
`WebServer._serve_capabilities`' `receivers` kept reading
`RadioProfile.receiver_count` unfiltered — one fact served from two
sources. **Owner ruling R49, 2026-09-08:** structural existence of the
second receiver follows the profile; the swap and equalize *actions* stay
gated by their own capability tags and are simply absent on rigs that lack
them. This supersedes the 2026-09-01 interim ruling recorded in
`docs/plans/2026-09-01-segmentline-peer-split.md` §5 under MOR-2144. Live
evidence from the bench session that prompted the ruling: on the FTX-1 all
`receiver.sub.*` fields including the S-meter arrive fresh, yet
`frontend/src/lib/runtime/adapters/presentation-capabilities.ts:
derivePresentationCapabilities` saw no `dual_rx` tag, pushed
`dual-rx-unavailable` and cut `operationalReceivers` to `['MAIN']`, which
forces every SUB field to the unknown state downstream.

## Handler gating — no guard was needed

Traced by reading; **no handler guard added**, and none of these gates
changed behaviour under this PR:

- `web/handlers/control.py: ControlHandler._enqueue_rc_frequency`
  (`vfo_swap` / `vfo_equalize`) gates on the profile's `vfo_scheme` plus
  the declared code, never on `dual_rx`. The FTX-1's `vfo_scheme` is
  `ab_shared`, which matches neither the `ab` nor the `main_sub` branch,
  so `declared_code` stays `None` and the command is refused with
  `ValueError("command 'vfo_swap' is not supported by active profile")`.
  Same reason `web/runtime_helpers.py: projected_vfo_capability_tags`
  yields no swap primitives for `ab_shared` (its `else: primitives = ()`).
- `web/handlers/control.py: ControlHandler._enqueue_rc_misc`
  (`quick_dualwatch` / `quick_split`) gates on
  `ControlHandler._ensure_capability("dual_rx", ...)`, which checks
  `radio.profile.capabilities` **before** `runtime_capabilities` and
  returns early on a match — its own comment says so. That gate therefore
  already passed for a profile declaring `dual_rx` before this PR, and is
  unaffected by it. The enqueued `QuickDwTrigger`/`QuickSplitTrigger`
  reach `backends/yaesu_cat/poller.py: YaesuCatPoller._execute_command`,
  whose `case _` raises `NotImplementedError`. The only executor that
  calls `equalize_main_sub` for those commands is
  `web/radio_poller.py: RadioPoller._execute_command`, and
  `web/web_startup.py` constructs `RadioPoller` only on the branch a radio
  implementing `create_observation_poller` never takes.
- `web/radio_poller.py: RadioPoller`'s own dual-RX gates read
  `RadioPoller._radio_capabilities`, i.e. raw `radio.capabilities`, never
  `runtime_capabilities` — so nothing in the poller changes either way.
- rigctld: `git grep -n 'dual_rx\|main_sub\|swap' src/rigplane/rigctld/`
  returns nothing; there is no swap/equalize path there at all.

## Frontend

No change. `derivePresentationCapabilities` reads the served tag list, so
serving `dual_rx` is enough: for `vfoScheme: "ab_shared"` it derives
`expectedCount = 2`, matches `caps.receivers = 2`, and with `dual` now
true skips the `dual-rx-unavailable` clause. Confirmed by reading; the
vitest suite was not run.

## Census

`git diff --numstat origin/main...HEAD` — 6 files, 89+/26- = 115 changed
lines at 5d178a9c. At the 6-file soft threshold and well under the line threshold; one unit of work: the discard removal, the tests that pin the served surface, the one moved test, the plan paragraph the removal falsified, and the two comments the review found the removal had falsified.

## Tests and mutations

Test-first. New `TestProfileDeclaredSecondReceiver` in
`tests/test_web_capability_guards.py` uses a **real** `YaesuCatRadio` on
the bundled `ftx1` profile (a `MagicMock` satisfies every runtime-checkable
Protocol trivially and could not tell the two behaviours apart): asserts
`runtime_capabilities` keeps `dual_rx` while `isinstance(radio,
DualReceiverCapable)` is false, `/info` reports `hasDualReceiver: true` and
`maxReceivers: 2`, `/api/v1/capabilities` lists `dual_rx` with
`receivers: 2`, `projected_vfo_capability_tags` returns an empty set, and
the `vfo_swap`/`vfo_equalize` handler refuses (both parametrised cases).

`tests/test_web_runtime_helpers.py::test_runtime_capabilities_filters_incompatible_tags`
was the test pinning the removed branch. It also pins `scope`, `audio` and
`repeater_shift`, so it **moved to the new truth** (`{"tx"}` →
`{"tx", "dual_rx"}`) rather than being deleted.
`tests/test_profile_command_coverage.py::test_ftx1_dual_rx_reports_stub_and_absent_methods`
is unchanged; it pins the implementation gap this PR does not close.

Mutations run:

1. Restore the `dual_rx` discard in `runtime_capabilities` → 4 failed:
   the three served-surface tests
   (`test_runtime_capabilities_keeps_dual_rx_without_the_protocol`,
   `test_info_reports_the_second_receiver`,
   `test_capabilities_endpoint_reports_the_second_receiver`) plus
   `test_runtime_capabilities_filters_incompatible_tags`.
2. Delete the `declared_code is None` refusal in
   `_enqueue_rc_frequency` → 2 failed:
   `test_swap_and_equalize_commands_are_refused[vfo_swap]` and
   `[vfo_equalize]`.

Both mutations reverted; `git diff` after restore showed only the intended
change.

## Gates

- `uv run pytest tests/test_web_capability_guards.py tests/test_web_runtime_helpers.py tests/test_profile_command_coverage.py` — **138 passed**
- Adjacent files (not modified, run for blast radius): `tests/test_web_server.py tests/test_web_server_coverage.py tests/test_yaesu_web_projection.py tests/test_profiles_routing.py tests/test_handlers_coverage.py tests/test_ftx1_radio.py` — **967 passed, 2 skipped**
- `uv run ruff check src/ tests/` — All checks passed
- `uv run ruff format --check src/ tests/` — 742 files already formatted
- `uv run mypy --strict src/rigplane/web` — Success, no issues in 27 files
- `uv run lint-imports` — Contracts: 5 kept, 0 broken
- `.github/scripts/check-doc-citations.sh` — **could not run locally**: it
  needs `declare -A`, and the only bash found on this machine (checking
  `/bin`, `/usr/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, `/opt/local/bin`,
  `/sw/bin` and `command -v bash`) is `/bin/bash` 3.2.57. Checked
  its rules by hand instead: applying the script's own `PATTERN` regex to
  the changed doc finds no `file:line` citation (the two citations added
  are file-plus-symbol), neither baseline file has an entry for this
  document, and no relative link was added or removed. CI is the authority.

## Docs

`docs/plans/2026-09-01-segmentline-peer-split.md` §5: deleted the sentence
claiming the web layer discards `dual_rx` because `YaesuCatRadio` does not
satisfy `DualReceiverCapable`, the "ship it that way" interim decision, and
the consequence paragraph describing the now-removed `dual-rx-unavailable`
path as the FTX-1 reality; replaced with one dated sentence recording the
2026-09-08 ruling. Section heading shortened to "The second receiver"
(nothing referenced the old heading).

`docs/release-notes/2026-beta-known-limitations.md` — **not changed**: it
has no FTX-1 dual-receiver entry this PR makes false. Its MOR-2144 entry is
the IC-7300 APF one (stays), and its "Dual-receiver topology (permanent
limitation)" section is about hardware certification, which this PR does
not touch.

## Seen, not changed

`tests/test_web_runtime_helpers.py::test_runtime_capabilities_drops_repeater_shift_without_both_methods`
carries a docstring calling the guard's motivation "the `dual_rx`/15-gates-dark
failure shape". That reads as a historical reference to a past incident, not a
claim about current `dual_rx` behaviour, so I left it rather than risk
introducing new prose I cannot establish.

Behaviour change outside the FTX-1, unpinned: a radio object whose capability set contains `dual_rx` but which carries no resolved profile is now accepted by `web/handlers/control.py: ControlHandler._ensure_receiver_supported` and `_ensure_capability` for the second receiver where the previous projection refused it. No shipped backend is profile-less (both the Icom and Yaesu radios carry a resolved profile), so nothing reaches that branch today.

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)


