### PR TITLE
feat: let a layout suppress the band key's printed permit through the wiring; the probe prints the name only

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -162,6 +162,11 @@
     scopeControlsInRegionContent?: boolean;
     regionExtras?: Snippet<['left' | 'right']>;
     vfoAppearance?: 'semantic' | 'sdr' | 'standard';
+    /** Whether the fallback band key PRINTS its permit sentence. The key's
+     *  accessible name and its `data-default-permit` carry that fact either
+     *  way — `semantic/BandInstrumentHost.svelte` owns the fact, the face
+     *  owns the print. */
+    bandPermitCaption?: boolean;
     displayFrameSource?: LcdSpectrumSource;
     readonlyDisplay?: Snippet<[RadioViewModel, LcdSpectrumFrame?]>;
   }
@@ -186,7 +191,7 @@
    * `zoneOwning()` returns non-null on both faces.
    */
   let {
-    children: hostedChildren, externalPresentation = null, strips = 'single', regions = false, regionContent, scopeControlsInRegionContent = false, regionExtras, vfoAppearance = 'semantic', displayFrameSource, readonlyDisplay,
+    children: hostedChildren, externalPresentation = null, strips = 'single', regions = false, regionContent, scopeControlsInRegionContent = false, regionExtras, vfoAppearance = 'semantic', bandPermitCaption = true, displayFrameSource, readonlyDisplay,
   }: Props = $props();
 
   /**
@@ -1580,6 +1585,7 @@
   <BandInstrumentHost
     {...bandFiniteRendererSelection} {view} entryRendererContext={bandFiniteRendererContext}
     onSelectBand={selectBand} onEnterFrequency={enterFrequency}
+    showPermitCaption={bandPermitCaption}
   >
   {#snippet children(bandInstruments)}
   <AntennaInstrumentHost

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -204,7 +204,9 @@ function publishAuthority(): void {
   }
 }
 
-function render(props: { strips?: 'single' | 'dual' } = {}): void {
+function render(props: {
+  strips?: 'single' | 'dual'; bandPermitCaption?: boolean;
+} = {}): void {
   target = document.createElement('div');
   document.body.appendChild(target);
   component = mount(SemanticRadioSurfaces, { target, props });
@@ -711,5 +713,75 @@ describe('a split TX target surfaces the caveat, end to end (fix-round F1)', () 
     expect(el('tx-caveat')!.textContent).toBe(t('core.band.tx.caveat.denied', {
       reason: t('core.band.tx.reason.outOfBand'),
     }));
+  });
+});
+
+/* ── the face decides whether the key PRINTS the permit ─────────── */
+
+describe('the layout decides whether the band key prints its permit', () => {
+  /** The three bands `BAND_PLAN` declares, in its own order. */
+  const NAMES = BAND_PLAN[0]!.bands.map((choice) => choice.name);
+
+  interface Key {
+    readonly name: string;
+    readonly text: string;
+    readonly ariaLabel: string;
+    readonly permit: string | null;
+    readonly defaultPermit: string | undefined;
+  }
+
+  /** Mounts the single composition, reads every band key, and unmounts —
+   *  so one test can compare two renders without leaving a live tree behind
+   *  for the `afterEach` teardown assertions. */
+  function readKeys(props: Parameters<typeof render>[0]): {
+    keys: Key[]; permitElements: number;
+  } {
+    render(props);
+    const permitElements =
+      target.querySelectorAll('[data-testid^="band-choice-permit-"]').length;
+    const keys = NAMES.map((name): Key => {
+      const button = btn(`choice-${name}`)!;
+      expect(button).not.toBeNull();
+      return {
+        name,
+        text: button.textContent ?? '',
+        ariaLabel: button.getAttribute('aria-label') ?? '',
+        permit: el(`choice-permit-${name}`)?.textContent ?? null,
+        defaultPermit: button.dataset.defaultPermit,
+      };
+    });
+    unmount(component!);
+    component = null;
+    return { keys, permitElements };
+  }
+
+  // MUTATION KILLED: a default that suppresses the caption. Every caller in
+  // the tree omits this prop, so the default is what they all render.
+  it('prints a caption on every key when the prop is omitted', () => {
+    const { keys, permitElements } = readKeys({});
+    expect(permitElements).toBe(NAMES.length);
+    for (const key of keys) {
+      expect(key.permit).not.toBeNull();
+      expect(key.permit).not.toBe('');
+      expect(key.text).toBe(`${key.name}${key.permit}`);
+      expect(key.ariaLabel).toBe(`${key.name} — ${key.permit}`);
+    }
+  });
+
+  // MUTATION KILLED: the prop left unthreaded by the wiring, which leaves the
+  // caption printed; and a suppression that takes the FACT away with the
+  // print — the accessible name and `data-default-permit` still carry it.
+  it('prints none with bandPermitCaption={false}, keeping every name and permit attribute', () => {
+    const printed = readKeys({}).keys;
+    const { keys, permitElements } = readKeys({ bandPermitCaption: false });
+    expect(permitElements).toBe(0);
+    expect(keys).toHaveLength(printed.length);
+    for (const [index, key] of keys.entries()) {
+      const before = printed[index]!;
+      expect(key.permit).toBeNull();
+      expect(key.text).toBe(key.name);
+      expect(key.ariaLabel).toBe(before.ariaLabel);
+      expect(key.defaultPermit).toBe(before.defaultPermit);
+    }
   });
 });

