### PR TITLE
fix: measure the probe rail under one rule: the transmit key governs, in pseudo-localisation

### DIFF
--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -189,7 +189,7 @@ export const flagshipProbeLayout: LayoutManifest = {
   // `__tests__/flagship-probe-registration.test.ts` requires this
   // declaration, that custom property and the `@container` literal to name
   // the same width.
-  stageSizing: { mode: 'fluid', responsiveBreakpoints: [1502] },
+  stageSizing: { mode: 'fluid', responsiveBreakpoints: [1128] },
   fallbackLayoutId: 'sdr-test',
 };
 

--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -189,7 +189,7 @@ export const flagshipProbeLayout: LayoutManifest = {
   // `__tests__/flagship-probe-registration.test.ts` requires this
   // declaration, that custom property and the `@container` literal to name
   // the same width.
-  stageSizing: { mode: 'fluid', responsiveBreakpoints: [1128] },
+  stageSizing: { mode: 'fluid', responsiveBreakpoints: [1116] },
   fallbackLayoutId: 'sdr-test',
 };
 

--- a/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
+++ b/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
@@ -105,10 +105,9 @@
 
     /*
       ONE-KEY floor: re-measured 2026-09-09 with every rail key's text
-      replaced by `lib/i18n/pseudo.ts`'s `pseudoize()` output, on the
-      fixture-stub harness — `vite.fixtures.config.ts`, fixture
-      `topology-2-main-sub`, headless Chromium; do not lower it to make a
-      layout fit.
+      replaced by `lib/i18n/pseudo.ts`'s `pseudoize()` output, on the real
+      skin through the fixture-stub seam (`vite.fixtures.config.ts`) in
+      headless Chromium; do not lower it to make a layout fit.
 
       192 is the larger of two measured terms rounded up: the widest single
       key in any of the ten rail surfaces — the CW keyer's
@@ -127,16 +126,29 @@
     /*
       The declared track widths — a rail's width and a receiver strip's
       minimum — and their sum with the three gutters `.probe-stage` puts
-      between the four columns. The rail's width is TWO keys, under the same
-      pseudo-localised labels: the transmit key and unkey standing abreast,
-      185.20 + 8 + 184.89 = 378.09px, rounded up. Sweeping the rail width one
-      pixel at a time, that is the widest two-key row of the ten rail
-      surfaces — the next widest still puts two keys on a line at a rail of
-      177px.
+      between the four columns.
+
+      THE WIDTH IS THE FLOOR. Art-direction ruling of 2026-09-09: a rail is
+      as wide as the widest thing that must be READABLE in one column of
+      controls, which is ONE key — not a row of two, and not the transmit
+      pair, whose `.rx-tx-actions` row may wrap
+      (`semantic/RxTxSurface.svelte`). That ruling also confines
+      pseudo-localisation to the key whose clipping would be a SAFETY
+      failure, the transmit key; every other rail key is measured in
+      English. Measured 2026-09-09 the same way as the floor above, over
+      every key the ten rail surfaces mount on that harness's dual-receiver
+      fixture, each toggle taken at both values its own fact renders: the
+      widest English key is the CW keyer's `Reverse paddle: on`, 131.61px —
+      below the floor. So the floor is the binding term and this track is a
+      fixed 192px.
+
+      Two properties for one number, not one: the tracks below stay written
+      as `minmax(floor, width)`, and `tests/e2e/i18n/desktop-geometry.spec.ts`
+      overrides BOTH to set the rail column it measures the transmit pair in.
     */
-    --flagship-probe-rail-width: 379px;
+    --flagship-probe-rail-width: 192px;
     --flagship-probe-strip-min-width: 360px;
