### PR TITLE
fix: move the transmit key out of the probe's deck into the transmit rail and collapse the deck's middle track

### DIFF
--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -168,13 +168,13 @@ export const flagshipProbeLayout: LayoutManifest = {
     { id: 'primary-vfo', surfaces: ['vfo'] },
     { id: 'secondary-vfo', surfaces: ['vfo'] },
     { id: 'global', surfaces: ['vfo'] },
-    { id: 'rx-tx', surfaces: ['rxTx'] },
     { id: 'rf-front-end', surfaces: ['rfFrontEnd'] },
     { id: 'dsp', surfaces: ['dsp'] },
     { id: 'filter', surfaces: ['filter'] },
     { id: 'rx-audio', surfaces: ['rxAudio'] },
     { id: 'antenna', surfaces: ['antenna'] },
     { id: 'band', surfaces: ['band'] },
+    { id: 'rx-tx', surfaces: ['rxTx'] },
     { id: 'tx-aux', surfaces: ['txAux'] },
     { id: 'cw-keyer', surfaces: ['cwKeyer'] },
     { id: 'rit-xit-scan', surfaces: ['ritXitScan'] },
@@ -189,7 +189,7 @@ export const flagshipProbeLayout: LayoutManifest = {
   // `__tests__/flagship-probe-registration.test.ts` requires this
   // declaration, that custom property and the `@container` literal to name
   // the same width.
-  stageSizing: { mode: 'fluid', responsiveBreakpoints: [1472] },
+  stageSizing: { mode: 'fluid', responsiveBreakpoints: [1304] },
   fallbackLayoutId: 'sdr-test',
 };
 

--- a/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
+++ b/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
@@ -18,25 +18,34 @@
     wide   — left rail | (deck over panorama) | right rail
     narrow — deck across the top, then left rail | panorama | right rail
 
+  THE TRANSMIT KEY IS NOT IN THE DECK. The art-direction line's rule of
+  2026-09-09: nothing that keys the transmitter may live in a scrolling or
+  clipped column. `semantic/RxTxSurface.svelte` renders that key, so its
+  `rx-tx` zone is placed FIRST in the right rail, above the other transmit
+  controls, in both arrangements — `__tests__/FlagshipProbe.component.test.ts`
+  requires the rail column, that position and the rail's declared width
+  together. Nothing then stands between the two receivers, and the deck's
+  middle track is gone rather than empty: the same test requires every track
+  in both column templates to be a column some area names.
+
   The switch is a container query on `.flagship-probe`, so it follows the
   width this skin is GIVEN rather than the viewport's. Its threshold is
-  `--flagship-probe-switch-width`: the five widths the wide arrangement's
-  column template declares — a rail twice, a receiver strip's minimum twice,
-  the RX/TX column once — PLUS the four gutters between them, which is the
-  width below which that template cannot give every track its declared size.
+  `--flagship-probe-switch-width`: the four widths the wide arrangement's
+  column template declares — a rail twice and a receiver strip's minimum
+  twice — PLUS the three gutters between them, which is the width below which
+  that template cannot give every track its declared size.
   `__tests__/FlagshipProbe.component.test.ts` recomputes the sum from the
   parsed column template and requires the `@container` literal to equal it;
   `presentation/layouts/__tests__/flagship-probe-registration.test.ts`
   requires the manifest's declared reflow width to equal it too.
 
   NO SURFACE MAY SIZE A TRACK. Every track in both column templates is a
-  declared size: the rails are `minmax(0, <rail>)`, RX/TX is a fixed width,
-  and the two receiver strips are the flexible tracks that take the
-  remainder. None is `auto`, `min-content`, `max-content` or `fit-content`,
-  in either direction. A surface wider than its column overflows inside that
-  column. The component test parses both templates and fails on any
-  content-sized track, on a rail written any other way, and on a grid item
-  left without `min-width: 0`.
+  declared size: the rails are `minmax(0, <rail>)` and the two receiver
+  strips are the flexible tracks that take the remainder. None is `auto`,
+  `min-content`, `max-content` or `fit-content`, in either direction. A
+  surface wider than its column overflows inside that column. The component
+  test parses both templates and fails on any content-sized track, on a rail
+  written any other way, and on a grid item left without `min-width: 0`.
 
   R52. This shell renders no control and no readout, so it announces nothing
   it does not know: it contributes no dash, no glyph and no disabled
@@ -85,14 +94,13 @@
     height: 100%;
 
     /*
-      The declared track widths — a rail's width, a receiver strip's minimum,
-      the RX/TX column's width — and their sum with the four gutters
-      `.probe-stage` puts between the five columns.
+      The declared track widths — a rail's width and a receiver strip's
+      minimum — and their sum with the three gutters `.probe-stage` puts
+      between the four columns.
     */
     --flagship-probe-rail-width: 280px;
     --flagship-probe-strip-min-width: 360px;
-    --flagship-probe-rx-tx-width: 160px;
-    --flagship-probe-switch-width: 1472px;
+    --flagship-probe-switch-width: 1304px;
   }
 
   /*
@@ -100,16 +108,16 @@
     adds the wide one: a container too small for the wide arrangement is also
     a container whose query has not matched.
 
-    Five tracks in both arrangements. Columns 1 and 5 are the rails, and the
-    panorama lives across columns 2-4 in both — which is what keeps it
-    between them. The deck spans all five columns in the narrow arrangement
-    and columns 2-4 in the wide one; that is the whole of the switch.
+    Four tracks in both arrangements. Columns 1 and 4 are the rails, and the
+    panorama lives across columns 2-3 in both — which is what keeps it
+    between them. The deck spans all four columns in the narrow arrangement
+    and columns 2-3 in the wide one; that is the whole of the switch.
 
-    Both templates size the rails and RX/TX to declared widths and give the
-    remainder to columns 2 and 4. The wide one alone floors those two at the
-    declared strip minimum, because it is the arrangement in which a
-    receiver strip occupies one of them on its own — in the narrow one each
-    strip spans a rail column and its neighbour.
+    Both templates size the rails to a declared width and give the remainder
+    to columns 2 and 3. The wide one alone floors those two at the declared
+    strip minimum, because it is the arrangement in which a receiver strip
+    occupies one of them on its own — in the narrow one each strip spans a
+    rail column and its neighbour.
   */
   .probe-stage {
     display: grid;
@@ -118,38 +126,36 @@
     grid-template-columns:
       minmax(0, var(--flagship-probe-rail-width))
       minmax(0, 1fr)
-      var(--flagship-probe-rx-tx-width)
       minmax(0, 1fr)
       minmax(0, var(--flagship-probe-rail-width));
     grid-template-areas:
-      'rx-main   rx-main    rx-mid     rx-sub     rx-sub'
-      'vfo-ops   vfo-ops    vfo-ops    vfo-ops    vfo-ops'
-      'rf        panorama   panorama   panorama   tx-aux'
-      'dsp       panorama   panorama   panorama   cw-keyer'
-      'filter    panorama   panorama   panorama   rit-xit'
-      'rx-audio  panorama   panorama   panorama   .'
-      'antenna   scope-ctl  scope-ctl  scope-ctl  .'
-      'band      scope-disp scope-disp scope-disp .'
-      'meters    meters     meters     meters     meters';
+      'rx-main   rx-main    rx-sub     rx-sub'
+      'vfo-ops   vfo-ops    vfo-ops    vfo-ops'
+      'rf        panorama   panorama   rx-tx'
+      'dsp       panorama   panorama   tx-aux'
+      'filter    panorama   panorama   cw-keyer'
+      'rx-audio  panorama   panorama   rit-xit'
+      'antenna   scope-ctl  scope-ctl  .'
+      'band      scope-disp scope-disp .'
+      'meters    meters     meters     meters';
   }
 