--- a/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
@@ -128,8 +128,11 @@ const DOM_BACKED: Readonly<Record<string, () => boolean>> = {
   'dual-receiver-cockpit': () => /<SemanticRadioSurfaces strips="dual"\s*\/>/.test(cockpitShellSource),
   // T160 PR-1: the geometry probe mounts the same dual-receiver composition
   // unconditionally, so every surface its manifest declares has a real DOM
-  // path rather than a forward declaration.
-  'flagship-probe': () => /<SemanticRadioSurfaces strips="dual"\s*\/>/.test(flagshipProbeShellSource),
+  // path rather than a forward declaration. Written in `peer-split`'s
+  // attribute-order-free form below, because this shell now passes a
+  // presentation prop beside `strips` — what is asserted is the dual mount,
+  // not the rest of the attribute list.
+  'flagship-probe': () => /<SemanticRadioSurfaces(?=[^>]*\bstrips\s*=\s*"dual")[^>]*\/>/.test(flagshipProbeShellSource),
   // MOR-2151: PeerSplitLayout.svelte mounts the same dual-receiver
   // composition unconditionally, so its manifest-declared VFO/RX-TX
   // surfaces have a real DOM path rather than a forward declaration.

--- a/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
+++ b/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
@@ -12,6 +12,14 @@
   What it deliberately does NOT do: the `memory` surface is not declared, the
   type ladder is not applied, and no key is given a lamp.
 
+  THE BAND KEY PRINTS ITS NAME ONLY: `bandPermitCaption={false}` suppresses
+  the key's printed permit caption and nothing else, the permit itself
+  staying in the key's accessible name and its `data-default-permit` —
+  `semantic/__tests__/BandInstrumentHost.isolated.test.ts`'s "suppresses only
+  the printed caption, keeping the accessible name and the attribute" pins
+  that split at the surface, and `__tests__/FlagshipProbe.component.test.ts`
+  requires it of the keys this shell mounts.
+
   ARRANGEMENT. Two receivers side by side in BOTH arrangements, and the
   panorama always between the two rails, never under one:
 
@@ -67,7 +75,7 @@
 
 <div class="flagship-probe" data-testid="flagship-geometry-probe">
   <div class="probe-stage" data-testid="probe-stage">
-    <SemanticRadioSurfaces strips="dual" />
+    <SemanticRadioSurfaces strips="dual" bandPermitCaption={false} />
     <!--
       `hideScopeControls`: the fact-backed half of the spectrum toolbar is
       suppressed because the semantic `scopeControls` surface renders it,

--- a/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
+++ b/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
@@ -642,3 +642,30 @@ describe('R52 — this shell announces nothing it does not know', () => {
     expect(markup).not.toContain('{#each');
   });
 });
