### PR TITLE
fix: refuse to build a serial radio without an explicit model

### DIFF
--- a/src/rigplane/backends/factory.py
+++ b/src/rigplane/backends/factory.py
@@ -65,8 +65,7 @@ def create_radio(config: BackendConfig) -> Radio:
         # Route to model-specific serial backend
         if config.model is None or not config.model.strip():
             # R59/MOR-2425: the default this replaced drove an IC-7300 as an
-            # IC-7610. Not resolved from ``radio_addr`` either — R59 rejected
-            # identifying the rig by anything but the caller naming it.
+            # IC-7610. Not resolved from ``radio_addr`` either.
             raise ValueError(
                 "Serial backend needs an explicit radio model: pass --model "
                 "(e.g. --model IC-7300); rigplane does not guess a default rig."

--- a/src/rigplane/backends/factory.py
+++ b/src/rigplane/backends/factory.py
@@ -63,7 +63,15 @@ def create_radio(config: BackendConfig) -> Radio:
         )
     if isinstance(config, SerialBackendConfig):
         # Route to model-specific serial backend
-        model = (config.model or "IC-7610").upper()
+        if config.model is None or not config.model.strip():
+            # R59/MOR-2425: the default this replaced drove an IC-7300 as an
+            # IC-7610. Not resolved from ``radio_addr`` either — R59 rejected
+            # identifying the rig by anything but the caller naming it.
+            raise ValueError(
+                "Serial backend needs an explicit radio model: pass --model "
+                "(e.g. --model IC-7300); rigplane does not guess a default rig."
+            )
+        model = config.model.upper()
 
         # Yaesu CAT radios (FTX-1, FT-710, FT-991A, etc.)
         _YAESU_MODELS = {"FTX-1", "FT-710", "FT-991A", "FT-991", "FTDX101", "FTDX10"}

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -3806,7 +3806,13 @@ async def _cmd_web(
 
     config_kwargs["discovery"] = getattr(args, "web_discovery", True)
     config_kwargs["webrtc_enabled"] = getattr(args, "webrtc_enabled", False)
-    config_kwargs["radio_model"] = getattr(radio, "model", "IC-7610")
+    # R59/MOR-2425: a radio that cannot name itself is left unnamed. Omitting
+    # the key keeps WebConfig's ``_RADIO_MODEL_UNSPECIFIED`` sentinel, which
+    # the server already treats as "nothing identifies the radio"
+    # (server.py: WebServer._resolve_profile_if_identified).
+    _radio_model = getattr(radio, "model", None)
+    if isinstance(_radio_model, str) and _radio_model:
+        config_kwargs["radio_model"] = _radio_model
     config_kwargs["await_initial_state"] = True
     config = WebConfig(**config_kwargs)
     server = WebServer(radio, config)

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -3130,8 +3130,12 @@ class RigctldHandler:
     async def _cmd_get_info(self, cmd: RigctldCommand) -> RigctldResponse:
         if self._routing is not None:
             return RigctldResponse(values=[self._routing.get_info()])
-        raw_model = getattr(self._radio, "model", "IC-7610")
-        model = raw_model if isinstance(raw_model, str) and raw_model else "IC-7610"
+        # R59/MOR-2425: a radio that does not name itself is reported to the
+        # client as unspecified rather than as an IC-7610. ``Radio.model``
+        # (``core/radio_protocol.py``) is declared ``str``; this fallback
+        # covers a radio object with no ``model``, or an empty one.
+        raw_model = getattr(self._radio, "model", None)
+        model = raw_model if isinstance(raw_model, str) and raw_model else "unspecified"
         return RigctldResponse(values=[f"Icom {model} (rigplane)"])
 
     async def _cmd_chk_vfo(self, cmd: RigctldCommand) -> RigctldResponse:

--- a/src/rigplane/runtime/_control_phase.py
+++ b/src/rigplane/runtime/_control_phase.py
@@ -915,7 +915,10 @@ class ControlPhaseRuntime:
             username=h._username,
             token=h._token,
             tok_request=h._tok_request,
-            radio_name=getattr(h, "model", "IC-7610"),
+            # R59/MOR-2425: a host that cannot name a radio puts no rig name
+            # on the wire. ``ControlPhaseHost`` does not declare ``model``;
+            # ``CoreRadio``, the only host built in ``src/``, always has it.
+            radio_name=getattr(h, "model", "unspecified"),
             mac_address=b"\x00" * 6,
             auth_seq=h._auth_seq,
             guid=guid,

--- a/tests/golden/protocol_golden.json
+++ b/tests/golden/protocol_golden.json
@@ -233,11 +233,11 @@
   },
   {
     "id": "get_info",
-    "description": "get_info — returns IC-7610 description string",
+    "description": "get_info — the fixture radio declares no model, so no rig is named",
     "input": "\\get_info",
     "mock": {},
-    "expected_output": "Icom IC-7610 (rigplane)\n",
-    "extended_output": "get_info:\nIcom IC-7610 (rigplane)\nRPRT 0\n"
+    "expected_output": "Icom unspecified (rigplane)\n",
+    "extended_output": "get_info:\nIcom unspecified (rigplane)\nRPRT 0\n"
   },
   {
     "id": "chk_vfo",

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -85,14 +85,29 @@ class TestCreateRadioFactory:
         assert radio._radio_addr == 0x94
 
     def test_create_radio_builds_serial_backend(self) -> None:
-        radio = create_radio(SerialBackendConfig(device="/dev/ttyUSB0"))
+        radio = create_radio(
+            SerialBackendConfig(device="/dev/ttyUSB0", model="IC-7610")
+        )
         assert isinstance(radio, Icom7610SerialRadio)
         assert radio.model == "IC-7610"
+
+    def test_create_radio_serial_without_model_refuses(self) -> None:
+        """R59/MOR-2425: no --model must refuse, not assume the IC-7610.
+
+        The old default drove an IC-7300 as an IC-7610: the server then
+        waited on sub-receiver fields the rig does not have.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            create_radio(SerialBackendConfig(device="/dev/ttyUSB0"))
+        message = str(excinfo.value)
+        assert "--model" in message
+        assert "IC-7610" not in message
 
     def test_create_radio_passes_serial_audio_overrides(self) -> None:
         radio = create_radio(
             SerialBackendConfig(
                 device="/dev/tty.usbmodem-IC7610",
+                model="IC-7610",
                 rx_device="IC-7610 USB Audio",
                 tx_device="BlackHole 2ch",
             )
@@ -105,6 +120,7 @@ class TestCreateRadioFactory:
         radio = create_radio(
             SerialBackendConfig(
                 device="/dev/tty.usbmodem-IC7610",
+                model="IC-7610",
                 allow_low_baud_scope=True,
             )
         )
@@ -115,6 +131,7 @@ class TestCreateRadioFactory:
         radio = create_radio(
             SerialBackendConfig(
                 device="/dev/tty.usbmodem-IC7610",
+                model="IC-7610",
                 ptt_mode="civ",
             )
         )
@@ -126,7 +143,9 @@ class TestCreateRadioFactory:
         assert radio.backend_id == "rigplane"
 
     def test_serial_icom_backend_has_icom_serial_backend_id(self) -> None:
-        radio = create_radio(SerialBackendConfig(device="/dev/ttyUSB0"))
+        radio = create_radio(
+            SerialBackendConfig(device="/dev/ttyUSB0", model="IC-7610")
+        )
         assert radio.backend_id == "icom_serial"
 
     def test_yaesu_cat_backend_config_has_yaesu_cat_backend_id(self) -> None:

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -911,6 +911,38 @@ async def test_web_launch_without_application_auth(command, environment, monkeyp
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("radio_model", [None, "", "IC-7300"])
+async def test_cmd_web_radio_model_never_falls_back_to_a_guessed_rig(radio_model):
+    """R59/MOR-2425: a radio that cannot name itself leaves WebConfig's own
+    ``_RADIO_MODEL_UNSPECIFIED`` sentinel in place instead of being labelled
+    IC-7610."""
+    from rigplane.web.server import _RADIO_MODEL_UNSPECIFIED
+
+    args = _build_parser().parse_args(["web"])
+    args.web_rigctld = False
+    radio = AsyncMock()
+    if radio_model is None:
+        del radio.model
+    else:
+        radio.model = radio_model
+    captured: dict[str, object] = {}
+
+    class FakeWebServer:
+        def __init__(self, _radio, cfg):
+            captured["cfg"] = cfg
+            self._runtime_log_path = None
+
+        async def serve_forever(self, *, on_started=None):
+            on_started()
+            raise asyncio.CancelledError
+
+    with patch("rigplane.web.server.WebServer", FakeWebServer):
+        assert await _cmd_web(radio, args) == 0
+    expected = radio_model or _RADIO_MODEL_UNSPECIFIED
+    assert captured["cfg"].radio_model == expected
+
+
+@pytest.mark.asyncio
 async def test_cmd_web_managed_ignores_env_auth_and_keeps_loopback_rigctld(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_radio_connect.py
+++ b/tests/test_radio_connect.py
@@ -2,6 +2,7 @@
 
 import struct
 import time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -18,6 +19,7 @@ from rigplane.radio import (
 )
 from rigplane.audio.route import AudioConfigSource
 from rigplane.profiles import RadioProfile
+from rigplane.runtime._control_phase import ControlPhaseRuntime
 from rigplane.transport import ConnectionState
 from rigplane.types import AudioCodec
 
@@ -185,6 +187,34 @@ class TestReceiveGuid:
         assert guid is None
 
 
+def _conninfo_radio_name(packet: bytes) -> bytes:
+    """The conninfo radio-name field — 32 ASCII bytes at 0x40, NUL-padded.
+
+    Offset and width per ``core/auth.py: build_conninfo_packet``.
+    """
+    return packet[0x40:0x60].rstrip(b"\x00")
+
+
+class _NamelessControlPhaseHost:
+    """Control-phase host with no ``model`` attribute at all.
+
+    Carries only what ``ControlPhaseRuntime._send_conninfo`` reads.
+    """
+
+    def __init__(self) -> None:
+        self._ctrl_transport = ConnectMockTransport()
+        self._username = "user"
+        self._token = 0x12345678
+        self._tok_request = 0xABCD
+        self._auth_seq = 0
+        self._audio_stream_contract = SimpleNamespace(
+            rx_codec=AudioCodec.PCM_1CH_16BIT,
+            tx_codec=AudioCodec.PCM_1CH_16BIT,
+            rx_sample_rate_hz=48000,
+            tx_sample_rate_hz=48000,
+        )
+
+
 class TestSendConninfo:
     @pytest.mark.asyncio
     async def test_sends_conninfo(self) -> None:
@@ -198,6 +228,28 @@ class TestSendConninfo:
         await radio._control_phase._send_conninfo(b"\x00" * 16)
         assert len(mt.sent_packets) == 1
         assert len(mt.sent_packets[0]) == CONNINFO_SIZE
+
+    @pytest.mark.asyncio
+    async def test_conninfo_carries_the_radios_own_model(self) -> None:
+        """The name field at 0x40 is whatever the rig calls itself."""
+        radio = IcomRadio("192.168.1.100", model="IC-7300")
+        mt = ConnectMockTransport()
+        radio._ctrl_transport = mt
+        await radio._control_phase._send_conninfo(b"\x00" * 16)
+        assert _conninfo_radio_name(mt.sent_packets[0]) == b"IC-7300"
+
+    @pytest.mark.asyncio
+    async def test_conninfo_names_no_radio_when_the_host_names_none(self) -> None:
+        """R59/MOR-2425: an unnamed host puts no rig name on the wire.
+
+        The default here used to be ``"IC-7610"``. ``ControlPhaseHost``
+        (``runtime/_runtime_protocols.py``) does not declare ``model``, so
+        ``_send_conninfo`` reaches for it with ``getattr``.
+        """
+        host = _NamelessControlPhaseHost()
+        await ControlPhaseRuntime(host)._send_conninfo(b"\x00" * 16)  # type: ignore[arg-type]
+        packet = host._ctrl_transport.sent_packets[0]
+        assert _conninfo_radio_name(packet) == b"unspecified"
 
     @pytest.mark.asyncio
     async def test_sends_conninfo_without_guid(self) -> None:

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -1836,10 +1836,18 @@ async def test_dump_caps_same_as_dump_state(
 
 
 @pytest.mark.asyncio
-async def test_get_info(handler: RigctldHandler, mock_radio: AsyncMock) -> None:
+async def test_get_info_names_no_rig_when_the_radio_names_none(
+    handler: RigctldHandler, mock_radio: AsyncMock
+) -> None:
+    """R59/MOR-2425: an unnamed radio is reported unspecified, not IC-7610.
+
+    ``mock_radio.model`` is an auto-generated ``AsyncMock`` attribute rather
+    than a ``str``, so this is the branch that used to hand a hamlib client
+    the name of a rig nobody attached.
+    """
     resp = await handler.execute(get_cmd("get_info"))
     assert resp.ok
-    assert "IC-7610" in resp.values[0]
+    assert resp.values[0] == "Icom unspecified (rigplane)"
 
 
 @pytest.mark.asyncio

--- a/tests/test_server_wire.py
+++ b/tests/test_server_wire.py
@@ -239,7 +239,9 @@ class TestGetSetRoundtrip:
         await w.drain()
 
         data = await _read(r)
-        assert data == b"Icom IC-7610 (rigplane)\n"
+        # The wire fixture's ``_MockRadio`` declares no ``model``; R59/MOR-2425
+        # says that reaches the client as unspecified, not as an IC-7610.
+        assert data == b"Icom unspecified (rigplane)\n"
         await _close(w)
 
     async def test_chk_vfo_wire(self, wire_server: RigctldServer) -> None:


### PR DESCRIPTION
4 code + 6 test and golden files = 10 files, at the hard file ceiling and not over it (the coordinating session records this under the owner's 2026-09-03 delegation: four sites of one class — the serial factory default, the CLI fallback, the rigctld name and the control-phase name — and the six test files that pinned the guessed name are one change).

Owner ruling R59 (2026-09-09): started without `--model`, the server must refuse rather than assume the IC-7610 — an IC-7300 driven as an IC-7610 left initial-state acquisition waiting on 93 fields (including 26 `receiver.sub.*` paths — the IC-7610 acquisition domain declares 93 paths, 26 of them `receiver.sub.*`; the IC-7300 declares 67 with none for a second receiver the rig does not have) and never completing, where `--model IC-7300` reported 63 fields and completed. Auto-detection by CI-V identity was not chosen and none is added here.

## The four sites

Step 1 removed the two guesses that named a model to the server itself; step 2 removed the two that named it to the outside, found by step 1's class sweep — a BLOCKED naming one instance is a review of its class.

1. `src/rigplane/backends/factory.py` — `create_radio`, `SerialBackendConfig` branch: `model = (config.model or "IC-7610").upper()`, directly above the MOR-174 comment "never silently impersonate an IC-7610". Now raises `ValueError` when `config.model` is absent or blank. The model is **not** resolved from `radio_addr`, per R59. The existing unsupported-model error for a wrong name is unchanged.

2. `src/rigplane/cli/__init__.py` — `_cmd_web`: `config_kwargs["radio_model"] = getattr(radio, "model", "IC-7610")`. The key is now simply omitted when the radio has no usable model string, which leaves `WebConfig`'s own `_RADIO_MODEL_UNSPECIFIED` default in place. **Sentinel, not raise** — that is the contract the surrounding code already states: `WebConfig.radio_model: str = _RADIO_MODEL_UNSPECIFIED` in `src/rigplane/web/server.py`, whose MOR-174 comment says callers inject the connected radio's model and an unconfigured server must not impersonate an IC-7610, and `WebServer._resolve_profile_if_identified` already filters that sentinel out of its candidates and treats "nothing identifies the radio" as a normal state. Raising here would be a new failure mode the server does not ask for. Omitting the key rather than importing the private sentinel across the layer keeps the default in the one place that defines it.

## CLI failure, verbatim

`create_radio`'s `ValueError` was already caught in `_run` and printed as `Error: {exc}` with exit 1, so no CLI change was needed for clean reporting. Run in this worktree at the head below (a `Logging to ...` line naming a local cache path is elided):

```
$ uv run rigplane --backend serial --serial-port /dev/null-nonexistent web --no-rigctld --no-discovery --port 8098
Error: Serial backend needs an explicit radio model: pass --model (e.g. --model IC-7300); rigplane does not guess a default rig.
$ echo $?
1
```

Nothing was connected or bound first. Control, same command plus `--model IC-7300`, which gets past model resolution and fails only at the device:

```
Error: Failed to connect serial session on /dev/null-nonexistent: [Errno 2] could not open port /dev/null-nonexistent: [Errno 2] No such file or directory: '/dev/null-nonexistent'
```

## LAN and rigctld when `config.model` is None — reported, not changed

Measured by running `create_radio` on each config at this head. The **LAN** branch passes `model`, `profile` and `radio_addr` straight to `IcomRadio.__init__`, which calls `resolve_radio_profile(profile=, model=, radio_addr=)` (`src/rigplane/profiles/__init__.py: resolve_radio_profile`). With none of the three set it raises `ValueError: Cannot resolve a radio profile: ... rigplane no longer guesses a default rig` — so the LAN path already refuses, and this PR does not change it. With `radio_addr=0x94` and no model it resolves to IC-7300 by CI-V address; that address lookup is pre-existing LAN behaviour, not added here, and R59's prohibition was on adding such detection. The **rigctld** branch (`src/rigplane/backends/rigctld_client/radio.py: RigctldClientRadio.__init__`) resolves no rig profile at all: `self._model = model or "External rigctld"`, and `radio.model` reads back as `'External rigctld'` — a literal label for an external server, not a guessed rig.

**README and epilog — since fixed elsewhere.** When this PR was written, `README.md`'s quickstart and the parser epilog both showed a bare `rigplane web` that identified no radio, and this PR deliberately left them alone. #3416 has since rewritten both (merged as `348ded75`); neither string exists at this head, verified by searching `README.md` and `cli/__init__.py`. What the measurement below still shows is the LAN path's own behaviour, which this PR does not change: `_auto_discover_lan` returns only a host, and `radio_addr`/`model_name` come only from `--radio-addr`/`--model` (`cli/__init__.py: _resolve_model`), so a bare `rigplane web` reaches `LanBackendConfig(model=None, radio_addr=None)` and refuses. Confirmed by running the same shape with an explicit host, which skips discovery but has identical model/addr:

```
$ uv run rigplane --host 192.0.2.1 web --no-rigctld --no-discovery --port 8099
Error: Cannot resolve a radio profile: no profile, model, or matching radio_addr identifies the radio. Pass an explicit profile= or model= — rigplane no longer guesses a default rig.
```

Fixing that documentation is a separate change; it is outside this PR's scope and is left unfixed and reported.

## Same-shape instances found and left unfixed

Enumerated with `git grep -n '"IC-7610"' -- src/` (excluding `rigs/`), then read at each hit. Two further sites defaulted an unnamed radio to IC-7610 with the identical `getattr` shape; step 2 below changes both:

- `src/rigplane/rigctld/handler.py` — `raw_model = getattr(self._radio, "model", "IC-7610")` and the `else "IC-7610"` on the following line.
- `src/rigplane/runtime/_control_phase.py` — `radio_name=getattr(h, "model", "IC-7610")`.

`src/rigplane/backends/icom7610/serial.py`'s `_DEFAULT_MODEL = "IC-7610"` is the IC-7610 class's own model, not a guess, and is correct as it stands.

The other half of the class is tests that relied on the removed factory default. Enumerated with `git grep -l 'SerialBackendConfig' -- tests/ src/` and reading every construction: five calls in `tests/test_backend_factory.py` passed `create_radio` a serial config with no model and asserted `Icom7610SerialRadio`. All five now pass `model="IC-7610"` explicitly, which is what they were actually about (audio overrides, low-baud scope, PTT mode, backend id). `tests/test_audio_probe_runner.py` also builds a model-less `SerialBackendConfig`, but that test asserts the LAN-only rejection that happens before `create_radio`, so it is unaffected and passes unchanged. No other test reached the default.


## Step 2 — the two names reported outward

3. `src/rigplane/rigctld/handler.py` — `\get_info` reported a radio whose `model` is absent or not a string to the hamlib client as "Icom IC-7610 (rigplane)". It now reads "Icom unspecified (rigplane)", the notion `WebConfig` already carries as `_RADIO_MODEL_UNSPECIFIED`, spelled out rather than imported because rigctld may not import from web/. `Radio.model` (`core/radio_protocol.py`) is declared `str`, so a conforming radio keeps reporting its own name. The handler test, the wire test and the get_info golden asserted the guessed name and now assert the neutral one.

4. `src/rigplane/runtime/_control_phase.py` — the Icom LAN conninfo packet's 32-byte name field (`core/auth.py: build_conninfo_packet`) took "IC-7610" when the host could not name a radio; it now takes "unspecified". `ControlPhaseHost` does not declare `model`; `CoreRadio`, the only host constructed in src/, always has it, so this is off the path of a LAN session. Pinned in `tests/test_radio_connect.py`.

The MOR-174 comment above the serial fallback — "never silently impersonate an IC-7610" — was true as an intention and false as a description of the code beneath it, long enough that a reader trusting it would have looked for the model choice in another file. It now describes what happens.

## Tests

- `tests/test_backend_factory.py::TestCreateRadioFactory::test_create_radio_serial_without_model_refuses` — model-less serial config raises `ValueError` whose message contains `--model` and does not contain `IC-7610`.
- `tests/test_backend_factory.py::TestCreateRadioFactory::test_create_radio_serial_known_model_dispatches_to_its_class` — already pinned on `main`; `model="IC-7300"` still builds `Ic7300SerialRadio` with `radio.model == "IC-7300"`.
- `tests/test_cli_coverage.py::test_cmd_web_radio_model_never_falls_back_to_a_guessed_rig` — parametrised over a radio with no `model` attribute, one with `""`, and one with `"IC-7300"`; asserts `WebConfig.radio_model` is `_RADIO_MODEL_UNSPECIFIED` for the first two and `"IC-7300"` for the third.

### Mutations

Each mutation was applied to the implementation alone, with the tests left as committed.

1. **Factory default restored** (`model = (config.model or "IC-7610").upper()`) → `tests/test_backend_factory.py` `1 failed, 24 passed`; the one kill is `test_create_radio_serial_without_model_refuses` (`Failed: DID NOT RAISE <class 'ValueError'>`). The five tests switched to explicit models stayed green, so they are not what carries the signal.
2. **Message without `--model`** (`"Serial backend needs an explicit radio model; rigplane does not guess a default rig."`) → `1 failed, 24 passed`; same test, `AssertionError: assert '--model' in '...'`.
3. **CLI default restored** (`getattr(radio, "model", "IC-7610")`) → `tests/test_cli_coverage.py` `2 failed, 78 passed`; kills `test_cmd_web_radio_model_never_falls_back_to_a_guessed_rig[None]` and `[]`.
4. **Refactor control** — the guard rewritten as `if not (config.model or "").strip():`, semantically equivalent → `tests/test_backend_factory.py tests/test_cli_coverage.py` `105 passed`.

The tree was restored from the pre-mutation copies afterwards; `git diff` at the commit shows only the intended change.

## Gates

**At the current head `44821b5c`** (after merging `main`, coordinator's worktree): `uv run pytest -n auto tests/test_backend_factory.py tests/test_cli_coverage.py tests/test_radio_connect.py tests/test_rigctld_handler.py tests/test_server_wire.py -q` → 602 passed; `ruff check` and `ruff format --check` on the four changed source files → clean; `lint-imports` → Contracts: 5 kept, 0 broken. Required CI at this head: `quick` pass (run 35037094854), `Agent Review Gate` pass, bound to this head.

Earlier evidence, kept for history, at the pre-merge head c4f80625 (independent verifier, worktree): `uv run pytest tests/test_backend_factory.py tests/test_cli_coverage.py tests/test_rigctld_handler.py tests/test_server_wire.py tests/test_radio_connect.py tests/test_cli_model.py -q` → 594 passed; `tests/test_golden_protocol.py` → 46 passed; `ruff check` → All checks passed!; `ruff format --check` → 742 files already formatted; `lint-imports` → Contracts: 5 kept, 0 broken.; `mypy --strict src/rigplane/web` → Success: no issues found in 27 source files. CI quick at c4f80625: 16191 passed, 220 skipped, 15 xfailed. Commit 073bf697 after review deletes one comment clause in `factory.py` (no code change; `tests/test_backend_factory.py` 25 passed, ruff clean).

Step-2 mutations (run by the verifier; the step-2 builder's shell hung before it could record them): rigctld fallback restored → 3 failed (handler, wire and the get_info golden); control-phase fallback restored → 1 failed; control phase always "unspecified" → the IC-7300 conninfo row fails; refactor control at all three sites → 640 passed.

Census at `44821b5c`, after merging current `main` into the branch: 10 files, 146+/13- = 159 changed lines (unchanged by the merge) (`git diff --numstat origin/main...HEAD`). Ten files is the hard ceiling, not over it; the exception is recorded as the first line. Documentation that relied on the removed default was corrected first, in #3416 (merged as `348ded75`). Its footprint is wider than this paragraph originally claimed — ten files: `README.md`, `docs/guide/cli.md`, `docs/guide/configuration.md`, `docs/guide/ic7300-usb-setup.md`, `docs/guide/ic7610-usb-setup.md`, `docs/guide/troubleshooting.md`, `docs/radio-protocol.md`, `src/rigplane/cli/__init__.py` (epilog and hint strings), `src/rigplane/profiles/LAYER.md` and `tests/test_cli.py`.

internal-identifier self-check — empty.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)




