### PR TITLE
feat: render a drain meter clamped at its calibration top as the top value with a plus

### DIFF
--- a/frontend/src/components-v2/panels/__tests__/MetersDockPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MetersDockPanel.isolated.test.ts
@@ -116,8 +116,8 @@ describe('formatAmps (calibrated: input is amps)', () => {
   it('returns 15.0 A', () => {
     expect(formatAmps(15)).toBe('15.0 A');
   });
-  it('clamps beyond-scale readings to the 25 A top knot', () => {
-    expect(formatAmps(300)).toBe('25.0 A');
+  it('marks beyond-scale readings as the 25 A top knot plus (T164)', () => {
+    expect(formatAmps(300)).toBe('25.0+ A');
   });
 });
 
@@ -128,8 +128,8 @@ describe('formatVolts (calibrated: input is volts)', () => {
   it('returns 10.0 V', () => {
     expect(formatVolts(10)).toBe('10.0 V');
   });
-  it('returns 16.0 V at the top knot', () => {
-    expect(formatVolts(16)).toBe('16.0 V');
+  it('returns 16.0+ V at the top knot (T164)', () => {
+    expect(formatVolts(16)).toBe('16.0+ V');
   });
 });
 

--- a/frontend/src/components-v2/panels/__tests__/MetersDockPanel.peakhold.svelte.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MetersDockPanel.peakhold.svelte.test.ts
@@ -163,7 +163,8 @@ describe('MetersDockPanel TX peak-hold ballistics (MOR-498)', () => {
     });
     vi.advanceTimersByTime(100);
     flushSync();
-    expect(t.querySelector('[data-meter="id"] .tile-value')?.textContent).toBe('25.0 A');
+    // 25 A is this fixture's Id top knot, so it renders with the T164 "+".
+    expect(t.querySelector('[data-meter="id"] .tile-value')?.textContent).toBe('25.0+ A');
 
     state.idMeter = 0;
     vi.advanceTimersByTime(100); // shortly into decay
@@ -180,12 +181,12 @@ describe('MetersDockPanel TX peak-hold ballistics (MOR-498)', () => {
   it('leaves the Vd NUMBER instantaneous (no peak-hold on the supply rail)', () => {
     const { t, state } = mountReactive({
       powerMeter: 0,
-      vdMeter: 16, // 16.0 V
+      vdMeter: 16, // this fixture's Vd top knot, so "16.0+ V" (T164)
       txActive: false,
     });
     vi.advanceTimersByTime(100);
     flushSync();
-    expect(t.querySelector('[data-meter="vd"] .tile-value')?.textContent).toBe('16.0 V');
+    expect(t.querySelector('[data-meter="vd"] .tile-value')?.textContent).toBe('16.0+ V');
 
     // A drop in supply voltage must be reflected immediately, not held.
     state.vdMeter = 13.8;

--- a/frontend/src/components-v2/panels/meter-utils.test.ts
+++ b/frontend/src/components-v2/panels/meter-utils.test.ts
@@ -511,6 +511,66 @@ describe('TX meters — IC-7300 profile anchors (MOR-1527)', () => {
   it('vdLevel normalizes against the 16 V top knot from this profile', () => {
     expect(vdLevel(13.8)).toBeCloseTo(13.8 / 16);
   });
+
+  it('marks a reading at this profile’s own drain tops with "+" (T164)', () => {
+    expect(formatVolts(16)).toBe('16.0+ V');
+    expect(formatAmps(25)).toBe('25.0+ A');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Drain readings clamped at the calibration top (T164, owner ruling R57
+// 2026-09-08).
+//
+// `src/rigplane/runtime/meter_cal.py: interpolate_meter` returns the last
+// knot's `actual` for every raw at or above that knot's `raw`. The FTX-1
+// drain tables mirrored below top out at raw 210 and raw 29 — both under the
+// 255 device-scale ceiling — so any larger raw publishes exactly the top
+// value. Rendering that as an exact reading would state a number the table
+// cannot support, so the top is rendered with a trailing "+" instead.
+// ---------------------------------------------------------------------------
+
+const FTX1_DRAIN_METER_CALS = {
+  vd: [
+    { raw: 0, actual: 0.0, label: '0' },
+    { raw: 210, actual: 13.8, label: '13.8' },
+  ],
+  id: [
+    { raw: 0, actual: 0.0, label: '0' },
+    { raw: 29, actual: 1.0, label: '1.0' },
+  ],
+};
+
+describe('formatVolts / formatAmps — clamped at the calibration top (T164)', () => {
+  beforeEach(() => {
+    setCapabilities(makeCaps({
+      model: 'FTX-1',
+      meterCalibrations: FTX1_DRAIN_METER_CALS,
+    }));
+  });
+
+  it('renders the drain voltage top as "13.8+ V", at the top and beyond it', () => {
+    expect(formatVolts(13.8)).toBe('13.8+ V');
+    expect(formatVolts(20)).toBe('13.8+ V');
+  });
+
+  it('renders the drain current top as "1.0+ A", at the top and beyond it', () => {
+    expect(formatAmps(1.0)).toBe('1.0+ A');
+    expect(formatAmps(5)).toBe('1.0+ A');
+  });
+
+  it('leaves readings below the top as plain numbers', () => {
+    expect(formatVolts(0)).toBe('0.0 V');
+    expect(formatVolts(12.4)).toBe('12.4 V');
+    expect(formatAmps(0)).toBe('0.0 A');
+    expect(formatAmps(0.5)).toBe('0.5 A');
+  });
+
+  it('mirrors the drain tables rigs/ftx1.toml declares', () => {
+    const tomlSource = readFileSync('../rigs/ftx1.toml', 'utf8');
+    expect(parseTomlCalibrationTable(tomlSource, 'vd')).toEqual(FTX1_DRAIN_METER_CALS.vd);
+    expect(parseTomlCalibrationTable(tomlSource, 'id')).toEqual(FTX1_DRAIN_METER_CALS.id);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -540,7 +600,7 @@ function parseTomlCalibrationTable(tomlSource: string, meterKey: string): TomlCa
       const actual = body.match(/actual\s*=\s*(-?[\d.]+)/)?.[1];
       const label = body.match(/label\s*=\s*"([^"]*)"/)?.[1];
       if (raw === undefined || actual === undefined || label === undefined) {
-        throw new Error(`Unparseable [[meters.${meterKey}.calibration]] knot while reading rigs/ic7300.toml`);
+        throw new Error(`Unparseable [[meters.${meterKey}.calibration]] knot`);
       }
       return { raw: Number(raw), actual: Number(actual), label };
     });

--- a/frontend/src/components-v2/panels/meter-utils.ts
+++ b/frontend/src/components-v2/panels/meter-utils.ts
@@ -66,6 +66,30 @@ function topActual(cal: MeterCalPoint[]): number {
   return cal[cal.length - 1].actual;
 }
 
+/**
+ * Renders a one-decimal drain reading against its calibration table.
+ *
+ * `src/rigplane/runtime/meter_cal.py: interpolate_meter` returns the last
+ * knot's `actual` for every raw at or above that knot's `raw`, so a value
+ * that has reached the top is a clamp, not a reading — how far past the top
+ * the rail actually went is not in the table. Such a value is rendered as
+ * the top with a trailing "+" (the shape `formatSwr` already shows through
+ * its top knot's own label); below the top, and with no table at all, the
+ * value is rendered as itself.
+ */
+function formatAgainstTop(
+  value: number,
+  cal: MeterCalPoint[] | null,
+  unit: string,
+): string {
+  const floored = Math.max(0, value);
+  if (cal) {
+    const top = topActual(cal);
+    if (floored >= top) return `${top.toFixed(1)}+ ${unit}`;
+  }
+  return `${floored.toFixed(1)} ${unit}`;
+}
+
 /** Honest raw readout for an uncalibrated meter — the device-scale number
  *  tagged "raw" so it is never mistaken for an engineering-unit claim
  *  (MOR-1527: the pre-fix bug rendered this as a naked number, e.g. a Vd
@@ -226,7 +250,7 @@ export function formatVolts(value: number, domain?: MeterValueDomain): string {
   }
   const cal = getCal('vd');
   if (!cal && domain === undefined) return formatRaw(value);
-  return `${Math.max(0, cal ? Math.min(topActual(cal), value) : value).toFixed(1)} V`;
+  return formatAgainstTop(value, cal, 'V');
 }
 
 export function vdLevel(value: number): number;
@@ -248,7 +272,7 @@ export function formatAmps(value: number, domain?: MeterValueDomain): string {
   }
   const cal = getCal('id');
   if (!cal && domain === undefined) return formatRaw(value);
-  return `${Math.max(0, cal ? Math.min(topActual(cal), value) : value).toFixed(1)} A`;
+  return formatAgainstTop(value, cal, 'A');
 }
 
 export function idLevel(value: number): number;


### PR DESCRIPTION
## The fact

`src/rigplane/runtime/meter_cal.py: interpolate_meter` returns the last calibration knot's `actual` for every raw at or above that knot's `raw`. The FTX-1 drain tables added in #3395 top out at raw 210 → 13.8 V and raw 29 → 1.0 A, both below the 255 device-scale ceiling, so any larger raw publishes exactly 13.8 / 1.0. In receive raw 212 is above the top knot and clamps to 13.8, but during a transmit the current tile would read a pinned `1.0 A` however much the PA draws — a confidently wrong number.

Owner ruling R57 (2026-09-08): render a value at or beyond the table's top as the top with a trailing `+`, the shape `formatSwr` already shows as `6.0+`, instead of collecting more calibration points now.

Calibration tables and `interpolate_meter` are unchanged.

## Seat chosen: frontend (option a)

`formatVolts` / `formatAmps` in `frontend/src/components-v2/panels/meter-utils.ts` already hold the full calibration table — `getCal('vd')` / `getCal('id')` — which is exactly how `formatSwr` reaches its own top knot. The threshold is therefore the active profile's own top, generic to whatever that is: an IC-7300 Vd reads `16.0+ V`, an FTX-1 Vd reads `13.8+ V`.

Option (b), a server-side `clamped`/`atTop` quality marker, was rejected on measurement: `interpolate_meter`'s existing tuple is `(value, calibrated: bool)`, not `(value, clamped: bool)` — the second element records whether a table was present, not whether the clamp branch was taken. Publishing an at-top flag would mean changing that function's return, threading a new field through the observation boundary and the wire, and consuming it in the frontend — a new wire field for a fact the frontend can already derive from the table it already has.

One seat covers the bar-meter consumers: `frontend/src/semantic/bar-meter-projector.ts` maps `drainVoltage`/`drainCurrent` to these same two functions (`BAR_DEFINITIONS`), and so do the v2 dock (`MetersDockPanel.svelte`) and `AmberTelemetryStrip.svelte`. The segmentline LCD path (`skins/segmentline/lcd-display-helpers.ts: telemetryText`, fed by `CenterstageDisplay.svelte` and `LcdTelemetryRail.svelte`) formats the number itself without a unit and does not receive the marker — pre-existing, unchanged here. `git grep -n "} V\`\|} A\`" origin/main -- frontend/src` returns exactly the two `meter-utils.ts` lines this PR replaced (and nothing at the new head, which no longer builds those strings inline).

## Tests

New, in `frontend/src/components-v2/panels/meter-utils.test.ts`:
- FTX-1 drain tables: `formatVolts(13.8)` and `formatVolts(20)` → `13.8+ V`; `formatAmps(1.0)` and `formatAmps(5)` → `1.0+ A`.
- Below the top stays a plain number: `0.0 V`, `12.4 V`, `0.0 A`, `0.5 A`.
- A fixture-mirror guard reading `rigs/ftx1.toml` through the file's existing `parseTomlCalibrationTable`, so the mirrored vd/id knots cannot drift from the profile.
- Generic-to-the-table case on the IC-7300 anchors block: `formatVolts(16)` → `16.0+ V`, `formatAmps(25)` → `25.0+ A`.

Updated (they pinned the old clamp-as-reading rendering): `MetersDockPanel.isolated.test.ts` (`formatAmps(300)`, `formatVolts(16)`) and `MetersDockPanel.peakhold.svelte.test.ts` (Id 25 A, Vd 16 V tiles).

Also narrowed one existing string: `parseTomlCalibrationTable`'s error message named `rigs/ic7300.toml`, which stopped being true once the same parser reads `rigs/ftx1.toml`. The file name is dropped rather than parameterised.

Gates, all run in this worktree at `c7a85374`:
- `npx vitest run src/components-v2/panels src/semantic src/skins src/lib/runtime/adapters src/components-v2/wiring` — 211 files, 6145 tests, 0 failures.
- `npm run check` — 4841 files, 0 errors, 0 warnings. `npm run lint`, `npm run lint:boundaries` — clean.
- `uv run ruff check src/ tests/` — all checks passed. `uv run ruff format --check src/ tests/` — 742 files already formatted. `uv run lint-imports` — 5 kept, 0 broken. `uv run mypy --strict src/rigplane/web` — no issues in 27 source files.

## Mutations

Run against `src/components-v2/panels` + `src/semantic` (3189 tests):
1. **Marker removed** — `` `${top.toFixed(1)}+ ${unit}` `` → `` `${top.toFixed(1)} ${unit}` `` (the pre-change behaviour exactly). **7 tests failed**: the three new `13.8+ V` / `1.0+ A` / IC-7300-tops cases, the two updated dock cases, and the two peak-hold tile cases.
2. **Threshold loosened** — `floored >= top` → `floored > top`, so a value landing exactly on the top loses its marker. **6 tests failed** — the same set minus `formatAmps(300)`, which is beyond the top and correctly survives.
3. **Behaviour-preserving refactor** — the same function rewritten as `Math.min(floored, top)` plus a computed suffix, with `Infinity` for the no-table case. **All 3189 green.**

The tree was restored from a pristine copy after each mutation; `git diff` at the pushed head shows only the intended change.

## Out of scope

- **More calibration points.** The FTX-1 drain tables still have one measured point each; R57 chose the marker over new bench measurements.
- **The bar scale (R52).** `vdLevel` / `idLevel` return `clamp01(value / top)`, so the FTX-1 Vd bar sits at full scale at 13.8 V and the Id bar at 1.0 A. Different functions, and no target geometry is specified, so they are unchanged.
- **The same clamp-as-reading shape in the other formatters of this file**, enumerated by reading every `Math.min(topActual(cal), value)` in `meter-utils.ts` and every shipped rig's table tops (`rigs/*.toml`, parsed with `tomllib`):
  - `formatPowerWatts` — IC-7610's power top is raw 212 of 255, so raws 213-255 all render `100W`; IC-7300's is raw 255, where nothing is above it. Same defect, reachable on the IC-7610 table.
  - `formatCompDb` — only the IC-7300 declares a comp table; its top is raw 241, so raws 242-255 would clamp. Whether the radio ever reports above 241 on that meter is not something I could establish from the code.
  - `formatAlc` — clamps to the redline or to 1.0 through a different mechanism (normalized/redline), not this shape.
  - `formatSwr` — already carries the `+` through its top knot's own label; unchanged.
  Each is left unfixed because this PR's spec covers the drain meters only.

`git diff --numstat origin/main...HEAD`: **4 files, 95+/10- = 105 changed lines at c7a85374**. Under both guardrails.

Internal-identifier self-check — empty.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

