### PR TITLE
feat: send a post-write read-back after the ack instead of merging it into an already-sent poll

### DIFF
--- a/src/rigplane/core/acquisition_drain.py
+++ b/src/rigplane/core/acquisition_drain.py
@@ -49,8 +49,8 @@ __all__ = [
     "InFlightLedger",
 ]
 
-#: request id -> (paths already sent for it, the clock reading of the pass
-#: that sent them, taken before its sends).
+#: request id -> (paths already sent for it, the clock reading of the latest
+#: pass that sent any of them, taken before its sends).
 InFlightLedger = MutableMapping[str, tuple[frozenset[FieldPath], float]]
 
 

--- a/src/rigplane/core/acquisition_drain.py
+++ b/src/rigplane/core/acquisition_drain.py
@@ -9,7 +9,8 @@ Injected, because the seats differ deliberately:
 
 * ``expired`` — rigctld expires a dispatched request at the earlier of its
   enqueue deadline and ``sent_at + timeout``; the web poller measures from
-  the send and its own comment calls the ``min`` form a false timeout.
+  ``sent_at`` alone and its own comment calls the ``min`` form a false
+  timeout.
 * ``dispatchable`` — which pending requests this seat may put on the wire
   this pass. rigctld stands the profile cadence down while an external CAT
   session owns the byte stream; no deadline rule can express that.
@@ -48,7 +49,8 @@ __all__ = [
     "InFlightLedger",
 ]
 
-#: request id -> (paths already sent for it, monotonic time of that send).
+#: request id -> (paths already sent for it, the clock reading of the pass
+#: that sent them, taken before its sends).
 InFlightLedger = MutableMapping[str, tuple[frozenset[FieldPath], float]]
 
 

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -575,7 +575,7 @@ class AcquisitionScheduler:
         key: _AcquisitionRequestKey,
         previous_id: str,
     ) -> AcquisitionRequest:
-        """Return ``request`` under a new id, moving the old id's state to it.
+        """Return ``request`` under a new id.
 
         A drain keys its in-flight ledger by request id and skips a request
         whose paths it has already sent, so a new id is what makes the next

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -572,20 +572,29 @@ class AcquisitionScheduler:
         self,
         request: AcquisitionRequest,
         *,
+        key: _AcquisitionRequestKey,
         previous_id: str,
     ) -> AcquisitionRequest:
-        """Return ``request`` under a new id, dropping the old id's state.
+        """Return ``request`` under a new id, moving the old id's state to it.
 
         A drain keys its in-flight ledger by request id and skips a request
         whose paths it has already sent, so a new id is what makes the next
         pass send them again. The old id's dispatch record and claim are
-        dropped with it.
+        dropped with it; a pending cadence update naming it is re-pointed at
+        the new id, which is what carries a part-completed group's
+        ``semantic_changed`` to the completion that consumes it.
         """
 
         request_id = f"acq-{self._next_id}"
         self._next_id += 1
         self._forget_dispatch(previous_id)
         self._claims_by_request_id.pop(previous_id, None)
+        pending_cadence = self._pending_cadence_by_key.get(key)
+        if pending_cadence is not None and pending_cadence.request_id == previous_id:
+            self._pending_cadence_by_key[key] = replace(
+                pending_cadence,
+                request_id=request_id,
+            )
         return replace(request, id=request_id)
 
     def ensure_fresh(
@@ -1406,7 +1415,11 @@ class AcquisitionScheduler:
                     existing.id,
                     grouped_paths,
                 ):
-                    request = self._reissue(request, previous_id=existing.id)
+                    request = self._reissue(
+                        request,
+                        key=key,
+                        previous_id=existing.id,
+                    )
                 self._requests_by_key[key] = request
                 queued.append(request)
                 continue

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -558,6 +558,37 @@ class AcquisitionScheduler:
     def _forget_dispatch(self, request_id: str) -> None:
         self._dispatch_by_request_id.pop(request_id, None)
 
+    def _dispatch_covers(
+        self,
+        request_id: str,
+        paths: Iterable[FieldPath],
+    ) -> bool:
+        dispatched = self._dispatch_by_request_id.get(request_id)
+        if dispatched is None:
+            return False
+        return any(path in dispatched for path in paths)
+
+    def _reissue(
+        self,
+        request: AcquisitionRequest,
+        *,
+        previous_id: str,
+    ) -> AcquisitionRequest:
+        """Return ``request`` under a new id, dropping the old id's state.
+
+        A drain keys its in-flight ledger by request id and skips a request
+        whose paths it has already sent, so a new id is what makes the next
+        pass send them again. The old id's dispatch record goes with it, or
+        :meth:`may_credit` would answer the new request from the old send;
+        so does its claim, which no longer names a pending request.
+        """
+
+        request_id = f"acq-{self._next_id}"
+        self._next_id += 1
+        self._forget_dispatch(previous_id)
+        self._claims_by_request_id.pop(previous_id, None)
+        return replace(request, id=request_id)
+
     def ensure_fresh(
         self,
         paths: FieldPath | str | Iterable[FieldPath | str],
@@ -566,6 +597,7 @@ class AcquisitionScheduler:
         priority: AcquisitionPriority | str,
         reason: str,
         timeout: float | None = None,
+        require_fresh_dispatch: bool = False,
     ) -> EnsureFreshResult:
         """Queue acquisition for one or more field paths if policy allows it.
 
