### PR TITLE
feat: refuse to start when a declared Yaesu read is rejected or answered in another shape

### DIFF
--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -7,10 +7,11 @@ import logging
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol, TypeVar
+from typing import TYPE_CHECKING, NoReturn, Protocol, TypeVar
 
 from rigplane.core.acquisition_scheduler import (
     AcquisitionScheduler,
+    DeclaredCommandDefect,
     resolve_available_when,
 )
 from rigplane.core.observation_adapter import ProviderObservationAdapter
@@ -406,13 +407,7 @@ class YaesuObservationAdapter:
                 KeyError,
                 CatCommandRejected,
             ) as exc:
-                self._log_field_skip(
-                    "ptt",
-                    "Skipping field %s — PTT read failed: %s",
-                    exc,
-                    paths=(_PTT,),
-                )
-                reading = TxStateReading(None, failure="read-error")
+                self._raise_declared_defect("ptt", exc, (_PTT,))
             except Exception:
                 publish_ptt_error()
                 raise
@@ -1331,65 +1326,86 @@ class YaesuObservationAdapter:
         *,
         paths: tuple[FieldPath, ...] = (),
     ) -> tuple[bool, _T | None]:
-        """Await one field read, tolerating FIELD-level CAT failures (MOR-473).
+        """Await one field read, classifying a FIELD-level CAT failure.
 
-        Returns ``(ok, value)``. On a field-level malformed/unsupported answer
-        the read is skipped: the warning is logged (the field ``label`` plus the
-        exception, which already embeds the offending CAT template + frame) and
-        ``(False, None)`` is returned so the caller drops just that field (or the
-        whole derived group it feeds).
+        Returns ``(ok, value)``. A read naming declared ``paths`` that the
+        radio refuses (``?;``) or answers in another shape raises
+        :class:`DeclaredCommandDefect` — see :meth:`_raise_declared_defect`.
+        A read with no declared ``paths`` is skipped instead: the warning is
+        logged and ``(False, None)`` is returned so the caller drops just
+        that field.
 
-        CONNECTION/timeout errors are NOT caught — they RE-RAISE so the poller's
-        ``_run_poll_cycle`` reconnect/backoff still fires; a dead link must never
-        be masked as a skipped field. ``CatCommandRejected`` and
-        ``CatTimeoutError`` both subclass ``CatTransportError``, so the SPECIFIC
-        ``CatCommandRejected`` (a ``?;`` reject = unsupported command on this
-        radio) is caught while the base/timeout propagates.
-
-        MOR-561: a permanently unsupported field fails identically every poll
-        cycle, several times a second. The FIRST failure for a given field
-        warns; every repeat is demoted to DEBUG so the log is not flooded.
+        TRANSPORT errors are NOT caught — they RE-RAISE so the poller's
+        ``_run_poll_cycle`` reconnect/backoff still fires. ``CatTimeoutError``
+        and ``CatGarbledFrameError`` reach that path unchanged;
+        ``CatCommandRejected`` is caught out of the same base class because a
+        refusal is an answer, not link quality.
         """
         try:
             return True, await read
         except (CatParseError, CatFormatError, ValueError, KeyError) as exc:
             # ValueError covers _read_meter / int() malformed-frame failures;
             # CatParse/FormatError subclass ValueError but are listed for clarity.
+            if paths:
+                self._raise_declared_defect(label, exc, paths)
             self._log_field_skip(
                 label,
                 "Skipping field %s — malformed CAT response: %s",
                 exc,
-                paths=paths,
             )
             return False, None
         except CatCommandRejected as exc:
-            # ``?;`` reject = command unsupported on this radio -> skip the field.
+            if paths:
+                self._raise_declared_defect(label, exc, paths)
             self._log_field_skip(
                 label,
                 "Skipping field %s — command rejected (?;): %s",
                 exc,
-                paths=paths,
             )
             return False, None
+
+    def _raise_declared_defect(
+        self,
+        label: str,
+        exc: Exception,
+        paths: tuple[FieldPath, ...],
+    ) -> NoReturn:
+        """Record and raise the defect for a declared read that cannot answer.
+
+        The recording is what the startup gate reads: this raise itself only
+        reaches the poller task that drove the read.
+        """
+        command = ""
+        frame = ""
+        if isinstance(exc, CatParseError):
+            command, frame = exc.template, exc.response
+        elif isinstance(exc, CatFormatError):
+            command = exc.template
+        elif isinstance(exc, CatCommandRejected):
+            command, frame = exc.command, "?;"
+        defect = DeclaredCommandDefect(
+            label=label,
+            paths=paths,
+            command=command,
+            frame=frame,
+            detail=str(exc),
+        )
+        scheduler = getattr(self.radio, "_acquisition_scheduler", None)
+        if isinstance(scheduler, AcquisitionScheduler):
+            scheduler.record_startup_defect(defect)
+        raise defect from exc
 
     def _log_field_skip(
         self,
         label: str,
         message: str,
         exc: Exception,
-        *,
-        paths: tuple[FieldPath, ...] = (),
     ) -> None:
         """Warn once per field, then demote repeats to DEBUG (MOR-561).
 
         The warned-field set lives on the radio (persistent across poll cycles)
         rather than the adapter (rebuilt every cycle). A non-``set`` attribute —
         e.g. a ``MagicMock`` test double — falls back to always-warn.
-
-        ``paths`` names the declared fields the skipped read would have
-        produced; see ``AcquisitionScheduler.abandon_startup_path`` and
-        ``tests/test_yaesu_cat_observation_adapter.py::
-        test_skipped_read_abandons_every_declared_path_it_feeds``.
         """
         warned = getattr(self.radio, "_poll_warned_fields", None)
         if isinstance(warned, set):
@@ -1397,13 +1413,6 @@ class YaesuObservationAdapter:
                 logger.debug(message, label, exc)
                 return
             warned.add(label)
-        if paths:
-            scheduler = getattr(self.radio, "_acquisition_scheduler", None)
-            if isinstance(scheduler, AcquisitionScheduler):
-                for path in paths:
-                    scheduler.abandon_startup_path(
-                        path, reason=f"yaesu field read skipped: {label}"
-                    )
         logger.warning(message, label, exc)
 
     def _adapter(self) -> ProviderObservationAdapter:

--- a/src/rigplane/backends/yaesu_cat/transport.py
+++ b/src/rigplane/backends/yaesu_cat/transport.py
@@ -44,6 +44,7 @@ __all__ = [
     "CatTransportError",
     "CatTimeoutError",
     "CatCommandRejected",
+    "CatGarbledFrameError",
 ]
 
 logger = logging.getLogger(__name__)
@@ -74,7 +75,24 @@ class CatTimeoutError(CatTransportError):
 
 
 class CatCommandRejected(CatTransportError):
-    """Raised when radio returns ``?;`` (command not recognized)."""
+    """Raised when radio returns ``?;`` (command not recognized).
+
+    ``command`` is the CAT command the radio refused, verbatim, for callers
+    that report the refusal rather than only logging it.
+    """
+
+    def __init__(self, message: str, *, command: str = "") -> None:
+        super().__init__(message)
+        self.command = command
+
+
+class CatGarbledFrameError(CatTransportError):
+    """Raised for a ``;``-terminated line carrying a byte outside 0x20-0x7E.
+
+    Link noise, not an answer: corruption that leaves the prefix ``query()``
+    matches on intact would otherwise reach the parser, where it is
+    indistinguishable from a clean frame of the wrong shape.
+    """
 
 
 # ── Stats ─────────────────────────────────────────────────────────────
@@ -264,6 +282,12 @@ class YaesuCatTransport:
            External callers should prefer ``query()`` which handles serialization.
 
         Returns the line with trailing ``;`` stripped.
+
+        Raises:
+            CatGarbledFrameError: If any byte of the line falls outside
+                printable ASCII (0x20-0x7E).
+            CatTimeoutError: If no ``;`` arrives within *timeout*.
+            CatTransportError: On serial I/O failure.
         """
         self._check_connected()
         assert self._reader is not None  # for type checker
@@ -277,11 +301,6 @@ class YaesuCatTransport:
                 timeout=timeout,
             )
             line = line_bytes.decode("ascii").rstrip(";")
