### PR TITLE
fix: re-measure the probe's rail floor as one key, with the pair wrapping and the band caption suppressed

### DIFF
--- a/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
+++ b/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
@@ -32,7 +32,7 @@
   `rx-tx` zone is placed FIRST in the right rail, above the other transmit
   controls, in both arrangements — `__tests__/FlagshipProbe.component.test.ts`
   requires the rail column, that position and the rail's declared track
-  together. The rail's own minimum is the width that key pair needs — see
+  together. The rail's own minimum is the width one key needs — see
   `--flagship-probe-rail-floor` below. Nothing then stands between the two
   receivers, and the deck's middle track is gone rather than empty: the same
   test requires every track in both column templates to be a column some area
@@ -104,29 +104,35 @@
     height: 100%;
 
     /*
-      TRANSMIT-KEY floor: measured 2026-09-09 with pseudo-localised key
-      labels (`⟦Ķéý ťŕáñšɱíťťéŕ ~~~~~~⟧` and `⟦Úñķéý ťŕáñšɱíťťéŕ ~~~~~~⟧`,
-      `lib/i18n/pseudo.ts`'s `pseudoize()` applied to the two hard-coded
-      English strings `semantic/RxTxSurface.svelte` renders) on the
+      ONE-KEY floor: re-measured 2026-09-09 with every rail key's text
+      replaced by `lib/i18n/pseudo.ts`'s `pseudoize()` output, on the
       fixture-stub harness — `vite.fixtures.config.ts`, fixture
-      `topology-2-main-sub`, Chromium; do not lower it to make a layout fit.
+      `topology-2-main-sub`, headless Chromium; do not lower it to make a
+      layout fit.
 
-      Derived from labels that CAN grow, not from the ones shipped today: the
-      key and unkey buttons are `white-space: nowrap`, and when this floor
-      was measured they sat on one non-wrapping flex row, so the pair could
-      not stack. Those two strings are hard-coded English, so nothing can grow
-      them today.
+      192 is the larger of two measured terms rounded up: the widest single
+      key in any of the ten rail surfaces — the CW keyer's
+      `⟦Ŕéṽéŕšé þáđđłé: — ~~~~~~⟧`, 191.77px at a computed font-size of
+      13.3333px, with no padding between its border box and its zone box —
+      and the transmit zone's min-content, 185.20px, which is that zone's own
+      `⟦Ķéý ťŕáñšɱíťťéŕ ~~~~~~⟧` button now that
+      `semantic/RxTxSurface.svelte`'s `.rx-tx-actions` row may wrap.
+
+      Derived from labels that CAN grow, not from the ones shipped today.
       `__tests__/FlagshipProbe.component.test.ts` pins this value and the
       shape of the two rail tracks below.
     */
-    --flagship-probe-rail-floor: 379px;
+    --flagship-probe-rail-floor: 192px;
 
     /*
       The declared track widths — a rail's width and a receiver strip's
       minimum — and their sum with the three gutters `.probe-stage` puts
-      between the four columns. The rail's width is the floor: the measured
-      floor came out above the 280px this rail carried before it, and a rail
-      narrower than its own floor is not a rail.
+      between the four columns. The rail's width is TWO keys, under the same
+      pseudo-localised labels: the transmit key and unkey standing abreast,
+      185.20 + 8 + 184.89 = 378.09px, rounded up. Sweeping the rail width one
+      pixel at a time, that is the widest two-key row of the ten rail
+      surfaces — the next widest still puts two keys on a line at a rail of
+      177px.
     */
     --flagship-probe-rail-width: 379px;
     --flagship-probe-strip-min-width: 360px;
@@ -143,7 +149,7 @@
     between them. The deck spans all four columns in the narrow arrangement
     and columns 2-3 in the wide one; that is the whole of the switch.
 
-    Both templates floor the rails at the transmit-key floor, cap them at the
+    Both templates floor the rails at the one-key floor, cap them at the
     declared rail width and give the remainder to columns 2 and 3. The wide
     one alone floors those two at the declared strip minimum, because it is
     the arrangement in which a receiver strip occupies one of them on its own

