### PR TITLE
fix: give the probe's rails a transmit-key floor measured with growable labels

### DIFF
--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -189,7 +189,7 @@ export const flagshipProbeLayout: LayoutManifest = {
   // `__tests__/flagship-probe-registration.test.ts` requires this
   // declaration, that custom property and the `@container` literal to name
   // the same width.
-  stageSizing: { mode: 'fluid', responsiveBreakpoints: [1304] },
+  stageSizing: { mode: 'fluid', responsiveBreakpoints: [1502] },
   fallbackLayoutId: 'sdr-test',
 };
 

--- a/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
+++ b/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
@@ -23,10 +23,12 @@
   clipped column. `semantic/RxTxSurface.svelte` renders that key, so its
   `rx-tx` zone is placed FIRST in the right rail, above the other transmit
   controls, in both arrangements — `__tests__/FlagshipProbe.component.test.ts`
-  requires the rail column, that position and the rail's declared width
-  together. Nothing then stands between the two receivers, and the deck's
-  middle track is gone rather than empty: the same test requires every track
-  in both column templates to be a column some area names.
+  requires the rail column, that position and the rail's declared track
+  together. The rail's own minimum is the width that key pair needs — see
+  `--flagship-probe-rail-floor` below. Nothing then stands between the two
+  receivers, and the deck's middle track is gone rather than empty: the same
+  test requires every track in both column templates to be a column some area
+  names.
 
   The switch is a container query on `.flagship-probe`, so it follows the
   width this skin is GIVEN rather than the viewport's. Its threshold is
@@ -40,7 +42,7 @@
   requires the manifest's declared reflow width to equal it too.
 
   NO SURFACE MAY SIZE A TRACK. Every track in both column templates is a
-  declared size: the rails are `minmax(0, <rail>)` and the two receiver
+  declared size: the rails are `minmax(<floor>, <rail>)` and the two receiver
   strips are the flexible tracks that take the remainder. None is `auto`,
   `min-content`, `max-content` or `fit-content`, in either direction. A
   surface wider than its column overflows inside that column. The component
@@ -94,13 +96,33 @@
     height: 100%;
 
     /*
+      TRANSMIT-KEY floor: measured 2026-09-09 with pseudo-localised key
+      labels (`⟦Ķéý ťŕáñšɱíťťéŕ ~~~~~~⟧` and `⟦Úñķéý ťŕáñšɱíťťéŕ ~~~~~~⟧`,
+      `lib/i18n/pseudo.ts`'s `pseudoize()` applied to the two hard-coded
+      English strings `semantic/RxTxSurface.svelte` renders) on the
+      fixture-stub harness — `vite.fixtures.config.ts`, fixture
+      `topology-2-main-sub`, Chromium; do not lower it to make a layout fit.
+
+      Derived from labels that CAN grow, not from the ones shipped today: the
+      key and unkey buttons are `white-space: nowrap` on one non-wrapping
+      flex row, so the pair is atomic — neither key is reachable without room
+      for both. Those two strings are hard-coded English, so nothing can grow
+      them today; the day they are localised they grow together.
+      `__tests__/FlagshipProbe.component.test.ts` pins this value and the
+      shape of the two rail tracks below.
+    */
+    --flagship-probe-rail-floor: 379px;
+
+    /*
       The declared track widths — a rail's width and a receiver strip's
       minimum — and their sum with the three gutters `.probe-stage` puts
-      between the four columns.
+      between the four columns. The rail's width is the floor: the measured
+      floor came out above the 280px this rail carried before it, and a rail
+      narrower than its own floor is not a rail.
     */
-    --flagship-probe-rail-width: 280px;
+    --flagship-probe-rail-width: 379px;
     --flagship-probe-strip-min-width: 360px;
