### PR TITLE
feat: carry a bar meter's scale domain into the level renderer view

### DIFF
--- a/docs/architecture/component-kit-sdk.md
+++ b/docs/architecture/component-kit-sdk.md
@@ -256,11 +256,7 @@ what it covers.
 ## 7. Compatibility matrix
 
 Every SDK version to date is a `frontend/component-kit-api` commit on this
-branch's history; only version-bumping commits are listed (a handful of
-other `MOR-2425` commits touched the package without bumping the version:
-`7081cd1c4` "persist hosted radio composition" and `0aaabbbeb` "expose
-finite option disabled reasons" both stayed at `0.2.0`; `1ffd2a68c` "add
-concrete component-kit fixture renderers" stayed at `0.5.0`).
+branch's history; only version-bumping commits are listed.
 
 | SDK version | Commit / PR | What it added | Known consumers |
 |---|---|---|---|

--- a/frontend/component-kit-api/src/index.ts
+++ b/frontend/component-kit-api/src/index.ts
@@ -76,6 +76,12 @@ export type MeterDisplayDomain =
   | Readonly<{ kind: 'raw' }>
   | Readonly<{ kind: 'unknown' }>;
 
+/** The two values a level bar's ends stand for: `min` at empty, `max` at full. */
+export interface MeterScaleDomain {
+  readonly min: number;
+  readonly max: number;
+}
+
 /** Stale evidence may retain its numeric value while live projected geometry is unavailable. */
 export type MeterNumericEvidence =
   | Readonly<{
@@ -126,6 +132,11 @@ interface LevelMeterRendererViewBase<Key extends LevelMeterKey> {
   readonly observed: boolean;
   readonly displayedFraction: number | null;
   readonly peakFraction: number | null;
+  /**
+   * What this bar's empty and full ends stand for, in the meter's own unit.
+   * Null where the level is not positioned against such a scale.
+   */
+  readonly scale: MeterScaleDomain | null;
   readonly displayText: string;
   readonly stateText: string;
   readonly accessibleDescription?: string;

--- a/frontend/component-kit-api/verify-package.mjs
+++ b/frontend/component-kit-api/verify-package.mjs
@@ -477,8 +477,10 @@ export default {
   type HostedFacePropsV1,
   type LayoutManifest,
   type LevelMeterRendererProps,
+  type LevelMeterRendererView,
   type MeterAppearance,
   type MeterNumericEvidence,
+  type MeterScaleDomain,
   type PresentationDeclaration,
   type ScalarAppearance,
   type ScalarRendererSeat,
@@ -559,6 +561,11 @@ function inspectHostedFace(props: HostedFacePropsV1): void {
 const invalidCurrentEvidence: MeterNumericEvidence = { state: 'current', domain: { kind: 'engineering', unit: 'w' } };
 // @ts-expect-error unknown signal evidence cannot smuggle a numeric value
 const invalidUnknownSignal: SignalMeterEvidence = { state: 'unknown', value: 0, domain: { kind: 'unknown' } };
+declare const levelView: LevelMeterRendererView;
+const levelScale: MeterScaleDomain | null = levelView.scale;
+const levelScaleEnds: readonly [number, number] | null =
+  levelScale === null ? null : [levelScale.min, levelScale.max];
+void levelScaleEnds;
 const oldChoiceOption: ControlOption<'OFF'> = { value: 'OFF', label: 'Off' };
 const reasonedChoiceOption: ControlOption<'DATA1'> = {
   value: 'DATA1', label: 'Data 1', disabled: true, disabledReason: 'Not available',
@@ -906,6 +913,7 @@ mount(App, { target: document.querySelector('#app')! });
       kind: 'level', key: 'power', label: 'Po',
       evidence: { state: 'current', value: 50, domain: { kind: 'engineering', unit: 'w' } },
       relevant: true, observed: true, displayedFraction: 0.5, peakFraction: 0.7,
+      scale: { min: 0, max: 200 },
       displayText: '50 W', stateText: '', accessibleDescription: 'Po: Current observation. 50 W',
       gauge: true, fault: false, peakEnabled: true,
     },
@@ -913,6 +921,7 @@ mount(App, { target: document.querySelector('#app')! });
       kind: 'level', key: 'alc', label: 'ALC',
       evidence: { state: 'stale', value: 0.2, domain: { kind: 'engineering', unit: 'normalized' } },
       relevant: true, observed: false, displayedFraction: null, peakFraction: null,
+      scale: { min: 0, max: 1 },
       displayText: 'STALE', stateText: 'STALE', accessibleDescription: 'ALC: Stale observation',
       gauge: true, fault: false, peakEnabled: false,
     },
@@ -920,24 +929,28 @@ mount(App, { target: document.querySelector('#app')! });
       kind: 'level', key: 'drainCurrent', label: 'Id',
       evidence: { state: 'idle', domain: { kind: 'engineering', unit: 'a' } },
       relevant: false, observed: false, displayedFraction: null, peakFraction: null,
+      scale: null,
       displayText: 'IDLE', stateText: 'IDLE', gauge: true, fault: false, peakEnabled: false,
     },
     {
       kind: 'level', key: 'drainVoltage', label: 'Vd',
       evidence: { state: 'unknown', domain: { kind: 'unknown' } },
       relevant: true, observed: false, displayedFraction: null, peakFraction: null,
+      scale: null,
       displayText: 'Vd ?', stateText: '', gauge: false, fault: false, peakEnabled: false,
     },
     {
       kind: 'level', key: 'compression', label: 'COMP',
       evidence: { state: 'unsupported', domain: { kind: 'engineering', unit: 'db' } },
       relevant: true, observed: false, displayedFraction: null, peakFraction: null,
+      scale: { min: 0, max: 20 },
       displayText: '?', stateText: '?', gauge: false, fault: false, peakEnabled: false,
     },
     {
       kind: 'level', key: 'swr', label: 'SWR',
       evidence: { state: 'current', value: 1.5, domain: { kind: 'engineering', unit: 'ratio' } },
       relevant: true, observed: true, displayedFraction: 0.2, peakFraction: null,
+      scale: { min: 0, max: 6 },
       displayText: '1.5', stateText: '', accessibleDescription: 'SWR: Current observation. 1.5',
       gauge: true, fault: false, peakEnabled: false, ratioScale: true,
     },
@@ -945,6 +958,7 @@ mount(App, { target: document.querySelector('#app')! });
       kind: 'level', key: 'swr', label: 'SWR',
       evidence: { state: 'current', value: 120, domain: { kind: 'raw' } },
       relevant: true, observed: true, displayedFraction: 0.47, peakFraction: null,
+      scale: null,
       displayText: '120 raw', stateText: '', accessibleDescription: 'SWR: 120 raw',
       gauge: true, fault: false, peakEnabled: false, ratioScale: false,
     },

--- a/frontend/src/semantic/__tests__/bar-meter-projector.test.ts
+++ b/frontend/src/semantic/__tests__/bar-meter-projector.test.ts
@@ -6,6 +6,7 @@ import type {
   DisplayObservation,
   MeterRfState,
   MeterSourceIdentity,
+  MeterValueDomain,
   MetersViewModel,
   RadioViewModel,
 } from '../radio-view-model';
@@ -14,6 +15,9 @@ import {
   projectSwrMeter,
   projectTxMeterPresentation,
   type BarMeterKey,
+  type BarMeterProjection,
+  type LevelMeterKey,
+  type SwrMeterProjection,
 } from '../bar-meter-projector';
 
 function base(rfState: MeterRfState = 'transmitting'): RadioViewModel {
@@ -494,4 +498,135 @@ describe('projectBarMeters — scale domains (T168)', () => {
     expect(vd.scale).toBeNull();
     expect(vd.motionFraction).toBeNull();
   });
+});
+
+// ---------------------------------------------------------------------------
+// Level/scale pairing per definition row (T172). `BAR_DEFINITIONS` and
+// `SWR_DEFINITION` pair a level function with a scale function on one row.
+// Each `*Scale` returns null for a unit it does not serve, so a row wired to
+// another row's scale function publishes a null scale while its level function
+// still returns a position. Every row is projected with a reading inside its
+// own domain and asserted against its own published scale, so such a pairing
+// fails here.
+// ---------------------------------------------------------------------------
+
+const PAIRING_CALS = {
+  power: [
+    { raw: 0, actual: 0, label: '0' },
+    { raw: 255, actual: 200, label: '200' },
+  ],
+  alc: [
+    { raw: 0, actual: 0, label: '0' },
+    { raw: 120, actual: 1, label: '1' },
+  ],
+  vd: [
+    { raw: 0, actual: 0.0, label: '0' },
+    { raw: 210, actual: 13.8, label: '13.8' },
+  ],
+  id: [
+    { raw: 0, actual: 0.0, label: '0' },
+    { raw: 29, actual: 1.0, label: '1.0' },
+  ],
+  comp: [
+    { raw: 0, actual: 0, label: '0' },
+    { raw: 255, actual: 20, label: '20' },
+  ],
+  swr: [
+    { raw: 0, actual: 1.0, label: '1.0' },
+    { raw: 255, actual: 6.0, label: '6.0+' },
+  ],
+};
+
+type PairingCase = {
+  readonly domain: MeterValueDomain;
+  readonly value: number;
+  readonly scale: { min: number; max: number };
+  readonly position: number;
+};
+
+const PAIRING_CASES: Readonly<Record<LevelMeterKey, PairingCase>> = {
+  power: {
+    domain: { kind: 'engineering', unit: 'w' },
+    value: 50, scale: { min: 0, max: 200 }, position: 0.25,
+  },
+  alc: {
+    domain: { kind: 'engineering', unit: 'normalized' },
+    value: 0.4, scale: { min: 0, max: 1 }, position: 0.4,
+  },
+  drainCurrent: {
+    domain: { kind: 'engineering', unit: 'a' },
+    value: 0.5, scale: { min: 0, max: 1.0 }, position: 0.5,
+  },
+  drainVoltage: {
+    domain: { kind: 'engineering', unit: 'v' },
+    value: 12.0, scale: { min: 11, max: 15 }, position: 0.25,
+  },
+  compression: {
+    domain: { kind: 'engineering', unit: 'db' },
+    value: 5, scale: { min: 0, max: 20 }, position: 0.25,
+  },
+  swr: {
+    domain: { kind: 'engineering', unit: 'ratio' },
+    value: 2.0, scale: { min: 0, max: 6.0 }, position: 2.0 / 6.0,
+  },
+};
+
+function pairingCaps(): Capabilities {
+  return { ...calibratedCaps(), meterCalibrations: PAIRING_CALS };
+}
+
+/** Every row projected at once, each with a reading inside its own domain. */
+function pairingRows(domainOf: (key: LevelMeterKey) => MeterValueDomain): Map<
+  LevelMeterKey, BarMeterProjection | SwrMeterProjection
+> {
+  const view = base();
+  for (const [key, { value }] of Object.entries(PAIRING_CASES) as [
+    LevelMeterKey, PairingCase,
+  ][]) {
+    view.meters![key] = {
+      ...view.meters![key],
+      reading: { status: 'known', value },
+      relevant: true,
+      domain: domainOf(key),
+    };
+  }
+  const rows = new Map<LevelMeterKey, BarMeterProjection | SwrMeterProjection>(
+    projectBarMeters(view).map((row) => [row.key, row]),
+  );
+  rows.set('swr', projectSwrMeter(view)!);
+  return rows;
+}
+
+describe('projectBarMeters/projectSwrMeter — level and scale come from one row (T172)', () => {
+  afterEach(() => clearCapabilities());
+
+  it('covers every projected row', () => {
+    setCapabilities(pairingCaps());
+    expect([...pairingRows((key) => PAIRING_CASES[key].domain).keys()].sort())
+      .toEqual(Object.keys(PAIRING_CASES).sort());
+  });
+
+  it.each(Object.keys(PAIRING_CASES) as LevelMeterKey[])(
+    'positions %s on the scale that row publishes',
+    (key) => {
+      setCapabilities(pairingCaps());
+      const { value, scale, position } = PAIRING_CASES[key];
+      const row = pairingRows((rowKey) => PAIRING_CASES[rowKey].domain).get(key)!;
+
+      expect(row.scale).toEqual(scale);
+      expect(row.motionFraction).toBeCloseTo(positionOn(row.scale, value), 10);
+      expect(row.motionFraction).toBeCloseTo(position, 10);
+    },
+  );
+
+  it.each(Object.keys(PAIRING_CASES) as LevelMeterKey[])(
+    'leaves %s with neither a scale nor a position in a domain its row cannot serve',
+    (key) => {
+      setCapabilities(pairingCaps());
+      const row = pairingRows(() => ({ kind: 'unknown' })).get(key)!;
+
+      expect(row.scale).toBeNull();
+      expect(row.motionFraction).toBeNull();
+    },
+  );
 });