--- a/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
+++ b/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
@@ -455,10 +455,10 @@ describe('no surface may size a track', () => {
   });
 
   // Kills: a rail whose maximum is anything but the declared rail width, and
-  // a rail whose minimum is anything but the transmit-key floor — including
+  // a rail whose minimum is anything but the rail floor — including
   // the `minmax(0, …)` this rail carried before the floor existed, which let
   // it compress to any width at all.
-  it.each([[0, 'narrow'], [1, 'wide']])('column template %i (%s) floors both rails at the transmit-key floor and caps them at the declared rail width', (index) => {
+  it.each([[0, 'narrow'], [1, 'wide']])('column template %i (%s) floors both rails at the rail floor and caps them at the declared rail width', (index) => {
     const tracks = columnTemplates()[index as number];
     expect(tracks[0]).toBe(RAIL_TRACK);
     expect(tracks[3]).toBe(tracks[0]);
@@ -512,16 +512,27 @@ describe('no surface may size a track', () => {
   });
 });
 
-describe('the transmit-key floor', () => {
+describe('the rail floor', () => {
   /**
-   * The floor was measured in Chromium on 2026-09-09, on the real
+   * Both numbers were measured in Chromium on 2026-09-09, on the real
    * `FlagshipProbeSkin` mounted through the fixture-stub seam
-   * (`vite.fixtures.config.ts`, fixture `topology-2-main-sub`), with the two
-   * transmit-key labels replaced in the DOM by `lib/i18n/pseudo.ts`'s
-   * `pseudoize()` output. The `.rx-tx-actions` row's min-content came to
-   * 378.09px there — 379 is that measurement rounded up to a whole pixel.
-   * The rail width equals it because that floor came out above the 280px the
-   * rail carried before. The PR body carries the full table.
+   * (`vite.fixtures.config.ts`, fixture `topology-2-main-sub`), with every
+   * rail key's text replaced in the DOM by `lib/i18n/pseudo.ts`'s
+   * `pseudoize()` output.
+   *
+   * The FLOOR is one key: the larger of the widest single key in any of the
+   * ten rail surfaces — the CW keyer's reverse-paddle key, 191.77px at a
+   * computed font-size of 13.3333px — and the transmit zone's min-content,
+   * 185.20px, which is that zone's own key button now that
+   * `semantic/RxTxSurface.svelte`'s `.rx-tx-actions` row may wrap. 192 is
+   * 191.77 rounded up to a whole pixel. The earlier 379 was the same pair,
+   * measured as one unwrappable row.
+   *
+   * The WIDTH is two keys: the transmit pair abreast, 185.20 + 8 + 184.89 =
+   * 378.09px, rounded up. Sweeping the rail width one pixel at a time, that
+   * is the widest two-key row of the ten — the next widest surface still
+   * puts two keys on a line at a rail of 177px. The PR body carries the full
+   * table.
    *
    * Kills: lowering the floor to make some layout fit, which is exactly what
    * the comment on the declaration forbids and what no other test here would
@@ -529,8 +540,8 @@ describe('the transmit-key floor', () => {
    * track, and `minmax(var(--floor), var(--width))` keeps its form at any
    * value of either.
    */
-  it('declares the measured floor, and a rail width raised to it', () => {
-    expect(px('--flagship-probe-rail-floor')).toBe(379);
+  it('declares the measured one-key floor and the measured two-key rail width', () => {
+    expect(px('--flagship-probe-rail-floor')).toBe(192);
     expect(px('--flagship-probe-rail-width')).toBe(379);
   });
 


### PR DESCRIPTION
## What the rule now measures

The rail floor of 379px measured a shape that no longer exists: it was the
transmit key and unkey standing abreast in a row that could not wrap, and the
widest single key it was compared against was the band key with its printed
permit caption. Since then `.rx-tx-actions` may wrap (#3407) and the probe
passes `bandPermitCaption={false}` (#3406).

Re-measured with the harness #3405's review used: the real `FlagshipProbeSkin`
mounted through the fixture-stub seam (`vite.fixtures.config.ts`, fixture
`topology-2-main-sub`, the default `flagshipProbeLayout` surface plan),
headless Chromium, every rail key's text replaced in the DOM by
`lib/i18n/pseudo.ts`'s `pseudoize()` output. Widths below are border-box
`max-content` widths of the key, measured on a clone laid out free of the
skin's `min-width: 0` / `overflow: auto`; "padding" is the horizontal padding
and border between the key's border box and its `[data-zone-id]` box.

## (a) The widest single key per rail surface, band caption suppressed

Ten rail surfaces — the six the left rail places and the four the right rail
places. Padding to the zone box measured 0 on every one of the ten, and each
zone's own horizontal padding measured 0.

| rail surface | widest key, pseudo-localised | px | English | computed font-size |
|---|---|---|---|---|
| `rf-front-end` | `⟦ĐÍĞÍ-ŠÉŁ: ? ~~~~⟧` | 133.95 | 87.86 | 13.3333px |
| `dsp` | `⟦ɱáñúáł ~~~⟧` | 98.03 | 59.73 | 13.3333px |
| `filter` | `⟦ŔŤŤÝ-Ŕ ~~~⟧` | 103.19 | 63.41 | 13.3333px |
| `rx-audio` | `⟦šþłíť óƒƒ ~~~~⟧` | 113.78 | 58.00 | 13.3333px |
| `antenna` | `⟦ŔẊ-ÁÑŤ: — ~~~~⟧` | 132.45 | 84.89 | 13.3333px |
| `band` | `⟦20ɱ ~~⟧` | 72.45 | 41.94 | 13.3333px |
| `rx-tx` | `⟦Ķéý ťŕáñšɱíťťéŕ ~~~~~~⟧` | 185.20 | 131.13 | 10px |
| `tx-aux` | `⟦ÇÓⱮÞ: ? ~~~⟧` | 100.81 | 69.44 | 9px |
| **`cw-keyer`** | `⟦Ŕéṽéŕšé þáđđłé: — ~~~~~~⟧` | **191.77** | 130.11 | 13.3333px |
| `rit-xit-scan` | `⟦ÇŁÉÁŔ ~~⟧` | 90.97 | 60.45 | 13.3333px |

The band key measured 72.45 pseudo / 41.94 English with the caption
suppressed; #3405 measured that key at 175.33 with the caption printed.

Term (a) = **191.77px**.

## (b) The transmit zone's min-content, the pair free to wrap

| quantity | pseudo | English |
|---|---|---|
| `rx-tx` zone min-content | 185.20 | 131.13 |
| `.rx-tx-actions` min-content | 185.20 | 131.13 |
| `.rx-tx-actions` max-content (pair abreast) | 378.09 | 269.95 |
| key button | 185.20 | 131.13 |
| unkey button | 184.89 | 130.83 |
| row gap | 8 | 8 |

Term (b) = **185.20px**, the key button, at a computed font-size of 10px.
185.20 + 8 + 184.89 = 378.09 reproduces #3405's number for the abreast pair.

The pair does stack: with both rail properties forced to 200px, the unkey
button's top (149.75) is below the key's bottom (141.75) and both stay inside
the 200px zone (key 185.20 wide, unkey 184.89, zone left 2200 / right 2400).

## The floor, the width, the threshold

Floor = ceil(max(191.77, 185.20)) = **192px**. Term (a) wins: the CW keyer's
reverse-paddle key, in the `cw-keyer` rail surface, at 13.3333px.

The probe's rails are not fixed key columns: every rail surface lays its keys
out in a wrapping row, and at a 379px rail they run 2 to 4 keys per line
(`rf-front-end` 4, `filter` 4, `dsp`/`rx-audio`/`tx-aux`/`cw-keyer` 3,
`antenna`/`band`/`rx-tx`/`rit-xit-scan` 2). Sweeping the rail width 120→440 by
1px and reading the most keys any one line holds, the width at which each
surface drops to a single key column is: `rx-tx` 379, `antenna` 177,
`tx-aux` 166, `band` 153, `dsp` 151, `cw-keyer` 151, `rx-audio` 150,
`rit-xit-scan` 144, `rf-front-end` and `filter` at or below 120. So the
two-key rail is **379px**, set by the transmit pair, and it is unchanged. At
the new floor of 192 every rail surface still holds two keys on a line except
`rx-tx`, which holds one — the drop from two key columns to one that the rule
allows.

Because the rail width is unchanged, so are the switch threshold
(2×379 + 2×360 + 3×8 = 1502), the `@container` literal and the manifest's
declared reflow width.

## The band

Measured on the changed skin, pseudo-localised labels still applied, by
setting `.flagship-probe`'s own width (it is the query container). "Boundary"
is 2×192 + 3×8 = 408, the container at which the two flexible columns reach 0.

| container | rail tracks | panorama | stage scrollWidth | clientWidth | rail zone | transmit key |
|---|---|---|---|---|---|---|
| 320 | `192 0 0 192` | 8 | 408 | 320 | 192 | stacked, inside |
| 400 | `192 0 0 192` | 8 | 408 | 400 | 192 | stacked, inside |
| 407 | `192 0 0 192` | 8 | 408 | 407 | 192 | stacked, inside |
| 408 | `192 0 0 192` | 8 | 408 | 408 | 192 | stacked, inside |
| 409 | `192.5 0 0 192.5` | 8 | 409 | 409 | 192.5 | stacked, inside |
| 640 | `308 0 0 308` | 8 | 640 | 640 | 308 | stacked, inside |
| 1501 | `379 359.5 359.5 379` | 727 | 1501 | 1501 | 379 | abreast, inside |
| 1502 | `379 360 360 379` | 728 | 1502 | 1502 | 379 | abreast, inside |
| 1503 | `379 360.5 360.5 379` | 729 | 1503 | 1503 | 379 | abreast, inside |
| 1920 | `379 569 569 379` | 1146 | 1920 | 1920 | 379 | abreast, inside |

Sweeping the container 300→900 by 1px, `scrollWidth` exceeds `clientWidth` at
407 and below, and at no width from 408 up. Sweeping 300→1000, the pair is
abreast from 781 up (rail 378.5) and stacked below it, and neither key left
its rail box at any of those 701 widths. The mobile handover is declared at a
viewport minimum dimension of 640; the widest container at which this stage
overflows is 407. No third arrangement is proposed here.

## Tests and mutations

- `FlagshipProbe.component.test.ts` value test moved first (red: `expected 379
  to be 192`), then the skin; 34 passed after.
- Its docstring's dated 378.09 sentence is replaced by both new measurements
  and by what sets each.
- No new jsdom test: jsdom runs no layout, so "the key is inside its rail at
  the floor" is not assertable there; the browser table above carries it.
- Mutation — floor lowered to 191px: 1 failed (`the rail floor > declares the
  measured one-key floor and the measured two-key rail width`), 33 passed.
- Mutation — both rails' floors removed (all four `minmax(var(--floor),
  var(--width))` → `minmax(0, var(--width))`): 4 failed (the two `puts rx-tx
  first in the right rail` cases and the two `floors both rails …` cases),
  30 passed.
- Refactor control — `--flagship-probe-strip-min-width` moved above
  `--flagship-probe-rail-width`: 34 passed.
- Gates run locally at this head: `npm run check` (0 errors), `npm run lint`,
  `npm run lint:boundaries`, `vitest run src/skins/flagship-probe/
  src/presentation/layouts/__tests__/flagship-probe-registration.test.ts`
  (39 passed), and the two `T185 transmit key pair` cases in
  `tests/e2e/i18n/desktop-geometry.spec.ts`, which override both rail
  properties (2 passed). The visual lane is left to CI.

Census at 7b0701b6: 2 files, 45+/28- = 73 changed lines.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