-  @container (min-width: 1472px) {
+  @container (min-width: 1304px) {
     .probe-stage {
       grid-template-columns:
         minmax(0, var(--flagship-probe-rail-width))
         minmax(var(--flagship-probe-strip-min-width), 1fr)
-        var(--flagship-probe-rx-tx-width)
         minmax(var(--flagship-probe-strip-min-width), 1fr)
         minmax(0, var(--flagship-probe-rail-width));
       grid-template-areas:
-        'rf        rx-main    rx-mid     rx-sub     tx-aux'
-        'dsp       vfo-ops    vfo-ops    vfo-ops    cw-keyer'
-        'filter    panorama   panorama   panorama   rit-xit'
-        'rx-audio  panorama   panorama   panorama   .'
-        'antenna   panorama   panorama   panorama   .'
-        'band      scope-ctl  scope-ctl  scope-ctl  .'
-        '.         scope-disp scope-disp scope-disp .'
-        'meters    meters     meters     meters     meters';
+        'rf        rx-main    rx-sub     rx-tx'
+        'dsp       vfo-ops    vfo-ops    tx-aux'
+        'filter    panorama   panorama   cw-keyer'
+        'rx-audio  panorama   panorama   rit-xit'
+        'antenna   panorama   panorama   .'
+        'band      scope-ctl  scope-ctl  .'
+        '.         scope-disp scope-disp .'
+        'meters    meters     meters     meters';
     }
   }
 
@@ -172,7 +178,6 @@
 
   .probe-stage :global([data-strip-receiver='MAIN']) { grid-area: rx-main; }
   .probe-stage :global([data-strip-receiver='SUB']) { grid-area: rx-sub; }
-  .probe-stage :global([data-zone-id='rx-tx']) { grid-area: rx-mid; }
   .probe-stage :global([data-zone-id='global']) { grid-area: vfo-ops; }
   .probe-stage :global([data-zone-id='rf-front-end']) { grid-area: rf; }
   .probe-stage :global([data-zone-id='dsp']) { grid-area: dsp; }
@@ -180,6 +185,7 @@
   .probe-stage :global([data-zone-id='rx-audio']) { grid-area: rx-audio; }
   .probe-stage :global([data-zone-id='antenna']) { grid-area: antenna; }
   .probe-stage :global([data-zone-id='band']) { grid-area: band; }
+  .probe-stage :global([data-zone-id='rx-tx']) { grid-area: rx-tx; }
   .probe-stage :global([data-zone-id='tx-aux']) { grid-area: tx-aux; }
   .probe-stage :global([data-zone-id='cw-keyer']) { grid-area: cw-keyer; }
   .probe-stage :global([data-zone-id='rit-xit-scan']) { grid-area: rit-xit; }

--- a/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
+++ b/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
@@ -259,7 +259,7 @@ function px(name: string): number {
 }
 
 const LEFT_RAIL = ['rf', 'dsp', 'filter', 'rx-audio', 'antenna', 'band'];
-const RIGHT_RAIL = ['tx-aux', 'cw-keyer', 'rit-xit'];
+const RIGHT_RAIL = ['rx-tx', 'tx-aux', 'cw-keyer', 'rit-xit'];
 
 /** Every column index at which `area` appears in `template`. */
 function columnsOf(template: Template, area: string): number[] {
@@ -324,17 +324,33 @@ describe('the panorama sits between the two rails, in both arrangements', () => 
     expect(Math.max(...panorama)).toBeLessThan(lastColumn);
   });
 
-  // Kills: stacking the receivers, or letting the RX/TX column drift out from
-  // between them.
+  // Kills: stacking the receivers, and putting any third area — the transmit
+  // key's old `rx-mid` track among them — back between them.
   it.each([[0, 'narrow'], [1, 'wide']])('template %i (%s) keeps the two receivers side by side', (index) => {
     const template = templates()[index as number];
     const deckRow = rowOf(template, 'rx-main');
-    expect(rowOf(template, 'rx-mid')).toBe(deckRow);
     expect(rowOf(template, 'rx-sub')).toBe(deckRow);
+    // Between the two rail columns the deck row is one cell per strip.
+    expect(template[deckRow].slice(1, template[0].length - 1)).toEqual(['rx-main', 'rx-sub']);
     expect(Math.max(...columnsOf(template, 'rx-main')))
-      .toBeLessThan(Math.min(...columnsOf(template, 'rx-mid')));
-    expect(Math.max(...columnsOf(template, 'rx-mid')))
       .toBeLessThan(Math.min(...columnsOf(template, 'rx-sub')));
+  });
+
+  // Kills: the transmit key going back into the deck, or anywhere but first
+  // in the right rail. The art-direction line's rule of 2026-09-09: nothing
+  // that keys the transmitter may live in a scrolling or clipped column. The
+  // rail column's declared width is asserted here rather than assumed,
+  // because that width is the whole of the key's room.
+  it.each([[0, 'narrow'], [1, 'wide']])('template %i (%s) puts rx-tx first in the right rail', (index) => {
+    const template = templates()[index as number];
+    const lastColumn = template[0].length - 1;
+    expect(columnsOf(template, 'rx-tx')).toEqual([lastColumn]);
+    expect(columnTemplates()[index as number][lastColumn])
+      .toBe('minmax(0, var(--flagship-probe-rail-width))');
+    // First in the rail: no other transmit control comes between the top of
+    // the transmit column and the key.
+    const rows = RIGHT_RAIL.map((area) => rowOf(template, area));
+    expect(rows).toEqual([...rows].sort((a, b) => a - b));
   });
 });
 