@@ -573,6 +605,13 @@ class AcquisitionScheduler:
         defers it under external CAT ownership) and returns immediately. The
         enqueued :class:`AcquisitionRequest` carries ``timeout`` for the
         backend executor's later in-flight read; nothing here awaits it.
+
+        ``require_fresh_dispatch`` is for a caller whose answer must come from
+        a send made after this call. Without it these paths merge into the
+        request already queued under their key and keep its id, which a drain
+        that has already sent them skips. With it, such a merge is issued
+        under a new id instead. It is not carried through the external-CAT
+        deferral (:class:`_PendingEnsureFresh`).
         """
 
         normalized_paths = _normalize_paths(paths)
@@ -614,6 +653,7 @@ class AcquisitionScheduler:
                         timeout=timeout,
                         requested_at=now,
                         external_cat_owner=self._external_cat_owner,
+                        require_fresh_dispatch=require_fresh_dispatch,
                     )
                 )
             if queued:
@@ -636,6 +676,7 @@ class AcquisitionScheduler:
             timeout=timeout,
             requested_at=now,
             external_cat_owner=None,
+            require_fresh_dispatch=require_fresh_dispatch,
         )
         if not queued_requests:
             return EnsureFreshResult(
@@ -1310,6 +1351,7 @@ class AcquisitionScheduler:
         external_cat_owner: str | None,
         reasons: tuple[str, ...] | None = None,
         deadline_monotonic: float | None = None,
+        require_fresh_dispatch: bool = False,
     ) -> tuple[AcquisitionRequest, ...]:
         request_reasons = (reason,) if reasons is None else reasons
         request_deadline = (
@@ -1325,6 +1367,7 @@ class AcquisitionScheduler:
             external_cat_owner=external_cat_owner,
             reasons=request_reasons,
             deadline_monotonic=request_deadline,
+            require_fresh_dispatch=require_fresh_dispatch,
         )
 
     def _queue_grouped(
@@ -1339,6 +1382,7 @@ class AcquisitionScheduler:
         external_cat_owner: str | None,
         reasons: tuple[str, ...] | None = None,
         deadline_monotonic: float | None = None,
+        require_fresh_dispatch: bool = False,
     ) -> tuple[AcquisitionRequest, ...]:
         request_reasons = (reason,) if reasons is None else reasons
         request_deadline = (
@@ -1359,6 +1403,11 @@ class AcquisitionScheduler:
                     requested_at=requested_at,
                     deadline_monotonic=request_deadline,
                 )
+                if require_fresh_dispatch and self._dispatch_covers(
+                    existing.id,
+                    grouped_paths,
+                ):
+                    request = self._reissue(request, previous_id=existing.id)
                 self._requests_by_key[key] = request
                 queued.append(request)
                 continue

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -578,9 +578,8 @@ class AcquisitionScheduler:
 
         A drain keys its in-flight ledger by request id and skips a request
         whose paths it has already sent, so a new id is what makes the next
-        pass send them again. The old id's dispatch record goes with it, or
-        :meth:`may_credit` would answer the new request from the old send;
-        so does its claim, which no longer names a pending request.
+        pass send them again. The old id's dispatch record and claim are
+        dropped with it.
         """
 
         request_id = f"acq-{self._next_id}"

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1431,6 +1431,10 @@ class RadioPoller:
             max_age=_POST_WRITE_READBACK_MAX_AGE,
             priority=AcquisitionPriority.USER,
             reason="post_write_readback",
