### PR TITLE
fix: let the transmit key pair wrap when its column is narrower than the pair

### DIFF
--- a/frontend/src/semantic/RxTxSurface.svelte
+++ b/frontend/src/semantic/RxTxSurface.svelte
@@ -159,7 +159,7 @@
   .rx-tx-state { display: flex; align-items: baseline; gap: 0.4ch; margin: 0; }
   .rx-tx-label { font-weight: 700; letter-spacing: 0.08em; }
   .rx-tx-fault { margin: 0; font-weight: 700; }
-  .rx-tx-actions { display: flex; gap: 0.5rem; }
+  .rx-tx-actions { display: flex; flex-wrap: wrap; gap: 0.5rem; }
   .rx-tx-blocked { margin: 0; padding-inline-start: 1.2em; }
   .rx-tx-blocked:empty { display: none; }
 </style>

--- a/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
+++ b/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
@@ -104,10 +104,10 @@
       `topology-2-main-sub`, Chromium; do not lower it to make a layout fit.
 
       Derived from labels that CAN grow, not from the ones shipped today: the
-      key and unkey buttons are `white-space: nowrap` on one non-wrapping
-      flex row, so the pair is atomic — neither key is reachable without room
-      for both. Those two strings are hard-coded English, so nothing can grow
-      them today; the day they are localised they grow together.
+      key and unkey buttons are `white-space: nowrap`, and when this floor
+      was measured they sat on one non-wrapping flex row, so the pair could
+      not stack. Those two strings are hard-coded English, so nothing can grow
+      them today.
       `__tests__/FlagshipProbe.component.test.ts` pins this value and the
       shape of the two rail tracks below.
     */

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -84,6 +84,10 @@ interface BootOptions {
   theme?: 'nord' | 'github-light';
   locale?: 'en-US' | 'ru-RU';
   extraCapabilities?: string[];
+  /** The QA-only skin `?layout=flagship-probe` selects
+   *  (`lib/stores/qa-cockpit-override.ts`). It is not a `CanonicalLayoutMode`,
+   *  so the workspace `layout` this helper writes cannot carry it. */
+  qaLayout?: 'flagship-probe';
 }
 
 async function boot(page: Page, layout: string, width: number, known: boolean, language = 'studioline', productionUnknown = false, topology?: TopologyId, options: BootOptions = {}) {
@@ -144,8 +148,10 @@ async function boot(page: Page, layout: string, width: number, known: boolean, l
         txObservation: { observedPtt: 'off' } } : {};
     return route.fulfill({ json: body });
   });
-  await page.goto(`/?locale=${locale}`, { waitUntil: 'networkidle' });
-  const shell = width <= 640 ? '.m-layout, .m-landscape'
+  const qaLayout = options.qaLayout;
+  await page.goto(`/?locale=${locale}${qaLayout ? `&layout=${qaLayout}` : ''}`, { waitUntil: 'networkidle' });
+  const shell = qaLayout ? '[data-testid="flagship-geometry-probe"]'
+    : width <= 640 ? '.m-layout, .m-landscape'
     : layout.startsWith('lcd') ? '.lcd-layout' : '.desktop-control-face';
   await expect(page.locator(shell).first()).toBeVisible();
   await page.evaluate(() => document.fonts.ready);
@@ -544,3 +550,67 @@ for (const layout of ['standard', 'sdr-test']) for (const language of ['studioli
     expect(await page.evaluate(() => (window as unknown as { geometryCommands: { type: string }[] }).geometryCommands.filter(c => c.type === 'cmd'))).toEqual([]);
   });
 }
