### PR TITLE
feat: declare and poll the FTX-1 drain voltage and current meters

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -135,6 +135,13 @@ polling_only = [
     "receiver.main.operator_controls.repeater_shift",
     "receiver.sub.operator_controls.repeater_shift",
     "global.tx_state.dual_watch",
+    # MOR-2425/T147: drain voltage/current (CAT RM P1 8 = VDD, 7 = IDD). Plain
+    # polling_only, not stream_like_meters: the stream class is pinned to a
+    # fast cadence and a <= 2.0s TTL by
+    # test_known_profiles_stream_like_meters_use_fast_non_decaying_policies,
+    # and these two ride the 1.0s slow-control group below instead.
+    "global.meters.vd",
+    "global.meters.id",
 ]
 stream_like_meters = [
     "receiver.main.meters.s_meter",
@@ -227,6 +234,33 @@ tx_only = true
 available_when = [
     { field = "global.tx_state.ptt", equals = true },
 ]
+
+# MOR-2425/T147: drain voltage and current (CAT RM P1 8 = VDD, 7 = IDD).
+# Neither `tx_only` nor `available_when`, unlike the four blocks above: a
+# read-only bench probe on 2026-09-08 sent `RM7;` and `RM8;` ten times each
+# with the FTX-1 receiving and got an answer to every one -- IDD raw 000, VDD
+# raw 212, no refusal, no timeout, no parse error, 8.3-14.4 ms per read. So
+# they join AcquisitionScheduler.unobserved_startup_paths (a tx_only path is
+# excluded from it) and that probe is the evidence the gate can be satisfied
+# without transmitting.
+#
+# 1.0s/2.0s is the slow-control tier's pair, described under its own header
+# below: these two are read by YaesuObservationAdapter.poll_slow_controls, so
+# 1.0s is YaesuCatPoller._SLOW_INTERVAL, the interval of the group that
+# actually re-reads them, and the TTL is twice the cadence -- the same pair
+# `receiver.main.operator_controls.af_level` carries, which
+# tests/test_yaesu_cat_poller.py::
+# test_slow_group_interval_matches_the_profile_slow_control_cadence pins to
+# `_SLOW_INTERVAL`. Pinned for these two paths by
+# tests/test_state_acquisition_policy.py::
+# test_ftx1_drain_meters_poll_in_receive_at_the_slow_control_cadence.
+[state_acquisition.field_policies."global.meters.vd"]
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
+
+[state_acquisition.field_policies."global.meters.id"]
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
 
 # --- Slow-control tier ------------------------------------------------------
 # MOR-2425 (owner ruling, 2026-09-07): 30.0s/120.0s -> 1.0s/2.0s. These
@@ -883,6 +917,54 @@ label = "S9+20"
 raw = 240
 actual = 40.0
 label = "S9+40"
+
+# MOR-2425/T147 -- drain voltage (CAT RM8, VDD). TWO POINTS, and the bench run
+# they come from establishes nothing about the curve between or beyond them:
+# the straight line is what `runtime/meter_cal.py: interpolate_meter` draws
+# through two points, not a measured property of this meter. Outside the
+# endpoints that function clamps, so raw 212 -- the value the radio answers
+# while receiving -- yields 13.8, not more.
+#
+# raw 210 -> 13.8 V: bench 2026-09-08. During a 3.007 s transmit at 5 W on
+# 14.113 MHz with the radio's MAIN display meter switched to VDD (`MS35;`), the
+# owner read 13.8 V off that display while `RM8;`, polled 190 times in the same
+# window from the same process, answered raw 210 on all 159 reads at
+# t >= 500 ms after key-down.
+#
+# raw 0 -> 0.0 V is an ASSUMED origin, not a measurement: no bench reading
+# below raw 210 exists for this meter, and the probe never took the supply
+# rail down.
+[[meters.vd.calibration]]
+raw = 0
+actual = 0.0
+label = "0"
+
+[[meters.vd.calibration]]
+raw = 210
+actual = 13.8
+label = "13.8"
+
+# MOR-2425/T147 -- drain current (CAT RM7, IDD). Two points, same caveat: the
+# line between them is interpolate_meter's, not a measured property.
+#
+# raw 29 -> 1.0 A: bench 2026-09-08, the second keyed window (3.001 s, 5 W,
+# 14.113 MHz) with the display switched to ID (`MS45;`). `RM7;` answered raw 29
+# on all 163 reads at t >= 500 ms after key-down. The owner's display reading
+# was reported as "just above 1" A -- the display's granularity is coarse and
+# no finer figure was taken -- and 1.0 is what this table records for it.
+#
+# raw 0 -> 0.0 A: `RM7;` answered raw 000 on all ten receive reads of the
+# read-only probe run the same day, and on the two receive baselines of this
+# run.
+[[meters.id.calibration]]
+raw = 0
+actual = 0.0
+label = "0"
+
+[[meters.id.calibration]]
+raw = 29
+actual = 1.0
+label = "1.0"
 
 [agc]
 modes = [0, 1, 2, 3, 4, 5, 6]

--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -69,6 +69,13 @@ _SWR_METER = FieldPath.global_("meters", "swr")
 # 0x15 0x14); the FTX-1 reads it via RM3. Emitted as a stream-like TX meter in
 # the same lane and under the same freshness/coalescing policy as alc/power/swr.
 _COMP_METER = FieldPath.global_("meters", "comp")
+# Drain voltage / current (MOR-2425/T147; CAT RM P1 8 = VDD, 7 = IDD). Read in
+# ``poll_slow_controls``, NOT ``poll_tx_meters``: a read-only bench probe on
+# 2026-09-08 got an answer to all ten ``RM7;`` and all ten ``RM8;`` reads with
+# the radio receiving, so these are supply telemetry rather than TX readings
+# and the profile declares them without ``tx_only``.
+_VD_METER = FieldPath.global_("meters", "vd")
+_ID_METER = FieldPath.global_("meters", "id")
 # Global TX / operator-control setpoints (MOR-447). ``power_level`` is the
 # watt SETPOINT (CAT ``PC``), distinct from the ``global.meters.power`` meter.
 _POWER_LEVEL = FieldPath.global_("operator_controls", "power_level")
@@ -264,6 +271,10 @@ class YaesuObservationRadio(Protocol):
     async def read_power_meter(self) -> int: ...
 
     async def read_swr_meter(self) -> int: ...
+
+    async def get_vd_meter(self) -> int: ...
+
+    async def get_id_meter(self) -> int: ...
 
     async def read_power(self) -> tuple[int, int]: ...
 
@@ -1098,6 +1109,41 @@ class YaesuObservationAdapter:
                         _CW_SPOT,
                         bool(value),
                         native_id="read_cw_spot",
+                    )
+                )
+        # Drain voltage / current (MOR-2425/T147; CAT ``RM8``/``RM7``). Read in
+        # this always-running lane rather than the PTT-gated ``poll_tx_meters``
+        # — the 2026-09-08 bench probe got an answer to both while receiving.
+        # ``get_vd_meter``/``get_id_meter`` route through ``_read_meter`` and do
+        # not mutate legacy state, so no ``read_*`` twin is needed. Scaled by
+        # the profile's ``[[meters.vd|id.calibration]]`` tables under the same
+        # ``_calibrate_meter`` the other meters use.
+        if self._has_runtime_capability("meters") and self._can_poll(_VD_METER):
+            ok, raw = await self._safe_read(
+                "vd", self.radio.get_vd_meter(), paths=(_VD_METER,)
+            )
+            if ok and raw is not None:
+                value, quality = self._calibrate_meter(raw, "vd")
+                observations.append(
+                    adapter.observation(
+                        _VD_METER,
+                        value,
+                        native_id="get_vd_meter",
+                        quality=quality,
+                    )
+                )
+        if self._has_runtime_capability("meters") and self._can_poll(_ID_METER):
+            ok, raw = await self._safe_read(
+                "id", self.radio.get_id_meter(), paths=(_ID_METER,)
+            )
+            if ok and raw is not None:
+                value, quality = self._calibrate_meter(raw, "id")
+                observations.append(
+                    adapter.observation(
+                        _ID_METER,
+                        value,
+                        native_id="get_id_meter",
+                        quality=quality,
                     )
                 )
         return tuple(observations)

