### PR TITLE
feat: discard a stored field once the profile declares it absent in the current mode or band

### DIFF
--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -1843,10 +1843,12 @@ class StateFreshnessService:
         """Advance freshness once and drive the profile's acquisition cadence.
 
         One tick releases due meter samples, re-primes never-observed
-        fields, ages the store, queues the reconciliations that ageing
-        produced, and calls :meth:`AcquisitionScheduler.due_requests` (when
-        a scheduler was wired) with the transmit fact
-        :func:`derive_tx_active` reads from the same store.
+        fields, discards the fields the profile declares absent in the
+        current state (:meth:`_discard_declared_absent`), ages the store,
+        queues the reconciliations that ageing produced, and calls
+        :meth:`AcquisitionScheduler.due_requests` (when a scheduler was
+        wired) with the transmit fact :func:`derive_tx_active` reads from
+        the same store.
 
         Invariant: ``now`` (explicit or defaulted) must come from the same
         monotonic domain as ``self._next_prime_monotonic`` — callers that
@@ -1859,6 +1861,7 @@ class StateFreshnessService:
         timestamp = time.monotonic() if now is None else now
         self.flush_due_meter_samples(now=timestamp)
         self._reprime_unobserved_if_due(now=timestamp)
+        self._discard_declared_absent()
         delta = self._store.mark_stale_due(now=now)
         for request in delta.reconciliation_requests:
             self._queue_reconciliation(request)
@@ -1871,6 +1874,34 @@ class StateFreshnessService:
         if (delta.freshness or delta.reconciliation_requests) and self._on_delta:
             self._on_delta(delta)
         return delta
+
+    def _discard_declared_absent(self) -> None:
+        """Remove stored fields the profile declares absent in this state.
+
+        :func:`resolve_available_when` reports ``False`` only where an
+        observed value contradicts a clause; ``None`` — a clause source
+        nobody has observed — is left alone, since nothing has established
+        the field is absent. Removal goes through
+        :meth:`StateStore.discard`, which invents no value, so the field is
+        published as unobserved and ``missing`` again (``tests/
+        test_web_runtime_helpers.py::
+        test_field_status_reports_missing_after_the_freshness_tick_discards``).
+        """
+
+        scheduler = self._scheduler
+        if scheduler is None:
+            return
+        snapshot = self._store.snapshot()
+        stored = {field.path for field in snapshot.fields}
+        absent = tuple(
+            path
+            for path, available in resolve_available_when(
+                scheduler._profile, snapshot
+            ).items()
+            if available is False and path in stored
+        )
+        if absent:
+            self._store.discard(absent)
 
     def flush_due_meter_samples(self, *, now: float | None = None) -> None:
         """Release meter samples whose coalescing window has elapsed.

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -3992,3 +3992,96 @@ def test_startup_domain_keeps_a_field_whose_condition_holds() -> None:
     assert scheduler.unobserved_startup_paths(
         (_AVAIL_MODE,), availability=availability
     ) == (_AVAIL_TARGET,)
+
+
+_AVAIL_FREQ = FieldPath.active("main", "freq_mode", "freq_hz")
+_AVAIL_ATT = FieldPath.receiver("main", "operator_controls", "att")
+
+
+def _ftx1_freshness_service(store: StateStore) -> StateFreshnessService:
+    acquisition = get_radio_profile("FTX-1").state_acquisition
+    assert acquisition is not None
+    return StateFreshnessService(
+        store=store,
+        scheduler=AcquisitionScheduler(profile=acquisition),
+    )
+
+
+def test_tick_discards_a_stored_field_once_its_mode_clause_is_contradicted() -> None:
+    """Observed under a holding clause, removed when the mode flips against it.
+
+    Ageing alone leaves the entry in place, so the last reading stays
+    deliverable; removing it is what ends delivery.
+    """
+
+    store = StateStore()
+    service = _ftx1_freshness_service(store)
+    store.apply(_observation(_AVAIL_MODE, "USB", at=1.0))
+    store.apply(_observation(_AVAIL_TARGET, 1500, at=1.0))
+
+    service.tick(now=1.0)
+    assert store.snapshot().field(_AVAIL_TARGET).value == 1500
+
+    store.apply(_observation(_AVAIL_MODE, "FM", at=2.0))
+    revision_before = store.snapshot().state_revision
+    service.tick(now=2.0)
+
+    after_flip = store.snapshot()
+    with pytest.raises(KeyError):
+        after_flip.field(_AVAIL_TARGET)
+    assert after_flip.state_revision > revision_before
+
+    store.apply(_observation(_AVAIL_MODE, "USB", at=3.0))
+    service.tick(now=3.0)
+    store.apply(_observation(_AVAIL_TARGET, 1600, at=3.0))
+    service.tick(now=3.0)
+
+    assert store.snapshot().field(_AVAIL_TARGET).value == 1600
+
+
+def test_tick_keeps_a_stored_field_whose_clause_source_is_unobserved() -> None:
+    """Unknown is not absent: nothing has established the rig lacks the field."""
+
+    store = StateStore()
+    service = _ftx1_freshness_service(store)
+    store.apply(_observation(_AVAIL_TARGET, 1500, at=1.0))
+
+    service.tick(now=1.0)
+
+    assert store.snapshot().field(_AVAIL_TARGET).value == 1500
+
+
+def test_tick_never_discards_a_field_the_profile_declares_unconditionally() -> None:
+    preamp = FieldPath.receiver("main", "operator_controls", "preamp")
+    store = StateStore()
+    service = _ftx1_freshness_service(store)
+    store.apply(_observation(_AVAIL_MODE, "FM", at=1.0))
+    store.apply(_observation(_AVAIL_FREQ, 461_550_000, at=1.0))
+    store.apply(_observation(preamp, 1, at=1.0))
+
+    service.tick(now=1.0)
+
+    assert store.snapshot().field(preamp).value == 1
+
+
+def test_tick_discards_the_attenuator_above_the_declared_band_bound() -> None:
+    store = StateStore()
+    service = _ftx1_freshness_service(store)
+    store.apply(_observation(_AVAIL_FREQ, 461_550_000, at=1.0))
+    store.apply(_observation(_AVAIL_ATT, 12, at=1.0))
+
+    service.tick(now=1.0)
+
+    with pytest.raises(KeyError):
+        store.snapshot().field(_AVAIL_ATT)
+
+
+def test_tick_keeps_the_attenuator_below_the_declared_band_bound() -> None:
+    store = StateStore()
+    service = _ftx1_freshness_service(store)
+    store.apply(_observation(_AVAIL_FREQ, 14_074_000, at=1.0))
+    store.apply(_observation(_AVAIL_ATT, 12, at=1.0))
+
+    service.tick(now=1.0)
+
+    assert store.snapshot().field(_AVAIL_ATT).value == 12

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -1081,3 +1081,18 @@ def test_conflicting_sources_at_equal_freshness_resolve_last_writer_wins() -> No
     assert second.observation_seq == 2
     assert field.value == 20
     assert field.source == civ_source
