### PR TITLE
fix: let no surface size a track in the flagship probe's grid

### DIFF
--- a/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
+++ b/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
@@ -20,15 +20,23 @@
 
   The switch is a container query on `.flagship-probe`, so it follows the
   width this skin is GIVEN rather than the viewport's. Its threshold is
-  `--flagship-probe-switch-width` — two rails, two receiver strips and the
-  RX/TX column, each at the minimum width declared below, PLUS the four
-  gutters the grid puts between those five columns. Those minimums are
-  DECLARED, not measured: nothing here measures what a surface actually
-  renders at.
-  `__tests__/FlagshipProbe.component.test.ts` recomputes the sum and requires
-  the `@container` literal to equal it;
+  `--flagship-probe-switch-width`: the five widths the wide arrangement's
+  column template declares — a rail twice, a receiver strip's minimum twice,
+  the RX/TX column once — PLUS the four gutters between them, which is the
+  width below which that template cannot give every track its declared size.
+  `__tests__/FlagshipProbe.component.test.ts` recomputes the sum from the
+  parsed column template and requires the `@container` literal to equal it;
   `presentation/layouts/__tests__/flagship-probe-registration.test.ts`
   requires the manifest's declared reflow width to equal it too.
+
+  NO SURFACE MAY SIZE A TRACK. Every track in both column templates is a
+  declared size: the rails are `minmax(0, <rail>)`, RX/TX is a fixed width,
+  and the two receiver strips are the flexible tracks that take the
+  remainder. None is `auto`, `min-content`, `max-content` or `fit-content`,
+  in either direction. A surface wider than its column overflows inside that
+  column. The component test parses both templates and fails on any
+  content-sized track, on a rail written any other way, and on a grid item
+  left without `min-width: 0`.
 
   R52. This shell renders no control and no readout, so it announces nothing
   it does not know: it contributes no dash, no glyph and no disabled
@@ -77,12 +85,13 @@
     height: 100%;
 
     /*
-      The declared minimum track widths, and their sum with the four gutters
+      The declared track widths — a rail's width, a receiver strip's minimum,
+      the RX/TX column's width — and their sum with the four gutters
       `.probe-stage` puts between the five columns.
     */
     --flagship-probe-rail-width: 280px;
     --flagship-probe-strip-min-width: 360px;
-    --flagship-probe-rx-tx-min-width: 160px;
+    --flagship-probe-rx-tx-width: 160px;
     --flagship-probe-switch-width: 1472px;
   }
 
@@ -95,17 +104,23 @@
     panorama lives across columns 2-4 in both — which is what keeps it
     between them. The deck spans all five columns in the narrow arrangement
     and columns 2-4 in the wide one; that is the whole of the switch.
