### PR TITLE
fix: carry the band key's permit as its own fact and give the keyer's posture its own line

### DIFF
--- a/frontend/component-kit-api/verify-package.mjs
+++ b/frontend/component-kit-api/verify-package.mjs
@@ -570,12 +570,21 @@ const oldChoiceOption: ControlOption<'OFF'> = { value: 'OFF', label: 'Off' };
 const reasonedChoiceOption: ControlOption<'DATA1'> = {
   value: 'DATA1', label: 'Data 1', disabled: true, disabledReason: 'Not available',
 };
+const captionedChoiceOption: ControlOption<'20m'> = {
+  value: '20m', label: '20m', caption: 'TX at 14.195 MHz: allowed',
+};
+const captionPrinted: string = captionedChoiceOption.caption === undefined
+  ? captionedChoiceOption.label
+  : captionedChoiceOption.label + ' ' + captionedChoiceOption.caption;
+void captionPrinted;
 function inspectChoice(props: ChoiceRendererProps<'OFF' | 'DATA1'>):
   FiniteControlReading<'OFF' | 'DATA1'> | undefined {
   const view = props.lease.view;
   if (view === undefined) return undefined;
   const option = view.options[0]?.value;
   const disabledReason: string | undefined = view.options[0]?.disabledReason;
+  const caption: string | undefined = view.options[0]?.caption;
+  void caption;
   const supported: FiniteChoiceValue | undefined = option;
   const optionalEvidence = [view.defaultValue, view.requested, view.feedback] as const;
   const request = option === undefined ? undefined : () => props.lease.invoke(option);

--- a/frontend/src/primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte
+++ b/frontend/src/primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte
@@ -46,8 +46,9 @@
           aria-describedby={reasonId} title={option.disabledReason}
           disabled={!view.available || option.disabled === true}
           data-testid={`external-${view.label}-${option.value}`}
+          data-option-label={option.label} data-option-caption={option.caption}
           onclick={() => invoke(option.value)}
-        >{option.label}</button>
+        >{option.caption === undefined ? option.label : `${option.label} ${option.caption}`}</button>
         {#if reasonId}<span id={reasonId} class="sr-only">{option.disabledReason}</span>{/if}
       {/each}
     </div>

--- a/frontend/src/primitives/control-instruments/control-instrument-renderer.svelte.ts
+++ b/frontend/src/primitives/control-instruments/control-instrument-renderer.svelte.ts
@@ -24,6 +24,9 @@ export interface ControlLabel {
 export interface ControlOption<T> {
   readonly value: T;
   readonly label: string;
+  /** A sentence about this option, carried apart from `label` so a renderer
+   *  decides whether to print it. */
+  readonly caption?: string;
   readonly disabled?: boolean;
   readonly disabledReason?: string;
 }

--- a/frontend/src/semantic/BandInstrumentHost.svelte
+++ b/frontend/src/semantic/BandInstrumentHost.svelte
@@ -25,6 +25,9 @@
     onEnterFrequency?: (frequencyHz: number) => void;
     entryRendererContext?: FiniteRendererContext | null;
     entryRenderer?: Component<FrequencyEntryRendererProps>;
+    /** Whether the fallback key PRINTS its permit sentence. Its accessible name
+     *  carries that sentence, and `data-default-permit` the status, either way. */
+    showPermitCaption?: boolean;
     children: Snippet<[BandInstrumentHandles]>;
   }
   type RendererSelection = { finiteAppearance?: undefined; rendererContext?: undefined } | {
@@ -35,7 +38,7 @@
 
   let {
     view, onSelectBand, onEnterFrequency, finiteAppearance, rendererContext,
-    entryRendererContext, entryRenderer, children,
+    entryRendererContext, entryRenderer, showPermitCaption = true, children,
   }: Props = $props();
   let band = $derived(view?.band);
   let receiverKnown = $derived(view?.activeReceiver.status === 'known');
@@ -87,7 +90,8 @@
     available: receiverKnown && band !== undefined,
     options: (band?.bandChoices ?? []).map(choice => ({
       value: choice.name,
-      label: `${choice.name} ${defaultPermitLabel(choice)}`,
+      label: choice.name,
+      caption: defaultPermitLabel(choice),
     })),
     invoke: selectBand,
   }));