--- a/frontend/src/semantic/__tests__/meter-renderer-view.test.ts
+++ b/frontend/src/semantic/__tests__/meter-renderer-view.test.ts
@@ -3,6 +3,7 @@ import type { Capabilities } from '$lib/types/capabilities';
 import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
 import type { SignalMeterFrame } from '../../components-v2/meters/signal-meter-motion.svelte';
 import type { SignalMeterProjection } from '../../components-v2/meters/smeter-scale';
+import { SUPPLY_VOLTAGE_WINDOW } from '../../components-v2/panels/meter-utils';
 import type { LevelMeterKey } from '../bar-meter-projector';
 import type { StationLevelMeterFrame } from '../StationMeterInstrumentHost.svelte';
 import { toLevelMeterRendererView, toSignalMeterRendererView } from '../meter-renderer-view';
@@ -50,7 +51,7 @@ function levelFrame(
       key, label: key === 'power' ? 'Po' : key, evidence: { state: 'current', value: 50 },
       relevant: true, observed: true, state: 'current',
       domain: { kind: 'engineering', unit: key === 'swr' ? 'ratio' : 'w' },
-      motionFraction: 0.25, displayText: '50W', stateText: '',
+      motionFraction: 0.25, scale: null, displayText: '50W', stateText: '',
       accessibleDescription: 'Po: Current observation. 50W', fault: false,
       showPeak: true, gauge: true,
       ...(key === 'swr' ? { ratioScale: true } : {}),
@@ -225,7 +226,7 @@ describe('toLevelMeterRendererView', () => {
     const view = toLevelMeterRendererView(source);
     expect(Reflect.ownKeys(view)).toEqual([
       'kind', 'key', 'label', 'evidence', 'relevant', 'observed',
-      'displayedFraction', 'peakFraction', 'displayText', 'stateText',
+      'displayedFraction', 'peakFraction', 'scale', 'displayText', 'stateText',
       'accessibleDescription', 'gauge', 'fault', 'peakEnabled',
     ]);
     expect(view).toMatchObject({
@@ -246,7 +247,7 @@ describe('toLevelMeterRendererView', () => {
     const expected = [
       'accessibleDescription', 'displayText', 'displayedFraction', 'evidence', 'fault',
       'gauge', 'key', 'kind', 'label', 'observed', 'peakEnabled', 'peakFraction',
-      'relevant', 'stateText', ...(key === 'swr' ? ['ratioScale'] : []),
+      'relevant', 'scale', 'stateText', ...(key === 'swr' ? ['ratioScale'] : []),
     ].sort();
     expect(Reflect.ownKeys(view).sort()).toEqual(expected);
     expect(view.evidence.domain).toEqual({ kind: 'unknown' });
@@ -319,6 +320,28 @@ describe('toLevelMeterRendererView', () => {
     expect(toLevelMeterRendererView(levelFrame('power', projection, motion))).toMatchObject({
       displayedFraction: fill, peakFraction: peak,
     });
+  });
+
+  // T171: `MeterRendererSeat.svelte` passes an external level renderer this
+  // view plus a reset-peak lease, and nothing else of the frame — so a scale
+  // left out of the copy is unreachable from a face however faithfully
+  // `LevelMeterProjection.scale` is derived.
+  it.each([
+    ['drainVoltage', { kind: 'engineering', unit: 'v' }, SUPPLY_VOLTAGE_WINDOW],
+    ['drainCurrent', { kind: 'engineering', unit: 'a' }, { min: 0, max: 1.0 }],
+    ['power', { kind: 'raw' }, null],
+  ] as const)('carries the %s projection scale into the public view', (key, domain, scale) => {
+    const view = toLevelMeterRendererView(levelFrame(key, { domain, scale }));
+    expect(view.scale).toEqual(scale);
+    expectFrozenDataGraph(view);
+  });
+
+  it('copies the scale rather than publishing the projection object itself', () => {
+    const view = toLevelMeterRendererView(levelFrame('drainVoltage', {
+      domain: { kind: 'engineering', unit: 'v' }, scale: SUPPLY_VOLTAGE_WINDOW,
+    }));
+    expect(view.scale).not.toBe(SUPPLY_VOLTAGE_WINDOW);
+    expect(Object.isFrozen(view.scale)).toBe(true);
   });
 
   it('emits ratioScale only for the SWR discriminant', () => {

--- a/frontend/src/semantic/meter-renderer-view.ts
+++ b/frontend/src/semantic/meter-renderer-view.ts
@@ -2,6 +2,7 @@ import type {
   LevelMeterRendererView,
   MeterNumericEvidence,
   MeterDisplayDomain,
+  MeterScaleDomain,
   SignalMeterEvidence,
   SignalMeterMark,
   SignalMeterRendererView,
@@ -86,6 +87,11 @@ export function toSignalMeterRendererView(
   });
 }
 
+/** A fresh frozen copy, so the public graph never aliases a projector constant. */
+function scaleDomain(scale: MeterScaleDomain | null): MeterScaleDomain | null {
+  return scale === null ? null : Object.freeze({ min: scale.min, max: scale.max });
+}
+
 function levelEvidence(
   frame: StationLevelMeterFrame,
   domain: MeterDisplayDomain,
@@ -123,6 +129,7 @@ export function toLevelMeterRendererView(
     displayedFraction: live ? frame.motion.smoothedFraction : null,
     peakFraction: live && projection.showPeak && validFraction(frame.motion.peakFraction)
       ? frame.motion.peakFraction : null,
+    scale: scaleDomain(projection.scale),
     displayText: projection.displayText,
     stateText: projection.stateText,
     ...(projection.accessibleDescription === undefined


### PR DESCRIPTION
## The gap

`#3399` added `scale` to `LevelMeterProjection`, derived per `BAR_DEFINITIONS`
row by the same function family that computes the position, so a face can
label a bar from the domain its fill was computed from. But
`meter-renderer-view.ts: toLevelMeterRendererView` copies the projection into
`LevelMeterRendererView` field by field and omitted `scale`. An external level
renderer reached through `component-kits/MeterRendererSeat.svelte` gets that
view and a reset-peak lease and nothing else of the frame, so the scale was
unreachable from a face — only in-tree renderers holding
`StationLevelMeterFrame.projection` could read it. The signal side already
publishes `marks` with actual + fraction, so the level side was the asymmetric
one.

## The field and its shape

`component-kit-api/src/index.ts` gains `MeterScaleDomain` (`readonly min`,
`readonly max`) and `LevelMeterRendererViewBase.scale: MeterScaleDomain | null`
— the same shape as the projection's, defined natively in the kit API the way
`MeterDisplayDomain`, `MeterNumericEvidence`, `SignalMeterMark` and
`SignalMeterTick` already are rather than aliased from a host module.
`toLevelMeterRendererView` copies it into a fresh frozen `{ min, max }`:
`vdScale` returns the module-level `SUPPLY_VOLTAGE_WINDOW` constant, which
must not be published by reference into a graph a face holds.

No behaviour change beyond the added field.

## Kit-API convention followed

`COMPONENT_KIT_API_VERSION` stays the literal `1` and the package version
stays `0.6.0`. The precedent for this exact shape of change — an additive
field on a type kits already consume — is `0aaabbbeb` (#3318) "expose finite
option disabled reasons", which added `ControlOption.disabledReason` with no
version bump and instead extended the tarball consumer proof in
`frontend/component-kit-api/verify-package.mjs`. This PR does the same: that
script's typed consumer gains a read of `LevelMeterRendererView.scale`, and
its seven `LevelMeterRendererView` literals gain the now-required field.
`npm run verify:component-kit-api` passes; it is both an npm script and a `quick.yml` step ("Verify portable component-kit package", gated on the frontend filter), and that step ran green in this PR's own quick run.

`docs/architecture/component-kit-sdk.md` §7 carried a colon-list of the
package commits that had touched it without bumping the version. This PR is
another such commit, which would leave that enumeration incomplete; the list
is deleted rather than extended, per CLAUDE.md §Testing ("delete before you
narrow"). The version table itself is unchanged.

## Tests

`frontend/src/semantic/__tests__/meter-renderer-view.test.ts` (T171): the
level view carries the projection's scale — the supply-voltage window for
`drainVoltage`, `{0, top}` for `drainCurrent`, null for a raw domain — as a
fresh frozen object that is not the projector's own constant. The two
existing exact-key-set assertions gain `scale`.

`frontend/src/semantic/__tests__/bar-meter-projector.test.ts` (T172): a table
over all six definition rows (the five in `BAR_DEFINITIONS` plus
`SWR_DEFINITION`), each projected with a reading inside its own domain, each
asserting its published scale and that `motionFraction` is that scale's own
position of the reading; plus a domain no row serves, where scale and position
are both null. A coverage case asserts the table's keys are exactly the
projected ones, so a new row cannot be added without one.

67 tests pass in the two touched files; 182 pass across those two plus
`component-kits/__tests__/activation.test.ts` and
`__tests__/external-hosted-face.component.test.ts`. `npm run check`,
`npm run lint` and `npm run lint:boundaries` are clean. The full vitest suite
was not run locally — that is CI's.

## Mutations

- `scale` copy deleted from `toLevelMeterRendererView` → 10 failures in
  `meter-renderer-view.test.ts` (the three new cases and the key-set
  assertions).
- `scale: projection.scale` (alias instead of a fresh frozen copy) → 3
  failures: the fresh-copy case and the two cases whose scale is a
  non-null object the frozen-graph walk finds unfrozen (the drain-voltage case
  reaches `SUPPLY_VOLTAGE_WINDOW`; the drain-current case reaches the test's own
  unfrozen tuple literal).
- `scaleDomain` rewritten by destructuring (behaviour-preserving) → 38/38
  green.
- `alcScale` and `compScale` swapped in `BAR_DEFINITIONS` → exactly the new
  `alc` and `compression` cases fail; every other case in the file, T168's
  included, stays green.
- `powerScale` and `swrScale` swapped → the new `power` and `swr` cases fail,
  along with one existing T168 case.

Each mutation was reverted and the file restored from a copy taken before it;
`git status` is clean and `git diff origin/main...HEAD` shows only the
intended change.

## Size

6 files, 194+/8- = 202 changed lines at `b0945ec15` — at the 6-file soft
threshold, well under the line thresholds. One unit of work: the field cannot
be added to the public view without the kit-API type, the copy, the tarball
proof's literals and the doc line that the non-bump makes stale, and the
pairing test is the evidence that the value being published is the one the
position came from.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

