### PR TITLE
fix: clear the spectrum trace when the hardware scope disconnects

### DIFF
--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -540,6 +540,21 @@
     if (managed) { spectrumPush = null; waterfallPush = null; }
   }
 
+  // R53: when the scope drops the trace goes dark instead of freezing under
+  // the disconnect overlay. Pinned by `stops painting on drop and repaints
+  // only from a post-reconnect frame`.
+  //
+  // The unmanaged audio-FFT source keeps its canvas: there `scopeConnected`
+  // reads `runtime.defaultScopeStatus`, a different observation than the
+  // frames this panel paints, and `preserves distinct 80/120/160 producer
+  // levels in the trace, peak hold and waterfall` paints frames while that
+  // observation reads `disconnected`.
+  let scopeTraceLive = $derived(scopeConnected || (!managed && audioFft));
+  $effect(() => {
+    if (scopeTraceLive) return;
+    untrack(() => clearSample());
+  });
+
   $effect(() => { if (managed) scopeDemandOn = scopeDemanded; });
   $effect(() => {
     if (!managed) return;
@@ -660,7 +675,7 @@
         <div class="scope-disconnected-overlay">{t('core.overlay.scopeDisconnected')}</div>
       {/if}
       {#if !audioFft}<BandPlanOverlay {startFreq} {endFreq} visible={showBandPlan} {hiddenLayers} />{/if}
-      {#if !managedUnavailable}
+      {#if scopeTraceLive}
       <SpectrumCanvas data={scopePixels} options={spectrumOptions} {spanHz} {enableAvg} {enablePeakHold} onRegisterPush={(fn) => { spectrumPush = fn; if (managed && scopePixels) fn(scopePixels); }} />
       {/if}
       {#if tuneVisible && spanHz > 0 && pbWidthPct > 0 && canResizePassband}

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -160,6 +160,16 @@ const runtimeHarness = vi.hoisted(() => {
 
 const mockRuntime = runtimeHarness.runtime;
 
+// SvelteMap-backed so that a write to `state.mockScopeConnected` during a
+// mounted test re-runs the panel's `$derived` chain; the plain-property
+// writes the rest of this file makes keep working through the setter.
+const hardwareScopeTransport = new SvelteMap<string, boolean>([['connected', true]]);
+Object.defineProperty(runtimeHarness.state, 'mockScopeConnected', {
+  configurable: true,
+  get: () => hardwareScopeTransport.get('connected')!,
+  set: (value: boolean) => hardwareScopeTransport.set('connected', value),
+});
+
 const authorityHarness = vi.hoisted(() => {
   const state = { current: null as any, useProductionSelector: false };
   return {
@@ -256,6 +266,7 @@ const passbandHarness = vi.hoisted(() => ({
 
 const spectrumRendererHarness = vi.hoisted(() => ({
   lastOptions: null as any,
+  constructed: 0,
   render: vi.fn((_ctx: unknown, _data: Uint8Array, _width: number, _height: number, options: any) => {
     spectrumRendererHarness.lastOptions = options;
   }),
@@ -299,6 +310,7 @@ vi.mock('$lib/runtime/adapters/panel-adapters', async (importOriginal) => {
 vi.mock('$lib/renderers/spectrum-renderer', async (importOriginal) => {
   const actual = await importOriginal<typeof import('$lib/renderers/spectrum-renderer')>();
   class SpectrumRenderer {
+    constructor() { spectrumRendererHarness.constructed++; }
     setAvgEnabled = spectrumRendererHarness.setAvgEnabled;
     setPeakHoldEnabled = spectrumRendererHarness.setPeakHoldEnabled;
     render = spectrumRendererHarness.render;
@@ -1656,5 +1668,40 @@ describe('SpectrumPanel colour roles', () => {
       ...spectrumColorRolesToOptions(defaultSpectrumColorRoles),
       tuneLineColor: '#0a0a0a',
     });
+  });
+});
+
+describe('hardware scope drop clears the trace (R53)', () => {
+  it('stops painting on drop and repaints only from a post-reconnect frame', async () => {
+    const target = mountPanel();
+    const spectrum = target.querySelector('.spectrum-area')!;
+    emitFrame({ pixels: new Uint8Array(475).fill(64) });
+    await vi.waitFor(() => expect(spectrumRendererHarness.render).toHaveBeenCalled());
+    expect(spectrumRendererHarness.render.mock.calls.at(-1)![1][0]).toBe(64);
+    const renderersBeforeDrop = spectrumRendererHarness.constructed;
+
+    runtimeHarness.state.mockScopeConnected = false;
+    flushSync();
+
+    // No paint surface while the scope is down: the pre-drop frame cannot be
+    // repainted, and the peak-hold/average state held by the SpectrumRenderer
+    // instance is discarded with it.
+    expect(spectrum.querySelector('canvas')).toBeNull();
+    spectrumRendererHarness.render.mockClear();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(spectrumRendererHarness.render).not.toHaveBeenCalled();
+
+    runtimeHarness.state.mockScopeConnected = true;
+    flushSync();
+    expect(spectrum.querySelector('canvas')).not.toBeNull();
+    expect(spectrumRendererHarness.constructed).toBe(renderersBeforeDrop + 1);
+
+    // Reconnecting alone paints nothing — the panel kept no pixels to repaint.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(spectrumRendererHarness.render).not.toHaveBeenCalled();
+
+    emitFrame({ pixels: new Uint8Array(475).fill(100) });
+    await vi.waitFor(() => expect(spectrumRendererHarness.render).toHaveBeenCalled());
+    expect(spectrumRendererHarness.render.mock.calls.at(-1)![1][0]).toBe(100);
   });
 });


### PR DESCRIPTION
## Mechanism

`SpectrumPanel.svelte` derives `scopeConnected`, but nothing on the unmanaged
hardware path cleared the sample when it went false: `scopePixels` kept the
last frame, `SpectrumCanvas` stayed mounted with its own `latestPixels` copy,
and its RAF loop kept repainting that frame under the `scope-disconnected`
overlay. Only the managed path cleared, through `managedUnavailable`.

The canvas mount guard now reads a single predicate, `scopeTraceLive`, and an
effect calls the existing `clearSample()` when it goes false. Unmounting the
canvas is what discards the pixels the canvas holds internally and the
peak-hold / average history, which live in the per-instance
`SpectrumRenderer` (`peakValues`, `peakTimestamps`, `frameHistory`); the
clear is what stops the pre-drop frame being repainted through the `data`
prop when the canvas remounts on reconnect. The next frame after reconnect
paints normally.

For the managed path `scopeTraceLive` is exactly the previous guard
(`scopeConnected === !managedUnavailable` when `managed`), so its behaviour is
unchanged.

## What is cleared, what is not

- Cleared on drop: everything `clearSample()` already cleared on the managed
  path — `scopePixels`, `startFreq`/`endFreq`, `frameScopeMode`, in-flight
  drag/resize captures, `dxSpots`. Reusing it keeps the two paths identical
  rather than adding a second reset.
- **Not** cleared: the waterfall history. `WaterfallCanvas` keeps its
  `{#if !managedUnavailable}` guard, so a hardware-scope drop leaves the
  waterfall's rows in place. R53 is about the trace, and a waterfall is a time
  history an operator still wants after a transient drop. This does leave the
  two paths asymmetric — the managed path already destroys the waterfall
  renderer on `managedUnavailable` — and that asymmetry is pre-existing, not
  introduced here. The rows stay, but not the markers over them: during an
  unmanaged hardware drop the retained waterfall loses its tune line, passband
  overlay and DX spots, and the 20 px `.freq-axis` row leaves the panel,
  because `clearSample()` zeroes `startFreq`/`endFreq` (so `spanHz` is 0) and
  `dxSpots` — measured by dumping `.spectrum-panel` innerHTML before and during
  the drop in a scratch copy of this head (independent review); the managed
  path does the same today.
- **Not** changed: the overlay's existence or wording, `spectrum-renderer.ts`,
  the colour roles.
- The unmanaged audio-FFT source is excluded from the clear. Its
  `scopeConnected` reads `runtime.defaultScopeStatus`, a different observation
  than the frames the panel paints: with the guard applied to it, three cases
  in `RadioLayout.audio-fft.component.test.ts` failed because frames were
  still arriving while that observation read `disconnected`.

## Note for the reviewer

R53 describes the target as "an empty grid". The canvas grid is painted by
`renderSpectrum`, which returns early on empty data, so painting a grid with
no trace would require a renderer change — out of scope here. With the canvas
unmounted the DOM dB scale (`.db-scale` ticks) remains and the canvas grid
goes with the trace, which is what the managed path already does today. Worth
an owner look if the grid specifically was intended.

## Tests

New case in `frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts`:
`stops painting on drop and repaints only from a post-reconnect frame`. It
feeds a frame, drops `hardwareScopeConnected`, and asserts no canvas and no
renderer call during the drop; then reconnects and asserts a fresh
`SpectrumRenderer` is constructed and still nothing paints until the next
frame arrives, which paints its own pixels. The harness flag is now
SvelteMap-backed so a mid-life transition re-runs the panel's `$derived`
chain.

Run at this head: `SpectrumPanel.component.test.ts` +
`RadioLayout.audio-fft.component.test.ts` +
`semantic-scope-projection.component.test.ts` — 141 passed, 0 failed. Every
test file mentioning `SpectrumPanel`/`SpectrumCanvas` (34 files) — 912 passed,
0 failed. `npm run check` — 4841 files, 0 errors, 0 warnings. `npm run lint`
and `npm run lint:boundaries` — clean.

## Mutation

- Revert the canvas guard to `{#if !managedUnavailable}` (keep the clear): the
  new case fails on the canvas assertion; with the two DOM assertions removed
  to see past it, the renderer was called about 18 times during the 20 ms drop
  window (17, 18, 18 across three runs; RAF-timing dependent) — the frozen-trace bug exactly.
- Remove the clearing effect (keep the guard): the new case fails after
  reconnect, renderer called 15 times with the pre-drop frame before any new
  frame.
- Behaviour-preserving rewrite of the predicate to
  `managed ? scopeConnected : (audioFft || scopeConnected)`: 141 tests stayed
  green across the three files named above (SpectrumPanel component, RadioLayout
  audio-FFT, semantic scope projection).

2 files, 63+/1- = 64 changed lines at 28d77d7a0.

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