@@ -162,11 +166,13 @@
           <button
             type="button" class="band-choice" data-testid={`band-choice-${choice.name}`}
             data-default-permit={choice.defaultHzTxPermit.status}
+            aria-label={`${choice.name} — ${defaultPermitLabel(choice)}`}
             aria-pressed={bandChoiceBehavior.isSelected(choice.name)}
             disabled={!bandChoiceBehavior.available}
             onclick={() => bandChoiceBehavior.invoke(choice.name)}
-          >{choice.name}<small data-testid={`band-choice-permit-${choice.name}`}
-          >{defaultPermitLabel(choice)}</small></button>
+          >{choice.name}{#if showPermitCaption}<small
+            data-testid={`band-choice-permit-${choice.name}`}
+          >{defaultPermitLabel(choice)}</small>{/if}</button>
         {/each}
       </div>
     {/if}

--- a/frontend/src/semantic/CwKeyerSurface.svelte
+++ b/frontend/src/semantic/CwKeyerSurface.svelte
@@ -351,29 +351,35 @@
   >
     {#if cw.breakIn.availability.structural}
       <div
-        class="cw-keyer-row" role="radiogroup" aria-label="Break-in"
         data-testid="cw-keyer-break-in"
         data-posture={breakInPosture(cw.breakIn)}
         data-permitted={permitAllowed}
       >
-        {#each BREAK_IN_CHOICES as [label, mode] (mode)}
-          <button
-            type="button" role="radio" class="cw-keyer-choice"
-            data-testid={`cw-keyer-break-in-${label}`}
-            aria-checked={cw.breakIn.reading.status === 'known'
-              && cw.breakIn.reading.value === label}
-            disabled={!usable(cw.breakIn) || !permitAllowed}
-            onclick={() => setBreakIn(mode)}
-          >{label}</button>
-        {/each}
+        <div class="cw-keyer-row" role="radiogroup" aria-label="Break-in">
+          {#each BREAK_IN_CHOICES as [label, mode] (mode)}
+            <button
+              type="button" role="radio" class="cw-keyer-choice"
+              data-testid={`cw-keyer-break-in-${label}`}
+              aria-checked={cw.breakIn.reading.status === 'known'
+                && cw.breakIn.reading.value === label}
+              disabled={!usable(cw.breakIn) || !permitAllowed}
+              onclick={() => setBreakIn(mode)}
+            >{label}</button>
+          {/each}
+        </div>
         <!-- Rule 5: the posture is TEXT, so it survives forced-colors and so
              "armed but not permitted" reads differently from "off and not
              permitted" — the operator's radio can still key from its own
-             paddle while this UI refuses to change the setting. -->
-        <output data-testid="cw-keyer-posture">{POSTURE_LABEL[breakInPosture(cw.breakIn)]}</output>
+             paddle while this UI refuses to change the setting. It is a
+             SENTENCE, so it gets its own line below the keys and may wrap. -->
+        <p class="cw-keyer-sentence">
+          <output data-testid="cw-keyer-posture">{POSTURE_LABEL[breakInPosture(cw.breakIn)]}</output>
+        </p>
         {#if !permitAllowed && breakInReason}
-          <output data-testid="cw-keyer-break-in-blocked" data-reason={breakInReason}
-          >{breakInBlockedLabel(breakInReason)}</output>
+          <p class="cw-keyer-sentence">
+            <output data-testid="cw-keyer-break-in-blocked" data-reason={breakInReason}
+            >{breakInBlockedLabel(breakInReason)}</output>
+          </p>
         {/if}
       </div>
     {/if}
@@ -507,6 +513,7 @@
      sole state channel (MOR-977, forced-colors). Nothing here animates. */
   .cw-keyer-surface { display: flex; flex-direction: column; gap: 0.25rem; }
   .cw-keyer-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin: 0; }
+  .cw-keyer-sentence { margin: 0; }
   .cw-keyer-level { display: flex; align-items: baseline; gap: 0.5rem; }
   .cw-keyer-name { min-width: 12ch; }
   .cw-keyer-choice[aria-checked='true'], .cw-keyer-toggle[aria-pressed='true'] { font-weight: 700; }

--- a/frontend/src/semantic/__tests__/BandInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/BandInstrumentHost.isolated.test.ts
@@ -12,6 +12,7 @@ import FiniteControlRendererFixture, {
   resetRetainedInvocations, retainedInvocations,
 } from '../../primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte';
 import { topologyFixtures, withBand } from '../fixtures/topologies';
+import { defaultPermitLabel } from '../band-instruments';
 import type { BandViewModel, RadioViewModel } from '../radio-view-model';
 import BandInstrumentHostFixture from './fixtures/BandInstrumentHostFixture.svelte';
 
@@ -90,6 +91,65 @@ describe('BandInstrumentHost', () => {
     expect(option?.textContent).toContain('denied');
     retainedInvocations.get('Band')?.('20m');
     expect(onSelectBand).toHaveBeenCalledExactlyOnceWith('20m');
+    unmount(component);
+  });
+
+  // The seat option carries the band name and the permit sentence as two
+  // fields. Kills: folding the sentence back into `label`, which is what made
+  // an unwrappable key label carry a wrappable sentence.
+  it('publishes the band name as the option label and the permit sentence as its caption', () => {
+    const view = base();
+    const component = mount(BandInstrumentHostFixture, {
+      target,
+      props: {
+        view, finiteAppearance: appearance, rendererContext: createFiniteRendererContext(),
+      },
+    });
+    flushSync();
+    for (const choice of (view.band as BandViewModel).bandChoices) {
+      const option = target.querySelector<HTMLElement>(`[data-testid="external-Band-${choice.name}"]`)!;
+      expect(option.dataset.optionLabel).toBe(choice.name);
+      expect(option.dataset.optionCaption).toBe(defaultPermitLabel(choice));
+      // This renderer prints both, so its text is what the combined label
+      // rendered before the split.
+      expect(option.textContent).toBe(`${choice.name} ${defaultPermitLabel(choice)}`);
+    }
+    unmount(component);
+  });
+
+  // Kills: dropping the printed caption from the fallback key, and an
+  // accessible name that reads the two facts as one run-on sentence.
+  it('prints name and permit on the fallback key and names both to a screen reader', () => {
+    const view = base();
+    const component = mount(BandInstrumentHostFixture, { target, props: { view } });
+    flushSync();
+    for (const choice of (view.band as BandViewModel).bandChoices) {
+      const button = target.querySelector<HTMLButtonElement>(`[data-testid="band-choice-${choice.name}"]`)!;
+      const permit = defaultPermitLabel(choice);
+      expect(button.textContent).toBe(`${choice.name}${permit}`);
+      expect(target.querySelector(`[data-testid="band-choice-permit-${choice.name}"]`)?.textContent)
+        .toBe(permit);
+      expect(button.getAttribute('aria-label')).toBe(`${choice.name} — ${permit}`);
+      expect(button.dataset.defaultPermit).toBe(choice.defaultHzTxPermit.status);
+    }
+    unmount(component);
+  });
+
+  // Kills: a suppression that either does nothing or takes the fact away with
+  // the print — the accessible name and the permit attribute are the fact.
+  it('suppresses only the printed caption, keeping the accessible name and the attribute', () => {
+    const view = base();
+    const component = mount(BandInstrumentHostFixture, {
+      target, props: { view, showPermitCaption: false },
+    });
+    flushSync();
+    for (const choice of (view.band as BandViewModel).bandChoices) {
+      const button = target.querySelector<HTMLButtonElement>(`[data-testid="band-choice-${choice.name}"]`)!;
+      expect(target.querySelector(`[data-testid="band-choice-permit-${choice.name}"]`)).toBeNull();
+      expect(button.textContent).toBe(choice.name);
+      expect(button.getAttribute('aria-label')).toBe(`${choice.name} — ${defaultPermitLabel(choice)}`);
+      expect(button.dataset.defaultPermit).toBe(choice.defaultHzTxPermit.status);
+    }
     unmount(component);
   });
 

--- a/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
@@ -708,6 +708,31 @@ describe('break-in POSTURE distinguishes armed from off, and unknown from both',
     expect(POSTURE_LABEL[p]).toMatch(/key/);
   });
 
+  // Kills: the posture sentence back inside the keys' row, where a sentence
+  // can only stretch the row or wrap between the keys.
+  it('gives the posture sentence its own line under the break-in keys', () => {
+    const r = render(base());
+    const keys = target.querySelector<HTMLElement>(
+      '[data-testid="cw-keyer-break-in"] [role="radiogroup"]',
+    )!;
+    const posture = target.querySelector<HTMLElement>('[data-testid="cw-keyer-posture"]')!;
+    expect(keys.querySelectorAll('button')).toHaveLength(BREAK_IN_CHOICES.length);
+    expect(keys.contains(posture)).toBe(false);
+    expect(posture.closest('[role="radiogroup"]')).toBeNull();
+    expect(keys.compareDocumentPosition(posture) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    r.dispose();
+  });
+
+  // Kills: a rule in this file that would clip the sentence or hold it on one
+  // line. Scoped to this stylesheet, which is what this file controls.
+  it('clips text in exactly one rule of its own stylesheet, the screen-reader one', () => {
+    const sheet = /<style>([\s\S]*?)<\/style>/.exec(CODE)![1];
+    const clipping = [...sheet.matchAll(/([^{}]+)\{([^{}]*)\}/g)]
+      .filter(([, , body]) => /white-space:\s*nowrap|text-overflow/.test(body))
+      .map(([, selector]) => selector.trim());
+    expect(clipping).toEqual(['.sr-only']);
+  });
+
   // The two "not permitted" states are visibly different, which is the whole
   // point of the decision above.
   it('renders armed-and-not-permitted differently from off-and-not-permitted', () => {

--- a/frontend/src/semantic/__tests__/fixtures/BandInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/BandInstrumentHostFixture.svelte
@@ -18,19 +18,21 @@
     rendererContext?: FiniteRendererContext | null;
     entryRendererContext?: FiniteRendererContext | null;
     entryRenderer?: Component<FrequencyEntryRendererProps>;
+    showPermitCaption?: boolean;
     onSelectBand?: (name: string) => void;
     onEnterFrequency?: (frequencyHz: number) => void;
   }
   let {
     view, presentation = 'grouped', finiteAppearance, rendererContext,
-    entryRendererContext, entryRenderer, onSelectBand, onEnterFrequency,
+    entryRendererContext, entryRenderer, showPermitCaption, onSelectBand, onEnterFrequency,
   }: Props = $props();
   let selection = $derived(finiteAppearance === undefined
     ? {} : { finiteAppearance, rendererContext: rendererContext ?? null });
 </script>
 
 <BandInstrumentHost
-  {view} {onSelectBand} {onEnterFrequency} {entryRendererContext} {entryRenderer} {...selection}
+  {view} {onSelectBand} {onEnterFrequency} {entryRendererContext} {entryRenderer}
+  {showPermitCaption} {...selection}
 >
   {#snippet children(handles: BandInstrumentHandles)}
     {#if presentation === 'surface'}


### PR DESCRIPTION
Soft threshold reached on files (8 files, 157 changed lines): the option
field, its two producers, the two test-support fixtures that consume it, the
package consumer proof and the two test files are one unit — the field is
unusable without a producer, and the fixtures are how "the rendered text did
not change" is asserted at all.

A LABEL never wraps; a SENTENCE always may. That distinction, and the split
between the SURFACE owning a fact and the FACE deciding whether it is
PRINTED, are the art-direction line's rule of 2026-09-08. Two surfaces broke
it in opposite directions, so the cures are opposite.

## Band — the label was secretly a sentence

Every band key published one seat option labelled
`160m TX at 1.825 MHz: allowed`, so a renderer drawing keys had to fit a
sentence into a key. The option now carries `label: '160m'` and
`caption: 'TX at 1.825 MHz: allowed'`. Nothing is abbreviated or truncated.

## CW keyer — a correct sentence in the wrong place

`break-in off — the key does not transmit` is written as a status sentence
and needs to wrap, but it sat in the same wrapping flex row as the three
break-in keys. The radiogroup now holds the radios alone; the posture, and
the blocked reason after it, are blocks below it, in the order they are
read. No string changes; the block keeps its `data-testid`,
`data-posture` and `data-permitted` on the wrapping element.

## The option field

`ControlOption.caption?: string`, in
`primitives/control-instruments/control-instrument-renderer.svelte.ts`. The
component-kit API re-exports `ControlOption` as an alias, so the field
reaches kit consumers with no version bump — the #3318/#3400 precedent — and
`verify-package.mjs`'s consumer proof now reads `caption` off a literal
option and off a lease view. The one in-tree renderer that printed the
joined label composes `label + ' ' + caption` back, so its text is byte-for-
byte what it rendered before (asserted, not assumed).

## The suppress mechanism

`showPermitCaption?: boolean` on `BandInstrumentHost`, defaulting to `true`.
The codebase's existing convention for "this host renders that part or not"
is an optional boolean prop named `show<Thing>` defaulting to shown —
`TxAuxSurface.showScalars`/`showFinite`, `CwKeyerSurface.showKeyerSpeed`/
`showPitchHz`, `VfoSurface.showRadioWideFacts`/`showVfoList` — so this is
that convention, not a new one. It gates the PRINT only: the key's
accessible name and `data-default-permit` are unchanged when it is false.
No caller passes it in this PR.

## Exact strings

- Visible by default, unchanged: `160m` immediately followed by
  `<small>TX at 1.825 MHz: allowed</small>`, no separator.
- Accessible name: `160m — TX at 1.825 MHz: allowed` (em dash; the permit
  string `core.band.tx.defaultPermit.label` supplies its own colon).
- Posture sentences: unchanged.

## No visible change to the band by default — evidence

The CW keyer's posture line does move, by design, in the three layouts that declare a `cwKeyer` zone (`desktop-v2`, `sdr-test`, `flagship-probe`): it leaves the keys' row for its own line below them. The approved visual baselines mount none of those layouts' keyer zone, so the visual gate is silent on it either way.

The visual job runs only on a non-draft PR, so it was measured here instead,
with the same comparator and specs CI uses. On the unmodified tree at
`dc6526ff` the whole approved set was re-pinned on this host
(`npm run test:e2e:visual -- --update-snapshots=all`, 37 passed); the change
was then applied and `npm run test:e2e:visual` compared against those
host-local baselines: **37 passed, no baseline byte rewritten**. The
re-pinned PNGs were restored from git afterwards and `git status` is clean of
them.

A DOM probe over the nine cockpit/LCD fixture ids the capture list uses
(temporary spec, since deleted; the PTT, spectrum and gallery entries were
not probed, only pixel-compared) found `band-choices`, `band-choice-permit-*`,
`cw-keyer-break-in` and `cw-keyer-posture` at count 0 in every one — those
captures mount the VFO, RX/TX, TX-aux, meters and scope surfaces, not these
two. Production reaches the external renderer path only through an installed
component kit, so a shipped face with no kit draws the fallback keys, which
are unchanged.

## Tests

Band (`BandInstrumentHost.isolated.test.ts`, three new cases): the option's
label is the bare name and its caption the permit sentence for every choice,
and the renderer that prints both renders exactly
`${name} ${permit}`; the fallback key prints name and caption, carries the
em-dash accessible name and `data-default-permit`; the suppressed case drops
the printed caption while keeping both. The existing `band-choice-permit-*`
assertions in `BandSurface.test.ts` are untouched and green.

CW keyer (`CwKeyerSurface.test.ts`, two new cases): the posture output is
outside the radiogroup and follows it in document order; the only rule in
this file's stylesheet that sets `white-space: nowrap` or `text-overflow` is
`.sr-only`.

Also run green: `band.test.ts`, `cw-keyer.test.ts`,
`CwKeyerInstrumentHost.isolated.test.ts`, the band/CW-keyer wiring tests,
`cw-keyer-zone-lifecycle`, `control-instrument-renderer.test.ts`,
`external-hosted-face.component.test.ts`, `npm run check`, `npm run lint`,
`npm run lint:boundaries`, `npm run i18n:check`,
`npm run verify:component-kit-api`.

## Mutations

| Mutation | Result |
|---|---|
| permit sentence joined back into the seat `label` | 1 failed — the label/caption case |
| accessible-name em dash replaced by a colon | 2 failed — the fallback-key and suppression cases |
| `showPermitCaption` ignored (`{#if true}`) | 1 failed — the suppression case |
| posture output moved back inside the radiogroup | 1 failed — the posture-line case |
| behaviour-preserving refactor (accessible name via a helper; `<p>` → `<div>`) | 107 passed, green |

The tree was restored after each; `git diff origin/main...HEAD` carries no
mutation residue.

Census at 51c57a146: 8 files, 135+/22- = 157 changed lines.

Internal-identifier self-check — empty.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

