### PR TITLE
feat: credit an acquisition request only from an observation after its current dispatch

### DIFF
--- a/src/rigplane/core/acquisition_drain.py
+++ b/src/rigplane/core/acquisition_drain.py
@@ -358,6 +358,10 @@ class AcquisitionDrain:
             newly_sent = tuple(result.sent_paths)
             if newly_sent:
                 self._in_flight[request.id] = (sent_paths.union(newly_sent), now)
+                # The seat-local ledger above only keeps these paths from
+                # being sent again; crediting a returning answer against
+                # this send needs the same fact on the scheduler.
+                scheduler.record_dispatch(request.id, paths=newly_sent, now=now)
                 self._report_sent(
                     request,
                     paths=newly_sent,

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -425,7 +425,7 @@ class AcquisitionScheduler:
         self._deferred: dict[_AcquisitionRequestKey, _PendingEnsureFresh] = {}
         self._cadence_by_key: dict[_AcquisitionRequestKey, _CadenceState] = {}
         self._claims_by_request_id: dict[str, _AcquisitionClaim] = {}
-        # request id -> per-path monotonic time of the send that covered it,
+        # request id -> per-path timestamp of the drain pass that sent it,
         # dropped where the request is removed from ``_requests_by_key``.
         self._dispatch_by_request_id: dict[str, dict[FieldPath, float]] = {}
         self._pending_cadence_by_key: dict[
@@ -522,10 +522,11 @@ class AcquisitionScheduler:
         paths: Iterable[FieldPath],
         now: float,
     ) -> None:
-        """Record that ``paths`` of one request went on the wire at ``now``.
+        """Record that the drain pass timestamped ``now`` sent ``paths``.
 
-        The drain calls this with the paths a send actually covered. Times
-        are per path because a request's paths need not go out in one send.
+        ``now`` is the pass's clock reading, taken before its sends. The
+        drain calls this with the paths a send actually covered. Times are
+        per path because a request's paths need not go out in one send.
         """
 
         dispatched = self._dispatch_by_request_id.setdefault(request_id, {})
@@ -541,7 +542,7 @@ class AcquisitionScheduler:
         """Return whether this observation can answer ``request``'s paths.
 
         False for a request no send has covered, and for one whose covering
-        send is later than the observation. ``request.paths`` is the caller's
+        pass timestamp is later than the observation. ``request.paths`` is the caller's
         matched subset, so paths of the same request that no send covered do
         not count.
         """

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -398,6 +398,7 @@ class AcquisitionScheduler:
         "_cadence_by_key",
         "_claims_by_request_id",
         "_deferred",
+        "_dispatch_by_request_id",
         "_external_cat_owner",
         "_external_cat_paused",
         "_external_cat_reason",
@@ -424,6 +425,9 @@ class AcquisitionScheduler:
         self._deferred: dict[_AcquisitionRequestKey, _PendingEnsureFresh] = {}
         self._cadence_by_key: dict[_AcquisitionRequestKey, _CadenceState] = {}
         self._claims_by_request_id: dict[str, _AcquisitionClaim] = {}
+        # request id -> per-path monotonic time of the send that covered it,
+        # dropped where the request is removed from ``_requests_by_key``.
+        self._dispatch_by_request_id: dict[str, dict[FieldPath, float]] = {}
         self._pending_cadence_by_key: dict[
             _AcquisitionRequestKey,
             _PendingCadenceUpdate,
@@ -510,6 +514,48 @@ class AcquisitionScheduler:
             and existing.provider_generation == provider_generation
         ):
             del self._claims_by_request_id[request_id]
+
+    def record_dispatch(
+        self,
+        request_id: str,
+        *,
+        paths: Iterable[FieldPath],
+        now: float,
+    ) -> None:
+        """Record that ``paths`` of one request went on the wire at ``now``.
+
+        The drain calls this with the paths a send actually covered. Times
+        are per path because a request's paths need not go out in one send.
+        """
+
+        dispatched = self._dispatch_by_request_id.setdefault(request_id, {})
+        for path in paths:
+            dispatched[path] = now
+
+    def may_credit(
+        self,
+        request: AcquisitionRequest,
+        *,
+        observation_timestamp: float,
+    ) -> bool:
+        """Return whether this observation can answer ``request``'s paths.
+
+        False for a request no send has covered, and for one whose covering
+        send is later than the observation. ``request.paths`` is the caller's
+        matched subset, so paths of the same request that no send covered do
+        not count.
+        """
+
+        dispatched = self._dispatch_by_request_id.get(request.id)
+        if dispatched is None:
+            return False
+        return any(
+            path in dispatched and dispatched[path] <= observation_timestamp
+            for path in request.paths
+        )
+
+    def _forget_dispatch(self, request_id: str) -> None:
+        self._dispatch_by_request_id.pop(request_id, None)
 
     def ensure_fresh(
         self,
@@ -1028,6 +1074,7 @@ class AcquisitionScheduler:
             else:
                 del self._requests_by_key[key]
                 self._claims_by_request_id.pop(request.id, None)
+                self._forget_dispatch(request.id)
 
         base_cadence = request.policy.cadence_seconds
         if base_cadence is None:
@@ -1128,6 +1175,7 @@ class AcquisitionScheduler:
             else:
                 del self._requests_by_key[key]
                 self._claims_by_request_id.pop(request.id, None)
+                self._forget_dispatch(request.id)
                 self._pending_cadence_by_key.pop(key, None)
 
         if request.policy.cadence_seconds is None:
@@ -1198,6 +1246,7 @@ class AcquisitionScheduler:
                 continue
             del self._requests_by_key[key]
             self._claims_by_request_id.pop(request.id, None)
+            self._forget_dispatch(request.id)
             self._defer(
                 key,
                 _PendingEnsureFresh(

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -2113,8 +2113,16 @@ class CivRuntime:
             )
             if not matched_paths:
                 continue
+            matched = _replace_dataclass(request, paths=matched_paths)
+            # Path equality alone would credit this request from a frame that
+            # was already on the wire before the request's own send.
+            if not scheduler.may_credit(
+                matched,
+                observation_timestamp=observation.timestamp_monotonic,
+            ):
+                continue
             scheduler.record_acquisition_result(
-                _replace_dataclass(request, paths=matched_paths),
+                matched,
                 _changeset_for_request_paths(
                     changeset,
                     observed_path=observation.path,

--- a/tests/test_acquisition_drain.py
+++ b/tests/test_acquisition_drain.py
@@ -9,6 +9,7 @@ in ``tests/test_rigctld_server.py``.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterable
 from typing import Any, cast
 
 import pytest
@@ -70,6 +71,16 @@ class _StubScheduler:
         self.tx_active_calls: list[bool] = []
         self.claimant_by_request: dict[str, object] = {}
         self.claim_generation_by_request: dict[str, int] = {}
+        self.dispatches: list[tuple[str, tuple[FieldPath, ...], float]] = []
+
+    def record_dispatch(
+        self,
+        request_id: str,
+        *,
+        paths: Iterable[FieldPath],
+        now: float,
+    ) -> None:
+        self.dispatches.append((request_id, tuple(paths), now))
 
     def note_tx_active(self, tx_active: bool) -> None:
         self.tx_active_calls.append(tx_active)
@@ -394,6 +405,58 @@ class TestAcquisitionDrainExecutor:
         assert reports.failures == [
             (request.id, "no_civ_query_mapping", frozenset({_MODE}))
         ]
+        # Only the path that went out is dispatched; the one the executor
+        # could not map is not.
+        assert scheduler.dispatches == [
+            (request.id, (_FREQ,), in_flight[request.id][1])
+        ]
+
+    async def test_a_send_is_reported_to_the_scheduler_as_a_dispatch(self) -> None:
+        request = _request()
+        scheduler = _StubScheduler((request,))
+        drain = _drain(
+            scheduler=scheduler, reports=_Reports(), executor=_StubExecutor()
+        )
+
+        await drain.run_once()
+
+        assert [entry[:2] for entry in scheduler.dispatches] == [(request.id, (_FREQ,))]
+
+    async def test_a_request_that_sent_nothing_is_not_reported_as_dispatched(
+        self,
+    ) -> None:
+        request = _request()
+        scheduler = _StubScheduler((request,))
+        drain = _drain(
+            scheduler=scheduler,
+            reports=_Reports(),
+            executor=_StubExecutor(
+                result=AcquisitionExecutionResult(
+                    sent_paths=(),
+                    failed_paths=(_FREQ,),
+                    failure_reason="no_civ_query_mapping",
+                )
+            ),
+        )
+
+        await drain.run_once()
+
+        assert scheduler.dispatches == []
+
+    async def test_a_request_whose_executor_raised_is_not_reported_as_dispatched(
+        self,
+    ) -> None:
+        request = _request()
+        scheduler = _StubScheduler((request,))
+        drain = _drain(
+            scheduler=scheduler,
+            reports=_Reports(),
+            executor=_StubExecutor(error=RuntimeError("port closed")),
+        )
+
+        await drain.run_once()
+
+        assert scheduler.dispatches == []
 
 
 class TestAcquisitionDrainLedger:

--- a/tests/test_acquisition_drain.py
+++ b/tests/test_acquisition_drain.py
@@ -64,8 +64,6 @@ def _always_expired(request: AcquisitionRequest, *, sent_at: float, now: float) 
 
 
 class _StubScheduler:
-    """Only the two methods the drain calls on a scheduler."""
-
     def __init__(self, pending: tuple[AcquisitionRequest, ...]) -> None:
         self.pending = pending
         self.tx_active_calls: list[bool] = []

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -4085,3 +4085,82 @@ def test_tick_keeps_the_attenuator_below_the_declared_band_bound() -> None:
     service.tick(now=1.0)
 
     assert store.snapshot().field(_AVAIL_ATT).value == 12
+
+
+def test_a_never_dispatched_request_may_not_be_credited() -> None:
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    scheduler = AcquisitionScheduler(profile=_profile([freq]))
+    result = scheduler.ensure_fresh(
+        freq, max_age=5.0, priority="user", reason="post_write_readback"
+    )
+    assert result.request is not None
+
+    assert scheduler.may_credit(result.request, observation_timestamp=100.0) is False
+
+
+def test_a_dispatched_request_may_be_credited_only_from_that_dispatch_on() -> None:
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    scheduler = AcquisitionScheduler(profile=_profile([freq]))
+    result = scheduler.ensure_fresh(
+        freq, max_age=5.0, priority="user", reason="post_write_readback"
+    )
+    assert result.request is not None
+    scheduler.record_dispatch(result.request.id, paths=(freq,), now=50.0)
+
+    assert scheduler.may_credit(result.request, observation_timestamp=49.999) is False
+    assert scheduler.may_credit(result.request, observation_timestamp=50.0) is True
+    assert scheduler.may_credit(result.request, observation_timestamp=50.001) is True
+
+
+def test_re_dispatching_a_coalesced_request_advances_its_dispatch_time() -> None:
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    mode = FieldPath.active("main", "freq_mode", "mode")
+    scheduler = AcquisitionScheduler(profile=_profile([freq, mode]))
+    first = scheduler.ensure_fresh(
+        freq, max_age=5.0, priority="background", reason="policy-cadence"
+    )
+    assert first.request is not None
+    scheduler.record_dispatch(first.request.id, paths=(freq,), now=50.0)
+    coalesced = scheduler.ensure_fresh(
+        freq, max_age=5.0, priority="user", reason="post_write_readback"
+    )
+    assert coalesced.request is not None
+    assert coalesced.request.id == first.request.id
+
+    # The coalesced request carries the first dispatch until it is sent again.
+    assert scheduler.may_credit(coalesced.request, observation_timestamp=60.0) is True
+    scheduler.record_dispatch(coalesced.request.id, paths=(freq,), now=70.0)
+    assert scheduler.may_credit(coalesced.request, observation_timestamp=60.0) is False
+    assert scheduler.may_credit(coalesced.request, observation_timestamp=70.0) is True
+
+
+def test_dispatch_time_is_tracked_per_path_of_one_request() -> None:
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    mode = FieldPath.active("main", "freq_mode", "mode")
+    scheduler = AcquisitionScheduler(profile=_profile([freq, mode]))
+    result = scheduler.ensure_fresh(
+        (freq, mode), max_age=5.0, priority="background", reason="policy-cadence"
+    )
+    assert result.request is not None
+    scheduler.record_dispatch(result.request.id, paths=(freq,), now=50.0)
+    scheduler.record_dispatch(result.request.id, paths=(mode,), now=70.0)
+
+    freq_only = replace(result.request, paths=(freq,))
+    mode_only = replace(result.request, paths=(mode,))
+    assert scheduler.may_credit(freq_only, observation_timestamp=60.0) is True
+    assert scheduler.may_credit(mode_only, observation_timestamp=60.0) is False
+
+
+def test_completing_a_request_drops_its_dispatch_record() -> None:
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    clock = FreshnessClock(start=50.0)
+    scheduler = AcquisitionScheduler(profile=_profile([freq]), clock=clock)
+    result = scheduler.ensure_fresh(
+        freq, max_age=5.0, priority="user", reason="post_write_readback"
+    )
+    assert result.request is not None
+    scheduler.record_dispatch(result.request.id, paths=(freq,), now=50.0)
+    scheduler.record_acquisition_result(result.request, _changeset(at=51.0))
+
+    assert scheduler.pending_requests() == ()
+    assert scheduler.may_credit(result.request, observation_timestamp=52.0) is False

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -2491,6 +2491,11 @@ def test_update_state_cache_records_scheduler_result_for_matching_pending_reques
     path = FieldPath.active("main", "freq_mode", "freq_hz")
     scheduler = _SpyScheduler(profile=_acquisition_profile(path))
     scheduler.due_requests(now=0.0)
+    pending = scheduler.pending_requests()
+    assert len(pending) == 1
+    scheduler.record_dispatch(
+        pending[0].id, paths=pending[0].paths, now=time.monotonic()
+    )
     radio._acquisition_scheduler = scheduler
 
     radio._civ_runtime._update_state_cache_from_frame(
@@ -2498,6 +2503,38 @@ def test_update_state_cache_records_scheduler_result_for_matching_pending_reques
     )
 
     assert scheduler.recorded_count == 1
+    assert scheduler.pending_requests() == ()
+
+
+def test_a_frame_decoded_before_the_request_was_dispatched_does_not_credit_it(
+    radio: IcomRadio,
+) -> None:
+    """Crediting is anchored to the request's own dispatch.
+
+    A pending request the drain has not sent is completed by no frame; once
+    it is sent, a frame decoded after that send completes it.
+    """
+
+    path = FieldPath.active("main", "freq_mode", "freq_hz")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
+    scheduler.due_requests(now=0.0)
+    pending = scheduler.pending_requests()
+    assert len(pending) == 1
+    radio._acquisition_scheduler = scheduler
+
+    radio._civ_runtime._update_state_cache_from_frame(
+        _make_frame(cmd=0x03, data=bcd_encode(14_074_000))
+    )
+
+    assert scheduler.pending_requests() == pending
+
+    scheduler.record_dispatch(
+        pending[0].id, paths=pending[0].paths, now=time.monotonic()
+    )
+    radio._civ_runtime._update_state_cache_from_frame(
+        _make_frame(cmd=0x03, data=bcd_encode(14_074_000))
+    )
+
     assert scheduler.pending_requests() == ()
 
 
@@ -2539,6 +2576,10 @@ def test_reconciliation_answer_landing_after_dekey_still_credits_pending_request
         reason="stale",
     )
     assert result.status is AcquisitionStatus.QUEUED
+    assert result.request is not None
+    scheduler.record_dispatch(
+        result.request.id, paths=result.request.paths, now=time.monotonic()
+    )
 
     # De-key before the answer arrives: the next drain caches tx_active=False.
     scheduler.due_requests(now=100.5, tx_active=False)
@@ -3205,6 +3246,9 @@ def test_same_value_coalesced_meter_flush_completes_scheduler_request(
     )
     scheduler = AcquisitionScheduler(profile=_acquisition_profile(path, policy=policy))
     scheduler.due_requests(now=100.0)
+    pending = scheduler.pending_requests()
+    assert len(pending) == 1
+    scheduler.record_dispatch(pending[0].id, paths=pending[0].paths, now=100.0)
     radio._acquisition_scheduler = scheduler
     radio._meter_observation_coalescer = MeterObservationCoalescer()
     radio._state_diagnostics = StateDiagnosticsRecorder(enabled=True)


### PR DESCRIPTION
## The mechanism

`AcquisitionScheduler` keeps the queue of reads the radio still owes us;
`AcquisitionDrain` turns those into wire sends and keeps a seat-local
in-flight ledger; `runtime/_civ_rx.py` decodes incoming CI-V frames and
completes pending requests. Until now that last step matched on the field
path alone: any decoded frame whose path matched a pending request's path
completed it, with no notion of whether — or when — that request had been
sent. So a reply to an earlier query, or a broadcast frame, completed a
request it could not be an answer to, and a request no send had covered at
all was completed just the same.

This PR gives the scheduler that fact. `record_dispatch(request_id, paths=,
now=)` stores, per request id and per path, the timestamp of the drain pass
that sent it — the pass's clock reading, taken before its sends (per path,
because the drain sends only what a previous pass did not). `AcquisitionDrain.run_once` calls it where it updates its own
ledger — i.e. only for paths a send actually covered. `may_credit(request,
observation_timestamp=)` answers whether an observation can complete a
request, and `_record_scheduler_result_for_observation` asks it before
calling `record_acquisition_result`. Both drain construction sites (the web
poller and rigctld) already hold the scheduler, so neither needed threading.

## What this fixes on its own

- A request that was never sent is no longer completed by any frame.
- A request whose current dispatch is at time T is no longer completed by a
  frame decoded before T — a reply that was already in flight when the
  request went out.

## Out of scope

- A post-write read-back for a pollable field still coalesces into an
  already-queued cadence request and keeps its id, so the drain may send
  nothing new; the pre-write dispatch time then satisfies the rule added
  here and the stale reply still credits it. Forcing a genuine post-write
  dispatch is the next PR.
- The frontend's pending marker still clears on a bare
  `lastObservedMonotonic` bump; unchanged here.
- No `correlation_id` field, no change to `_coalesce` or the request key,
  no `CommandService` or frontend change.

## Tests

New, scheduler predicate (`tests/test_acquisition_scheduler.py`): a
never-dispatched request may not be credited; a dispatched one may be
credited at or after its dispatch and not before; re-dispatching a coalesced
request advances its dispatch time; dispatch time is tracked per path;
completing a request drops its dispatch record.

New, drain (`tests/test_acquisition_drain.py`): a successful send is
reported to the scheduler as a dispatch; a send that put nothing on the wire
and one whose executor raised are not.

New, CI-V seat (`tests/test_civ_rx_coverage.py`): a frame decoded before the
request was dispatched does not credit it; the same frame after the dispatch
does.

Rewritten with a dispatch step, assertions unchanged:
`test_update_state_cache_records_scheduler_result_for_matching_pending_request`,
`test_reconciliation_answer_landing_after_dekey_still_credits_pending_request`
(its MOR-1533 intent — an answer landing after de-key still credits a
request that *was* dispatched — is preserved), and
`test_same_value_coalesced_meter_flush_completes_scheduler_request`, which
went red for the same reason and is the only test outside the two named in
the plan that did.

## Mutations run

| Mutation | Killed by |
|---|---|
| `may_credit` ignores the timestamp comparison | 3 scheduler tests (dispatch-on, coalesced re-dispatch, per-path) |
| `may_credit` returns True for a never-dispatched request | 2 scheduler tests + the new CI-V seat test |
| drain stops calling `record_dispatch` | 2 drain tests + the 4 params of `test_scheduler_active_freq_mode_request_completes_from_civ_rx_loop`, which drives the real poller drain and CI-V pump |
| behaviour-preserving refactor of `may_credit` (`any(...)` → explicit loop) | nothing — 576 passed |

Gates run locally: `ruff check src/ tests/`, `ruff format --check src/
tests/`, `lint-imports` (5 contracts kept), `mypy --strict src/rigplane/web`
— all clean. Full suite is CI's.

Not caused by this change: `tests/test_rigctld_server_coverage.py::test_max_clients_rejected`
hangs on this machine on the unmodified tree as well (checked by stashing
the change and re-running it alone).

## Size

6 files, 249+/3- = 252 changed lines at f28669e5. One unit of work: the
scheduler's new fact, the one seat that produces it, the one seat that
consumes it, and their tests — splitting it would land a recorded dispatch
nobody reads, or a predicate nothing feeds.

internal-identifier self-check — empty.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)