+
+
+def test_discarding_an_absent_path_emits_no_change_and_no_revision() -> None:
+    """The second discard of one path is a no-op, so repeat calls are safe."""
+
+    path = FieldPath.receiver("main", "operator_controls", "manual_notch_freq")
+    store = StateStore()
+    store.apply(_observation(path, 1500, at=1.0))
+
+    first = store.discard((path,))
+    second = store.discard((path,))
+
+    assert len(first.changes) == 1
+    assert second.changes == ()
+    assert second.revision == first.revision

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -18,6 +18,10 @@ from rigplane.web.runtime_helpers import (
     runtime_capabilities,
 )
 from rigplane.web.server import WebServer
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionScheduler,
+    StateFreshnessService,
+)
 from rigplane.core.state_pipeline_contracts import (
     FieldPath,
     Observation,
@@ -30,6 +34,7 @@ from rigplane.core.state_store import (
     StateSnapshot,
     StateStore,
 )
+from rigplane.profiles import get_radio_profile
 from rigplane.core.tx_target import KnownTxTarget, TxTarget, UnknownTxTarget
 from rigplane.core.types import ScopeFixedEdge
 from rigplane.radio_state import RadioState
@@ -1366,3 +1371,34 @@ def test_observed_scope_settings_popover_leaves_survive_frontend_parent_veto() -
     for suffix in _SCOPE_SETTINGS_POPOVER_SUFFIXES:
         path = f"scopeControls.{suffix}"
         assert _frontend_availability(field_status, path) == "available", suffix
+
+
+def test_field_status_reports_missing_after_the_freshness_tick_discards() -> None:
+    """A discarded path is published as unobserved and ``missing``."""
+
+    acquisition = get_radio_profile("FTX-1").state_acquisition
+    assert acquisition is not None
+    notch = FieldPath.receiver("main", "operator_controls", "manual_notch_freq")
+    mode = FieldPath.active("main", "freq_mode", "mode")
+    store = StateStore()
+    service = StateFreshnessService(
+        store=store,
+        scheduler=AcquisitionScheduler(profile=acquisition),
+    )
+    store.apply(_observation(mode, "USB", at=1.0))
+    store.apply(_observation(notch, 1500, at=1.0))
+    service.tick(now=1.0)
+    before = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=1
+    )
+    assert before["fieldStatus"]["main.manualNotchFreq"]["observed"] is True
+
+    store.apply(_observation(mode, "FM", at=2.0))
+    service.tick(now=2.0)
+
+    after = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=1
+    )
+    status = after["fieldStatus"]["main.manualNotchFreq"]
+    assert status["observed"] is False
+    assert status["availability"] == "missing"


### PR DESCRIPTION
## What

`StateFreshnessService.tick` (`core/acquisition_scheduler.py`) now calls a new
`StateFreshnessService._discard_declared_absent`, which resolves
`resolve_available_when(profile, snapshot)` against the store on every tick and
passes each path whose availability reads `False`, and which currently has an
entry in the store, to `StateStore.discard`. The profile is reached through the
scheduler the service is already constructed with (`AcquisitionScheduler._profile`,
the same private attribute `web/web_startup.py: start_web_server` already reads —
no public accessor exists). Nothing else changes: the startup gate and the Yaesu
adapter (`backends/yaesu_cat/observations.py: YaesuObservationAdapter._available`)
are untouched, no store method and no wire field is added.

