### PR TITLE
feat: declare the IC-7300 transmit meters absent outside transmit so they are discarded on dekey

### DIFF
--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -504,29 +504,52 @@ adaptive_decay = false
 # cadence changes)
 # for as long as the key is down -- an accepted, TX-scoped tradeoff, not a
 # steady-state regression of the MOR-1484 serial medians.
+#
+# MOR-2425/T141: observed on the bench 2026-09-08 -- after dekey the four
+# stayed in the store carrying their last transmit values instead of leaving
+# it. The clause below declares them absent while `global.tx_state.ptt` reads
+# false, so StateFreshnessService.tick discards them (tests/
+# test_acquisition_scheduler.py::
+# test_tick_discards_every_ic7300_transmit_meter_on_dekey). `tx_only` stays
+# and gains nothing from the clause: AcquisitionScheduler.
+# unobserved_startup_paths already excludes a tx_only path (tests/
+# test_startup_state_gate.py::
+# test_unobserved_tx_only_path_does_not_keep_the_predicate_incomplete).
 [state_acquisition.field_policies."global.meters.power"]
 cadence_seconds = 1.0
 freshness_ttl_seconds = 2.0
 adaptive_decay = false
 tx_only = true
+available_when = [
+    { field = "global.tx_state.ptt", equals = true },
+]
 
 [state_acquisition.field_policies."global.meters.swr"]
 cadence_seconds = 1.0
 freshness_ttl_seconds = 2.0
 adaptive_decay = false
 tx_only = true
+available_when = [
+    { field = "global.tx_state.ptt", equals = true },
+]
 
 [state_acquisition.field_policies."global.meters.alc"]
 cadence_seconds = 1.0
 freshness_ttl_seconds = 2.0
 adaptive_decay = false
 tx_only = true
+available_when = [
+    { field = "global.tx_state.ptt", equals = true },
+]
 
 [state_acquisition.field_policies."global.meters.comp"]
 cadence_seconds = 1.0
 freshness_ttl_seconds = 2.0
 adaptive_decay = false
 tx_only = true
+available_when = [
+    { field = "global.tx_state.ptt", equals = true },
+]
 
 # Vd/Id are supply telemetry, not TX readings -- the radio answers them in RX
 # too (proven: rigctld's ``_OBSERVABLE_CMD15_FIELDS`` one-shots already flip

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -4156,6 +4156,75 @@ def test_tick_keeps_the_transmit_meters_while_ptt_is_unobserved() -> None:
     assert [snapshot.field(path).value for path in _TX_METERS] == [1.0] * 4
 
 
+def _ic7300_freshness_service(store: StateStore) -> StateFreshnessService:
+    acquisition = get_radio_profile("IC-7300").state_acquisition
+    assert acquisition is not None
+    return StateFreshnessService(
+        store=store,
+        scheduler=AcquisitionScheduler(profile=acquisition),
+    )
+
+
+def test_tick_keeps_the_ic7300_transmit_meters_while_ptt_reads_true() -> None:
+    store = StateStore()
+    service = _ic7300_freshness_service(store)
+    store.apply(_observation(_AVAIL_PTT, True, at=1.0))
+    for path in _TX_METERS:
+        store.apply(_observation(path, 1.0, at=1.0))
+
+    service.tick(now=1.0)
+
+    snapshot = store.snapshot()
+    assert [snapshot.field(path).value for path in _TX_METERS] == [1.0] * 4
+
+
+def test_tick_discards_every_ic7300_transmit_meter_on_dekey() -> None:
+    """Dekey removes the four TX meters; a later key-down re-populates them.
+
+    Ageing alone leaves the last reading in the store and deliverable, so
+    removal is what stops a receive-time face from drawing it.
+    """
+
+    store = StateStore()
+    service = _ic7300_freshness_service(store)
+    store.apply(_observation(_AVAIL_PTT, True, at=1.0))
+    for path in _TX_METERS:
+        store.apply(_observation(path, 1.0, at=1.0))
+    service.tick(now=1.0)
+
+    store.apply(_observation(_AVAIL_PTT, False, at=2.0))
+    revision_before = store.snapshot().state_revision
+    service.tick(now=2.0)
+
+    after_dekey = store.snapshot()
+    for path in _TX_METERS:
+        with pytest.raises(KeyError):
+            after_dekey.field(path)
+    assert after_dekey.state_revision > revision_before
+
+    store.apply(_observation(_AVAIL_PTT, True, at=3.0))
+    for path in _TX_METERS:
+        store.apply(_observation(path, 2.0, at=3.0))
+    service.tick(now=3.0)
+
+    rekeyed = store.snapshot()
+    assert [rekeyed.field(path).value for path in _TX_METERS] == [2.0] * 4
+
+
+def test_tick_keeps_the_ic7300_transmit_meters_while_ptt_is_unobserved() -> None:
+    """Unknown is not false: nothing has established the rig is receiving."""
+
+    store = StateStore()
+    service = _ic7300_freshness_service(store)
+    for path in _TX_METERS:
+        store.apply(_observation(path, 1.0, at=1.0))
+
+    service.tick(now=1.0)
+
+    snapshot = store.snapshot()
+    assert [snapshot.field(path).value for path in _TX_METERS] == [1.0] * 4
+
+
 def test_a_never_dispatched_request_may_not_be_credited() -> None:
     freq = FieldPath.active("main", "freq_mode", "freq_hz")
     scheduler = AcquisitionScheduler(profile=_profile([freq]))

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -1648,6 +1648,10 @@ def test_available_when_is_declared_only_where_a_probe_established_it() -> None:
         ("FTX-1", "receiver.sub.operator_controls.rf_gain"),
         ("FTX-1", "receiver.sub.operator_controls.repeater_shift"),
         ("FTX-1", "receiver.sub.operator_controls.squelch"),