@@ -359,7 +375,7 @@ describe('the container-width switch', () => {
   // leave the rails' columns to it, which is the whole reason it moves.
   it('narrow gives the deck the full width; wide shares its row with both rails', () => {
     const [narrow, wide] = templates();
-    const deck = ['rx-main', 'rx-mid', 'rx-sub'];
+    const deck = ['rx-main', 'rx-sub'];
     const narrowDeckRow = narrow[rowOf(narrow, 'rx-main')];
     expect(new Set(narrowDeckRow)).toEqual(new Set(deck));
     const wideDeckRow = wide[rowOf(wide, 'rx-main')];
@@ -369,7 +385,7 @@ describe('the container-width switch', () => {
 
   // Kills: changing the threshold in one place and not the other two — the
   // number is the sum of the arrangement's own declared minimum widths and
-  // the four gutters between the five columns they size. The
+  // the three gutters between the four columns they size. The
   // manifest declares that same width, and
   // `presentation/layouts/__tests__/flagship-probe-registration.test.ts` is
   // where the two are required to agree (this directory may not name the
@@ -377,10 +393,9 @@ describe('the container-width switch', () => {
   it('the threshold is the sum of the declared minimum track widths and the gutters', () => {
     const rail = px('--flagship-probe-rail-width');
     const strip = px('--flagship-probe-strip-min-width');
-    const rxTx = px('--flagship-probe-rx-tx-width');
-    // Five columns, four gutters. Read from the same style block as the
+    // Four columns, three gutters. Read from the same style block as the
     // widths, so the gap and the threshold cannot drift apart either.
-    const sum = 2 * rail + 2 * strip + rxTx + 4 * px('gap');
+    const sum = 2 * rail + 2 * strip + 3 * px('gap');
 
     expect(px('--flagship-probe-switch-width')).toBe(sum);
     expect(Number(style.match(/@container \(min-width: (\d+)px\)/)![1])).toBe(sum);
@@ -431,7 +446,7 @@ describe('no surface may size a track', () => {
   // `max-content` or `fit-content`, in either direction.
   it.each([[0, 'narrow'], [1, 'wide']])('column template %i (%s) declares no content-sized track', (index) => {
     const tracks = columnTemplates()[index as number];
-    expect(tracks).toHaveLength(5);
+    expect(tracks).toHaveLength(4);
     for (const track of tracks) expect(track).not.toMatch(CONTENT_SIZED);
   });
 
@@ -440,7 +455,7 @@ describe('no surface may size a track', () => {
   it.each([[0, 'narrow'], [1, 'wide']])('column template %i (%s) caps both rails at the declared rail width', (index) => {
     const tracks = columnTemplates()[index as number];
     expect(tracks[0]).toBe('minmax(0, var(--flagship-probe-rail-width))');
-    expect(tracks[4]).toBe(tracks[0]);
+    expect(tracks[3]).toBe(tracks[0]);
   });
 
   // Kills: the strip columns losing their declared floor, which is the half
@@ -449,15 +464,15 @@ describe('no surface may size a track', () => {
   it('gives the wide arrangement its strip minimum as a track minimum', () => {
     const [, wide] = columnTemplates();
     expect(wide[1]).toBe('minmax(var(--flagship-probe-strip-min-width), 1fr)');
-    expect(wide[3]).toBe(wide[1]);
+    expect(wide[2]).toBe(wide[1]);
   });
 
   // Kills: the threshold drifting away from the widths the wide column
   // template actually declares — the `@container` literal must be the sum of
-  // those five and the four gutters between them.
-  it('switches at the sum of the wide template\'s five declared widths and the gutters', () => {
+  // those four and the three gutters between them.
+  it('switches at the sum of the wide template\'s four declared widths and the gutters', () => {
     const [, wide] = columnTemplates();
-    const sum = wide.reduce((total, track) => total + declaredPx(track), 0) + 4 * px('gap');
+    const sum = wide.reduce((total, track) => total + declaredPx(track), 0) + 3 * px('gap');
     expect(px('--flagship-probe-switch-width')).toBe(sum);
     expect(Number(style.match(/@container \(min-width: (\d+)px\)/)![1])).toBe(sum);
   });
@@ -488,6 +503,21 @@ describe('no surface may size a track', () => {
   it('contains what does not fit inside the column it belongs to', () => {
     expect(style).toMatch(/:global\(\[data-zone-id\]\)\s*\{[^}]*overflow:\s*auto/);
     expect(style).toMatch(/\.probe-panorama\s*\{[^}]*overflow:\s*auto/);
+  });
+});
+
+describe('the collapsed middle track leaves no gutter behind', () => {
+  // Kills: leaving the deck's former 160px RX/TX track in either column
+  // template now that the transmit key has moved to the rail. A track no
+  // area names is an empty column, and the two gaps on either side of it are
+  // the reserved gutter this arrangement must not hold open.
+  it.each([[0, 'narrow'], [1, 'wide']])('column template %i (%s) declares one track per named column, none of them empty', (index) => {
+    const template = templates()[index as number];
+    const tracks = columnTemplates()[index as number];
+    expect(tracks).toHaveLength(template[0].length);
+    for (let column = 0; column < tracks.length; column += 1) {
+      expect(template.some((row) => row[column] !== '.')).toBe(true);
+    }
   });
 });
 


### PR DESCRIPTION
## The safety rule and the fact

The art-direction line's rule of 2026-09-09: **nothing that keys the
transmitter may live in a scrolling or clipped column.**

`semantic/RxTxSurface.svelte` renders the key button
(`data-testid="rx-tx-key"`, `onclick={onRequestKey}`) beside the unkey button
and the TX-target readout. After #3398/#3401 the flagship geometry probe put
that surface's `rx-tx` zone in the deck, on a fixed 160 px track between the
two receiver strips, under the skin's own containment (`min-width: 0;
overflow: auto`).

**Measured on this build** (headless Chromium 145.0.7632.6 via
`playwright-core` from `frontend/node_modules`, the real `RxTxSurface` mounted
over the probe's own style block with `:global(...)` unwrapped — see
"Measurement" below for exactly what was real and what was a stand-in): in a
160 px column the two buttons do not overflow the column at all — they are
**compressed**. `columnScrollWidth == columnClientWidth == 160`, so nothing
scrolls; the key button shrinks to **79.6 px** with `scrollWidth 103` against
`clientWidth 78`, i.e. its label is truncated with no scrollbar to reveal it.
The unkey button shrinks to 72.4 px (`scrollWidth 100 / clientWidth 70`).

Two corrections to the brief this PR was written from, both from the
measurement above rather than from reading:

- I measured the zone's natural width on this build as **270 px**
  (`max-content` 270, `min-content` 270, the key button 131.1 px at
  min-content). I could **not** reproduce the 374 px figure the brief carries
  from an earlier live look, and I did not run that look; I cannot say what
  differs.
- The brief says the key "scrolls inside its column" at 160. What I measured
  is compression with a clipped label, not scrolling. Either shape is the one
  the rule forbids — a control the operator cannot fully see — but the
  mechanism is the one above.

## The placement chosen, and why

The `rx-tx` zone moves out of the deck into the **right rail**, placed
**first**, above `tx-aux` → `cw-keyer` → `rit-xit-scan`, in both arrangements.

First rather than after `tx-aux`, because the rule that moved it is about the
key being seen and reached: first in the rail means no other transmit control
comes between the top of the transmit column and the key. The AD's "beside the
other transmit controls" is satisfied by `tx-aux` sitting immediately below it.
The order is pinned, not asserted in prose — the component test reads the four
rail areas' row indices out of both `grid-template-areas` and requires them
ascending in `RIGHT_RAIL` order.

The rail's floor and width are untouched: `--flagship-probe-rail-width` stays
280 px in both templates (T182 owns the floor). The measurement below is the
check that this did not create a reason to widen it.

## The deck's middle track collapses

With nothing left between the receivers, the RX/TX track is **removed**, not
zeroed: a 0-width track between two 8 px gaps would still hold 16 px of gutter
open where there was one gap. Both templates drop from five columns to four,
and `--flagship-probe-rx-tx-width` is deleted.

New threshold arithmetic — 2 rails + 2 strip minima + **three** gutters, no
rxTx term:

```
2×280 + 2×360 + 3×8 = 560 + 720 + 24 = 1304   (was 2×280 + 2×360 + 160 + 4×8 = 1472)
```

Updated together: the `--flagship-probe-switch-width` custom property, the
`@container (min-width: …)` literal, the manifest's
`stageSizing.responsiveBreakpoints`, and the two tests that recompute the sum
(both read the gap out of the style block, per #3401).

## Manifest

`rx-tx` stays declared and still mounts; its position in `zones[]` moves from
before `rf-front-end` to just before `tx-aux`, where the rail places it. This
is a manifest ordering only — per the T170 finding, DOM order is the wiring's,
not the manifest's, and no DOM order changes here.

## Measurement

Headless Chromium **145.0.7632.6**, driven by `playwright-core` from
`frontend/node_modules`, against a `vite` dev server on this branch at
`01c3ba9c`. The page injects **the skin's own style block**, read with `?raw`
and with `:global(...)` unwrapped, over a DOM carrying the same hooks: the
`display: contents` wrappers, two `data-strip-receiver` strips, one div per
`data-zone-id`, `.probe-panorama`. The `rx-tx` zone holds the **real**
`RxTxSurface.svelte` (RX, target known MAIN/A/14250000 Hz, permit allowed, no
fault) inside the wiring's `.rx-tx-zone` flex-column rule, with
`components-v2/theme/index` loaded as the skin loads it. Every other zone is a
stand-in div; `band` and `cw-keyer` carry 1813 px and 518 px children, the
natural widths PR #3401's body records from its live look — cited, not measured
here. The page is not committed.

Boxes are `getBoundingClientRect`; `sw`/`cw` are `scrollWidth`/`clientWidth`.

| container | arrangement | `grid-template-columns` | MAIN / SUB width | MAIN / SUB `clientWidth` | rx-tx zone (rail column) | key button | key inside rail | unkey inside rail |
|---|---|---|---|---|---|---|---|---|
| 1303 | narrow | `280px 359.5px 359.5px 280px` | 647.5 / 647.5 | 648 / 648 | 1023..1303 (280; sw 280 / cw 280) | 1023..1154.1 (131.1; sw 129 / cw 129) | yes | yes |
| 1304 | wide | `280px 360px 360px 280px` | 360 / 360 | 360 / 360 | 1024..1304 (280; sw 280 / cw 280) | 1024..1155.1 (131.1; sw 129 / cw 129) | yes | yes |
| 1920 | wide | `280px 668px 668px 280px` | 668 / 668 | 668 / 668 | 1640..1920 (280; sw 280 / cw 280) | 1640..1771.1 (131.1; sw 129 / cw 129) | yes | yes |
| 2400 | wide | `280px 908px 908px 280px` | 908 / 908 | 908 / 908 | 2120..2400 (280; sw 280 / cw 280) | 2120..2251.1 (131.1; sw 129 / cw 129) | yes | yes |

Rows 1303 and 1304 are threshold−1 and the threshold: the switch fires where
the arithmetic says it does, and the two flexible tracks reach their declared
360 px floor exactly at 1304.

At every width the rail column is 280 px wide and the `rx-tx` zone reports
`scrollWidth == clientWidth == 280` — **the zone needs no horizontal scrolling
at the rail's declared 280**. The key button is 131.1 px there with
`scrollWidth == clientWidth == 129`, so nothing is clipped inside it either;
its box lies fully inside the rail at all four widths, and so does the unkey
button (which ends 10 px short of the rail's right edge at every width).

At 280 the surface neither wraps nor scrolls: the target readout is one 24 px
line, and the zone's `min-content` width is 270 px — 10 px under the rail. So
this move did not become a reason to widen the rail.

Panorama and strip boxes are stand-in-driven only in their *content*; their
*tracks* are the numbers above, and the 1813 px stand-in in `band` leaves the
left rail's track at 280 in every row, as #3401 established for the same DOM.

## Tests

`frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts`
(the arrangement is a container query and jsdom evaluates none, so the CSS half
of this file parses both `grid-template-areas` and both `grid-template-columns`
out of the skin's own style block):

- **new** — `template %i (%s) puts rx-tx first in the right rail`: `rx-tx`
  occupies only the last column in both templates, that column's track is
  `minmax(0, var(--flagship-probe-rail-width))`, and the four rail areas'
  row indices ascend in `rx-tx → tx-aux → cw-keyer → rit-xit` order.
- **new** — `column template %i (%s) declares one track per named column, none
  of them empty`: the track count equals the areas template's column count, and
  no column is `.` in every row. This is the no-empty-gutter rule.
- **rewritten** — `keeps the two receivers side by side`: between the two rail
  columns the deck row is exactly `['rx-main', 'rx-sub']` — no third area.
- **updated** — the deck set in `narrow gives the deck the full width`; both
  threshold-sum tests (now `2·rail + 2·strip + 3·gap`, and the wide template's
  own four declared widths + three gutters); the track-count and rail-index
  assertions (5 → 4 columns); `RIGHT_RAIL`.

`frontend/src/presentation/layouts/__tests__/flagship-probe-registration.test.ts`
is unchanged and still green: it derives the reflow width from the skin source,
so it followed 1472 → 1304 on its own.

Local runs on `01c3ba9c`: `vitest run src/skins/flagship-probe/
src/presentation/layouts/ src/semantic/__tests__/rx-tx-surface.component.test.ts`
→ **29 files, 498 tests, 0 failures**. `npm run check` → 4844 files, 0 errors,
0 warnings. `npm run lint` and `npm run lint:boundaries` → clean. The full
suite is CI's.

## Mutations run

Each was applied to the skin, the tests run, then the tree restored with
`git checkout --`; `git diff` is empty against the commit.

| mutation | result |
|---|---|
| **1 — the exact bug removed**: `rx-tx` back in the deck between the strips on a `var(--flagship-probe-rx-tx-width)` = 160 px track, both templates back to five columns, threshold back to 1472 | **15 failed**, incl. `puts rx-tx first in the right rail` (both templates), `keeps the two receivers side by side` (both), `narrow gives the deck the full width`, both threshold sums, and the registration file's `declares the same reflow width the shell switches at` |
| **2 — the 160 px track left in the wide template only**, no area naming it | **6 failed**, incl. the named `column template 1 (wide) declares one track per named column, none of them empty` |
| **3 — `rx-tx` in the rail but second**, below `tx-aux`, both templates | **3 failed**: `puts rx-tx first in the right rail` (both templates) on the row-order assertion, and `wide shares its row with both rails` |
| **refactor control** — the `grid-area: rx-tx` rule moved back among its siblings and the narrow column template rewrapped onto two lines | **green**, 36/36 |

Mutation 3 is the one that shows the ordering claim in the skin header is
carried by a test rather than by prose.

## Size

`git diff --numstat origin/main...HEAD` — **3 files, 101+/65- = 166 changed
lines** at `01c3ba9c`. Under the 6-file / 600-line soft threshold.

## Out of scope

- The rail's floor and width (T182) — 280 px is untouched here.
- The flagship's own between-receivers column (T183).

internal-identifier self-check — empty.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