+
+    Both templates size the rails and RX/TX to declared widths and give the
+    remainder to columns 2 and 4. The wide one alone floors those two at the
+    declared strip minimum, because it is the arrangement in which a
+    receiver strip occupies one of them on its own — in the narrow one each
+    strip spans a rail column and its neighbour.
   */
   .probe-stage {
     display: grid;
     gap: 8px;
     align-content: start;
     grid-template-columns:
-      minmax(var(--flagship-probe-rail-width), auto)
+      minmax(0, var(--flagship-probe-rail-width))
       minmax(0, 1fr)
-      auto
+      var(--flagship-probe-rx-tx-width)
       minmax(0, 1fr)
-      minmax(var(--flagship-probe-rail-width), auto);
+      minmax(0, var(--flagship-probe-rail-width));
     grid-template-areas:
       'rx-main   rx-main    rx-mid     rx-sub     rx-sub'
       'vfo-ops   vfo-ops    vfo-ops    vfo-ops    vfo-ops'
@@ -120,6 +135,12 @@
 
   @container (min-width: 1472px) {
     .probe-stage {
+      grid-template-columns:
+        minmax(0, var(--flagship-probe-rail-width))
+        minmax(var(--flagship-probe-strip-min-width), 1fr)
+        var(--flagship-probe-rx-tx-width)
+        minmax(var(--flagship-probe-strip-min-width), 1fr)
+        minmax(0, var(--flagship-probe-rail-width));
       grid-template-areas:
         'rf        rx-main    rx-mid     rx-sub     tx-aux'
         'dsp       vfo-ops    vfo-ops    vfo-ops    cw-keyer'
@@ -149,18 +170,9 @@
     display: contents;
   }
 
-  .probe-stage :global([data-strip-receiver='MAIN']) {
-    grid-area: rx-main;
-    min-width: var(--flagship-probe-strip-min-width);
-  }
-  .probe-stage :global([data-strip-receiver='SUB']) {
-    grid-area: rx-sub;
-    min-width: var(--flagship-probe-strip-min-width);
-  }
-  .probe-stage :global([data-zone-id='rx-tx']) {
-    grid-area: rx-mid;
-    min-width: var(--flagship-probe-rx-tx-min-width);
-  }
+  .probe-stage :global([data-strip-receiver='MAIN']) { grid-area: rx-main; }
+  .probe-stage :global([data-strip-receiver='SUB']) { grid-area: rx-sub; }
+  .probe-stage :global([data-zone-id='rx-tx']) { grid-area: rx-mid; }
   .probe-stage :global([data-zone-id='global']) { grid-area: vfo-ops; }
   .probe-stage :global([data-zone-id='rf-front-end']) { grid-area: rf; }
   .probe-stage :global([data-zone-id='dsp']) { grid-area: dsp; }
@@ -175,8 +187,26 @@
   .probe-stage :global([data-zone-id='scope-display']) { grid-area: scope-disp; }
   .probe-stage :global([data-zone-id='meters']) { grid-area: meters; }
 
+  /*
+    CONTAINMENT. `min-width: 0` replaces the automatic minimum size a grid
+    item carries by default — its min-content width — which is the one
+    remaining path by which a surface could push its own box past its column.
+    Overflow decides what then happens to the part that does not fit, and
+    every region here gets the same answer, `auto`: a clip removes content
+    without a trace, and a clipped control is an unreachable one. The
+    panorama is not the exception it looks like — `SpectrumPanel` mounts its
+    toolbar inside it. A scroll container leaves what does not fit reachable
+    and makes the too-wide surface look wrong inside its own column, which
+    is where that fix belongs.
+  */
+  .probe-stage :global([data-zone-id]) {
+    min-width: 0;
+    overflow: auto;
+  }
+
   .probe-panorama {
     grid-area: panorama;
     min-width: 0;
+    overflow: auto;
   }
 </style>

--- a/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
+++ b/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
@@ -195,7 +195,8 @@
     every region here gets the same answer, `auto`: a clip removes content
     without a trace, and a clipped control is an unreachable one. The
     panorama is not the exception it looks like — `SpectrumPanel` mounts its
-    toolbar inside it. A scroll container leaves what does not fit reachable
+    toolbar inside it in every scope mode but audio FFT. A scroll container
+    leaves what does not fit reachable
     and makes the too-wide surface look wrong inside its own column, which
     is where that fix belongs.
   */

--- a/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
+++ b/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
@@ -464,15 +464,23 @@ describe('no surface may size a track', () => {
 
   // Kills: dropping `min-width: 0` from a grid item, which restores the
   // item's automatic minimum size — its min-content width — and lets a
-  // surface push its own box past its column; and giving an item a declared
-  // width of its own, which is a surface claiming track width again.
-  it('caps every grid item at its column, and no item declares a width of its own', () => {
+  // surface push its own box past its column; and any `width`, `min-width`
+  // or `max-width` other than zero in a grid-item rule, each of which is a
+  // surface claiming track width again. Scanned over the rules whose
+  // selector names a grid item — `[data-zone-id`, `[data-strip-receiver`,
+  // `.probe-panorama` — so a width on `.flagship-probe`, the query
+  // container, is out of scope rather than a failure.
+  it('caps every grid item at its column: no grid-item rule declares a width, min-width or max-width other than zero', () => {
     expect(style).toMatch(/:global\(\[data-zone-id\]\)\s*\{[^}]*min-width:\s*0/);
     expect(style).toMatch(/\.probe-panorama\s*\{[^}]*min-width:\s*0/);
-    const declared = [...style.matchAll(/(?<![-\w(])min-width:\s*([^;{}]+);/g)]
+    // Innermost rules only: `[^{}]` on both sides skips the `@container`
+    // prelude and cannot span a nested block.
+    const declared = [...style.matchAll(/([^{}]+)\{([^{}]*)\}/g)]
+      .filter(([, selector]) => /\[data-zone-id|\[data-strip-receiver|\.probe-panorama/.test(selector))
+      .flatMap(([, , body]) => [...body.matchAll(/(?<![-\w(])(?:min-|max-)?width:\s*([^;{}]+)/g)])
       .map(([, value]) => value.trim());
     expect(declared.length).toBeGreaterThan(1);
-    expect([...new Set(declared)]).toEqual(['0']);
+    expect(declared.filter((value) => !/^0(px)?$/.test(value))).toEqual([]);
   });
 
   // Kills: leaving a grid item's overflow visible, which puts the part that

--- a/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
+++ b/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
@@ -377,13 +377,141 @@ describe('the container-width switch', () => {
   it('the threshold is the sum of the declared minimum track widths and the gutters', () => {
     const rail = px('--flagship-probe-rail-width');
     const strip = px('--flagship-probe-strip-min-width');
-    const rxTx = px('--flagship-probe-rx-tx-min-width');
+    const rxTx = px('--flagship-probe-rx-tx-width');
     // Five columns, four gutters. Read from the same style block as the
     // widths, so the gap and the threshold cannot drift apart either.
     const sum = 2 * rail + 2 * strip + rxTx + 4 * px('gap');
 
     expect(px('--flagship-probe-switch-width')).toBe(sum);
     expect(Number(style.match(/@container \(min-width: (\d+)px\)/)![1])).toBe(sum);
+  });
+});
+
+// ── The tracks ─────────────────────────────────────────────────────────────
+//
+// One `grid-template-columns` per arrangement, parsed out of the same style
+// block and split into its track sizing functions at paren depth 0.
+
+function splitTracks(body: string): string[] {
+  const tracks: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const character of body) {
+    if (character === '(') depth += 1;
+    if (character === ')') depth -= 1;
+    if (depth === 0 && /\s/.test(character)) {
+      if (current !== '') tracks.push(current);
+      current = '';
+    } else current += character;
+  }
+  if (current !== '') tracks.push(current);
+  return tracks.map((track) => track.replace(/\s+/g, ' '));
+}
+
+function columnTemplates(): string[][] {
+  return [...style.matchAll(/grid-template-columns:([^;]*);/g)]
+    .map(([, body]) => splitTracks(body));
+}
+
+/** The one px length a track sizing function declares, after substituting the
+ *  custom properties it is written with. */
+function declaredPx(track: string): number {
+  const resolved = track.replace(/var\((--[a-z-]+)\)/g, (_match, name: string) => `${px(name)}px`);
+  const lengths = [...resolved.matchAll(/(\d+)px/g)].map(([, value]) => Number(value));
+  expect(lengths).toHaveLength(1);
+  return lengths[0];
+}
+
+const CONTENT_SIZED = /\b(auto|min-content|max-content|fit-content)\b/;
+
+describe('no surface may size a track', () => {
+  // Kills: a track written `auto` — the shape the left rail carried, which
+  // grew it to the band surface's max-content width and left the two
+  // receiver strips' flexible columns at 0 — or written `min-content`,
+  // `max-content` or `fit-content`, in either direction.
+  it.each([[0, 'narrow'], [1, 'wide']])('column template %i (%s) declares no content-sized track', (index) => {
+    const tracks = columnTemplates()[index as number];
+    expect(tracks).toHaveLength(5);
+    for (const track of tracks) expect(track).not.toMatch(CONTENT_SIZED);
+  });
+
+  // Kills: a rail whose maximum is anything but the declared rail width, and
+  // a rail whose minimum is anything but 0.
+  it.each([[0, 'narrow'], [1, 'wide']])('column template %i (%s) caps both rails at the declared rail width', (index) => {
+    const tracks = columnTemplates()[index as number];
+    expect(tracks[0]).toBe('minmax(0, var(--flagship-probe-rail-width))');
+    expect(tracks[4]).toBe(tracks[0]);
+  });
+
+  // Kills: the strip columns losing their declared floor, which is the half
+  // of the threshold arithmetic below that makes it true of the layout
+  // rather than only of the variables.
+  it('gives the wide arrangement its strip minimum as a track minimum', () => {
+    const [, wide] = columnTemplates();
+    expect(wide[1]).toBe('minmax(var(--flagship-probe-strip-min-width), 1fr)');
+    expect(wide[3]).toBe(wide[1]);
+  });
+
+  // Kills: the threshold drifting away from the widths the wide column
+  // template actually declares — the `@container` literal must be the sum of
+  // those five and the four gutters between them.
+  it('switches at the sum of the wide template\'s five declared widths and the gutters', () => {
+    const [, wide] = columnTemplates();
+    const sum = wide.reduce((total, track) => total + declaredPx(track), 0) + 4 * px('gap');
+    expect(px('--flagship-probe-switch-width')).toBe(sum);
+    expect(Number(style.match(/@container \(min-width: (\d+)px\)/)![1])).toBe(sum);
+  });
+
+  // Kills: dropping `min-width: 0` from a grid item, which restores the
+  // item's automatic minimum size — its min-content width — and lets a
+  // surface push its own box past its column; and giving an item a declared
+  // width of its own, which is a surface claiming track width again.
+  it('caps every grid item at its column, and no item declares a width of its own', () => {
+    expect(style).toMatch(/:global\(\[data-zone-id\]\)\s*\{[^}]*min-width:\s*0/);
+    expect(style).toMatch(/\.probe-panorama\s*\{[^}]*min-width:\s*0/);
+    const declared = [...style.matchAll(/(?<![-\w(])min-width:\s*([^;{}]+);/g)]
+      .map(([, value]) => value.trim());
+    expect(declared.length).toBeGreaterThan(1);
+    expect([...new Set(declared)]).toEqual(['0']);
+  });
+
+  // Kills: leaving a grid item's overflow visible, which puts the part that
+  // does not fit over the neighbouring column instead of inside its own.
+  it('contains what does not fit inside the column it belongs to', () => {
+    expect(style).toMatch(/:global\(\[data-zone-id\]\)\s*\{[^}]*overflow:\s*auto/);
+    expect(style).toMatch(/\.probe-panorama\s*\{[^}]*overflow:\s*auto/);
+  });
+});
+
+describe('a zone whose surface does not mount reserves nothing', () => {
+  // Kills: a row sizing function or an item height, either of which would
+  // keep a row open at a height of its own when the zones on it do not
+  // mount. jsdom performs no layout, so this is asserted on the CSS that
+  // leaves every row `auto`; the browser measurement is in the PR body.
+  it('declares no row sizing and no item height', () => {
+    const grid = style.slice(style.indexOf('.probe-stage'));
+    expect(grid).not.toMatch(/grid-template-rows|grid-auto-rows/);
+    expect(grid).not.toMatch(/(?<![-\w])(min-|max-)?height:/);
+  });
+
+  // Kills: mounting an empty box for a surface the radio does not carry,
+  // which is a hole the arrangement would then hold a row open for.
+  it('mounts no element for a zone whose surface the radio does not carry', () => {
+    const base = mainSubCaps();
+    const dropped = ['antenna', 'rx_antenna', 'scope'];
+    h.caps = {
+      ...base,
+      scope: false,
+      antennas: 0,
+      capabilities: (base.capabilities as readonly string[]).filter((name) => !dropped.includes(name)),
+    } as unknown as Capabilities;
+    render();
+    expect(q('[data-zone-id="antenna"]')).toBeNull();
+    expect(q('[data-zone-id="scope-controls"]')).toBeNull();
+    // The rails they sat on are still there, so the absence above is the
+    // surface's own gate and not a collapsed mount.
+    expect(q('[data-zone-id="band"]')).not.toBeNull();
+    expect(q('[data-zone-id="rf-front-end"]')).not.toBeNull();
   });
 });
 


### PR DESCRIPTION
## The defect (measured live on the FTX-1, 2026-09-08, against #3398)

The wide arrangement's grid had the rails and RX/TX on `auto`-max tracks and
the two receiver strips on `minmax(0, 1fr)`. The surfaces' natural widths are
large — left rail 1813 px, set by the band surface's sentence labels; right
rail 518, set by cw-keyer — so Chromium grew the three `auto` tracks to their
max-content limits before expanding the flexible ones. Columns 2 and 4 stayed
at **0 px until the container passed 2738**. At 1472, the declared switch,
MAIN was printed over RX/TX by **352 px** and SUB over the right rail, and
stayed overlapped until **3442**. The panorama measured **390 px at 1472, at
1920 and at 2400 alike**.

## The mechanism (art direction, carried verbatim)

> NO SURFACE MAY SIZE A TRACK. Rails are `minmax(0, <rail>)` (a fixed rail
> width — keep the existing 280 as the declared rail for now), the strips and
> the panorama take the remainder as the flexible tracks, RX/TX is a fixed
> track; nothing in that grid is `auto`. Content that does not fit is the
> SURFACE's problem, contained inside its own column (`min-width: 0` on the
> grid items; overflow contained — decide `overflow: hidden` vs `auto` per
> region and say why; the band surface overflowing must look wrong locally,
> one surface, not move the arrangement). The `minmax(0,1fr)` collapse is the
> same disease the other way: no track may be sized by content in either
> direction. Zones whose surface never mounts COLLAPSE (no reserved hole): on
> the FTX-1 `antenna` and `scope-controls` never mount; establish how an empty
> grid area behaves under your row sizing and make the rail rows collapse when
> the zone element is absent.

### How it is implemented

Narrow (base) and wide (`@container`) now each declare their own
`grid-template-columns`:

| | col 1 | col 2 | col 3 | col 4 | col 5 |
|---|---|---|---|---|---|
| narrow | `minmax(0, rail)` | `minmax(0, 1fr)` | `rx-tx` | `minmax(0, 1fr)` | `minmax(0, rail)` |
| wide | `minmax(0, rail)` | `minmax(strip, 1fr)` | `rx-tx` | `minmax(strip, 1fr)` | `minmax(0, rail)` |

`--flagship-probe-rx-tx-min-width` is renamed `--flagship-probe-rx-tx-width`:
it is a fixed track now, not a minimum. The strips' `min-width` moves off the
grid items and onto the wide template's two flexible tracks — the floor is a
property of the track, not of the surface. The panorama is not a track of its
own: it spans columns 2-4, so it takes the remainder the way the mechanism
asks by spanning the flexible tracks and RX/TX.

**Overflow: `auto` for every region, `hidden` for none.** A clip removes
content with no trace and a clipped control is an unreachable one. The
panorama is not the exception it looks like — `SpectrumPanel.svelte` mounts
`<SpectrumToolbar>` inside it as the `{:else}` arm of `{#if audioFft}`, so the
toolbar is there in every scope mode but audio FFT. A scroll container leaves
what does not fit reachable and makes the too-wide surface look wrong inside
its own column, which is where that fix belongs.

**The threshold is unchanged at 1472** = 2×280 + 2×360 + 160 + 4×8, and it is
now the wide template's own arithmetic: the width below which that template
cannot give every track its declared size (row 5 of the table below).

## Measured on this build, with stand-ins

Headless Chromium driven by Playwright 1.58.2 from `frontend/node_modules`:
the skin's own style block (`:global(...)` unwrapped) over a DOM carrying the
same hooks — one div per `data-zone-id`, two `data-strip-receiver` strips, the
`display: contents` wrappers, `.probe-panorama`. Widths are `getBoundingClientRect`
on that DOM, so the box heights are a text line, not a real surface. "Overrun"
is `MAIN.right > rxTx.left || rxTx.right > SUB.left`.

| container | arrangement | `grid-template-columns` | MAIN | RX/TX | SUB | left rail | panorama | overrun |
|---|---|---|---|---|---|---|---|---|
| 1471 | narrow | `280 359.5 160 359.5 280` | 647.5 | 160 | 647.5 | 280 | 895 | no |
| 1472 | wide | `280 360 160 360 280` | 360 | 160 | 360 | 280 | 896 | no |
| 1920 | wide | `280 584 160 584 280` | 584 | 160 | 584 | 280 | 1344 | no |
| 2400 | wide | `280 824 160 824 280` | 824 | 160 | 824 | 280 | 1824 | no |
| 1471, wide template forced on | wide | `279.5 360 160 360 279.5` | 647.5 | 160 | 647.5 | 279.5 | 896 | no |
| 1472 + 1813 px stand-in in the left rail | wide | `280 360 160 360 280` | 360 | 160 | 360 | 280 (`scrollWidth` 1813, `clientWidth` 280) | 896 | no |
| 1920 + the same stand-in | wide | `280 584 160 584 280` | 584 | 160 | 584 | 280 (`scrollWidth` 1813, `clientWidth` 280) | 1344 | no |

The strips and the panorama grow with the container while the rails stay 280;
the stand-in rows are identical to their stand-in-free counterparts in every
column, and the 1813 px child is confined to its own rail's scroll box.

**Control, same harness, `origin/main`'s style block, same stand-in:** at 1472
the columns are `1000px 0px 160px 0px 280px`, MAIN `[1008..1368]` over RX/TX
`[1016..1176]` (overrun), panorama 176, and the stage overflows its container
(`scrollWidth` 1813 vs `clientWidth` 1472). At 1920, `1448px 0px 160px 0px 280px`.
So the harness reproduces the bench defect on the old CSS and not on the new.

### Collapse

Rows are left `auto` — the skin declares no `grid-template-rows`, no
`grid-auto-rows` and no item height — so a row whose zones do not mount is
zero-height. Measured with `antenna` and `scope-controls` omitted from the
DOM, the two zones the bench found never mount on the FTX-1:

| | rows | stage height |
|---|---|---|
| 1920, wide, all zones | `18 18 18 18 18 18 18 18` | 200 |
| 1920, wide, both absent | `18 18 18 18 **0** 18 18 18` | 182 |
| 1200, narrow, all zones | `18 18 18 18 18 18 18 18 18` | 226 |
| 1200, narrow, both absent | `18 18 18 18 18 18 **0** 18 18` | 208 |

The row collapses to 0 and the 8 px gap it sits between remains: the height
falls by exactly the row's 18 px, not by 26. That residual gap is the whole of
the "hole" the arrangement keeps.

## Tests

All in `FlagshipProbe.component.test.ts`. Two new suites:

- *no surface may size a track* — both parsed column templates have five
  tracks and none matches `auto|min-content|max-content|fit-content`; both
  rails are exactly `minmax(0, var(--flagship-probe-rail-width))`; the wide
  template's columns 2 and 4 are exactly
  `minmax(var(--flagship-probe-strip-min-width), 1fr)`; the `@container`
  literal and `--flagship-probe-switch-width` both equal the sum of the wide
  template's five declared px widths (substituting the custom properties) plus
  4 × `gap`; every grid item is reached by a `min-width: 0` rule and **every**
  `width`, `min-width` and `max-width` declared by a grid-item rule — those
  whose selector names `[data-zone-id`, `[data-strip-receiver` or
  `.probe-panorama` — is zero; both containment rules declare `overflow: auto`.
- *a zone whose surface does not mount reserves nothing* — no
  `grid-template-rows`, no `grid-auto-rows` and no height anywhere from
  `.probe-stage` on; and, mounted against caps carrying neither antenna nor
  scope, no element exists for `antenna` or `scope-controls` while `band` and
  `rf-front-end` still do. jsdom performs no layout, so the row half is
  asserted on the CSS and measured in the browser above.

The pre-existing threshold test keeps its variable arithmetic (renamed
property); the parsed-template test is what ties it to the layout.

### Mutations run

| mutation | result |
|---|---|
| A — the wide template's rails and RX/TX restored to `origin/main`'s `minmax(rail, auto)` / `auto`, strips back to `minmax(0, 1fr)` | 4 failures: *declares no content-sized track (wide)*, *caps both rails*, *gives the wide arrangement its strip minimum*, *switches at the sum …* |
| B — `min-width: 0` deleted from the grid-item rule | 1 failure: *caps every grid item at its column …* |
| D — the MAIN strip given back `min-width: var(--flagship-probe-strip-min-width)` | 1 failure: *caps every grid item at its column …* |
| C — behaviour-preserving: the two declarations inside the containment rule swapped, the MAIN and SUB rules swapped | green, 27/27 |
| E — `width: 400px` on the MAIN strip rule | 1 failure: *caps every grid item at its column …* (`expected [ '400px' ] to deeply equal []`) |
| F — `max-width: 200px` on the grid-item rule | 1 failure: same test (`expected [ '200px' ] to deeply equal []`) |
| G — `min-width: 0px` instead of `0` on the grid-item rule | green, 27/27 — `0px` is zero |
| H — `min-width: 320px` on `.flagship-probe`, the query container | green, 27/27 — the container is not a grid item |

E is the case the independent review measured: against the min-width-only
assertion it left the file 27/27 green while Chromium printed MAIN over RX/TX
by 32 px at a 1472 container. F is the same class in the other direction. B and
D above were re-run against the widened assertion and still fail on it.

The tree was restored from a pristine copy after each; `git status` at the head
shows only the two intended files.

## Gates

- `npx vitest run src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts src/presentation/layouts/__tests__/flagship-probe-registration.test.ts` — **32 passed, 0 failed**
- `npx vitest run src/presentation/layouts/__tests__ src/skins/__tests__ src/__tests__/presentation-switch-{tx,resources}.component.test.ts src/presentation/languages/__tests__` — **634 passed, 0 failed** (run at 89c9274a, before the width assertion was widened; that later commit changed one test file and no source)
- `npm run check` — 4844 files, 0 errors, 0 warnings
- `npm run lint`, `npm run lint:boundaries` — clean

`git diff --numstat origin/main...HEAD`: **2 files, 192+ / 25- = 217 changed
lines at 36cb39ce** (the last commit narrows one comment line in the skin). Under the 6/600 soft threshold.

## What a zone's `overflow: auto` can clip

Audited by the independent review and re-derived here from the same files:
every `position: absolute` under `src/semantic/` is the `.sr-only` shape (11
occurrences, `git grep -n "position: absolute" -- 'src/semantic/*.svelte'`,
each on or under an `.sr-only` selector). `ScopeSettingsPopover` mounts only
under `{#if hasCapability('scope') && !hideScopeControls}` and this skin passes
`hideScopeControls={true}`, so it never mounts here. The toolbar's layer
dropdown, its backdrop and the popover backdrop are `position: fixed`. The one
absolutely-positioned popover a zone's `overflow: auto` could clip is the
toolbar's `.display-gear-popover`, whose trigger group carries `show-mobile` —
`display: none` except under `@media (max-width: 640px)` — so it is reachable
only on a mobile-width viewport.

## What this change does not establish

- The real surfaces' rendered heights or the arrangement's appearance: the
  measurements above are stand-ins in a bare DOM, not the mounted face.
- RX/TX is a fixed 160 px track now, and the bench measured that surface's
  natural width at 374.47 px, so it will scroll inside its column on that
  radio. That is the surface's problem by the mechanism, and it is not fixed
  here.

## Out of scope

- Surface labels — the band surface's "160m TX at 1.825 MHz: allowed" and
  cw-keyer's sentence are a content change, T178.
- The type ladder, T162.
- The threshold's rail constant stays declared at 280.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)