+        ("IC-7300", "global.meters.alc"),
+        ("IC-7300", "global.meters.comp"),
+        ("IC-7300", "global.meters.power"),
+        ("IC-7300", "global.meters.swr"),
     }
 
 
@@ -1655,6 +1659,30 @@ def test_ftx1_declares_the_transmit_meters_absent_outside_transmit() -> None:
     """The four tx_only meters exist only while the canonical PTT reads true."""
 
     acquisition = get_radio_profile("FTX-1").state_acquisition
+    assert acquisition is not None
+
+    ptt = FieldPath.global_("tx_state", "ptt")
+    clause = AvailabilityClause(field=ptt, operator="equals", value=True)
+    tx_meters = (
+        FieldPath.global_("meters", "alc"),
+        FieldPath.global_("meters", "power"),
+        FieldPath.global_("meters", "swr"),
+        FieldPath.global_("meters", "comp"),
+    )
+    for path in tx_meters:
+        policy = acquisition.policy_for(path)
+        assert policy.available_when == (clause,), path
+        assert policy.tx_only is True, path
+
+    # The condition source is itself polled, or nothing would ever resolve it.
+    assert acquisition.capability_for(ptt).can_poll
+    assert acquisition.policy_for(ptt).available_when == ()
+
+
+def test_ic7300_declares_the_transmit_meters_absent_outside_transmit() -> None:
+    """The four tx_only meters exist only while the canonical PTT reads true."""
+
+    acquisition = get_radio_profile("IC-7300").state_acquisition
     assert acquisition is not None
 
     ptt = FieldPath.global_("tx_state", "ptt")


### PR DESCRIPTION
Owner rulings R40, R42 and R52 (2026-09-08): a field the rig lacks in its current state is declared absent in the profile and neither polled, waited for, nor shown; an empty transmit instrument during receive is acceptable. This is the same change as #3393, now for the IC-7300 profile.

## The bench fact

The live transmit check on the IC-7300 (2026-09-08, under owner ruling R54) reproduced the FTX-1 symptom #3393 fixed. Before the first transmit the four `tx_only` meters — `global.meters.alc`, `.power`, `.swr`, `.comp` — read `observed: false` / `missing`, so "missing at idle" was never observed rather than discarded. After dekey they stayed in the store, fresh at +1 s and then stale, holding their transmit values for over sixteen minutes, serving `swrMeter 1.0` and `alcMeter 0.217` to a receiving radio. `grep -n available_when rigs/ic7300.toml` at the base of this branch returns nothing: #3393 declared the clause only in `rigs/ftx1.toml`.

## The canonical push-to-talk field, and its type

`global.tx_state.ptt`, holding a Python `bool`.

