### PR TITLE
feat: expose the spectrum's colour roles as one prop shared by the canvas and the DOM overlay

### DIFF
--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -5,6 +5,9 @@
   import DxOverlay from './DxOverlay.svelte';
   import {
     defaultSpectrumOptions,
+    resolveSpectrumColorRoles,
+    spectrumColorRolesToOptions,
+    type SpectrumColorRoles,
     type SpectrumOptions,
   } from '../../lib/renderers/spectrum-renderer';
   import {
@@ -61,12 +64,20 @@
   // layouts that have no `applyModeDefault()` driver for the shared
   // tuning-step store. `MobileRadioLayout` passes `true`; `RadioLayout`
   // omits it (defaults `false`, toggle shown) because it owns the driver.
+  //
+  // `colorRoles` lets a host restyle the panorama without editing this shared
+  // component. It is resolved over the defaults once, and the one resolved
+  // record feeds both the canvas renderer options and the CSS custom
+  // properties the DOM overlay below reads.
   let { hideSourceControls = false, hideScopeControls = false, hideAutoStepToggle = false, scopeControls,
-    scopeProjection, scopeDemanded = true, onScopeDemandChange }: {
+    scopeProjection, scopeDemanded = true, onScopeDemandChange, colorRoles }: {
     hideSourceControls?: boolean; hideScopeControls?: boolean; hideAutoStepToggle?: boolean; scopeControls?: Snippet;
     scopeProjection?: ScopeDisplayProjection | null;
     scopeDemanded?: boolean; onScopeDemandChange?: (enabled: boolean) => void;
+    colorRoles?: Partial<SpectrumColorRoles>;
   } = $props();
+
+  let resolvedColorRoles = $derived(resolveSpectrumColorRoles(colorRoles));
 
   const vfoHandlers = getVfoHandlers();
   const filterHandlers = getFilterHandlers();
@@ -217,6 +228,7 @@
 
   let spectrumOptions = $derived<SpectrumOptions>({
     ...defaultSpectrumOptions,
+    ...spectrumColorRolesToOptions(resolvedColorRoles),
     spanHz: audioFft || tuneVisible ? spanHz : 0,
     showRfOverlays: !audioFft,
     centerHz,
@@ -615,7 +627,17 @@
 -->
 {#key `${audioFft}:${managed}`}
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-<div class="spectrum-panel" class:audio-fft={audioFft} class:fullscreen data-waterfall tabindex="-1" onwheel={handleWheel}>
+<div
+  class="spectrum-panel"
+  class:audio-fft={audioFft}
+  class:fullscreen
+  data-waterfall
+  tabindex="-1"
+  onwheel={handleWheel}
+  style:--scope-tune-line={resolvedColorRoles.tuneLine}
+  style:--scope-passband-fill={resolvedColorRoles.passbandFill}
+  style:--scope-passband-edge={resolvedColorRoles.passbandEdge}
+>
   {#if audioFft}
     <div class="audio-source-label">
       <span>Audio FFT · AF</span>
@@ -818,7 +840,7 @@
     top: 0;
     bottom: 0;
     width: 1px;
-    background: rgba(239, 68, 68, 0.75);
+    background: var(--scope-tune-line, rgba(239, 68, 68, 0.75));
     pointer-events: none;
     z-index: 5;
     transform: translateX(-0.5px);
@@ -828,9 +850,9 @@
     position: absolute;
     top: 0;
     bottom: 0;
-    background: rgba(59, 130, 246, 0.15);
-    border-left: 1px dashed rgba(59, 130, 246, 0.4);
-    border-right: 1px dashed rgba(59, 130, 246, 0.4);
+    background: var(--scope-passband-fill, rgba(59, 130, 246, 0.15));
+    border-left: 1px dashed var(--scope-passband-edge, rgba(59, 130, 246, 0.4));
+    border-right: 1px dashed var(--scope-passband-edge, rgba(59, 130, 246, 0.4));
     pointer-events: none;
     z-index: 4;
   }

--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -65,8 +65,7 @@
   // tuning-step store. `MobileRadioLayout` passes `true`; `RadioLayout`
   // omits it (defaults `false`, toggle shown) because it owns the driver.
   //
-  // `colorRoles` lets a host restyle the panorama without editing this shared
-  // component. It is resolved over the defaults once, and the one resolved
+  // `colorRoles` is resolved over the defaults once, and the one resolved
   // record feeds both the canvas renderer options and the CSS custom
   // properties the DOM overlay below reads.
   let { hideSourceControls = false, hideScopeControls = false, hideAutoStepToggle = false, scopeControls,

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -374,6 +374,10 @@ vi.mock('$lib/runtime/props/panel-props', async (importOriginal) => ({
 import { WaterfallRenderer } from '$lib/renderers/waterfall-renderer';
 import SpectrumPanel from '../SpectrumPanel.svelte';
 import spectrumPanelSource from '../SpectrumPanel.svelte?raw';
+import {
+  defaultSpectrumColorRoles,
+  spectrumColorRolesToOptions,
+} from '$lib/renderers/spectrum-renderer';
 import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
 const authorityPluginSource = readFileSync(
   resolve(process.cwd(), 'scripts/radio-authority-eslint-plugin.mjs'),
@@ -1572,5 +1576,72 @@ describe('managed scope projection (MOR-2367)', () => {
     setFilterWidthLifecycle({ outcome: { phase } }); flushSync();
     expect(target.querySelector<HTMLElement>('.passband-overlay')!.style.width).toBe('24%');
     expect(input.passband).toEqual(projection().passband);
+  });
+});
+
+describe('SpectrumPanel colour roles', () => {
+  const distinct = {
+    trace: '#010101',
+    traceFill: { top: '#020202', bottom: '#030303' },
+    grid: '#040404',
+    axisText: '#050505',
+    tuneLine: '#060606',
+    passbandFill: '#070707',
+    passbandEdge: '#080808',
+  };
+
+  it('sends every role to the renderer options', async () => {
+    mountPanel({ colorRoles: distinct });
+    emitFrame();
+    await vi.waitFor(() => expect(spectrumRendererHarness.render).toHaveBeenCalled());
+    expect(spectrumRendererHarness.lastOptions).toMatchObject({
+      lineColor: '#010101', fillColor: '#020202', fillColorBottom: '#030303',
+      gridColor: '#040404', textColor: '#050505', tuneLineColor: '#060606',
+      passbandFillColor: '#070707', passbandEdgeColor: '#080808',
+    });
+  });
+
+  it('publishes the DOM-overlay roles as custom properties the overlay styles read', () => {
+    const target = mountPanel({ colorRoles: distinct });
+    emitFrame();
+    const panel = target.querySelector<HTMLElement>('.spectrum-panel')!;
+    expect(panel.style.getPropertyValue('--scope-tune-line')).toBe('#060606');
+    expect(panel.style.getPropertyValue('--scope-passband-fill')).toBe('#070707');
+    expect(panel.style.getPropertyValue('--scope-passband-edge')).toBe('#080808');
+    expect(target.querySelector('.tune-line')).not.toBeNull();
+    expect(target.querySelector('.passband-overlay')).not.toBeNull();
+    // The overlay elements resolve their paint through those same properties,
+    // so the canvas and the DOM twin cannot be set apart.
+    expect(spectrumPanelSource).toMatch(
+      /\.tune-line\s*\{[^}]*background:\s*var\(--scope-tune-line,\s*rgba\(239, 68, 68, 0\.75\)\)/,
+    );
+    expect(spectrumPanelSource).toMatch(
+      /\.passband-overlay\s*\{[^}]*background:\s*var\(--scope-passband-fill,\s*rgba\(59, 130, 246, 0\.15\)\)/,
+    );
+    expect(spectrumPanelSource).toMatch(
+      /\.passband-overlay\s*\{[^}]*border-left:\s*1px dashed var\(--scope-passband-edge,\s*rgba\(59, 130, 246, 0\.4\)\)/,
+    );
+    expect(spectrumPanelSource).toMatch(
+      /\.passband-overlay\s*\{[^}]*border-right:\s*1px dashed var\(--scope-passband-edge,\s*rgba\(59, 130, 246, 0\.4\)\)/,
+    );
+  });
+
+  it('leaves an omitted prop on the renderer defaults', async () => {
+    mountPanel();
+    emitFrame();
+    await vi.waitFor(() => expect(spectrumRendererHarness.render).toHaveBeenCalled());
+    expect(spectrumRendererHarness.lastOptions).toMatchObject(
+      spectrumColorRolesToOptions(defaultSpectrumColorRoles),
+    );
+  });
+
+  it('takes the unlisted roles from the defaults when only one is overridden', async () => {
+    mountPanel({ colorRoles: { tuneLine: '#0a0a0a' } });
+    emitFrame();
+    await vi.waitFor(() => expect(spectrumRendererHarness.render).toHaveBeenCalled());
+    expect(spectrumRendererHarness.lastOptions).toMatchObject({
+      ...spectrumColorRolesToOptions(defaultSpectrumColorRoles),
+      tuneLineColor: '#0a0a0a',
+    });
   });
 });

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -1610,8 +1610,6 @@ describe('SpectrumPanel colour roles', () => {
     expect(panel.style.getPropertyValue('--scope-passband-edge')).toBe('#080808');
     expect(target.querySelector('.tune-line')).not.toBeNull();
     expect(target.querySelector('.passband-overlay')).not.toBeNull();
-    // The overlay elements resolve their paint through those same properties,
-    // so the canvas and the DOM twin cannot be set apart.
     expect(spectrumPanelSource).toMatch(
       /\.tune-line\s*\{[^}]*background:\s*var\(--scope-tune-line,\s*rgba\(239, 68, 68, 0\.75\)\)/,
     );
@@ -1633,6 +1631,21 @@ describe('SpectrumPanel colour roles', () => {
     expect(spectrumRendererHarness.lastOptions).toMatchObject(
       spectrumColorRolesToOptions(defaultSpectrumColorRoles),
     );
+  });
+
+  it('keeps both paths on the default when a role is passed as undefined', async () => {
+    const target = mountPanel({
+      colorRoles: { tuneLine: undefined, traceFill: { top: undefined, bottom: undefined } },
+    });
+    emitFrame();
+    await vi.waitFor(() => expect(spectrumRendererHarness.render).toHaveBeenCalled());
+    expect(spectrumRendererHarness.lastOptions).toMatchObject({
+      tuneLineColor: defaultSpectrumColorRoles.tuneLine,
+      fillColor: defaultSpectrumColorRoles.traceFill.top,
+      fillColorBottom: defaultSpectrumColorRoles.traceFill.bottom,
+    });
+    const panel = target.querySelector<HTMLElement>('.spectrum-panel')!;
+    expect(panel.style.getPropertyValue('--scope-tune-line')).toBe(defaultSpectrumColorRoles.tuneLine);
   });
 
   it('takes the unlisted roles from the defaults when only one is overridden', async () => {

--- a/frontend/src/lib/renderers/__tests__/spectrum-renderer.test.ts
+++ b/frontend/src/lib/renderers/__tests__/spectrum-renderer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   renderSpectrum, SpectrumRenderer, defaultSpectrumOptions, spectrumDisplayAmplitude,
   defaultSpectrumColorRoles, resolveSpectrumColorRoles, spectrumColorRolesToOptions,
-  type SpectrumOptions,
+  type SpectrumColorRoles, type SpectrumOptions,
 } from '../spectrum-renderer';
 
 function createMockCtx() {
@@ -285,6 +285,22 @@ describe('spectrum colour roles', () => {
       passbandEdge: PREVIOUS_LITERALS.passbandEdge,
     });
     expect(resolveSpectrumColorRoles()).toEqual(defaultSpectrumColorRoles);
+  });
+
+  it('resolves an undefined-valued override to the default, nested fill included', () => {
+    // `Partial<SpectrumColorRoles>` admits an explicit `undefined` for every
+    // top-level role; the nested cast stands for a host record that carries
+    // one under `traceFill` too.
+    const overrides: Partial<SpectrumColorRoles> = {
+      tuneLine: undefined,
+      traceFill: { top: undefined, bottom: undefined } as unknown as SpectrumColorRoles['traceFill'],
+    };
+    expect(resolveSpectrumColorRoles(overrides)).toEqual(defaultSpectrumColorRoles);
+    expect(spectrumColorRolesToOptions(resolveSpectrumColorRoles(overrides))).toMatchObject({
+      tuneLineColor: PREVIOUS_LITERALS.tuneLine,
+      fillColor: PREVIOUS_LITERALS.fillTop,
+      fillColorBottom: PREVIOUS_LITERALS.fillBottom,
+    });
   });
 
   it('carries the resolved roles into the option fields of the same names', () => {

--- a/frontend/src/lib/renderers/__tests__/spectrum-renderer.test.ts
+++ b/frontend/src/lib/renderers/__tests__/spectrum-renderer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   renderSpectrum, SpectrumRenderer, defaultSpectrumOptions, spectrumDisplayAmplitude,
+  defaultSpectrumColorRoles, resolveSpectrumColorRoles, spectrumColorRolesToOptions,
   type SpectrumOptions,
 } from '../spectrum-renderer';
 
@@ -226,5 +227,128 @@ describe('spectrumDisplayAmplitude', () => {
   it('keeps the existing reference adjustment in the shared transfer', () => {
     expect(spectrumDisplayAmplitude(40, 30)).toBeCloseTo(Math.sqrt(0.75), 8);
     expect(spectrumDisplayAmplitude(40, -30)).toBe(0.5);
+  });
+});
+
+// ── Colour roles ────────────────────────────────────────────────────────────
+//
+// PREVIOUS_LITERALS is transcribed from
+// `git show 8ff079b1c:frontend/src/lib/renderers/spectrum-renderer.ts`
+// (lines 28-31, 140, 180, 184, 198) — the strings this module painted with
+// before colour roles existed. It is deliberately a duplicate of the
+// production defaults so that changing a default without changing this
+// record turns the first test below red.
+const PREVIOUS_LITERALS = {
+  line: 'rgba(210,220,230,0.85)',
+  fillTop: 'rgba(30,58,138,0.30)',
+  fillBottom: 'rgba(30,58,138,0.02)',
+  grid: 'rgba(255,255,255,0.15)',
+  text: 'rgba(180,200,220,0.6)',
+  tuneLine: 'rgba(239,68,68,0.75)',
+  passbandFill: 'rgba(59,130,246,0.15)',
+  passbandEdge: 'rgba(59,130,246,0.4)',
+} as const;
+
+/** Records every paint-affecting assignment in the order the renderer makes it. */
+function createPaintCtx() {
+  const paint = {
+    fillStyle: [] as string[],
+    strokeStyle: [] as string[],
+    gradientStops: [] as [number, string][],
+  };
+  const noop = () => {};
+  const gradient = { addColorStop: (o: number, c: string) => paint.gradientStops.push([o, c]) };
+  const ctx = {
+    clearRect: noop, closePath: noop, stroke: noop, fill: noop, beginPath: noop,
+    fillRect: noop, fillText: noop, moveTo: noop, lineTo: noop, setLineDash: noop,
+    createLinearGradient: () => gradient,
+    set fillStyle(v: unknown) { if (typeof v === 'string') paint.fillStyle.push(v); },
+    set strokeStyle(v: unknown) { if (typeof v === 'string') paint.strokeStyle.push(v); },
+    set lineWidth(_: unknown) {}, set font(_: unknown) {}, set textAlign(_: unknown) {},
+  } as unknown as CanvasRenderingContext2D;
+  return { ctx, paint };
+}
+
+const overlayOpts = (o: Partial<SpectrumOptions> = {}): SpectrumOptions => opts({
+  spanHz: 1e6, centerHz: 14_500_000, tuneHz: 14_500_000, passbandHz: 2_400, mode: 'USB', ...o,
+});
+
+describe('spectrum colour roles', () => {
+  it('resolves to the literals this renderer painted with before roles existed', () => {
+    expect(resolveSpectrumColorRoles()).toEqual({
+      trace: PREVIOUS_LITERALS.line,
+      traceFill: { top: PREVIOUS_LITERALS.fillTop, bottom: PREVIOUS_LITERALS.fillBottom },
+      grid: PREVIOUS_LITERALS.grid,
+      axisText: PREVIOUS_LITERALS.text,
+      tuneLine: PREVIOUS_LITERALS.tuneLine,
+      passbandFill: PREVIOUS_LITERALS.passbandFill,
+      passbandEdge: PREVIOUS_LITERALS.passbandEdge,
+    });
+    expect(resolveSpectrumColorRoles()).toEqual(defaultSpectrumColorRoles);
+  });
+
+  it('carries the resolved roles into the option fields of the same names', () => {
+    const roles = resolveSpectrumColorRoles({ trace: '#111111', traceFill: { top: '#222222', bottom: '#333333' } });
+    expect(spectrumColorRolesToOptions(roles)).toEqual({
+      lineColor: '#111111',
+      fillColor: '#222222',
+      fillColorBottom: '#333333',
+      gridColor: PREVIOUS_LITERALS.grid,
+      textColor: PREVIOUS_LITERALS.text,
+      tuneLineColor: PREVIOUS_LITERALS.tuneLine,
+      passbandFillColor: PREVIOUS_LITERALS.passbandFill,
+      passbandEdgeColor: PREVIOUS_LITERALS.passbandEdge,
+    });
+  });
+
+  it('keeps the default option colours equal to the previous literals', () => {
+    expect(defaultSpectrumOptions).toMatchObject({
+      lineColor: PREVIOUS_LITERALS.line,
+      fillColor: PREVIOUS_LITERALS.fillTop,
+      fillColorBottom: PREVIOUS_LITERALS.fillBottom,
+      gridColor: PREVIOUS_LITERALS.grid,
+      textColor: PREVIOUS_LITERALS.text,
+      tuneLineColor: PREVIOUS_LITERALS.tuneLine,
+      passbandFillColor: PREVIOUS_LITERALS.passbandFill,
+      passbandEdgeColor: PREVIOUS_LITERALS.passbandEdge,
+    });
+  });
+
+  it('paints the default overlay pass with the previous tune-line and passband literals', () => {
+    const { ctx, paint } = createPaintCtx();
+    renderSpectrum(ctx, data50(), 800, 400, overlayOpts());
+    expect(paint.gradientStops).toEqual([[0, PREVIOUS_LITERALS.fillTop], [1, PREVIOUS_LITERALS.fillBottom]]);
+    expect(paint.fillStyle).toEqual([PREVIOUS_LITERALS.text, PREVIOUS_LITERALS.passbandFill]);
+    expect(paint.strokeStyle).toEqual([
+      PREVIOUS_LITERALS.grid,
+      PREVIOUS_LITERALS.line,
+      PREVIOUS_LITERALS.passbandEdge,
+      PREVIOUS_LITERALS.tuneLine,
+    ]);
+  });
+
+  it('paints the overlay pass with the supplied colours instead of the previous literals', () => {
+    const { ctx, paint } = createPaintCtx();
+    renderSpectrum(ctx, data50(), 800, 400, overlayOpts({
+      ...spectrumColorRolesToOptions(resolveSpectrumColorRoles({
+        trace: '#010101', traceFill: { top: '#020202', bottom: '#030303' }, grid: '#040404',
+        axisText: '#050505', tuneLine: '#060606', passbandFill: '#070707', passbandEdge: '#080808',
+      })),
+    }));
+    expect(paint.gradientStops).toEqual([[0, '#020202'], [1, '#030303']]);
+    expect(paint.fillStyle).toEqual(['#050505', '#070707']);
+    expect(paint.strokeStyle).toEqual(['#040404', '#010101', '#080808', '#060606']);
+    for (const literal of Object.values(PREVIOUS_LITERALS)) {
+      expect([...paint.fillStyle, ...paint.strokeStyle]).not.toContain(literal);
+    }
+  });
+
+  it('rebuilds the cached gradient when only the bottom stop changes', () => {
+    const cache = { current: null } as Parameters<typeof renderSpectrum>[5];
+    const first = createPaintCtx();
+    renderSpectrum(first.ctx, data50(), 800, 400, opts(), cache);
+    const second = createPaintCtx();
+    renderSpectrum(second.ctx, data50(), 800, 400, opts({ fillColorBottom: '#090909' }), cache);
+    expect(second.paint.gradientStops).toEqual([[0, PREVIOUS_LITERALS.fillTop], [1, '#090909']]);
   });
 });

--- a/frontend/src/lib/renderers/spectrum-renderer.ts
+++ b/frontend/src/lib/renderers/spectrum-renderer.ts
@@ -31,10 +31,28 @@ export const defaultSpectrumColorRoles: SpectrumColorRoles = {
   passbandEdge: 'rgba(59,130,246,0.4)',
 };
 
+/**
+ * Fills in every role a host left out. An override whose value is `undefined`
+ * — including one under `traceFill` — resolves to the default, pinned by
+ * `resolves an undefined-valued override to the default, nested fill included`.
+ */
 export function resolveSpectrumColorRoles(
   overrides?: Partial<SpectrumColorRoles>,
 ): SpectrumColorRoles {
-  return { ...defaultSpectrumColorRoles, ...overrides };
+  const fallback = defaultSpectrumColorRoles;
+  const fill = overrides?.traceFill as Partial<SpectrumColorRoles['traceFill']> | undefined;
+  return {
+    trace: overrides?.trace ?? fallback.trace,
+    traceFill: {
+      top: fill?.top ?? fallback.traceFill.top,
+      bottom: fill?.bottom ?? fallback.traceFill.bottom,
+    },
+    grid: overrides?.grid ?? fallback.grid,
+    axisText: overrides?.axisText ?? fallback.axisText,
+    tuneLine: overrides?.tuneLine ?? fallback.tuneLine,
+    passbandFill: overrides?.passbandFill ?? fallback.passbandFill,
+    passbandEdge: overrides?.passbandEdge ?? fallback.passbandEdge,
+  };
 }
 
 export function spectrumColorRolesToOptions(roles: SpectrumColorRoles) {

--- a/frontend/src/lib/renderers/spectrum-renderer.ts
+++ b/frontend/src/lib/renderers/spectrum-renderer.ts
@@ -4,13 +4,63 @@
 
 import { getPassbandGeometry } from '../../components/spectrum/passband-geometry';
 
+/**
+ * The colour vocabulary a host may restyle. `renderSpectrum` paints every
+ * role on the canvas; `tuneLine`, `passbandFill` and `passbandEdge` are also
+ * painted by SpectrumPanel's DOM overlay over the waterfall, which reads them
+ * from the same resolved record through CSS custom properties.
+ */
+export interface SpectrumColorRoles {
+  trace: string;
+  /** Vertical gradient under the trace: `top` at y=0, `bottom` at y=height. */
+  traceFill: { top: string; bottom: string };
+  grid: string;
+  axisText: string;
+  tuneLine: string;
+  passbandFill: string;
+  passbandEdge: string;
+}
+
+export const defaultSpectrumColorRoles: SpectrumColorRoles = {
+  trace: 'rgba(210,220,230,0.85)',
+  traceFill: { top: 'rgba(30,58,138,0.30)', bottom: 'rgba(30,58,138,0.02)' },
+  grid: 'rgba(255,255,255,0.15)',
+  axisText: 'rgba(180,200,220,0.6)',
+  tuneLine: 'rgba(239,68,68,0.75)',
+  passbandFill: 'rgba(59,130,246,0.15)',
+  passbandEdge: 'rgba(59,130,246,0.4)',
+};
+
+export function resolveSpectrumColorRoles(
+  overrides?: Partial<SpectrumColorRoles>,
+): SpectrumColorRoles {
+  return { ...defaultSpectrumColorRoles, ...overrides };
+}
+
+export function spectrumColorRolesToOptions(roles: SpectrumColorRoles) {
+  return {
+    lineColor: roles.trace,
+    fillColor: roles.traceFill.top,
+    fillColorBottom: roles.traceFill.bottom,
+    gridColor: roles.grid,
+    textColor: roles.axisText,
+    tuneLineColor: roles.tuneLine,
+    passbandFillColor: roles.passbandFill,
+    passbandEdgeColor: roles.passbandEdge,
+  };
+}
+
 export interface SpectrumOptions {
   showRfOverlays?: boolean;
   bgColor: string;
   lineColor: string;
   fillColor: string;
+  fillColorBottom: string;
   gridColor: string;
   textColor: string;
+  tuneLineColor: string;
+  passbandFillColor: string;
+  passbandEdgeColor: string;
   refLevel: number;   // dB reference (reserved for future dB axis labels)
   spanHz: number;     // frequency span in Hz
   centerHz: number;   // center frequency in Hz
@@ -25,10 +75,7 @@ export interface SpectrumOptions {
 
 export const defaultSpectrumOptions: SpectrumOptions = {
   bgColor: 'transparent',
-  lineColor: 'rgba(210,220,230,0.85)',
-  fillColor: 'rgba(30,58,138,0.30)',
-  gridColor: 'rgba(255,255,255,0.15)',
-  textColor: 'rgba(180,200,220,0.6)',
+  ...spectrumColorRolesToOptions(defaultSpectrumColorRoles),
   refLevel: 0,
   spanHz: 0,
   centerHz: 0,
@@ -52,7 +99,9 @@ export function spectrumDisplayAmplitude(sample: number, refLevel: number): numb
   return Math.sqrt(adjusted / SPECTRUM_AMPLITUDE_MAX);
 }
 
-type GradCache = { grad: CanvasGradient; height: number; fillColor: string };
+type GradCache = {
+  grad: CanvasGradient; height: number; fillColor: string; fillColorBottom: string;
+};
 
 /**
  * Render a spectrum line chart onto an existing 2D canvas context.
@@ -78,7 +127,7 @@ export function renderSpectrum(
   const n = data.length;
   if (!n || width <= 0 || height <= 0) return;
 
-  const { bgColor, lineColor, fillColor, gridColor, textColor, spanHz, centerHz, lineWidth, tuneHz, passbandHz, passbandShiftHz } =
+  const { bgColor, lineColor, fillColor, fillColorBottom, gridColor, textColor, spanHz, centerHz, lineWidth, tuneHz, passbandHz, passbandShiftHz } =
     options;
 
   ctx.clearRect(0, 0, width, height);
@@ -132,13 +181,14 @@ export function renderSpectrum(
     yPoints[x] = height * (1 - amplitude);
   }
 
-  // Filled area under spectrum (gradient cached per-instance; recreated only when height or fillColor changes)
+  // Filled area under spectrum (gradient cached per-instance; recreated only when height or either stop changes)
   const cache = gradCache ?? { current: null };
-  if (!cache.current || cache.current.height !== height || cache.current.fillColor !== fillColor) {
+  if (!cache.current || cache.current.height !== height
+    || cache.current.fillColor !== fillColor || cache.current.fillColorBottom !== fillColorBottom) {
     const grad = ctx.createLinearGradient(0, 0, 0, height);
     grad.addColorStop(0, fillColor);
-    grad.addColorStop(1, 'rgba(30,58,138,0.02)');
-    cache.current = { grad, height, fillColor };
+    grad.addColorStop(1, fillColorBottom);
+    cache.current = { grad, height, fillColor, fillColorBottom };
   }
   ctx.fillStyle = cache.current.grad;
   ctx.beginPath();
@@ -177,11 +227,11 @@ export function renderSpectrum(
         const pbLeft = geometry.leftPx;
         const pbRight = geometry.rightPx;
 
-        ctx.fillStyle = 'rgba(59,130,246,0.15)';
+        ctx.fillStyle = options.passbandFillColor;
         ctx.fillRect(pbLeft, 0, pbRight - pbLeft, height);
 
         // Passband edges
-        ctx.strokeStyle = 'rgba(59,130,246,0.4)';
+        ctx.strokeStyle = options.passbandEdgeColor;
         ctx.lineWidth = 1;
         ctx.setLineDash([3, 3]);
         ctx.beginPath();
@@ -195,7 +245,7 @@ export function renderSpectrum(
     }
 
     // Center frequency line (carrier)
-    ctx.strokeStyle = 'rgba(239,68,68,0.75)';
+    ctx.strokeStyle = options.tuneLineColor;
     ctx.lineWidth = 1;
     ctx.beginPath();
     ctx.moveTo(tunePx, 0);


### PR DESCRIPTION
## What this does

Every paint colour in the shared spectrum was a literal inside the shared
components, so a face could not restyle the panorama without editing them.
This adds one path.

Seven colour roles become a typed record, `SpectrumColorRoles`, with defaults
equal to the literals in force before this change. `SpectrumPanel` takes an
optional `colorRoles?: Partial<SpectrumColorRoles>`, resolves it over those
defaults **once**, and feeds the single resolved record to both consumers:

- the canvas, via `spectrumColorRolesToOptions(resolved)` spread into
  `spectrumOptions`;
- the DOM overlay over the waterfall, via CSS custom properties set on the
  panel root (`--scope-tune-line`, `--scope-passband-fill`,
  `--scope-passband-edge`), which `.tune-line` and `.passband-overlay` read
  through `var(--scope-…, <the literal that was there before>)`.

There is no second settable property: the canvas and its DOM twin read the
same resolved role.

## The seven roles

| Role | Canvas | DOM overlay |
|---|---|---|
| `trace` | `SpectrumOptions.lineColor` | — |
| `traceFill.top` | `SpectrumOptions.fillColor` (gradient stop 0) | — |
| `traceFill.bottom` | `SpectrumOptions.fillColorBottom` (gradient stop 1, new — was an inline literal) | — |
| `grid` | `SpectrumOptions.gridColor` | — |
| `axisText` | `SpectrumOptions.textColor` | — |
| `tuneLine` | `SpectrumOptions.tuneLineColor` (new — was inline) | `--scope-tune-line` → `.tune-line` background |
| `passbandFill` | `SpectrumOptions.passbandFillColor` (new — was inline) | `--scope-passband-fill` → `.passband-overlay` background |
| `passbandEdge` | `SpectrumOptions.passbandEdgeColor` (new — was inline) | `--scope-passband-edge` → `.passband-overlay` dashed borders |

No existing option field is renamed; the new fields are additions. Only the
three roles the DOM overlay actually paints are published as CSS custom
properties — publishing the other four would create custom properties nothing
reads.

`renderSpectrum` now reads the tune-line, passband-fill, passband-edge and
gradient-bottom colours from its options. The per-instance gradient cache key
gained the bottom stop, so changing only that stop rebuilds the gradient.

## How byte-identical default rendering was established

**Proof (a) — committed test.** `spectrum-renderer.test.ts` carries a
`PREVIOUS_LITERALS` record transcribed from
`git show 8ff079b1c:frontend/src/lib/renderers/spectrum-renderer.ts`
(the eight literals at lines 28-31, 140, 180, 184, 198), not from the new
code. Five tests assert against it: the resolved defaults, the option
defaults, the role→option mapping, the explicit-undefined override resolving
to those same defaults, and the full ordered paint program
`renderSpectrum` emits with the defaults (gradient stops, `fillStyle` and
`strokeStyle` in order).

**Proof (b) — old-vs-new paint program, run once, not committed.** The
`origin/main` copy of `spectrum-renderer.ts` was written to a scratch module
(`git show origin/main:frontend/src/lib/renderers/spectrum-renderer.ts`), and
a throwaway vitest ran both versions against one recording context over six
option shapes (bare defaults; axis + overlays; fixed scope; LSB with a
passband shift and a non-zero ref level; painted background; overlays off),
comparing the entire ordered call log — every `moveTo`/`lineTo`/`fillRect`/
`fillText` with its arguments, plus every colour assignment and gradient stop.
All six matched exactly (`6 passed`), each log over 100 entries. The
comparison is not vacuous: changing one default's alpha from `0.75` to `0.76`
turned four of the six red on the tune-line stroke. Both scratch files were
deleted; `git status` is clean.

**Proof (c) — the Playwright visual suite: ran, and reports nothing about this
change.** `npm run test:e2e:visual` was run on the untouched tree at
`8ff079b1c` and again at this head. Both runs: **25 failed, 11 passed, 46.5s**
— identical counts, unchanged by this PR, and **no baseline was regenerated**
(the `manifest.json` its teardown rewrites was reverted both times).

Two separate facts behind that, both established rather than assumed:

1. The approved-baselines harness does not render `SpectrumPanel` at all. It
   mounts `ReferenceLayout.svelte`, not `RadioLayout` — and says so in its own
   words: `fixtures/ReferenceLayout.svelte` and `fixtures/assertions.ts` both
   record that the cockpit's scope area is "the legacy `SpectrumPanel`, out of
   scope for this grammar". `grep -rn 'RadioLayout\|SpectrumPanel' fixtures/`
   returns only prose saying so. So no visual baseline can move when the
   spectrum's colours change, in either direction.
2. Those 25 were already red on this host before any edit. The committed
   baselines are pinned to Linux CI (see the "Platform" section of
   `fixtures/approved-baselines/README.md`); this run was on macOS. The suite
   is not part of `quick.yml`.

I could not establish byte-identity through the visual suite, and do not claim
it. Proofs (a) and (b) are what the identity claim rests on.

## Tests

Added to two existing files (no new test file):

- `spectrum-renderer.test.ts` — resolved defaults equal the pre-change
  literals (all seven roles, both gradient stops); the role→option mapping;
  `defaultSpectrumOptions`' colour fields; the ordered default paint program;
  supplied colours replacing every literal; the gradient cache rebuilding when
  only the bottom stop changes.
- `SpectrumPanel.component.test.ts` — a `colorRoles` value with a distinct
  colour per role reaches the renderer options **and** the three CSS custom
  properties on the panel root, with the overlay rules shown to consume those
  properties; an omitted prop leaves the renderer on the defaults; a
  single-role override leaves the other six on the defaults.
- Both files also pin the explicit-`undefined` case: a role passed as
  `undefined` (nested `traceFill` stops included) resolves to the default on
  the renderer options and on `--scope-tune-line`.

### Mutations run (each reverted before the next)

| Mutation | Result |
|---|---|
| `defaultSpectrumColorRoles.tuneLine` alpha `0.75` → `0.76` | 4 killed: defaults, mapping, option defaults, default paint program |
| `var(--scope-tune-line, …)` removed from `.tune-line` | 1 killed: the dual-path test |
| `renderSpectrum` reverted to the inline tune-line and passband-fill literals | 1 killed: "paints the overlay pass with the supplied colours" |
| the roles spread removed from the panel's `spectrumOptions` | 2 killed: "sends every role to the renderer options", single-role override |
| behaviour-preserving refactor (destructure `traceFill` before the mapping) | stayed green, 144 passed at 3da4c471 |
| `resolveSpectrumColorRoles` reverted to `{ ...defaults, ...overrides }` | 2 killed: the two explicit-`undefined` tests |

### Gates

- `npx vitest run` (whole frontend suite) at `677ee820`: **468 files, 11497
  tests, 0 failures**
- `npx vitest run` on the two touched files at `3da4c471e`: **144 passed**
- `npm run lint` — clean; `npm run lint:boundaries` — clean
- `npm run check` (svelte-check + two tsc projects): **4841 files, 0 errors, 0 warnings**
- internal-identifier self-check over `git diff origin/main...HEAD` — empty

`4 files, 333+/20- = 353 changed lines at 3da4c471e` — inside the soft
threshold (6 files / 600 lines). Re-derived with `git diff --numstat
origin/main...HEAD` at that head.

## Out of scope

- The waterfall's `COLOR_SCHEMES` presets (`classic`/`thermal`/`grayscale`) —
  operator-chosen, untouched.
- `SpectrumToolbar` chrome — untouched.
- Every consumer: no caller passes `colorRoles`, so every existing mount keeps
  the defaults.
- `.passband-resize-zone` and the panel's other chrome are not among the seven
  roles and were not changed.
- The peak-hold fill: `SpectrumRenderer._drawPeakHold` paints it from the
  literal `rgba(200, 200, 200, 0.25)`, which no role reaches, and it is on by
  default (`enablePeakHold = $state(true)` in `SpectrumPanel`,
  `peakHoldEnabled = true` in the renderer).
- The DOM axis labels: `.freq-axis .tick` and `.db-scale .tick` take their
  colour from `var(--text-muted)`, which no role reaches either.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)