## Why

Skipping the read is not enough on its own. A field observed while its condition
held — the FTX-1 manual-notch frequency read in USB — keeps its entry after the
mode flips to FM, so the snapshot still publishes it as observed and consumers
still hold the pre-flip value. Removing the entry is what returns the path to the
`observed: false` / `availability: "missing"` shape, which is what the existing
consumer gates act on.

## `None` is not a discard

`resolve_available_when` reports three states. `False` means an observed value
contradicts a clause — the field is absent now. `None` means a clause's source
field has not been observed, so nothing has established anything about the field;
discarding there would delete a good reading on the strength of missing
information. Only `False` discards.

## Census

`git diff --numstat origin/main...HEAD`

```
35	4	src/rigplane/core/acquisition_scheduler.py
93	0	tests/test_acquisition_scheduler.py
15	0	tests/test_state_store.py
36	0	tests/test_web_runtime_helpers.py
```

4 files, 179+/4- = 183 changed lines. Under both guardrail thresholds.

## Tests

Test-first; all five service tests use the real `rigs/ftx1.toml` profile through
`get_radio_profile("FTX-1")`.

`tests/test_acquisition_scheduler.py`
- `test_tick_discards_a_stored_field_once_its_mode_clause_is_contradicted` — notch
  observed in USB survives a tick; after the mode flips to FM the next tick removes
  the entry and bumps `state_revision`; back in USB nothing is discarded and a new
  observation lands and stays.
- `test_tick_keeps_a_stored_field_whose_clause_source_is_unobserved` — mode never
  observed, notch observed: not discarded.
- `test_tick_never_discards_a_field_the_profile_declares_unconditionally` — preamp
  survives a tick in which both conditional fields' clauses are contradicted.
- `test_tick_discards_the_attenuator_above_the_declared_band_bound` — 461.55 MHz.
- `test_tick_keeps_the_attenuator_below_the_declared_band_bound` — 14.074 MHz.

`tests/test_state_store.py`
- `test_discarding_an_absent_path_emits_no_change_and_no_revision` — the second
  `discard` of one path yields no changes and no revision bump.

`tests/test_web_runtime_helpers.py`
- `test_field_status_reports_missing_after_the_freshness_tick_discards` — after the
  discard, `build_public_state_payload_from_snapshot(...)["fieldStatus"]
  ["main.manualNotchFreq"]` is `observed: false`, `availability: "missing"`.

Run (foreground, this branch's head): `tests/test_acquisition_scheduler.py`,
`test_state_store.py`, `test_web_runtime_helpers.py`,
`test_state_acquisition_policy.py`, `test_startup_state_gate.py`,
`test_yaesu_cat_observation_adapter.py`, `test_radio_poller_coverage.py`,
`test_rigctld_handler.py`, `test_rigctld_server.py`,
`test_field_status_frontend_fixture.py`, `test_web_server.py`,
`test_web_server_coverage.py` — **1487 passed, 2 skipped**. No full-suite run was
made locally; CI owns that.

Gates: `ruff check src/ tests/` clean; `ruff format --check src/ tests/` — 742 files
already formatted; `mypy --strict src/rigplane/web` — no issues in 27 source files;
`lint-imports` — 5 contracts kept, 0 broken.

## Mutations

Each run over `test_acquisition_scheduler.py`, `test_web_runtime_helpers.py`,
`test_state_store.py`, `test_state_acquisition_policy.py`,
`test_startup_state_gate.py`; the tree was restored between runs and
`git status` before the commit showed only the four intended files.

1. `available is False` → `available is not True` (discard on unknown too): **1
   failed** — `test_tick_keeps_a_stored_field_whose_clause_source_is_unobserved`.
2. Drop the `path in stored` filter: **279 passed — the mutation survives.**
   Reported rather than papered over: `StateStore.discard` is itself a no-op on an
   absent path (that is exactly what the new store test pins), so the service-level
   filter cannot change any observable outcome. It is a guard, not the mechanism.
3. Remove the `self._discard_declared_absent()` call from `tick`: **3 failed** —
   both discard tests plus the web-side witness.
4. Behaviour-preserving refactor (comprehension rewritten as an explicit loop over
   the stored paths with `availability.get(path)`): **279 passed**, as intended.

## Seen, not changed

`AcquisitionScheduler.prime_unobserved` skips any path that is both pollable and
carries a `cadence_seconds`; both FTX-1 conditional fields are `can_poll=True` with
`cadence_seconds=1.0` (checked by loading the profile), so a discarded field is not
re-queued as a newly-unobserved prime. Whether the cadence path
(`due_requests`/`_poll_cadence_groups`) would poll a discarded conditional field is
not exercised by any shipped profile — no Icom profile declares `available_when`,
and the Yaesu dispatch does not go through `due_requests` — so it is left alone.
`rigs/_schema.md` describes only how `available_when` is declared and needed no
change.

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
