### PR TITLE
fix: give every CW keyer sentence its own line and the keys their row gap

### DIFF
--- a/frontend/src/semantic/CwKeyerSurface.svelte
+++ b/frontend/src/semantic/CwKeyerSurface.svelte
@@ -351,7 +351,7 @@
   >
     {#if cw.breakIn.availability.structural}
       <div
-        data-testid="cw-keyer-break-in"
+        class="cw-keyer-block" data-testid="cw-keyer-break-in"
         data-posture={breakInPosture(cw.breakIn)}
         data-permitted={permitAllowed}
       >
@@ -459,40 +459,49 @@
            ordinal and the ordinal itself is shown verbatim; "which type" would
            need an `apfOn`/`apfType` fact that slice 9A deliberately did not
            promote (MOR-1296 open question 2) — flagged, not guessed. -->
-      <div
-        class="cw-keyer-row" role="radiogroup" aria-label="Audio peak filter"
-        data-testid="cw-keyer-apf" data-observed={usable(cw.apf)}
-      >
-        {#each APF_CHOICES as [label, on] (label)}
-          <button
-            type="button" role="radio" class="cw-keyer-choice"
-            data-testid={`cw-keyer-apf-${label}`}
-            aria-checked={apfChoice.isSelected(on)}
-            disabled={!apfChoice.available}
-            onclick={() => apfChoice.invoke(on)}
-          >APF {label}</button>
-        {/each}
-        <output data-testid="cw-keyer-apf-value">{textOf(cw.apf)}</output>
+      <div class="cw-keyer-block">
+        <div
+          class="cw-keyer-row" role="radiogroup" aria-label="Audio peak filter"
+          data-testid="cw-keyer-apf" data-observed={usable(cw.apf)}
+        >
+          {#each APF_CHOICES as [label, on] (label)}
+            <button
+              type="button" role="radio" class="cw-keyer-choice"
+              data-testid={`cw-keyer-apf-${label}`}
+              aria-checked={apfChoice.isSelected(on)}
+              disabled={!apfChoice.available}
+              onclick={() => apfChoice.invoke(on)}
+            >APF {label}</button>
+          {/each}
+          <output data-testid="cw-keyer-apf-value">{textOf(cw.apf)}</output>
+        </div>
         {#if mutexed('apf')}
-          <output data-testid="cw-keyer-apf-mutex" data-reason="mutually-exclusive-control"
-          >{MUTEX_LABEL.apf}</output>
+          <p class="cw-keyer-sentence">
+            <output data-testid="cw-keyer-apf-mutex" data-reason="mutually-exclusive-control"
+            >{MUTEX_LABEL.apf}</output>
+          </p>
         {/if}
       </div>
     {/if}
 
     {#if cw.twinPeak.availability.structural}
-      <div class="cw-keyer-row" data-testid="cw-keyer-twin-peak" data-observed={usable(cw.twinPeak)}>
-        <button
-          type="button" class="cw-keyer-toggle" data-testid="cw-keyer-twin-peak-toggle"
-          aria-pressed={pressedOf(cw.twinPeak)}
-          disabled={!twinPeakToggle.available}
-          onclick={() => twinPeakToggle.invoke()}
-        >TPF: {textOf(cw.twinPeak)}</button>
+      <div class="cw-keyer-block">
+        <div class="cw-keyer-row" data-testid="cw-keyer-twin-peak" data-observed={usable(cw.twinPeak)}>
+          <button
+            type="button" class="cw-keyer-toggle" data-testid="cw-keyer-twin-peak-toggle"
+            aria-pressed={pressedOf(cw.twinPeak)}
+            disabled={!twinPeakToggle.available}
+            onclick={() => twinPeakToggle.invoke()}
+          >TPF: {textOf(cw.twinPeak)}</button>
+        </div>
         {#if mutexed('twinPeak')}
           <!-- Rule 4: RTTY is named, so a permanently-disabled control in a
-               block the operator reads as "CW" is never unexplained. -->
-          <output data-testid="cw-keyer-twin-peak-mutex" data-reason="mutually-exclusive-control"
-          >{MUTEX_LABEL.twinPeak}</output>
+               block the operator reads as "CW" is never unexplained. It is a
+               SENTENCE, so it leaves the keys row for its own line. -->
+          <p class="cw-keyer-sentence">
+            <output data-testid="cw-keyer-twin-peak-mutex" data-reason="mutually-exclusive-control"
+            >{MUTEX_LABEL.twinPeak}</output>
+          </p>
         {/if}
       </div>
     {/if}
@@ -511,7 +520,7 @@
 <style>
   /* Structure only — a design language owns colour and must never become the
      sole state channel (MOR-977, forced-colors). Nothing here animates. */
-  .cw-keyer-surface { display: flex; flex-direction: column; gap: 0.25rem; }
+  .cw-keyer-surface, .cw-keyer-block { display: flex; flex-direction: column; gap: 0.25rem; }
   .cw-keyer-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin: 0; }
   .cw-keyer-sentence { margin: 0; }
   .cw-keyer-level { display: flex; align-items: baseline; gap: 0.5rem; }

--- a/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
@@ -813,6 +813,78 @@ describe('the mutex reasons are rendered with the other mode NAMED (MOR-1296 O1)
   });
 });
 
+/* ── a sentence never sits in a keys row ──────────────────────── */
+
+describe('every sentence gets its own line, and the keys keep their gap', () => {
+  /** Each sentence this surface can render, with a selector for the keys row
+   *  it explains. `cw-keyer-apf-value` is NOT here: it is the APF ordinal
+   *  read back, a reading beside its keys, not a sentence. */
+  const SENTENCES = [
+    ['posture', '[data-testid="cw-keyer-break-in"] .cw-keyer-row'],
+    ['break-in-blocked', '[data-testid="cw-keyer-break-in"] .cw-keyer-row'],
+    ['apf-mutex', '[data-testid="cw-keyer-apf"]'],
+    ['twin-peak-mutex', '[data-testid="cw-keyer-twin-peak"]'],
+  ] as const;
+
+  /** One view carrying all four at once: `2/ab_shared` denies the permit and
+   *  records the break-in reason, and both mutex reasons are added on top. */
+  const everySentence = (): RadioViewModel => withReasons(
+    withCwKeyer(topologyFixtures['2/ab_shared']),
+    { field: 'cwKeyer.apf', code: 'mutually-exclusive-control' },
+    { field: 'cwKeyer.twinPeak', code: 'mutually-exclusive-control' },
+  );
+
+  // Kills: any sentence left inside `.cw-keyer-row`, where it can only
+  // stretch the row or wrap between the keys.
+  it('renders all four sentences, none of them inside a keys row', () => {
+    const r = render(everySentence());
+    const rows = [...target.querySelectorAll<HTMLElement>('.cw-keyer-row')];
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) expect(row.querySelector('.cw-keyer-sentence')).toBeNull();
+    for (const [id] of SENTENCES) {
+      const el = r.el(id);
+      expect(el).not.toBeNull();
+      expect(el!.closest('.cw-keyer-row')).toBeNull();
+      expect(el!.closest('.cw-keyer-sentence')).not.toBeNull();
+    }
+    r.dispose();
+  });
+
+  // Kills: a sentence hoisted above its keys, or parked in a different block.
+  it.each(SENTENCES)('puts %s on its own line directly below its keys row', (id, rowSelector) => {
+    const r = render(everySentence());
+    const row = target.querySelector<HTMLElement>(rowSelector)!;
+    const sentence = r.el(id)!.closest<HTMLElement>('.cw-keyer-sentence')!;
+    expect(row.contains(sentence)).toBe(false);
+    expect(row.compareDocumentPosition(sentence) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(sentence.parentElement).toBe(row.closest('.cw-keyer-block'));
+    r.dispose();
+  });
+
+  // Kills: the #3402 wrapper shipped with no class, which left the keys and
+  // the sentences flush because nothing gave that wrapper the surface's gap.
+  it('wraps every keys row that owns a sentence in a gapped block', () => {
+    const r = render(everySentence());
+    for (const [, rowSelector] of SENTENCES) {
+      const row = target.querySelector<HTMLElement>(rowSelector)!;
+      expect(row.closest('.cw-keyer-block')).not.toBeNull();
+    }
+    r.dispose();
+  });
+
+  // Kills: a second gap number for the blocks. The block reuses the ONE
+  // declaration `.cw-keyer-surface` already had, in that same rule.
+  it('takes the block gap from the surface rule itself, not a second number', () => {
+    const sheet = /<style>([\s\S]*?)<\/style>/.exec(CODE)![1];
+    const withBlock = [...sheet.matchAll(/([^{}]+)\{([^{}]*)\}/g)]
+      .filter(([, selector]) => selector.includes('.cw-keyer-block'));
+    expect(withBlock).toHaveLength(1);
+    const [, selector, body] = withBlock[0];
+    expect(selector).toContain('.cw-keyer-surface');
+    expect(body).toMatch(/gap:\s*0\.25rem/);
+  });
+});
+
 /* ── facts render honestly ─────────────────────────────────────── */
 
 describe('every unread fact renders honestly, never as a v2 default', () => {


### PR DESCRIPTION
Art direction, 2026-09-08: a LABEL never wraps, a SENTENCE always may, and a
sentence does not sit in a keys row.

## The two facts

1. #3402 moved the break-in posture and blocked-reason sentences out of the
   radiogroup into blocks below it, but the wrapper `<div>` it added carries no
   class. The surface's own `gap: 0.25rem` separates the surface's children, not
   that wrapper's, so the keys row and the sentences sat flush.
2. `CwKeyerSurface.svelte: MUTEX_LABEL` holds two more sentences — the APF one
   and the twin-peak one — and both rendered as bare `<output>` INSIDE
   `.cw-keyer-row` flex rows, beside the APF radios and the TPF toggle: the same
   shape #3402 cured for the posture.

## What moved

- Each mutex `<output>` leaves its `.cw-keyer-row` for a
  `<p class="cw-keyer-sentence">` directly below that row, in the visible order
  keys-then-sentence. Both keys rows gained a wrapper block to hold the pair.
- `cw-keyer-apf-value` stays inside the APF row: it is the ordinal read back, a
  reading beside its keys, not a sentence.
- No string changed; no label changed. `MUTEX_LABEL` and `POSTURE_LABEL` are
  untouched.

## The gap reused

The wrapper class `.cw-keyer-block` was added to the selector of the rule this
stylesheet already had:

```css
.cw-keyer-surface, .cw-keyer-block { display: flex; flex-direction: column; gap: 0.25rem; }
```

That is the same `gap: 0.25rem` declaration `.cw-keyer-surface` used before this
change — one declaration, no second number. A test parses the component's own
`<style>` block and fails if a rule mentioning `.cw-keyer-block` is anywhere but
in the surface's own gap rule.

## Tests

Seven new cases in `CwKeyerSurface.test.ts`, over a view carrying all four
sentences at once (`2/ab_shared` denies the permit and records the break-in
reason; both mutex reasons are added on top):

- all four sentences render, no `.cw-keyer-row` contains a `.cw-keyer-sentence`,
  and each sentence's `closest('.cw-keyer-row')` is null;
- one case per sentence: its `.cw-keyer-sentence` follows its keys row in
  document order and is a child of the same `.cw-keyer-block`;
- every keys row that owns a sentence sits inside a `.cw-keyer-block`;
- the stylesheet's block gap is the surface rule itself.

Wrapping is left unforbidden by the file's pre-existing case
`clips text in exactly one rule of its own stylesheet, the screen-reader one`,
which asserts over the whole `<style>` block that `.sr-only` is the only rule
setting `white-space: nowrap` or `text-overflow`.

## Mutations run

| Mutation | Killed by |
|---|---|
| twin-peak mutex `<output>` put back inside its `.cw-keyer-row`, sentence block removed | 2 cases: `renders all four sentences, none of them inside a keys row`, `puts twin-peak-mutex on its own line directly below its keys row` |
| `.cw-keyer-block` dropped from the CSS gap rule (markup unchanged) | 1 case: `takes the block gap from the surface rule itself, not a second number` |
| `class="cw-keyer-block"` removed from all three wrappers — the #3402 shape | 5 cases: the four `puts %s on its own line directly below its keys row` and `wraps every keys row that owns a sentence in a gapped block` |

The tree was restored from a pristine copy after each mutation; `git status`
shows only the two intended files.

## Gates run locally

- `CwKeyerSurface`, `CwKeyerInstrumentHost.isolated`, `cw-keyer`,
  `semantic-cw-keyer-wiring.component`, `cw-keyer-zone-lifecycle.component`,
  `cw-keyer-declarability`, `cw-keyer-adapter`, `cw-keyer-purity.isolated`,
  `DualReceiverCockpit.component` — 9 files, 294 passed, 0 failed.
- `npm run check` — 4844 files, 0 errors, 0 warnings.
- `npm run lint` — clean. `npm run lint:boundaries` — clean.

## Visual CI

Measured, not assumed: a throwaway Playwright probe loaded each fixture URL the
approved whole-page baselines capture (the 14 distinct fixture/language/mode
combinations in `visual-baselines.spec.ts`'s `COCKPIT` list) at 1280x800,
1100x800 and 390x844, plus `spectrum-witness.html`, and counted
`[data-testid="cw-keyer-surface"]` and `.cw-keyer-row`. Every combination
reported `surfaces=0 rows=0`; 38 of the 42 fixture-viewport pairs completed
before the probe timed out on a phone-viewport load, and all 38 were zero. The
probe file was deleted and is not in this diff. So no approved baseline mounts
this surface, and this change should move no pixels in the `visual` job.

## Size

`git diff --numstat origin/main...HEAD` at c65514df7:

```
37	28	frontend/src/semantic/CwKeyerSurface.svelte
72	0	frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
```

2 files, 109+/28- = 137 changed lines at c65514df7 — inside the 6-file / 600-line
soft threshold.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
