### PR TITLE
feat: expose the spectrum panel's resolved colour roles on its root element

### DIFF
--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -66,8 +66,10 @@
   // omits it (defaults `false`, toggle shown) because it owns the driver.
   //
   // `colorRoles` is resolved over the defaults once, and the one resolved
-  // record feeds both the canvas renderer options and the CSS custom
-  // properties the DOM overlay below reads.
+  // record feeds the canvas renderer options, the CSS custom properties the
+  // DOM overlay below reads, and the `data-scope-color-roles` JSON on the
+  // panel root — one resolution for all three, pinned by `resolves the roles
+  // once per mount for both the root attribute and the renderer options`.
   let { hideSourceControls = false, hideScopeControls = false, hideAutoStepToggle = false, scopeControls,
     scopeProjection, scopeDemanded = true, onScopeDemandChange, colorRoles }: {
     hideSourceControls?: boolean; hideScopeControls?: boolean; hideAutoStepToggle?: boolean; scopeControls?: Snippet;
@@ -646,6 +648,7 @@
   class:audio-fft={audioFft}
   class:fullscreen
   data-waterfall
+  data-scope-color-roles={JSON.stringify(resolvedColorRoles)}
   tabindex="-1"
   onwheel={handleWheel}
   style:--scope-tune-line={resolvedColorRoles.tuneLine}

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -267,6 +267,7 @@ const passbandHarness = vi.hoisted(() => ({
 const spectrumRendererHarness = vi.hoisted(() => ({
   lastOptions: null as any,
   constructed: 0,
+  resolveColorRolesCalls: 0,
   render: vi.fn((_ctx: unknown, _data: Uint8Array, _width: number, _height: number, options: any) => {
     spectrumRendererHarness.lastOptions = options;
   }),
@@ -315,7 +316,14 @@ vi.mock('$lib/renderers/spectrum-renderer', async (importOriginal) => {
     setPeakHoldEnabled = spectrumRendererHarness.setPeakHoldEnabled;
     render = spectrumRendererHarness.render;
   }
-  return { ...actual, SpectrumRenderer };
+  return {
+    ...actual,
+    resolveSpectrumColorRoles: (...args: Parameters<typeof actual.resolveSpectrumColorRoles>) => {
+      spectrumRendererHarness.resolveColorRolesCalls++;
+      return actual.resolveSpectrumColorRoles(...args);
+    },
+    SpectrumRenderer,
+  };
 });
 
 vi.mock('$lib/runtime/tx-controller/managed-app-host', () => ({
@@ -1668,6 +1676,40 @@ describe('SpectrumPanel colour roles', () => {
       ...spectrumColorRolesToOptions(defaultSpectrumColorRoles),
       tuneLineColor: '#0a0a0a',
     });
+  });
+
+  function publishedRoles(target: HTMLElement) {
+    const panel = target.querySelector<HTMLElement>('.spectrum-panel')!;
+    return JSON.parse(panel.dataset.scopeColorRoles!);
+  }
+
+  it('publishes on the root the same seven resolved roles it sends to the renderer', async () => {
+    const target = mountPanel({ colorRoles: distinct });
+    emitFrame();
+    await vi.waitFor(() => expect(spectrumRendererHarness.render).toHaveBeenCalled());
+    const published = publishedRoles(target);
+    expect(published).toEqual(distinct);
+    expect(spectrumRendererHarness.lastOptions).toMatchObject(spectrumColorRolesToOptions(published));
+  });
+
+  it('publishes the defaults on the root when no roles are passed', () => {
+    expect(publishedRoles(mountPanel())).toEqual(defaultSpectrumColorRoles);
+  });
+
+  it('publishes the default on the root for an explicit undefined override', () => {
+    const target = mountPanel({
+      colorRoles: { tuneLine: undefined, traceFill: { top: undefined, bottom: undefined } },
+    });
+    expect(publishedRoles(target)).toEqual(defaultSpectrumColorRoles);
+  });
+
+  it('resolves the roles once per mount for both the root attribute and the renderer options', async () => {
+    spectrumRendererHarness.resolveColorRolesCalls = 0;
+    const target = mountPanel({ colorRoles: distinct });
+    emitFrame();
+    await vi.waitFor(() => expect(spectrumRendererHarness.render).toHaveBeenCalled());
+    expect(publishedRoles(target)).toEqual(distinct);
+    expect(spectrumRendererHarness.resolveColorRolesCalls).toBe(1);
   });
 });
 


### PR DESCRIPTION
2 files, 48+/3- = 51 changed lines at 143416d77.

## Mechanism

`SpectrumPanel` resolves its `colorRoles` prop over the defaults once, in a
single `resolvedColorRoles = $derived(resolveSpectrumColorRoles(colorRoles))`,
and that record already feeds two consumers: the canvas renderer options (via
`spectrumColorRolesToOptions`) and the three `--scope-tune-line` /
`--scope-passband-fill` / `--scope-passband-edge` custom properties the DOM
overlay reads.

Four of the seven roles — `trace`, `traceFill` (both stops), `grid`,
`axisText` — reach only the canvas, so nothing in the DOM reports the value the
panel resolved for them, and the pixel witness added in #3391 does not flag a
pale trace recolour.

This adds a third read of the same derived: the panel root element now carries
the whole resolved record as JSON. No second resolution, and the renderer, the
roles record, the defaults and the custom properties are untouched.

## The surface

Attribute `data-scope-color-roles` on `.spectrum-panel` (the panel root, the
same element that carries `data-waterfall` and the `--scope-*` properties),
holding `JSON.stringify(resolvedColorRoles)`. Read it with
`panel.dataset.scopeColorRoles`.

Key order is the object-literal order of `resolveSpectrumColorRoles`'s return.
With no `colorRoles` prop the attribute is exactly (printed from
`JSON.stringify(resolveSpectrumColorRoles())` at this head):

```json
{"trace":"rgba(210,220,230,0.85)","traceFill":{"top":"rgba(30,58,138,0.30)","bottom":"rgba(30,58,138,0.02)"},"grid":"rgba(255,255,255,0.15)","axisText":"rgba(180,200,220,0.6)","tuneLine":"rgba(239,68,68,0.75)","passbandFill":"rgba(59,130,246,0.15)","passbandEdge":"rgba(59,130,246,0.4)"}
```

A consumer should parse it rather than match the string: the values are
whatever the host passed, and only the keys are fixed by `SpectrumColorRoles`.

## Tests

Four tests added to the existing `SpectrumPanel colour roles` describe in
`frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts`,
reusing that block's `distinct` seven-value fixture (`traceFill` top and bottom
distinct):

- *publishes on the root the same seven resolved roles it sends to the
  renderer* — parses the attribute, asserts it equals `distinct`, and asserts
  the captured renderer options match `spectrumColorRolesToOptions(parsed)`, so
  the two consumers are checked against one object rather than separately.
- *publishes the defaults on the root when no roles are passed*.
- *publishes the default on the root for an explicit undefined override* —
  `tuneLine: undefined` and both `traceFill` stops undefined (the #3388 rule).
- *resolves the roles once per mount for both the root attribute and the
  renderer options* — the file's existing `$lib/renderers/spectrum-renderer`
  mock now wraps `resolveSpectrumColorRoles` with a counter delegating to the
  real one; the test asserts one call per mount. No test before this change
  pinned the resolver's call count.

`SpectrumPanel.component.test.ts` as a whole: 118 passed, 0 failed.

## Mutations

Run on the implemented tree; the tree was restored afterwards and `git diff`
against the commit is empty.

1. Delete the `data-scope-color-roles` attribute from the panel root →
   4 failed, 114 passed (all four new tests).
2. Feed the attribute from a second
   `JSON.stringify(resolveSpectrumColorRoles(colorRoles))` call instead of the
   shared derived → 1 failed, 117 passed: only the once-per-mount test,
   `expected 2 to be 1`. The other three stay green, which is correct — a
   second resolution of the same input produces the same values.
3. Behaviour-preserving control: route the attribute through an intermediate
   `colorRolesAttr = $derived(JSON.stringify(resolvedColorRoles))` →
   118 passed.

## Gates run locally

- `npx vitest run src/components/spectrum/__tests__/SpectrumPanel.component.test.ts` — 118 passed
- `npm run check` — 4841 files, 0 errors, 0 warnings
- `npm run lint` — clean
- `npm run lint:boundaries` — clean

The `visual` job is expected green: this change adds a data attribute and
paints nothing, and #3391's witness is a `toHaveScreenshot` pixel comparison.
Confirm it on this head's run rather than on that reasoning.

## Out of scope

No consumer of the attribute, no face colour values, and no fixture change —
#3391's witness and its baseline PNG are untouched. The face lane writes the
test that pins its seven values.

Internal-identifier self-check — empty.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

