### PR TITLE
feat: declare the FTX-1 transmit meters absent outside transmit so they are discarded on dekey

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -178,12 +178,25 @@ available_when = [
 # _emit_fast_observations (backends/yaesu_cat/poller.py) reaches
 # poll_tx_meters, the only source of these four paths, only under a truthy
 # PTT observation.
+#
+# MOR-2425/T141: observed on the bench 2026-09-08 -- after dekey the four
+# stayed in the store carrying their last transmit values instead of leaving
+# it. The clause below declares them absent while `global.tx_state.ptt` reads
+# false, so StateFreshnessService.tick discards them (tests/
+# test_acquisition_scheduler.py::
+# test_tick_discards_every_transmit_meter_on_dekey). `tx_only` stays and gains
+# nothing from the clause: AcquisitionScheduler.unobserved_startup_paths
+# already excludes a tx_only path (tests/test_startup_state_gate.py::
+# test_unobserved_tx_only_path_does_not_keep_the_predicate_incomplete).
 [state_acquisition.field_policies."global.meters.alc"]
 cadence_seconds = 0.2
 freshness_ttl_seconds = 0.8
 adaptive_decay = false
 meter_coalescing_window_seconds = 0.2
 tx_only = true
+available_when = [
+    { field = "global.tx_state.ptt", equals = true },
+]
 
 [state_acquisition.field_policies."global.meters.power"]
 cadence_seconds = 0.2
@@ -191,6 +204,9 @@ freshness_ttl_seconds = 0.8
 adaptive_decay = false
 meter_coalescing_window_seconds = 0.2
 tx_only = true
+available_when = [
+    { field = "global.tx_state.ptt", equals = true },
+]
 
 [state_acquisition.field_policies."global.meters.swr"]
 cadence_seconds = 0.2
@@ -198,6 +214,9 @@ freshness_ttl_seconds = 0.8
 adaptive_decay = false
 meter_coalescing_window_seconds = 0.2
 tx_only = true
+available_when = [
+    { field = "global.tx_state.ptt", equals = true },
+]
 
 [state_acquisition.field_policies."global.meters.comp"]
 cadence_seconds = 0.2
@@ -205,6 +224,9 @@ freshness_ttl_seconds = 0.8
 adaptive_decay = false
 meter_coalescing_window_seconds = 0.2
 tx_only = true
+available_when = [
+    { field = "global.tx_state.ptt", equals = true },
+]
 
 # --- Slow-control tier ------------------------------------------------------
 # MOR-2425 (owner ruling, 2026-09-07): 30.0s/120.0s -> 1.0s/2.0s. These

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -4087,6 +4087,75 @@ def test_tick_keeps_the_attenuator_below_the_declared_band_bound() -> None:
     assert store.snapshot().field(_AVAIL_ATT).value == 12
 
 
+_AVAIL_PTT = FieldPath.global_("tx_state", "ptt")
+_TX_METERS = (
+    FieldPath.global_("meters", "alc"),
+    FieldPath.global_("meters", "power"),
+    FieldPath.global_("meters", "swr"),
+    FieldPath.global_("meters", "comp"),
+)
+
+
+def test_tick_keeps_the_transmit_meters_while_ptt_reads_true() -> None:
+    store = StateStore()
+    service = _ftx1_freshness_service(store)
+    store.apply(_observation(_AVAIL_PTT, True, at=1.0))
+    for path in _TX_METERS:
+        store.apply(_observation(path, 1.0, at=1.0))
+
+    service.tick(now=1.0)
+
+    snapshot = store.snapshot()
+    assert [snapshot.field(path).value for path in _TX_METERS] == [1.0] * 4
+
+
+def test_tick_discards_every_transmit_meter_on_dekey() -> None:
+    """Dekey removes the four TX meters; a later key-down re-populates them.
+
+    Ageing alone leaves the last reading in the store and deliverable, so
+    removal is what stops a receive-time face from drawing it.
+    """
+
+    store = StateStore()
+    service = _ftx1_freshness_service(store)
+    store.apply(_observation(_AVAIL_PTT, True, at=1.0))
+    for path in _TX_METERS:
+        store.apply(_observation(path, 1.0, at=1.0))
+    service.tick(now=1.0)
+
+    store.apply(_observation(_AVAIL_PTT, False, at=2.0))
+    revision_before = store.snapshot().state_revision
+    service.tick(now=2.0)
+
+    after_dekey = store.snapshot()
+    for path in _TX_METERS:
+        with pytest.raises(KeyError):
+            after_dekey.field(path)
+    assert after_dekey.state_revision > revision_before
+
+    store.apply(_observation(_AVAIL_PTT, True, at=3.0))
+    for path in _TX_METERS:
+        store.apply(_observation(path, 2.0, at=3.0))
+    service.tick(now=3.0)
+
+    rekeyed = store.snapshot()
+    assert [rekeyed.field(path).value for path in _TX_METERS] == [2.0] * 4
+
+
+def test_tick_keeps_the_transmit_meters_while_ptt_is_unobserved() -> None:
+    """Unknown is not false: nothing has established the rig is receiving."""
+
+    store = StateStore()
+    service = _ftx1_freshness_service(store)
+    for path in _TX_METERS:
+        store.apply(_observation(path, 1.0, at=1.0))
+
+    service.tick(now=1.0)
+
+    snapshot = store.snapshot()
+    assert [snapshot.field(path).value for path in _TX_METERS] == [1.0] * 4
+
+
 def test_a_never_dispatched_request_may_not_be_credited() -> None:
     freq = FieldPath.active("main", "freq_mode", "freq_hz")
     scheduler = AcquisitionScheduler(profile=_profile([freq]))

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -1635,6 +1635,10 @@ def test_available_when_is_declared_only_where_a_probe_established_it() -> None:
                 declared.add((model, str(path)))
 
     assert declared == {
+        ("FTX-1", "global.meters.alc"),
+        ("FTX-1", "global.meters.comp"),
+        ("FTX-1", "global.meters.power"),
+        ("FTX-1", "global.meters.swr"),
         ("FTX-1", "receiver.main.operator_controls.att"),
         ("FTX-1", "receiver.main.operator_controls.manual_notch_freq"),
         ("FTX-1", "receiver.sub.active.freq_mode.freq_hz"),
@@ -1645,6 +1649,30 @@ def test_available_when_is_declared_only_where_a_probe_established_it() -> None:
         ("FTX-1", "receiver.sub.operator_controls.repeater_shift"),
         ("FTX-1", "receiver.sub.operator_controls.squelch"),
     }
+
+
+def test_ftx1_declares_the_transmit_meters_absent_outside_transmit() -> None:
+    """The four tx_only meters exist only while the canonical PTT reads true."""
+
+    acquisition = get_radio_profile("FTX-1").state_acquisition
+    assert acquisition is not None
+
+    ptt = FieldPath.global_("tx_state", "ptt")
+    clause = AvailabilityClause(field=ptt, operator="equals", value=True)
+    tx_meters = (
+        FieldPath.global_("meters", "alc"),
+        FieldPath.global_("meters", "power"),
+        FieldPath.global_("meters", "swr"),
+        FieldPath.global_("meters", "comp"),
+    )
+    for path in tx_meters:
+        policy = acquisition.policy_for(path)
+        assert policy.available_when == (clause,), path
+        assert policy.tx_only is True, path
+
+    # The condition source is itself polled, or nothing would ever resolve it.
+    assert acquisition.capability_for(ptt).can_poll
+    assert acquisition.policy_for(ptt).available_when == ()
 
 
 def test_ftx1_declares_every_sub_receiver_field_on_dual_receive() -> None:


### PR DESCRIPTION
## Mechanism

On the FTX-1 the four `tx_only` meters — `global.meters.alc`, `.power`,
`.swr`, `.comp` — are observed while PTT is true and, after dekey, stayed in
the store carrying their last transmit values (observed on the bench
2026-09-08). A face gating on availability therefore drew a live-looking
needle during receive.

Per R42 a field absent in the current state is neither polled nor shown, and
the profile is where that is declared. This PR declares the four
`available_when` `global.tx_state.ptt` `equals` `true` — the same path
`derive_tx_active` reads and the same path `YAESU_PTT_PATH` in
`backends/yaesu_cat/observations.py` resolves to (`YAESU_PTT_PATH = _PTT =
FieldPath.global_("tx_state", "ptt")`), i.e. the field the store actually
holds rather than a derived one. `StateFreshnessService._discard_declared_absent`
then removes them from the store on the first tick after PTT reads false,
through `StateStore.discard`, which invents no value and bumps the state
revision — so they are published as `missing`, not as a stale reading.

**No source change: this is a profile declaration plus its tests.**

### Polling is unchanged

`YaesuCatPoller._emit_fast_observations` reaches
`YaesuObservationAdapter.poll_tx_meters` — the only source of these four
paths — only when `self._current_ptt_observation()` returns a truthy
observation; otherwise it calls `poll_rx_meters`. `poll_tx_meters` itself
gates its four reads on `_has_runtime_capability("meters")` and
`_can_poll(path)` only: it does **not** consult `_available(path)`. (The
`_available()` guard is consulted at nine other call sites in that file —
the SUB freq/mode/s_meter/af/rf/squelch/repeater_shift pair, the MAIN
attenuator and the MAIN manual-notch frequency — but not in
`poll_tx_meters`.) So the declaration adds no new suppression on the read
side; it changes only what survives in the store after dekey.

### `tx_only` and the startup gate

`tx_only = true` is kept on all four.
`AcquisitionScheduler.unobserved_startup_paths` filters
`not profile.policy_for(path).tx_only and availability.get(path, True) is
True` — a `tx_only` path was already excluded before this change, and stays
excluded for the same reason, so the new clause does not double-gate the
startup predicate (`tests/test_startup_state_gate.py::test_unobserved_tx_only_path_does_not_keep_the_predicate_incomplete`
pins the `tx_only` half). `prime_unobserved` skips cadence-owned paths
entirely, and these four carry `cadence_seconds = 0.2` on pollable
capabilities, so it never touched them either.

## Ordering and worst-case latency

The PTT observation and the freshness tick are independent loops: the poller
applies observations through the observation callback, while
`StateFreshnessService.run` ticks on its own timer. `tick` therefore reads
whatever the store holds at that instant — if a tick lands just before the
`ptt = false` observation is applied, the discard happens on the next tick.

**Worst case: one tick interval, 0.050 s.** Source: `StateFreshnessService.__init__`
default `interval_seconds: float = 0.05`, and `StateFreshnessService.run`
sleeps exactly `self._interval_seconds` between ticks. All three production
construction sites accept that default — `web/server.py` (both the
constructor-time service and the one built during acquisition bootstrap) and
`rigctld/server.py`; `grep -rn "interval_seconds=" src/` returns no
`StateFreshnessService` caller that overrides it.

This is the latency from *the store seeing `ptt = false`* to the discard. How
long it takes the store to see `ptt = false` after the operator dekeys is the
PTT read cadence, a separate quantity this PR does not change and did not
measure.

## IC-7300

The earlier bench check recorded the IC-7300's `tx_only` meters as missing at
idle. Established by reading the code, not by a bench probe:

- **Nothing discards them.** `_discard_declared_absent` only considers paths
  whose policy carries a non-empty `available_when` (`resolve_available_when`
  returns no entry for the others), and `rigs/ic7300.toml` declares none on
  these four. The other `StateStore.discard` call sites are the relative-VFO
  retention paths (`freq_hz`/`mode`/`filter_num`/`data_mode`) in
  `core/state_store.py`, and in `web/radio_poller.py` three sites — the
  `filter_width` invalidation on `SetMode`, and `_vfo_identity_paths` in
  `reset_vfo_session` and in `_discard_vfo_identity` — none of them names a
  `global.meters.*` path.
- **They are never stored in RX.** The only ingress for those paths is
  `_OBSERVABLE_CMD15_FIELDS` in `runtime/_civ_rx.py` (subs `0x11`/`0x12`/
  `0x13`/`0x14`), which fires when a 0x15 frame arrives; the frame arrives
  only because `due_requests` dispatched the read, and `tx_only = true` keeps
  that cadence group idle while PTT reads false.

So "missing at idle" is explained by *never observed in that session*, not by
a discard. **I could not establish whether the bench session had transmitted
before the idle check.** If it had, the same values would have persisted
after dekey exactly as on the FTX-1 — the IC-7300 has the same latent shape.
No bench measurement establishes the symptom on the IC-7300, so
`rigs/ic7300.toml` is unchanged here, per the task's instruction.

## Tests

New, on the real FTX-1 profile through `StateFreshnessService.tick`:

- `tests/test_acquisition_scheduler.py::test_tick_keeps_the_transmit_meters_while_ptt_reads_true`
- `tests/test_acquisition_scheduler.py::test_tick_discards_every_transmit_meter_on_dekey`
  — all four removed, state revision bumped, and a later key-down
  re-populates them
- `tests/test_acquisition_scheduler.py::test_tick_keeps_the_transmit_meters_while_ptt_is_unobserved`
  — unknown is not false
- `tests/test_state_acquisition_policy.py::test_ftx1_declares_the_transmit_meters_absent_outside_transmit`
  — the clause and `tx_only` on each of the four, plus that the clause source
  is itself pollable
- `tests/test_state_acquisition_policy.py::test_available_when_is_declared_only_where_a_probe_established_it`
  — the shipped-profile census gains the four rows

Gates run locally at `c6598cb0b`:

- `uv run pytest tests/test_acquisition_scheduler.py tests/test_state_acquisition_policy.py -q` — 178 passed
- plus `tests/test_startup_state_gate.py tests/test_yaesu_cat_observation_adapter.py tests/test_yaesu_cat_poller.py` — 587 passed together with the two above
- `tests/test_tx_policy_shipped_profiles.py tests/test_rig_loader.py tests/test_mor2337_profile_compatibility.py tests/test_installed_profile_smoke.py tests/test_state_pipeline_contracts.py tests/test_web_runtime_helpers.py tests/validation/test_generator.py tests/validation/test_registry.py` — 755 passed, 1 skipped
- `uv run ruff check src/ tests/` — All checks passed
- `uv run ruff format --check src/ tests/` — 742 files already formatted
- `uv run lint-imports` — 5 kept, 0 broken
- `uv run mypy --strict src/rigplane/web` — no issues in 27 source files

The full suite is CI's; no local full-suite run was made.

## Mutations

Each applied to `rigs/ftx1.toml`, then `tests/test_acquisition_scheduler.py`
+ `tests/test_state_acquisition_policy.py` re-run (178 tests); the tree was
restored from a pristine copy after each.

1. **Clause removed from `global.meters.swr` only** → 3 failed, 175 passed:
   `test_tick_discards_every_transmit_meter_on_dekey`,
   `test_available_when_is_declared_only_where_a_probe_established_it` (its
   `global.meters.swr` row), and
   `test_ftx1_declares_the_transmit_meters_absent_outside_transmit`.
2. **Sense inverted on all four** (`equals = true` → `equals = false`) → 3
   failed, 175 passed: `test_tick_keeps_the_transmit_meters_while_ptt_reads_true`,
   `test_tick_discards_every_transmit_meter_on_dekey`, and
   `test_ftx1_declares_the_transmit_meters_absent_outside_transmit`.
   `test_tick_keeps_the_transmit_meters_while_ptt_is_unobserved` correctly
   survives — an unobserved source resolves `None` either way.
3. **Behaviour-preserving**: `available_when` moved above `tx_only` in the
   `global.meters.alc` block (TOML key order is not significant) → 178
   passed, no change.

`git diff` against the restored tree is the intended change only; no mutation
survives in the pushed head.

## Size

`git diff --numstat origin/main...HEAD` at `c6598cb0b`:

```
22	0	rigs/ftx1.toml
69	0	tests/test_acquisition_scheduler.py
28	0	tests/test_state_acquisition_policy.py
```

3 files, 119+/0- = 119 changed lines at `c6598cb0b`. Under both guardrails
(soft 6 files / 600 lines).

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