-
-            if self._debug_logging:
-                logger.debug("CAT RX: %r", line)
-
-            return line
         except asyncio.TimeoutError as exc:
             self._stats.timeouts += 1
             raise CatTimeoutError(
@@ -290,6 +309,15 @@ class YaesuCatTransport:
         except Exception as exc:
             self._stats.record_error(f"read failed: {exc}")
             raise CatTransportError(f"Read failed: {exc}") from exc
+
+        if any(byte < 0x20 or byte > 0x7E for byte in line_bytes):
+            self._stats.record_error(f"garbled frame: {line_bytes!r}")
+            raise CatGarbledFrameError(f"Garbled frame on the wire: {line_bytes!r}")
+
+        if self._debug_logging:
+            logger.debug("CAT RX: %r", line)
+
+        return line
 
     async def flush_rx(self) -> int:
         """Discard any bytes sitting in the receive buffer.
@@ -332,11 +360,19 @@ class YaesuCatTransport:
                 line = await self.readline(timeout=drain_timeout)
             except CatTimeoutError:
                 break  # Silence — buffer is clean
+            except CatGarbledFrameError:
+                # Noise among the echo/auto-info being discarded anyway; it is
+                # not this SET command's outcome. Pinned by
+                # ``test_drained_garbled_line_after_a_write_is_discarded``.
+                drained += 1
+                self._stats.stale_lines_skipped += 1
+                continue
             drained += 1
             if line == "?":
                 self._stats.record_error(f"rejected: {command}")
                 raise CatCommandRejected(
-                    f"Radio rejected command {command!r} (returned '?;')"
+                    f"Radio rejected command {command!r} (returned '?;')",
+                    command=command,
                 )
             self._stats.stale_lines_skipped += 1
             if self._debug_logging:
@@ -420,7 +456,8 @@ class YaesuCatTransport:
                 if response == "?":
                     self._stats.record_error(f"rejected: {command}")
                     raise CatCommandRejected(
-                        f"Radio rejected command {command!r} (returned '?;')"
+                        f"Radio rejected command {command!r} (returned '?;')",
+                        command=command,
                     )
 
                 # ── Echo suppression ──

--- a/src/rigplane/backends/yaesu_cat/transport.py
+++ b/src/rigplane/backends/yaesu_cat/transport.py
@@ -300,19 +300,22 @@ class YaesuCatTransport:
                 self._reader.readuntil(b";"),
                 timeout=timeout,
             )
+            # Classify before decoding: a byte >= 0x80 would otherwise raise
+            # UnicodeDecodeError and be caught below as CatTransportError.
+            if any(byte < 0x20 or byte > 0x7E for byte in line_bytes):
+                self._stats.record_error(f"garbled frame: {line_bytes!r}")
+                raise CatGarbledFrameError(f"Garbled frame on the wire: {line_bytes!r}")
             line = line_bytes.decode("ascii").rstrip(";")
         except asyncio.TimeoutError as exc:
             self._stats.timeouts += 1
             raise CatTimeoutError(
                 f"Read timeout ({timeout}s) waiting for ';' terminator"
             ) from exc
+        except CatGarbledFrameError:
+            raise
         except Exception as exc:
             self._stats.record_error(f"read failed: {exc}")
             raise CatTransportError(f"Read failed: {exc}") from exc
-
-        if any(byte < 0x20 or byte > 0x7E for byte in line_bytes):
-            self._stats.record_error(f"garbled frame: {line_bytes!r}")
-            raise CatGarbledFrameError(f"Garbled frame on the wire: {line_bytes!r}")
 
         if self._debug_logging:
             logger.debug("CAT RX: %r", line)

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -49,6 +49,7 @@ __all__ = [
     "AcquisitionRequest",
     "AcquisitionScheduler",
     "AcquisitionStatus",
+    "DeclaredCommandDefect",
     "EnsureFreshResult",
     "IcomCivAcquisitionExecutor",
     "MeterObservationCoalescer",
@@ -63,6 +64,41 @@ __all__ = [
 
 
 logger = logging.getLogger(__name__)
+
+
+class DeclaredCommandDefect(RuntimeError):
+    """A declared read the radio refused, or answered in another shape.
+
+    A product defect — profile, parser or firmware mismatch — as opposed to
+    link quality, which reaches a backend as a transport error and never
+    builds one of these.
+
+    ``str()`` is the detail clause the startup gate puts between ``aborted:``
+    and ``Refusing to start a half-working server.``; it names the declared
+    paths, the command or parse template, and the frame received verbatim.
+    """
+
+    def __init__(
+        self,
+        *,
+        label: str,
+        paths: tuple[FieldPath, ...],
+        command: str,
+        frame: str,
+        detail: str,
+    ) -> None:
+        self.label = label
+        self.paths = paths
+        self.command = command
+        self.frame = frame
+        self.detail = detail
+        parts = [f"declared read {label!r} ({', '.join(str(p) for p in paths)})"]
+        if command:
+            parts.append(f"command {command!r}")
+        if frame:
+            parts.append(f"frame {frame!r}")
+        super().__init__(f"{'; '.join(parts)}: {detail}")
+
 
 AcquisitionMethod = Literal["poll", "command_response", "wait_for_unsolicited"]
 
@@ -357,7 +393,6 @@ class AcquisitionScheduler:
     """Minimal priority/dedupe queue for backend-neutral acquisition reads."""
 
     __slots__ = (
-        "_abandoned_startup_paths",
         "_clock",
         "_cadence_by_key",
         "_claims_by_request_id",
@@ -372,6 +407,7 @@ class AcquisitionScheduler:
         "_prime_cursor",
         "_profile",
         "_requests_by_key",
+        "_startup_defect",
         "_tx_active",
     )
 
@@ -393,7 +429,7 @@ class AcquisitionScheduler:
         ] = {}
         self._failed_request_count = 0
         self._failure_count_by_reason: dict[str, int] = {}
-        self._abandoned_startup_paths: set[FieldPath] = set()
+        self._startup_defect: DeclaredCommandDefect | None = None
         self._next_id = 1
         # Round-robin starting offset into field_policies for
         # prime_unobserved (MOR-1501, A1 from #2415 review): see that
@@ -891,23 +927,25 @@ class AcquisitionScheduler:
             return True
         return False
 
-    def abandon_startup_path(self, path: FieldPath, *, reason: str) -> None:
-        """Drop one path from :meth:`unobserved_startup_paths` for good.
+    def record_startup_defect(self, defect: DeclaredCommandDefect) -> None:
+        """Keep the first declared-command defect a backend reports.
 
-        For a backend that has given up on a declared field. The first call
-        for a path logs it by name, with ``reason``, at WARNING; repeats are
-        silent. Pinned by ``tests/test_acquisition_scheduler.py::
-        test_abandon_startup_path_warns_once_naming_the_path_and_reason``.
+        The first is kept and logged at ERROR; later ones are dropped
+        silently, because the read that produced this one repeats every poll
+        cycle. Pinned by ``tests/test_acquisition_scheduler.py::
+        test_record_startup_defect_keeps_and_logs_the_first_only``.
         """
 
-        if path in self._abandoned_startup_paths:
+        if self._startup_defect is not None:
             return
-        self._abandoned_startup_paths.add(path)
-        logger.warning(
-            "acquisition: abandoning startup path %s (%s)",
-            path,
-            reason,
-        )
+        self._startup_defect = defect
+        logger.error("acquisition: declared read defect — %s", defect)
+
+    @property
+    def startup_defect(self) -> DeclaredCommandDefect | None:
+        """Return the first recorded defect, or ``None`` if there is none."""
+
+        return self._startup_defect
 
     def unobserved_startup_paths(
         self,
@@ -918,10 +956,9 @@ class AcquisitionScheduler:
         """Return the declared paths the store has never seen, sorted by path.
 
         The domain is every pollable capability plus every explicit
-        ``field_policies`` key, minus three exclusions: the paths whose
-        resolved policy carries ``tx_only``, the paths passed to
-        :meth:`abandon_startup_path`, and the paths ``availability`` maps to
-        ``False`` or ``None``. ``tx_only`` is read from the profile
+        ``field_policies`` key, minus two exclusions: the paths whose
+        resolved policy carries ``tx_only``, and the paths ``availability``
+        maps to ``False`` or ``None``. ``tx_only`` is read from the profile
         (:attr:`AcquisitionPolicy.tx_only`), never from a list kept here;
         :meth:`due_requests` gates those cadence groups on ``tx_active``, so
         a caller that waited on them would be waiting for a transmission.
@@ -945,7 +982,6 @@ class AcquisitionScheduler:
                     path
                     for path in domain
                     if path not in observed
-                    and path not in self._abandoned_startup_paths
                     and not profile.policy_for(path).tx_only
                     and availability.get(path, True) is True
                 ),

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -75,7 +75,8 @@ class DeclaredCommandDefect(RuntimeError):
 
     ``str()`` is the detail clause the startup gate puts between ``aborted:``
     and ``Refusing to start a half-working server.``; it names the declared
-    paths, the command or parse template, and the frame received verbatim.
+    paths and, for a refusal or a parse failure, the command or parse template
+    and the frame received verbatim.
     """
 
     def __init__(

--- a/src/rigplane/web/web_startup.py
+++ b/src/rigplane/web/web_startup.py
@@ -156,6 +156,22 @@ def _startup_gap_seconds(radio: object) -> float:
     return _STARTUP_GATE_POLL_SECONDS
 
 
+def _abort_on_startup_defect(scheduler: AcquisitionScheduler) -> None:
+    """Raise if a backend has recorded a declared-command defect.
+
+    The backend's own raise stays inside its poller task; the scheduler both
+    sides already hold is what carries the defect here. Bind happens strictly
+    after the gate, so raising here means no listener is created.
+    """
+
+    defect = scheduler.startup_defect
+    if defect is None:
+        return
+    raise RuntimeError(
+        f"web startup aborted: {defect}. Refusing to start a half-working server."
+    )
+
+
 async def _await_initial_state_acquisition(
     server: WebServer,
     *,
@@ -163,7 +179,9 @@ async def _await_initial_state_acquisition(
 ) -> None:
     """Block until ``AcquisitionScheduler.unobserved_startup_paths`` is empty.
 
-    The wait is indefinite by design: there is no serve-anyway timeout.
+    The wait is indefinite unless a backend records a
+    :class:`DeclaredCommandDefect` on the scheduler, which aborts it — see
+    :func:`_abort_on_startup_defect`. There is no serve-anyway timeout.
 
     ``sweep`` re-primes the scheduler while the gate is open. It is set only
     on the branch that builds a :class:`RadioPoller`, because that is the
@@ -186,6 +204,7 @@ async def _await_initial_state_acquisition(
     scheduler = _acquisition_scheduler(server)
     if scheduler is None:
         return
+    _abort_on_startup_defect(scheduler)
     outstanding = scheduler.unobserved_startup_paths(
         _observed_paths(server, scheduler),
         availability=resolve_available_when(
@@ -218,6 +237,7 @@ async def _await_initial_state_acquisition(
                 for path in request.paths:
                     primed_at[path] = queued_at
         await asyncio.sleep(gap)
+        _abort_on_startup_defect(scheduler)
         outstanding = scheduler.unobserved_startup_paths(
             _observed_paths(server, scheduler),
             availability=resolve_available_when(

--- a/tests/contracts/test_tx_observation_conformance.py
+++ b/tests/contracts/test_tx_observation_conformance.py
@@ -10,6 +10,7 @@ import asyncio
 from collections.abc import AsyncIterator
 from dataclasses import fields
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from fake_rigctld import FakeRigctldBehavior, FakeRigctldServer
@@ -27,6 +28,7 @@ from tx_observation_fakes import (
 
 from rigplane.backends.rigctld_client.radio import RigctldClientRadio
 from rigplane.backends.yaesu_cat import YaesuCatRadio
+from rigplane.core.state_pipeline_contracts import FieldPath
 from rigplane.core.tx_observation import RADIO_READBACK_SOURCES, TxStateReading
 
 # ---------------------------------------------------------------------------
@@ -354,7 +356,19 @@ async def test_a_set_ptt_write_alone_produces_no_observation(
 
     poller = harness.extras["poller"]
     if harness.name == "yaesu-ftx1":
-        await poller._emit_medium_observations()
+        # ``ScriptedCatTransport`` answers every query with the transmit-state
+        # frame, so any other declared read in this lane would see a frame of
+        # the wrong shape and raise. Narrow the lane to the field this row is
+        # about; the PTT read still goes over the same scripted wire.
+        from rigplane.backends.yaesu_cat.observations import YaesuObservationAdapter
+
+        ptt_only = FieldPath.global_("tx_state", "ptt")
+        with patch.object(
+            YaesuObservationAdapter,
+            "_can_poll",
+            lambda _self, path: path == ptt_only,
+        ):
+            await poller._emit_medium_observations()
     else:
         await poller._poll_medium()
 

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -19,6 +19,7 @@ from rigplane.core.acquisition_scheduler import (
     AcquisitionPriority,
     AcquisitionScheduler,
     AcquisitionStatus,
+    DeclaredCommandDefect,
     MeterObservationCoalescer,
     RadioStateModelService,
     StateFreshnessService,
@@ -3771,14 +3772,14 @@ def test_freshness_service_without_a_radio_still_ticks() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Startup-gate abandonment
+# Startup-gate defects
 # ---------------------------------------------------------------------------
 
 _MAIN_S_METER = FieldPath.receiver("main", "meters", "s_meter")
 _SUB_S_METER = FieldPath.receiver("sub", "meters", "s_meter")
 
 
-def _abandon_scheduler() -> AcquisitionScheduler:
+def _defect_scheduler() -> AcquisitionScheduler:
     """Two declared, non-``tx_only`` meter paths — the FTX-1 pair's shape."""
 
     return AcquisitionScheduler(
@@ -3800,45 +3801,44 @@ def _abandon_scheduler() -> AcquisitionScheduler:
     )
 
 
-def test_abandoned_startup_path_leaves_the_unobserved_set() -> None:
-    scheduler = _abandon_scheduler()
+def _defect(label: str = "sub.s_meter") -> DeclaredCommandDefect:
+    return DeclaredCommandDefect(
+        label=label,
+        paths=(_SUB_S_METER,),
+        command="SM1{raw:03d};",
+        frame="SM0048;",
+        detail="Parse error",
+    )
+
+
+def test_a_recorded_defect_releases_no_path_from_the_unobserved_set() -> None:
+    scheduler = _defect_scheduler()
     assert scheduler.unobserved_startup_paths(()) == (_MAIN_S_METER, _SUB_S_METER)
 
-    scheduler.abandon_startup_path(_SUB_S_METER, reason="malformed CAT response")
+    scheduler.record_startup_defect(_defect())
 
-    assert scheduler.unobserved_startup_paths(()) == (_MAIN_S_METER,)
-    assert scheduler.initial_acquisition_complete(()) is False
-    assert scheduler.initial_acquisition_complete((_MAIN_S_METER,)) is True
-
-
-def test_abandoning_an_observed_path_does_not_change_the_unobserved_set() -> None:
-    scheduler = _abandon_scheduler()
-    observed = (_SUB_S_METER,)
-    before = scheduler.unobserved_startup_paths(observed)
-
-    scheduler.abandon_startup_path(_SUB_S_METER, reason="malformed CAT response")
-
-    assert before == (_MAIN_S_METER,)
-    assert scheduler.unobserved_startup_paths(observed) == before
+    assert scheduler.unobserved_startup_paths(()) == (_MAIN_S_METER, _SUB_S_METER)
+    assert scheduler.initial_acquisition_complete((_MAIN_S_METER,)) is False
 
 
-def test_abandon_startup_path_warns_once_naming_the_path_and_reason(
+def test_record_startup_defect_keeps_and_logs_the_first_only(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    scheduler = _abandon_scheduler()
+    scheduler = _defect_scheduler()
+    assert scheduler.startup_defect is None
+    first = _defect()
 
-    with caplog.at_level(logging.WARNING, logger="rigplane.core.acquisition_scheduler"):
-        scheduler.abandon_startup_path(_SUB_S_METER, reason="malformed CAT response")
-        scheduler.abandon_startup_path(_SUB_S_METER, reason="malformed CAT response")
+    with caplog.at_level(logging.ERROR, logger="rigplane.core.acquisition_scheduler"):
+        scheduler.record_startup_defect(first)
+        scheduler.record_startup_defect(_defect("main.s_meter"))
 
-    warnings = [
-        record for record in caplog.records if record.levelno == logging.WARNING
-    ]
-    assert len(warnings) == 1
-    assert str(_SUB_S_METER) in warnings[0].getMessage()
-    assert "malformed CAT response" in warnings[0].getMessage()
-    # Idempotent: the repeat leaves the filtered set as the first call left it.
-    assert scheduler.unobserved_startup_paths(()) == (_MAIN_S_METER,)
+    assert scheduler.startup_defect is first
+    errors = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert len(errors) == 1
+    message = errors[0].getMessage()
+    assert str(_SUB_S_METER) in message
+    assert "SM1{raw:03d};" in message
+    assert "SM0048;" in message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ftx1_tuner_route.py
+++ b/tests/test_ftx1_tuner_route.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from rigplane.backends.yaesu_cat.observations import YaesuObservationAdapter
+from rigplane.core.acquisition_scheduler import DeclaredCommandDefect
 from rigplane.core.state_pipeline_contracts import FieldPath
 from rigplane.runtime.managed_tx_fence import TxAbortFence
 from rigplane.runtime.local_tx_work import LocalTxWorkRunner
@@ -248,20 +249,37 @@ async def test_force_receive_has_no_tuner_acquisition_dependency() -> None:
 @pytest.mark.parametrize(
     "answer, expected", (("AC103", 2), ("AC101", 1), ("AC102", None), ("AC121", None))
 )
-async def test_real_ac_observation_normalizes_or_omits_unknown(
+async def test_real_ac_observation_normalizes_or_faults_on_unknown(
     monkeypatch: pytest.MonkeyPatch,
     answer: str,
     expected: int | None,
 ) -> None:
+    """An AC answer outside the mapped domain is a defect, not an omission.
+
+    ``_read_atu_route`` raises ``ValueError`` for a src/type/state triple its
+    table does not map; that reaches ``_safe_read`` on a read naming a
+    declared path, so it raises rather than emitting nothing.
+    """
     radio = radio_with_answer(answer)
     path = FieldPath.global_("operator_controls", "tuner_status")
     monkeypatch.setattr(
         YaesuObservationAdapter, "_can_poll", lambda self, field: field == path
     )
-    observations = await YaesuObservationAdapter.from_radio(radio).poll_tx_controls()
+    # The fixture answers every query with the AC frame, so every other read
+    # in this lane would see a frame of the wrong shape. Only the tuner read
+    # is under test; leave the rest ungated.
+    monkeypatch.setattr(
+        YaesuObservationAdapter,
+        "_has_runtime_capability",
+        lambda self, capability: capability == "tuner",
+    )
+    adapter = YaesuObservationAdapter.from_radio(radio)
     if expected is None:
-        assert observations == ()
+        with pytest.raises(DeclaredCommandDefect) as caught:
+            await adapter.poll_tx_controls()
+        assert caught.value.paths == (path,)
     else:
+        observations = await adapter.poll_tx_controls()
         assert len(observations) == 1
         assert observations[0].path == path
         assert observations[0].value == expected

--- a/tests/test_startup_state_gate.py
+++ b/tests/test_startup_state_gate.py
@@ -27,6 +27,7 @@ import pytest
 from rigplane.core.acquisition_scheduler import (
     AcquisitionRequest,
     AcquisitionScheduler,
+    DeclaredCommandDefect,
     resolve_available_when,
 )
 from rigplane.core.civ import CivFrame
@@ -415,6 +416,7 @@ class _RecordingScheduler:
         )
         self.prime_limits: list[int | None] = []
         self.on_prime: Callable[[], None] | None = None
+        self.startup_defect: DeclaredCommandDefect | None = None
 
     def unobserved_startup_paths(
         self,
@@ -653,7 +655,7 @@ async def test_web_ui_banner_prints_only_after_the_server_reports_started(
 
 
 # ---------------------------------------------------------------------------
-# A declared field the backend gives up on
+# A declared field the radio answers in another shape
 # ---------------------------------------------------------------------------
 
 SUB_S_METER = FieldPath.receiver("sub", "meters", "s_meter")
@@ -703,6 +705,9 @@ class _YaesuAdapterPoller:
     def bind_provider_generation(self, *, capture: object, advance: object) -> None:
         return None
 
+    def bind_managed_tx_authority(self, _authority: object) -> None:
+        return None
+
 
 class _MalformedSubMeterRadio:
     """Answers the MAIN meter and returns an unparseable SUB meter frame."""
@@ -742,16 +747,32 @@ class _MalformedSubMeterRadio:
     ) -> object:
         return _YaesuAdapterPoller(callback, self)
 
+    # -- what ``cli/__init__.py: _run`` needs before it reaches the gate ----
+
+    async def __aenter__(self) -> "_MalformedSubMeterRadio":
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
+
+    async def actuate(
+        self, _token: object, _operation: object, *, is_current: Callable[[], bool]
+    ) -> object:
+        from rigplane.runtime.managed_tx_state import ActuationResult
+
+        return ActuationResult.ACCEPTED if is_current() else ActuationResult.REJECTED
+
+    async def set_ptt(self, _on: bool) -> None:
+        return None
+
 
 @pytest.mark.asyncio
-async def test_gate_completes_when_the_backend_abandons_a_declared_path(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """The bind happens even though one declared field never answers usably.
+async def test_gate_refuses_to_bind_when_a_declared_read_never_parses() -> None:
+    """No listener exists when a declared field is answered in another shape.
 
     ``SUB_S_METER`` is polled every cycle and every answer is unparseable, so
-    no observation for it can ever reach the store. Without the backend
-    telling the scheduler to release it, this gate never returns.
+    no observation for it can ever reach the store. The message names the
+    field, the parse template and the frame the radio sent.
     """
     radio = _MalformedSubMeterRadio()
     server = WebServer(radio, _gated_config())
@@ -763,19 +784,56 @@ async def test_gate_completes_when_the_backend_abandons_a_declared_path(
         binds.append("bind")
         return _FakeAsyncServer()
 
-    with caplog.at_level(logging.WARNING, logger="rigplane.core.acquisition_scheduler"):
-        with patch("rigplane.web.web_startup.asyncio.start_server", new=_bind):
+    with patch("rigplane.web.web_startup.asyncio.start_server", new=_bind):
+        with pytest.raises(RuntimeError) as caught:
             await asyncio.wait_for(server.start(), timeout=10.0)
-            await server.stop()
+        await server.stop()
 
-    assert binds == ["bind"]
-    assert scheduler.unobserved_startup_paths(_observed_paths(server, scheduler)) == ()
-    abandoned = [
-        record
-        for record in caplog.records
-        if record.levelno == logging.WARNING and str(SUB_S_METER) in record.getMessage()
-    ]
-    assert len(abandoned) == 1
+    assert binds == []
+    message = str(caught.value)
+    assert message.startswith("web startup aborted: ")
+    assert message.endswith("Refusing to start a half-working server.")
+    assert str(SUB_S_METER) in message
+    assert "SM1{raw:03d};" in message
+    assert "SM0000;" in message
+    assert SUB_S_METER in scheduler.unobserved_startup_paths(
+        _observed_paths(server, scheduler)
+    )
+
+
+@pytest.mark.asyncio
+async def test_cli_web_exits_one_and_prints_the_defect(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``rigplane web`` reports the defect on stderr and exits 1.
+
+    Same radio as the gate test above, driven through the real
+    ``cli/__init__.py: _run`` so the exit code and the ``Error:`` line come
+    from the CLI's own handling, not from a re-raise the test composed.
+    """
+    from rigplane.cli import _build_parser, _run
+
+    radio = _MalformedSubMeterRadio()
+
+    async def _bind(*_args: object, **_kwargs: object) -> _FakeAsyncServer:
+        raise AssertionError("the listener must never bind")
+
+    args = _build_parser().parse_args(["--host", "1.2.3.4", "web", "--no-rigctld"])
+    args.web_bridge = None  # no audio bridge; the gate is what is under test
+    with (
+        patch("rigplane.cli.create_radio", return_value=radio),
+        patch("rigplane.cli.check_ports_available"),
+        patch("rigplane.web.web_startup.asyncio.start_server", new=_bind),
+    ):
+        rc = await asyncio.wait_for(_run(args), timeout=10.0)
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert err.startswith("Error: web startup aborted: ")
+    assert str(SUB_S_METER) in err
+    assert "SM1{raw:03d};" in err
+    assert "SM0000;" in err
+    assert "Refusing to start a half-working server." in err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -11,7 +11,10 @@ from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
-from rigplane.core.acquisition_scheduler import AcquisitionScheduler
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionScheduler,
+    DeclaredCommandDefect,
+)
 from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
 from rigplane.core.state_pipeline_contracts import (
     FieldPath,
@@ -28,7 +31,12 @@ from rigplane.radio_state import RadioState
 from rigplane.backends.yaesu_cat.observations import YaesuObservationAdapter
 from rigplane.backends.yaesu_cat.parser import CatParseError
 from rigplane.backends.yaesu_cat.radio import RadioConnectionError, YaesuCatRadio
-from rigplane.backends.yaesu_cat.transport import CatCommandRejected, CatTransportError
+from rigplane.backends.yaesu_cat.transport import (
+    CatCommandRejected,
+    CatGarbledFrameError,
+    CatTimeoutError,
+    CatTransportError,
+)
 
 
 def _clock() -> float:
@@ -1737,38 +1745,39 @@ async def test_repeater_shift_emits_both_receivers_directly(code: int) -> None:
 
 
 @pytest.mark.parametrize(
-    ("side_effect", "expected_path", "expected_value"),
+    ("side_effect", "defective_path", "awaited"),
     [
         (
             [ValueError("MAIN failed"), 2],
-            "receiver.sub.operator_controls.repeater_shift",
-            2,
+            "receiver.main.operator_controls.repeater_shift",
+            [call(0)],
         ),
         (
             [1, ValueError("SUB failed")],
-            "receiver.main.operator_controls.repeater_shift",
-            1,
+            "receiver.sub.operator_controls.repeater_shift",
+            [call(0), call(1)],
         ),
     ],
 )
 @pytest.mark.asyncio
-async def test_repeater_shift_receiver_failures_are_isolated(
-    side_effect: list[object], expected_path: str, expected_value: int
+async def test_repeater_shift_receiver_failures_name_only_their_own_side(
+    side_effect: list[object], defective_path: str, awaited: list[object]
 ) -> None:
+    """OS0 and OS1 are read independently, so one side's defect names one path.
+
+    The read that fails raises where it fails; a side already read stays read
+    and a side not yet reached is not queried.
+    """
     radio = _make_radio()
     radio.capabilities.add("repeater_shift")
     radio.read_repeater_shift = AsyncMock(side_effect=side_effect)
     adapter = YaesuObservationAdapter(radio, profile=_profile_state_acquisition())
 
-    observations = await adapter.poll_slow_controls()
-    shifts = {
-        str(item.path): item.value
-        for item in observations
-        if str(item.path).endswith("repeater_shift")
-    }
+    with pytest.raises(DeclaredCommandDefect) as caught:
+        await adapter.poll_slow_controls()
 
-    assert shifts == {expected_path: expected_value}
-    assert radio.read_repeater_shift.await_args_list == [call(0), call(1)]
+    assert [str(path) for path in caught.value.paths] == [defective_path]
+    assert radio.read_repeater_shift.await_args_list == awaited
 
 
 @pytest.mark.asyncio
@@ -2051,68 +2060,8 @@ async def test_read_if_shift_and_narrow_are_pure_reads() -> None:
 
 
 # ---------------------------------------------------------------------------
-# MOR-473: per-field poll-lane resilience (_safe_read)
+# MOR-473: transport failures still propagate out of the poll lanes
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_rx_meters_emit_main_when_sub_s_meter_raises_parse_error() -> None:
-    """MOR-473: a malformed SUB ``SM1;`` answer must not drop the MAIN meter.
-
-    A ``CatParseError`` from the SUB s-meter read must skip that single field
-    and still emit the MAIN s-meter.
-    """
-    radio = _make_radio()
-    radio.read_s_meter = AsyncMock(
-        side_effect=lambda receiver=0: (
-            120
-            if receiver == 0
-            else _raise(CatParseError("SM{receiver}{raw:03d};", "SM?;", "x"))
-        )
-    )
-    adapter = YaesuObservationAdapter(
-        radio,
-        profile=_profile_state_acquisition(),
-        clock=_clock,
-    )
-
-    observations = await adapter.poll_rx_meters()
-
-    assert [(str(item.path), item.value) for item in observations] == [
-        ("receiver.main.meters.s_meter", -7),
-    ]
-
-
-@pytest.mark.asyncio
-async def test_slow_poll_skips_raising_sql_type_but_emits_rest() -> None:
-    """MOR-473: a raising ``read_sql_type`` must not abort the whole slow lane.
-
-    A field-level malformed/unsupported answer (``CatParseError``) skips the
-    derived CTCSS toggle group but leaves af_level/rf_gain/agc/etc. intact.
-    """
-    radio = _make_radio()
-    radio.read_sql_type = AsyncMock(
-        side_effect=CatParseError("CT0{type};", "?;", "rejected")
-    )
-    adapter = YaesuObservationAdapter(
-        radio,
-        profile=_profile_state_acquisition(),
-        clock=_clock,
-    )
-
-    observations = await adapter.poll_slow_controls()
-    paths = [str(item.path) for item in observations]
-
-    # The whole derived CTCSS-toggle group is skipped together (one read,
-    # N observations invariant).
-    assert "receiver.main.operator_toggles.repeater_tone" not in paths
-    assert "receiver.main.operator_toggles.repeater_tsql" not in paths
-    # Everything else in the lane still emits.
-    assert "receiver.main.operator_controls.af_level" in paths
-    assert "receiver.main.operator_controls.rf_gain" in paths
-    assert "receiver.main.operator_controls.agc" in paths
-    assert "receiver.main.operator_controls.tone_freq" in paths
-    assert "global.slow_state.active" in paths
 
 
 @pytest.mark.asyncio
@@ -2196,94 +2145,61 @@ async def test_happy_path_slow_poll_unchanged_when_all_reads_succeed() -> None:
 
 
 @pytest.mark.asyncio
-async def test_sub_s_meter_parse_warning_logged_once_then_suppressed(
+async def test_tx_target_frequency_skip_warns_once_then_suppresses(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """MOR-561: a SUB ``SM1;`` answer that never parses must not flood the log.
+    """MOR-561: the remaining skip surface must not flood the log.
 
-    The poller queries the field several times per second, so a per-cycle
-    WARNING floods the log. The first occurrence must WARN once; every repeat
-    for the same field must demote to DEBUG (no repeated WARNING).
+    ``tx_target.freq`` is the read that feeds no declared path of its own, so
+    it is skipped rather than treated as a defect. The poller runs it several
+    times a second: the first occurrence WARNs, every repeat demotes to DEBUG.
     """
-    radio = _make_radio()
-    # The real YaesuCatRadio owns this persistent set; the MagicMock double
-    # must too, so the once-then-suppress dedup has somewhere to record the
-    # already-warned field across poll cycles (MOR-561).
-    radio._poll_warned_fields = set()
-    radio.read_s_meter = AsyncMock(
-        side_effect=lambda receiver=0: (
-            120
-            if receiver == 0
-            else _raise(
-                CatParseError(
-                    "SM{receiver}{raw:03d};",
-                    "SM?;",
-                    "Response does not match pattern",
-                )
-            )
-        )
-    )
+    radio = _gate_radio()
+    radio.capabilities = radio.capabilities - {"dual_rx"}
+    radio.get_tx_func = AsyncMock(return_value=1)
+    _break_read(radio, "read_freq", 1)
 
-    def _poll_meters() -> "object":
+    def _poll() -> "object":
         # Fresh adapter per cycle (matches the poller, which rebuilds the
         # adapter every poll cycle via YaesuObservationAdapter.from_radio).
         return YaesuObservationAdapter(
             radio,
             profile=_profile_state_acquisition(),
             clock=_clock,
-        ).poll_rx_meters()
+        ).poll_medium()
 
     with caplog.at_level("DEBUG"):
         for _ in range(5):
-            await _poll_meters()
+            await _poll()
 
-    sub_warnings = [
+    warnings = [
         rec
         for rec in caplog.records
-        if rec.levelname == "WARNING" and "sub.s_meter" in rec.getMessage()
+        if rec.levelname == "WARNING" and "tx_target.freq" in rec.getMessage()
     ]
-    sub_debugs = [
+    debugs = [
         rec
         for rec in caplog.records
-        if rec.levelname == "DEBUG" and "sub.s_meter" in rec.getMessage()
+        if rec.levelname == "DEBUG" and "tx_target.freq" in rec.getMessage()
     ]
-    # Exactly one WARNING across all five cycles; repeats demoted to DEBUG.
-    assert len(sub_warnings) == 1
-    assert len(sub_debugs) == 4
-    # The MAIN meter still emits every cycle (sub failure is isolated).
-    observations = await _poll_meters()
-    assert ("receiver.main.meters.s_meter", -7) in [
-        (str(item.path), item.value) for item in observations
-    ]
+    assert len(warnings) == 1
+    assert len(debugs) == 4
 
 
 def _raise(exc: Exception) -> object:
     raise exc
 
 
-class _AbandonRecordingScheduler(AcquisitionScheduler):
-    """Real scheduler that records every ``abandon_startup_path`` call."""
-
-    def __init__(self, profile: RadioAcquisitionProfile) -> None:
-        super().__init__(profile=profile)
-        self.abandoned: list[tuple[FieldPath, str]] = []
-
-    def abandon_startup_path(self, path: FieldPath, *, reason: str) -> None:
-        self.abandoned.append((path, reason))
-        super().abandon_startup_path(path, reason=reason)
-
-
 @pytest.mark.asyncio
-async def test_first_sub_s_meter_skip_releases_the_path_from_the_startup_gate() -> None:
-    """The skipped field must not leave the startup gate waiting for it.
+async def test_unparseable_sub_s_meter_is_a_startup_defect() -> None:
+    """A declared read answered in another shape stops the cycle, not the gate.
 
-    Same frame as ``test_sub_s_meter_parse_warning_logged_once_then_suppressed``:
-    the sub ``SM1;`` answer fails to parse every cycle, so no
-    ``receiver.sub.meters.s_meter`` observation ever arrives. The first skip
-    tells the scheduler; the repeats that demote to DEBUG do not tell it again.
+    The sub ``SM1;`` answer fails to parse, so no
+    ``receiver.sub.meters.s_meter`` observation can ever arrive. The defect is
+    raised and recorded, and the path stays outstanding — nothing releases it.
     """
     profile = _profile_state_acquisition()
-    scheduler = _AbandonRecordingScheduler(profile)
+    scheduler = AcquisitionScheduler(profile=profile)
     sub_path = FieldPath.receiver("sub", "meters", "s_meter")
     assert sub_path in scheduler.unobserved_startup_paths(())
 
@@ -2297,26 +2213,29 @@ async def test_first_sub_s_meter_skip_releases_the_path_from_the_startup_gate() 
             else _raise(
                 CatParseError(
                     "SM{receiver}{raw:03d};",
-                    "SM?;",
+                    "SM0048;",
                     "Response does not match pattern",
                 )
             )
         )
     )
 
-    for _ in range(3):
+    with pytest.raises(DeclaredCommandDefect) as caught:
         await YaesuObservationAdapter(
             radio,
             profile=profile,
             clock=_clock,
         ).poll_rx_meters()
 
-    assert [path for path, _ in scheduler.abandoned] == [sub_path]
-    assert sub_path not in scheduler.unobserved_startup_paths(())
-    # The MAIN meter, whose answer parses, is not abandoned.
-    assert FieldPath.receiver(
-        "main", "meters", "s_meter"
-    ) in scheduler.unobserved_startup_paths(())
+    assert caught.value.paths == (sub_path,)
+    assert caught.value.command == "SM{receiver}{raw:03d};"
+    assert caught.value.frame == "SM0048;"
+    assert scheduler.startup_defect is caught.value
+    message = str(caught.value)
+    assert str(sub_path) in message
+    assert "SM{receiver}{raw:03d};" in message
+    assert "SM0048;" in message
+    assert sub_path in scheduler.unobserved_startup_paths(())
 
 
 @pytest.mark.asyncio
@@ -2343,7 +2262,7 @@ async def test_sub_s_meter_reads_through_the_profile_despite_the_echoed_side(
         return {str(item.path): item.value for item in observations}
 
     radio = _radio()
-    scheduler = _AbandonRecordingScheduler(_profile_state_acquisition())
+    scheduler = AcquisitionScheduler(profile=_profile_state_acquisition())
     radio._acquisition_scheduler = scheduler
 
     with caplog.at_level("DEBUG"):
@@ -2369,7 +2288,7 @@ async def test_sub_s_meter_reads_through_the_profile_despite_the_echoed_side(
     assert [
         rec.getMessage() for rec in caplog.records if "s_meter" in rec.getMessage()
     ] == []
-    assert scheduler.abandoned == []
+    assert scheduler.startup_defect is None
 
 
 def _gate_radio() -> MagicMock:
@@ -2381,25 +2300,37 @@ def _gate_radio() -> MagicMock:
     return radio
 
 
-def _break_read(radio: MagicMock, method: str, receiver: int | None) -> None:
-    """Make ``method`` answer with an unparseable frame.
+def _break_read(
+    radio: MagicMock,
+    method: str,
+    receiver: int | None,
+    *,
+    failure: str = "parse",
+) -> None:
+    """Make ``method`` answer with an unparseable frame, or refuse the command.
 
     ``receiver`` selects which call fails: ``None`` fails every call, an int
     fails only the call whose first positional argument equals it, so a read
-    shared by MAIN and SUB can be broken on one side alone.
+    shared by MAIN and SUB can be broken on one side alone. ``failure``
+    picks the R48 class: ``"parse"`` is a clean frame of another shape,
+    ``"reject"`` is the radio's ``?;``.
     """
     original = getattr(radio, method)
 
     async def _answer(*args: object, **kwargs: object) -> object:
         if receiver is None or (args and args[0] == receiver):
+            if failure == "reject":
+                raise CatCommandRejected(
+                    "Radio rejected command 'XX;' (returned '?;')", command="XX;"
+                )
             raise CatParseError("XX{p};", "??;", "Response does not match pattern")
         return await original(*args, **kwargs)
 
     setattr(radio, method, _answer)
 
 
-# (id, radio method, failing receiver, poll method, declared paths abandoned)
-_ABANDON_ROWS: tuple[tuple[str, str, int | None, str, tuple[str, ...]], ...] = (
+# (id, radio method, failing receiver, poll method, declared paths the defect names)
+_DEFECT_ROWS: tuple[tuple[str, str, int | None, str, tuple[str, ...]], ...] = (
     (
         "main.freq",
         "read_freq",
@@ -2716,47 +2647,53 @@ _ABANDON_ROWS: tuple[tuple[str, str, int | None, str, tuple[str, ...]], ...] = (
 )
 
 
+@pytest.mark.parametrize("failure", ["parse", "reject"])
 @pytest.mark.parametrize(
     ("method", "receiver", "poll", "expected"),
-    [row[1:] for row in _ABANDON_ROWS],
-    ids=[row[0] for row in _ABANDON_ROWS],
+    [row[1:] for row in _DEFECT_ROWS],
+    ids=[row[0] for row in _DEFECT_ROWS],
 )
 @pytest.mark.asyncio
-async def test_skipped_read_abandons_every_declared_path_it_feeds(
+async def test_defective_read_names_every_declared_path_it_feeds(
     method: str,
     receiver: int | None,
     poll: str,
     expected: tuple[str, ...],
+    failure: str,
 ) -> None:
-    """One unparseable read releases the declared paths it feeds, and no others.
+    """One refused or wrong-shape read raises naming the paths it feeds.
 
-    A path the backend can never observe must not hold the startup gate open;
-    a path some other read still supplies must not be released with it.
+    A path the backend can never observe must not be released from the
+    startup gate, and the defect must not name a path some other read still
+    supplies.
     """
     profile = _profile_state_acquisition()
-    scheduler = _AbandonRecordingScheduler(profile)
+    scheduler = AcquisitionScheduler(profile=profile)
     radio = _gate_radio()
     radio._acquisition_scheduler = scheduler
-    _break_read(radio, method, receiver)
+    before = scheduler.unobserved_startup_paths(())
+    _break_read(radio, method, receiver, failure=failure)
 
     adapter = YaesuObservationAdapter(radio, profile=profile, clock=_clock)
-    await getattr(adapter, poll)()
+    with pytest.raises(DeclaredCommandDefect) as caught:
+        await getattr(adapter, poll)()
 
-    assert sorted(str(path) for path, _ in scheduler.abandoned) == sorted(expected)
-    for name in expected:
-        assert FieldPath.parse(name) not in scheduler.unobserved_startup_paths(())
+    assert sorted(str(path) for path in caught.value.paths) == sorted(expected)
+    assert scheduler.startup_defect is caught.value
+    # Nothing is released: the gate's outstanding set is exactly what it was.
+    assert scheduler.unobserved_startup_paths(()) == before
 
 
 @pytest.mark.asyncio
-async def test_tx_target_frequency_read_abandons_nothing() -> None:
+async def test_tx_target_frequency_read_raises_no_defect() -> None:
     """The TX-target frequency is a sub-read of a field emitted either way.
 
     ``global.tx_state.tx_target`` is appended whether or not that frequency
-    parses (the frequency degrades to ``None``), so a skip there releases no
-    path from the gate.
+    parses (the frequency degrades to ``None``), so that read names no
+    declared path and stays a skip.
     """
     profile = _profile_state_acquisition()
-    scheduler = _AbandonRecordingScheduler(profile)
+    scheduler = AcquisitionScheduler(profile=profile)
     radio = _gate_radio()
     radio._acquisition_scheduler = scheduler
     radio.capabilities = radio.capabilities - {"dual_rx"}
@@ -2767,7 +2704,7 @@ async def test_tx_target_frequency_read_abandons_nothing() -> None:
         radio, profile=profile, clock=_clock
     ).poll_medium()
 
-    assert scheduler.abandoned == []
+    assert scheduler.startup_defect is None
     emitted = [
         item.value
         for item in observations
@@ -2776,6 +2713,66 @@ async def test_tx_target_frequency_read_abandons_nothing() -> None:
     assert len(emitted) == 1
     assert isinstance(emitted[0], KnownTxTarget)
     assert emitted[0].frequency_hz is None
+
+
+@pytest.mark.parametrize(
+    "noise",
+    [
+        CatTimeoutError("Read timeout (1.0s) waiting for ';' terminator"),
+        CatTransportError("Read failed: device disappeared"),
+    ],
+    ids=("timeout", "transport"),
+)
+@pytest.mark.asyncio
+async def test_transport_noise_re_raises_without_recording_a_defect(
+    noise: Exception,
+) -> None:
+    """Link quality is not a product defect: no defect, no gate abort.
+
+    The exception reaches ``YaesuCatPoller._run_poll_cycle``, which is what
+    drives reconnect/backoff.
+    """
+    profile = _profile_state_acquisition()
+    scheduler = AcquisitionScheduler(profile=profile)
+    radio = _gate_radio()
+    radio._acquisition_scheduler = scheduler
+    radio.read_s_meter = AsyncMock(
+        side_effect=lambda receiver=0: 120 if receiver == 0 else _raise(noise)
+    )
+
+    with pytest.raises(type(noise)):
+        await YaesuObservationAdapter(
+            radio, profile=profile, clock=_clock
+        ).poll_rx_meters()
+
+    assert scheduler.startup_defect is None
+    assert FieldPath.receiver(
+        "sub", "meters", "s_meter"
+    ) in scheduler.unobserved_startup_paths(())
+
+
+@pytest.mark.asyncio
+async def test_a_garbled_frame_on_the_wire_is_noise_not_a_defect() -> None:
+    """Real transport, real profile: the corrupt byte never reaches the parser.
+
+    ``b"SM\\x00048;"`` keeps the ``SM`` prefix, so the query's stale-line
+    filter passes it through. Without the transport's printability check it
+    would reach the parse template and be recorded as a defect, which is what
+    this row exists to deny.
+    """
+    scheduler = AcquisitionScheduler(profile=_profile_state_acquisition())
+    radio = YaesuCatRadio("/dev/null", audio_driver=MagicMock())
+    radio._acquisition_scheduler = scheduler
+    radio._transport._connected = True
+    radio._transport._writer = MagicMock(drain=AsyncMock())
+    radio._transport._reader = MagicMock(
+        readuntil=AsyncMock(return_value=b"SM\x00048;")
+    )
+
+    with pytest.raises(CatGarbledFrameError):
+        await YaesuObservationAdapter.from_radio(radio, clock=_clock).poll_rx_meters()
+
+    assert scheduler.startup_defect is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_yaesu_cat_transport.py
+++ b/tests/test_yaesu_cat_transport.py
@@ -438,8 +438,7 @@ class TestYaesuCatTransport:
         """A ``;``-terminated line with a byte outside 0x20-0x7E is link noise.
 
         It never reaches the parser, where it would be indistinguishable from
-        a clean frame of the wrong shape.  Bytes >= 0x80 are the commonest
-        UART corruption and are classified the same way as control bytes.
+        a clean frame of the wrong shape.  Bytes >= 0x80 are classified the same way as control bytes.
         """
         reader = FakeStreamReader([garbled])
         writer = FakeStreamWriter()

--- a/tests/test_yaesu_cat_transport.py
+++ b/tests/test_yaesu_cat_transport.py
@@ -14,7 +14,10 @@ from rigplane.backends.yaesu_cat import (
     CatTransportError,
     YaesuCatTransport,
 )
-from rigplane.backends.yaesu_cat.transport import CatCommandRejected
+from rigplane.backends.yaesu_cat.transport import (
+    CatCommandRejected,
+    CatGarbledFrameError,
+)
 from rigplane.core.priority_exchange import ExchangeTier
 
 
@@ -420,6 +423,63 @@ class TestYaesuCatTransport:
 
         with pytest.raises(CatTransportError, match="not connected"):
             await transport.readline()
+
+    async def test_readline_rejects_a_terminated_line_carrying_control_bytes(
+        self, mock_serial_connection: Any
+    ) -> None:
+        """A ``;``-terminated line with a byte outside 0x20-0x7E is link noise.
+
+        It never reaches the parser, where it would be indistinguishable from
+        a clean frame of the wrong shape.
+        """
+        reader = FakeStreamReader([b"SM\x00048;"])
+        writer = FakeStreamWriter()
+        mock_serial_connection.open_serial_connection = AsyncMock(
+            return_value=(reader, writer)
+        )
+
+        transport = YaesuCatTransport(device="/dev/test")
+        await transport.connect()
+
+        with pytest.raises(CatGarbledFrameError) as caught:
+            await transport.readline()
+        assert isinstance(caught.value, CatTransportError)
+        assert repr(b"SM\x00048;") in str(caught.value)
+
+    async def test_readline_accepts_the_printable_ascii_edges(
+        self, mock_serial_connection: Any
+    ) -> None:
+        """0x20 and 0x7E are inside the accepted range."""
+        reader = FakeStreamReader([b" \x7e;"])
+        writer = FakeStreamWriter()
+        mock_serial_connection.open_serial_connection = AsyncMock(
+            return_value=(reader, writer)
+        )
+
+        transport = YaesuCatTransport(device="/dev/test")
+        await transport.connect()
+
+        assert await transport.readline() == " \x7e"
+
+    async def test_drained_garbled_line_after_a_write_is_discarded(
+        self, mock_serial_connection: Any
+    ) -> None:
+        """A garbled line in the post-write drain stays a discarded line.
+
+        ``write()`` drains echo/auto-info; noise there is not the SET
+        command's outcome and must not fail it.
+        """
+        reader = FakeStreamReader([b"MD\x000E;"])
+        writer = FakeStreamWriter()
+        mock_serial_connection.open_serial_connection = AsyncMock(
+            return_value=(reader, writer)
+        )
+
+        transport = YaesuCatTransport(device="/dev/test")
+        await transport.connect()
+        await transport.write("MD0E;")
+
+        assert writer.written == [b"MD0E;"]
 
     async def test_query_sends_and_reads(self, mock_serial_connection: Any) -> None:
         """query() sends command and returns response."""

--- a/tests/test_yaesu_cat_transport.py
+++ b/tests/test_yaesu_cat_transport.py
@@ -424,15 +424,24 @@ class TestYaesuCatTransport:
         with pytest.raises(CatTransportError, match="not connected"):
             await transport.readline()
 
-    async def test_readline_rejects_a_terminated_line_carrying_control_bytes(
-        self, mock_serial_connection: Any
+    @pytest.mark.parametrize(
+        "garbled",
+        [
+            pytest.param(b"SM\x00048;", id="control-byte"),
+            pytest.param(b"SM\x80048;", id="high-bit-set"),
+            pytest.param(b"\xff;", id="all-bits-set"),
+        ],
+    )
+    async def test_readline_rejects_a_terminated_line_carrying_a_byte_outside_0x20_0x7e(
+        self, mock_serial_connection: Any, garbled: bytes
     ) -> None:
         """A ``;``-terminated line with a byte outside 0x20-0x7E is link noise.
 
         It never reaches the parser, where it would be indistinguishable from
-        a clean frame of the wrong shape.
+        a clean frame of the wrong shape.  Bytes >= 0x80 are the commonest
+        UART corruption and are classified the same way as control bytes.
         """
-        reader = FakeStreamReader([b"SM\x00048;"])
+        reader = FakeStreamReader([garbled])
         writer = FakeStreamWriter()
         mock_serial_connection.open_serial_connection = AsyncMock(
             return_value=(reader, writer)
@@ -444,7 +453,7 @@ class TestYaesuCatTransport:
         with pytest.raises(CatGarbledFrameError) as caught:
             await transport.readline()
         assert isinstance(caught.value, CatTransportError)
-        assert repr(b"SM\x00048;") in str(caught.value)
+        assert repr(garbled) in str(caught.value)
 
     async def test_readline_accepts_the_printable_ascii_edges(
         self, mock_serial_connection: Any
@@ -461,15 +470,22 @@ class TestYaesuCatTransport:
 
         assert await transport.readline() == " \x7e"
 
+    @pytest.mark.parametrize(
+        "noise",
+        [
+            pytest.param(b"MD\x000E;", id="control-byte"),
+            pytest.param(b"MD\x800E;", id="high-bit-set"),
+        ],
+    )
     async def test_drained_garbled_line_after_a_write_is_discarded(
-        self, mock_serial_connection: Any
+        self, mock_serial_connection: Any, noise: bytes
     ) -> None:
         """A garbled line in the post-write drain stays a discarded line.
 
         ``write()`` drains echo/auto-info; noise there is not the SET
         command's outcome and must not fail it.
         """
-        reader = FakeStreamReader([b"MD\x000E;"])
+        reader = FakeStreamReader([noise])
         writer = FakeStreamWriter()
         mock_serial_connection.open_serial_connection = AsyncMock(
             return_value=(reader, writer)


### PR DESCRIPTION
Soft-threshold justification (10 files · 860 changed lines — `git diff --numstat origin/main...HEAD` at `4e2a1b59`: +564 −296; hard ceiling 10 files / 1000 lines not crossed): this is one classification rule applied end to end. The transport must learn to name garbled bytes before the adapter can treat a template mismatch as a defect; the scheduler must hold the defect before the gate can refuse to bind; and the tests that pinned the old "release the path" contract go red the moment any one of those lands. Splitting it would land a tree where the startup gate is either permanently open or permanently closed.

## What changes for the user

Today a declared field the radio refuses (`?;`) or answers in a shape the profile does not describe is skipped: a warning once, then DEBUG, and the startup gate is told to release the path so the server binds anyway. The operator gets a UI with a silently missing field.

After this change that is a startup-critical error. `rigplane web` / `rigplane station` stops before the listener binds and prints, on stderr, exit code 1:

```
Error: web startup aborted: declared read 'sub.s_meter' (receiver.sub.meters.s_meter); command 'SM1{raw:03d};'; frame 'SM0000;': Parse error for 'SM1{raw:03d};' against 'SM0000;': Response does not match pattern. Refusing to start a half-working server.
```

## Classification rule

- **Defect** (startup-critical): `CatCommandRejected` (`?;`), `CatParseError` / `CatFormatError`, and a bare `ValueError` / `KeyError` — on a read that names declared field paths.
- **Noise** (unchanged, drives reconnect/backoff): `CatTimeoutError`, `CatGarbledFrameError` (new), and every other `CatTransportError`.
- **Skip** (unchanged): the same failures on a read that names no declared path — `tx_target.freq`, and the three `_normalize_power_level` metadata skips, which call `_log_field_skip` directly and never reach `_safe_read`.

`ValueError` / `KeyError` decision: treated as defects. The spec asked about `_normalize_power_level` and the CTCSS index; neither reaches `_safe_read` (the first calls `_log_field_skip` with no paths, the second has its own `except ValueError` in `poll_slow_controls`), so their behaviour is unchanged. What *does* reach `_safe_read` as a bare `ValueError` is decoding of a frame the radio just returned — `int()` on a meter field, and `YaesuCatRadio._read_atu_route`'s "Unsupported ATU response" — which is the wrong-shape class, so it is classified with it. For this class the message names the field and the payload but not the command template or the frame: `_raise_declared_defect` fills `command` / `frame` only for `CatParseError`, `CatFormatError` and `CatCommandRejected`, so the ATU defect reads

```
declared read 'tuner' (global.operator_controls.tuner_status): Unsupported ATU response: {'src': '1', 'type': '0', 'state': '2'}
```

— measured by driving `YaesuObservationAdapter.poll_tx_controls` against an `AC102` wire and printing `str(defect)`. R48's "names the command and the frame" therefore holds fully for the refusal and parse classes only. See the ATU note below.

Termination needs no new check: `readline()` uses `readuntil(b";")`, so an unterminated read is already `CatTimeoutError`. Printability had no owner anywhere; it is now the transport's, checked on the raw bytes before the line ever reaches the parser. A garbled line inside `write()`'s post-write drain is still discarded rather than failing the SET command.

## How the defect reaches the gate

The adapter runs inside the poller's own asyncio task, so its raise cannot reach `web_startup._await_initial_state_acquisition` directly. The smallest honest mechanism: `YaesuObservationAdapter._raise_declared_defect` records the defect on the scheduler the radio already carries (`AcquisitionScheduler.record_startup_defect`, first one wins, logged once at ERROR) and then raises. The gate calls `_abort_on_startup_defect(scheduler)` once before its loop and once per iteration, and raises a `RuntimeError` shaped like `startup_checks.assert_radio_startup_ready`'s. Bind is strictly after the gate, so no listener is created; `cli/__init__.py: _run`'s existing catch-all turns it into `Error: …` / exit 1 with no new CLI plumbing (`station` shares `_cmd_web`).

## Removed

`AcquisitionScheduler.abandon_startup_path`, `_abandoned_startup_paths` (slot, init, and the filter in `unobserved_startup_paths`), and the abandon call in `_log_field_skip` — plus every docstring describing them. `git grep -i abandon` over `src/` and `tests/` finds no remaining reference to this mechanism. `_log_field_skip` keeps the once-per-label warn/DEBUG demotion for the empty-paths skips; its now-unused `paths` parameter is gone.

## Tests

- `tests/test_yaesu_cat_transport.py`: garbled terminated line raises `CatGarbledFrameError`; 0x20 and 0x7E are accepted; a garbled line in the post-write drain is discarded.
- `tests/test_yaesu_cat_observation_adapter.py`: `_ABANDON_ROWS` → `_DEFECT_ROWS`, still 49 rows, now parametrized over both failure classes (98 cases) — each asserts the raised defect names exactly the paths that read feeds and that `unobserved_startup_paths` is unchanged. Plus: the sub S-meter defect carries command + frame; a real-transport garbled `b"SM\x00048;"` is noise and records no defect; timeout/transport re-raise without a defect; `tx_target.freq` still skips; the once-then-suppress dedup is re-pinned on `tx_target.freq`, the surface that still uses it.
- `tests/test_acquisition_scheduler.py`: the three abandon tests are replaced by two — a recorded defect releases no path, and only the first defect is kept and logged.
- `tests/test_startup_state_gate.py`: the FTX-1-shaped synthetic profile now asserts `binds == []` and a message naming path, template and frame; a new test drives the real `cli/__init__.py: _run` and asserts exit 1 with that message on stderr.
- Two "one field's failure is isolated" tests in the adapter file are deleted (the behaviour they pinned is what this change removes); the repeater-shift isolation test is inverted to per-side defect naming.
- Two fixtures adjusted, not behaviour: `tests/test_ftx1_tuner_route.py` and `tests/contracts/test_tx_observation_conformance.py` each script a wire that answers *every* query with one frame, so unrelated declared reads in the same lane now raise. Both are narrowed to the field they are about.

## Mutations run

| Mutation | Result |
|---|---|
| Defect swallowed — both `if paths: self._raise_declared_defect(...)` lines deleted, skip restored | 103 failed: the whole defect table, both gate tests, the two ATU rows |
| Printability check deleted from `YaesuCatTransport.readline` | 5 failed over `tests/test_yaesu_cat_transport.py` + `tests/test_yaesu_cat_observation_adapter.py` at `b5820d7`: all three printability rows, the high-bit drain row, and `test_a_garbled_frame_on_the_wire_is_noise_not_a_defect` — the garbled frame surfaces as a defect, which is exactly the confusion the check prevents |
| Printability check moved back after `line_bytes.decode("ascii")` | 3 failed over the same two files at `b5820d7`: the `high-bit-set` and `all-bits-set` printability rows and the `high-bit-set` drain row — a byte >= 0x80 raises `UnicodeDecodeError` first and surfaces as `CatTransportError` |
| `_abort_on_startup_defect` made a no-op | 2 failed: both gate tests (the gate waits forever instead of aborting) |
| Behaviour-preserving refactor (`any(b < 0x20 or b > 0x7E …)` → `not all(0x20 <= b <= 0x7E …)`; rename a local in `DeclaredCommandDefect`) | green (the count was measured before `b5820d7` added three cases and is not restated) |

Tree restored after each; `git diff` against the pushed head shows only the intended change.

## Follow-ups (not in this PR)

1. **Runtime critical stop.** After bind, `YaesuCatPoller._run_poll_cycle`'s `except Exception` catches the defect, logs a warning and reconnects forever. R48's runtime half needs new plumbing to stop the server; no existing shutdown-on-defect path exists to reuse.
2. **Icom CI-V NAK.** The CI-V acquisition path is fire-and-forget, so a NAK to a declared read is not attributed to that read at all. Needs its own exploration before it can be classified.
3. **The PTT `read-error` path.** `YaesuCatRadio.read_transmit_state` converts `CatCommandRejected` / `CatParseError` into `TxStateReading(failure="read-error")` before the adapter sees them, so on a real radio a refused or wrong-shape PTT read is still a skip. The adapter's own `except` clause for those types is now a defect (which is what the `ptt` table row exercises), but making the `read-error` *value* a defect changes `read_transmit_state`'s contract and reddens `tests/test_yaesu_cat_poller.py::test_canonical_ptt_requires_qualified_readback[read-error]` and the tx-observation conformance rows — outside this change's scope. Enumerated over every `_safe_read` / `_log_field_skip` call site in `observations.py`, measured at `b5820d7`: 48 `_safe_read` call sites — every one in `src/` — of which 47 pass declared `paths=` and one does not (`tx_target.freq`); and 5 `_log_field_skip` call sites (3 metadata skips inside `_normalize_power_level`, 2 inside `_safe_read` itself).

## ATU (`AC`) mapping — settled

`YaesuCatRadio._read_atu_route` raises `ValueError("Unsupported ATU response: …")` for an `AC` answer whose src/type/state triple is outside its mapping (`{"0": 0, "1": 1, "3": 2}`). Under this change such an answer at startup blocks the bind instead of omitting the field.

The `AC102` inversion is right. `rigs/ftx1.toml`, at the `get_tuner` entry and citing "FTX-1 CAT Operation Reference 2508-C, AC table, printed page 6", already records the ATU domain as `p3=OFF0/ON1/START3 (2 reserved)`. State 2 is not a defined ATU state, so rejecting it is the mapping working rather than a gap in it.

The documented case the mapping does not cover is P2. The same comment records `p2=ATU0/ATAS2`, so a P2=2 answer such as `AC121` is a documented shape, not corruption — and `_read_atu_route` rejects any `typ != "0"` (pinned by the `AC121` rows in `tests/test_ftx1_tuner_route.py: test_unknown_route_or_state_never_writes` and `test_real_ac_observation_normalizes_or_faults_on_unknown`). An FTX-1 with ATAS selected would therefore refuse to bind until the mapping covers or carves out P2=2. That is a follow-up, not fixable here: it needs a captured `AC;` answer from a radio with ATAS selected, which no data in this repository supplies.

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)