+            # The answer must come from a query sent after this write. Merged
+            # into the cadence poll's already-sent request, this read-back
+            # would be answered by the query that went out before it.
+            require_fresh_dispatch=True,
         )
 
     def _apply_global_control_observation(

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -4275,3 +4275,50 @@ def test_fresh_dispatch_reissue_drops_the_previous_id_dispatch_and_claim() -> No
         )
         is False
     )
+
+
+def test_fresh_dispatch_reissue_carries_the_pending_cadence_update() -> None:
+    policy = AcquisitionPolicy(
+        cadence_seconds=1.0,
+        freshness_ttl_seconds=10.0,
+        adaptive_decay=AdaptiveDecayPolicy(
+            enabled=True,
+            idle_multiplier=2.0,
+            max_cadence_seconds=8.0,
+        ),
+    )
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    mode = FieldPath.active("main", "freq_mode", "mode")
+    clock = FreshnessClock(start=230.0)
+    scheduler = AcquisitionScheduler(
+        profile=_profile([freq, mode], default_policy=policy),
+        clock=clock,
+    )
+
+    grouped = scheduler.due_requests()[0]
+    scheduler.record_dispatch(grouped.id, paths=(freq,), now=clock.now())
+    scheduler.record_acquisition_result(
+        replace(grouped, paths=(mode,), capability_ids=(str(mode),)),
+        _changeset(
+            changes=(FieldChange(path=mode, previous="USB", current="LSB"),),
+            at=clock.now(),
+        ),
+    )
+
+    readback = scheduler.ensure_fresh(
+        freq,
+        max_age=5.0,
+        priority="user",
+        reason="post_write_readback",
+        require_fresh_dispatch=True,
+    )
+    assert readback.request is not None
+    assert readback.request.id != grouped.id
+
+    scheduler.record_acquisition_result(readback.request, _changeset(at=clock.now()))
+
+    # The change on ``mode`` was carried across the reissue, so the group's
+    # cadence resets to its base rather than decaying by idle_multiplier.
+    diagnostics = scheduler.diagnostics()
+    assert diagnostics["cadenceByPath"][str(freq)]["currentCadenceSeconds"] == 1.0
+    assert scheduler._pending_cadence_by_key == {}

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -4322,3 +4322,26 @@ def test_fresh_dispatch_reissue_carries_the_pending_cadence_update() -> None:
     diagnostics = scheduler.diagnostics()
     assert diagnostics["cadenceByPath"][str(freq)]["currentCadenceSeconds"] == 1.0
     assert scheduler._pending_cadence_by_key == {}
+
+
+def test_fresh_dispatch_reissue_needs_only_one_incoming_path_dispatched() -> None:
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    mode = FieldPath.active("main", "freq_mode", "mode")
+    scheduler = AcquisitionScheduler(profile=_profile([freq, mode]))
+    cadence = scheduler.ensure_fresh(
+        (freq, mode), max_age=5.0, priority="background", reason="policy-cadence"
+    )
+    assert cadence.request is not None
+    scheduler.record_dispatch(cadence.request.id, paths=(freq,), now=50.0)
+
+    # ``freq`` has gone out under that id and ``mode`` has not; the read-back
+    # asks for both, and the sent one is enough to reissue.
+    readback = scheduler.ensure_fresh(
+        (freq, mode),
+        max_age=5.0,
+        priority="user",
+        reason="post_write_readback",
+        require_fresh_dispatch=True,
+    )
+    assert readback.request is not None
+    assert readback.request.id != cadence.request.id

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -4164,3 +4164,114 @@ def test_completing_a_request_drops_its_dispatch_record() -> None:
 
     assert scheduler.pending_requests() == ()
     assert scheduler.may_credit(result.request, observation_timestamp=52.0) is False
