### PR TITLE
feat: observe FTX-1 dual receive and declare the second receiver's fields conditional on it

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -240,11 +240,11 @@ freshness_ttl_seconds = 2.0
 cadence_seconds = 1.0
 freshness_ttl_seconds = 2.0
 
-# Dual receive (CAT `FR`; FTX-1_CAT_OM_ENG_2508-C p.17: P1 `00` = dual
+# Dual receive (CAT `FR`; FTX-1_CAT_OM_ENG_2508-C printed page 16: P1 `00` = dual
 # receive, `01` = single receive), published on the canonical
 # `global.tx_state.dual_watch` path rigs/ic7610.toml already declares. The
 # FTX-1's second receiver exists only while dual receive is on, so the seven
-# `receiver.sub.*` paths below declare themselves absent until this one is
+# `receiver.sub.*` paths declare themselves absent until this one is
 # observed true. Read in backends/yaesu_cat/observations.py:
 # YaesuObservationAdapter.poll_slow_controls ahead of the SUB reads it gates,
 # so it rides the same YaesuCatPoller._SLOW_INTERVAL as the rest of this tier

--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -134,6 +134,7 @@ polling_only = [
     "receiver.main.operator_controls.tsql_freq",
     "receiver.main.operator_controls.repeater_shift",
     "receiver.sub.operator_controls.repeater_shift",
+    "global.tx_state.dual_watch",
 ]
 stream_like_meters = [
     "receiver.main.meters.s_meter",
@@ -169,6 +170,9 @@ cadence_seconds = 0.2
 freshness_ttl_seconds = 0.8
 adaptive_decay = false
 meter_coalescing_window_seconds = 0.2
+available_when = [
+    { field = "global.tx_state.dual_watch", equals = true },
+]
 
 # MOR-2425/T80b: emitted only while transmitting -- YaesuCatPoller.
 # _emit_fast_observations (backends/yaesu_cat/poller.py) reaches
@@ -236,17 +240,60 @@ freshness_ttl_seconds = 2.0
 cadence_seconds = 1.0
 freshness_ttl_seconds = 2.0
 
+# Dual receive (CAT `FR`; FTX-1_CAT_OM_ENG_2508-C p.17: P1 `00` = dual
+# receive, `01` = single receive), published on the canonical
+# `global.tx_state.dual_watch` path rigs/ic7610.toml already declares. The
+# FTX-1's second receiver exists only while dual receive is on, so the seven
+# `receiver.sub.*` paths below declare themselves absent until this one is
+# observed true. Read in backends/yaesu_cat/observations.py:
+# YaesuObservationAdapter.poll_slow_controls ahead of the SUB reads it gates,
+# so it rides the same YaesuCatPoller._SLOW_INTERVAL as the rest of this tier
+# and carries that tier's cadence rather than the IC-7610's 1.5s.
+[state_acquisition.field_policies."global.tx_state.dual_watch"]
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
+
+# These two had no field_policies entry before the clause below needed
+# somewhere to live, so they inherited the 2.0s profile default. What actually
+# re-reads them is YaesuCatPoller._poll_medium at _MEDIUM_INTERVAL (0.200s,
+# backends/yaesu_cat/poller.py); 1.0s is the freq/mode ("live") class bound
+# tests/test_state_acquisition_policy.py::
+# test_field_policies_obey_their_cadence_class_not_their_rig enforces on any
+# path that carries its own entry.
+[state_acquisition.field_policies."receiver.sub.active.freq_mode.freq_hz"]
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
+available_when = [
+    { field = "global.tx_state.dual_watch", equals = true },
+]
+
+[state_acquisition.field_policies."receiver.sub.active.freq_mode.mode"]
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
+available_when = [
+    { field = "global.tx_state.dual_watch", equals = true },
+]
+
 [state_acquisition.field_policies."receiver.sub.operator_controls.af_level"]
 cadence_seconds = 1.0
 freshness_ttl_seconds = 2.0
+available_when = [
+    { field = "global.tx_state.dual_watch", equals = true },
+]
 
 [state_acquisition.field_policies."receiver.sub.operator_controls.rf_gain"]
 cadence_seconds = 1.0
 freshness_ttl_seconds = 2.0
+available_when = [
+    { field = "global.tx_state.dual_watch", equals = true },
+]
 
 [state_acquisition.field_policies."receiver.sub.operator_controls.squelch"]
 cadence_seconds = 1.0
 freshness_ttl_seconds = 2.0
+available_when = [
+    { field = "global.tx_state.dual_watch", equals = true },
+]
 
 # Bench probe 2026-09-08: `RA0;` was refused (`?;`) with MAIN on 461.550 MHz
 # FM. `RA` has a fixed P1 and no SUB form, so band and mode could not be
@@ -447,6 +494,9 @@ freshness_ttl_seconds = 2.0
 [state_acquisition.field_policies."receiver.sub.operator_controls.repeater_shift"]
 cadence_seconds = 1.0
 freshness_ttl_seconds = 2.0
+available_when = [
+    { field = "global.tx_state.dual_watch", equals = true },
+]
 
 [ctcss]
 table = "standard_50"

--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -111,7 +111,7 @@ _MAIN_MANUAL_NOTCH_FREQ = FieldPath.receiver(
 _SPLIT = FieldPath.global_("tx_state", "split")
 _ACTIVE = FieldPath.global_("slow_state", "active")
 _ACTIVE_INDEX_TO_STR = {0: "MAIN", 1: "SUB"}
-# Dual receive (CAT ``FR``; FTX-1_CAT_OM_ENG_2508-C p.17: P1 ``00`` = dual
+# Dual receive (CAT ``FR``; FTX-1_CAT_OM_ENG_2508-C printed page 16: P1 ``00`` = dual
 # receive, ``01`` = single receive) is emitted as the canonical
 # ``global.tx_state.dual_watch`` bool — the same path and value type the Icom
 # backend publishes from CI-V 0x07 0xC2 (``runtime/_civ_rx.py``).

--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -107,12 +107,15 @@ _MAIN_MANUAL_NOTCH_FREQ = FieldPath.receiver(
 # str consumed by the rigctld VFOA/VFOB mapping and the dual-RX runtime. The
 # ``VS`` index (0/1) is coerced to that str; the per-receiver
 # ``receiver.<rx>.vfo.active_slot`` ("A"/"B") field is a DIFFERENT concept
-# (which VFO slot within a receiver) and is NOT the target. FR/FT routing
-# (``get_rx_func``/``get_tx_func``) has no backend-neutral FieldPath and stays
-# vendor-namespaced compat-only per the promotion-criterion ADR — not observed.
+# (which VFO slot within a receiver) and is NOT the target.
 _SPLIT = FieldPath.global_("tx_state", "split")
 _ACTIVE = FieldPath.global_("slow_state", "active")
 _ACTIVE_INDEX_TO_STR = {0: "MAIN", 1: "SUB"}
+# Dual receive (CAT ``FR``; FTX-1_CAT_OM_ENG_2508-C p.17: P1 ``00`` = dual
+# receive, ``01`` = single receive) is emitted as the canonical
+# ``global.tx_state.dual_watch`` bool — the same path and value type the Icom
+# backend publishes from CI-V 0x07 0xC2 (``runtime/_civ_rx.py``).
+_DUAL_WATCH = FieldPath.global_("tx_state", "dual_watch")
 # Clarifier (RIT/XIT) controls (MOR-454). GLOBAL slow-changing operator/TX
 # controls (CAT ``CF000``/``CF001``): ``rit_on``/``rit_tx`` are global tx_state
 # bools (RX/TX clarifier flags), ``rit_freq`` is the global operator-control
@@ -218,6 +221,8 @@ class YaesuObservationRadio(Protocol):
     async def read_transmit_state(self) -> TxStateReading: ...
 
     async def get_tx_func(self) -> int: ...
+
+    async def get_rx_func(self) -> int: ...
 
     async def read_af_level(self, receiver: int = 0) -> int: ...
 
@@ -346,7 +351,11 @@ class YaesuObservationAdapter:
                 observations.append(
                     adapter.observation(_MAIN_MODE, result[0], native_id="read_mode")
                 )
-        if self._has_runtime_capability("dual_rx") and self._can_poll(_SUB_FREQ):
+        if (
+            self._has_runtime_capability("dual_rx")
+            and self._can_poll(_SUB_FREQ)
+            and self._available(_SUB_FREQ)
+        ):
             ok, value = await self._safe_read(
                 "sub.freq", self.radio.read_freq(1), paths=(_SUB_FREQ,)
             )
@@ -354,7 +363,11 @@ class YaesuObservationAdapter:
                 observations.append(
                     adapter.observation(_SUB_FREQ, value, native_id="read_freq")
                 )
-        if self._has_runtime_capability("dual_rx") and self._can_poll(_SUB_MODE):
+        if (
+            self._has_runtime_capability("dual_rx")
+            and self._can_poll(_SUB_MODE)
+            and self._available(_SUB_MODE)
+        ):
             ok, result = await self._safe_read(
                 "sub.mode", self.radio.read_mode(1), paths=(_SUB_MODE,)
             )
@@ -545,6 +558,7 @@ class YaesuObservationAdapter:
             self._has_runtime_capability("meters")
             and self._has_runtime_capability("dual_rx")
             and self._can_poll(_SUB_S_METER)
+            and self._available(_SUB_S_METER)
         ):
             ok, raw = await self._safe_read(
                 "sub.s_meter", self.radio.read_s_meter(1), paths=(_SUB_S_METER,)
@@ -688,6 +702,18 @@ class YaesuObservationAdapter:
     async def poll_slow_controls(self) -> tuple[Observation, ...]:
         adapter = self._adapter()
         observations: list[Observation] = []
+        # First read of the cycle: the SUB fields below name this path in their
+        # profile ``available_when`` clauses. Pinned by
+        # ``tests/test_yaesu_cat_observation_adapter.py::
+        # test_dual_receive_is_read_before_the_sub_controls_it_gates``.
+        if self._can_poll(_DUAL_WATCH):
+            ok, mode = await self._safe_read(
+                "main.rx_func", self.radio.get_rx_func(), paths=(_DUAL_WATCH,)
+            )
+            if ok and mode is not None:
+                observations.append(
+                    adapter.observation(_DUAL_WATCH, mode == 0, native_id="get_rx_func")
+                )
         if self._has_runtime_capability("af_level") and self._can_poll(_MAIN_AF):
             ok, value = await self._safe_read(
                 "main.af_level", self.radio.read_af_level(0), paths=(_MAIN_AF,)
@@ -728,6 +754,7 @@ class YaesuObservationAdapter:
             self._has_runtime_capability("dual_rx")
             and self._has_runtime_capability("af_level")
             and self._can_poll(_SUB_AF)
+            and self._available(_SUB_AF)
         ):
             ok, value = await self._safe_read(
                 "sub.af_level", self.radio.read_af_level(1), paths=(_SUB_AF,)
@@ -744,6 +771,7 @@ class YaesuObservationAdapter:
             self._has_runtime_capability("dual_rx")
             and self._has_runtime_capability("rf_gain")
             and self._can_poll(_SUB_RF)
+            and self._available(_SUB_RF)
         ):
             ok, value = await self._safe_read(
                 "sub.rf_gain", self.radio.read_rf_gain(1), paths=(_SUB_RF,)
@@ -760,6 +788,7 @@ class YaesuObservationAdapter:
             self._has_runtime_capability("dual_rx")
             and self._has_runtime_capability("squelch")
             and self._can_poll(_SUB_SQL)
+            and self._available(_SUB_SQL)
         ):
             ok, value = await self._safe_read(
                 "sub.squelch", self.radio.read_squelch(1), paths=(_SUB_SQL,)
@@ -1029,7 +1058,7 @@ class YaesuObservationAdapter:
             if self._has_runtime_capability("dual_rx"):
                 receiver_paths += ((1, "sub", _SUB_REPEATER_SHIFT),)
             for receiver, label, path in receiver_paths:
-                if self._can_poll(path):
+                if self._can_poll(path) and self._available(path):
                     ok, shift_code = await self._safe_read(
                         f"{label}.repeater_shift",
                         self.radio.read_repeater_shift(receiver),

--- a/tests/test_startup_state_gate.py
+++ b/tests/test_startup_state_gate.py
@@ -24,7 +24,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from rigplane.core.acquisition_scheduler import AcquisitionRequest, AcquisitionScheduler
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionRequest,
+    AcquisitionScheduler,
+    resolve_available_when,
+)
 from rigplane.core.civ import CivFrame
 from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
@@ -39,7 +43,7 @@ from rigplane.core.state_pipeline_contracts import (
 )
 from rigplane.core.state_store import StateStore
 from rigplane.core.types import bcd_encode
-from rigplane.profiles import resolve_radio_profile
+from rigplane.profiles import get_radio_profile, resolve_radio_profile
 from rigplane.radio_state import RadioState
 from rigplane.runtime._civ_rx import _profile_path_for_observation
 from rigplane.web import web_startup
@@ -822,3 +826,67 @@ async def test_field_declared_absent_in_the_current_mode_does_not_hold_the_gate(
     await asyncio.wait_for(
         _await_initial_state_acquisition(server, sweep=False), timeout=5.0
     )
+
+
+# ---------------------------------------------------------------------------
+# The FTX-1's second receiver: in the gate only while dual receive is on
+# ---------------------------------------------------------------------------
+
+
+DUAL_WATCH = FieldPath.global_("tx_state", "dual_watch")
+FTX1_SUB_PATHS = (
+    FieldPath.active("sub", "freq_mode", "freq_hz"),
+    FieldPath.active("sub", "freq_mode", "mode"),
+    FieldPath.receiver("sub", "meters", "s_meter"),
+    FieldPath.receiver("sub", "operator_controls", "af_level"),
+    FieldPath.receiver("sub", "operator_controls", "rf_gain"),
+    FieldPath.receiver("sub", "operator_controls", "squelch"),
+    FieldPath.receiver("sub", "operator_controls", "repeater_shift"),
+)
+
+
+def _ftx1_scheduler() -> AcquisitionScheduler:
+    acquisition = get_radio_profile("FTX-1").state_acquisition
+    assert acquisition is not None
+    return AcquisitionScheduler(profile=acquisition)
+
+
+def _ftx1_outstanding(
+    store: StateStore, observed: tuple[FieldPath, ...] = ()
+) -> tuple[FieldPath, ...]:
+    scheduler = _ftx1_scheduler()
+    return scheduler.unobserved_startup_paths(
+        observed,
+        availability=resolve_available_when(scheduler._profile, store.snapshot()),
+    )
+
+
+def _dual_receive_store(on: bool) -> StateStore:
+    store = StateStore()
+    store.apply(_observation(DUAL_WATCH, on, at=1.0))
+    return store
+
+
+def test_ftx1_sub_paths_stay_out_of_the_gate_until_dual_receive_is_observed() -> None:
+    """No SUB field holds the gate open before ``FR`` has answered."""
+
+    outstanding = _ftx1_outstanding(StateStore())
+
+    assert set(FTX1_SUB_PATHS).isdisjoint(outstanding)
+    # Not vacuous: the condition source is itself in the gate, so the gate
+    # still waits for the read that resolves the clause.
+    assert DUAL_WATCH in outstanding
+
+
+def test_ftx1_sub_paths_stay_out_of_the_gate_while_dual_receive_is_off() -> None:
+    outstanding = _ftx1_outstanding(_dual_receive_store(False), (DUAL_WATCH,))
+
+    assert set(FTX1_SUB_PATHS).isdisjoint(outstanding)
+    assert DUAL_WATCH not in outstanding
+
+
+def test_ftx1_sub_paths_enter_the_gate_once_dual_receive_is_observed_on() -> None:
+    outstanding = _ftx1_outstanding(_dual_receive_store(True), (DUAL_WATCH,))
+
+    assert set(FTX1_SUB_PATHS).issubset(outstanding)
+    assert DUAL_WATCH not in outstanding

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -136,8 +136,6 @@ _INHERITED_DEFAULT_OUT_OF_CLASS: dict[str, tuple[FieldPath, ...]] = {
         FieldPath.global_("tx_state", "ptt"),
         FieldPath.active("main", "freq_mode", "freq_hz"),
         FieldPath.active("main", "freq_mode", "mode"),
-        FieldPath.active("sub", "freq_mode", "freq_hz"),
-        FieldPath.active("sub", "freq_mode", "mode"),
     ),
 }
 
@@ -733,7 +731,7 @@ def test_field_policies_obey_their_cadence_class_not_their_rig() -> None:
     that instead inherits the profile's ``default_cadence_seconds`` is
     invisible to it -- see ``_INHERITED_DEFAULT_OUT_OF_CLASS`` and
     ``test_inherited_default_cadence_out_of_class_paths_are_exactly_named``
-    below for the ten such paths that are out of class today. A profile that
+    below for the eight such paths that are out of class today. A profile that
     declares no ``field_policies`` at all makes no per-field cadence claim --
     every path inherits one default -- so it is skipped; ``checked ==
     {...}`` below pins which profiles were walked, not that every classified
@@ -808,12 +806,12 @@ def _inherited_default_out_of_class() -> dict[str, tuple[FieldPath, ...]]:
 
 
 def test_inherited_default_cadence_out_of_class_paths_are_exactly_named() -> None:
-    """On the profiles the gate walks, the paths it cannot see are exactly the named ten.
+    """On the profiles the gate walks, the paths it cannot see are exactly the named eight.
 
     ``test_field_policies_obey_their_cadence_class_not_their_rig`` only
     checks a path with its own ``field_policies`` entry. This test covers
     the gap: it re-derives ``_INHERITED_DEFAULT_OUT_OF_CLASS`` from the
-    profiles that declare ``field_policies``, so fixing one of the ten (or
+    profiles that declare ``field_policies``, so fixing one of the eight (or
     introducing a new inherited-default violation on one of those profiles)
     changes the derived set and this assertion goes red, naming what
     changed. A profile with no ``field_policies`` is not walked, so a
@@ -1334,8 +1332,8 @@ def test_ic7300_activation_does_not_change_ftx1_acquisition_contract() -> None:
     assert acquisition is not None
 
     assert acquisition.provider == "yaesu_cat"
-    assert len(acquisition.capabilities) == 55
-    assert len(acquisition.field_policies) == 48
+    assert len(acquisition.capabilities) == 56
+    assert len(acquisition.field_policies) == 51
     assert acquisition.default_policy.cadence_seconds == 2.0
     assert acquisition.default_policy.freshness_ttl_seconds == 8.0
 
@@ -1625,7 +1623,7 @@ def test_ftx1_declares_when_manual_notch_and_attenuator_exist() -> None:
 
 
 def test_available_when_is_declared_only_where_a_probe_established_it() -> None:
-    """Loading every shipped profile turns up exactly the two declarations."""
+    """Loading every shipped profile turns up exactly these declarations."""
 
     declared: set[tuple[str, str]] = set()
     for model, rig in discover_rigs(RIGS_DIR).items():
@@ -1639,4 +1637,40 @@ def test_available_when_is_declared_only_where_a_probe_established_it() -> None:
     assert declared == {
         ("FTX-1", "receiver.main.operator_controls.att"),
         ("FTX-1", "receiver.main.operator_controls.manual_notch_freq"),
+        ("FTX-1", "receiver.sub.active.freq_mode.freq_hz"),
+        ("FTX-1", "receiver.sub.active.freq_mode.mode"),
+        ("FTX-1", "receiver.sub.meters.s_meter"),
+        ("FTX-1", "receiver.sub.operator_controls.af_level"),
+        ("FTX-1", "receiver.sub.operator_controls.rf_gain"),
+        ("FTX-1", "receiver.sub.operator_controls.repeater_shift"),
+        ("FTX-1", "receiver.sub.operator_controls.squelch"),
     }
+
+
+def test_ftx1_declares_every_sub_receiver_field_on_dual_receive() -> None:
+    """The second receiver exists only while dual receive is on."""
+
+    acquisition = get_radio_profile("FTX-1").state_acquisition
+    assert acquisition is not None
+
+    clause = AvailabilityClause(
+        field=FieldPath.global_("tx_state", "dual_watch"),
+        operator="equals",
+        value=True,
+    )
+    sub_paths = (
+        FieldPath.active("sub", "freq_mode", "freq_hz"),
+        FieldPath.active("sub", "freq_mode", "mode"),
+        FieldPath.receiver("sub", "meters", "s_meter"),
+        FieldPath.receiver("sub", "operator_controls", "af_level"),
+        FieldPath.receiver("sub", "operator_controls", "rf_gain"),
+        FieldPath.receiver("sub", "operator_controls", "squelch"),
+        FieldPath.receiver("sub", "operator_controls", "repeater_shift"),
+    )
+    for path in sub_paths:
+        assert acquisition.policy_for(path).available_when == (clause,), path
+
+    # The condition source is itself polled, or nothing would ever resolve it.
+    dual_watch = FieldPath.global_("tx_state", "dual_watch")
+    assert acquisition.capability_for(dual_watch).can_poll
+    assert acquisition.policy_for(dual_watch).available_when == ()

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -164,6 +164,8 @@ def _make_radio() -> MagicMock:
     radio.get_vfo_select = AsyncMock(return_value=1)
     radio.read_vfo_select = AsyncMock(return_value=1)
     radio.get_tx_func = AsyncMock(return_value=0)
+    # Dual receive: CAT ``FR`` P1, 0 = dual receive, 1 = single receive.
+    radio.get_rx_func = AsyncMock(return_value=0)
     # Clarifier RIT/XIT observation reads (MOR-454). ``read_clarifier`` returns
     # the (rx, tx) clarifier flags; ``read_clarifier_freq`` returns the signed
     # Hz offset on the device scale.
@@ -313,6 +315,9 @@ class _SideEffectingYaesuRadio:
 
     async def get_tx_func(self) -> int:
         # Unlike legacy getters, FT readback has no RadioState side effect.
+        return 0
+
+    async def get_rx_func(self) -> int:
         return 0
 
     async def read_s_meter(self, receiver: int = 0) -> int:
@@ -813,6 +818,7 @@ async def test_slow_poll_emits_declared_control_observations_only() -> None:
     # The nb/nr toggles are derived from the level read in the same cycle
     # (``level > 0``); a non-zero level → toggle ON, a single read each.
     assert [(str(item.path), item.value) for item in observations] == [
+        ("global.tx_state.dual_watch", True),
         (
             "receiver.main.operator_controls.af_level",
             pytest.approx(_normalized_255(128)),
@@ -918,6 +924,7 @@ async def test_slow_poll_skips_sub_controls_without_matching_runtime_capability(
     # here); AGC and narrow have no FTX-1 capability tag and mirror the legacy
     # poller's unconditional poll, so they still emit when policy is pollable.
     assert [(str(item.path), item.value) for item in observations] == [
+        ("global.tx_state.dual_watch", True),
         (
             "receiver.main.operator_controls.af_level",
             pytest.approx(_normalized_255(128)),
@@ -1337,6 +1344,7 @@ async def test_adapter_uses_read_only_yaesu_paths_when_getters_mutate_state() ->
         ("global.meters.power", 180),
         ("global.meters.swr", 120),
         ("global.meters.comp", 90),
+        ("global.tx_state.dual_watch", True),
         (
             "receiver.main.operator_controls.af_level",
             pytest.approx(_normalized_255(128)),
@@ -2148,6 +2156,7 @@ async def test_happy_path_slow_poll_unchanged_when_all_reads_succeed() -> None:
     observations = await adapter.poll_slow_controls()
 
     assert [(str(item.path), item.value) for item in observations] == [
+        ("global.tx_state.dual_watch", True),
         (
             "receiver.main.operator_controls.af_level",
             pytest.approx(_normalized_255(128)),
@@ -2697,6 +2706,13 @@ _ABANDON_ROWS: tuple[tuple[str, str, int | None, str, tuple[str, ...]], ...] = (
         "poll_tx_controls",
         ("global.operator_controls.break_in_delay",),
     ),
+    (
+        "main.rx_func",
+        "get_rx_func",
+        None,
+        "poll_slow_controls",
+        ("global.tx_state.dual_watch",),
+    ),
 )
 
 
@@ -2901,3 +2917,173 @@ async def test_a_non_state_store_attribute_leaves_both_reads_ungated() -> None:
     radio.read_manual_notch_freq.assert_awaited()
     assert _ATT_PATH in paths
     assert _NOTCH_FREQ_PATH in paths
+
+
+# ---------------------------------------------------------------------------
+# Dual receive: the CAT ``FR`` read and the SUB fields it gates
+# ---------------------------------------------------------------------------
+
+
+_DUAL_WATCH_PATH = "global.tx_state.dual_watch"
+
+# (id, poll method, radio read method, the declared SUB path it feeds)
+_SUB_GATED_ROWS: tuple[tuple[str, str, str, str], ...] = (
+    (
+        "sub.freq",
+        "poll_medium",
+        "read_freq",
+        "receiver.sub.active.freq_mode.freq_hz",
+    ),
+    (
+        "sub.mode",
+        "poll_medium",
+        "read_mode",
+        "receiver.sub.active.freq_mode.mode",
+    ),
+    (
+        "sub.s_meter",
+        "poll_rx_meters",
+        "read_s_meter",
+        "receiver.sub.meters.s_meter",
+    ),
+    (
+        "sub.af_level",
+        "poll_slow_controls",
+        "read_af_level",
+        "receiver.sub.operator_controls.af_level",
+    ),
+    (
+        "sub.rf_gain",
+        "poll_slow_controls",
+        "read_rf_gain",
+        "receiver.sub.operator_controls.rf_gain",
+    ),
+    (
+        "sub.squelch",
+        "poll_slow_controls",
+        "read_squelch",
+        "receiver.sub.operator_controls.squelch",
+    ),
+    (
+        "sub.repeater_shift",
+        "poll_slow_controls",
+        "read_repeater_shift",
+        "receiver.sub.operator_controls.repeater_shift",
+    ),
+)
+
+
+def _dual_watch_store(*, on: bool) -> StateStore:
+    """``_availability_store`` plus an observed dual-receive state."""
+
+    store = _availability_store(mode="USB", freq_hz=14_074_000)
+    store.apply(
+        Observation(
+            path=FieldPath.global_("tx_state", "dual_watch"),
+            value=on,
+            source=SourceMetadata(source="poll_response", provider="yaesu_cat"),
+            timestamp_monotonic=_clock(),
+        )
+    )
+    return store
+
+
+def _dual_watch_adapter(*, on: bool) -> tuple[MagicMock, YaesuObservationAdapter]:
+    radio = _gate_radio()
+    radio._state_store = _dual_watch_store(on=on)
+    adapter = YaesuObservationAdapter(
+        radio, profile=_profile_state_acquisition(), clock=_clock
+    )
+    return radio, adapter
+
+
+def _sub_receiver_awaited(radio: MagicMock, method: str) -> bool:
+    return any(call.args[:1] == (1,) for call in getattr(radio, method).await_args_list)
+
+
+@pytest.mark.asyncio
+async def test_dual_receive_on_is_observed_as_dual_watch_true() -> None:
+    """``FR00`` = dual receive, so the canonical bool reads True."""
+
+    radio, adapter = _dual_watch_adapter(on=True)
+    radio.get_rx_func = AsyncMock(return_value=0)
+
+    observations = await adapter.poll_slow_controls()
+
+    assert [
+        item.value for item in observations if str(item.path) == _DUAL_WATCH_PATH
+    ] == [True]
+
+
+@pytest.mark.asyncio
+async def test_single_receive_is_observed_as_dual_watch_false() -> None:
+    """``FR01`` = single receive, so the canonical bool reads False."""
+
+    radio, adapter = _dual_watch_adapter(on=True)
+    radio.get_rx_func = AsyncMock(return_value=1)
+
+    observations = await adapter.poll_slow_controls()
+
+    assert [
+        item.value for item in observations if str(item.path) == _DUAL_WATCH_PATH
+    ] == [False]
+
+
+@pytest.mark.asyncio
+async def test_dual_receive_is_read_before_the_sub_controls_it_gates() -> None:
+    """The gating read must precede the reads whose clauses name it."""
+
+    radio, adapter = _dual_watch_adapter(on=True)
+    order: list[str] = []
+
+    def _record(name: str) -> None:
+        original = getattr(radio, name)
+
+        async def _call(*args: object, **kwargs: object) -> object:
+            order.append(f"{name}{args[:1]}")
+            return await original(*args, **kwargs)
+
+        setattr(radio, name, _call)
+
+    for method in ("get_rx_func", "read_af_level", "read_rf_gain", "read_squelch"):
+        _record(method)
+
+    await adapter.poll_slow_controls()
+
+    assert order[0] == "get_rx_func()"
+    for method in ("read_af_level", "read_rf_gain", "read_squelch"):
+        assert order.index("get_rx_func()") < order.index(f"{method}(1,)")
+
+
+@pytest.mark.parametrize(
+    ("poll", "method", "path"),
+    [row[1:] for row in _SUB_GATED_ROWS],
+    ids=[row[0] for row in _SUB_GATED_ROWS],
+)
+@pytest.mark.asyncio
+async def test_sub_read_is_withheld_while_dual_receive_is_off(
+    poll: str, method: str, path: str
+) -> None:
+    radio, adapter = _dual_watch_adapter(on=False)
+
+    observations = await getattr(adapter, poll)()
+
+    assert not _sub_receiver_awaited(radio, method)
+    assert path not in [str(item.path) for item in observations]
+
+
+@pytest.mark.parametrize(
+    ("poll", "method", "path"),
+    [row[1:] for row in _SUB_GATED_ROWS],
+    ids=[row[0] for row in _SUB_GATED_ROWS],
+)
+@pytest.mark.asyncio
+async def test_sub_read_is_sent_while_dual_receive_is_on(
+    poll: str, method: str, path: str
+) -> None:
+    radio, adapter = _dual_watch_adapter(on=True)
+
+    observations = await getattr(adapter, poll)()
+
+    assert _sub_receiver_awaited(radio, method)
+    assert path in [str(item.path) for item in observations]

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -1078,6 +1078,10 @@ class _SideEffectingYaesuRadio:
         """Pure native FT0 fixture; unlike legacy getters it mutates no state."""
         return 0
 
+    async def get_rx_func(self) -> int:
+        """Pure native FR00 fixture: 0 = dual receive."""
+        return 0
+
     async def read_s_meter(self, receiver: int = 0) -> int:
         return 150 if receiver == 0 else 75
 
@@ -2712,6 +2716,7 @@ async def test_observation_poller_uses_read_only_paths_when_getters_mutate_state
         ("global.tx_state.ptt", False),
         ("receiver.main.meters.s_meter", 6),
         ("receiver.sub.meters.s_meter", -37),
+        ("global.tx_state.dual_watch", True),
         (
             "receiver.main.operator_controls.af_level",
             pytest.approx(_normalized_255(128)),

--- a/tests/test_yaesu_web_projection.py
+++ b/tests/test_yaesu_web_projection.py
@@ -216,6 +216,8 @@ def _make_radio() -> MagicMock:
     radio.read_freq = AsyncMock(side_effect=lambda receiver=0: 14_074_000)
     radio.read_mode = AsyncMock(side_effect=lambda receiver=0: ("USB", None))
     radio.get_tx_func = AsyncMock(return_value=0)
+    # Dual receive: CAT ``FR`` P1, 0 = dual receive, 1 = single receive.
+    radio.get_rx_func = AsyncMock(return_value=0)
     radio.read_ptt = AsyncMock(return_value=False)
     radio.read_transmit_state = AsyncMock(
         return_value=TxStateReading(False, "rx", "yaesu_poll_response", True)


### PR DESCRIPTION
Size exception: 7 code files, 406 changed lines — one file over the 6-file soft threshold. The 7th (`tests/test_yaesu_cat_poller.py`, +5/-0) is a fake-radio stub plus one row in an ordered-observation list, forced by the new read; without it that file is red. Hard ceiling (10 files / 1000 lines) not approached.

## What and why

The FTX-1's second receiver exists only while dual receive is on. Per the CAT manual 2508-C (printed page 16), `FR;` answers `FR00;` (dual receive) or `FR01;` (single receive) — but that read never reached the live observation path: `YaesuCatRadio.get_rx_func` (`backends/yaesu_cat/radio.py`) was called only from `YaesuCatPoller._poll_slow` (`backends/yaesu_cat/poller.py`), a body that returns early on any poller built with an observation callback, which is what the web server builds for this rig. So nothing on the wire distinguished dual from single receive, and all seven `receiver.sub.*` paths were polled and gate-waited unconditionally.

- `backends/yaesu_cat/observations.py: YaesuObservationAdapter.poll_slow_controls` now reads `FR` through `_safe_read("main.rx_func", …, paths=(_DUAL_WATCH,))`, guarded by `_can_poll` like its neighbours, and emits `global.tx_state.dual_watch`.
- The same file's seven SUB read sites gain an `_available(...)` term next to their existing `_can_poll` guard: `_SUB_FREQ`/`_SUB_MODE` in `poll_medium`, `_SUB_S_METER` in `poll_rx_meters`, `_SUB_AF`/`_SUB_RF`/`_SUB_SQL` and the `_SUB_REPEATER_SHIFT` loop in `poll_slow_controls`.
- `rigs/ftx1.toml` declares `global.tx_state.dual_watch` in `polling_only` with a slow-tier `field_policies` block, and gives each of the seven SUB paths `available_when = [{ field = "global.tx_state.dual_watch", equals = true }]`.

The dead legacy `_poll_slow` body is untouched. The frontend is untouched.

## Field-reuse decision and value-type agreement

Reusing the canonical `global.tx_state.dual_watch` rather than adding a Yaesu-namespaced field: Icom "dual watch" and Yaesu "dual receive" are the same concept (both receivers listen), so the field-path promotion ADR's two-backend ground is satisfied. `rigs/ic7610.toml` and `rigs/ic9700.toml` already declare it.

Value type agrees across backends: `runtime/_civ_rx.py` publishes `bool(val07)` for CI-V 0x07 0xC2; this change publishes `mode == 0`, also a `bool`. `core/state_pipeline_contracts.py` specs the path as `"bool"`. On the profile side `equals = true` in TOML parses to Python `True`, and `acquisition_scheduler.availability_clause_holds` compares `value == operand` — so the Yaesu-emitted `True` and the Icom-emitted `True` satisfy the clause identically.

## Read ordering

The `FR` read is the **first** read of `poll_slow_controls`, before the three SUB slow-control reads and the SUB repeater-shift loop in the same method. The SUB reads consult the store, and this cycle's observations are applied only after `poll_slow_controls` returns, so they see the previous cycle's dual-receive value regardless of this ordering; the FR-first order is defence in depth should the store ever become write-through mid-cycle. Pinned by `test_dual_receive_is_read_before_the_sub_controls_it_gates`, which records the call order of `get_rx_func`, `read_af_level`, `read_rf_gain` and `read_squelch` and asserts `get_rx_func` comes first; the repeater-shift loop's position is not pinned.

## Capability tag: not added

`dual_watch` was **not** added to `[capabilities].features`. The frontend keys that tag only on SET affordances — `lib/runtime/commands/panel-commands.ts: onDualWatchToggle` (dispatches `set_dual_watch`) and `onQuickDw` (dispatches `quick_dualwatch`) — and `rigs/ftx1.toml` declares no `set_dual_watch` CAT template, so `YaesuCatRadio.set_dual_watch` logs a warning and no-ops. Adding the tag would surface a control this radio cannot actuate. The observed value reaches the frontend as the existing `dualWatch` state field, which `lib/runtime/adapters/radio-view-model-adapter.ts` reads without consulting that tag.

## Cadence deviation from the dispatch

The dispatch asked for the IC-7610's cadence for this field (1.5s/3.0s). The declared value is **1.0s/2.0s** instead — the FTX-1 slow-control tier's own numbers. On this rig the field is re-read by `YaesuCatPoller._poll_slow` at `_SLOW_INTERVAL` (1.000s, `backends/yaesu_cat/poller.py`), which `rigs/ftx1.toml`'s slow-tier comment and `tests/test_yaesu_cat_poller.py::test_slow_group_interval_matches_the_profile_slow_control_cadence` both tie the declared number to. 1.5s would name an interval nothing on this rig uses.

The two new `receiver.sub.active.freq_mode.*` blocks carry `1.0`/`2.0` for a different reason: creating an entry for them made them visible to `tests/test_state_acquisition_policy.py::test_field_policies_obey_their_cadence_class_not_their_rig`, whose "live" class bound is 1.0s (they previously inherited the 2.0s profile default and were listed in `_INHERITED_DEFAULT_OUT_OF_CLASS`, from which they are now removed). What re-reads them is `_poll_medium` at `_MEDIUM_INTERVAL` (0.200s).

## Tests

Test-first. New in `tests/test_yaesu_cat_observation_adapter.py`:

- `test_dual_receive_on_is_observed_as_dual_watch_true` (`FR00` → `True`) and `test_single_receive_is_observed_as_dual_watch_false` (`FR01` → `False`).
- `test_dual_receive_is_read_before_the_sub_controls_it_gates`.
- `test_sub_read_is_withheld_while_dual_receive_is_off` / `..._is_sent_while_dual_receive_is_on`, parametrised over all seven SUB paths against an attached `StateStore`.
- The abandon table gains a 49th row (`main.rx_func` → `global.tx_state.dual_watch`); four ordered-observation lists gain the new row.

New in `tests/test_startup_state_gate.py`, over the real FTX-1 profile: the seven SUB paths are outside `unobserved_startup_paths` while `dual_watch` is unobserved and while it is observed `False`, and inside it once observed `True`.

`tests/test_state_acquisition_policy.py`: the shipped-profile `available_when` census gains the seven rows, plus `test_ftx1_declares_every_sub_receiver_field_on_dual_receive`; the FTX-1 contract counts move 55→56 capabilities and 48→51 field policies.

### Mutations run

| Mutation | Result |
|---|---|
| `mode == 0` → `mode == 1` in the `FR` emit | 7 red, incl. `test_dual_receive_on_is_observed_as_dual_watch_true`, `test_single_receive_is_observed_as_dual_watch_false`, and four ordered-list tests |
| `available_when` deleted from `receiver.sub.meters.s_meter` in the profile | 5 red: the adapter row `test_sub_read_is_withheld_while_dual_receive_is_off[sub.s_meter]`, both gate tests, and both policy-census tests |
| `FR` read moved after the SUB slow-control reads | 5 red, incl. `test_dual_receive_is_read_before_the_sub_controls_it_gates` |
| Control: rename the local to `rx_func`, hoist `dual_receive = rx_func == 0` | 173 passed, green as expected |

Tree restored after each; `git diff` at the head shows only the intended change.

### Gates

- `uv run pytest tests/test_yaesu_cat_observation_adapter.py tests/test_startup_state_gate.py tests/test_state_acquisition_policy.py tests/test_yaesu_cat_poller.py tests/test_yaesu_web_projection.py tests/test_ftx1_radio.py` — **774 passed, 0 failed**
- A wider targeted sweep of the FTX-1/web/rigctld files (`test_web_server.py`, `test_handlers_coverage.py`, `test_radio_poller_coverage.py`, `test_rigctld_dump_state_snapshot.py`, `test_acquisition_scheduler.py`, `test_rig_loader.py`, and others) — 1471 passed, 6 skipped. No full-suite run was made locally; CI owns that.
- `uv run ruff check src/ tests/` — All checks passed
- `uv run ruff format --check src/ tests/` — 742 files already formatted
- `uv run mypy --strict src/rigplane/web` — Success, no issues in 27 source files
- `uv run lint-imports` — 5 kept, 0 broken

## Census

`git diff --numstat origin/main...HEAD`:

```
50	0	rigs/ftx1.toml
35	6	src/rigplane/backends/yaesu_cat/observations.py
70	2	tests/test_startup_state_gate.py
42	8	tests/test_state_acquisition_policy.py
186	0	tests/test_yaesu_cat_observation_adapter.py
5	0	tests/test_yaesu_cat_poller.py
2	0	tests/test_yaesu_web_projection.py
```

7 files, 390+/16- = 406 changed lines at acdd64dc.

## Prose deleted

The comment above `_SPLIT`/`_ACTIVE` in `observations.py` claimed `FR`/`FT` routing "has no backend-neutral FieldPath and stays vendor-namespaced compat-only … not observed". This change falsifies that for `FR`; the sentence is deleted rather than rewritten. No other document touched by this change carries a claim this falsifies.

## Seen but not changed

- `docs/architecture/field-path-promotion-criterion.md` still says Yaesu `FR`/`FT` routing stays vendor-namespaced, in two places: the Decision section's worked example and the Consequences list. Now strained for `FR`: this PR promotes the derived dual-receive boolean onto the canonical dual-watch path while the `FR`/`FT` routing model itself stays vendor-namespaced. Out of this change's file set; reported for a follow-up.
- The "provisional pending a MAIN retune" clause in this file's attenuator comment: a later bench probe separated band from mode and could retire it. Out of this change's scope, left as-is.

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)