+
+// T185 — the transmit key pair wraps when its column is narrower than the pair.
+// Measured in the flagship probe because it leaves `semantic/RxTxSurface.svelte`'s
+// `.rx-tx-actions` row as that surface declares it, while
+// `skins/desktop-v2/semantic-controls.css`, `components-v2/layout/LcdLayout.svelte`
+// and `presentation/languages/fieldline/fieldline.css` each replace that row with a
+// single column, where there is no line for a second button to share.
+test.describe('T185 transmit key pair', () => {
+  async function measurePair(page: Page) {
+    const zone = page.locator('[data-zone-id="rx-tx"]').first();
+    await expect(zone, 'the probe paints a transmit zone').toBeVisible();
+    return zone.evaluate(element => {
+      const actions = element.querySelector<HTMLElement>('.rx-tx-actions')!;
+      const rect = (selector: string) =>
+        element.querySelector(selector)!.getBoundingClientRect().toJSON();
+      return {
+        zone: element.getBoundingClientRect().toJSON(),
+        actions: actions.getBoundingClientRect().toJSON(),
+        key: rect('[data-testid="rx-tx-key"]'),
+        unkey: rect('[data-testid="rx-tx-unkey"]'),
+        gap: Number.parseFloat(getComputedStyle(actions).columnGap),
+      };
+    });
+  }
+
+  type Box = { left: number; right: number };
+  const contained = (box: Box, zone: Box) => box.left >= zone.left - 1 && box.right <= zone.right + 1;
+
+  test('stacks when its column is narrower than the pair', async ({ page }, info) => {
+    // `layout` is the workspace value; `qaLayout` is what actually selects the skin.
+    await boot(page, 'standard', 1440, true, 'studioline', false, undefined,
+      { qaLayout: 'flagship-probe' });
+    // The probe's own rail is wider than the pair (the case below measures that),
+    // so the narrow column comes from narrowing the rail. Both of the custom
+    // properties the skin's two grid templates size a rail track from — the
+    // `minmax()` floor and its width — have to come down, or the floor holds the
+    // track open. `!important` because the skin's own declarations are
+    // Svelte-scoped, and a plain `.flagship-probe` selector loses to that class.
+    await page.addStyleTag({ content: '.flagship-probe { --flagship-probe-rail-floor: 200px !important;'
+      + ' --flagship-probe-rail-width: 200px !important; }' });
+    const geometry = await measurePair(page);
+    await info.attach('narrow', { body: JSON.stringify(geometry), contentType: 'application/json' });
+    expect(geometry.unkey.top, 'the unkey button starts below the key button')
+      .toBeGreaterThan(geometry.key.bottom - 1);
+    expect(contained(geometry.key, geometry.zone), 'the key stays inside its column').toBe(true);
+    expect(contained(geometry.unkey, geometry.zone), 'the unkey stays inside its column').toBe(true);
+    // With each button on its own line, the widths measured are the pair's own,
+    // and their sum exceeds the line the two were given.
+    expect(geometry.key.width + geometry.gap + geometry.unkey.width,
+      'the column under test is narrower than the pair').toBeGreaterThan(geometry.actions.width);
+  });
+
+  test('stays on one line when its column is wider than the pair', async ({ page }, info) => {
+    await boot(page, 'standard', 1440, true, 'studioline', false, undefined,
+      { qaLayout: 'flagship-probe' });
+    const geometry = await measurePair(page);
+    await info.attach('wide', { body: JSON.stringify(geometry), contentType: 'application/json' });
+    expect(geometry.key.width + geometry.gap + geometry.unkey.width,
+      'the probe rail is wider than the pair').toBeLessThanOrEqual(geometry.actions.width);
+    expect(geometry.unkey.top, 'both buttons share one line').toBe(geometry.key.top);
+    expect(contained(geometry.key, geometry.zone), 'the key stays inside its column').toBe(true);
+    expect(contained(geometry.unkey, geometry.zone), 'the unkey stays inside its column').toBe(true);
+  });
+});


### PR DESCRIPTION
`semantic/RxTxSurface.svelte` styles `.rx-tx-actions` as `display: flex` with a gap and no `flex-wrap`, so the key/unkey pair was a no-wrap row by CSS default. That rule arrived with the file's first commit, and no later commit, ticket or test asserted that the two buttons share a line — the no-wrap was a default, with no recorded reason. This adds `flex-wrap: wrap` and nothing else to the surface: no strings, no markup, no consumer touched.