-    --flagship-probe-switch-width: 1304px;
+    --flagship-probe-switch-width: 1502px;
   }
 
   /*
@@ -113,21 +135,29 @@
     between them. The deck spans all four columns in the narrow arrangement
     and columns 2-3 in the wide one; that is the whole of the switch.
 
-    Both templates size the rails to a declared width and give the remainder
-    to columns 2 and 3. The wide one alone floors those two at the declared
-    strip minimum, because it is the arrangement in which a receiver strip
-    occupies one of them on its own — in the narrow one each strip spans a
-    rail column and its neighbour.
+    Both templates floor the rails at the transmit-key floor, cap them at the
+    declared rail width and give the remainder to columns 2 and 3. The wide
+    one alone floors those two at the declared strip minimum, because it is
+    the arrangement in which a receiver strip occupies one of them on its own
+    — in the narrow one each strip spans a rail column and its neighbour.
+
+    The rail floor is a hard track minimum, so the two flexible columns are
+    what gives first: at a container narrower than both rails and the three
+    gutters together they reach 0, and this grid then overflows its container
+    rather than compressing a rail. That is the intended answer — below this
+    arrangement is the mobile skin, which `skins/registry.ts: resolveSkinId`
+    returns ahead of this one whenever the app reports a mobile viewport, and
+    which is a separate design rather than this one squeezed.
   */
   .probe-stage {
     display: grid;
     gap: 8px;
     align-content: start;
     grid-template-columns:
-      minmax(0, var(--flagship-probe-rail-width))
+      minmax(var(--flagship-probe-rail-floor), var(--flagship-probe-rail-width))
       minmax(0, 1fr)
       minmax(0, 1fr)
-      minmax(0, var(--flagship-probe-rail-width));
+      minmax(var(--flagship-probe-rail-floor), var(--flagship-probe-rail-width));
     grid-template-areas:
       'rx-main   rx-main    rx-sub     rx-sub'
       'vfo-ops   vfo-ops    vfo-ops    vfo-ops'
@@ -140,13 +170,13 @@
       'meters    meters     meters     meters';
   }
 