-    --flagship-probe-switch-width: 1502px;
+    --flagship-probe-switch-width: 1128px;
   }
 
   /*
@@ -184,7 +196,7 @@
       'meters    meters     meters     meters';
   }
 
-  @container (min-width: 1502px) {
+  @container (min-width: 1128px) {
     .probe-stage {
       grid-template-columns:
         minmax(var(--flagship-probe-rail-floor), var(--flagship-probe-rail-width))

--- a/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
+++ b/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
@@ -132,8 +132,7 @@
       and 201.05 / 208.47 at `on` / `off`. The rule excludes all three: it is
       no safety key. Its value sits inside its own label —
       `semantic/CwKeyerSurface.svelte`'s `cw-keyer-reverse-paddle` prints the
-      state after the name — which is a labelling defect to fix, not 6px of
-      rail to buy.
+      state after the name — which is a labelling defect to fix.
 
       Two properties, one number: the templates below stay written as
       `minmax(floor, width)`, and `tests/e2e/i18n/desktop-geometry.spec.ts`
@@ -143,7 +142,8 @@
       `--flagship-probe-switch-width` is the wide template's four declared
       widths plus the three gutters `.probe-stage` puts between its columns:
       2*186 + 2*360 + 3*8 = 1116. `__tests__/FlagshipProbe.component.test.ts`
-      pins these values and the shape of the two rail tracks.
+      requires the `@container` literal and the manifest breakpoint to equal
+      this sum, and pins the shape of the two rail tracks.
     */
     --flagship-probe-rail-floor: 186px;
     --flagship-probe-rail-width: 186px;

--- a/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
+++ b/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
@@ -104,51 +104,51 @@
     height: 100%;
 
     /*
-      ONE-KEY floor: re-measured 2026-09-09 with every rail key's text
-      replaced by `lib/i18n/pseudo.ts`'s `pseudoize()` output, on the real
-      skin through the fixture-stub seam (`vite.fixtures.config.ts`) in
-      headless Chromium; do not lower it to make a layout fit.
+      THE RAIL RULE (art direction, 2026-09-09). A rail is as wide as the
+      widest thing that must be READABLE in one column of controls, which is
+      ONE key — not a row of two, and not the transmit pair, whose
+      `.rx-tx-actions` row may wrap (`semantic/RxTxSurface.svelte`).
+      Pseudo-localisation is a stress model, not a width source: it fixes a
+      number only where clipping would be a SAFETY failure — the transmit
+      key — and every other rail key is measured in English.
 
-      192 is the larger of two measured terms rounded up: the widest single
-      key in any of the ten rail surfaces — the CW keyer's
-      `⟦Ŕéṽéŕšé þáđđłé: — ~~~~~~⟧`, 191.77px at a computed font-size of
-      13.3333px, with no padding between its border box and its zone box —
-      and the transmit zone's min-content, 185.20px, which is that zone's own
-      `⟦Ķéý ťŕáñšɱíťťéŕ ~~~~~~⟧` button now that
-      `semantic/RxTxSurface.svelte`'s `.rx-tx-actions` row may wrap.
+      Both terms below are that one rule. Measured 2026-09-09 in headless
+      Chromium on this skin, mounted through the fixture-stub seam
+      (`vite.fixtures.config.ts`) from an entry written for the measurement:
+      every `<button>` the ten rail zones mount, each taken alone at
+      `width: max-content` plus the padding and border between its border box
+      and its zone box, and taken again with `on` and with `off` in place of
+      an unread fact. Pseudo text is `lib/i18n/pseudo.ts`'s `pseudoize()`
+      applied to the rendered string.
 
-      Derived from labels that CAN grow, not from the ones shipped today.
-      `__tests__/FlagshipProbe.component.test.ts` pins this value and the
-      shape of the two rail tracks below.
-    */
-    --flagship-probe-rail-floor: 192px;
+        safety term  — the transmit key, pseudo-localised, 185.20px. 186 is
+                       that rounded up, and it GOVERNS both properties.
+        English term — the widest rail key in English is the CW keyer's
+                       `Reverse paddle: on`, 131.61px at a computed
+                       font-size of 13.3333px. Below 186, so it does not
+                       bind.
 