+
+describe('the band key prints its name only', () => {
+  /**
+   * Kills: this shell omitting `bandPermitCaption` or passing `true`, and the
+   * wiring not threading it to the band surface — either leaves the caption
+   * printed. Also kills a suppression that takes the permit away with the
+   * print: the key's accessible name and `data-default-permit` still carry
+   * it, which is the same split
+   * `semantic/__tests__/BandInstrumentHost.isolated.test.ts`'s "suppresses
+   * only the printed caption, keeping the accessible name and the attribute"
+   * pins at the surface.
+   */
+  it('mounts band keys with no printed permit, each still naming its permit', () => {
+    render();
+    const keys = qa<HTMLButtonElement>('button[data-testid^="band-choice-"]');
+    expect(keys.length).toBeGreaterThan(0);
+    expect(qa('[data-testid^="band-choice-permit-"]')).toEqual([]);
+    for (const key of keys) {
+      const name = key.dataset.testid!.slice('band-choice-'.length);
+      expect(key.textContent).toBe(name);
+      const label = key.getAttribute('aria-label') ?? '';
+      expect(label.startsWith(`${name} — `)).toBe(true);
+      expect(label.length).toBeGreaterThan(`${name} — `.length);
+      expect(key.dataset.defaultPermit).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
**The rule.** The surface owns the fact; the face owns whether it is printed.

**The fact.** `semantic/BandInstrumentHost.svelte` already carried that split:
its `showPermitCaption` (default `true`, added in #3402) gates only the
printed `<small data-testid="band-choice-permit-…">` caption, while the key's
`aria-label` (`name — permit`) and its `data-default-permit` carry the permit
either way. `semantic/__tests__/BandInstrumentHost.isolated.test.ts`'s
"suppresses only the printed caption, keeping the accessible name and the
attribute" pins that at the surface. No face could reach it: nothing threaded
the prop, and `git grep -n showPermitCaption -- frontend/src` at
`origin/main` (0e568fdb) matched only the host, that test and its fixture.

**The prop.** `components-v2/wiring/SemanticRadioSurfaces.svelte` gains one
optional `bandPermitCaption?: boolean` (default `true`), destructured beside
`vfoAppearance` and passed as `showPermitCaption={bandPermitCaption}` at its
single `<BandInstrumentHost>` mount site. `vfoAppearance` is the precedent: a
plain prop threaded to one deep surface, rather than a layout-manifest field.
Every existing caller omits it and renders exactly as before.

**The probe.** `skins/flagship-probe/FlagshipProbeSkin.svelte` mounts
`<SemanticRadioSurfaces strips="dual" bandPermitCaption={false} />`, so each
band key prints its name only.

**Tests.**

- `components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts` —
  with the prop omitted every key prints a caption and its accessible name is
  `name — caption`; with `bandPermitCaption={false}` no
  `band-choice-permit-*` element renders, each key's text is its name alone,
  and every `aria-label` and `data-default-permit` is byte-for-byte the value
  the default render produced for that same key (compared render to render,
  not against a re-derived expectation).
- `skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts` — the
  mounted probe has band keys, no `band-choice-permit-*` element, and every
  key's accessible name still begins `name — ` and is longer than that.
- `presentation/layouts/__tests__/forward-declaration-inventory.test.ts` — the
  `flagship-probe` DOM-backing prober moves to the attribute-order-free form
  `peer-split` already uses in the same map, because the probe's mount now
  carries a second attribute. It still asserts the same thing: an
  unconditional self-closing `strips="dual"` mount.

**Mutations run** (each reverted; the final suite ran on the restored tree):

| Mutation | Result |
|---|---|
| `showPermitCaption={bandPermitCaption}` deleted from the wiring (default only) | wiring false-case **and** probe test fail — 2 failed, 69 passed |
| probe passes `bandPermitCaption={true}` | probe test fails, wiring green — 1 failed, 70 passed |
| probe omits the prop | probe test fails, wiring and inventory green — 1 failed, 75 passed |

Restored: `git status --short` shows the five files below and nothing else.

**Gates run locally** (`frontend/`): the three touched test files plus the
`BandInstrumentHost.isolated` file cited above — 89 passed, 0 failed; `npm run check` — 4844 files, 0 errors, 0 warnings;
`npm run lint` and `npm run lint:boundaries` — clean. The wider directories
this change can reach (`src/skins src/presentation src/components-v2
src/semantic src/__tests__` plus `qa-cockpit-override`) — 306 files, 7584
passed, 0 failed. No whole-suite run; CI's is the record.

**`visual`**: no baseline can move. With the prop omitted the composed DOM is
byte-identical between base and head (independent review measured it), only the
probe passes `false`, and
`grep -n "'band'" frontend/src/presentation/layouts/*.ts` shows only
`desktop-v2`, `sdr-test` and `flagship-probe` declare one — none of which is
behind any scene in `tests/e2e/visual/visual-baselines.spec.ts` (those resolve
the `dual-receiver-cockpit` plan or a segmentline manifest, per
`frontend/fixtures/main.ts`). The probe itself has no baseline. The default
is unchanged besides.

**Out of scope**: the rail-floor re-measurement with the caption suppressed
(T187), and the transmit-pair wrap (T185).

5 files, 121+/5- = 126 changed lines at 2d142685 — under the 6-file/600-line
soft threshold.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