-  @container (min-width: 1304px) {
+  @container (min-width: 1502px) {
     .probe-stage {
       grid-template-columns:
-        minmax(0, var(--flagship-probe-rail-width))
+        minmax(var(--flagship-probe-rail-floor), var(--flagship-probe-rail-width))
         minmax(var(--flagship-probe-strip-min-width), 1fr)
         minmax(var(--flagship-probe-strip-min-width), 1fr)
-        minmax(0, var(--flagship-probe-rail-width));
+        minmax(var(--flagship-probe-rail-floor), var(--flagship-probe-rail-width));
       grid-template-areas:
         'rf        rx-main    rx-sub     rx-tx'
         'dsp       vfo-ops    vfo-ops    tx-aux'

--- a/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
+++ b/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
@@ -345,8 +345,7 @@ describe('the panorama sits between the two rails, in both arrangements', () => 
     const template = templates()[index as number];
     const lastColumn = template[0].length - 1;
     expect(columnsOf(template, 'rx-tx')).toEqual([lastColumn]);
-    expect(columnTemplates()[index as number][lastColumn])
-      .toBe('minmax(0, var(--flagship-probe-rail-width))');
+    expect(columnTemplates()[index as number][lastColumn]).toBe(RAIL_TRACK);
     // First in the rail: no other transmit control comes between the top of
     // the transmit column and the key.
     const rows = RIGHT_RAIL.map((area) => rowOf(template, area));
@@ -428,14 +427,19 @@ function columnTemplates(): string[][] {
     .map(([, body]) => splitTracks(body));
 }
 
-/** The one px length a track sizing function declares, after substituting the
- *  custom properties it is written with. */
+/** The largest px length a track sizing function declares, after substituting
+ *  the custom properties it is written with: a rail's maximum (its declared
+ *  width, the minimum being the floor), and a strip's minimum (its maximum
+ *  being `1fr`, which declares no length). */
 function declaredPx(track: string): number {
   const resolved = track.replace(/var\((--[a-z-]+)\)/g, (_match, name: string) => `${px(name)}px`);
   const lengths = [...resolved.matchAll(/(\d+)px/g)].map(([, value]) => Number(value));
-  expect(lengths).toHaveLength(1);
-  return lengths[0];
+  expect(lengths.length).toBeGreaterThan(0);
+  return Math.max(...lengths);
 }
+
+/** The one shape a rail track may take. */
+const RAIL_TRACK = 'minmax(var(--flagship-probe-rail-floor), var(--flagship-probe-rail-width))';
 
 const CONTENT_SIZED = /\b(auto|min-content|max-content|fit-content)\b/;
 
@@ -451,10 +455,12 @@ describe('no surface may size a track', () => {
   });
 
   // Kills: a rail whose maximum is anything but the declared rail width, and
-  // a rail whose minimum is anything but 0.
-  it.each([[0, 'narrow'], [1, 'wide']])('column template %i (%s) caps both rails at the declared rail width', (index) => {
+  // a rail whose minimum is anything but the transmit-key floor — including
+  // the `minmax(0, …)` this rail carried before the floor existed, which let
+  // it compress to any width at all.
+  it.each([[0, 'narrow'], [1, 'wide']])('column template %i (%s) floors both rails at the transmit-key floor and caps them at the declared rail width', (index) => {
     const tracks = columnTemplates()[index as number];
-    expect(tracks[0]).toBe('minmax(0, var(--flagship-probe-rail-width))');
+    expect(tracks[0]).toBe(RAIL_TRACK);
     expect(tracks[3]).toBe(tracks[0]);
   });
 
@@ -503,6 +509,36 @@ describe('no surface may size a track', () => {
   it('contains what does not fit inside the column it belongs to', () => {
     expect(style).toMatch(/:global\(\[data-zone-id\]\)\s*\{[^}]*overflow:\s*auto/);
     expect(style).toMatch(/\.probe-panorama\s*\{[^}]*overflow:\s*auto/);
+  });
+});
+
+describe('the transmit-key floor', () => {
+  /**
+   * The floor was measured in Chromium on 2026-09-09, on the real
+   * `FlagshipProbeSkin` mounted through the fixture-stub seam
+   * (`vite.fixtures.config.ts`, fixture `topology-2-main-sub`), with the two
+   * transmit-key labels replaced in the DOM by `lib/i18n/pseudo.ts`'s
+   * `pseudoize()` output. The `.rx-tx-actions` row's min-content came to
+   * 378.09px there — 379 is that measurement rounded up to a whole pixel.
+   * The rail width equals it because that floor came out above the 280px the
+   * rail carried before. The PR body carries the full table.
+   *
+   * Kills: lowering the floor to make some layout fit, which is exactly what
+   * the comment on the declaration forbids and what no other test here would
+   * notice — every other assertion in this file is about the FORM of the
+   * track, and `minmax(var(--floor), var(--width))` keeps its form at any
+   * value of either.
+   */
+  it('declares the measured floor, and a rail width raised to it', () => {
+    expect(px('--flagship-probe-rail-floor')).toBe(379);
+    expect(px('--flagship-probe-rail-width')).toBe(379);
+  });
+
+  // Kills: a rail width below its own floor, which would make `minmax()`
+  // resolve to the floor and leave the declared width a dead number.
+  it('never declares a rail width below the floor', () => {
+    expect(px('--flagship-probe-rail-floor'))
+      .toBeLessThanOrEqual(px('--flagship-probe-rail-width'));
   });
 });
 


### PR DESCRIPTION
The probe's rails were `minmax(0, var(--flagship-probe-rail-width))` at 280px,
so they compressed to 104px at a 400px container and 64px at 320px. This gives
them a floor, and the floor is measured rather than declared.

## How the numbers were taken

A scratch harness (not committed) mounted the real `FlagshipProbeSkin` through
the existing fixture-stub seam — `vite.fixtures.config.ts`, `fixtures/catalog.ts`
fixture `topology-2-main-sub`, `resolveSurfacePlan(flagshipProbeLayout,
readWorkspace({version:1}).workspace)` — driven by the same vite `createServer` +
Chromium bootstrap `fixtures/capture.mjs` uses. So the numbers come off the real
wiring, the real semantic surfaces and the real token layer.

Two measurement primitives, both restoring the element's inline style afterwards:

- `minContent(el)`: `el.style.width = 'min-content'`, read `getBoundingClientRect().width`.
- `intrinsic(el)`: `flex: none; width: max-content; min-width: max-content; max-width: none`.
  `flex: none` is load-bearing — the key/unkey buttons are flex items, so a plain
  `width: min-content` on one of them is still a base size that `flex-shrink` then
  pulls back to whatever the line has room for. Without it the pseudo-localised
  key and unkey read 138.16 and 133.84, which sum with the 8px gap to exactly the
  280px rail: the shrink, not the width.

Method check: with the shipped English labels this harness reproduces the #3404
review's numbers exactly — key 131.13, unkey 130.83, gap 8, `.rx-tx-actions`
min-content 269.95 (the review reported 131.1 / 130.8 / 270).

## Widest single key per rail surface

Container 1920px. `withPadding` = widest key + that zone's own
`padding-left` + `padding-right`; every rail zone measured 0/0, because
`SemanticRadioSurfaces.svelte`'s `.surface-zone` and `.rx-tx-zone` are
`display: flex; flex-direction: column; gap: 8px` and declare no padding.

| zone | widest single key (px) | that key's label | pad L/R | with padding |
|---|---|---|---|---|
| `band` | 175.33 | `20m` (the same button carries its `<small>` permit line, `TX at 14.195 MHz: allowed`) | 0/0 | 175.33 |
| `cw-keyer` | 130.11 | `Reverse paddle: —` | 0/0 | 130.11 |
| `rf-front-end` | 87.86 | `DIGI-SEL: ?` | 0/0 | 87.86 |
| `antenna` | 84.89 | `RX-ANT: —` | 0/0 | 84.89 |
| `tx-aux` | 69.44 | `COMP: ?` | 0/0 | 69.44 |
| `filter` | 63.41 | `RTTY-R` | 0/0 | 63.41 |
| `rit-xit-scan` | 60.45 | `CLEAR` | 0/0 | 60.45 |
| `dsp` | 59.73 | `manual` | 0/0 | 59.73 |
| `rx-audio` | 58.25 | `split on` | 0/0 | 58.25 |

Widest across the nine: **175.33px**.

## The pseudo-localised transmit pair

`semantic/RxTxSurface.svelte`'s two labels are hard-coded English, so the harness
replaced their text in the DOM with `lib/i18n/pseudo.ts`'s own `pseudoize()`
output — the repo's `qps-ploc` rule (diacritic substitution, `⟦`/`⟧` wrappers,
`Math.ceil(len * 0.35)` `~` padding), applied by importing that module rather
than by re-deriving it. Exact strings:

- `Key transmitter` → `⟦Ķéý ťŕáñšɱíťťéŕ ~~~~~~⟧`
- `Unkey transmitter` → `⟦Úñķéý ťŕáñšɱíťťéŕ ~~~~~~⟧`

| labels | key | gap | unkey | `.rx-tx-actions` min-content |
|---|---|---|---|---|
| shipped English | 131.13 | 8 | 130.83 | 269.95 |
| pseudo-localised | 185.20 | 8 | 184.89 | **378.09** |

The `rx-tx` zone's min-content equals the row's in both cases (zone padding 0).
The pair is atomic: `.v2-control-button` is `white-space: nowrap`
(`components-v2/controls/control-button.css`) and `.rx-tx-actions` is a
default-`nowrap` flex row, so neither key is reachable without room for both.

## The floor

```
floor = max(widest single key + surface padding, pseudo-localised pair min-content)
      = max(175.33, 378.09)
      = 378.09  ->  --flagship-probe-rail-floor: 379px   (rounded up to a whole pixel)
```

**The transmit-pair term wins, by 202.76px.** The widest rail key is not close.

**280 did not survive.** The floor exceeds it, so the rail width rises to the
floor: `--flagship-probe-rail-width` 280px → 379px, and the switch threshold
with it: `2*379 + 2*360 + 3*8 = 1502`, in `--flagship-probe-switch-width`, the
`@container` literal and `flagshipProbeLayout.stageSizing.responsiveBreakpoints`
(1304 → 1502).

What 280 does to that pair, measured directly: with the rail forced back to
280px and the same pseudo-localised labels, the key button's box is 136px wide
against 160px of content (`clientWidth` 136 vs `scrollWidth` 160; unkey 132 vs
157). The transmit key clips — in a rail width a measurement had certified as
safe. The 10px of headroom the English labels leave was a coincidence of two
strings nobody can translate yet.

Both rail tracks in **both** column templates are now
`minmax(var(--flagship-probe-rail-floor), var(--flagship-probe-rail-width))`.

## Mobile boundary and the band below the floor

`skins/registry.ts: resolveSkinId` returns `'mobile'` on its **first** branch,
`if (ctx.isMobile)`, ahead of the `'flagship-probe'` branch — so the probe is
unreachable whenever the app reports a mobile viewport. `App.svelte` computes
that as `Math.min(windowWidth, windowHeight) < 640 || ('ontouchstart' in
globalThis && Math.min(windowWidth, windowHeight) < 500)`.

`App.svelte` mounts a self-contained skin as a bare `<SelfContainedComponent />`
with no wrapper, and the only `#app` rule in the tree (`src/app.css`) declares
`min-height` alone, over `body { margin: 0 }` — so the probe's container width is
the document's own width. That is read from those two files; I did not measure it
end to end through the real `App`.

**Rails are never rendered below the floor at any container width.** The floor is
a hard track minimum, so the two flexible columns give instead. Measured:

- Both flexible columns reach 0 at container **782px** (`2*379 + 3*8`), leaving
  the panorama box at 8px — the gap between two zero-width tracks.
- Below 782px the stage **overflows horizontally**: `scrollWidth` stays pinned at
  782 while `clientWidth` follows the container. So the answer to "shrink or
  overflow" is: the panorama shrinks first, to nothing, and then the stage
  overflows.
- **The band to report: 640 ≤ container < 782.** That is the part reachable
  through `resolveSkinId` — the panorama has no width and the stage overflows by
  up to 142px at 640.
- Below container 534.13px the transmit key's own right edge lies outside the
  container box (its right edge sits at x = 534.13 for every container ≤ 782).
  That is under the 640 the mobile predicate leaves, so it is not reachable
  through `resolveSkinId`.

No third arrangement was added.

## Browser table

Chromium, fixture `topology-2-main-sub`, shipped English labels, container width
set on the box the skin is mounted in. "Below floor?" compares the used rail
track against 379. "Key fully inside?" is the key's own `scrollWidth` vs
`clientWidth` (clipping) and its rect against its zone's rect.

| container | rail tracks (used) | below floor? | transmit key fully inside? | stage `scrollWidth`/`clientWidth` |
|---|---|---|---|---|
| 320 | 379 / 0 / 0 / 379 | no | not clipped (129 = 129), inside its zone; right edge x=534.13 is outside the 320 container | 782 / 320 |
| 400 | 379 / 0 / 0 / 379 | no | not clipped, inside its zone; right edge x=534.13 outside the 400 container | 782 / 400 |
| 640 | 379 / 0 / 0 / 379 | no | yes | 782 / 640 |
| 781 | 379 / 0 / 0 / 379 | no | yes | 782 / 781 |
| 782 | 379 / 0 / 0 / 379 | no | yes | 782 / 782 |
| 783 | 379 / 0.5 / 0.5 / 379 | no | yes | 783 / 783 |
| 1501 | 379 / 359.5 / 359.5 / 379 | no | yes | 1501 / 1501 |
| 1502 | 379 / 360 / 360 / 379 | no | yes | 1502 / 1502 |
| 1503 | 379 / 360.5 / 360.5 / 379 | no | yes | 1503 / 1503 |
| 1920 | 379 / 569 / 569 / 379 | no | yes | 1920 / 1920 |

781/782/783 are the floor boundary ±1; 1501/1502/1503 are the new switch
threshold ±1. The key's rect is 131.13 and its `scrollWidth`/`clientWidth` are
129/129 on every row. No console errors at any width.

## Tests

`src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts`:

- New `describe('the transmit-key floor')`: the **declared-value** case pins
  `--flagship-probe-rail-floor` and `--flagship-probe-rail-width` at 379, and a
  second case requires floor ≤ width.
- The existing rail-**form** case now requires both rail tracks in both column
  templates to be exactly
  `minmax(var(--flagship-probe-rail-floor), var(--flagship-probe-rail-width))`,
  as does the `rx-tx first in the right rail` case.
- `declaredPx` now takes the largest px length a track declares (a rail's
  maximum, a strip's minimum) instead of requiring exactly one — a rail track
  now carries two.

## Mutations run

| mutation | result |
|---|---|
| `--flagship-probe-rail-floor: 379px` → `340px` (below the measured 378.09 pair) | **killed** `the transmit-key floor > declares the measured floor, and a rail width raised to it`. The floor ≤ width case correctly stayed green (340 ≤ 379). |
| both rail tracks back to `minmax(0, var(--flagship-probe-rail-width))` | **killed 4**: `no surface may size a track > column template 0 (narrow)` and `1 (wide) floors both rails …`, plus `the panorama sits between the two rails > template 0 (narrow)` and `1 (wide) puts rx-tx first in the right rail`. |
| refactor, no value change: `--flagship-probe-rail-floor` declaration moved below `--flagship-probe-rail-width` | **green**, 38/38 — the tests pin values and form, not source order. |

The tree was restored after each; `git diff` at the pushed head shows only the
intended change.

## Gates

- `npm run lint` — clean
- `npm run lint:boundaries` — clean
- `npm run check` — 4844 files, 0 errors, 0 warnings
- `npx vitest run src/presentation/ src/skins/` — 82 files, **1827 passed, 0 failed**

The full vitest suite was not run locally (one tree state, one instrument); the
`visual` CI lane is what covers the rendered baselines.

3 files, 94+/28- = 122 changed lines at `56a2be8e` — inside the 6-file / 600-line
soft threshold.

## Out of scope

- **Localising the transmit key labels (T184).** `semantic/RxTxSurface.svelte`
  still renders `Key transmitter` and `Unkey transmitter` as literal English.
  This PR changes no label; the floor is what makes localising them safe here.
- **`App.svelte`'s `isMobile` second disjunct.** `Math.min(w,h) < 640 ||
  ('ontouchstart' in globalThis && Math.min(w,h) < 500)` — the second disjunct is
  implied by the first, so it can never change the result. Noticed while
  establishing the mobile boundary; not touched.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
