### PR TITLE
feat: map the supply-voltage bar into a fixed 11–15 V window and expose each bar's scale domain

### DIFF
--- a/frontend/src/components-v2/panels/meter-utils.test.ts
+++ b/frontend/src/components-v2/panels/meter-utils.test.ts
@@ -117,6 +117,8 @@ import {
   isAlcFault,
   updatePeakHold,
   peakHoldDisplay,
+  vdScale,
+  SUPPLY_VOLTAGE_WINDOW,
   type PeakHoldState,
 } from './meter-utils';
 import { calibratedToRaw as calibratedToRawFromFacade, isSmeterCalibrated } from '../meters/smeter-scale';
@@ -320,6 +322,35 @@ describe('explicit meter domains override capability metadata (MOR-2425)', () =>
   });
 });
 
+// ---------------------------------------------------------------------------
+// The supply-voltage window (T168; the art direction chose 11-15 V on
+// 2026-09-08). `vdLevel`'s calibrated branch maps against this window and not
+// against the profile's calibration top, so a voltage lands in the same place
+// whatever table the profile declares. This ladder is asserted verbatim under
+// the three vd tables below — top 16 V twice, top 13.8 V once; the rows are
+// [volts, expected vdLevel].
+// ---------------------------------------------------------------------------
+const SUPPLY_VOLTAGE_WINDOW_LADDER: readonly (readonly [number, number])[] = [
+  [10.5, 0],
+  [11, 0],
+  [12.0, 0.25],
+  [13.8, 0.7],
+  [15, 1],
+  [16, 1],
+];
+
+function expectWindowedVdLevel(): void {
+  for (const [volts, fraction] of SUPPLY_VOLTAGE_WINDOW_LADDER) {
+    expect(vdLevel(volts), `vdLevel(${volts})`).toBeCloseTo(fraction);
+  }
+}
+
+describe('SUPPLY_VOLTAGE_WINDOW', () => {
+  it('is the 11-15 V window the level function and every face label share', () => {
+    expect(SUPPLY_VOLTAGE_WINDOW).toEqual({ min: 11, max: 15 });
+  });
+});
+
 describe('formatVolts / vdLevel (calibrated: input is volts)', () => {
   it('renders the bench supply voltage as-is', () => {
     expect(formatVolts(13.8)).toBe('13.8 V');
@@ -327,9 +358,11 @@ describe('formatVolts / vdLevel (calibrated: input is volts)', () => {
   it('renders 0 V', () => {
     expect(formatVolts(0)).toBe('0.0 V');
   });
-  it('vdLevel normalizes against the 16 V top knot', () => {
-    expect(vdLevel(13.8)).toBeCloseTo(13.8 / 16);
-    expect(vdLevel(16)).toBeCloseTo(1.0);
+  it('vdLevel maps into the fixed window, not against this table top of 16 V', () => {
+    expectWindowedVdLevel();
+  });
+  it('vdScale reports the window this profile\'s bar is drawn against', () => {
+    expect(vdScale()).toEqual(SUPPLY_VOLTAGE_WINDOW);
   });
 });
 
@@ -508,8 +541,8 @@ describe('TX meters — IC-7300 profile anchors (MOR-1527)', () => {
     expect(formatAmps(10)).toBe('10.0 A');
   });
 
-  it('vdLevel normalizes against the 16 V top knot from this profile', () => {
-    expect(vdLevel(13.8)).toBeCloseTo(13.8 / 16);
+  it('vdLevel maps into the fixed window, not against this profile\'s 16 V top knot', () => {
+    expectWindowedVdLevel();
   });
 
   it('marks a reading at this profile’s own drain tops with "+" (T164)', () => {
@@ -564,6 +597,10 @@ describe('formatVolts / formatAmps — clamped at the calibration top (T164)', (
     expect(formatVolts(12.4)).toBe('12.4 V');
     expect(formatAmps(0)).toBe('0.0 A');
     expect(formatAmps(0.5)).toBe('0.5 A');
+  });
+
+  it('maps vdLevel into the same window as every other profile, though this table tops out at 13.8 V (T168)', () => {
+    expectWindowedVdLevel();
   });
 
   it('mirrors the drain tables rigs/ftx1.toml declares', () => {

--- a/frontend/src/components-v2/panels/meter-utils.ts
+++ b/frontend/src/components-v2/panels/meter-utils.ts
@@ -33,12 +33,39 @@ import {
   getCalibratedScaleMaxRaw,
   isSmeterCalibrated,
 } from '../../primitives/meters/s-meter-scale';
+import { valueToPosition } from '../../primitives/scalar/value-control-core';
 import type {
   MeterEngineeringUnit,
   MeterValueDomain,
 } from '../../semantic/radio-view-model';
 
 export type MeterSource = 'S' | 'SWR' | 'POWER' | 'po';
+
+/**
+ * The two values a bar's ends stand for: `min` at empty, `max` at full.
+ * Every `*Scale` function below returns the domain its matching `*Level`
+ * function positions against; null means that function is not positioning
+ * against a scale at all (an explicit raw domain, a domain it cannot serve,
+ * or no usable calibration data).
+ */
+export interface MeterScaleDomain {
+  readonly min: number;
+  readonly max: number;
+}
+
+/**
+ * The scale the supply-voltage bar is drawn against, in volts — a fixed
+ * window rather than the profile's calibration range, so a sag moves the
+ * bar by the same amount on every radio. The art-direction line chose these
+ * ends on 2026-09-08 (11 V = a 12 V supply in trouble, 15 V = faulty); they
+ * are an instrument choice, not a rating read off a radio.
+ *
+ * `vdScale` returns this and `vdLevel` positions against it, so a face
+ * labelling the scale from `BarMeterProjection.scale` prints the numbers
+ * the fill was computed from. Pinned by meter-utils.test.ts
+ * "SUPPLY_VOLTAGE_WINDOW" and the three profile ladders that follow it.
+ */
+export const SUPPLY_VOLTAGE_WINDOW: MeterScaleDomain = { min: 11, max: 15 };
 
 /** Raw device-scale ceiling (CI-V meter byte range). Used only as the
  *  neutral bar-geometry edge for uncalibrated meters — never a claimed
@@ -64,6 +91,18 @@ function getCal(meterType: string): MeterCalPoint[] | null {
 
 function topActual(cal: MeterCalPoint[]): number {
   return cal[cal.length - 1].actual;
+}
+
+/** Zero to the table's top knot. Null when the profile declares no table. */
+function topScale(meterType: string): MeterScaleDomain | null {
+  const cal = getCal(meterType);
+  return cal ? { min: 0, max: topActual(cal) } : null;
+}
+
+/** A reading's place on its own scale: 0 at `min`, 1 at `max`, clamped to
+ *  that interval. A scale with no positive span yields 0. */
+function positionIn(value: number, scale: MeterScaleDomain): number {
+  return scale.max > scale.min ? valueToPosition(value, scale.min, scale.max) : 0;
 }
 
 /**
@@ -136,15 +175,21 @@ export function formatPowerWatts(value: number, domain?: MeterValueDomain): stri
   return `${Math.round(watts)}W`;
 }
 
+/** The watt scale the power bar is drawn against, or null when there is none. */
+export function powerScale(domain?: MeterValueDomain): MeterScaleDomain | null {
+  if (domain?.kind === 'raw') return null;
+  if (domain !== undefined && !matchesEngineering(domain, 'w')) return null;
+  return topScale('power');
+}
+
 export function normalizePower(value: number): number;
 export function normalizePower(value: number, domain: MeterValueDomain): number | null;
 export function normalizePower(value: number, domain?: MeterValueDomain): number | null {
   if (domain?.kind === 'raw') return normalize(value);
   if (domain !== undefined && !matchesEngineering(domain, 'w')) return null;
-  const cal = getCal('power');
-  if (!cal) return domain === undefined ? normalize(value) : null;
-  const max = topActual(cal);
-  return max > 0 ? clamp01(value / max) : 0;
+  const scale = powerScale(domain);
+  if (!scale) return domain === undefined ? normalize(value) : null;
+  return positionIn(value, scale);
 }
 
 // ---- SWR (ratio when calibrated) ----
@@ -181,16 +226,22 @@ export function formatSwr(value: number, domain?: MeterValueDomain): string {
   return Math.max(cal[0].actual, value).toFixed(1);
 }
 
+/** The ratio scale the SWR bar is drawn against, or null when there is none. */
+export function swrScale(domain?: MeterValueDomain): MeterScaleDomain | null {
+  if (domain?.kind === 'raw') return null;
+  if (domain !== undefined && !matchesEngineering(domain, 'ratio')) return null;
+  return topScale('swr');
+}
+
 /** SWR level in its explicit raw domain or against a declared ratio scale. */
 export function swrLevel(value: number): number;
 export function swrLevel(value: number, domain: MeterValueDomain): number | null;
 export function swrLevel(value: number, domain?: MeterValueDomain): number | null {
   if (domain?.kind === 'raw') return normalize(value);
   if (domain !== undefined && !matchesEngineering(domain, 'ratio')) return null;
-  const cal = getCal('swr');
-  if (!cal) return domain === undefined ? normalize(value) : null;
-  const max = topActual(cal);
-  return max > 0 ? clamp01(value / max) : 0;
+  const scale = swrScale(domain);
+  if (!scale) return domain === undefined ? normalize(value) : null;
+  return positionIn(value, scale);
 }
 
 /** True when SWR exceeds 2.0 in an explicit or legacy-qualified ratio domain. */
@@ -218,18 +269,28 @@ export function formatAlc(value: number, domain?: MeterValueDomain): string {
   return formatRaw(value);
 }
 
+/** ALC's calibrated scale — the value arrives normalized 0-1 (file header). */
+const NORMALIZED_FULL_SCALE: MeterScaleDomain = { min: 0, max: 1 };
+
+/** The ALC bar's scale: the normalized unit interval when calibrated, zero
+ *  to the declared redline otherwise. Null when the profile declares
+ *  neither. */
+export function alcScale(domain?: MeterValueDomain): MeterScaleDomain | null {
+  if (domain?.kind === 'raw') return null;
+  if (domain !== undefined && !matchesEngineering(domain, 'normalized')) return null;
+  if (getCal('alc') || matchesEngineering(domain, 'normalized')) return NORMALIZED_FULL_SCALE;
+  const redline = getMeterRedline('alc');
+  return redline !== null && redline > 0 ? { min: 0, max: redline } : null;
+}
+
 /** Redline-relative ALC level, neutral raw geometry, or no supported motion. */
 export function alcLevel(value: number): number;
 export function alcLevel(value: number, domain: MeterValueDomain): number | null;
 export function alcLevel(value: number, domain?: MeterValueDomain): number | null {
   if (domain?.kind === 'raw') return normalize(value);
   if (domain !== undefined && !matchesEngineering(domain, 'normalized')) return null;
-  if (getCal('alc') || matchesEngineering(domain, 'normalized')) return clamp01(value);
-  const redline = getMeterRedline('alc');
-  if (redline !== null && redline > 0) {
-    return Math.max(0, Math.min(redline, value)) / redline;
-  }
-  return normalize(value);
+  const scale = alcScale(domain);
+  return scale ? positionIn(value, scale) : normalize(value);
 }
 
 /** True when ALC is past 90% in an explicit normalized or legacy-qualified domain. */
@@ -253,15 +314,24 @@ export function formatVolts(value: number, domain?: MeterValueDomain): string {
   return formatAgainstTop(value, cal, 'V');
 }
 
+/**
+ * The supply-voltage bar's scale: `SUPPLY_VOLTAGE_WINDOW`, not this profile's
+ * calibration range. Null when the profile declares no vd table.
+ */
+export function vdScale(domain?: MeterValueDomain): MeterScaleDomain | null {
+  if (domain?.kind === 'raw') return null;
+  if (domain !== undefined && !matchesEngineering(domain, 'v')) return null;
+  return getCal('vd') ? SUPPLY_VOLTAGE_WINDOW : null;
+}
+
 export function vdLevel(value: number): number;
 export function vdLevel(value: number, domain: MeterValueDomain): number | null;
 export function vdLevel(value: number, domain?: MeterValueDomain): number | null {
   if (domain?.kind === 'raw') return normalize(value);
   if (domain !== undefined && !matchesEngineering(domain, 'v')) return null;
-  const cal = getCal('vd');
-  if (!cal) return domain === undefined ? normalize(value) : null;
-  const max = topActual(cal);
-  return max > 0 ? clamp01(value / max) : 0;
+  const scale = vdScale(domain);
+  if (!scale) return domain === undefined ? normalize(value) : null;
+  return positionIn(value, scale);
 }
 
 export function formatAmps(value: number, domain?: MeterValueDomain): string {
@@ -275,15 +345,21 @@ export function formatAmps(value: number, domain?: MeterValueDomain): string {
   return formatAgainstTop(value, cal, 'A');
 }
 
+/** The drain-current bar's scale: zero to the profile table's top, unwindowed. */
+export function idScale(domain?: MeterValueDomain): MeterScaleDomain | null {
+  if (domain?.kind === 'raw') return null;
+  if (domain !== undefined && !matchesEngineering(domain, 'a')) return null;
+  return topScale('id');
+}
+
 export function idLevel(value: number): number;
 export function idLevel(value: number, domain: MeterValueDomain): number | null;
 export function idLevel(value: number, domain?: MeterValueDomain): number | null {
   if (domain?.kind === 'raw') return normalize(value);
   if (domain !== undefined && !matchesEngineering(domain, 'a')) return null;
-  const cal = getCal('id');
-  if (!cal) return domain === undefined ? normalize(value) : null;
-  const max = topActual(cal);
-  return max > 0 ? clamp01(value / max) : 0;
+  const scale = idScale(domain);
+  if (!scale) return domain === undefined ? normalize(value) : null;
+  return positionIn(value, scale);
 }
 
 export function formatCompDb(value: number, domain?: MeterValueDomain): string {
@@ -297,15 +373,21 @@ export function formatCompDb(value: number, domain?: MeterValueDomain): string {
   return `${Math.round(Math.max(0, cal ? Math.min(topActual(cal), value) : value))} dB`;
 }
 
+/** The compression bar's scale: zero to the profile table's top, in dB. */
+export function compScale(domain?: MeterValueDomain): MeterScaleDomain | null {
+  if (domain?.kind === 'raw') return null;
+  if (domain !== undefined && !matchesEngineering(domain, 'db')) return null;
+  return topScale('comp');
+}
+
 export function compLevel(value: number): number;
 export function compLevel(value: number, domain: MeterValueDomain): number | null;
 export function compLevel(value: number, domain?: MeterValueDomain): number | null {
   if (domain?.kind === 'raw') return normalize(value);
   if (domain !== undefined && !matchesEngineering(domain, 'db')) return null;
-  const cal = getCal('comp');
-  if (!cal) return domain === undefined ? normalize(value) : null;
-  const max = topActual(cal);
-  return max > 0 ? clamp01(value / max) : 0;
+  const scale = compScale(domain);
+  if (!scale) return domain === undefined ? normalize(value) : null;
+  return positionIn(value, scale);
 }
 
 // ---- S-meter (dB-rel-S9 when calibrated; MOR-1451) ----

--- a/frontend/src/semantic/__tests__/bar-meter-projector.test.ts
+++ b/frontend/src/semantic/__tests__/bar-meter-projector.test.ts
@@ -114,7 +114,7 @@ describe('projectBarMeters', () => {
     ]);
     expect(Object.keys(projected[0]).sort()).toEqual([
       'accessibleDescription', 'displayText', 'domain', 'evidence', 'fault', 'gauge', 'key',
-      'label', 'motionFraction', 'observed', 'relevant', 'showPeak', 'source',
+      'label', 'motionFraction', 'observed', 'relevant', 'scale', 'showPeak', 'source',
       'state', 'stateText',
     ]);
     expect(projected[0]).toMatchObject({
@@ -377,5 +377,121 @@ describe('projectBarMeters', () => {
       ratioScale: false,
       fault: true,
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bar scale domains (T168). The product owns value-to-position, so it must
+// also publish the two numbers the position was computed from — otherwise a
+// face labelling the scale from anywhere else prints ends the fill does not
+// agree with. Wherever a case has both a scale and a reading it asserts the
+// scale AND that `motionFraction` is that scale's own position of the
+// reading; a scale that diverged from the level function fails the second
+// assertion even when the first still passes.
+// ---------------------------------------------------------------------------
+
+const FTX1_DRAIN_CALS = {
+  vd: [
+    { raw: 0, actual: 0.0, label: '0' },
+    { raw: 210, actual: 13.8, label: '13.8' },
+  ],
+  id: [
+    { raw: 0, actual: 0.0, label: '0' },
+    { raw: 29, actual: 1.0, label: '1.0' },
+  ],
+};
+
+function drainCaps(): Capabilities {
+  const base = calibratedCaps();
+  return { ...base, meterCalibrations: { ...base.meterCalibrations, ...FTX1_DRAIN_CALS } };
+}
+
+function positionOn(scale: { min: number; max: number } | null, value: number): number {
+  if (!scale) throw new Error('no scale to position against');
+  return (value - scale.min) / (scale.max - scale.min);
+}
+
+describe('projectBarMeters — scale domains (T168)', () => {
+  it('draws the supply-voltage bar against the fixed 11-15 V window, fill included', () => {
+    setCapabilities(drainCaps());
+    const view = base();
+    setMeter(view, 'drainVoltage', {
+      reading: { status: 'known', value: 12.0 },
+      domain: { kind: 'engineering', unit: 'v' },
+    });
+
+    const vd = projectBarMeters(view).find(({ key }) => key === 'drainVoltage')!;
+    expect(vd.scale).toEqual({ min: 11, max: 15 });
+    expect(vd.motionFraction).toBeCloseTo(positionOn(vd.scale, 12.0));
+    expect(vd.motionFraction).toBeCloseTo(0.25);
+  });
+
+  it('publishes the window even with nothing to show on it, so an empty bar can still be labelled', () => {
+    setCapabilities(drainCaps());
+    const view = base();
+    setMeter(view, 'drainVoltage', {
+      reading: { status: 'unknown' },
+      availability: { structural: true, operational: false },
+      domain: { kind: 'engineering', unit: 'v' },
+    });
+
+    const vd = projectBarMeters(view).find(({ key }) => key === 'drainVoltage')!;
+    expect(vd.motionFraction).toBeNull();
+    expect(vd.scale).toEqual({ min: 11, max: 15 });
+  });
+
+  it('leaves the drain-current bar unwindowed: zero to the profile table top', () => {
+    setCapabilities(drainCaps());
+    const view = base();
+    setMeter(view, 'drainCurrent', {
+      reading: { status: 'known', value: 0.5 },
+      relevant: true,
+      domain: { kind: 'engineering', unit: 'a' },
+    });
+
+    const id = projectBarMeters(view).find(({ key }) => key === 'drainCurrent')!;
+    expect(id.scale).toEqual({ min: 0, max: 1.0 });
+    expect(id.motionFraction).toBeCloseTo(positionOn(id.scale, 0.5));
+    expect(id.motionFraction).toBeCloseTo(0.5);
+  });
+
+  it('gives the power bar zero to its own table top', () => {
+    setCapabilities(drainCaps());
+    const view = base();
+    setDisplay(view, 'power', { state: 'current', value: 50 });
+    setMeter(view, 'power', { domain: { kind: 'engineering', unit: 'w' } });
+
+    const power = projectBarMeters(view)[0];
+    expect(power.scale).toEqual({ min: 0, max: 200 });
+    expect(power.motionFraction).toBeCloseTo(positionOn(power.scale, 50));
+  });
+
+  it('carries no scale for a raw-domain meter — raw/255 is bar geometry, not a scale', () => {
+    setCapabilities(drainCaps());
+    const view = base();
+    setDisplay(view, 'power', { state: 'current', value: 50 });
+    setMeter(view, 'power', { domain: { kind: 'raw' } });
+
+    const power = projectBarMeters(view)[0];
+    expect(power.scale).toBeNull();
+    expect(power.motionFraction).toBeCloseTo(50 / 255);
+  });
+
+  it('carries no scale for an unknown domain, nor when the profile declares no table', () => {
+    setCapabilities(drainCaps());
+    const unknown = base();
+    setDisplay(unknown, 'power', { state: 'current', value: 50 });
+    setMeter(unknown, 'power', { domain: { kind: 'unknown' } });
+    expect(projectBarMeters(unknown)[0].scale).toBeNull();
+
+    clearCapabilities();
+    const uncalibrated = base();
+    setMeter(uncalibrated, 'drainVoltage', {
+      reading: { status: 'known', value: 12.0 },
+      domain: { kind: 'engineering', unit: 'v' },
+    });
+    const vd = projectBarMeters(uncalibrated).find(({ key }) => key === 'drainVoltage')!;
+    expect(vd.scale).toBeNull();
+    expect(vd.motionFraction).toBeNull();
   });
 });

--- a/frontend/src/semantic/bar-meter-projector.ts
+++ b/frontend/src/semantic/bar-meter-projector.ts
@@ -1,7 +1,9 @@
 import { t } from '$lib/i18n';
 import {
   alcLevel,
+  alcScale,
   compLevel,
+  compScale,
   formatAlc,
   formatAmps,
   formatCompDb,
@@ -10,12 +12,17 @@ import {
   formatVolts,
   hasSwrRatioScale,
   idLevel,
+  idScale,
   isAlcFault,
   isSwrFault,
   normalizePower,
+  powerScale,
   swrLevel,
+  swrScale,
   vdLevel,
+  vdScale,
 } from '../components-v2/panels/meter-utils';
+import type { MeterScaleDomain } from '../components-v2/panels/meter-utils';
 import { projectTxMeterDisplay } from './tx-meter-display';
 import type {
   DisplayObservedMeterField,
@@ -41,6 +48,15 @@ export interface LevelMeterProjection<Key extends LevelMeterKey = LevelMeterKey>
   readonly state: LevelMeterState;
   readonly evidence: LevelMeterEvidence;
   readonly domain: MeterValueDomain | undefined;
+  /**
+   * What the bar's empty and full ends stand for, in the meter's own unit,
+   * for a face to draw labels from — the same domain `motionFraction` was
+   * positioned against. Null where there is no such scale; the `*Scale`
+   * functions in `meter-utils.ts` decide that per meter. Set independently
+   * of whether there is anything to show, so a mounted-but-empty bar can
+   * still be labelled.
+   */
+  readonly scale: MeterScaleDomain | null;
   readonly motionFraction: number | null;
   readonly displayText: string;
   readonly stateText: string;
@@ -56,24 +72,28 @@ export type SwrMeterProjection = LevelMeterProjection<'swr'> & {
   readonly ratioScale: boolean;
 };
 
+// The scale function sits next to the level function it belongs to, so the
+// domain a bar is labelled from and the domain its fill is computed from are
+// chosen on one row.
 type MeterDefinition<Key extends LevelMeterKey> = readonly [
   Key,
   string,
   (value: number, domain?: MeterValueDomain) => number | null,
   (value: number, domain?: MeterValueDomain) => string,
   boolean,
+  (domain?: MeterValueDomain) => MeterScaleDomain | null,
 ];
 
 const BAR_DEFINITIONS = [
-  ['power', 'Po', normalizePower, formatPowerWatts, true],
-  ['alc', 'ALC', alcLevel, formatAlc, true],
-  ['drainCurrent', 'Id', idLevel, formatAmps, true],
-  ['drainVoltage', 'Vd', vdLevel, formatVolts, false],
-  ['compression', 'COMP', compLevel, formatCompDb, false],
+  ['power', 'Po', normalizePower, formatPowerWatts, true, powerScale],
+  ['alc', 'ALC', alcLevel, formatAlc, true, alcScale],
+  ['drainCurrent', 'Id', idLevel, formatAmps, true, idScale],
+  ['drainVoltage', 'Vd', vdLevel, formatVolts, false, vdScale],
+  ['compression', 'COMP', compLevel, formatCompDb, false, compScale],
 ] as const satisfies readonly MeterDefinition<BarMeterKey>[];
 
 const SWR_DEFINITION = [
-  'swr', 'SWR', swrLevel, formatSwr, false,
+  'swr', 'SWR', swrLevel, formatSwr, false, swrScale,
 ] as const satisfies MeterDefinition<'swr'>;
 
 const FAULT_CHECKS: Partial<
@@ -137,7 +157,7 @@ function projectLevelMeter<Key extends LevelMeterKey>(
   rfState: MeterRfState,
   txObserved: boolean,
 ): LevelMeterProjection<Key> {
-  const [key, label, level, format, peakEligible] = definition;
+  const [key, label, level, format, peakEligible, scaleOf] = definition;
   const tx = txObserved ? projectTxMeterPresentation(field, rfState) : null;
   const isObserved = tx ? tx.value !== null : observed(field);
   const value = tx ? tx.value ?? 0 : reading(field);
@@ -161,6 +181,7 @@ function projectLevelMeter<Key extends LevelMeterKey>(
     state,
     evidence,
     domain: field.domain,
+    scale: scaleOf(field.domain),
     motionFraction,
     displayText,
     stateText,


### PR DESCRIPTION
## The fact

Five of the six bar meters positioned from one expression in
`frontend/src/components-v2/panels/meter-utils.ts`:
`clamp01(value / topActual(cal))` (ALC used `clamp01(value)` when calibrated, or the redline) — the value over the calibration table's
top knot. For the supply voltage that makes the scale radio-dependent: the
FTX-1's vd table tops out at 13.8 V, so the bench supply parked the bar at
**full scale**; the IC-7300's tops out at 16.0 V, so the same 13.8 V read
**86%**. A sag from 13.8 V to 12.0 V moved the bar ~11% on the IC-7300 scale.

## The window

`vdLevel`'s calibrated branch now positions against a single exported
constant, `SUPPLY_VOLTAGE_WINDOW = { min: 11, max: 15 }` (volts). The same
sag now moves 45%, and 13.8 V reads 0.70 on every profile.

The window is **the art-direction line's choice of 2026-09-08** — 11 V reads
as a 12 V supply in trouble, 15 V as faulty. It is a choice about where the
instrument's ends sit, not a rating read off any radio, and it is stated that
way in the constant's doc comment.

Drain current is **not** windowed: `idScale` stays zero to the profile
table's top.

## The projection field (face lane reads this)

`LevelMeterProjection` — and so `BarMeterProjection` and
`SwrMeterProjection` — gains:

```ts
readonly scale: { readonly min: number; readonly max: number } | null;
```

- `drainVoltage` → `{ min: 11, max: 15 }`
- every other engineering meter → `{ min: 0, max: <table top> }`
  (ALC → `{ min: 0, max: 1 }` when a table or an explicit normalized domain is present, `{ min: 0, max: redline }` only when neither)
- raw domain, unknown domain, or no usable calibration data → `null`

`scale` is set independently of whether there is a reading, so a
mounted-but-empty bar can still be labelled. It is the same domain
`motionFraction` was positioned against: each meter's scale function sits
next to its level function on one row of `BAR_DEFINITIONS`, and every level
function derives its position from its own scale function, so the label
source and the fill source cannot be changed apart.

No ticks or labels were drawn on `BarGauge` — the product exposes the
domain, a face labels from it.

## Tests

`frontend/src/components-v2/panels/meter-utils.test.ts`

- One ladder — `vdLevel` at 10.5, 11, 12.0, 13.8, 15, 16 V → 0, 0, 0.25,
  0.70, 1, 1 — asserted verbatim under three different vd calibration tables
  (top 16 V twice, top 13.8 V once). The two pre-existing assertions that
  normalised against the 16 V top knot moved into it.
- `SUPPLY_VOLTAGE_WINDOW` and `vdScale()` pinned directly.
- Raw and unknown branches unchanged (existing assertions still green).

`frontend/src/semantic/__tests__/bar-meter-projector.test.ts`

- `drainVoltage` carries `{11, 15}`; `drainCurrent` carries `{0, 1.0}`;
  `power` carries `{0, 200}`; a raw-domain meter and an unknown-domain meter
  carry `null`, and so does a meter whose profile declares no table.
- Where a case has both a scale and a reading it asserts the scale **and**
  that `motionFraction` equals `(value - scale.min) / (scale.max - scale.min)`.
- An unobserved-but-structural `drainVoltage` still carries the window.
- The projection key census gained `scale`.

**Gates run at the head** (`npm run` in `frontend/`): `check` — 4841 files,
0 errors, 0 warnings; `lint` — clean; `lint:boundaries` — clean; the two
changed test files — 106 passed, 0 failed. (`meter-utils.ts` importing
`primitives/scalar/value-control-core`'s `valueToPosition` is inside the
panels boundary: that block bans stores/transport/audio-manager, not
primitives, and this file already imported `primitives/meters/s-meter-scale`.)

## Mutations

| Mutation | Result |
|---|---|
| `SUPPLY_VOLTAGE_WINDOW` 11 → 12 | **6 fail** — the window pin, all three profile ladders, and both projector window cases |
| `vdLevel` positions against its own second constant `{11, 16}` instead of the scale `vdScale` gave it | **4 fail** — the three ladders, plus the projector case at the equality assertion (line 423), with the `toEqual({min:11,max:15})` on the line above it still passing |
| Behaviour-preserving: `positionIn(value, scale)` inlined as `clamp01((value - scale.min) / (scale.max - scale.min))` | **green, 106/106** — the tests pin the behaviour, not the code path |

## Visual baselines

The `dual-main-sub--*` baselines are pixel-inert, for two independent
reasons read out of `frontend/fixtures/catalog.ts`: `baseCaps` declares
`meterCalibrations: { s_meter: … }` only, so `getCal('vd')` is `null`
throughout the visual harness and `vdLevel`'s calibrated branch is never
reached; and the harness's `withMeters` gives `vdMeter` no `calibrated`
quality, so the field's domain never matches engineering-volts either.

## Out of scope

- **Ticks and labels on `BarGauge`** — new UI surface; `BarGauge` draws no
  scale labels today and still doesn't.
- **A window for drain current** — the 0-to-table-top scale is unchanged.
- **v2.** `MetersDockPanel.svelte` calls `vdLevel` directly and will show the
  windowed fill. Accepted: v2 is dead, and it must not break — it doesn't.
  Confirmed while sweeping: Vd is never peak-held in either seat
  (`peakEligible` is `false` for `drainVoltage` in `BAR_DEFINITIONS`, and the
  v2 dock's vd tile has no `peakFillPct`).

**4 files, 295+/39− = 334 changed lines at e2e82f94** — under the 6-file /
600-line soft threshold.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