- `src/rigplane/runtime/_civ_rx.py` — on a CI-V frame with `command == 0x1C` and `sub == 0x00` carrying data, the Icom ingress appends an observation of `FieldPath.global_("tx_state", "ptt")` with value `bool(frame.data[0])`. The same frame also publishes `OBSERVED_PTT_PATH` (`global.tx_state.observed_ptt`), which carries the `ObservedPtt` enum, not a bool; the clause names `tx_state.ptt`, not that path.
- The bench state documents from the transmit check show the served `ptt` key as a JSON bool (read back with `json.load`; `False` in the post-dekey and pre-shutdown documents).
- `core/acquisition_scheduler.py: availability_clause_holds` resolves `equals` as `bool(value == clause.value)`, so a stored bool `True` satisfies the declared `true`.
- The path is already polled on this profile: `rigs/ic7300.toml` lists `global.tx_state.ptt` in `[state_acquisition.capabilities]` and gives it its own `field_policies` entry, and the new census test asserts `capability_for(ptt).can_poll`.

## Mechanism

`StateFreshnessService.tick` calls `_discard_declared_absent` before the stale-marking step. That resolves each conditional field through `resolve_available_when` and passes the ones an observed value contradicts to `StateStore.discard`, which invents no value — so the field is published unobserved and `missing` again. `None` (clause source never observed) is left alone.

Backend-neutral because both sides are the same store: `_civ_rx` applies observations into `self._host._state_store`, which is `IcomRadio.state_store`, and `web/server.py` builds the `StateFreshnessService` over `radio.state_store` as `command_state_store`. The Icom path bypasses `CommandService` for ingress, but not the store.

Polling is unchanged, and no second gate is added:

- `AcquisitionScheduler.due_requests` already skips a `tx_only` cadence group entirely while `tx_active` is false, so the 0x15 dispatch was already withheld outside transmit; `derive_tx_active` reads the same `global.tx_state.ptt`.
- `AcquisitionScheduler.unobserved_startup_paths` already excludes every path whose resolved policy carries `tx_only`, reading it from the profile — pinned by `tests/test_startup_state_gate.py::test_unobserved_tx_only_path_does_not_keep_the_predicate_incomplete`.

No source file changes; the FTX-1 profile and the frontend are untouched.

## Tests

`tests/test_acquisition_scheduler.py`, on the real IC-7300 profile through `StateFreshnessService.tick`:

- `test_tick_keeps_the_ic7300_transmit_meters_while_ptt_reads_true`
- `test_tick_discards_every_ic7300_transmit_meter_on_dekey` — all four removed on a false push-to-talk, with a state-revision bump, and re-populated on a later key-down
- `test_tick_keeps_the_ic7300_transmit_meters_while_ptt_is_unobserved`

`tests/test_state_acquisition_policy.py`:

- `test_available_when_is_declared_only_where_a_probe_established_it` gains the four `IC-7300` rows
- `test_ic7300_declares_the_transmit_meters_absent_outside_transmit`

No test asserted that the IC-7300 declares no `available_when`; the cross-profile census above was the only closed enumeration and it now carries the four rows.

## Mutations

Each run over `tests/test_acquisition_scheduler.py` and `tests/test_state_acquisition_policy.py`, with the profile restored between runs:

| Mutation | Result |
|---|---|
| Clause removed from `global.meters.swr` only | 3 failed, 185 passed — `test_tick_discards_every_ic7300_transmit_meter_on_dekey`, `test_available_when_is_declared_only_where_a_probe_established_it`, `test_ic7300_declares_the_transmit_meters_absent_outside_transmit` |
| Sense inverted (`equals = false`) on all four | 3 failed, 185 passed — `test_tick_keeps_the_ic7300_transmit_meters_while_ptt_reads_true`, `test_tick_discards_every_ic7300_transmit_meter_on_dekey`, `test_ic7300_declares_the_transmit_meters_absent_outside_transmit` |
| `swr` and `alc` policy blocks swapped (declaration order only) | 188 passed |

The tree was restored from a pre-mutation copy after each; `git diff` at the head shows only the intended change.

## Gates run locally

- `uv run pytest tests/test_acquisition_scheduler.py tests/test_state_acquisition_policy.py tests/test_startup_state_gate.py tests/test_rig_loader.py tests/test_web_runtime_helpers.py` — 667 passed, 1 skipped
- `uv run ruff check src/ tests/` — All checks passed
- `uv run ruff format --check src/ tests/` — 742 files already formatted
- `uv run lint-imports` — Contracts: 5 kept, 0 broken
- `uv run mypy --strict src/rigplane/web` — no issues in 27 source files

The full suite is CI's; this PR's `quick` run is the record.

Internal-identifier self-check — empty.

Census: 3 files, 120+/0- = 120 changed lines at 8fa83da3.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
