### PR TITLE
feat: make the FTX-1 dual-watch key act through the FR write and the dual_watch tag

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -45,6 +45,14 @@ max_watts = 100
 features = [
     "audio",
     "dual_rx",
+    # set_dual_watch reaches the radio through the FR receive-function write
+    # (`set_rx_func`): YaesuCatRadio.set_dual_watch falls back to it when the
+    # profile declares no `set_dual_watch` — pinned by
+    # tests/test_ftx1_radio.py::test_set_dual_watch_on_sends_fr00.
+    # YaesuCatRadio.get_dual_watch raises NotImplementedError; the observed
+    # value comes from the FR read the `global.tx_state.dual_watch` field
+    # policy below declares.
+    "dual_watch",
     "af_level",
     "rf_gain",
     "squelch",

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -662,11 +662,15 @@ class YaesuCatRadio:
     async def set_dual_watch(self, on: bool) -> None:
         """Enable or disable dual watch.
 
-        No-op with warning if the rig profile does not define a
-        ``set_dual_watch`` command.
+        Uses the profile's ``set_dual_watch`` write when it declares one.
+        Otherwise falls back to ``set_rx_func``, whose mode is inverted
+        relative to ``on``: 0 = dual receive, 1 = single receive. No-op
+        with warning if the profile declares neither.
         """
         if self._has_write_command("set_dual_watch"):
             await self._write("set_dual_watch", state="1" if on else "0")
+        elif self._has_write_command("set_rx_func"):
+            await self.set_rx_func(0 if on else 1)
         else:
             logger.warning("set_dual_watch: no CAT command defined for %s", self.model)
 

--- a/tests/golden/validation/ftx1.dry-run.json
+++ b/tests/golden/validation/ftx1.dry-run.json
@@ -84,8 +84,8 @@
     },
     {
       "check_id": "dual_watch.set",
-      "status": "unsupported",
-      "declaration": "unsupported"
+      "status": "skip",
+      "declaration": "supported"
     },
     {
       "check_id": "filter_width.set",

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -15,6 +15,7 @@ from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
 from rigplane.backends.yaesu_cat import radio as yaesu_radio
 from rigplane.backends.yaesu_cat.parser import CatParseError
 from rigplane.backends.yaesu_cat.transport import CatTimeoutError
+from rigplane.commands.command_spec import CatCommandSpec
 from rigplane.exceptions import CommandError
 from rigplane.exceptions import ConnectionError as RadioConnectionError
 from rigplane.profiles import TxPolicy
@@ -1039,6 +1040,57 @@ async def test_set_cross_band_split_rejects_out_of_range_tx(connected_radio):
     with pytest.raises(ValueError, match="tx_xcvr"):
         await connected_radio.set_cross_band_split(rx_xcvr=0, tx_xcvr=2)
     connected_radio._transport.write.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# set_dual_watch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_dual_watch_on_sends_fr00(connected_radio):
+    """On the bundled FTX-1 profile, set_dual_watch(True) sends exactly FR00;."""
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_dual_watch(True)
+    assert connected_radio._transport.write.call_args_list == [call("FR00;")]
+
+
+@pytest.mark.asyncio
+async def test_set_dual_watch_off_sends_fr01(connected_radio):
+    """On the bundled FTX-1 profile, set_dual_watch(False) sends exactly FR01;."""
+    connected_radio._transport.write = AsyncMock()
+    await connected_radio.set_dual_watch(False)
+    assert connected_radio._transport.write.call_args_list == [call("FR01;")]
+
+
+@pytest.mark.asyncio
+async def test_set_dual_watch_prefers_a_declared_set_dual_watch_command(config):
+    """A declared ``set_dual_watch`` write is used instead of the FR fallback."""
+    config.commands["set_dual_watch"] = CatCommandSpec(write="DW{state};")
+    radio = YaesuCatRadio("/dev/null", profile=config)
+    radio._transport._connected = True
+    radio._transport.write = AsyncMock()
+    await radio.set_dual_watch(True)
+    await radio.set_dual_watch(False)
+    assert radio._transport.write.call_args_list == [call("DW1;"), call("DW0;")]
+
+
+@pytest.mark.asyncio
+async def test_set_dual_watch_without_either_command_warns_and_writes_nothing(
+    config, caplog
+):
+    """With neither ``set_dual_watch`` nor ``set_rx_func``, nothing is written."""
+    del config.commands["set_rx_func"]
+    radio = YaesuCatRadio("/dev/null", profile=config)
+    radio._transport._connected = True
+    radio._transport.write = AsyncMock()
+    with caplog.at_level("WARNING"):
+        await radio.set_dual_watch(True)
+    radio._transport.write.assert_not_called()
+    assert any(
+        record.levelname == "WARNING" and "set_dual_watch" in record.message
+        for record in caplog.records
+    )
 
 
 @pytest.mark.asyncio
@@ -2500,7 +2552,6 @@ class TestProfileSourcedCommands:
 
 
 from rigplane.backends.yaesu_cat.parser import CatCommandParser  # noqa: E402
-from rigplane.command_spec import CatCommandSpec  # noqa: E402
 from rigplane.radio_protocol import (  # noqa: E402
     ReceiverBankCapable,
     VfoSlotCapable,

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -817,3 +817,40 @@ class TestProfileDeclaredSecondReceiver:
                 name, {}, SimpleNamespace(put=queue.append), radio
             )
         assert queue == []
+
+
+# ── Profile-declared dual watch (MOR-2425) ─────────────────────
+
+
+class TestProfileDeclaredDualWatch:
+    """The bundled FTX-1 profile's ``dual_watch`` tag reaches the served surface.
+
+    The radio here is a real :class:`YaesuCatRadio` on the bundled ``ftx1``
+    profile, so the tag is read from the shipped TOML rather than from a
+    hand-built capability set.
+    """
+
+    def test_runtime_capabilities_serve_dual_watch(self) -> None:
+        from rigplane.web.runtime_helpers import runtime_capabilities
+
+        radio = _yaesu()
+        assert "dual_watch" in radio.capabilities
+        assert "dual_watch" in runtime_capabilities(radio)
+
+    @pytest.mark.asyncio
+    async def test_capabilities_endpoint_serves_dual_watch(self) -> None:
+        radio = _yaesu()
+        srv = WebServer(radio)
+        writer = _FakeWriter()
+        await srv._serve_capabilities(writer)  # noqa: SLF001
+        data = _parse_json_body(writer)
+        assert "dual_watch" in data["capabilities"]
+
+    @pytest.mark.asyncio
+    async def test_info_endpoint_serves_dual_watch(self) -> None:
+        radio = _yaesu()
+        srv = WebServer(radio)
+        writer = _FakeWriter()
+        await srv._serve_info(writer)  # noqa: SLF001
+        data = _parse_json_body(writer)
+        assert "dual_watch" in data["capabilities"]["tags"]


### PR DESCRIPTION
Two commits, one change: the FTX-1's dual-watch control was dead, and it takes
both a backend fallback and a profile tag to make it live.

## The defect

`YaesuCatRadio.set_dual_watch` (`src/rigplane/backends/yaesu_cat/radio.py`)
wrote the profile command `set_dual_watch` when the profile declared one, and
otherwise logged a warning and sent nothing. `rigs/ftx1.toml` declares no
`set_dual_watch`. So on the FTX-1 the dual-watch control was dead: the web
command reached the radio and no CAT frame went out.

**How this was established** — code trace on `e68de9ce5`, no live toggle:

- `src/rigplane/web/handlers/control.py`, `case "set_dual_watch"`, calls
  `self._ensure_capability("dual_rx", "set_dual_watch")` and enqueues
  `SetDualWatch`; `rigs/ftx1.toml` declares `dual_rx`, so the command is
  reachable on the FTX-1.
- `src/rigplane/backends/yaesu_cat/poller.py` dispatches `SetDualWatch` to
  `radio.set_dual_watch(on)`, with no capability gate of its own. (The
  `CAP_DUAL_WATCH` gate on `SetDualWatch` in `src/rigplane/web/radio_poller.py`
  is not on this path: `src/rigplane/web/web_startup.py` builds `RadioPoller`
  only in its final else-branch, for Icom CI-V radios; a `YaesuCatRadio` takes
  the observation-poller branch above it.)
- `grep -n "set_dual_watch" rigs/ftx1.toml` — no command declaration (the
  matches there are all `global.tx_state.dual_watch` state paths).
- `rigs/ftx1.toml` does declare
  `set_rx_func = { cat = { write = "FR{mode:02d};" } }`.
- FTX-1 CAT manual (`FTX-1_CAT_OM_ENG_2508-C`, printed page 16, as cited in
  `src/rigplane/backends/yaesu_cat/observations.py`): `FR` Set form `FR P1P1;`
  with `00` = dual receive, `01` = single receive.
- The read side already relies on that sense: `observations.py` emits
  `global.tx_state.dual_watch` as `mode == 0` from `get_rx_func`, and
  `radio.py: YaesuCatRadio.set_cross_band_split` already calls
  `self.set_rx_func(0)  # FR00: Dual RX`.

Separately, the key was never drawn: the `onDualWatchToggle` and `onQuickDw`
guards in `frontend/src/lib/runtime/commands/panel-commands.ts` each require
**both** `dual_rx` and `dual_watch` in the served capability list, and
`rigs/ftx1.toml` declared only `dual_rx`.

## What changes

**Step 1 — `b99bdb46d`, the FR fallback.** One `elif` branch in
`YaesuCatRadio.set_dual_watch`: when the profile declares no `set_dual_watch`
write but does declare `set_rx_func`, write FR with the inverted sense —
`on=True` → `set_rx_func(0)`, `on=False` → `set_rx_func(1)`. The
declared-`set_dual_watch` path is first and unchanged; the warning is kept for
a profile that declares neither. The docstring is rewritten to state only that.

The fallback is generic for any Yaesu profile declaring `set_rx_func`; the
`FR{mode:02d};` template cannot invert the sense, so it could not live in TOML.

One unrelated line is deleted in `tests/test_ftx1_radio.py`: a mid-file
`from rigplane.command_spec import CatCommandSpec  # noqa: E402` that `ruff`
flagged as `F811` against the canonical top-level import step 1 adds.

**Step 2 — `6f809d3f3`, the capability tag.** `"dual_watch"` is added to
`rigs/ftx1.toml`'s `[capabilities] features`, next to `dual_rx`, with a comment
naming the FR write path and the test that pins it. #3384 withheld this tag
deliberately — the tag gates set affordances the radio could not then actuate.
Step 1 makes the write actuatable, so the tag belongs in this PR.

`tests/golden/validation/ftx1.dry-run.json`: the `dual_watch.set` check moves
from `unsupported`/`unsupported` to `skip`/`supported`. Only that entry is
changed. A full `--regen-golden` would also adopt `repeater_shift.presence`, a
check already unadopted on `origin/main` (verified: the gate passes on the
clean tree while reporting it as new), so it is deliberately left out and the
golden's only delta is this change's own.

## Two arms behind the tag that do not work on this radio

Neither is changed here; both are reported rather than papered over.

- **`get_dual_watch`.** `YaesuCatRadio.get_dual_watch` raises
  `NotImplementedError("Dual watch query not supported on Yaesu radios")`. With
  the tag served, `ControlHandler._ro_get_dual_watch` and the `rigplane
  dualwatch` CLI read stop refusing on the capability and reach that raise
  instead. Both were already failures and both are contained:
  `ControlHandler._dispatch_command` catches every `Exception` and answers with
  an `ok:false` frame, and the CLI's top-level handler prints the message and
  returns 1. `grep -rn "get_dual_watch" frontend/src/` — no hits, so no shipped
  face calls it.
- **`quick_dualwatch` — the dispatch guard now passes; no live surface draws it.**
  `panel-commands.ts: onQuickDw` is gated on `dual_watch`, so with the tag
  served its guard passes, and `YaesuCatPoller`'s dispatcher has no
  `QuickDwTrigger` case: it reaches `case _: raise NotImplementedError`,
  which `_drain_commands` catches with a warning after the web handler has
  already acked `ok:true`. But no shipped semantic surface renders the
  Quick-DW affordance: `radio-view-model-adapter.ts` sets `quickDualWatch`
  to `compositeUnavailable`, and `VfoOperationGroup` / `VfoOperationSeatHost`
  render only structural operations (`docs/internals/ui-radio-control-contract.toml`,
  family `vfo_identity_topology`, `composite_reachability`). The
  `withDoubleClick(onDualWatchToggle, onQuickDw)` binding survives only in the
  legacy `VfoHeader`/`VfoOps` path that `RadioLayout` renders outside the
  semantic deck. The same dead-end already exists on `main` for
  `quick_split` (the FTX-1 declares `split`, and `QuickSplitTrigger` lands on
  the same `case _`), so this is one more instance of a standing class, not a
  new one. Left for a separate ticket against the class.

## Tests

**Step 1** — `tests/test_ftx1_radio.py`, driving a real `YaesuCatRadio` against
the bundled FTX-1 profile over a mocked transport (no `MagicMock` radio):

1. `test_set_dual_watch_on_sends_fr00` — `set_dual_watch(True)` sends exactly
   `FR00;`.
2. `test_set_dual_watch_off_sends_fr01` — `set_dual_watch(False)` sends exactly
   `FR01;`.
3. `test_set_dual_watch_prefers_a_declared_set_dual_watch_command` — with a
   `set_dual_watch` write spec injected into the profile, the writes are
   `DW1;` / `DW0;`, not FR.
4. `test_set_dual_watch_without_either_command_warns_and_writes_nothing` — with
   `set_rx_func` deleted from the profile, nothing is written and a WARNING
   naming `set_dual_watch` is logged.

Written first; 1 and 2 failed before the implementation (`assert [] ==
[call('FR00;')]`), 3 and 4 passed, pinning existing behaviour.

**Step 2** — `tests/test_web_capability_guards.py`, new class
`TestProfileDeclaredDualWatch`, beside the #3381 served-surface tests and using
the same real `YaesuCatRadio` on the bundled FTX-1 profile:

5. `test_runtime_capabilities_serve_dual_watch` — the tag is in
   `radio.capabilities` and survives `runtime_capabilities`.
6. `test_capabilities_endpoint_serves_dual_watch` — `/api/v1/capabilities`
   lists it.
7. `test_info_endpoint_serves_dual_watch` — `/api/v1/info` lists it under
   `capabilities.tags`.

Written first; all three failed before the profile edit (`assert 'dual_watch'
in {'af_level', 'agc', ...}`).

## Mutations run

**Step 1**, each applied to `set_dual_watch` alone, then reverted:

| Mutation | Result |
|---|---|
| Sense inverted (`set_rx_func(1 if on else 0)`) | 2 failed (tests 1, 2), 2 passed |
| Fallback branch deleted | 2 failed (tests 1, 2), 2 passed |
| Behaviour-preserving refactor (mode codes hoisted to named locals) | 4 passed |
| Declared-`set_dual_watch` branch deleted | 1 failed (test 3), 3 passed |

Rows 1 and 2 were re-run independently for step 2 and reproduced: the sense
inversion gives `assert [call('FR01;')] == [call('FR00;')]` and
`2 failed, 332 passed` over the whole file; the deleted branch gives
`assert [] == [call('FR00;')]`. Rows 3 and 4 are carried from step 1's record
and were not re-run.

**Step 2**:

| Mutation | Result |
|---|---|
| `"dual_watch"` removed from `rigs/ftx1.toml` | 3 failed (tests 5, 6, 7); golden gate FAIL, `dual_watch.set: status 'skip' -> 'unsupported'` |
| Refactor control: tag moved to a different position in the `features` list | 3 passed; golden gate PASS |

A stale `__pycache__` survived one mutation revert and made a restored tree
report the mutated result. Every mutation and gate figure above was
re-measured after `find . -name __pycache__ -type d -not -path './.venv/*'
-exec rm -rf {} +`; `git status --short` is empty at this head.

## Gates (run locally at this head, `6f809d3f3`)

- `uv run pytest tests/test_web_capability_guards.py tests/test_ftx1_radio.py
  -q --tb=short --timeout=300 --timeout-method=thread` → **396 passed**
- A wider sweep, run in two batches → **2497 passed, 1 skipped** and
  **1794 passed, 2 skipped**. Selection: the test files matching
  `git grep -lil 'ftx1\|ftx-1'` under `tests/` that also mention
  `capabilit`/`dual_watch`/`features`, plus all of `tests/validation/`,
  `tests/test_cli_model.py`, `tests/test_installed_profile_smoke.py` and
  `tests/test_discovery.py`.
- `uv run ruff check src/ tests/` → **All checks passed!**
- `uv run ruff format --check src/ tests/` → **742 files already formatted**
- `uv run lint-imports` → **Contracts: 5 kept, 0 broken.**
- The three validation golden gates `quick.yml` runs → **PASS** for FTX-1 (65
  checks), IC-7610 (81), X6200 (64)

The full suite was not run locally. CI's `quick` run at `6f809d3f3`
(run 34353233618): 16185 passed, 220 skipped, 15 xfailed.

## Class sweep

The class is: a `YaesuCatRadio` write method that logs
`"<name>: no CAT command defined"` and sends nothing when the profile declares
no matching write. Enumerated with `grep -rn "no CAT command defined" src/` —
two hits, both in `src/rigplane/backends/yaesu_cat/radio.py`:
`set_dual_watch` (fixed here) and `set_data_mode`.

For each, the web gate in `control.py` was checked against every bundled
profile that carries CAT command specs (`grep -c "cat = {" rigs/*.toml` →
`rigs/ftx1.toml` and `rigs/tx500.toml` only):

- `set_data_mode` is gated on the `data_mode` capability; neither
  `rigs/ftx1.toml` nor `rigs/tx500.toml` declares it, so no bundled CAT profile
  reaches it. Re-derived for step 2: `grep -c '"data_mode"' rigs/ftx1.toml` →
  0, and `grep -n 'set_data_mode\|get_data_mode' rigs/ftx1.toml` → no hits.
  Left unfixed — its own docstring says a real implementation needs
  profile-level mode-pair mapping, a different change and outside this PR's
  scope.
- `set_dual_watch` on `rigs/tx500.toml`: that profile declares neither
  `dual_rx` nor `set_rx_func`, so the command is blocked at the capability gate
  and the warning path is correct there. Left unchanged.

`set_nb` / `set_nr` share the shape but already carry a level-based fallback
and no warning path; not members.

## Bench

**Bench: not run — the hardware flip is unverified.** Step 1's dispatch named a
bench procedure file that does not exist in the handoff directory; the nearest
match documents a strictly read-only probe and states that no write of any kind
reached either radio, so it does not establish a procedure for this write.
Step 2 was dispatched with no bench work and no radio contact. The code trace
and tests above stand on their own; the observed `global.tx_state.dual_watch`
flip on hardware is unverified.

## Census

`Census at 6f809d3f30108505e728ca4d67c8698553dd4260: 5 files, 105+/5- = 110 changed lines`

Measured with `git diff --numstat origin/main...HEAD` (merge base
`e68de9ce5`), which matches `gh pr view 3409 --json files` file-for-file and
line-for-line. The two-dot form `origin/main..HEAD` reports 7 files / 183 lines
because `origin/main` has since advanced past the merge base with a commit
touching two `frontend/src/skins/flagship-probe/` files; those are not part of
this PR. Under both the soft threshold (6 files / 600 lines) and the hard
ceiling (10 files / 1000 lines).

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