-    /*
-      The declared track widths — a rail's width and a receiver strip's
-      minimum — and their sum with the three gutters `.probe-stage` puts
-      between the four columns.
+      Pseudo-localised, that CW key measures 191.77px with its fact unread
+      and 201.05 / 208.47 at `on` / `off`. The rule excludes all three: it is
+      no safety key. Its value sits inside its own label —
+      `semantic/CwKeyerSurface.svelte`'s `cw-keyer-reverse-paddle` prints the
+      state after the name — which is a labelling defect to fix, not 6px of
+      rail to buy.
 
-      THE WIDTH IS THE FLOOR. Art-direction ruling of 2026-09-09: a rail is
-      as wide as the widest thing that must be READABLE in one column of
-      controls, which is ONE key — not a row of two, and not the transmit
-      pair, whose `.rx-tx-actions` row may wrap
-      (`semantic/RxTxSurface.svelte`). That ruling also confines
-      pseudo-localisation to the key whose clipping would be a SAFETY
-      failure, the transmit key; every other rail key is measured in
-      English. Measured 2026-09-09 the same way as the floor above, over
-      every key the ten rail surfaces mount on that harness's dual-receiver
-      fixture, each toggle taken at both values its own fact renders: the
-      widest English key is the CW keyer's `Reverse paddle: on`, 131.61px —
-      below the floor. So the floor is the binding term and this track is a
-      fixed 192px.
-
-      Two properties for one number, not one: the tracks below stay written
-      as `minmax(floor, width)`, and `tests/e2e/i18n/desktop-geometry.spec.ts`
+      Two properties, one number: the templates below stay written as
+      `minmax(floor, width)`, and `tests/e2e/i18n/desktop-geometry.spec.ts`
       overrides BOTH to set the rail column it measures the transmit pair in.
+      Do not lower either to make a layout fit.
+
+      `--flagship-probe-switch-width` is the wide template's four declared
+      widths plus the three gutters `.probe-stage` puts between its columns:
+      2*186 + 2*360 + 3*8 = 1116. `__tests__/FlagshipProbe.component.test.ts`
+      pins these values and the shape of the two rail tracks.
     */
-    --flagship-probe-rail-width: 192px;
+    --flagship-probe-rail-floor: 186px;
+    --flagship-probe-rail-width: 186px;
     --flagship-probe-strip-min-width: 360px;