+
+
+def test_fresh_dispatch_request_is_reissued_out_of_an_already_sent_request() -> None:
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    scheduler = AcquisitionScheduler(profile=_profile([freq]))
+    cadence = scheduler.ensure_fresh(
+        freq, max_age=5.0, priority="background", reason="policy-cadence"
+    )
+    assert cadence.request is not None
+    scheduler.record_dispatch(cadence.request.id, paths=(freq,), now=50.0)
+
+    readback = scheduler.ensure_fresh(
+        freq,
+        max_age=5.0,
+        priority="user",
+        reason="post_write_readback",
+        require_fresh_dispatch=True,
+    )
+    assert readback.request is not None
+
+    assert readback.request.id != cadence.request.id
+    assert readback.request.priority is AcquisitionPriority.USER
+    assert readback.request.reasons == ("policy-cadence", "post_write_readback")
+    assert scheduler.pending_requests() == (readback.request,)
+    # No send has covered the reissued id, so the answer to the send at 50.0
+    # cannot complete it.
+    assert scheduler.may_credit(readback.request, observation_timestamp=60.0) is False
+
+
+def test_fresh_dispatch_request_merges_into_a_request_no_send_covered() -> None:
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    scheduler = AcquisitionScheduler(profile=_profile([freq]))
+    cadence = scheduler.ensure_fresh(
+        freq, max_age=5.0, priority="background", reason="policy-cadence"
+    )
+    assert cadence.request is not None
+
+    readback = scheduler.ensure_fresh(
+        freq,
+        max_age=5.0,
+        priority="user",
+        reason="post_write_readback",
+        require_fresh_dispatch=True,
+    )
+    assert readback.request is not None
+    assert readback.request.id == cadence.request.id
+
+
+def test_fresh_dispatch_reissue_is_per_path_of_the_incoming_request() -> None:
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    mode = FieldPath.active("main", "freq_mode", "mode")
+    scheduler = AcquisitionScheduler(profile=_profile([freq, mode]))
+    cadence = scheduler.ensure_fresh(
+        (freq, mode), max_age=5.0, priority="background", reason="policy-cadence"
+    )
+    assert cadence.request is not None
+    scheduler.record_dispatch(cadence.request.id, paths=(freq,), now=50.0)
+
+    # ``mode`` never went out under that id, so the pass that has yet to send
+    # it is already the fresh send this caller needs.
+    mode_readback = scheduler.ensure_fresh(
+        mode,
+        max_age=5.0,
+        priority="user",
+        reason="post_write_readback",
+        require_fresh_dispatch=True,
+    )
+    assert mode_readback.request is not None
+    assert mode_readback.request.id == cadence.request.id
+
+    freq_readback = scheduler.ensure_fresh(
+        freq,
+        max_age=5.0,
+        priority="user",
+        reason="post_write_readback",
+        require_fresh_dispatch=True,
+    )
+    assert freq_readback.request is not None
+    assert freq_readback.request.id != cadence.request.id
+
+
+def test_fresh_dispatch_reissue_drops_the_previous_id_dispatch_and_claim() -> None:
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    scheduler = AcquisitionScheduler(profile=_profile([freq]))
+    cadence = scheduler.ensure_fresh(
+        freq, max_age=5.0, priority="background", reason="policy-cadence"
+    )
+    assert cadence.request is not None
+    seat = object()
+    assert (
+        scheduler.try_claim(cadence.request, claimant=seat, provider_generation=0)
+        is True
+    )
+    scheduler.record_dispatch(cadence.request.id, paths=(freq,), now=50.0)
+
+    readback = scheduler.ensure_fresh(
+        freq,
+        max_age=5.0,
+        priority="user",
+        reason="post_write_readback",
+        require_fresh_dispatch=True,
+    )
+    assert readback.request is not None
+
+    assert scheduler.may_credit(cadence.request, observation_timestamp=60.0) is False
+    assert (
+        scheduler.claim_is_current(
+            cadence.request, claimant=seat, provider_generation=0
+        )
+        is False
+    )

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -71,6 +71,7 @@ from rigplane.core.tx_observation import (
     project_observed_ptt,
 )
 from rigplane.core.state_pipeline_contracts import (
+    CommandIntent,
     FieldPath,
     Observation,
     SourceMetadata,
@@ -2682,6 +2683,87 @@ async def test_scheduler_active_freq_mode_request_completes_from_civ_rx_loop(
 
     assert scheduler.pending_requests() == ()
     assert radio._state_store.snapshot().field(stored_path).value == expected
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_post_write_readback_is_sent_after_the_ack_and_credited_by_its_answer(
+    radio: IcomRadio,
+) -> None:
+    """Owner ruling R39: the read-back's answer is the one it asked for.
+
+    The whole chain, through the real scheduler, the real drain and the real
+    CI-V receive path: the cadence poll's query goes out, a write is acked and
+    ``RadioPoller._request_post_write_readback`` runs, and the next drain pass
+    must put the same query on the wire a second time. Until then the
+    pre-write query's answer, decoded before that second send, must leave the
+    read-back pending.
+    """
+
+    path = FieldPath.active("main", "freq_mode", "freq_hz")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
+    radio._acquisition_scheduler = scheduler  # noqa: SLF001
+    sent: list[tuple[int, bytes]] = []
+
+    async def _record_send(cmd: int, **kwargs: Any) -> None:
+        sent.append((cmd, bytes(kwargs.get("data") or b"")))
+
+    radio.send_civ = _record_send  # type: ignore[method-assign,assignment]
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+
+    StateFreshnessService(
+        store=poller._state_store,  # noqa: SLF001
+        scheduler=scheduler,
+    ).tick()
+    await poller._send_query()  # noqa: SLF001
+
+    assert len(sent) == 1
+    assert scheduler.pending_requests()[0].paths == (path,)
+
+    before_the_readback_send = time.monotonic()
+
+    poller._request_post_write_readback(  # noqa: SLF001
+        CommandIntent(
+            id="cmd-1",
+            name="set_freq",
+            params={"freq_hz": 14_074_000, "receiver": 0},
+            source="websocket",
+            target=path,
+            expected_observations=(path,),
+        )
+    )
+
+    await poller._send_query()  # noqa: SLF001
+
+    assert sent == [sent[0], sent[0]], (
+        "the drain must put the read-back's query on the wire after the ack; "
+        "instead the pass sent nothing new"
+    )
+
+    # The pre-write query's answer, decoded before the read-back's own query
+    # went out.
+    with patch(
+        "rigplane.runtime._civ_rx.time.monotonic",
+        return_value=before_the_readback_send,
+    ):
+        radio._civ_runtime._apply_state_store_observations(  # noqa: SLF001
+            _make_frame(cmd=0x25, data=b"\x00" + bcd_encode(14_000_000))
+        )
+
+    assert scheduler.pending_requests() != (), (
+        "a reply decoded before the read-back's own query went out must not complete it"
+    )
+
+    radio._civ_runtime._apply_state_store_observations(  # noqa: SLF001
+        _make_frame(cmd=0x25, data=b"\x00" + bcd_encode(14_074_000))
+    )
+
+    assert scheduler.pending_requests() == ()
+    assert (
+        radio._state_store.snapshot()  # noqa: SLF001
+        .field("receiver.0.active.freq_mode.freq_hz")
+        .value
+        == 14_074_000
+    )
 
 
 def test_meter_coalescing_applies_latest_due_sample_and_records_diagnostics(


### PR DESCRIPTION
Step two of MOR-2425's read-back chain, on top of #3389.

## What this closes

After a write is acked, `RadioPoller._request_post_write_readback` calls
`ensure_fresh(priority=USER, reason="post_write_readback")`. For a pollable
field that request lands on the cadence poll's `_AcquisitionRequestKey`,
`_coalesce` merges it into the request already queued there and `replace()`
keeps that request's id. `AcquisitionDrain.run_once` finds the id in its
in-flight ledger with the paths already covered and sends nothing new, so no
query goes out after the write at all. With #3389 in place the merged request
still carried the pre-write pass's dispatch timestamp, so the stale reply was
still allowed to complete it.

## Mechanism chosen, and why

`ensure_fresh` gains `require_fresh_dispatch` (keyword, default `False`).
When it is set and the request already queued under the key has a recorded
dispatch covering the *incoming* paths, `_queue_grouped` issues the merged
request under a new id (`_reissue`). The
drain's ledger sweep already forgets an id that is no longer pending, so the
next pass finds no sent paths for the new id, sends the query, and
`record_dispatch` stamps that pass against the new id — after which #3389's
`may_credit` rejects the pre-write reply and accepts the fresh one.

Of the three candidates the exploration named, this one touches the fewest
invariants:

- It changes only the `existing is not None` branch of `_queue_grouped`, and
  only when the caller asks for it. Cadence-into-cadence and
  background-into-background merging is untouched, and so is a merge into
  paths no send has covered — `test_duplicate_requests_coalesce_with_highest_
  priority_and_urgent_deadline` and `test_same_family_requests_share_one_
  acquisition_request` pass as written, with no edit to either.
- A `resend` marker honoured by the drain would need the drain to clear the
  marker after sending — a second scheduler mutator, in a file both the web
  and rigctld seats share — or the request would be re-sent on every pass.
- A discriminated request key would take the read-back out of the poll's key
  entirely, which is also the key `_due_poll_groups` and `_cadence_by_key` use
  to decide what is due and how often.

The predicate is `require_fresh_dispatch` rather than
`reason == "post_write_readback"`: the reason string is a web-layer value that
`core/` would then have to know, and an existing test
(`test_re_dispatching_a_coalesced_request_advances_its_dispatch_time`) calls
`ensure_fresh` with exactly that reason to pin the plain coalescing contract —
a reason-string trigger would have reddened it.

The dispatch check is per incoming path (`any(path in dispatched ...)`), not
per request: if the queued request was sent for `freq_hz` but the read-back
asks for `mode`, the pass that has yet to send `mode` is already the fresh send
the caller needs, and the id is kept.

`require_fresh_dispatch` is not carried through the external-CAT deferral
(`_PendingEnsureFresh`); that path is unchanged.

### What the new id takes with it

The old id's dispatch record and claim are dropped. Its
`_pending_cadence_by_key` entry is re-pointed at the new id instead of
dropped: a group whose first slice completed with a semantic change parks
`semantic_changed` there under the id of the request still holding the
remaining paths, and it is the completion of *that* request — now the reissued
one — that consumes it. Leaving the entry on the old id both discarded the
flag (the group decayed instead of resetting to its base cadence) and left the
entry in the dict with nothing to clear it.

## The end-to-end test, in words

`test_post_write_readback_is_sent_after_the_ack_and_credited_by_its_answer`
(`tests/test_civ_rx_coverage.py`), through the real scheduler, the real
`AcquisitionDrain` behind `RadioPoller._send_query`, and the real CI-V
receive path:

1. `StateFreshnessService.tick()` queues the cadence request for
   `active.main.freq_mode.freq_hz`; one drain pass puts one query on the wire.
2. A write is acked: `_request_post_write_readback` runs for a `CommandIntent`
   whose `expected_observations` name that path.
3. The next drain pass must send the same query a second time — asserted on
   the frames the executor handed to `send_civ`.
4. The pre-write query's answer, decoded with a timestamp taken before that
   second send, must leave the request pending.
5. A reply decoded after that send completes it, and the value reaches the
   store.

Unit tests in `tests/test_acquisition_scheduler.py` cover the merge decision
itself:

- reissue out of an already-sent request (new id, merged priority and reasons,
  and not creditable from the earlier send);
- plain merge into a request no send covered;
- the per-path rule in both directions
  (`test_fresh_dispatch_reissue_is_per_path_of_the_incoming_request`);
- `test_fresh_dispatch_reissue_needs_only_one_incoming_path_dispatched` — a
  read-back naming `freq_hz` and `mode` against a queued request where only
  `freq_hz` has gone out still reissues;
- the dropping of the previous id's dispatch record and claim (asserted
  indirectly, through `may_credit` and `claim_is_current` on the old request —
  the scheduler exposes no accessor for either dict);
- `test_fresh_dispatch_reissue_carries_the_pending_cadence_update` — a group
  part-completed with a change, then reissued, resets to its 1.0 s base
  cadence rather than decaying to 2.0 s, and leaves `_pending_cadence_by_key`
  empty.

## Mutations run

All rows re-run at `aaa0b8ab0`. The first three are over
`tests/test_acquisition_scheduler.py` + `tests/test_civ_rx_coverage.py`
(564 tests); the last two are over the full gate set below (976 tests).

| Mutation | Result |
|---|---|
| Delete the `_reissue` call in `_queue_grouped` (the whole mechanism) | 6 failed, 558 passed — the end-to-end test at "the drain must put the read-back's query on the wire after the ack; instead the pass sent nothing new", plus all five reissue unit tests |
| Drop #3389's timestamp comparison in `may_credit`, keeping its never-dispatched rule | 4 failed, 560 passed — the end-to-end test at "a reply decoded before the read-back's own query went out must not complete it", plus the three #3389 unit tests |
| Rewrite `_dispatch_covers` as a set-disjointness check (behaviour-preserving) | 564 passed |
| `_dispatch_covers`: `any` → `all` | 1 failed, 975 passed — only `test_fresh_dispatch_reissue_needs_only_one_incoming_path_dispatched`. That test is new here; the review that asked for it reported this mutation surviving without it |
| Delete the `_pending_cadence_by_key` re-pointing in `_reissue` | 1 failed, 975 passed — only `test_fresh_dispatch_reissue_carries_the_pending_cadence_update`, at `assert 2.0 == 1.0` |

Tree restored after each; `git status --short` empty before the final run.

## Gates

`tests/test_acquisition_scheduler.py`, `tests/test_civ_rx_coverage.py`,
`tests/test_acquisition_drain.py`, `tests/test_post_write_readback_one_path.py`,
`tests/test_radio_poller_coverage.py`, `tests/test_combined_acquisition_drain.py`,
`tests/test_rigctld_server.py`: **976 passed**. `ruff check`, `ruff format
--check` (742 files), `lint-imports` (5 contracts kept), `mypy --strict
src/rigplane/web` (27 files) all clean. The full suite is CI's.

## Census

`git diff --numstat origin/main...HEAD` at `d14e22f2f`: 5 files, 332+/2- = 334
changed lines. Under both soft thresholds.

Internal-identifier self-check over the diff — empty.

## Also in this PR

Three `docs:` commits:

- one narrows two sentences in `core/acquisition_drain.py` that overstated the
  value stored per in-flight request (T149): the `InFlightLedger` comment
  called it the time of the send, and the module docstring said the web poller
  measures from the send. `run_once` reads its clock once at the top of the
  pass and stores that reading, before the pass's sends;
- one corrects that same `InFlightLedger` comment again and deletes a false
  clause from `_reissue`'s docstring. The comment named "the pass that sent
  them" for a set `run_once` accumulates across passes
  (`self._in_flight[request.id] = (sent_paths.union(newly_sent), now)`) while
  storing the latest pass's reading. The docstring said the old id's dispatch
  record had to go "or `may_credit` would answer the new request from the old
  send" — `may_credit` looks up the new id, so retaining the old record cannot
  credit the new request;
- one drops `_reissue`'s summary clause "moving the old id's state to it": the
  body drops two of the three id-keyed records and re-points one, so the
  summary now says only that the request returns under a new id.

## Out of scope

- The frontend pending marker still clears on any newer observation of the
  field; that is PR3/PR4.
- **The Yaesu path is unchanged, and is not affected at all.** The only caller
  passing `require_fresh_dispatch=True` is
  `web/radio_poller.py: RadioPoller._request_post_write_readback`
  (`grep -rn "require_fresh_dispatch" src/` finds that one call site outside
  the scheduler). `grep -rn "ensure_fresh" src/rigplane/backends/yaesu_cat/`
  returns no lines at all. The wider
  `grep -rn "ensure_fresh\|AcquisitionDrain\|AcquisitionScheduler"
  src/rigplane/backends/yaesu_cat/` returns two lines, both in
  `observations.py` and both the same reference: the `AcquisitionScheduler`
  import and the `isinstance` guard in front of
  `AcquisitionScheduler.record_startup_defect`, which is neither coalescing nor
  dispatch.
- Sweeping the class "callers of `ensure_fresh` whose answer must post-date the
  call", enumerated from `grep -rn "ensure_fresh(" src/rigplane/` — twelve
  lines, of which four are definitions (`core/radio_protocol.py`,
  `AcquisitionScheduler.ensure_fresh`, `RadioStateModelService.ensure_fresh`,
  `rigctld/handler.py: _ensure_fresh`), two are internal calls to
  `handler._ensure_fresh`, and six are call sites:
  - **Fixed here:** `web/radio_poller.py: RadioPoller._request_post_write_readback`
    (post-write read-back).
  - **Left unfixed and reported:** `core/command_service.py`'s
    `reason=f"post_write:{intent.name}"` write-confirmation read is the same
    shape, but it reaches the scheduler through the `StateModelService`
    protocol; the sixth call site,
    `RadioStateModelService.ensure_fresh` (`core/acquisition_scheduler.py`), is
    the delegating wrapper it goes through. Fixing it means widening that
    protocol surface — outside this step.
  - **Judged outside the class:** `AcquisitionScheduler.prime_unobserved`
    (BACKGROUND priming), `StateFreshnessService._queue_reconciliation`
    (RECONCILIATION cadence), and `rigctld/handler.py: _ensure_fresh` (a
    read-through for a GET that re-projects and reads back on a miss).

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)