Why it matters: the flagship probe's rail floor came out at 379px (#3405) because the pseudo-localised pair (185 + 8 + 185) could not wrap. Stacked, the zone's minimum becomes one key rather than two.

## Consumers

Three rules replace the row with a single column before it reaches a face, so none of them changes here and none can witness a wrap: `skins/desktop-v2/semantic-controls.css` and `components-v2/layout/LcdLayout.svelte` (`display: grid; grid-template-columns: minmax(0,1fr)`), and `presentation/languages/fieldline/fieldline.css` (`flex-direction: column`). `presentation/languages/studioline/studioline.css` sets only gap and margin, leaving the row. Those four are every rule for `.rx-tx-actions` outside the surface itself (`grep -rn "rx-tx-actions" frontend/src`).

## Geometry

Headless Chromium, the built app at 1440x1000, the flagship probe skin (`?layout=flagship-probe`), studioline, measured inside `[data-zone-id="rx-tx"]`:

| | line width | key | unkey | pair |
|---|---|---|---|---|
| wide (the probe's declared 379px rail) | 379 | top 428.53, w 131.125 | top 428.53, w 130.828 | 269.95 |
| narrow (rail floor and width overridden to 200px) | 200 | top 476.53, w 131.125 | top 512.53, w 130.828 | 269.95 |

Narrow: the unkey button starts 8px below the key button's bottom and both stay inside the zone. Wide: both share a top, and every measured box — zone, line, key, unkey, gap — is identical to the same measurement taken on `origin/main`'s tree in the same harness (compared as JSON, equal). On the pre-change tree the narrow case instead shows both buttons at top 476.53, shrunk to 98.34 and 93.66.

## Baselines

`visual` runs on this PR (it triggers on `pull_request` for `frontend/**`); green with no baseline change is a merge precondition, read from the checks at the exact head. Independently of CI: I measured every `.rx-tx-actions` in the 18 scenes `tests/e2e/visual/visual-baselines.spec.ts` captures, on both trees, through the same fixtures server that suite uses — 12 surfaces, and every rect (line, key, unkey) identical before and after. In the cockpit scenes the zone spans the frame, 1280px on desktop and 375px on phone portrait, against a 269.95px pair, so no line is narrow enough to wrap; the two fieldline scenes were already stacked by that language's own column rule.

## Tests

`frontend/tests/e2e/i18n/desktop-geometry.spec.ts` gains two cases plus a `qaLayout` boot option, so the helper can reach the QA-only `?layout=flagship-probe` skin (that skin is not a `CanonicalLayoutMode`, so the workspace `layout` the helper writes cannot carry it). `quick.yml` runs this suite via `npm run test:e2e:i18n` under its `frontend` path filter, so both cases are CI-visible here; no vitest style pin was added, since the browser case is not the only-honest-witness fallback.

Run locally at this head: `desktop-geometry.spec.ts` 42/42 passed; `npx vitest run src/semantic src/skins src/components-v2/wiring` 117 files / 3711 tests passed; `npm run check` 0 errors over 4844 files; `npm run lint` and `npm run lint:boundaries` clean.

## Mutations

- `flex-wrap` removed: the narrow case fails on `the unkey button starts below the key button` (expected > 503.53, received 476.53); the wide case still passes.
- Declarations reordered to `gap; flex-wrap; display`: both cases pass.

## Comment corrected in this PR

`skins/flagship-probe/FlagshipProbeSkin.svelte`'s rail-floor comment (landed in #3405) said the key and unkey buttons sat "on one non-wrapping flex row, so the pair is atomic — neither key is reachable without room for both". This change makes the row wrap, so the second commit dates that premise to the measurement ("when this floor was measured they sat on one non-wrapping flex row, so the pair could not stack"). The 379px floor itself is unchanged here and its tests stay green; re-measuring it is T187. A sweep over `frontend/src`, `frontend/tests`, `frontend/fixtures` and `docs` for every other statement that the pair cannot wrap found only that comment.

3 files, 77+/7- = 84 changed lines at 1588da55.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