-    --flagship-probe-switch-width: 1128px;
+    --flagship-probe-switch-width: 1116px;
   }
 
   /*
@@ -196,7 +196,7 @@
       'meters    meters     meters     meters';
   }
 
-  @container (min-width: 1128px) {
+  @container (min-width: 1116px) {
     .probe-stage {
       grid-template-columns:
         minmax(var(--flagship-probe-rail-floor), var(--flagship-probe-rail-width))

--- a/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
+++ b/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
@@ -539,13 +539,11 @@ describe('the rail floor', () => {
    *
    * Pseudo-localised, that CW key is 191.77px with its fact unread and
    * 201.05 / 208.47 at `on` / `off`; the rule excludes all three, it being no
-   * safety key. The PR body carries the full table.
+   * safety key.
    *
    * Kills: lowering the floor to make some layout fit. With the floor at 180
    * and the width left at 186, this is the only assertion in the file that
-   * fails — every other one is about the FORM of the track, and
-   * `minmax(var(--floor), var(--width))` keeps its form at any value of
-   * either.
+   * fails.
    */
   it('declares the measured one-key floor, and a rail width equal to it', () => {
     expect(px('--flagship-probe-rail-floor')).toBe(186);

--- a/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
+++ b/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
@@ -514,35 +514,39 @@ describe('no surface may size a track', () => {
 
 describe('the rail floor', () => {
   /**
-   * Both numbers were measured in Chromium on 2026-09-09, on the real
-   * `FlagshipProbeSkin` mounted through the fixture-stub seam
-   * (`vite.fixtures.config.ts`, fixture `topology-2-main-sub`), with every
-   * rail key's text replaced in the DOM by `lib/i18n/pseudo.ts`'s
-   * `pseudoize()` output.
+   * Both numbers were measured in Chromium, on the real `FlagshipProbeSkin`
+   * mounted through the fixture-stub seam (`vite.fixtures.config.ts`) from a
+   * harness entry written for the measurement — `fixtures/main.ts` mounts no
+   * flagship-probe fixture.
    *
-   * The FLOOR is one key: the larger of the widest single key in any of the
-   * ten rail surfaces — the CW keyer's reverse-paddle key, 191.77px at a
-   * computed font-size of 13.3333px — and the transmit zone's min-content,
-   * 185.20px, which is that zone's own key button now that
+   * The FLOOR, measured 2026-09-09 with every rail key's text replaced by
+   * `lib/i18n/pseudo.ts`'s `pseudoize()` output, is one key: the larger of
+   * the widest single key in any of the ten rail surfaces — the CW keyer's
+   * reverse-paddle key, 191.77px at a computed font-size of 13.3333px — and
+   * the transmit zone's own key button, 185.20px, now that
    * `semantic/RxTxSurface.svelte`'s `.rx-tx-actions` row may wrap. 192 is
-   * 191.77 rounded up to a whole pixel. The earlier 379 was the same pair,
-   * measured as one unwrappable row.
+   * 191.77 rounded up to a whole pixel.
    *
-   * The WIDTH is two keys: the transmit pair abreast, 185.20 + 8 + 184.89 =
-   * 378.09px, rounded up. Sweeping the rail width one pixel at a time, that
-   * is the widest two-key row of the ten — the next widest surface still
-   * puts two keys on a line at a rail of 177px. The PR body carries the full
-   * table.
+   * The WIDTH is that same one key, re-derived 2026-09-09 under the
+   * art-direction ruling that a rail is as wide as the widest thing that
+   * must be readable in ONE column — never a two-key row, and never the
+   * transmit pair, which wraps. That ruling confines pseudo-localisation to
+   * the transmit key, where clipping is a safety failure, and measures every
+   * other rail key in English: over every key the ten rail surfaces mount on
+   * the harness's dual-receiver fixture, each toggle taken at both values
+   * its own fact renders, the widest English key is the CW keyer's
+   * `Reverse paddle: on` at 131.61px. That is below the floor, so the width
+   * IS the floor. The PR body carries the full table.
    *
-   * Kills: lowering the floor to make some layout fit, which is exactly what
-   * the comment on the declaration forbids and what no other test here would
-   * notice — every other assertion in this file is about the FORM of the
-   * track, and `minmax(var(--floor), var(--width))` keeps its form at any
-   * value of either.
+   * Kills: lowering the floor to make some layout fit, or letting the width
+   * drift off it — what no other test here would notice, because every other
+   * assertion in this file is about the FORM of the track, and
+   * `minmax(var(--floor), var(--width))` keeps its form at any value of
+   * either.
    */
-  it('declares the measured one-key floor and the measured two-key rail width', () => {
+  it('declares the measured one-key floor, and a rail width equal to it', () => {
     expect(px('--flagship-probe-rail-floor')).toBe(192);
-    expect(px('--flagship-probe-rail-width')).toBe(379);
+    expect(px('--flagship-probe-rail-width')).toBe(192);
   });
 
   // Kills: a rail width below its own floor, which would make `minmax()`

--- a/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
+++ b/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
@@ -514,39 +514,42 @@ describe('no surface may size a track', () => {
 
 describe('the rail floor', () => {
   /**
-   * Both numbers were measured in Chromium, on the real `FlagshipProbeSkin`
-   * mounted through the fixture-stub seam (`vite.fixtures.config.ts`) from a
-   * harness entry written for the measurement — `fixtures/main.ts` mounts no
-   * flagship-probe fixture.
+   * THE RAIL RULE (art direction, 2026-09-09): a rail is as wide as the
+   * widest thing that must be readable in ONE column of controls — never a
+   * two-key row, and never the transmit pair, which may wrap.
+   * Pseudo-localisation is a stress model, not a width source, so it fixes a
+   * number only where clipping would be a safety failure — the transmit
+   * key — and every other rail key is measured in English.
    *
-   * The FLOOR, measured 2026-09-09 with every rail key's text replaced by
-   * `lib/i18n/pseudo.ts`'s `pseudoize()` output, is one key: the larger of
-   * the widest single key in any of the ten rail surfaces — the CW keyer's
-   * reverse-paddle key, 191.77px at a computed font-size of 13.3333px — and
-   * the transmit zone's own key button, 185.20px, now that
-   * `semantic/RxTxSurface.svelte`'s `.rx-tx-actions` row may wrap. 192 is
-   * 191.77 rounded up to a whole pixel.
+   * Both properties are that one rule, measured 2026-09-09 in Chromium on
+   * the real `FlagshipProbeSkin` mounted through the fixture-stub seam
+   * (`vite.fixtures.config.ts`) from a harness entry written for the
+   * measurement — `fixtures/main.ts` mounts no flagship-probe fixture. Every
+   * `<button>` the ten rail zones mount was taken alone at
+   * `width: max-content` plus the padding and border between its border box
+   * and its zone box, and taken again with `on` and with `off` in place of
+   * an unread fact:
    *
-   * The WIDTH is that same one key, re-derived 2026-09-09 under the
-   * art-direction ruling that a rail is as wide as the widest thing that
-   * must be readable in ONE column — never a two-key row, and never the
-   * transmit pair, which wraps. That ruling confines pseudo-localisation to
-   * the transmit key, where clipping is a safety failure, and measures every
-   * other rail key in English: over every key the ten rail surfaces mount on
-   * the harness's dual-receiver fixture, each toggle taken at both values
-   * its own fact renders, the widest English key is the CW keyer's
-   * `Reverse paddle: on` at 131.61px. That is below the floor, so the width
-   * IS the floor. The PR body carries the full table.
+   *   safety term  — the transmit key, pseudo-localised with
+   *                  `lib/i18n/pseudo.ts`'s `pseudoize()`, 185.20px. 186 is
+   *                  that rounded up, and it governs both properties.
+   *   English term — the widest rail key in English is the CW keyer's
+   *                  `Reverse paddle: on`, 131.61px at a computed font-size
+   *                  of 13.3333px, which is below 186.
    *
-   * Kills: lowering the floor to make some layout fit, or letting the width
-   * drift off it — what no other test here would notice, because every other
-   * assertion in this file is about the FORM of the track, and
+   * Pseudo-localised, that CW key is 191.77px with its fact unread and
+   * 201.05 / 208.47 at `on` / `off`; the rule excludes all three, it being no
+   * safety key. The PR body carries the full table.
+   *
+   * Kills: lowering the floor to make some layout fit. With the floor at 180
+   * and the width left at 186, this is the only assertion in the file that
+   * fails — every other one is about the FORM of the track, and
    * `minmax(var(--floor), var(--width))` keeps its form at any value of
    * either.
    */
   it('declares the measured one-key floor, and a rail width equal to it', () => {
-    expect(px('--flagship-probe-rail-floor')).toBe(192);
-    expect(px('--flagship-probe-rail-width')).toBe(192);
+    expect(px('--flagship-probe-rail-floor')).toBe(186);
+    expect(px('--flagship-probe-rail-width')).toBe(186);
   });
 
   // Kills: a rail width below its own floor, which would make `minmax()`

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -582,12 +582,13 @@ test.describe('T185 transmit key pair', () => {
     // `layout` is the workspace value; `qaLayout` is what actually selects the skin.
     await boot(page, 'standard', 1440, true, 'studioline', false, undefined,
       { qaLayout: 'flagship-probe' });
-    // The probe's own rail is wider than the pair (the case below measures that),
-    // so the narrow column comes from narrowing the rail. Both of the custom
-    // properties the skin's two grid templates size a rail track from — the
-    // `minmax()` floor and its width — have to come down, or the floor holds the
-    // track open. `!important` because the skin's own declarations are
-    // Svelte-scoped, and a plain `.flagship-probe` selector loses to that class.
+    // Both cases set the rail column they measure in, rather than inheriting
+    // whatever the skin declares: the two custom properties its grid templates
+    // size a rail track from are the `minmax()` floor and its width, and BOTH
+    // have to be pinned or the one left alone decides the track. 200px is
+    // narrower than the pair, which is the column this case needs.
+    // `!important` because the skin's own declarations are Svelte-scoped, and
+    // a plain `.flagship-probe` selector loses to that class.
     await page.addStyleTag({ content: '.flagship-probe { --flagship-probe-rail-floor: 200px !important;'
       + ' --flagship-probe-rail-width: 200px !important; }' });
     const geometry = await measurePair(page);
@@ -605,10 +606,14 @@ test.describe('T185 transmit key pair', () => {
   test('stays on one line when its column is wider than the pair', async ({ page }, info) => {
     await boot(page, 'standard', 1440, true, 'studioline', false, undefined,
       { qaLayout: 'flagship-probe' });
+    // The mirror of the case above: 400px is wider than the pair. The skin's
+    // own rail is one key wide (T194), so this column has to be set here too.
+    await page.addStyleTag({ content: '.flagship-probe { --flagship-probe-rail-floor: 400px !important;'
+      + ' --flagship-probe-rail-width: 400px !important; }' });
     const geometry = await measurePair(page);
     await info.attach('wide', { body: JSON.stringify(geometry), contentType: 'application/json' });
     expect(geometry.key.width + geometry.gap + geometry.unkey.width,
-      'the probe rail is wider than the pair').toBeLessThanOrEqual(geometry.actions.width);
+      'the column under test is wider than the pair').toBeLessThanOrEqual(geometry.actions.width);
     expect(geometry.unkey.top, 'both buttons share one line').toBe(geometry.key.top);
     expect(contained(geometry.key, geometry.zone), 'the key stays inside its column').toBe(true);
     expect(contained(geometry.unkey, geometry.zone), 'the unkey stays inside its column').toBe(true);

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -607,7 +607,7 @@ test.describe('T185 transmit key pair', () => {
     await boot(page, 'standard', 1440, true, 'studioline', false, undefined,
       { qaLayout: 'flagship-probe' });
     // The mirror of the case above: 400px is wider than the pair. The skin's
-    // own rail is one key wide (T194), so this column has to be set here too.
+    // own rail is one key wide, so this column has to be set here too.
     await page.addStyleTag({ content: '.flagship-probe { --flagship-probe-rail-floor: 400px !important;'
       + ' --flagship-probe-rail-width: 400px !important; }' });
     const geometry = await measurePair(page);


### PR DESCRIPTION
**The ruling (2026-09-09).** Pseudo-localisation is a stress model, not a width source: it sets a number only where the failure it prevents is unacceptable — the transmit key, because clipping it is a safety failure — and every other key is measured in English plus the measured margin. That is ONE rule, and both terms of the rail come from it, so this branch's earlier 192 is replaced by **186**.

## The rule applied to both terms

Measured 2026-09-09 in headless Chromium on the changed skin, mounted through the fixture-stub seam (`vite.fixtures.config.ts`) from a harness entry written for the measurement — `fixtures/main.ts` mounts no flagship-probe fixture, so no catalog page mounts this skin. Every `<button>` the ten rail zones mount (`rf-front-end`, `dsp`, `filter`, `rx-audio`, `antenna`, `band`, `rx-tx`, `tx-aux`, `cw-keyer`, `rit-xit-scan`) was taken alone at `width: max-content`, plus the padding and border between its border box and its zone box, and taken again with `on` and with `off` in place of an unread fact. Pseudo text is `lib/i18n/pseudo.ts`'s `pseudoize()` applied to the rendered string.

| term | value | key |
|---|---|---|
| **safety** — the transmit key, pseudo-localised | **185.20 px** (10px type) → **186** | `rx-tx/rx-tx-key`, `⟦Ķéý ťŕáñšɱíťťéŕ ~~~~~~⟧` |
| **English** — the widest rail key at any value its fact renders | **131.61 px** (13.3333px type) | `cw-keyer/cw-keyer-reverse-paddle` at `on`, `Reverse paddle: on` |

The safety term governs; the English term is below it and does not bind. Runners-up in English: `rx-tx-key` 131.13 as rendered, `cw-keyer-reverse-paddle` 131.36 at `off`.

**The key that does not buy 6 px.** Pseudo-localised, `cw-keyer-reverse-paddle` measures 191.77 px with its fact unread, 201.05 at `on` and 208.47 at `off` — all above 186. The rule excludes all three: it is no safety key. Its value sits inside its own label (`semantic/CwKeyerSurface.svelte`'s `cw-keyer-reverse-paddle` prints the state after the name), which is a labelling defect to fix, not rail width to buy.

**Result.** `--flagship-probe-rail-floor: 186px` and `--flagship-probe-rail-width: 186px`. Both properties stay: the two column templates keep their tracks written as `minmax(floor, width)`, and `tests/e2e/i18n/desktop-geometry.spec.ts` overrides both to set the rail column it measures the transmit pair in.

**Threshold.** 2 × 186 + 2 × 360 + 3 × 8 = **1116**, in the `--flagship-probe-switch-width` literal, the `@container` literal and `presentation/layouts/declarations.ts`'s `responsiveBreakpoints`.

## Band on the changed skin

Container swept 300 → 1000 by 1 px pseudo-localised, plus 1106–1126 for the switch and one reading at 1658.

| container | stage overflows (`scrollWidth > clientWidth`) | key outside its rail box | arrangement |
|---|---|---|---|
| 300–395 | yes (at 395: `scrollWidth` 396 vs `clientWidth` 395) | none | narrow |
| 396–1000 | no | none | narrow |
| 1106–1115 | no | none | narrow |
| 1116–1126 | no | none | wide |

396 is exactly both rails plus the three gutters (186 + 186 + 24) — the overflow the skin's own comment describes — and it is the first width that does **not** overflow, so overflow is at ≤ 395 rather than ≤ 396. No key left its rail box at any width swept; in particular the transmit key, 185.20 px pseudo-localised, stays inside a 186 px rail from the floor up.

The switch is exact: narrow at 1115 (strips 359.5), wide at 1116 (strips exactly 360). At **1658 px**: tracks **186 / 631 / 631 / 186**, panorama **1270**, no overflow, no key outside its rail box, wide arrangement.

## The two prose deletions

1. **The unqualified totality.** The skin comment and the test docstring both said "the widest single key in any of the ten rail surfaces" without saying at which value the key was measured — a key with a toggle in its label has several widths. Both sentences are rewritten to name the value (`Reverse paddle: on`, 131.61 px in English; 191.77 / 201.05 / 208.47 pseudo-localised at unread / `on` / `off`).
2. **The false "no other test would notice".** The docstring's "or letting the width drift off it — what no other test here would notice, because every other assertion in this file is about the FORM of the track" was wrong about the width: a drifting width fails `the threshold is the sum of the declared minimum track widths and the gutters` and `switches at the sum of the wide template's four declared widths and the gutters` (mutation 2 below). The Kills sentence is now about the **floor** alone, and mutation 4 measures it.

Also dropped: the `(T194)` label on the 400 px column override in `tests/e2e/i18n/desktop-geometry.spec.ts`; nothing in the tree defines it. The override itself stays.

## Tests

- `npm run check` — `COMPLETED 4844 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`
- `npm run lint` — clean, no output
- `npm run lint:boundaries` — clean, no output
- `vitest run src/skins/flagship-probe/ src/presentation/layouts/__tests__/flagship-probe-registration.test.ts` — `Test Files 2 passed (2) · Tests 39 passed (39)`
- `playwright test -c ./playwright.i18n.config.ts tests/e2e/i18n/desktop-geometry.spec.ts -g "T185 transmit key pair"` after `npm run build` — `2 passed (3.4s)`

## Mutations

1. **floor 186 → 185**, width left at 186 — the transmit key at 185.20 no longer fits. `× declares the measured one-key floor, and a rail width equal to it`, `AssertionError: expected 185 to be 186`. `Tests 1 failed | 38 passed (39)`. **No test detects the key overflow itself**: the vitest suite runs in jsdom, which performs no layout, and the only two cases that mount this skin in a browser — the two `T185 transmit key pair` cases — override *both* rail properties (to 200 and to 400) before measuring, so neither reads the skin's declared rail. Established by grepping `frontend/tests/e2e` for `flagship-probe`: those two cases are the only hits outside `__screenshots__`.
2. **width 186 → 187** — three fail: `× the threshold is the sum of the declared minimum track widths and the gutters` and `× switches at the sum of the wide template's four declared widths and the gutters` (both `expected 1116 to be 1118`), and `× declares the measured one-key floor, and a rail width equal to it` (`expected 187 to be 186`). `Tests 3 failed | 36 passed (39)`.
3. **Threshold desync** — the skin's `@container` and `--flagship-probe-switch-width` moved to 1117 with `declarations.ts` left at 1116. `× declares the same reflow width the shell switches at`, `× the threshold is the sum of the declared minimum track widths and the gutters`, `× switches at the sum of the wide template's four declared widths and the gutters`. `Tests 3 failed | 36 passed (39)`.
4. **floor 186 → 180**, width left at 186 — `× declares the measured one-key floor, and a rail width equal to it`, `expected 180 to be 186`. `Tests 1 failed | 38 passed (39)` — exactly one assertion, which is what the rewritten Kills sentence claims.
5. **Control: declaration reorder**, `--flagship-probe-switch-width` swapped above `--flagship-probe-strip-min-width`, no value changed — `Test Files 2 passed (2) · Tests 39 passed (39)`, green as required.

The tree was restored after every mutation and `git diff` at the head shows only the intended change.

## Recorded, not fixed

`cw-keyer-reverse-paddle` renders its state inside its own label, which is why its English width has a value in it at all and why its pseudo-localised widths (191.77 / 201.05 / 208.47) sit above the rail. Fixing that label is out of this change's scope.

Census at c5c2fe6121febcbf46cef443354527544dbad63e: 4 files, 86+/62- = 148 changed lines
internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

