### PR TITLE
feat: add a geometry-probe skin arranging the semantic surfaces in the flagship layout

### DIFF
--- a/frontend/src/__tests__/presentation-switch-resources.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-resources.component.test.ts
@@ -244,9 +244,11 @@ const WIDTH_FOR: Record<SkinId, number> = {
   'unified-instrument': 1280,
   'panadapter-first': 1281,
   'dual-sdr-face': 1700,
-  // T160 PR-1: no picker or `resolveSkinId` path reaches this skin, so this
-  // entry only satisfies `Record<SkinId, number>` exhaustiveness. 1800 is
-  // unused by every other entry in this table.
+  // T160 PR-1: `flagship-probe` is reached only through the QA
+  // `?layout=flagship-probe` override (`lib/stores/qa-cockpit-override.ts`),
+  // which this file's width knob does not set, so this entry only satisfies
+  // `Record<SkinId, number>` exhaustiveness. 1800 is unused by every other
+  // entry in this table.
   'flagship-probe': 1800,
 };
 function widthToSkin(): SkinId {

--- a/frontend/src/__tests__/presentation-switch-resources.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-resources.component.test.ts
@@ -228,6 +228,9 @@ const SKIN_PLAN: Record<SkinId, readonly AppResource[]> = {
   'panadapter-first': ['hardware-scope', 'audio-fft'],
   'sdr-test': ['hardware-scope', 'audio-fft'],
   'dual-sdr-face': ['hardware-scope'],
+  // T160 PR-1: one SpectrumPanel and no audio-FFT surface — the same plan
+  // `mobile` above carries, for the same reason.
+  'flagship-probe': ['hardware-scope'],
 };
 
 const WIDTH_FOR: Record<SkinId, number> = {
@@ -241,6 +244,10 @@ const WIDTH_FOR: Record<SkinId, number> = {
   'unified-instrument': 1280,
   'panadapter-first': 1281,
   'dual-sdr-face': 1700,
+  // T160 PR-1: no picker or `resolveSkinId` path reaches this skin, so this
+  // entry only satisfies `Record<SkinId, number>` exhaustiveness. 1800 is
+  // unused by every other entry in this table.
+  'flagship-probe': 1800,
 };
 function widthToSkin(): SkinId {
   const width = window.innerWidth;

--- a/frontend/src/__tests__/presentation-switch-tx.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-tx.component.test.ts
@@ -148,6 +148,10 @@ const WIDTH_FOR: Record<SkinId, number> = {
   'panadapter-first': 1281,
   // Production entrypoint is readonly and receives no command callback.
   'dual-sdr-face': 1700,
+  // T160 PR-1: same as `peer-split` above — no picker/resolveSkinId path, so
+  // this entry exists only for `Record<SkinId, number>` exhaustiveness. 1800
+  // is unused by every other entry in this table.
+  'flagship-probe': 1800,
 };
 function widthToSkin(): SkinId {
   const width = window.innerWidth;

--- a/frontend/src/__tests__/presentation-switch-tx.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-tx.component.test.ts
@@ -139,18 +139,19 @@ const WIDTH_FOR: Record<SkinId, number> = {
   'lcd-scope': 900,
   'sdr-test': 1400,
   'mobile': 390,
-  // MOR-2155: `peer-split` has no picker/resolveSkinId path (MOR-2152), so
-  // this file's TX-authority sweeps never request it directly — it is here
-  // only to satisfy `Record<SkinId, number>` exhaustiveness. 1600 is unused
-  // by every other entry in this table.
+  // MOR-2155: this file's TX-authority sweeps never request `peer-split`
+  // directly, so this entry is here only to satisfy `Record<SkinId, number>`
+  // exhaustiveness. 1600 is unused by every other entry in this table.
   'peer-split': 1600,
   'unified-instrument': 1280,
   'panadapter-first': 1281,
   // Production entrypoint is readonly and receives no command callback.
   'dual-sdr-face': 1700,
-  // T160 PR-1: same as `peer-split` above — no picker/resolveSkinId path, so
-  // this entry exists only for `Record<SkinId, number>` exhaustiveness. 1800
-  // is unused by every other entry in this table.
+  // T160 PR-1: `flagship-probe` is reached only through the QA
+  // `?layout=flagship-probe` override (`lib/stores/qa-cockpit-override.ts`),
+  // which this file's width knob does not set, so this entry exists only for
+  // `Record<SkinId, number>` exhaustiveness. 1800 is unused by every other
+  // entry in this table.
   'flagship-probe': 1800,
 };
 function widthToSkin(): SkinId {

--- a/frontend/src/lib/stores/__tests__/qa-cockpit-override.test.ts
+++ b/frontend/src/lib/stores/__tests__/qa-cockpit-override.test.ts
@@ -6,6 +6,13 @@ describe('readQaCockpitLayoutOverride (MOR-1257)', () => {
     expect(readQaCockpitLayoutOverride('?layout=dual-receiver-cockpit')).toBe('dual-receiver-cockpit');
   });
 
+  // T160 PR-1: the flagship geometry probe rides the same param. Kill-test:
+  // dropping it from the module's value list returns null here, which
+  // resolves to the normal preference and leaves the probe unreachable.
+  it('returns the flagship-probe override when the exact query param is present', () => {
+    expect(readQaCockpitLayoutOverride('?layout=flagship-probe')).toBe('flagship-probe');
+  });
+
   it('returns null for an empty search string', () => {
     expect(readQaCockpitLayoutOverride('')).toBeNull();
   });
@@ -18,7 +25,8 @@ describe('readQaCockpitLayoutOverride (MOR-1257)', () => {
   // persisted-style value a user might guess) would wrongly activate the
   // QA-only cockpit.
   it('returns null for any other layout value, including near-misses', () => {
-    for (const value of ['standard', 'lcd-cockpit', 'dual-receiver', 'Dual-Receiver-Cockpit', '']) {
+    for (const value of ['standard', 'lcd-cockpit', 'dual-receiver', 'Dual-Receiver-Cockpit', '',
+      'flagship', 'Flagship-Probe', 'flagship-probe-x']) {
       expect(readQaCockpitLayoutOverride(`?layout=${value}`)).toBeNull();
     }
   });

--- a/frontend/src/lib/stores/qa-cockpit-override.ts
+++ b/frontend/src/lib/stores/qa-cockpit-override.ts
@@ -1,14 +1,15 @@
 /**
- * Interim QA reachability for the dual-receiver cockpit (MOR-1257).
+ * Interim QA reachability for the dual-receiver cockpit (MOR-1257) and, on
+ * the same terms, the flagship geometry probe (T160 PR-1).
  *
  * Staple reachability arrives with the MOR-1081 workspace-owned layout
  * chain (layout selection migrates there). Until then, the ONLY way to
- * reach the cockpit skin is the exact `?layout=dual-receiver-cockpit`
- * query param — it is not a `CanonicalLayoutMode` (see
- * `lib/stores/layout.svelte.ts`), so it can never be persisted via
- * `setLayoutMode`/localStorage, and it is deliberately absent from
- * `components-v2/layout/StatusBar.svelte`'s hardcoded skin-selector
- * options, so it never appears as a normal layout choice.
+ * reach either skin is the exact `?layout=<id>` query param naming it —
+ * neither id is a `CanonicalLayoutMode` (see
+ * `lib/stores/layout.svelte.ts`), so neither can be persisted via
+ * `setLayoutMode`/localStorage, and `components-v2/layout/StatusBar.svelte`
+ * types its hardcoded skin-selector options `CanonicalLayoutMode`, so
+ * listing either one there is a compile error rather than an omission.
  *
  * Kept in its own module — not `layout.svelte.ts` or `skins/registry.ts` —
  * so `App.svelte` importing it cannot be shadowed by the partial
@@ -32,19 +33,23 @@
  * `console.warn` makes that non-obvious no-op self-explaining.
  */
 const QA_COCKPIT_QUERY_PARAM = 'layout';
-const QA_COCKPIT_QUERY_VALUE = 'dual-receiver-cockpit';
+export type QaLayoutOverride = 'dual-receiver-cockpit' | 'flagship-probe';
+/** Exact match only: anything not in this list falls through to the normal
+ *  preference, so a guessed `?layout=...` cannot reach a QA-only skin. */
+const QA_QUERY_VALUES: readonly QaLayoutOverride[] = ['dual-receiver-cockpit', 'flagship-probe'];
 const MOBILE_MIN_DIMENSION_PX = 640;
 
-export function readQaCockpitLayoutOverride(search?: string): 'dual-receiver-cockpit' | null {
+export function readQaCockpitLayoutOverride(search?: string): QaLayoutOverride | null {
   const raw = search ?? (typeof window !== 'undefined' ? window.location.search : '');
-  const matched = new URLSearchParams(raw).get(QA_COCKPIT_QUERY_PARAM) === QA_COCKPIT_QUERY_VALUE;
-  if (matched && typeof window !== 'undefined'
+  const value = new URLSearchParams(raw).get(QA_COCKPIT_QUERY_PARAM);
+  const matched = QA_QUERY_VALUES.find((id) => id === value) ?? null;
+  if (matched !== null && typeof window !== 'undefined'
     && Math.min(window.innerWidth, window.innerHeight) < MOBILE_MIN_DIMENSION_PX) {
     console.warn(
-      '[rigplane] ?layout=dual-receiver-cockpit is set, but the viewport is under '
-      + `${MOBILE_MIN_DIMENSION_PX}px — the mobile skin takes precedence and the cockpit will `
+      `[rigplane] ?layout=${matched} is set, but the viewport is under `
+      + `${MOBILE_MIN_DIMENSION_PX}px — the mobile skin takes precedence and that skin will `
       + 'not show. Widen the window to at least 640x640 to view it.',
     );
   }
-  return matched ? 'dual-receiver-cockpit' : null;
+  return matched;
 }

--- a/frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts
+++ b/frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts
@@ -165,6 +165,12 @@ describe('every barrel-exported layout is design-language-listed or explicitly e
       layoutId: 'sdr-test',
       reason: 'minimal teaching example; no design-language chrome by design (owner ruling 2026-08-31, MOR-2070)',
     },
+    {
+      layoutId: 'flagship-probe',
+      reason:
+        'geometry probe: it places the semantic surfaces and adds no chrome, colour or type scale of '
+        + 'its own, so it has nothing for a design language to dress (T160 PR-1)',
+    },
   ];
   const EXEMPT_LAYOUT_IDS = new Set(LAYOUT_EXEMPTIONS.map((exemption) => exemption.layoutId));
 

--- a/frontend/src/presentation/layout-mode.ts
+++ b/frontend/src/presentation/layout-mode.ts
@@ -25,12 +25,16 @@
  *                 through to 'auto'. It can therefore never be persisted via
  *                 setLayoutMode/the workspace and never appears in the
  *                 StatusBar skin selector.
+ * 'flagship-probe' = QA-ONLY (T160 PR-1), on exactly those terms and through
+ *                 the same module: `?layout=flagship-probe`, excluded from
+ *                 CanonicalLayoutMode below.
  */
 export type LayoutMode =
   | 'auto' | 'lcd' | 'lcd-cockpit' | 'lcd-scope' | 'standard' | 'sdr-test'
   | 'peer-split' | 'unified-instrument' | 'panadapter-first'
-  | 'dual-sdr-face' | 'dual-receiver-cockpit';
-export type CanonicalLayoutMode = Exclude<LayoutMode, 'lcd' | 'dual-receiver-cockpit'>;
+  | 'dual-sdr-face' | 'dual-receiver-cockpit' | 'flagship-probe';
+export type CanonicalLayoutMode =
+  Exclude<LayoutMode, 'lcd' | 'dual-receiver-cockpit' | 'flagship-probe'>;
 
 export const CANONICAL_LAYOUT_MODES = new Set<CanonicalLayoutMode>([
   'auto',

--- a/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
@@ -52,7 +52,8 @@ describe('exactly the reviewed manifests declare an antenna zone (MOR-1367)', ()
   // MOR-2231 (step 1, batch 2) added `sdr-test`, by hand and with the layout
   // review this literal exists to force: the same declaration retires that
   // face's legacy twins through the `declared.has(...)` channel.
-  const DECLARES_ANTENNA = ['desktop-v2', 'sdr-test'];
+  // T160 PR-1 added `flagship-probe`, which places this surface in its left rail.
+  const DECLARES_ANTENNA = ['desktop-v2', 'flagship-probe', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
@@ -64,7 +64,8 @@ describe('exactly the reviewed manifests declare a band zone (MOR-1367)', () => 
   // mounts on that face drop their HAM tab and HAM grid while the BAND panel
   // itself keeps rendering — it is the only production host of the broadcast
   // presets. Measured on the rendered face, not inferred from the channel.
-  const DECLARES_BAND = ['desktop-v2', 'sdr-test'];
+  // T160 PR-1 added `flagship-probe`, which places this surface in its left rail.
+  const DECLARES_BAND = ['desktop-v2', 'flagship-probe', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/cockpit-topology-adaptation.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/cockpit-topology-adaptation.test.ts
@@ -14,8 +14,9 @@ import { getLayout, type LayoutManifest } from '../contract';
 // the fast pool's `isolate: false` it would leak that registration into
 // sibling files (the MOR-1092 lesson, restated on MOR-1067).
 import {
-  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  panadapterFirstLayout, peerSplitLayout, sdrTestLayout, unifiedInstrumentLayout,
+  desktopV2Layout, dualReceiverCockpitLayout, flagshipProbeLayout, lcdCockpitLayout,
+  lcdScopeLayout, mobileLayout, panadapterFirstLayout, peerSplitLayout, sdrTestLayout,
+  unifiedInstrumentLayout,
 } from '../declarations';
 // Namespace import of the SAME barrel, used ONLY to derive the F8
 // completeness set structurally (MOR-2074) — never to register anything (a
@@ -74,6 +75,7 @@ describe('F8 — every registered layout manifest names a loadable skin', () => 
   const REAL_LAYOUTS: readonly LayoutManifest[] = [
     sdrTestLayout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
     desktopV2Layout, peerSplitLayout, unifiedInstrumentLayout, panadapterFirstLayout,
+    flagshipProbeLayout,
   ];
 
   // MOR-2074: REAL_LAYOUTS above is a hand-list, so a new manifest exported

--- a/frontend/src/presentation/layouts/__tests__/cw-keyer-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/cw-keyer-declarability.test.ts
@@ -65,7 +65,8 @@ describe('exactly the reviewed manifests declare a cwKeyer zone (MOR-1368)', () 
    * adding `cwKeyer` there would put break-in controls in the cockpit with no
    * updated sequence pin.
    */
-  const DECLARES_CW_KEYER = ['desktop-v2', 'sdr-test'];
+  // T160 PR-1 added `flagship-probe`, which places this surface in its right rail.
+  const DECLARES_CW_KEYER = ['desktop-v2', 'flagship-probe', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
@@ -49,7 +49,8 @@ describe('exactly the reviewed manifests declare a dsp zone (MOR-1368)', () => {
   // `DspPanel` in both sidebars, `AgcPanel` in the left one, and the settings
   // modal's `desktop-dsp` AND `desktop-agc` sections — because `DspSurface`
   // owns the AGC leaf (5A/MOR-1290) and AGC has no zone of its own.
-  const DECLARES_DSP = ['desktop-v2', 'sdr-test'];
+  // T160 PR-1 added `flagship-probe`, which places this surface in its left rail.
+  const DECLARES_DSP = ['desktop-v2', 'flagship-probe', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
@@ -50,7 +50,8 @@ describe('exactly the reviewed manifests declare a filter zone (MOR-1366)', () =
   // MOR-2231 (step 1, batch 2) added `sdr-test`, by hand and with the layout
   // review this literal exists to force: the same declaration retires that
   // face's legacy twins through the `declared.has(...)` channel.
-  const DECLARES_FILTER = ['desktop-v2', 'sdr-test'];
+  // T160 PR-1 added `flagship-probe`, which places this surface in its left rail.
+  const DECLARES_FILTER = ['desktop-v2', 'flagship-probe', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/flagship-probe-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/flagship-probe-registration.test.ts
@@ -1,0 +1,75 @@
+/**
+ * T160 PR-1 — the flagship geometry probe's manifest, and the one agreement
+ * that cannot be asserted from the skin's own directory: this file is inside
+ * `presentation/layouts/`, which is where `stage-sizing-boundary.test.ts`
+ * (MOR-1247) allows the identifier `stageSizing` to appear.
+ *
+ * The shell's reflow threshold lives in its CSS and the manifest declares the
+ * same number; the last test below requires the two to agree.
+ * Each test's doc line names the mutation it kills.
+ */
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+// The barrel is where this manifest is declared and registered.
+import { flagshipProbeLayout } from '../declarations';
+import { getLayout, type SemanticSurfaceName } from '../contract';
+
+const SKIN_PATH = 'src/skins/flagship-probe/FlagshipProbeSkin.svelte';
+const skinSource = readFileSync(SKIN_PATH, 'utf8');
+
+describe('the flagship-probe registration', () => {
+  // Kills: declarations.ts never calling registerLayout for this manifest.
+  it('registers through the app-wide barrel', () => {
+    expect(getLayout('flagship-probe')).toBe(flagshipProbeLayout);
+  });
+
+  // Kills: a zone gaining a second surface, or drifting to an id the skin's
+  // style block does not place — the id IS the contract with the arrangement.
+  it('declares one surface per zone, under the ids the skin places', () => {
+    const placed = new Set(
+      [...skinSource.matchAll(/\[data-zone-id='([a-z-]+)'\]/g)].map(([, id]) => id),
+    );
+    // The deck's two receiver strips are placed by `data-strip-receiver`, so
+    // their zone ids are the only declared ones the style block does not name.
+    const deck = new Set(['primary-vfo', 'secondary-vfo']);
+    for (const zone of flagshipProbeLayout.zones) {
+      expect(zone.surfaces).toHaveLength(1);
+      expect(placed.has(zone.id) || deck.has(zone.id)).toBe(true);
+    }
+    expect([...placed].every((id) => flagshipProbeLayout.zones.some((z) => z.id === id))).toBe(true);
+  });
+
+  // Kills: declaring `memory`, the one declarable surface this arrangement
+  // leaves out, or dropping one of the fourteen it places.
+  it('mounts fourteen of the fifteen declarable surfaces, all but memory', () => {
+    const declared = new Set<SemanticSurfaceName>(
+      flagshipProbeLayout.zones.flatMap((zone) => [...zone.surfaces]),
+    );
+    expect([...declared].sort()).toEqual([
+      'antenna', 'band', 'cwKeyer', 'dsp', 'filter', 'meters', 'rfFrontEnd', 'ritXitScan',
+      'rxAudio', 'rxTx', 'scopeControls', 'scopeDisplay', 'txAux', 'vfo',
+    ]);
+    expect(declared.has('memory' as SemanticSurfaceName)).toBe(false);
+  });
+
+  // Kills: admitting a single-receiver topology — the arrangement puts two
+  // receivers side by side in both of its arrangements, and there would be
+  // nothing to put in the second.
+  it('is compatible with the dual-receiver topologies only', () => {
+    expect([...flagshipProbeLayout.compatibleTopologies].sort())
+      .toEqual(['2/ab_shared', '2/main_sub']);
+  });
+
+  // Kills: the manifest's declared threshold drifting away from the width the
+  // shell actually switches at, in either direction.
+  it('declares the same reflow width the shell switches at', () => {
+    const container = skinSource.match(/@container \(min-width: (\d+)px\)/);
+    expect(container).not.toBeNull();
+    const switchWidth = skinSource.match(/--flagship-probe-switch-width:\s*(\d+)px/);
+    expect(switchWidth).not.toBeNull();
+    expect(Number(container![1])).toBe(Number(switchWidth![1]));
+    expect(flagshipProbeLayout.stageSizing).toEqual({
+      mode: 'fluid', responsiveBreakpoints: [Number(container![1])],
+    });
+  });
+});

--- a/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
@@ -70,6 +70,7 @@ const cockpitShellSource = readFileSync('src/skins/dual-receiver-cockpit/DualRec
 const peerSplitShellSource = readFileSync('src/skins/segmentline/PeerSplitLayout.svelte', 'utf8');
 const unifiedInstrumentShellSource = readFileSync('src/skins/lcd-unified-instrument/LcdUnifiedInstrumentSkin.svelte', 'utf8');
 const panadapterFirstShellSource = readFileSync('src/skins/lcd-panadapter-first/LcdPanadapterFirstSkin.svelte', 'utf8');
+const flagshipProbeShellSource = readFileSync('src/skins/flagship-probe/FlagshipProbeSkin.svelte', 'utf8');
 
 /**
  * L1 hosted path. App owns one semantic host and passes its named composition
@@ -125,6 +126,10 @@ const DOM_BACKED: Readonly<Record<string, () => boolean>> = {
   'lcd-scope': () => /<SemanticRadioSurfaces\s*\/>/.test(lcdLayoutSource),
   'mobile': () => /<SemanticRadioSurfaces\s*\/>/.test(mobileLayoutSource),
   'dual-receiver-cockpit': () => /<SemanticRadioSurfaces strips="dual"\s*\/>/.test(cockpitShellSource),
+  // T160 PR-1: the geometry probe mounts the same dual-receiver composition
+  // unconditionally, so every surface its manifest declares has a real DOM
+  // path rather than a forward declaration.
+  'flagship-probe': () => /<SemanticRadioSurfaces strips="dual"\s*\/>/.test(flagshipProbeShellSource),
   // MOR-2151: PeerSplitLayout.svelte mounts the same dual-receiver
   // composition unconditionally, so its manifest-declared VFO/RX-TX
   // surfaces have a real DOM path rather than a forward declaration.

--- a/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
@@ -56,7 +56,8 @@ describe('exactly the reviewed manifests declare a meters zone (MOR-1341)', () =
    *  so `SemanticRadioSurfaces`'s bare-render fallback (MOR-1273) mounted the
    *  semantic surface ALONGSIDE the never-suppressed legacy dock — the same
    *  double MOR-1341 closed for `desktop-v2`. */
-  const DECLARES_METERS = ['desktop-v2', 'sdr-test'];
+  // T160 PR-1 added `flagship-probe`, which places this surface in its bottom dock.
+  const DECLARES_METERS = ['desktop-v2', 'flagship-probe', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
@@ -56,7 +56,8 @@ describe('exactly the reviewed manifests declare an rfFrontEnd zone (MOR-1366)',
   // MOR-2231 (step 1, batch 2) added `sdr-test`, by hand and with the layout
   // review this literal exists to force: the same declaration retires that
   // face's legacy twins through the `declared.has(...)` channel.
-  const DECLARES_RF_FRONT_END = ['desktop-v2', 'sdr-test'];
+  // T160 PR-1 added `flagship-probe`, which places this surface in its left rail.
+  const DECLARES_RF_FRONT_END = ['desktop-v2', 'flagship-probe', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/ritxit-scan-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/ritxit-scan-declarability.test.ts
@@ -49,7 +49,8 @@ describe('exactly the reviewed manifests declare a ritXitScan zone (MOR-1367)', 
   // MOR-2231 (step 1, batch 2) added `sdr-test`, by hand and with the layout
   // review this literal exists to force: the same declaration retires that
   // face's legacy twins through the `declared.has(...)` channel.
-  const DECLARES_RITXIT_SCAN = ['desktop-v2', 'sdr-test'];
+  // T160 PR-1 added `flagship-probe`, which places this surface in its right rail.
+  const DECLARES_RITXIT_SCAN = ['desktop-v2', 'flagship-probe', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
@@ -54,7 +54,8 @@ describe('exactly the reviewed manifests declare an rxAudio zone (MOR-1368)', ()
   // review this literal exists to force: the same declaration retires that
   // face's RX AUDIO panel in BOTH sidebars through the `declared.has(...)`
   // channel. It retires no settings-modal section — this family has none.
-  const DECLARES_RX_AUDIO = ['desktop-v2', 'sdr-test'];
+  // T160 PR-1 added `flagship-probe`, which places this surface in its left rail.
+  const DECLARES_RX_AUDIO = ['desktop-v2', 'flagship-probe', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/scope-controls-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/scope-controls-declarability.test.ts
@@ -71,7 +71,8 @@ describe('exactly the reviewed manifests declare a scopeControls zone (MOR-1370)
   // `hideScopeControls={declared.has('scopeControls')}`, which `RadioLayout`
   // forwards to a `SpectrumPanel` that keeps rendering and drops the
   // toolbar's fact-backed half.
-  const DECLARES_SCOPE_CONTROLS = ['desktop-v2', 'sdr-test'];
+  // T160 PR-1 added `flagship-probe`, which places this surface in its centre column, under the panorama.
+  const DECLARES_SCOPE_CONTROLS = ['desktop-v2', 'flagship-probe', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/scope-display-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/scope-display-declarability.test.ts
@@ -61,7 +61,8 @@ describe('exactly the reviewed manifests declare a scopeDisplay zone (MOR-1365)'
   // face's status-bar scope indicator through the `declared.has(...)` channel
   // (`StatusBar.svelte`'s `{#if hasAnyScope() && !declared.has('scopeDisplay')}`).
   // That is the only host it retires.
-  const DECLARES_SCOPE_DISPLAY = ['desktop-v2', 'sdr-test'];
+  // T160 PR-1 added `flagship-probe`, which places this surface in its centre column, under the panorama.
+  const DECLARES_SCOPE_DISPLAY = ['desktop-v2', 'flagship-probe', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
@@ -58,7 +58,8 @@ describe('exactly the reviewed manifests declare a txAux zone (MOR-1336)', () =>
   // predicate exists on any host, so the zone only places `TxAuxSurface`.
   // The sidebars' `<TxPanel>` is a different channel (`hideTxPanel`, which
   // follows the semantic deck for R9), already suppressed on that face.
-  const DECLARES_TX_AUX = ['desktop-v2', 'dual-receiver-cockpit', 'sdr-test'];
+  // T160 PR-1 added `flagship-probe`, which places this surface in its right rail.
+  const DECLARES_TX_AUX = ['desktop-v2', 'dual-receiver-cockpit', 'flagship-probe', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -137,3 +137,57 @@ export {
   peerSplitLayout,
   unifiedInstrumentLayout,
 } from './segmentline-declarations';
+
+/**
+ * The flagship geometry probe's manifest (T160 PR-1), declared inline here as
+ * `sdrTestLayout` above is.
+ *
+ * Every zone id below is one this repository already uses for that surface:
+ * the twelve control zones take `sdr-test`'s and `desktop-v2`'s ids, and the
+ * deck takes the cockpit's four. Two of those four are not a free choice —
+ * `SemanticRadioSurfaces.svelte: visibleStrips` writes `primary-vfo` and
+ * `secondary-vfo` into the DOM itself.
+ *
+ * WHY ALL FOURTEEN ARE DECLARED. In the dual composition nine of these
+ * surfaces mount with `allowBare={false}` — without a declared zone they
+ * render nothing at all, which is what an undeclared rail would be here.
+ * `memory` is the one declarable surface this layout leaves out.
+ *
+ * `compatibleTopologies` names the two dual-receiver pairs only: the
+ * arrangement puts two receivers side by side in both of its arrangements,
+ * and a single-receiver radio has no second one to place.
+ */
+export const flagshipProbeLayout: LayoutManifest = {
+  schemaVersion: 1,
+  id: 'flagship-probe',
+  displayName: 'Flagship geometry probe',
+  zones: [
+    { id: 'primary-vfo', surfaces: ['vfo'] },
+    { id: 'secondary-vfo', surfaces: ['vfo'] },
+    { id: 'global', surfaces: ['vfo'] },
+    { id: 'rx-tx', surfaces: ['rxTx'] },
+    { id: 'rf-front-end', surfaces: ['rfFrontEnd'] },
+    { id: 'dsp', surfaces: ['dsp'] },
+    { id: 'filter', surfaces: ['filter'] },
+    { id: 'rx-audio', surfaces: ['rxAudio'] },
+    { id: 'antenna', surfaces: ['antenna'] },
+    { id: 'band', surfaces: ['band'] },
+    { id: 'tx-aux', surfaces: ['txAux'] },
+    { id: 'cw-keyer', surfaces: ['cwKeyer'] },
+    { id: 'rit-xit-scan', surfaces: ['ritXitScan'] },
+    { id: 'scope-controls', surfaces: ['scopeControls'] },
+    { id: 'scope-display', surfaces: ['scopeDisplay'] },
+    { id: 'meters', surfaces: ['meters'] },
+  ],
+  compatibleTopologies: ['2/ab_shared', '2/main_sub'],
+  requiredSemanticSurfaces: ['vfo', 'rxTx'],
+  // The one threshold the shell implements, recorded here as the cockpit's
+  // pair is: the number is the skin's `--flagship-probe-switch-width`, and
+  // `skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts` requires
+  // this declaration, that custom property and the `@container` literal to
+  // name the same width.
+  stageSizing: { mode: 'fluid', responsiveBreakpoints: [1440] },
+  fallbackLayoutId: 'sdr-test',
+};
+
+registerLayout(flagshipProbeLayout);

--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -151,6 +151,9 @@ export {
  * WHY ALL FOURTEEN ARE DECLARED. In the dual composition nine of these
  * surfaces mount with `allowBare={false}` — without a declared zone they
  * render nothing at all, which is what an undeclared rail would be here.
+ * The other five are declared so the arrangement has a `data-zone-id` to
+ * place them by: `__tests__/flagship-probe-registration.test.ts` requires
+ * every id the skin's style block places to be a zone declared here.
  * `memory` is the one declarable surface this layout leaves out.
  *
  * `compatibleTopologies` names the two dual-receiver pairs only: the
@@ -183,10 +186,10 @@ export const flagshipProbeLayout: LayoutManifest = {
   requiredSemanticSurfaces: ['vfo', 'rxTx'],
   // The one threshold the shell implements, recorded here as the cockpit's
   // pair is: the number is the skin's `--flagship-probe-switch-width`, and
-  // `skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts` requires
-  // this declaration, that custom property and the `@container` literal to
-  // name the same width.
-  stageSizing: { mode: 'fluid', responsiveBreakpoints: [1440] },
+  // `__tests__/flagship-probe-registration.test.ts` requires this
+  // declaration, that custom property and the `@container` literal to name
+  // the same width.
+  stageSizing: { mode: 'fluid', responsiveBreakpoints: [1472] },
   fallbackLayoutId: 'sdr-test',
 };
 

--- a/frontend/src/skins/__tests__/entrypoints.test.ts
+++ b/frontend/src/skins/__tests__/entrypoints.test.ts
@@ -141,6 +141,11 @@ const SKIN_ENTRYPOINT_COVERAGE: Readonly<Record<SkinId, EntrypointCoverage>> = {
     testFile: 'src/skins/dual-sdr-face/__tests__/DualSdrFaceSkin.component.test.ts',
     entryComponentFile: 'DualSdrFaceSkin.svelte',
   },
+  'flagship-probe': {
+    kind: 'covered-elsewhere',
+    testFile: 'src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts',
+    entryComponentFile: 'FlagshipProbeSkin.svelte',
+  },
 };
 
 const allSkinIds = Object.keys(SKIN_ENTRYPOINT_COVERAGE) as SkinId[];

--- a/frontend/src/skins/__tests__/registry.test.ts
+++ b/frontend/src/skins/__tests__/registry.test.ts
@@ -149,11 +149,12 @@ describe('skin registry', () => {
     }
   });
 
-  // `dual-receiver-cockpit` is deliberately absent from this table: its own
-  // lazy-load pin lives in the QA-only describe block below and must run
-  // AFTER this table (see that block's call-order comment) — this file has
-  // no per-test mock reset, so merging it here would double-invoke its
-  // loader before that block's "not called merely by resolving" assertion.
+  // `dual-receiver-cockpit` and `flagship-probe` are deliberately absent from
+  // this table: their lazy-load pins live in the QA-only describe block below
+  // and must run AFTER this table (see that block's call-order comment) —
+  // this file has no per-test mock reset, so merging them here would
+  // double-invoke their loaders before that block's "not called merely by
+  // resolving" assertion.
   const LAZY_LOAD_TABLE = [
     ['desktop-v2', entrypoints['desktop-v2'], lazyImports['desktop-v2']],
     ['lcd-cockpit', entrypoints['lcd-cockpit'], lazyImports['lcd-cockpit']],
@@ -164,7 +165,6 @@ describe('skin registry', () => {
     ['panadapter-first', entrypoints['panadapter-first'], lazyImports['panadapter-first']],
     ['sdr-test', entrypoints['sdr-test'], lazyImports['sdr-test']],
     ['dual-sdr-face', entrypoints['dual-sdr-face'], lazyImports['dual-sdr-face']],
-    ['flagship-probe', entrypoints['flagship-probe'], lazyImports['flagship-probe']],
   ] as const;
 
   it.each(LAZY_LOAD_TABLE)('lazily loads the %s entrypoint', async (skinId: SkinId, entrypoint, lazyImport) => {
@@ -183,12 +183,12 @@ describe('skin registry', () => {
   });
 });
 
-// MOR-1257 — interim QA reachability for the dual-receiver cockpit, gated
-// behind the exact `?layout=dual-receiver-cockpit` query param (the URL ->
+// MOR-1257 (cockpit) and T160 PR-1 (flagship probe) — interim QA
+// reachability, gated behind the exact `?layout=<id>` query param (the URL ->
 // LayoutMode translation itself is `readQaCockpitLayoutOverride`, pinned
 // separately in lib/stores/__tests__/qa-cockpit-override.test.ts). These
 // tests pin resolveSkinId's half of the contract only.
-describe('MOR-1257: QA-only dual-receiver-cockpit reachability', () => {
+describe('QA-only layout reachability', () => {
   // Kill-test: removing this branch (or mistyping the literal) leaves the
   // QA-only preference falling through `normalizeLayoutMode` to 'auto',
   // which resolves to 'desktop-v2' unconditionally (MOR-1097 cutover) —
@@ -196,6 +196,13 @@ describe('MOR-1257: QA-only dual-receiver-cockpit reachability', () => {
   it('resolves the QA-only preference to the cockpit skin', () => {
     expect(resolve({ layoutPreference: 'dual-receiver-cockpit' })).toBe('dual-receiver-cockpit');
     expect(resolve({ layoutPreference: 'dual-receiver-cockpit', hasAnyScope: true })).toBe('dual-receiver-cockpit');
+  });
+
+  // Kill-test: removing the T160 branch leaves 'flagship-probe' falling
+  // through `normalizeLayoutMode` to 'auto', hence to 'desktop-v2'.
+  it('resolves the QA-only preference to the flagship geometry probe', () => {
+    expect(resolve({ layoutPreference: 'flagship-probe' })).toBe('flagship-probe');
+    expect(resolve({ layoutPreference: 'flagship-probe', hasAnyScope: true })).toBe('flagship-probe');
   });
 
   // Default-path pin (ticket acceptance): every OTHER forced preference is
@@ -210,20 +217,20 @@ describe('MOR-1257: QA-only dual-receiver-cockpit reachability', () => {
   // tension: the mobile short-circuit stays first, so an actual phone
   // viewport keeps the mobile skin even with the QA param present. QA is
   // expected to open the URL on a desktop-sized viewport.
-  it('still gives mobile precedence over the QA-only preference', () => {
-    expect(resolve({ isMobile: true, layoutPreference: 'dual-receiver-cockpit', hasAnyScope: true }))
-      .toBe('mobile');
-  });
+  it.each(['dual-receiver-cockpit', 'flagship-probe'] as const)(
+    'still gives mobile precedence over the QA-only %s preference', (layoutPreference) => {
+      expect(resolve({ isMobile: true, layoutPreference, hasAnyScope: true })).toBe('mobile');
+    });
 
   // Must run before the lazy-load test below actually triggers the import —
   // this file has no per-test mock reset, so call order is significant here
   // (mirrors "does not import a skin entrypoint while the registry is
   // initialized" above, which runs before every "lazily loads" case).
-  it('does not import the dual-receiver-cockpit entrypoint merely by resolving other preferences', () => {
+  it('does not import a QA-gated entrypoint merely by resolving other preferences', () => {
     for (const layoutPreference of ['auto', 'standard', 'lcd-cockpit', 'lcd-scope', 'sdr-test'] as const) {
       resolve({ layoutPreference });
     }
-    expect(lazyImports['dual-receiver-cockpit']).not.toHaveBeenCalled();
+    for (const id of QA_GATED_LAZY_LOAD_IDS) expect(lazyImports[id]).not.toHaveBeenCalled();
   });
 
   // MOR-2074 review: unlike `LAZY_LOAD_TABLE` above, whose "has a pin"

--- a/frontend/src/skins/__tests__/registry.test.ts
+++ b/frontend/src/skins/__tests__/registry.test.ts
@@ -35,6 +35,7 @@ const entrypoints = vi.hoisted(() => {
     'sdr-test': { name: 'sdr-test' },
     'dual-receiver-cockpit': { name: 'dual-receiver-cockpit' },
     'dual-sdr-face': { name: 'dual-sdr-face' },
+    'flagship-probe': { name: 'flagship-probe' },
   };
   return table;
 });
@@ -51,6 +52,7 @@ const lazyImports = vi.hoisted(() => {
     'sdr-test': vi.fn(() => ({ default: entrypoints['sdr-test'] })),
     'dual-receiver-cockpit': vi.fn(() => ({ default: entrypoints['dual-receiver-cockpit'] })),
     'dual-sdr-face': vi.fn(() => ({ default: entrypoints['dual-sdr-face'] })),
+    'flagship-probe': vi.fn(() => ({ default: entrypoints['flagship-probe'] })),
   };
   return table;
 });
@@ -65,6 +67,7 @@ vi.mock('../lcd-panadapter-first/LcdPanadapterFirstSkin.svelte', () => lazyImpor
 vi.mock('../sdr-test/SdrTestSkin.svelte', () => lazyImports['sdr-test']());
 vi.mock('../dual-receiver-cockpit/DualReceiverCockpit.svelte', () => lazyImports['dual-receiver-cockpit']());
 vi.mock('../dual-sdr-face/DualSdrFaceSkin.svelte', () => lazyImports['dual-sdr-face']());
+vi.mock('../flagship-probe/FlagshipProbeSkin.svelte', () => lazyImports['flagship-probe']());
 
 import {
   commitExternalPresentationBatch, getPresentationRecord, isPresentationIdReserved,
@@ -161,6 +164,7 @@ describe('skin registry', () => {
     ['panadapter-first', entrypoints['panadapter-first'], lazyImports['panadapter-first']],
     ['sdr-test', entrypoints['sdr-test'], lazyImports['sdr-test']],
     ['dual-sdr-face', entrypoints['dual-sdr-face'], lazyImports['dual-sdr-face']],
+    ['flagship-probe', entrypoints['flagship-probe'], lazyImports['flagship-probe']],
   ] as const;
 
   it.each(LAZY_LOAD_TABLE)('lazily loads the %s entrypoint', async (skinId: SkinId, entrypoint, lazyImport) => {
@@ -276,6 +280,9 @@ describe('presentation resource plan', () => {
     // The mobile layout mounts SpectrumPanel but no audio-FFT surface.
     'mobile': ['hardware-scope'],
     'dual-sdr-face': ['hardware-scope'],
+    // T160 PR-1: the geometry probe's one resource-demanding component is a
+    // SpectrumPanel, the same reason `mobile` above names this alone.
+    'flagship-probe': ['hardware-scope'],
   };
 
   it('keeps panadapter-first resource order hardware-selected, with the LCD shell AF consumer retained', () => {
@@ -313,6 +320,7 @@ describe('presentation host mode', () => {
     'unified-instrument': 'self-contained',
     'panadapter-first': 'self-contained',
     'dual-sdr-face': 'self-contained',
+    'flagship-probe': 'self-contained',
   };
 
   it.each(Object.entries(EXPECTED_HOST_MODE) as Array<[SkinId, PresentationHostMode]>) (

--- a/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
+++ b/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
@@ -21,10 +21,10 @@
   The switch is a container query on `.flagship-probe`, so it follows the
   width this skin is GIVEN rather than the viewport's. Its threshold is
   `--flagship-probe-switch-width` — two rails, two receiver strips and the
-  RX/TX column, each at the minimum width declared below, which makes it the
-  narrowest container in which the wide arrangement can meet all five of
-  those minimums at once. Those minimums are DECLARED, not measured: nothing
-  here measures what a surface actually renders at.
+  RX/TX column, each at the minimum width declared below, PLUS the four
+  gutters the grid puts between those five columns. Those minimums are
+  DECLARED, not measured: nothing here measures what a surface actually
+  renders at.
   `__tests__/FlagshipProbe.component.test.ts` recomputes the sum and requires
   the `@container` literal to equal it;
   `presentation/layouts/__tests__/flagship-probe-registration.test.ts`
@@ -76,11 +76,14 @@
     container-type: inline-size;
     height: 100%;
 
-    /* The declared minimum track widths, and their sum. */
+    /*
+      The declared minimum track widths, and their sum with the four gutters
+      `.probe-stage` puts between the five columns.
+    */
     --flagship-probe-rail-width: 280px;
     --flagship-probe-strip-min-width: 360px;
     --flagship-probe-rx-tx-min-width: 160px;
-    --flagship-probe-switch-width: 1440px;
+    --flagship-probe-switch-width: 1472px;
   }
 
   /*
@@ -115,7 +118,7 @@
       'meters    meters     meters     meters     meters';
   }
 
-  @container (min-width: 1440px) {
+  @container (min-width: 1472px) {
     .probe-stage {
       grid-template-areas:
         'rf        rx-main    rx-mid     rx-sub     tx-aux'

--- a/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
+++ b/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
@@ -1,0 +1,179 @@
+<!--
+  Flagship geometry probe — a GEOMETRY PROBE, not the flagship face.
+
+  What it does: places the EXISTING semantic surfaces, drawn by the existing
+  wiring, in the flagship's arrangement, and mounts the existing
+  `SpectrumPanel` between the two rails. Its style block declares one grid
+  and nothing else: no colour, no font, no border and no control of its own,
+  so what appears inside it is drawn entirely by
+  `components-v2/wiring/SemanticRadioSurfaces.svelte`, by the surfaces it
+  composes, and by `SpectrumPanel` — each at its own native size.
+
+  What it deliberately does NOT do: the `memory` surface is not declared, the
+  type ladder is not applied, and no key is given a lamp.
+
+  ARRANGEMENT. Two receivers side by side in BOTH arrangements, and the
+  panorama always between the two rails, never under one:
+
+    wide   — left rail | (deck over panorama) | right rail
+    narrow — deck across the top, then left rail | panorama | right rail
+
+  The switch is a container query on `.flagship-probe`, so it follows the
+  width this skin is GIVEN rather than the viewport's. Its threshold is
+  `--flagship-probe-switch-width` — two rails, two receiver strips and the
+  RX/TX column, each at the minimum width declared below, which makes it the
+  narrowest container in which the wide arrangement can meet all five of
+  those minimums at once. Those minimums are DECLARED, not measured: nothing
+  here measures what a surface actually renders at.
+  `__tests__/FlagshipProbe.component.test.ts` recomputes the sum and requires
+  the `@container` literal to equal it;
+  `presentation/layouts/__tests__/flagship-probe-registration.test.ts`
+  requires the manifest's declared reflow width to equal it too.
+
+  R52. This shell renders no control and no readout, so it announces nothing
+  it does not know: it contributes no dash, no glyph and no disabled
+  element, and its grid is identical in receive and in transmit — no row,
+  area or track below is conditional on anything.
+-->
+<script lang="ts">
+  // The same side-effect import, for the same reason, that
+  // `dual-receiver-cockpit/DualReceiverCockpit.svelte` carries (MOR-1257 N4):
+  // the components-v2 theme layer is code-split, and this shell composes
+  // neither of the two layouts that pull it in (`RadioLayout.svelte` and
+  // `LcdLayout.svelte` both `import '../theme/index'`).
+  import '../../components-v2/theme/index';
+  import SemanticRadioSurfaces from '../../components-v2/wiring/SemanticRadioSurfaces.svelte';
+  import SpectrumPanel from '../../components/spectrum/SpectrumPanel.svelte';
+</script>
+
+<div class="flagship-probe" data-testid="flagship-geometry-probe">
+  <div class="probe-stage" data-testid="probe-stage">
+    <SemanticRadioSurfaces strips="dual" />
+    <!--
+      `hideScopeControls`: the fact-backed half of the spectrum toolbar is
+      suppressed because the semantic `scopeControls` surface renders it,
+      once, in its own declared zone directly under this panel. No
+      `scopeControls` snippet is passed: that snippet exists only on the
+      hosted `instruments` composition, which a self-contained skin does not
+      receive. No `colorRoles`: this probe adds no colour.
+      `scopeProjection` is likewise not passed, which leaves SpectrumPanel on
+      its own unmanaged path — it acquires and releases its own scope lease,
+      exactly as it does under `RadioLayout`'s second `<SpectrumPanel>`.
+    -->
+    <div class="probe-panorama" data-testid="probe-panorama">
+      <SpectrumPanel hideSourceControls={true} hideScopeControls={true} />
+    </div>
+  </div>
+</div>
+
+<style>
+  /*
+    The query container. It must be an ancestor of the grid rather than the
+    grid itself: an element cannot answer a container query about its own
+    size. Same idiom as `skins/dual-sdr-face/DualSdrFace.svelte`.
+  */
+  .flagship-probe {
+    container-type: inline-size;
+    height: 100%;
+
+    /* The declared minimum track widths, and their sum. */
+    --flagship-probe-rail-width: 280px;
+    --flagship-probe-strip-min-width: 360px;
+    --flagship-probe-rx-tx-min-width: 160px;
+    --flagship-probe-switch-width: 1440px;
+  }
+
+  /*
+    NARROW is the base arrangement, so the container query below only ever
+    adds the wide one: a container too small for the wide arrangement is also
+    a container whose query has not matched.
+
+    Five tracks in both arrangements. Columns 1 and 5 are the rails, and the
+    panorama lives across columns 2-4 in both — which is what keeps it
+    between them. The deck spans all five columns in the narrow arrangement
+    and columns 2-4 in the wide one; that is the whole of the switch.
+  */
+  .probe-stage {
+    display: grid;
+    gap: 8px;
+    align-content: start;
+    grid-template-columns:
+      minmax(var(--flagship-probe-rail-width), auto)
+      minmax(0, 1fr)
+      auto
+      minmax(0, 1fr)
+      minmax(var(--flagship-probe-rail-width), auto);
+    grid-template-areas:
+      'rx-main   rx-main    rx-mid     rx-sub     rx-sub'
+      'vfo-ops   vfo-ops    vfo-ops    vfo-ops    vfo-ops'
+      'rf        panorama   panorama   panorama   tx-aux'
+      'dsp       panorama   panorama   panorama   cw-keyer'
+      'filter    panorama   panorama   panorama   rit-xit'
+      'rx-audio  panorama   panorama   panorama   .'
+      'antenna   scope-ctl  scope-ctl  scope-ctl  .'
+      'band      scope-disp scope-disp scope-disp .'
+      'meters    meters     meters     meters     meters';
+  }
+
+  @container (min-width: 1440px) {
+    .probe-stage {
+      grid-template-areas:
+        'rf        rx-main    rx-mid     rx-sub     tx-aux'
+        'dsp       vfo-ops    vfo-ops    vfo-ops    cw-keyer'
+        'filter    panorama   panorama   panorama   rit-xit'
+        'rx-audio  panorama   panorama   panorama   .'
+        'antenna   panorama   panorama   panorama   .'
+        'band      scope-ctl  scope-ctl  scope-ctl  .'
+        '.         scope-disp scope-disp scope-disp .'
+        'meters    meters     meters     meters     meters';
+    }
+  }
+
+  /*
+    The `:global(...)` halves reach into the shared wiring's composed blocks
+    on purpose — this skin owns its own arrangement, and rooting every
+    selector at `.probe-stage` keeps them off every other face that mounts
+    the same wiring. The coupling to those attribute values is not silent:
+    the component test requires every `data-zone-id` named here to exist in
+    the mounted tree.
+
+    `display: contents` on the wiring's two containers is what makes the
+    zones below grid items of THIS grid rather than of a box this skin does
+    not own.
+  */
+  .probe-stage :global(.semantic-surfaces),
+  .probe-stage :global(.channel-strips) {
+    display: contents;
+  }
+
+  .probe-stage :global([data-strip-receiver='MAIN']) {
+    grid-area: rx-main;
+    min-width: var(--flagship-probe-strip-min-width);
+  }
+  .probe-stage :global([data-strip-receiver='SUB']) {
+    grid-area: rx-sub;
+    min-width: var(--flagship-probe-strip-min-width);
+  }
+  .probe-stage :global([data-zone-id='rx-tx']) {
+    grid-area: rx-mid;
+    min-width: var(--flagship-probe-rx-tx-min-width);
+  }
+  .probe-stage :global([data-zone-id='global']) { grid-area: vfo-ops; }
+  .probe-stage :global([data-zone-id='rf-front-end']) { grid-area: rf; }
+  .probe-stage :global([data-zone-id='dsp']) { grid-area: dsp; }
+  .probe-stage :global([data-zone-id='filter']) { grid-area: filter; }
+  .probe-stage :global([data-zone-id='rx-audio']) { grid-area: rx-audio; }
+  .probe-stage :global([data-zone-id='antenna']) { grid-area: antenna; }
+  .probe-stage :global([data-zone-id='band']) { grid-area: band; }
+  .probe-stage :global([data-zone-id='tx-aux']) { grid-area: tx-aux; }
+  .probe-stage :global([data-zone-id='cw-keyer']) { grid-area: cw-keyer; }
+  .probe-stage :global([data-zone-id='rit-xit-scan']) { grid-area: rit-xit; }
+  .probe-stage :global([data-zone-id='scope-controls']) { grid-area: scope-ctl; }
+  .probe-stage :global([data-zone-id='scope-display']) { grid-area: scope-disp; }
+  .probe-stage :global([data-zone-id='meters']) { grid-area: meters; }
+
+  .probe-panorama {
+    grid-area: panorama;
+    min-width: 0;
+  }
+</style>

--- a/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
+++ b/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
@@ -139,6 +139,10 @@ import {
 
 const SKIN_PATH = 'src/skins/flagship-probe/FlagshipProbeSkin.svelte';
 const source = readFileSync(SKIN_PATH, 'utf8');
+/** The style block alone, comments stripped — so no assertion below can be
+ *  satisfied by the header comment quoting the CSS it describes. */
+const style = source.slice(source.indexOf('<style>'), source.indexOf('</style>'))
+  .replace(/\/\*[\s\S]*?\*\//g, '');
 
 const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
 
@@ -247,9 +251,9 @@ function templates(): Template[] {
     [...body.matchAll(/'([^']*)'/g)].map(([, row]) => row.trim().split(/\s+/)));
 }
 
-/** A pixel-valued custom property declared in the skin's own style block. */
+/** A pixel-valued declaration in the skin's own style block. */
 function px(name: string): number {
-  const hit = source.match(new RegExp(`${name}:\\s*(\\d+)px`));
+  const hit = style.match(new RegExp(`${name}:\\s*(\\d+)px`));
   expect(hit).not.toBeNull();
   return Number(hit![1]);
 }
@@ -339,9 +343,16 @@ describe('the container-width switch', () => {
   // arrangement in force at every width.
   it('declares exactly two arrangements, and the wide one is inside a container query', () => {
     expect(templates()).toHaveLength(2);
-    const container = source.slice(source.indexOf('@container'));
+    const container = style.slice(style.indexOf('@container'));
     expect(container).toContain('grid-template-areas');
-    expect(source.indexOf('@container')).toBeLessThan(source.lastIndexOf('grid-template-areas'));
+    expect(style.indexOf('@container')).toBeLessThan(style.lastIndexOf('grid-template-areas'));
+  });
+
+  // Kills: dropping `container-type` from the skin root, which leaves the
+  // query above resolving against some ancestor's width — or, with no
+  // container anywhere above, never matching at all.
+  it('declares the query container on the skin root itself', () => {
+    expect(style).toMatch(/\.flagship-probe\s*\{[^}]*container-type:\s*inline-size/);
   });
 
   // Kills: a "narrow" template that is really the wide one — the deck must
@@ -357,26 +368,26 @@ describe('the container-width switch', () => {
   });
 
   // Kills: changing the threshold in one place and not the other two — the
-  // number is the sum of the arrangement's own declared minimum widths. The
+  // number is the sum of the arrangement's own declared minimum widths and
+  // the four gutters between the five columns they size. The
   // manifest declares that same width, and
   // `presentation/layouts/__tests__/flagship-probe-registration.test.ts` is
   // where the two are required to agree (this directory may not name the
   // manifest field: `stage-sizing-boundary.test.ts`).
-  it('the threshold is the sum of the declared minimum track widths', () => {
+  it('the threshold is the sum of the declared minimum track widths and the gutters', () => {
     const rail = px('--flagship-probe-rail-width');
     const strip = px('--flagship-probe-strip-min-width');
     const rxTx = px('--flagship-probe-rx-tx-min-width');
-    const sum = 2 * rail + 2 * strip + rxTx;
+    // Five columns, four gutters. Read from the same style block as the
+    // widths, so the gap and the threshold cannot drift apart either.
+    const sum = 2 * rail + 2 * strip + rxTx + 4 * px('gap');
 
     expect(px('--flagship-probe-switch-width')).toBe(sum);
-    expect(Number(source.match(/@container \(min-width: (\d+)px\)/)![1])).toBe(sum);
+    expect(Number(style.match(/@container \(min-width: (\d+)px\)/)![1])).toBe(sum);
   });
 });
 
 describe('geometry only — the shell draws nothing', () => {
-  const style = source.slice(source.indexOf('<style>'), source.indexOf('</style>'))
-    .replace(/\/\*[\s\S]*?\*\//g, '');
-
   // Kills: the shell acquiring a look of its own — a colour, a font size, a
   // border or a lamp — which is exactly what this PR is not allowed to add
   // and what its design-language exemption

--- a/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
+++ b/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
@@ -1,0 +1,431 @@
+/**
+ * The flagship geometry probe, mounted end to end against the real adapter,
+ * the real wiring and the real semantic surfaces. Replaced: the runtime
+ * singleton, the TX authority, the MOD-input guard and the command
+ * vocabulary — all four by the same pattern
+ * `DualReceiverCockpit.component.test.ts` uses — and `SpectrumPanel`, by the
+ * shared `SpectrumPanelStub`, so this file pays for the arrangement rather
+ * than for a canvas.
+ *
+ * The two arrangements are a container query, and jsdom evaluates none, so
+ * the DOM half of this file proves what mounts and the source half proves
+ * where the two `grid-template-areas` put it. Each test's doc line names the
+ * mutation it kills.
+ */
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import { ManagedAppTxHarness } from '$lib/runtime/tx-controller/__tests__/support/managed-app-tx-harness';
+
+let txHarness: ManagedAppTxHarness;
+
+const h = vi.hoisted(() => ({
+  state: null as unknown,
+  caps: null as unknown,
+  session: { state: 'disconnected' as const, epoch: 0 },
+  selectVfo: vi.fn(),
+  splitToggle: vi.fn(),
+  dualWatchToggle: vi.fn(),
+  modInputGuard: { visible: false, sourceLabel: null } as { visible: boolean; sourceLabel: string | null },
+  /** One stand-in for every command intent: this file asserts arrangement,
+   *  never command dispatch. */
+  noop: vi.fn(),
+}));
+
+vi.mock('$lib/runtime', () => ({
+  runtime: {
+    onTxAudioDied: () => () => {},
+    get state() { return h.state; },
+    get caps() { return h.caps; },
+    get controlSession() { return h.session; },
+    subscribeControlAuthority(handler: (publication: unknown) => void) {
+      handler({
+        state: h.state, caps: h.caps, session: h.session,
+        rxAudioTarget: Object.freeze({ muted: true, rxEnabled: false }),
+      });
+      return () => {};
+    },
+    get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
+    get connectionAudio() { return false; },
+    get defaultScopeStatus() {
+      return {
+        source: null, available: false, resourceSelected: false, demand: 0,
+        lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+      };
+    },
+    get radioPowerOn() { return null; },
+    get scope() { return { hardwareScopeConnected: false }; },
+  },
+}));
+vi.mock('$lib/runtime/tx-controller/managed-app-host', () => ({
+  getManagedAppTxController: () => txHarness.controller,
+}));
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => h.modInputGuard,
+  getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+}));
+/** The shared stub records `hideScopeControls`, which is the one prop this
+ *  skin passes that the arrangement depends on — the scope toolbar's
+ *  fact-backed half must not double the semantic `scopeControls` zone. */
+vi.mock('../../../components/spectrum/SpectrumPanel.svelte', async () => ({
+  default: (await import('../../../components-v2/layout/__tests__/SpectrumPanelStub.svelte')).default,
+}));
+vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/commands/panel-commands')>();
+  return {
+    ...actual,
+    makeVfoHandlers: () => ({
+      onVfoSelect: h.selectVfo, onSplitToggle: h.splitToggle, onDualWatchToggle: h.dualWatchToggle,
+    }),
+    makeVoxHandlers: () => ({
+      onVoxToggle: h.noop, onVoxGainChange: h.noop, onAntiVoxGainChange: h.noop, onVoxDelayChange: h.noop,
+    }),
+    makeTxHandlers: () => ({
+      onRfPowerChange: h.noop, onMicGainChange: h.noop, onAtuToggle: h.noop, onAtuTune: h.noop,
+      onVoxToggle: h.noop, onCompToggle: h.noop, onCompLevelChange: h.noop, onMonToggle: h.noop,
+      onMonLevelChange: h.noop, onDriveGainChange: h.noop,
+    }),
+    makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
+    makeCwPanelHandlers: () => ({
+      onKeySpeedChange: h.noop, onCwPitchChange: h.noop, onBreakInDelayChange: h.noop,
+      onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
+      onReversePaddleToggle: h.noop,
+    }),
+    makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
+    makeModeHandlers: () => ({
+      onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop,
+    }),
+    makeFilterHandlers: () => ({
+      onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
+      onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
+    }),
+    makeDspHandlers: () => ({
+      onNrModeChange: h.noop, onNrLevelChange: h.noop, onNbToggle: h.noop, onNbLevelChange: h.noop,
+      onNbDepthChange: h.noop, onNbWidthChange: h.noop, onNotchModeChange: h.noop,
+      onNotchFreqChange: h.noop, onManualNotchWidthChange: h.noop, onAgcTimeChange: h.noop,
+    }),
+    makeAgcHandlers: () => ({ onAgcModeChange: h.noop }),
+    makeRfFrontEndHandlers: () => ({
+      onAttChange: h.noop, onPreChange: h.noop, onRfGainChange: h.noop, onSquelchChange: h.noop,
+      onDigiSelToggle: h.noop, onIpPlusToggle: h.noop,
+    }),
+    makeBandHandlers: () => ({ onBandSelect: h.noop }),
+    makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
+    makeRitXitHandlers: () => ({
+      onRitToggle: h.noop, onXitToggle: h.noop, onRitOffsetChange: h.noop,
+      onXitOffsetChange: h.noop, onClear: h.noop,
+    }),
+    makeScanHandlers: () => ({
+      onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
+    }),
+    makeScopeControlsHandlers: () => ({
+      onModeChange: h.noop, onEdgeChange: h.noop, onSpanChange: h.noop, onSpeedChange: h.noop,
+      onHoldChange: h.noop, onRefChange: h.noop, onDualChange: h.noop, onReceiverChange: h.noop,
+      onDuringTxChange: h.noop, onCenterTypeChange: h.noop, onVbwChange: h.noop, onRbwChange: h.noop,
+    }),
+  };
+});
+
+import FlagshipProbeSkin from '../FlagshipProbeSkin.svelte';
+// Read through the app-wide registration barrel, never through a direct
+// module import, so the zone ids asserted below are the ids the app registers.
+import { flagshipProbeLayout } from '../../../presentation/layouts/declarations';
+import { readWorkspace } from '../../../presentation/workspace/contract';
+import {
+  resolveSurfacePlan, SURFACE_PLAN_CONTEXT_KEY, type SurfacePlan,
+} from '../../../presentation/workspace/resolution';
+
+const SKIN_PATH = 'src/skins/flagship-probe/FlagshipProbeSkin.svelte';
+const source = readFileSync(SKIN_PATH, 'utf8');
+
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+
+/**
+ * 2/main_sub: MAIN and SUB each carry A/B slots (4 vfo tiles total). Meter
+ * readings are part of the fixture because `deriveMeters` returns the group
+ * only when at least one raw meter value is present, and this layout declares
+ * a `meters` zone — without them the dock would be an empty declared zone.
+ */
+function mainSubState(): ServerState {
+  const paths = ['active', 'split', 'dualWatch', 'txTarget',
+    'main.sMeter', 'powerMeter', 'swrMeter', 'alcMeter'];
+  for (const rx of ['main', 'sub']) {
+    paths.push(`${rx}.activeSlot`);
+    for (const v of ['vfoA', 'vfoB']) paths.push(`${rx}.${v}.freqHz`, `${rx}.${v}.mode`, `${rx}.${v}.filterNum`);
+  }
+  const slot = (hz: number) => ({ freqHz: hz, mode: 'USB', filterNum: 1 });
+  const receiver = (hz: number, sMeter?: number) => ({
+    vfoA: slot(hz), vfoB: slot(hz + 30000), activeSlot: 'A', sMeter,
+  });
+  return {
+    active: 'MAIN', split: true, dualWatch: true, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
+    main: receiver(14250000, 42), sub: receiver(21295000),
+    powerMeter: 0, swrMeter: 0, alcMeter: 0,
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+
+/** Copied verbatim from `DualReceiverCockpit.component.test.ts`'s
+ *  `mainSubCaps()`. It carries evidence for every group this layout declares
+ *  a zone for — which is what the "binds every zone id" test above proves. */
+const mainSubCaps = (): Capabilities => ({
+  model: 'fixture', scope: true, audio: true, tx: true,
+  capabilities: [
+    'audio', 'tx', 'dual_rx', 'tuner', 'dual_watch', 'lan_dual_rx_audio_routing',
+    'af_level', 'rf_gain', 'squelch', 'attenuator', 'preamp', 'digisel', 'ip_plus',
+    'antenna', 'rx_antenna', 'nb', 'nr', 'notch', 'apf', 'twin_peak', 'pbt',
+    'filter_width', 'filter_shape', 'split', 'ssb_tx_bw', 'cw', 'break_in', 'rit', 'xit',
+    'meters', 'data_mode', 'mod_input_routing', 'agc', 'power_control', 'dial_lock',
+    'scan', 'bsr', 'main_sub_tracking', 'tuning_step', 'band_edge', 'xfc', 'system_settings',
+    'scope', 'vox', 'compressor', 'monitor', 'drive_gain',
+  ],
+  receivers: 2, vfoScheme: 'main_sub',
+  freqRanges: [{ start: 1800000, end: 54000000, label: 'HF+6m', bands: [
+    { name: '20m', start: 14000000, end: 14350000, default: 14195000 },
+    { name: '40m', start: 7000000, end: 7300000, default: 7100000 },
+  ] }],
+  modes: ['USB', 'LSB', 'CW', 'CW-R', 'AM', 'FM', 'RTTY', 'RTTY-R', 'PSK', 'PSK-R'],
+  filters: ['FIL1', 'FIL2', 'FIL3'],
+  antennas: 2,
+  attValues: [0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45],
+  preValues: [0, 1, 2],
+  agcModes: [1, 2, 3], agcLabels: { '1': 'FAST', '2': 'MID', '3': 'SLOW' },
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+  scopeSource: null, audioFftAvailable: false,
+} as unknown as Capabilities);
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null = null;
+
+/** The plan App resolves for this layout when the operator expressed no
+ *  visibleSurfaces/zoneOrder preference — every declared zone, verbatim. */
+function defaultPlan(): SurfacePlan {
+  return resolveSurfacePlan(flagshipProbeLayout, readWorkspace({ version: 1 }).workspace);
+}
+
+function render(): void {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  const plan = defaultPlan();
+  component = mount(FlagshipProbeSkin, {
+    target,
+    context: new Map<unknown, unknown>([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]),
+  });
+  flushSync();
+}
+
+const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+const qa = <T extends HTMLElement>(sel: string) => [...target.querySelectorAll<T>(sel)];
+
+beforeEach(() => {
+  txHarness = new ManagedAppTxHarness();
+  h.state = mainSubState();
+  h.caps = mainSubCaps();
+  h.modInputGuard = { visible: false, sourceLabel: null };
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+});
+
+// ── The arrangement, as CSS ────────────────────────────────────────────────
+//
+// One `grid-template-areas` per arrangement, parsed out of the skin's own
+// style block. Cell [row][column]; '.' is an empty cell.
+type Template = string[][];
+
+function templates(): Template[] {
+  const blocks = [...source.matchAll(/grid-template-areas:([^;]*);/g)];
+  return blocks.map(([, body]) =>
+    [...body.matchAll(/'([^']*)'/g)].map(([, row]) => row.trim().split(/\s+/)));
+}
+
+/** A pixel-valued custom property declared in the skin's own style block. */
+function px(name: string): number {
+  const hit = source.match(new RegExp(`${name}:\\s*(\\d+)px`));
+  expect(hit).not.toBeNull();
+  return Number(hit![1]);
+}
+
+const LEFT_RAIL = ['rf', 'dsp', 'filter', 'rx-audio', 'antenna', 'band'];
+const RIGHT_RAIL = ['tx-aux', 'cw-keyer', 'rit-xit'];
+
+/** Every column index at which `area` appears in `template`. */
+function columnsOf(template: Template, area: string): number[] {
+  const cols = new Set<number>();
+  for (const row of template) row.forEach((cell, index) => { if (cell === area) cols.add(index); });
+  return [...cols].sort((a, b) => a - b);
+}
+
+/** The single row index `area` occupies; fails loudly if it spans rows. */
+function rowOf(template: Template, area: string): number {
+  const rows = template.flatMap((row, index) => (row.includes(area) ? [index] : []));
+  expect(new Set(rows).size).toBe(1);
+  return rows[0];
+}
+
+describe('the arrangement mounts the surfaces the manifest declares', () => {
+  // Kills: a shell that mounts the wiring without `strips="dual"`, or one
+  // receiver's strip going missing under a dual-receiver view model.
+  it('renders both receiver strips, side by side, always', () => {
+    render();
+    expect(qa('[data-testid^="channel-strip-"]')).toHaveLength(2);
+    expect(q('[data-testid="channel-strip-MAIN"]')).not.toBeNull();
+    expect(q('[data-testid="channel-strip-SUB"]')).not.toBeNull();
+  });
+
+  // Kills: a zone id in the style block that no mounted element carries —
+  // the silent way this arrangement would lose a rail panel.
+  it('binds every zone id the style block places to a real element', () => {
+    render();
+    const placed = [...source.matchAll(/\[data-zone-id='([a-z-]+)'\]/g)].map(([, id]) => id);
+    for (const id of new Set(placed)) expect(qa(`[data-zone-id="${id}"]`)).toHaveLength(1);
+    // Total in both directions: the mounted zones are exactly the placed ones
+    // plus the deck's two receiver strips, which this skin places by
+    // `data-strip-receiver` instead — so a declared zone that mounts nothing,
+    // and a mounted zone this arrangement never places, both fail here.
+    expect(qa('[data-zone-id]').map((el) => el.dataset.zoneId).sort())
+      .toEqual([...new Set([...placed, 'primary-vfo', 'secondary-vfo'])].sort());
+    expect(new Set(placed).size).toBe(flagshipProbeLayout.zones.length - 2);
+  });
+
+  // Kills: dropping `hideScopeControls`, which would draw the scope toolbar's
+  // fact-backed controls a second time beside the semantic scopeControls zone.
+  it('mounts the panorama with the scope toolbar\'s fact-backed half suppressed', () => {
+    render();
+    const panorama = q('[data-testid="probe-panorama"]')!;
+    expect(panorama).not.toBeNull();
+    expect(panorama.querySelector('[data-hide-scope-controls="true"]')).not.toBeNull();
+  });
+});
+
+describe('the panorama sits between the two rails, in both arrangements', () => {
+  // Kills: moving the panorama into a rail column, or widening a rail across
+  // the column the panorama occupies.
+  it.each([[0, 'narrow'], [1, 'wide']])('template %i (%s)', (index) => {
+    const template = templates()[index as number];
+    for (const area of LEFT_RAIL) expect(columnsOf(template, area)).toEqual([0]);
+    const lastColumn = template[0].length - 1;
+    for (const area of RIGHT_RAIL) expect(columnsOf(template, area)).toEqual([lastColumn]);
+    const panorama = columnsOf(template, 'panorama');
+    expect(panorama.length).toBeGreaterThan(0);
+    expect(Math.min(...panorama)).toBeGreaterThan(0);
+    expect(Math.max(...panorama)).toBeLessThan(lastColumn);
+  });
+
+  // Kills: stacking the receivers, or letting the RX/TX column drift out from
+  // between them.
+  it.each([[0, 'narrow'], [1, 'wide']])('template %i (%s) keeps the two receivers side by side', (index) => {
+    const template = templates()[index as number];
+    const deckRow = rowOf(template, 'rx-main');
+    expect(rowOf(template, 'rx-mid')).toBe(deckRow);
+    expect(rowOf(template, 'rx-sub')).toBe(deckRow);
+    expect(Math.max(...columnsOf(template, 'rx-main')))
+      .toBeLessThan(Math.min(...columnsOf(template, 'rx-mid')));
+    expect(Math.max(...columnsOf(template, 'rx-mid')))
+      .toBeLessThan(Math.min(...columnsOf(template, 'rx-sub')));
+  });
+});
+
+describe('the container-width switch', () => {
+  // Kills: deleting the `@container` block, which would leave the narrow
+  // arrangement in force at every width.
+  it('declares exactly two arrangements, and the wide one is inside a container query', () => {
+    expect(templates()).toHaveLength(2);
+    const container = source.slice(source.indexOf('@container'));
+    expect(container).toContain('grid-template-areas');
+    expect(source.indexOf('@container')).toBeLessThan(source.lastIndexOf('grid-template-areas'));
+  });
+
+  // Kills: a "narrow" template that is really the wide one — the deck must
+  // leave the rails' columns to it, which is the whole reason it moves.
+  it('narrow gives the deck the full width; wide shares its row with both rails', () => {
+    const [narrow, wide] = templates();
+    const deck = ['rx-main', 'rx-mid', 'rx-sub'];
+    const narrowDeckRow = narrow[rowOf(narrow, 'rx-main')];
+    expect(new Set(narrowDeckRow)).toEqual(new Set(deck));
+    const wideDeckRow = wide[rowOf(wide, 'rx-main')];
+    expect(wideDeckRow[0]).toBe(LEFT_RAIL[0]);
+    expect(wideDeckRow[wideDeckRow.length - 1]).toBe(RIGHT_RAIL[0]);
+  });
+
+  // Kills: changing the threshold in one place and not the other two — the
+  // number is the sum of the arrangement's own declared minimum widths. The
+  // manifest declares that same width, and
+  // `presentation/layouts/__tests__/flagship-probe-registration.test.ts` is
+  // where the two are required to agree (this directory may not name the
+  // manifest field: `stage-sizing-boundary.test.ts`).
+  it('the threshold is the sum of the declared minimum track widths', () => {
+    const rail = px('--flagship-probe-rail-width');
+    const strip = px('--flagship-probe-strip-min-width');
+    const rxTx = px('--flagship-probe-rx-tx-min-width');
+    const sum = 2 * rail + 2 * strip + rxTx;
+
+    expect(px('--flagship-probe-switch-width')).toBe(sum);
+    expect(Number(source.match(/@container \(min-width: (\d+)px\)/)![1])).toBe(sum);
+  });
+});
+
+describe('geometry only — the shell draws nothing', () => {
+  const style = source.slice(source.indexOf('<style>'), source.indexOf('</style>'))
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // Kills: the shell acquiring a look of its own — a colour, a font size, a
+  // border or a lamp — which is exactly what this PR is not allowed to add
+  // and what its design-language exemption
+  // (`presentation/languages/__tests__/layout-compatibility-inventory.test.ts`)
+  // is granted on.
+  it('declares no colour, font, border or shadow', () => {
+    const properties = [...style.matchAll(/(^|[;{])\s*([a-z-]+)\s*:/gm)].map(([, , name]) => name);
+    expect(properties.filter((name) => /^(color|background|font|border|box-shadow|text-)/.test(name)))
+      .toEqual([]);
+  });
+
+  // Kills: a second grid or flex container creeping in beside the one the
+  // arrangement is expressed as.
+  it('declares exactly one grid and no other layout container', () => {
+    expect([...style.matchAll(/display:\s*grid/g)]).toHaveLength(1);
+    expect(style).not.toMatch(/display:\s*(flex|inline-flex)/);
+  });
+
+  // Kills: the semantic scope controls drifting away from the panel they
+  // belong to — the spec places them directly under the panorama, in both
+  // arrangements, and nothing else may come between.
+  it.each([[0, 'narrow'], [1, 'wide']])('template %i (%s) puts scope-ctl directly under the panorama', (index) => {
+    const template = templates()[index as number];
+    const panoramaRows = template.flatMap((row, i) => (row.includes('panorama') ? [i] : []));
+    expect(rowOf(template, 'scope-ctl')).toBe(Math.max(...panoramaRows) + 1);
+    expect(columnsOf(template, 'scope-ctl')).toEqual(columnsOf(template, 'panorama'));
+  });
+});
+
+describe('R52 — this shell announces nothing it does not know', () => {
+  /** The markup between the script and the style block: everything this skin
+   *  itself puts in the DOM. */
+  const markup = source
+    .slice(source.indexOf('</script>'), source.indexOf('<style>'))
+    .replace(/<!--[\s\S]*?-->/g, '');
+
+  // Kills: adding a dash/placeholder readout or an inert control of the
+  // shell's own, the shape `dual-sdr-face`'s hand-drawn rail took.
+  it('renders no placeholder and no control of its own', () => {
+    expect(markup).not.toMatch(/—|&mdash;|&#8212;/);
+    expect(markup).not.toMatch(/\bdisabled\b|aria-disabled/);
+    expect(markup).not.toMatch(/<button|<input|<select/);
+  });
+
+  // Kills: a row, area or track made conditional on TX (or on anything else),
+  // which is how the geometry would come to differ between receive and
+  // transmit.
+  it('has no conditional in its markup, so the geometry cannot change with state', () => {
+    expect(markup).not.toContain('{#if');
+    expect(markup).not.toContain('{#each');
+  });
+});

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -25,7 +25,8 @@ import {
 
 export type SkinId =
   | 'desktop-v2' | 'dual-receiver-cockpit' | 'lcd-cockpit' | 'lcd-scope' | 'mobile' | 'peer-split'
-  | 'sdr-test' | 'dual-sdr-face' | 'unified-instrument' | 'panadapter-first';
+  | 'sdr-test' | 'dual-sdr-face' | 'unified-instrument' | 'panadapter-first'
+  | 'flagship-probe';
 
 export type PresentationId = string;
 export type PresentationHostMode =
@@ -198,6 +199,20 @@ const SKIN_LOADERS = {
     kind: 'built-in-instrument-layout',
     loader: () => import('./sdr-test/SdrTestSkin.svelte'),
     resources: ['hardware-scope', 'audio-fft'],
+  },
+  // T160 PR-1 — the flagship geometry probe. Self-contained, like the
+  // cockpit: it mounts `SemanticRadioSurfaces` itself and owns its own grid.
+  // No `resolveSkinId` branch below returns it and `StatusBar`'s picker does
+  // not list it, so this entry is what makes the id addressable at all.
+  //
+  // `hardware-scope` alone: the shell mounts one `SpectrumPanel` and no
+  // audio-FFT surface — the same plan, for the same reason, that `mobile`
+  // and `dual-sdr-face` carry.
+  'flagship-probe': {
+    id: 'flagship-probe',
+    kind: 'built-in-self-contained',
+    loader: () => import('./flagship-probe/FlagshipProbeSkin.svelte'),
+    resources: ['hardware-scope'],
   },
   'dual-sdr-face': {
     id: 'dual-sdr-face',

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -91,6 +91,8 @@ export interface SkinResolutionContext {
  * - QA-only: layoutPreference === 'dual-receiver-cockpit' → dual-receiver-cockpit
  *   (MOR-1257 — only reachable via the exact `?layout=dual-receiver-cockpit`
  *   query param; see `lib/stores/qa-cockpit-override.ts`)
+ * - QA-only: layoutPreference === 'flagship-probe' → flagship-probe
+ *   (T160 PR-1 — same module, same terms, `?layout=flagship-probe`)
  * - User forced 'sdr-test' → sdr-test
  * - User forced 'lcd' or 'lcd-cockpit' → lcd-cockpit
  * - User forced 'lcd-scope' → lcd-scope
@@ -108,6 +110,9 @@ export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
   // `normalizeLayoutMode` below would fall it straight through to 'auto'.
   // Checked here, before normalization, for that reason.
   if (ctx.layoutPreference === 'dual-receiver-cockpit') return 'dual-receiver-cockpit';
+  // T160 PR-1: the geometry probe is gated the same way and checked here for
+  // the same reason — it is not a `CanonicalLayoutMode` either.
+  if (ctx.layoutPreference === 'flagship-probe') return 'flagship-probe';
   const layoutPreference = normalizeLayoutMode(ctx.layoutPreference);
   if (layoutPreference === 'sdr-test') return 'sdr-test';
   if (layoutPreference === 'lcd-cockpit') return 'lcd-cockpit';
@@ -142,9 +147,8 @@ const SKIN_LOADERS = {
   },
   // MOR-1068 (F8): the cockpit's layout manifest registers under this exact
   // id, so it needs the matching loadable SkinId — it was the only registered
-  // manifest the App had no way to load. `resolveSkinId` does not yet return
-  // it (that needs a `LayoutMode` preference and a picker affordance, tracked
-  // separately); the entry here is what makes the id addressable at all.
+  // manifest the App had no way to load. MOR-1257 later added the QA branch
+  // in `resolveSkinId` above that returns it.
   'dual-receiver-cockpit': {
     id: 'dual-receiver-cockpit',
     kind: 'built-in-self-contained',
@@ -202,8 +206,8 @@ const SKIN_LOADERS = {
   },
   // T160 PR-1 — the flagship geometry probe. Self-contained, like the
   // cockpit: it mounts `SemanticRadioSurfaces` itself and owns its own grid.
-  // No `resolveSkinId` branch below returns it and `StatusBar`'s picker does
-  // not list it, so this entry is what makes the id addressable at all.
+  // Reached only through the QA branch in `resolveSkinId` above; `StatusBar`'s
+  // picker cannot list it, because that array is typed `CanonicalLayoutMode`.
   //
   // `hardware-scope` alone: the shell mounts one `SpectrumPanel` and no
   // audio-FFT surface — the same plan, for the same reason, that `mobile`


### PR DESCRIPTION
File-count exception granted by the coordinating session under the owner's delegation of 2026-09-03: 8 code + 19 census tables = 27 files (904+/53- = 957 changed lines, under the line ceiling; no regenerated baselines or PNGs in this PR). The overflow is one declaration dragged through exhaustive census tables: declaring the probe's surface set in the layout manifest trips twelve per-surface declarability tests and seven inventory/registry tables, each by two to eight lines; nine of the surfaces mount only when declared, so the set cannot be cut without emptying the rails, which is the question this probe exists to answer. Three of the eight code files are the review round's reachability change (`qa-cockpit-override.ts` and its test, `layout-mode.ts`).

**This is a geometry probe, not the flagship face.** Owner rulings R56/R57 (2026-09-08): route A — a skin that lays out the existing semantic surfaces in the flagship's arrangement, with no new drawing code and no restyling of any shared component, to answer whether the arrangement survives live data. The surfaces render at their native sizes; the type ladder arrives later through size tokens. The skin's display name says "probe"; nothing in it should be shown as the face.

**How to open it.** `?layout=flagship-probe` on a viewport of at least 640x640. It rides the interim QA override the dual-receiver cockpit already uses (`lib/stores/qa-cockpit-override.ts`), checked in `resolveSkinId` before normalization. Below 640px the mobile skin takes precedence and the console says so. There is deliberately no picker row: `flagship-probe` is excluded from `CanonicalLayoutMode`, which is the type `StatusBar`'s `skinOptions` array is declared with, so listing it there is a compile error.

**Arrangement.** A self-contained skin (`flagship-probe`, kind built-in-self-contained, resources hardware-scope) mounts the dual-strip semantic surfaces and the shared spectrum panel, and places the wiring's zones through one CSS grid of five columns with two template-area sets. Deck: primary VFO, RX/TX, secondary VFO — the two receivers side by side in both arrangements. Left rail, receive-chain order: RF front end, DSP, filter, RX audio, antenna, band. Centre: the panorama, then scope controls, then scope display — always between the rails. Right rail: TX aux, CW keyer, RIT/XIT/scan. Dock: meters, full width. Memory is out. Wide: rail, deck over panorama, rail. Narrow: deck across all five columns, rails either side of the panorama beneath. No colour, font, border or shadow is declared anywhere in the style block.

**Switch threshold: declared arithmetic, gutters included.** `--flagship-probe-switch-width: 1472px` = two rails of 280 + two strips of 360 + 160 for RX/TX + the four 8px gutters `.probe-stage` puts between those five columns. The first round declared 1440 and omitted the gutters. A test recomputes the sum — reading `gap` from the same style block as the widths — and requires the container-query literal and the manifest's breakpoint to equal it.

Measured in headless Chromium (Playwright, from `frontend/node_modules`), driving this skin's own style block over a DOM carrying the same hooks (`.semantic-surfaces` / `.channel-strips` / `[data-strip-receiver]` / `[data-zone-id]`):

| container | threshold in the build | arrangement | resolved columns | MAIN right edge vs RX/TX left edge |
|---|---|---|---|---|
| 1440 | 1440 (first round) | wide | 280 / 344 / 160 / 344 / 280 | 648 vs 640 — the strip overruns the RX/TX column by 8px; SUB overruns the right rail by 8px on the same row |
| 1471 | 1472 (this round) | narrow — the query does not match | n/a | n/a |
| 1472 | 1472 (this round) | wide | 280 / 360 / 160 / 360 / 280 | 648 vs 656 — no overrun; every track sits exactly at its declared minimum |

Declared minimums plus gutters, measured in a headless browser on this build; not the flagship's threshold. The harness mounts empty stand-ins where the surfaces go, so it still establishes nothing about what a real rail renders at. The bench's 194/1716 numbers are ladder-dependent and are not used.

**What the arrangement could not accommodate, reported:** DOM order differs from visual order (the wiring renders zones in a fixed order and the grid reorders them), so the cockpit's DOM-order-is-focus-order doctrine does not hold here and cannot be fixed from a skin; the `scopeControls` snippet exists only on the hosted instrument composition, so the panel's own controls are hidden and the semantic scope-controls zone sits under it instead; the meters dock stands empty unless the fixture carries raw meter values.

**Tests.** Component test: both receiver strips present in both arrangements; the panorama occupies columns two to four in both templates; scope controls directly under the panorama; the switch width equals the declared sum plus gutters; the query container (`container-type: inline-size`) is declared on the skin root; the style block declares no colour, font, border or shadow; nothing in the skin's own markup renders a dash placeholder or a disabled control of its own (R52). Registration test for the manifest. QA-reachability pins in `registry.test.ts` and `qa-cockpit-override.test.ts`. Census tables extended with the new skin.

Mutations run in the first round: the container query removed fails seven (six in the component test, one in the registration test — re-measured at this head); the panorama moved into the left column fails the wide-template test; scope display swapped above scope controls fails; a colour and a border added fails the no-styling test; a rule split and reorder stays green.

Mutations run in this round, each restored before the next: threshold back to 1440 at both sites — the sum test and the registration test fail; `container-type` deleted — the new query-container test fails, and only that one; `@container` rewritten as `@media` — the sliced two-arrangements test, the sum test and the registration test's reflow-width pin fail (three) (with the previous `source`-indexed assertion the two-arrangements test stayed green under that same mutation, which is what the fix was for); `flagship-probe` dropped from the override's value list — the override test fails; the `resolveSkinId` branch deleted — the reachability pin and the lazy-load completeness check fail.

Reported, not fixed: `registry.ts: presentationResourcePlan`'s doc comment enumerates which layouts mount each resource producer and omits `dual-sdr-face` and now `flagship-probe`. Pre-existing, outside this PR's hunks.

Gates — CI `quick` at 395a59f99e4ff21abd7fe0f24d93c8bb0d58539b, passed (see checks): pytest 16180 passed / 218 skipped / 15 xfailed / 0 failed; frontend vitest 470 files / 11567 tests / 0 failed; svelte-check 0 errors 0 warnings; ruff lint and format clean (742 files); `mypy --strict src/rigplane/web` no issues in 27 source files. `npm run lint` is part of that job and passed; `npm run lint:boundaries`, which `quick.yml` does not run, was run locally at this head and is clean. internal-identifier self-check — empty.

Out of scope: colour roles, the type ladder (T162), the lit-key lamp rendering, memory, any measurement of what the surfaces themselves render at, the StatusBar picker entry (the cockpit has none either).

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