--- a/tests/test_rig_multi_vendor.py
+++ b/tests/test_rig_multi_vendor.py
@@ -403,24 +403,46 @@ class TestMultiVendorProfiles:
         assert len(rig.meter_calibrations["s_meter"]) >= 6
 
     def test_ftx1_pa_meters_declare_no_calibration_table(self):
-        """MOR-1527: power/ALC/COMP/Vd/Id have no trustworthy source for the
+        """MOR-1527: power/ALC/COMP have no trustworthy source for the
         FTX-1. Unlike the IC-7300 (hamlib's ic7300.c driver documents its
         PA-meter scales, see rigs/ic7300.toml), no equivalent published
         table exists for the FTX-1 — it postdates hamlib's own FTX-1
         support (Hamlib#1600, "waiting for CAT manual" as of this ticket)
         and the pre-existing [meters.swr] table on this profile is itself
         labelled a best-effort approximation pending bench calibration, not
-        a citable source for the other five meters. Per MOR-1291 doctrine
+        a citable source for the other meters. Per MOR-1291 doctrine
         (no invented defaults), the honest choice is to declare nothing:
-        these five meters stay uncalibrated and render the raw device byte
+        these three meters stay uncalibrated and render the raw device byte
         (tagged "raw" — see meter-utils.ts's formatRaw) until a real
         source (live bench measurement or a matured hamlib driver) exists.
         This test pins that absence so a future change does not
-        accidentally invent unsourced anchors."""
+        accidentally invent unsourced anchors.
+
+        Vd/Id left this list under MOR-2425/T147: the bench measurement the
+        docstring above names as the qualifying source was taken on
+        2026-09-08, and rigs/ftx1.toml now carries a two-point table for
+        each, provenance in the comment above the blocks. They are pinned
+        instead by ``test_ftx1_drain_meters_declare_the_bench_two_point_table``
+        below."""
         rig = load_rig(RIGS_DIR / "ftx1.toml")
         assert rig.meter_calibrations is not None
-        for meter_key in ("power", "alc", "comp", "vd", "id"):
+        for meter_key in ("power", "alc", "comp"):
             assert meter_key not in rig.meter_calibrations
+
+    def test_ftx1_drain_meters_declare_the_bench_two_point_table(self):
+        """MOR-2425/T147: Vd/Id carry exactly the two bench points each.
+
+        Two points, no more: the 2026-09-08 run took one display reading per
+        meter during transmit, and nothing in it establishes the shape of the
+        curve away from those anchors."""
+        rig = load_rig(RIGS_DIR / "ftx1.toml")
+        assert rig.meter_calibrations is not None
+        assert [
+            (point["raw"], point["actual"]) for point in rig.meter_calibrations["vd"]
+        ] == [(0, 0.0), (210, 13.8)]
+        assert [
+            (point["raw"], point["actual"]) for point in rig.meter_calibrations["id"]
+        ] == [(0, 0.0), (29, 1.0)]
 
     def test_ftx1_nb_level_is_toggle(self):
         rig = load_rig(RIGS_DIR / "ftx1.toml")

--- a/tests/test_startup_state_gate.py
+++ b/tests/test_startup_state_gate.py
@@ -948,3 +948,30 @@ def test_ftx1_sub_paths_enter_the_gate_once_dual_receive_is_observed_on() -> Non
 
     assert set(FTX1_SUB_PATHS).issubset(outstanding)
     assert DUAL_WATCH not in outstanding
+
+
+FTX1_DRAIN_PATHS = (
+    FieldPath.global_("meters", "vd"),
+    FieldPath.global_("meters", "id"),
+)
+
+
+def test_ftx1_drain_meters_hold_the_gate_open_until_they_are_observed() -> None:
+    """MOR-2425/T147: declaring VDD/IDD without ``tx_only`` enrols them.
+
+    ``AcquisitionScheduler.unobserved_startup_paths`` drops a ``tx_only``
+    path, which is why the four transmit meters never hold the gate. These
+    two are not ``tx_only``, so the web start-up wait covers them -- the
+    2026-09-08 bench probe is the evidence that a receiving FTX-1 answers
+    both, in 8.3-14.4 ms per read.
+    """
+    outstanding = _ftx1_outstanding(StateStore())
+
+    assert set(FTX1_DRAIN_PATHS).issubset(outstanding)
+    # Not vacuous: the transmit meters sharing the same CAT command are
+    # excluded from the same set by their ``tx_only``.
+    assert FieldPath.global_("meters", "swr") not in outstanding
+
+    observed = _ftx1_outstanding(StateStore(), FTX1_DRAIN_PATHS)
+
+    assert set(FTX1_DRAIN_PATHS).isdisjoint(observed)

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -911,6 +911,41 @@ def test_ftx1_tx_meters_are_declared_tx_only() -> None:
         assert ftx1.state_acquisition.policy_for(path).tx_only is True
 
 
+def test_ftx1_drain_meters_poll_in_receive_at_the_slow_control_cadence() -> None:
+    """MOR-2425/T147: VDD/IDD are declared, pollable, and NOT ``tx_only``.
+
+    A read-only bench probe on 2026-09-08 got an answer to all ten ``RM7;``
+    and all ten ``RM8;`` reads with the FTX-1 receiving, so these two carry
+    neither ``tx_only`` nor an ``available_when`` clause -- unlike the four
+    transmit meters above. They are read by
+    ``YaesuObservationAdapter.poll_slow_controls``, so their cadence is the
+    slow-control tier's 1.0s, the same number
+    ``YaesuCatPoller._SLOW_INTERVAL`` carries, with the TTL at twice that.
+    """
+    ftx1 = get_radio_profile("FTX-1")
+    assert ftx1.state_acquisition is not None
+    acquisition = ftx1.state_acquisition
+
+    af_level = FieldPath.receiver("main", "operator_controls", "af_level")
+    for path in (
+        FieldPath.global_("meters", "vd"),
+        FieldPath.global_("meters", "id"),
+    ):
+        capability = acquisition.capability_for(path)
+        policy = acquisition.policy_for(path)
+        assert capability.can_poll is True, path
+        # Not the stream-meter class: that class is bound to a fast cadence by
+        # test_known_profiles_stream_like_meters_use_fast_non_decaying_policies.
+        assert capability.stream_like is False, path
+        assert policy.tx_only is False, path
+        assert policy.available_when == (), path
+        assert policy.cadence_seconds == 1.0, path
+        assert policy.freshness_ttl_seconds == 2.0, path
+        assert (
+            policy.cadence_seconds == acquisition.policy_for(af_level).cadence_seconds
+        )
+
+
 def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
     profile = get_radio_profile("IC-7300")
     acquisition = profile.state_acquisition
@@ -1332,8 +1367,8 @@ def test_ic7300_activation_does_not_change_ftx1_acquisition_contract() -> None:
     assert acquisition is not None
 
     assert acquisition.provider == "yaesu_cat"
-    assert len(acquisition.capabilities) == 56
-    assert len(acquisition.field_policies) == 51
+    assert len(acquisition.capabilities) == 58
+    assert len(acquisition.field_policies) == 53
     assert acquisition.default_policy.cadence_seconds == 2.0
     assert acquisition.default_policy.freshness_ttl_seconds == 8.0
 

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -153,6 +153,10 @@ def _make_radio() -> MagicMock:
     radio.read_power_meter = AsyncMock(return_value=180)
     radio.get_swr_meter = AsyncMock(return_value=120)
     radio.read_swr_meter = AsyncMock(return_value=120)
+    # Drain meters (MOR-2425/T147): the raw values a read-only bench probe read
+    # off the FTX-1 on 2026-09-08 while receiving — VDD 212, IDD 0.
+    radio.get_vd_meter = AsyncMock(return_value=212)
+    radio.get_id_meter = AsyncMock(return_value=0)
     # Global TX / operator-control setpoints (MOR-447).
     radio.get_power = AsyncMock(return_value=(2, 55))
     radio.read_power = AsyncMock(return_value=(2, 55))
@@ -253,6 +257,9 @@ class _SideEffectingYaesuRadio:
         self.radio_state.comp_meter = 5
         self.radio_state.power_meter = 5
         self.radio_state.swr_meter = 6
+        # Sentinels for the pure drain reads (MOR-2425/T147).
+        self.radio_state.vd_meter = 23
+        self.radio_state.id_meter = 24
         self.radio_state.main.af_level = 7
         self.radio_state.main.rf_gain = 8
         self.radio_state.main.squelch = 9
@@ -368,6 +375,16 @@ class _SideEffectingYaesuRadio:
         value = await self.read_swr_meter()
         self.radio_state.swr_meter = value
         return value
+
+    # Drain meters (MOR-2425/T147): unlike the meters above, the FTX-1 backend
+    # has no ``read_*`` twin for these — ``get_vd_meter``/``get_id_meter`` are
+    # already pure ``_read_meter`` calls that never touch legacy state, which
+    # is what the sentinels seeded in ``__init__`` are here to prove.
+    async def get_vd_meter(self) -> int:
+        return 212
+
+    async def get_id_meter(self) -> int:
+        return 0
 
     async def read_af_level(self, receiver: int = 0) -> int:
         return 128 if receiver == 0 else 64
@@ -870,9 +887,16 @@ async def test_slow_poll_emits_declared_control_observations_only() -> None:
         # like the legacy poller's always-on ``get_vfo_select`` read. The int
         # receiver index (1=SUB) coerces to the neutral "MAIN"/"SUB" str.
         ("global.slow_state.active", "SUB"),
-        # cw_spot (MOR-456): global slow_state bool (CAT ``CS``), closes the
-        # slow-control lane, gated on the legacy poller's ``"cw" in caps`` gate.
+        # cw_spot (MOR-456): global slow_state bool (CAT ``CS``), gated on the
+        # legacy poller's ``"cw" in caps`` gate.
         ("global.slow_state.cw_spot", True),
+        # Drain voltage/current (MOR-2425/T147): supply telemetry read in this
+        # always-running lane, not the PTT-gated ``poll_tx_meters``. Raw 212/0
+        # are scaled through the FTX-1 profile's two-point tables; the clamp
+        # at raw 212 is pinned by
+        # ``test_slow_poll_clamps_the_receive_drain_voltage_to_the_last_point``.
+        ("global.meters.vd", 13.8),
+        ("global.meters.id", 0.0),
     ]
     assert all(item.source.source == "yaesu_poll_response" for item in observations)
     assert all(item.max_age == 2.0 for item in observations)
@@ -1108,6 +1132,91 @@ async def test_tx_meters_poll_skips_alc_comp_without_meters_capability() -> None
     radio.read_power_meter.assert_not_awaited()
     radio.read_swr_meter.assert_not_awaited()
     radio.read_comp_meter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_drain_meters_ride_the_slow_lane_and_not_the_tx_meter_lane() -> None:
+    """RM8/RM7 are read by ``poll_slow_controls``, never ``poll_tx_meters``.
+
+    ``poll_tx_meters`` runs only under a truthy PTT observation
+    (``poller.py: YaesuCatPoller._emit_fast_observations``), so a drain read
+    placed there would never fire on a receiving radio — and the profile
+    declares these two paths without ``tx_only``, which puts them in the
+    startup gate.
+    """
+    radio = _make_radio()
+    adapter = YaesuObservationAdapter(
+        radio,
+        profile=_profile_state_acquisition(),
+        clock=_clock,
+    )
+
+    tx_meters = await adapter.poll_tx_meters()
+
+    assert [str(item.path) for item in tx_meters] == [
+        "global.meters.alc",
+        "global.meters.power",
+        "global.meters.swr",
+        "global.meters.comp",
+    ]
+    radio.get_vd_meter.assert_not_awaited()
+    radio.get_id_meter.assert_not_awaited()
+
+    slow = await adapter.poll_slow_controls()
+
+    assert [str(item.path) for item in slow][-2:] == [
+        "global.meters.vd",
+        "global.meters.id",
+    ]
+    radio.get_vd_meter.assert_awaited_once()
+    radio.get_id_meter.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_slow_poll_clamps_the_receive_drain_voltage_to_the_last_point() -> None:
+    """Raw 212 yields 13.8 V, not an extrapolation above it (MOR-2425/T147).
+
+    ``runtime/meter_cal.py: interpolate_meter`` clamps outside its endpoints,
+    and the FTX-1 profile's last ``vd`` point is raw 210 -> 13.8, so the raw
+    212 the radio answers while receiving lands exactly on that endpoint.
+    """
+    radio = _make_radio()
+    adapter = YaesuObservationAdapter(
+        radio,
+        profile=_profile_state_acquisition(),
+        clock=_clock,
+    )
+
+    by_path = {str(item.path): item for item in await adapter.poll_slow_controls()}
+
+    assert by_path["global.meters.vd"].value == 13.8
+    assert by_path["global.meters.vd"].quality == ("confirmed", "calibrated")
+    assert by_path["global.meters.id"].value == 0.0
+    assert by_path["global.meters.id"].quality == ("confirmed", "calibrated")
+
+
+@pytest.mark.asyncio
+async def test_slow_poll_interpolates_a_drain_reading_between_the_two_points() -> None:
+    """A raw between the two ``id`` points is the line through them.
+
+    Raw 29 -> 1.0 A is the profile's transmit point, so half of it is half an
+    amp. This is what fails if either calibration point moves.
+    """
+    radio = _make_radio()
+    radio.get_id_meter = AsyncMock(return_value=29)
+    radio.get_vd_meter = AsyncMock(return_value=105)
+    adapter = YaesuObservationAdapter(
+        radio,
+        profile=_profile_state_acquisition(),
+        clock=_clock,
+    )
+
+    by_path = {
+        str(item.path): item.value for item in await adapter.poll_slow_controls()
+    }
+
+    assert by_path["global.meters.id"] == 1.0
+    assert by_path["global.meters.vd"] == pytest.approx(6.9)
 
 
 @pytest.mark.asyncio
@@ -1401,6 +1510,11 @@ async def test_adapter_uses_read_only_yaesu_paths_when_getters_mutate_state() ->
         # cw_spot (MOR-456) — global slow_state bool, gated on the ``cw`` cap
         # (present here); ``read_cw_spot`` does not mutate legacy state.
         ("global.slow_state.cw_spot", True),
+        # Drain meters (MOR-2425/T147) close the slow-control lane; the raw
+        # counts are emitted because this double's profile carries no
+        # ``meter_calibrations`` dict.
+        ("global.meters.vd", 212),
+        ("global.meters.id", 0),
         (
             "global.operator_controls.power_level",
             pytest.approx(_normalized_power(55)),
@@ -1442,6 +1556,10 @@ async def test_adapter_uses_read_only_yaesu_paths_when_getters_mutate_state() ->
     assert radio.radio_state.comp_meter == 5
     assert radio.radio_state.power_meter == 5
     assert radio.radio_state.swr_meter == 6
+    # The drain reads have no ``read_*`` twin: ``get_vd_meter``/``get_id_meter``
+    # are themselves pure, so the sentinels survive the poll (MOR-2425/T147).
+    assert radio.radio_state.vd_meter == 23
+    assert radio.radio_state.id_meter == 24
     assert radio.radio_state.main.af_level == 7
     assert radio.radio_state.main.rf_gain == 8
     assert radio.radio_state.main.squelch == 9
@@ -2136,6 +2254,8 @@ async def test_happy_path_slow_poll_unchanged_when_all_reads_succeed() -> None:
         ("receiver.main.operator_controls.tsql_freq", 8850),
         ("global.slow_state.active", "SUB"),
         ("global.slow_state.cw_spot", True),
+        ("global.meters.vd", 13.8),
+        ("global.meters.id", 0.0),
     ]
 
 
@@ -2550,6 +2670,20 @@ _DEFECT_ROWS: tuple[tuple[str, str, int | None, str, tuple[str, ...]], ...] = (
         None,
         "poll_slow_controls",
         ("global.slow_state.cw_spot",),
+    ),
+    (
+        "vd",
+        "get_vd_meter",
+        None,
+        "poll_slow_controls",
+        ("global.meters.vd",),
+    ),
+    (
+        "id",
+        "get_id_meter",
+        None,
+        "poll_slow_controls",
+        ("global.meters.id",),
     ),
     (
         "power_level",

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -1082,6 +1082,14 @@ class _SideEffectingYaesuRadio:
         """Pure native FR00 fixture: 0 = dual receive."""
         return 0
 
+    # Drain meters (MOR-2425/T147): pure ``_read_meter`` calls on the real
+    # backend — no legacy mirror, so no ``legacy_getter_calls`` bump here.
+    async def get_vd_meter(self) -> int:
+        return 212
+
+    async def get_id_meter(self) -> int:
+        return 0
+
     async def read_s_meter(self, receiver: int = 0) -> int:
         return 150 if receiver == 0 else 75
 
@@ -2747,10 +2755,15 @@ async def test_observation_poller_uses_read_only_paths_when_getters_mutate_state
         # filter_width/if_shift need their runtime caps (absent here); narrow
         # is unconditional and MAIN-only, like AGC (MOR-445).
         ("receiver.main.operator_toggles.narrow", True),
-        # active-slot (MOR-446) closes the slow-control lane; unconditional like
-        # AGC/narrow, the SUB index coerces to the neutral "SUB" str. split is
-        # skipped: this radio lacks the ``split`` runtime cap.
+        # active-slot (MOR-446): unconditional like AGC/narrow, the SUB index
+        # coerces to the neutral "SUB" str. split is skipped: this radio lacks
+        # the ``split`` runtime cap.
         ("global.slow_state.active", "SUB"),
+        # Drain voltage/current (MOR-2425/T147) close the slow-control lane,
+        # scaled through the FTX-1 profile's two-point tables. cw_spot is
+        # skipped: this radio lacks the ``cw`` runtime cap.
+        ("global.meters.vd", 13.8),
+        ("global.meters.id", 0.0),
         (
             "global.operator_controls.power_level",
             pytest.approx(_normalized_power(55)),

--- a/tests/test_yaesu_web_projection.py
+++ b/tests/test_yaesu_web_projection.py
@@ -209,6 +209,10 @@ def _make_radio() -> MagicMock:
     radio.read_comp_meter = AsyncMock(return_value=30)
     radio.read_power_meter = AsyncMock(return_value=180)
     radio.read_swr_meter = AsyncMock(return_value=120)
+    # Drain meters (MOR-2425/T147), read in the slow lane: the raw values the
+    # 2026-09-08 read-only bench probe got from a receiving FTX-1.
+    radio.get_vd_meter = AsyncMock(return_value=212)
+    radio.get_id_meter = AsyncMock(return_value=0)
     # An unrelated RX-meter read used to prove no snap-back.
     radio.read_s_meter = AsyncMock(return_value=150)
     # Filter / IF-shift / narrow DSP controls (MOR-445). filter_width is read


### PR DESCRIPTION
## The fact

The FTX-1 reports drain voltage and current over CAT — `RM P1 8` = VDD,
`7` = IDD, raw 000–255 — and `backends/yaesu_cat/radio.py:
YaesuCatRadio.get_vd_meter()`/`get_id_meter()` already implement both reads.
Nothing polled them, and `rigs/ftx1.toml` never declared them, so the two
paths the state vocabulary already reserves (`global.meters.vd` unit `v`,
`global.meters.id` unit `a`) were never observed on this radio. Absence
follows the profile, and the profile must not omit what the radio reports.

## Two-point calibration and its provenance

Measured on the bench 2026-09-08, driven through the library object with the
CAT frame log captured in the same process that keyed the radio:

| meter | point | how it was established |
|---|---|---|
| `vd` | raw 210 → 13.8 V | 3.007 s transmit at 5 W on 14.113 MHz, display switched to VDD; the owner read 13.8 V off the radio's own meter while `RM8;` answered raw 210 on all 159 reads at t ≥ 500 ms after key-down |
| `vd` | raw 0 → 0.0 V | **assumed origin, not a measurement** — no reading below raw 210 exists for this meter |
| `id` | raw 29 → 1.0 A | second 3.001 s transmit at 5 W, display switched to ID; `RM7;` answered raw 29 on all 163 reads at t ≥ 500 ms. The owner's display reading was reported as "just above 1" A — the display granularity is coarse and no finer figure was taken — and 1.0 is what the table records |
| `id` | raw 0 → 0.0 A | `RM7;` answered raw 000 on all ten receive reads of the read-only probe the same day, and on the receive baseline of each of the two passes of the calibration run (the preflight pass and the keyed run's own preflight, 32 s apart) |

Two points each, and nothing in that run establishes the shape of the curve
away from the anchors: the straight line between them is what
`runtime/meter_cal.py: interpolate_meter` draws through two points, not a
property of the meter. That function **clamps** outside its endpoints, so
raw 212 — the value a receiving FTX-1 answers — yields exactly 13.8 V, not
an extrapolation above it.

## Poll tier and cadence

Read in `YaesuObservationAdapter.poll_slow_controls`, the always-running,
non-PTT-gated lane — not `poll_tx_meters`, which
`YaesuCatPoller._emit_fast_observations` reaches only under a truthy PTT
observation and which would therefore never fire on a receiving radio. Gated
the same way as the existing meter reads (`_has_runtime_capability("meters")`
and `_can_poll`) and routed through the existing `_safe_read` contract, so a
`?;` refusal or a malformed frame on either read is a `DeclaredCommandDefect`
naming its declared path.

Cadence 1.0 s / TTL 2.0 s: the pair every slow-control entry in this profile
carries. 1.0 s is `YaesuCatPoller._SLOW_INTERVAL`, the interval of the group
that actually re-reads them, and the TTL is twice the cadence. Declared
`polling_only`, not `stream_like_meters` — that class is pinned to a fast
cadence and a ≤ 2.0 s TTL by
`test_known_profiles_stream_like_meters_use_fast_non_decaying_policies`.

## Startup-gate consequence

Neither path is `tx_only`, so both join
`AcquisitionScheduler.unobserved_startup_paths` and the web start-up wait
(`web_startup.py: _await_initial_state_acquisition`, which has no
serve-anyway timeout) now covers them. The read-only probe on 2026-09-08 is
the evidence that this is safe: ten `RM7;` and ten `RM8;` reads with the
radio receiving, every one answered — IDD raw 0, VDD raw 212 — with no
refusal, timeout or parse error, at 8.3–14.4 ms per read.

## Tests

- `test_state_acquisition_policy.py::test_ftx1_drain_meters_poll_in_receive_at_the_slow_control_cadence`
  — both declared, pollable, not stream-like, `tx_only` false, no
  `available_when`, cadence 1.0 / TTL 2.0.
- `test_startup_state_gate.py::test_ftx1_drain_meters_hold_the_gate_open_until_they_are_observed`
  — on the real profile, both are outstanding until observed, while a
  `tx_only` transmit meter sharing the same CAT command is not.
- `test_yaesu_cat_observation_adapter.py`:
  `test_drain_meters_ride_the_slow_lane_and_not_the_tx_meter_lane`,
  `test_slow_poll_clamps_the_receive_drain_voltage_to_the_last_point`
  (raw 212 → 13.8, raw 0 → 0.0, both `("confirmed", "calibrated")`),
  `test_slow_poll_interpolates_a_drain_reading_between_the_two_points`
  (raw 105 → 6.9 V, raw 29 → 1.0 A), plus two new `_DEFECT_ROWS`
  (`vd`, `id`) driving the parametrised defect table in both the `parse`
  and `reject` failure classes.
- `test_rig_multi_vendor.py`: the MOR-1527 "no calibration table" test
  narrowed to power/ALC/COMP — its own docstring names a live bench
  measurement as the qualifying source — with
  `test_ftx1_drain_meters_declare_the_bench_two_point_table` pinning the
  two points each in its place.
- Census updates: the FTX-1 capability/policy counts (56/51 → 58/53), the
  slow-poll observation lists in the adapter and poller tests, and the
  drain reads added to the three radio doubles that drive
  `poll_slow_controls`.

## Mutations run

| mutation | result |
|---|---|
| `vd` calibration point 210 → 13.8 changed to 210 → 12.0 | 6 tests failed, including `test_slow_poll_clamps_the_receive_drain_voltage_to_the_last_point` and `test_ftx1_drain_meters_declare_the_bench_two_point_table` |
| both reads moved from `poll_slow_controls` into `poll_tx_meters` | 13 tests failed, including `test_drain_meters_ride_the_slow_lane_and_not_the_tx_meter_lane` and all four `[vd-*]`/`[id-*]` defect-table cases |
| `tx_only = true` added to the `global.meters.vd` policy | 2 tests failed: the policy census and the startup-gate test |
| behaviour-preserving refactor (shared capability gate hoisted to a local, one read's local renamed) | 561 passed — green |

Tree restored after each; `git diff` carries no trace of any mutation.

## Gates

`uv run pytest` over the 58 test files that reference the FTX-1 — 4505
passed, 6 skipped, 3 xfailed. `tests/validation tests/contracts tests/smoke
tests/golden` — 502 passed, 1 skipped. `ruff check` clean, `ruff format
--check` clean, `lint-imports` 5 contracts kept / 0 broken, `mypy --strict
src/rigplane/web` clean. No full-suite run was made locally; that is CI's.

## Size

`git diff --numstat origin/main...HEAD`: **8 files, 375+/12- = 387 changed
lines at 7660614a1**. This crosses the soft file-count threshold (6) and not
the line threshold; the hard ceiling (10 / 1000) is not crossed. It is one
unit of work: declaring two paths in one profile changes what
`poll_slow_controls` emits, and five of the eight files are the test doubles
and observation censuses that enumerate that lane — each would fail on its
own if split from the declaration.

Internal-identifier self-check — empty.

## Out of scope

- The IC-7300: untouched. Its own `vd`/`id` declaration, cadence and
  hamlib-sourced calibration are unchanged.
- T150 — `YaesuCatRadio._read_meter` does not compare the reply's type digit
  against the requested one, and the transport's prefix match for `RM8;` is
  the digit-stripped `RM`. This is unchanged by this PR and is not specific
  to it: every meter read on this backend, including the four already
  shipped, goes through the same `_read_meter`. Both 2026-09-08 runs recorded
  the parsed type field, and all 789 replies carried the digit that was
  requested.
- Linearity beyond the two points, and the meters' behaviour at any power
  other than 5 W or any band other than 20 m.
- The frontend: `lib/runtime/adapters/radio-view-model-adapter.ts` already
  derives `drainVoltage`/`drainCurrent` from `vdMeter`/`idMeter` with units
  `v`/`a` for any radio that populates them, so no frontend change is part of
  this PR.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

