### PR TITLE
feat: skip and un-gate fields the profile declares absent in the current mode or band

### DIFF
--- a/rigs/_schema.md
+++ b/rigs/_schema.md
@@ -241,10 +241,7 @@ field's value, in one of three shapes:
 An unknown key, no comparison, more than one comparison, a `field` that does
 not parse, a non-list `in`/`not_in`, or a non-numeric `min`/`max` is a load
 error naming the policy path and the clause
-(`rig_loader.py: _parse_available_when`). Nothing acts on the parsed clauses
-yet: they reach
-`state_acquisition_policy.py: AcquisitionPolicy.available_when` and stop
-there.
+(`rig_loader.py: _parse_available_when`).
 
 ```toml
 [state_acquisition.field_policies."receiver.main.operator_controls.manual_notch_freq"]

--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -9,10 +9,14 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, TypeVar
 
-from rigplane.core.acquisition_scheduler import AcquisitionScheduler
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionScheduler,
+    resolve_available_when,
+)
 from rigplane.core.observation_adapter import ProviderObservationAdapter
 from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
 from rigplane.core.state_pipeline_contracts import FieldPath, Observation
+from rigplane.core.state_store import StateStore
 from rigplane.core.tx_observation import (
     OBSERVED_PTT_PATH,
     TxStateReading,
@@ -775,7 +779,11 @@ class YaesuObservationAdapter:
         # The ``RA0`` attenuator read returns a bool; the int registry path
         # receives the coerced ``int(on_off)`` (0/1) — no scaling beyond the
         # bool→int match (cross-vendor calibration is MOR-453).
-        if self._has_runtime_capability("attenuator") and self._can_poll(_MAIN_ATT):
+        if (
+            self._has_runtime_capability("attenuator")
+            and self._can_poll(_MAIN_ATT)
+            and self._available(_MAIN_ATT)
+        ):
             ok, value = await self._safe_read(
                 "main.att", self.radio.read_attenuator(0), paths=(_MAIN_ATT,)
             )
@@ -901,8 +909,10 @@ class YaesuObservationAdapter:
                         _MAIN_MANUAL_NOTCH, value, native_id="read_manual_notch"
                     )
                 )
-        if self._has_runtime_capability("notch") and self._can_poll(
-            _MAIN_MANUAL_NOTCH_FREQ
+        if (
+            self._has_runtime_capability("notch")
+            and self._can_poll(_MAIN_MANUAL_NOTCH_FREQ)
+            and self._available(_MAIN_MANUAL_NOTCH_FREQ)
         ):
             ok, value = await self._safe_read(
                 "main.manual_notch_freq",
@@ -1378,6 +1388,20 @@ class YaesuObservationAdapter:
     def _can_poll(self, path: FieldPath) -> bool:
         capability = self.profile.capability_for(path)
         return bool(capability.can_poll)
+
+    def _available(self, path: FieldPath) -> bool:
+        """Return False while the profile declares this field absent.
+
+        The ``available_when`` clauses are resolved against a
+        :class:`StateStore` attached to the radio as ``_state_store``; with
+        none attached the read proceeds unchanged.
+        """
+
+        store = getattr(self.radio, "_state_store", None)
+        if not isinstance(store, StateStore):
+            return True
+        availability = resolve_available_when(self.profile, store.snapshot())
+        return availability.get(path, True) is True
 
     def _has_runtime_capability(self, capability: str) -> bool:
         raw: object = getattr(self.radio, "capabilities", set())

--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -1390,7 +1390,7 @@ class YaesuObservationAdapter:
         return bool(capability.can_poll)
 
     def _available(self, path: FieldPath) -> bool:
-        """Return False while the profile declares this field absent.
+        """Return False while a declared clause is contradicted or unobserved.
 
         The ``available_when`` clauses are resolved against a
         :class:`StateStore` attached to the radio as ``_state_store``; with

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Awaitable, Callable, Iterable, Sequence
+from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from enum import StrEnum
+from types import MappingProxyType
 from typing import Any, Literal, Protocol
 
 from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
+    AvailabilityClause,
+    AvailabilityOperator,
     ExternalCatPauseBehavior,
     FieldAvailability,
     FieldCapability,
@@ -32,6 +35,7 @@ from rigplane.core.state_store import (
     FreshnessState,
     ReconciliationRequest,
     SnapshotDelta,
+    StateSnapshot,
     StateStore,
 )
 
@@ -50,15 +54,22 @@ __all__ = [
     "MeterObservationCoalescer",
     "RadioStateModelService",
     "StateFreshnessService",
+    "availability_clause_holds",
     "civ_acquisition_executor_for_provider",
     "derive_tx_active",
     "provider_uses_civ_acquisition",
+    "resolve_available_when",
 ]
 
 
 logger = logging.getLogger(__name__)
 
 AcquisitionMethod = Literal["poll", "command_response", "wait_for_unsolicited"]
+
+#: Default for :meth:`AcquisitionScheduler.unobserved_startup_paths`'s
+#: ``availability`` keyword: no field's declared conditions were resolved,
+#: so every path keeps the membership it had before ``available_when``.
+_NO_RESOLVED_AVAILABILITY: Mapping[FieldPath, bool | None] = MappingProxyType({})
 
 
 @dataclass(frozen=True, slots=True)
@@ -901,17 +912,24 @@ class AcquisitionScheduler:
     def unobserved_startup_paths(
         self,
         observed_paths: Iterable[FieldPath],
+        *,
+        availability: Mapping[FieldPath, bool | None] = _NO_RESOLVED_AVAILABILITY,
     ) -> tuple[FieldPath, ...]:
         """Return the declared paths the store has never seen, sorted by path.
 
         The domain is every pollable capability plus every explicit
-        ``field_policies`` key, minus the paths whose resolved policy carries
-        ``tx_only``. That flag is read from the profile
+        ``field_policies`` key, minus three exclusions: the paths whose
+        resolved policy carries ``tx_only``, the paths passed to
+        :meth:`abandon_startup_path`, and the paths ``availability`` maps to
+        ``False`` or ``None``. ``tx_only`` is read from the profile
         (:attr:`AcquisitionPolicy.tx_only`), never from a list kept here;
         :meth:`due_requests` gates those cadence groups on ``tx_active``, so
         a caller that waited on them would be waiting for a transmission.
-        Paths passed to :meth:`abandon_startup_path` are filtered out the
-        same way.
+
+        ``availability`` carries what :func:`resolve_available_when` made of
+        each conditional field's declared clauses. A path it omits is
+        unconditional and keeps its membership; ``None`` (no clause source
+        observed yet) excludes the same way ``False`` does.
 
         Unlike :meth:`has_unobserved_policy_fields`, this does not exclude
         cadence-owned paths: a path :meth:`due_requests` will poll is still
@@ -929,6 +947,7 @@ class AcquisitionScheduler:
                     if path not in observed
                     and path not in self._abandoned_startup_paths
                     and not profile.policy_for(path).tx_only
+                    and availability.get(path, True) is True
                 ),
                 key=str,
             )
@@ -1693,6 +1712,58 @@ def derive_tx_active(store: StateStore) -> bool:
     except KeyError:
         return False
     return ptt_field.freshness is FreshnessState.FRESH and bool(ptt_field.value)
+
+
+def availability_clause_holds(clause: AvailabilityClause, value: Any) -> bool:
+    """Return whether one ``available_when`` clause holds for ``value``.
+
+    ``min``/``max`` compare numerically and read False against a value that
+    is not a number.
+    """
+
+    operator = AvailabilityOperator(str(clause.operator))
+    if operator is AvailabilityOperator.IN:
+        return any(value == candidate for candidate in clause.value)
+    if operator is AvailabilityOperator.NOT_IN:
+        return all(value != candidate for candidate in clause.value)
+    if operator is AvailabilityOperator.EQUALS:
+        return bool(value == clause.value)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    if operator is AvailabilityOperator.MIN:
+        return float(value) >= float(clause.value)
+    return float(value) <= float(clause.value)
+
+
+def resolve_available_when(
+    profile: RadioAcquisitionProfile,
+    snapshot: StateSnapshot,
+) -> dict[FieldPath, bool | None]:
+    """Resolve each conditional field's declared availability in ``snapshot``.
+
+    Keyed by the ``field_policies`` paths carrying a non-empty
+    :attr:`AcquisitionPolicy.available_when`; unconditional fields are
+    absent. ``True`` when every clause holds, ``False`` when one is
+    contradicted, ``None`` while a clause's source field has not been
+    observed and none of the others is contradicted.
+    """
+
+    resolved: dict[FieldPath, bool | None] = {}
+    for path, policy in profile.field_policies.items():
+        if not policy.available_when:
+            continue
+        state: bool | None = True
+        for clause in policy.available_when:
+            try:
+                source = snapshot.field(clause.field)
+            except KeyError:
+                state = None
+                continue
+            if not availability_clause_holds(clause, source.value):
+                state = False
+                break
+        resolved[path] = state
+    return resolved
 
 
 class StateFreshnessService:

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -1057,6 +1057,7 @@ class WebServer:
             setattr(radio, "_state_freshness_service", freshness_service)
             setattr(radio, "_acquisition_scheduler", scheduler)
             setattr(radio, "_meter_observation_coalescer", coalescer)
+            setattr(radio, "_state_store", self.command_state_store)
         except Exception:
             logger.debug("state acquisition: failed to attach services", exc_info=True)
 

--- a/src/rigplane/web/web_startup.py
+++ b/src/rigplane/web/web_startup.py
@@ -16,7 +16,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
-from ..core.acquisition_scheduler import AcquisitionScheduler
+from ..core.acquisition_scheduler import AcquisitionScheduler, resolve_available_when
 from ..core.radio_protocol import ObservationPollable, StatePollable, StateStoreCapable
 from ..core.state_pipeline_contracts import FieldPath, Observation
 from ..radio_state import RadioState
@@ -186,7 +186,12 @@ async def _await_initial_state_acquisition(
     scheduler = _acquisition_scheduler(server)
     if scheduler is None:
         return
-    outstanding = scheduler.unobserved_startup_paths(_observed_paths(server, scheduler))
+    outstanding = scheduler.unobserved_startup_paths(
+        _observed_paths(server, scheduler),
+        availability=resolve_available_when(
+            scheduler._profile, server.command_state_store.snapshot()
+        ),
+    )
     if not outstanding:
         return
     logger.info(
@@ -214,7 +219,10 @@ async def _await_initial_state_acquisition(
                     primed_at[path] = queued_at
         await asyncio.sleep(gap)
         outstanding = scheduler.unobserved_startup_paths(
-            _observed_paths(server, scheduler)
+            _observed_paths(server, scheduler),
+            availability=resolve_available_when(
+                scheduler._profile, server.command_state_store.snapshot()
+            ),
         )
         now = time.monotonic()
         if len(outstanding) < fewest:

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -23,10 +23,12 @@ from rigplane.core.acquisition_scheduler import (
     RadioStateModelService,
     StateFreshnessService,
     derive_tx_active,
+    resolve_available_when,
 )
 from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
     AdaptiveDecayPolicy,
+    AvailabilityClause,
     ExternalCatPauseBehavior,
     FieldAvailability,
     FieldCapability,
@@ -45,6 +47,7 @@ from rigplane.core.state_store import (
     FreshnessClock,
     FreshnessState,
     SnapshotDelta,
+    StateSnapshot,
     StateStore,
 )
 from rigplane.commands.command_map import CommandMap
@@ -3836,3 +3839,156 @@ def test_abandon_startup_path_warns_once_naming_the_path_and_reason(
     assert "malformed CAT response" in warnings[0].getMessage()
     # Idempotent: the repeat leaves the filtered set as the first call left it.
     assert scheduler.unobserved_startup_paths(()) == (_MAIN_S_METER,)
+
+
+# ---------------------------------------------------------------------------
+# available_when: the declared conditions under which a field exists at all
+# ---------------------------------------------------------------------------
+
+_AVAIL_TARGET = FieldPath.receiver("main", "operator_controls", "manual_notch_freq")
+_AVAIL_MODE = FieldPath.active("main", "freq_mode", "mode")
+
+
+def _availability_profile(*clauses: AvailabilityClause) -> RadioAcquisitionProfile:
+    return _profile(
+        (_AVAIL_MODE, _AVAIL_TARGET),
+        field_policies={_AVAIL_TARGET: AcquisitionPolicy(available_when=clauses)},
+    )
+
+
+def _snapshot_of(values: dict[FieldPath, Any]) -> StateSnapshot:
+    store = StateStore()
+    for path, value in values.items():
+        store.apply(_observation(path, value, at=1.0))
+    return store.snapshot()
+
+
+@pytest.mark.parametrize(
+    ("operator", "operand", "holds", "contradicts"),
+    [
+        ("in", ["USB", "LSB"], "USB", "FM"),
+        ("not_in", ["FM", "FM-N"], "USB", "FM"),
+        ("equals", "USB", "USB", "FM"),
+        ("max", 60_000_000, 14_074_000, 461_000_000),
+        ("min", 60_000_000, 461_000_000, 14_074_000),
+    ],
+)
+def test_resolve_available_when_separates_true_false_and_unobserved(
+    operator: str,
+    operand: Any,
+    holds: Any,
+    contradicts: Any,
+) -> None:
+    clause = AvailabilityClause(field=_AVAIL_MODE, operator=operator, value=operand)
+    profile = _availability_profile(clause)
+
+    assert resolve_available_when(profile, StateSnapshot.empty()) == {
+        _AVAIL_TARGET: None
+    }
+    assert resolve_available_when(profile, _snapshot_of({_AVAIL_MODE: holds})) == {
+        _AVAIL_TARGET: True
+    }
+    assert resolve_available_when(
+        profile, _snapshot_of({_AVAIL_MODE: contradicts})
+    ) == {_AVAIL_TARGET: False}
+
+
+def test_bound_clauses_hold_at_the_bound() -> None:
+    """``min``/``max`` are "at or above"/"at or below", per ``rigs/_schema.md``."""
+
+    at_most = _availability_profile(
+        AvailabilityClause(field=_AVAIL_MODE, operator="max", value=60_000_000)
+    )
+    at_least = _availability_profile(
+        AvailabilityClause(field=_AVAIL_MODE, operator="min", value=60_000_000)
+    )
+    snapshot = _snapshot_of({_AVAIL_MODE: 60_000_000})
+
+    assert resolve_available_when(at_most, snapshot) == {_AVAIL_TARGET: True}
+    assert resolve_available_when(at_least, snapshot) == {_AVAIL_TARGET: True}
+
+
+def test_a_bound_clause_against_a_non_numeric_value_reads_as_contradicted() -> None:
+    profile = _availability_profile(
+        AvailabilityClause(field=_AVAIL_MODE, operator="max", value=60_000_000)
+    )
+
+    assert resolve_available_when(profile, _snapshot_of({_AVAIL_MODE: "USB"})) == {
+        _AVAIL_TARGET: False
+    }
+
+
+def test_resolve_available_when_ands_every_clause() -> None:
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    profile = _profile(
+        (_AVAIL_MODE, freq, _AVAIL_TARGET),
+        field_policies={
+            _AVAIL_TARGET: AcquisitionPolicy(
+                available_when=(
+                    AvailabilityClause(
+                        field=_AVAIL_MODE, operator="not_in", value=["FM"]
+                    ),
+                    AvailabilityClause(field=freq, operator="max", value=60_000_000),
+                )
+            )
+        },
+    )
+
+    both = _snapshot_of({_AVAIL_MODE: "USB", freq: 14_074_000})
+    one_contradicted = _snapshot_of({_AVAIL_MODE: "USB", freq: 461_000_000})
+    one_unobserved = _snapshot_of({_AVAIL_MODE: "USB"})
+
+    assert resolve_available_when(profile, both) == {_AVAIL_TARGET: True}
+    assert resolve_available_when(profile, one_contradicted) == {_AVAIL_TARGET: False}
+    assert resolve_available_when(profile, one_unobserved) == {_AVAIL_TARGET: None}
+
+
+def test_a_field_without_clauses_is_absent_from_the_resolution() -> None:
+    profile = _profile(
+        (_AVAIL_MODE, _AVAIL_TARGET),
+        field_policies={_AVAIL_TARGET: AcquisitionPolicy()},
+    )
+
+    assert resolve_available_when(profile, _snapshot_of({_AVAIL_MODE: "USB"})) == {}
+
+
+def _fm_absent_scheduler() -> AcquisitionScheduler:
+    return AcquisitionScheduler(
+        profile=_availability_profile(
+            AvailabilityClause(field=_AVAIL_MODE, operator="not_in", value=["FM"])
+        )
+    )
+
+
+def test_startup_domain_drops_a_field_its_condition_contradicts() -> None:
+    scheduler = _fm_absent_scheduler()
+    availability = resolve_available_when(
+        scheduler._profile, _snapshot_of({_AVAIL_MODE: "FM"})
+    )
+
+    assert scheduler.unobserved_startup_paths((_AVAIL_MODE,)) == (_AVAIL_TARGET,)
+    assert (
+        scheduler.unobserved_startup_paths((_AVAIL_MODE,), availability=availability)
+        == ()
+    )
+
+
+def test_startup_domain_drops_a_field_whose_condition_is_unobserved() -> None:
+    scheduler = _fm_absent_scheduler()
+    availability = resolve_available_when(scheduler._profile, StateSnapshot.empty())
+
+    assert availability == {_AVAIL_TARGET: None}
+    assert scheduler.unobserved_startup_paths((), availability=availability) == (
+        _AVAIL_MODE,
+    )
+
+
+def test_startup_domain_keeps_a_field_whose_condition_holds() -> None:
+    scheduler = _fm_absent_scheduler()
+    availability = resolve_available_when(
+        scheduler._profile, _snapshot_of({_AVAIL_MODE: "USB"})
+    )
+
+    assert scheduler.unobserved_startup_paths(
+        (_AVAIL_MODE,), availability=availability
+    ) == (_AVAIL_TARGET,)

--- a/tests/test_startup_state_gate.py
+++ b/tests/test_startup_state_gate.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable, Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from types import SimpleNamespace
+from types import MappingProxyType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -28,6 +28,7 @@ from rigplane.core.acquisition_scheduler import AcquisitionRequest, AcquisitionS
 from rigplane.core.civ import CivFrame
 from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
+    AvailabilityClause,
     FieldCapability,
     RadioAcquisitionProfile,
 )
@@ -412,10 +413,17 @@ class _RecordingScheduler:
         self.on_prime: Callable[[], None] | None = None
 
     def unobserved_startup_paths(
-        self, observed_paths: Iterable[FieldPath]
+        self,
+        observed_paths: Iterable[FieldPath],
+        *,
+        availability: Mapping[FieldPath, bool | None] = MappingProxyType({}),
     ) -> tuple[FieldPath, ...]:
         observed = frozenset(observed_paths)
-        return tuple(path for path in self._required if path not in observed)
+        return tuple(
+            path
+            for path in self._required
+            if path not in observed and availability.get(path, True) is True
+        )
 
     def prime_unobserved(
         self,
@@ -764,3 +772,53 @@ async def test_gate_completes_when_the_backend_abandons_a_declared_path(
         if record.levelno == logging.WARNING and str(SUB_S_METER) in record.getMessage()
     ]
     assert len(abandoned) == 1
+
+
+# ---------------------------------------------------------------------------
+# available_when: a field the profile declares absent in the current mode
+# ---------------------------------------------------------------------------
+
+
+NOTCH_FREQ = FieldPath.receiver("main", "operator_controls", "manual_notch_freq")
+
+
+def _conditional_profile() -> RadioAcquisitionProfile:
+    """``FREQ``/``MODE`` plus one field declared absent while the mode is FM."""
+
+    return RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=(
+            FieldCapability(path=FREQ, polling=True),
+            FieldCapability(path=MODE, polling=True),
+            FieldCapability(path=NOTCH_FREQ, polling=True),
+        ),
+        field_policies={
+            NOTCH_FREQ: AcquisitionPolicy(
+                cadence_seconds=1.0,
+                freshness_ttl_seconds=2.0,
+                available_when=(
+                    AvailabilityClause(field=MODE, operator="not_in", value=["FM"]),
+                ),
+            ),
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_field_declared_absent_in_the_current_mode_does_not_hold_the_gate() -> (
+    None
+):
+    scheduler = AcquisitionScheduler(profile=_conditional_profile())
+    server = WebServer(_CivRadio(scheduler), _gated_config())
+    server.command_state_store.apply(_observation(FREQ, 14_074_000, at=1.0))
+    server.command_state_store.apply(_observation(MODE, "FM", at=1.0))
+
+    # Not vacuous: the same predicate without the availability term still
+    # reports the conditional field outstanding.
+    assert scheduler.unobserved_startup_paths(_observed_paths(server, scheduler)) == (
+        NOTCH_FREQ,
+    )
+
+    await asyncio.wait_for(
+        _await_initial_state_acquisition(server, sweep=False), timeout=5.0
+    )

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -2865,9 +2865,32 @@ async def test_slow_poll_reads_the_attenuator_below_the_declared_bound() -> None
 
 
 @pytest.mark.asyncio
-async def test_slow_poll_reads_both_conditional_fields_without_a_state_store() -> None:
-    """Outside the web seat nothing attaches a store, and nothing is gated."""
+async def test_slow_poll_withholds_a_read_whose_condition_is_unobserved() -> None:
+    radio, adapter = _availability_adapter(StateStore())
 
+    observations = await adapter.poll_slow_controls()
+    paths = [str(item.path) for item in observations]
+
+    radio.read_attenuator.assert_not_awaited()
+    radio.read_manual_notch_freq.assert_not_awaited()
+    assert _ATT_PATH not in paths
+    assert _NOTCH_FREQ_PATH not in paths
+
+    radio, adapter = _availability_adapter(
+        _availability_store(mode="USB", freq_hz=14_074_000)
+    )
+
+    observations = await adapter.poll_slow_controls()
+    paths = [str(item.path) for item in observations]
+
+    radio.read_attenuator.assert_awaited()
+    radio.read_manual_notch_freq.assert_awaited()
+    assert _ATT_PATH in paths
+    assert _NOTCH_FREQ_PATH in paths
+
+
+@pytest.mark.asyncio
+async def test_a_non_state_store_attribute_leaves_both_reads_ungated() -> None:
     radio, adapter = _availability_adapter(None)
     assert not isinstance(getattr(radio, "_state_store", None), StateStore)
 

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, call
@@ -12,7 +13,12 @@ import pytest
 
 from rigplane.core.acquisition_scheduler import AcquisitionScheduler
 from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
-from rigplane.core.state_pipeline_contracts import FieldPath
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import StateStore
 from rigplane.core.tx_observation import OBSERVED_PTT_PATH, ObservedPtt, TxStateReading
 from rigplane.core.tx_target import KnownTxTarget, TxReceiver, UnknownTxTarget
 from rigplane.core.types import BreakInMode
@@ -2754,3 +2760,121 @@ async def test_tx_target_frequency_read_abandons_nothing() -> None:
     assert len(emitted) == 1
     assert isinstance(emitted[0], KnownTxTarget)
     assert emitted[0].frequency_hz is None
+
+
+# ---------------------------------------------------------------------------
+# available_when: the two fields ``rigs/ftx1.toml`` declares conditional
+# ---------------------------------------------------------------------------
+
+
+_ATT_PATH = "receiver.main.operator_controls.att"
+_NOTCH_FREQ_PATH = "receiver.main.operator_controls.manual_notch_freq"
+
+
+def _availability_store(*, mode: str, freq_hz: int) -> StateStore:
+    store = StateStore()
+    for path, value in (
+        (FieldPath.active("main", "freq_mode", "mode"), mode),
+        (FieldPath.active("main", "freq_mode", "freq_hz"), freq_hz),
+    ):
+        store.apply(
+            Observation(
+                path=path,
+                value=value,
+                source=SourceMetadata(source="poll_response", provider="yaesu_cat"),
+                timestamp_monotonic=_clock(),
+            )
+        )
+    return store
+
+
+def _availability_adapter(store: StateStore | None) -> tuple[MagicMock, object]:
+    radio = _make_radio()
+    if store is not None:
+        radio._state_store = store
+    adapter = YaesuObservationAdapter(
+        radio, profile=_profile_state_acquisition(), clock=_clock
+    )
+    return radio, adapter
+
+
+@pytest.mark.asyncio
+async def test_slow_poll_does_not_read_manual_notch_freq_in_fm(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    radio, adapter = _availability_adapter(
+        _availability_store(mode="FM", freq_hz=14_074_000)
+    )
+
+    with caplog.at_level(
+        logging.WARNING, logger="rigplane.backends.yaesu_cat.observations"
+    ):
+        observations = await adapter.poll_slow_controls()
+
+    radio.read_manual_notch_freq.assert_not_awaited()
+    assert _NOTCH_FREQ_PATH not in [str(item.path) for item in observations]
+    # A read never sent is not a failed read: it does not go through
+    # ``_log_field_skip``, so nothing warns about the field.
+    assert [
+        record
+        for record in caplog.records
+        if "manual_notch_freq" in record.getMessage()
+    ] == []
+    # The band-conditional sibling is unaffected in this snapshot.
+    radio.read_attenuator.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_slow_poll_reads_manual_notch_freq_in_usb() -> None:
+    radio, adapter = _availability_adapter(
+        _availability_store(mode="USB", freq_hz=14_074_000)
+    )
+
+    observations = await adapter.poll_slow_controls()
+
+    radio.read_manual_notch_freq.assert_awaited()
+    assert _NOTCH_FREQ_PATH in [str(item.path) for item in observations]
+
+
+@pytest.mark.asyncio
+async def test_slow_poll_does_not_read_the_attenuator_above_the_declared_bound() -> (
+    None
+):
+    radio, adapter = _availability_adapter(
+        _availability_store(mode="USB", freq_hz=461_000_000)
+    )
+
+    observations = await adapter.poll_slow_controls()
+
+    radio.read_attenuator.assert_not_awaited()
+    assert _ATT_PATH not in [str(item.path) for item in observations]
+    # The mode-conditional sibling is unaffected in this snapshot.
+    radio.read_manual_notch_freq.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_slow_poll_reads_the_attenuator_below_the_declared_bound() -> None:
+    radio, adapter = _availability_adapter(
+        _availability_store(mode="USB", freq_hz=14_074_000)
+    )
+
+    observations = await adapter.poll_slow_controls()
+
+    radio.read_attenuator.assert_awaited()
+    assert _ATT_PATH in [str(item.path) for item in observations]
+
+
+@pytest.mark.asyncio
+async def test_slow_poll_reads_both_conditional_fields_without_a_state_store() -> None:
+    """Outside the web seat nothing attaches a store, and nothing is gated."""
+
+    radio, adapter = _availability_adapter(None)
+    assert not isinstance(getattr(radio, "_state_store", None), StateStore)
+
+    observations = await adapter.poll_slow_controls()
+    paths = [str(item.path) for item in observations]
+
+    radio.read_attenuator.assert_awaited()
+    radio.read_manual_notch_freq.assert_awaited()
+    assert _ATT_PATH in paths
+    assert _NOTCH_FREQ_PATH in paths


### PR DESCRIPTION
## What

`AcquisitionPolicy.available_when` — the per-field clauses a profile uses to
declare that a field does not exist on the radio in the current mode, band or
state — was parsed and validated but read by nothing. Three consumers now
honour it.

- `core/acquisition_scheduler.py: availability_clause_holds` — pure per-clause
  evaluator for the five operators the loader produces (`in`, `not_in`, `min`,
  `max`, `equals`). `min`/`max` compare numerically and read False against a
  non-numeric value.
- `core/acquisition_scheduler.py: resolve_available_when` — resolves every
  conditional field against a `StateSnapshot`, next to `derive_tx_active` and
  following the same pattern (a module-level function reads the store; callers
  thread the result in). Three states: `True` when every clause holds, `False`
  when one is contradicted, `None` while a clause's source field has not been
  observed.
- `core/acquisition_scheduler.py: AcquisitionScheduler.unobserved_startup_paths`
  gains a keyword `availability`. `None` and `False` both drop the path from
  the outstanding set; `True` and an absent entry behave as before. `tx_only`
  is untouched.
- `web/web_startup.py: _await_initial_state_acquisition` resolves availability
  on every loop iteration alongside `_observed_paths` and threads it in, so a
  field the radio does not currently have never holds the startup gate.
- `web/server.py: WebServer._bootstrap_state_acquisition` attaches
  `_state_store` beside the existing `_acquisition_scheduler` attachment, the
  same `setattr` pattern, so the backend adapter can reach the live store.
  `rigctld/server.py: _attach_state_acquisition_services` already attaches an
  attribute of that name for the same purpose.
- `backends/yaesu_cat/observations.py: YaesuObservationAdapter._available`
  reads that attribute (isinstance-guarded) and resolves the path's clauses;
  `poll_slow_controls` adds it to the `att` and `manual_notch_freq` guards, so
  the read is **not sent** while the condition is false or unknown. No seat
  outside the web startup constructs a `YaesuCatPoller` —
  `grep -rn "create_state_poller\|create_observation_poller" src/` finds
  `web/web_startup.py` as the only non-docstring caller of either factory (the grep also returns the two factory definitions, the protocol declarations and a docstring example) — so `_available` is not
  reached elsewhere. A non-`StateStore` `_state_store` attribute leaves both
  reads ungated, pinned by
  `test_a_non_state_store_attribute_leaves_both_reads_ungated`.

No observation is emitted for a read that is never sent, and the
skip-warning / `abandon_startup_path` path is untouched — that path is for a
read that was sent and answered badly.

`unobserved_startup_paths` is the only scheduler consumer of the resolution:
the CI-V cadence path — `due_requests`, `prime_unobserved`,
`dispatchable_requests` — does not consult it, and can still queue a read for
a field whose clauses exclude it. That is inert today: `available_when` is
declared only in `rigs/ftx1.toml` (`grep -rln available_when rigs/`), and the
FTX-1 takes `web_startup.py`'s `ObservationPollable` branch, which leaves
`startup_sweep` False and builds no `AcquisitionDrain`.

## Why

Owner rulings R42 (a field that does not exist in the current mode/band/state
is neither polled, nor waited for at startup, nor shown) and R48 (no incorrect
commands). `rigs/ftx1.toml` declares two such fields:
`receiver.main.operator_controls.manual_notch_freq` is absent in the FM family,
and `receiver.main.operator_controls.att` is absent above 60 MHz.

## Open gap (deferred)

This PR delivers "never send the read" and "do not wait for it at startup".
It does **not** discard a value already in the store: a field observed while
its condition held keeps that last value under the staleness-tolerance hold
rule (`frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts: seen`
treats an observed-but-stale field as available), so after a mode or band
change the previous reading can still be shown. Closing that needs a
`StateStore.discard` call site driven by an availability transition, built on
`resolve_available_when` — the follow-up PR.

## Census

`git diff --numstat origin/main...HEAD`:

```
1	4	rigs/_schema.md
28	4	src/rigplane/backends/yaesu_cat/observations.py
76	5	src/rigplane/core/acquisition_scheduler.py
1	0	src/rigplane/web/server.py
11	3	src/rigplane/web/web_startup.py
156	0	tests/test_acquisition_scheduler.py
62	4	tests/test_startup_state_gate.py
148	1	tests/test_yaesu_cat_observation_adapter.py
```

**8 files, 483+/21- = 504 changed lines.** Over the 6-file soft threshold,
inside the 10-file / 1000-line hard ceiling. Why this is one unit of work: the
three consumers cannot land separately — a scheduler keyword nothing passes is
dead, and a `_available` helper with no store attached is a no-op — so the
evaluator, the two call sites and the one `setattr` that feeds them are a
single change. The three test files are one per changed behaviour, and
`tests/test_startup_state_gate.py` also had to update its `_RecordingScheduler`
double for the new keyword. `rigs/_schema.md` is a one-sentence deletion: it
said nothing acts on the parsed clauses, which this PR makes false.

## Tests

`uv run pytest tests/test_acquisition_scheduler.py tests/test_startup_state_gate.py tests/test_yaesu_cat_observation_adapter.py tests/test_state_acquisition_policy.py tests/test_web_server.py -q`
— **517 passed, 2 skipped** (the 2 skips are pre-existing in
`tests/test_web_server.py`). No full-suite run was done locally; CI owns that.

New coverage:

- `resolve_available_when` — the three states, parametrised over all five
  operators; the inclusive `min`/`max` bound; a non-numeric value against a
  bound; clauses ANDed; a field with no clauses absent from the result.
- `unobserved_startup_paths` — a conditional path drops out of the outstanding
  set while its condition is contradicted or unobserved, and stays in while it
  holds. Each asserts the same call without the keyword still reports the path,
  so the keyword is what does the work.
- The startup gate end to end — with mode observed as FM,
  `_await_initial_state_acquisition` returns instead of blocking on the
  conditional field.
- The Yaesu adapter against the real `rigs/ftx1.toml` profile — FM ⇒
  `read_manual_notch_freq` never awaited, no observation, nothing warned; USB ⇒
  awaited and observed; 461 MHz ⇒ `read_attenuator` never awaited; 14 MHz ⇒
  awaited and observed; an empty store (neither condition field observed) ⇒
  neither awaited and neither observed, and both awaited once mode and freq
  are observed; a non-`StateStore` `_state_store` attribute ⇒ both awaited.

Pre-existing tests still green: the 48-row profile table and the five
`available_when` loader tests in `tests/test_state_acquisition_policy.py`, and
the `tx_only` / `tx_active` tests in `tests/test_acquisition_scheduler.py` and
`tests/test_startup_state_gate.py`.

## Mutations run

Each mutation was applied to the working tree, the three test files were run,
then the tree was restored; `git diff` was checked for residue before the final
run and the commit.

| Mutation | Result |
|---|---|
| `availability_clause_holds`: `not_in` inverted to `any(value == …)` | **9 failed** (measured at 6a2d6122; the new withheld-read test's USB half fails too) — including `test_slow_poll_does_not_read_manual_notch_freq_in_fm`, `test_slow_poll_reads_manual_notch_freq_in_usb`, `test_field_declared_absent_in_the_current_mode_does_not_hold_the_gate` |
| Scheduler gate: `availability.get(path, True) is True` → `is not False` (treat `None` as `True`) | **1 failed** — `test_startup_domain_drops_a_field_whose_condition_is_unobserved` |
| `_available`: `availability.get(path, True) is True` → `is not False` (an unknown condition no longer withholds the read) | **1 failed** — `test_slow_poll_withholds_a_read_whose_condition_is_unobserved` |
| `_available(_MAIN_ATT)` guard removed from `poll_slow_controls` | **2 failed** — `test_slow_poll_does_not_read_the_attenuator_above_the_declared_bound` and `test_slow_poll_withholds_a_read_whose_condition_is_unobserved` (measured at 6a2d6122) |
| Behaviour-preserving refactor (`in` rewritten as `not all(value != …)`; the gate's `is True` split into `is not None and is not False`) | **stayed green**, as it should |

## Gates

- `uv run pytest` on the five named files — 517 passed, 2 skipped
- `uv run ruff check src/ tests/` — All checks passed
- `uv run ruff format --check src/ tests/` — 742 files already formatted
- `uv run mypy --strict src/rigplane/web` — no issues in 27 source files
- `uv run lint-imports` — 5 contracts kept, 0 broken

Internal-identifier self-check — empty.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

