### PR TITLE
feat: let the probe strip its deck by slot instead of receiver

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -89,7 +89,7 @@
     createFiniteRendererContext,
     type FiniteRendererContext,
   } from '../../primitives/control-instruments/control-instrument-renderer.svelte';
-  import type { RadioViewModel, VfoSlot } from '../../semantic/radio-view-model';
+  import type { ReceiverId, RadioViewModel, VfoSlot } from '../../semantic/radio-view-model';
   import RfFrontEndSurface, {
     type RfFrontEndLevelField,
   } from '../../semantic/RfFrontEndSurface.svelte';
@@ -133,7 +133,7 @@
     type ScopeChoiceField, type ScopeToggleField,
   } from '../../semantic/ScopeControlsSurface.svelte';
   import {
-    forReceiver, receiversOf, isActiveStrip, isOperationalStrip,
+    forReceiver, forSlot, receiversOf, slotsOf, isActiveStrip, isOperationalStrip,
   } from './dual-receiver-strips';
   import { guardRadioViewModel } from './radio-view-model-guard';
   import type {
@@ -157,6 +157,14 @@
     children?: Snippet<[InstrumentComposition]>;
     externalPresentation?: ExternalPresentation | null;
     strips?: 'single' | 'dual';
+    /**
+     * What ONE strip of the `dual` composition is. `'receiver'` (default) is
+     * the shipped deck: one strip per structural receiver. `'slot'` is owner
+     * ruling R58's deck: one strip per DECK SLOT, so a single-receiver radio
+     * gets its unselected VFO in the second column. Read only under
+     * `strips === 'dual'`.
+     */
+    stripBy?: 'receiver' | 'slot';
     regions?: boolean;
     regionContent?: Snippet<[Snippet | undefined, ManagedScopeRegion | undefined]>;
     scopeControlsInRegionContent?: boolean;
@@ -191,7 +199,7 @@
    * `zoneOwning()` returns non-null on both faces.
    */
   let {
-    children: hostedChildren, externalPresentation = null, strips = 'single', regions = false, regionContent, scopeControlsInRegionContent = false, regionExtras, vfoAppearance = 'semantic', bandPermitCaption = true, displayFrameSource, readonlyDisplay,
+    children: hostedChildren, externalPresentation = null, strips = 'single', stripBy = 'receiver', regions = false, regionContent, scopeControlsInRegionContent = false, regionExtras, vfoAppearance = 'semantic', bandPermitCaption = true, displayFrameSource, readonlyDisplay,
   }: Props = $props();
 
   /**
@@ -263,6 +271,40 @@
         receiverId, zoneId: index === 0 ? 'primary-vfo' : 'secondary-vfo',
       }))
       .filter(({ zoneId }) => zoneShows(zoneId, 'vfo'));
+  }
+  interface RenderedStrip {
+    key: string;
+    receiverId: ReceiverId;
+    zoneId: string;
+    /** Omitted on the `receiver` path, so its `.channel-strip` carries no
+     *  `data-strip-slot` attribute at all. */
+    slotPosition?: 'primary' | 'secondary';
+    sliced: RadioViewModel;
+  }
+  /**
+   * MOR-2425 / R58: the same two zones, sliced by DECK SLOT instead of by
+   * receiver. On a two-receiver radio the two agree entry for entry; on a
+   * one-receiver radio the slot path gives the unselected VFO the second
+   * column, with no receiver instruments of its own (`forSlot`).
+   */
+  function renderedStrips(model: RadioViewModel): RenderedStrip[] {
+    if (stripBy === 'slot') {
+      return slotsOf(model)
+        .map((slot, index): RenderedStrip => ({
+          key: slot.key,
+          receiverId: slot.receiver,
+          zoneId: index === 0 ? 'primary-vfo' : 'secondary-vfo',
+          slotPosition: index === 0 ? 'primary' : 'secondary',
+          sliced: forSlot(model, slot),
+        }))
+        .filter(({ zoneId }) => zoneShows(zoneId, 'vfo'));
+    }
+    return visibleStrips(model).map(({ receiverId, zoneId }): RenderedStrip => ({
+      key: receiverId,
+      receiverId,
+      zoneId,
+      sliced: forReceiver(model, receiverId),
+    }));
   }
 
   const semanticHandlers = bindSemanticSurfaceHandlers();
@@ -1630,18 +1672,22 @@
   {#if view}
     {#if strips === 'dual'}
       <div class="channel-strips" data-testid="channel-strips">
-        {#each visibleStrips(view) as { receiverId, zoneId } (receiverId)}
+        {#each renderedStrips(view) as { key, receiverId, zoneId, slotPosition, sliced } (key)}
           <!--
-            `data-zone-id`: `ReceiverId` is `'MAIN' | 'SUB'`, so the index is
-            total over the manifest's two per-receiver zones. A degraded
-            single-receiver view model renders `primary-vfo` and NO
+            `data-zone-id`: the first strip is `primary-vfo` and every later
+            one `secondary-vfo` — the manifest's two per-receiver zones. A
+            degraded single-receiver view model renders `primary-vfo` and NO
             `secondary-vfo` — an absent zone, never an empty promise.
+            `data-strip-slot` is emitted on the `slot` path only: on the
+            `receiver` path `slotPosition` is undefined and the attribute is
+            absent, which is what keeps the shipped decks unchanged.
           -->
           <div
             class="channel-strip"
-            data-testid={`channel-strip-${receiverId}`}
+            data-testid={`channel-strip-${key}`}
             data-zone-id={zoneId}
             data-strip-receiver={receiverId}
+            data-strip-slot={slotPosition}
             data-strip-active={isActiveStrip(view, receiverId)}
             data-strip-operational={isOperationalStrip(view, receiverId)}
           >
@@ -1664,7 +1710,7 @@
               radio-wide regardless of which strip this gates.
             -->
             <VfoSurface
-              viewModel={forReceiver(view, receiverId)}
+              viewModel={sliced}
               selectionPoolSize={view.vfos.length}
               showRadioWideFacts={false}
               groupLabel={t('core.vfo.receiverGroupLabel', { receiver: receiverId })}

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -1702,9 +1702,7 @@
         {#each renderedStrips(view) as { key, receiverId, zoneId, slotPosition, sliced, active, groupLabel } (key)}
           <!--
             `data-zone-id`: the first strip is `primary-vfo` and every later
-            one `secondary-vfo`. A degraded single-receiver view model renders
-            `primary-vfo` and NO `secondary-vfo` — an absent zone, never an
-            empty promise.
+            one `secondary-vfo`.
             `data-strip-slot` is emitted on the `slot` path only: on the
             `receiver` path `slotPosition` is undefined and the attribute is
             absent, which is what keeps the shipped decks unchanged.

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -133,7 +133,9 @@
     type ScopeChoiceField, type ScopeToggleField,
   } from '../../semantic/ScopeControlsSurface.svelte';
   import {
-    forReceiver, forSlot, receiversOf, slotsOf, isActiveStrip, isOperationalStrip,
+    forReceiver, forSlot, receiversOf, slotsOf,
+    isActiveStrip, isActiveSlotStrip, isOperationalStrip,
+    type StripSlot,
   } from './dual-receiver-strips';
   import { guardRadioViewModel } from './radio-view-model-guard';
   import type {
@@ -280,6 +282,24 @@
      *  `data-strip-slot` attribute at all. */
     slotPosition?: 'primary' | 'secondary';
     sliced: RadioViewModel;
+    /** Whether this column carries the deck's active mark. Per RECEIVER on the
+     *  `receiver` path; per SLOT on the `slot` path, where two columns can
+     *  share one receiver (`isActiveSlotStrip`). */
+    active: boolean;
+    /** This column's accessible group name. */
+    groupLabel: string;
+  }
+  /**
+   * A slot column's accessible name. The column carrying the receiver's
+   * instruments takes the receiver name the shipped decks use; a column
+   * carrying none is named by its own VFO position, so the two columns of a
+   * one-receiver deck are not one name twice (MOR-2425).
+   */
+  function slotGroupLabel(slot: StripSlot, sliced: RadioViewModel): string {
+    const positionLabel = sliced.vfos[0]?.label;
+    return slot.ownsReceiverInstruments || positionLabel === undefined
+      ? t('core.vfo.receiverGroupLabel', { receiver: slot.receiver })
+      : positionLabel;
   }
   /**
    * MOR-2425 / R58: the same two zones, sliced by DECK SLOT instead of by
@@ -290,13 +310,18 @@
   function renderedStrips(model: RadioViewModel): RenderedStrip[] {
     if (stripBy === 'slot') {
       return slotsOf(model)
-        .map((slot, index): RenderedStrip => ({
-          key: slot.key,
-          receiverId: slot.receiver,
-          zoneId: index === 0 ? 'primary-vfo' : 'secondary-vfo',
-          slotPosition: index === 0 ? 'primary' : 'secondary',
-          sliced: forSlot(model, slot),
-        }))
+        .map((slot, index): RenderedStrip => {
+          const sliced = forSlot(model, slot);
+          return {
+            key: slot.key,
+            receiverId: slot.receiver,
+            zoneId: index === 0 ? 'primary-vfo' : 'secondary-vfo',
+            slotPosition: index === 0 ? 'primary' : 'secondary',
+            sliced,
+            active: isActiveSlotStrip(model, slot),
+            groupLabel: slotGroupLabel(slot, sliced),
+          };
+        })
         .filter(({ zoneId }) => zoneShows(zoneId, 'vfo'));
     }
     return visibleStrips(model).map(({ receiverId, zoneId }): RenderedStrip => ({
@@ -304,6 +329,8 @@
       receiverId,
       zoneId,
       sliced: forReceiver(model, receiverId),
+      active: isActiveStrip(model, receiverId),
+      groupLabel: t('core.vfo.receiverGroupLabel', { receiver: receiverId }),
     }));
   }
 
@@ -1672,12 +1699,12 @@
   {#if view}
     {#if strips === 'dual'}
       <div class="channel-strips" data-testid="channel-strips">
-        {#each renderedStrips(view) as { key, receiverId, zoneId, slotPosition, sliced } (key)}
+        {#each renderedStrips(view) as { key, receiverId, zoneId, slotPosition, sliced, active, groupLabel } (key)}
           <!--
             `data-zone-id`: the first strip is `primary-vfo` and every later
-            one `secondary-vfo` — the manifest's two per-receiver zones. A
-            degraded single-receiver view model renders `primary-vfo` and NO
-            `secondary-vfo` — an absent zone, never an empty promise.
+            one `secondary-vfo`. A degraded single-receiver view model renders
+            `primary-vfo` and NO `secondary-vfo` — an absent zone, never an
+            empty promise.
             `data-strip-slot` is emitted on the `slot` path only: on the
             `receiver` path `slotPosition` is undefined and the attribute is
             absent, which is what keeps the shipped decks unchanged.
@@ -1688,7 +1715,7 @@
             data-zone-id={zoneId}
             data-strip-receiver={receiverId}
             data-strip-slot={slotPosition}
-            data-strip-active={isActiveStrip(view, receiverId)}
+            data-strip-active={active}
             data-strip-operational={isOperationalStrip(view, receiverId)}
           >
             <!--
@@ -1702,7 +1729,14 @@
               a strip owns nothing but its own receiver.
               `groupLabel`: without it all three mounted surfaces share one
               generic accessible name and assistive tech cannot tell the
-              strips apart.
+              strips apart. On the `slot` path two columns can share one
+              receiver, so the one carrying no receiver instruments is named
+              by its own VFO position instead (`slotGroupLabel`).
+              `suppressIdentitySelectors` (T207, STOPGAP): the A/B identity
+              selectors resolve which COLUMN is A and which is B — a relation
+              between the two, not a fact of either — so the slot path
+              withholds them until that relation has a surface of its own
+              (T183).
               `disabled` (MOR-1256): a structurally-dual, operationally-
               degraded receiver (`dual-rx-unavailable`) keeps its strip
               PRESENT but forces its select controls inert — the shared
@@ -1713,11 +1747,12 @@
               viewModel={sliced}
               selectionPoolSize={view.vfos.length}
               showRadioWideFacts={false}
-              groupLabel={t('core.vfo.receiverGroupLabel', { receiver: receiverId })}
+              {groupLabel}
               onSelectVfo={selectVfo}
               onTuneFrequency={tuneFrequency}
               disabled={!isOperationalStrip(view, receiverId)}
               indicatorReceiver={receiverId}
+              suppressIdentitySelectors={stripBy === 'slot'}
               {receiverInstruments}
               continuitySession={meterContinuitySession}
               {pendingFrequencyHz}

--- a/frontend/src/components-v2/wiring/__tests__/dual-receiver-slots.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/dual-receiver-slots.test.ts
@@ -1,0 +1,257 @@
+/**
+ * MOR-2425 / owner ruling R58 (2026-09-09) — `slotsOf` / `forSlot`, the
+ * DECK-SLOT counterpart of `receiversOf` / `forReceiver`.
+ *
+ * Every view model below is built by the REAL adapter (`toRadioViewModel`)
+ * from a ServerState/Capabilities pair, never by hand: the thing under test
+ * is which positions the adapter's own `vfos` flatMap produces per topology,
+ * and a hand-built model would be a restatement of the expectation rather
+ * than evidence for it. Each test's doc line names the mutation it kills.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
+import { forSlot, slotsOf } from '../dual-receiver-strips';
+import type { RadioViewModel, VfoSlot } from '../../../semantic/radio-view-model';
+
+const fresh: FieldStatus = {
+  storePath: 'x', observed: true, freshness: 'fresh', availability: 'available',
+};
+
+function caps(over: Partial<Capabilities>): Capabilities {
+  return {
+    model: 'fixture', scope: false, audio: true, tx: true,
+    capabilities: ['audio', 'tx'],
+    receivers: 1, vfoScheme: 'ab',
+    freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false },
+    txBands: [], scopeSource: null, audioFftAvailable: false,
+    ...over,
+  } as unknown as Capabilities;
+}
+
+const dualCaps = (over: Partial<Capabilities>) =>
+  caps({ receivers: 2, capabilities: ['audio', 'tx', 'dual_rx'], ...over });
+
+function state(payload: Record<string, unknown>, paths: readonly string[]): ServerState {
+  return {
+    split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'unknown', reason: 'not-observed' },
+    ...payload,
+    fieldStatus: Object.fromEntries(paths.map((path) => [path, fresh])),
+  } as unknown as ServerState;
+}
+
+const leaf = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
+const rx = (freqHz: number) => ({ freqHz, mode: 'USB', filter: 1, dataMode: 0 });
+const leafPaths = (base: string) => [`${base}.freqHz`, `${base}.mode`, `${base}.filterNum`];
+const rxPaths = (base: string) => [`${base}.freqHz`, `${base}.mode`, `${base}.filter`];
+
+function view(s: ServerState, c: Capabilities): RadioViewModel {
+  const model = toRadioViewModel(s, c);
+  expect(model).not.toBeNull();
+  return model!;
+}
+
+/** 1/single — one receiver, one unslotted VFO. */
+const single = () => view(
+  state({ active: 'MAIN', main: rx(14250000) }, ['active', ...rxPaths('main')]),
+  caps({ vfoScheme: 'single' }),
+);
+
+/** 1/ab, IC-7300 shaped: `activeSlot` never observed and the readback is
+ *  relative, so the adapter emits selected + unselected RELATIVE positions. */
+const abRelative = () => view(
+  state(
+    { active: 'MAIN', main: { ...rx(14250000), unselectedVfo: leaf(14300000) } },
+    ['active', ...rxPaths('main'), ...leafPaths('main.unselectedVfo')],
+  ),
+  caps({ vfoScheme: 'ab', vfoReadback: 'selected_unselected' }),
+);
+
+/** 1/ab with the slot view observed and B selected: two SLOTTED positions,
+ *  emitted by the adapter in declaration order A, B. */
+const abSlottedActiveB = () => view(
+  state(
+    {
+      active: 'MAIN',
+      main: { ...rx(14250000), activeSlot: 'B', vfoA: leaf(14250000), vfoB: leaf(14300000) },
+    },
+    [
+      'active', ...rxPaths('main'), 'main.activeSlot',
+      ...leafPaths('main.vfoA'), ...leafPaths('main.vfoB'),
+    ],
+  ),
+  caps({ vfoScheme: 'ab' }),
+);
+
+/** 1/ab whose slot B payload is absent: ONE position of unknown identity. */
+const abSlotUnknown = () => view(
+  state(
+    { active: 'MAIN', main: { ...rx(14250000), activeSlot: 'A', vfoA: leaf(14250000) } },
+    ['active', ...rxPaths('main'), 'main.activeSlot', ...leafPaths('main.vfoA')],
+  ),
+  caps({ vfoScheme: 'ab' }),
+);
+
+/** 2/ab_shared, FTX-1 shaped: one unslotted VFO per receiver, SUB active. */
+const abShared = () => view(
+  state(
+    { active: 'SUB', main: rx(14250000), sub: rx(7100000) },
+    ['active', ...rxPaths('main'), ...rxPaths('sub')],
+  ),
+  dualCaps({ vfoScheme: 'ab_shared' }),
+);
+
+/** 2/main_sub: A/B slots on BOTH receivers — four `vfos` entries. */
+const mainSub = () => view(
+  state(
+    {
+      active: 'MAIN',
+      main: { ...rx(14250000), activeSlot: 'A', vfoA: leaf(14250000), vfoB: leaf(14280000) },
+      sub: { ...rx(7100000), activeSlot: 'A', vfoA: leaf(7100000), vfoB: leaf(7150000) },
+    },
+    [
+      'active', ...rxPaths('main'), ...rxPaths('sub'), 'main.activeSlot', 'sub.activeSlot',
+      ...leafPaths('main.vfoA'), ...leafPaths('main.vfoB'),
+      ...leafPaths('sub.vfoA'), ...leafPaths('sub.vfoB'),
+    ],
+  ),
+  dualCaps({ vfoScheme: 'main_sub' }),
+);
+
+const identity = (slot: VfoSlot): string =>
+  slot.kind === 'slotted' ? slot.id : slot.kind === 'relative' ? slot.role : slot.kind;
+
+/** What each deck slot is: its receiver, the `vfos` positions it holds (by
+ *  slot identity, read back through `forSlot`), and whether it owns its
+ *  receiver's instruments. */
+const deck = (model: RadioViewModel) => slotsOf(model).map((slot) => ({
+  key: slot.key,
+  receiver: slot.receiver,
+  holds: forSlot(model, slot).vfos.map((vfo) => identity(vfo.slot)),
+  owns: slot.ownsReceiverInstruments,
+}));
+
+describe('what the adapter actually produces, per topology', () => {
+  // The premise every expectation below rests on. Kills: a fixture that
+  // silently stops exercising the branch it was written for — a 1/ab state
+  // that resolves to slotted positions instead of relative ones, say.
+  it.each([
+    ['1/single', single, [['MAIN', 'unslotted']]],
+    ['1/ab relative', abRelative, [['MAIN', 'selected'], ['MAIN', 'unselected']]],
+    ['1/ab slotted', abSlottedActiveB, [['MAIN', 'A'], ['MAIN', 'B']]],
+    ['1/ab slot unknown', abSlotUnknown, [['MAIN', 'unknown']]],
+    ['2/ab_shared', abShared, [['MAIN', 'unslotted'], ['SUB', 'unslotted']]],
+    ['2/main_sub', mainSub,
+      [['MAIN', 'A'], ['MAIN', 'B'], ['SUB', 'A'], ['SUB', 'B']]],
+  ])('%s', (_name, build, expected) => {
+    expect((build as () => RadioViewModel)().vfos.map((vfo) => [vfo.receiver, identity(vfo.slot)]))
+      .toEqual(expected);
+  });
+});
+
+describe('slotsOf', () => {
+  // R58: on a one-receiver radio the second deck slot is the unselected VFO.
+  // Kills: slicing by receiver (`receiversOf`) — which yields ONE slot here,
+  // the defect this ticket exists to remove.
+  it('gives a 1/ab radio two slots: the selected VFO, then the unselected one', () => {
+    expect(deck(abRelative())).toEqual([
+      { key: 'MAIN-selected', receiver: 'MAIN', holds: ['selected'], owns: true },
+      { key: 'MAIN-unselected', receiver: 'MAIN', holds: ['unselected'], owns: false },
+    ]);
+  });
+
+  // R58: the left column is the ACTIVE slot. Kills: emitting the adapter's
+  // declaration order A, B when B is the observed selected slot.
+  it('puts the observed active slot first on a slotted single-receiver radio', () => {
+    expect(deck(abSlottedActiveB())).toEqual([
+      { key: 'MAIN-B', receiver: 'MAIN', holds: ['B'], owns: true },
+      { key: 'MAIN-A', receiver: 'MAIN', holds: ['A'], owns: false },
+    ]);
+  });
+
+  // R58: on a two-receiver radio the second slot IS the SUB receiver, whose
+  // own instruments it keeps. Kills: reordering the two receivers behind the
+  // active one, which would move SUB into the left column here (this fixture
+  // observes SUB as active) and out of the deck's `rx-sub` area.
+  it('gives a 2/ab_shared radio one slot per receiver, MAIN then SUB', () => {
+    expect(deck(abShared())).toEqual([
+      { key: 'MAIN', receiver: 'MAIN', holds: ['unslotted'], owns: true },
+      { key: 'SUB', receiver: 'SUB', holds: ['unslotted'], owns: true },
+    ]);
+  });
+
+  // Kills: one slot per `vfos` entry on a two-receiver radio, which would
+  // give 2/main_sub four columns for a two-column deck.
+  it('gives a 2/main_sub radio two slots, each holding its receiver\'s A and B', () => {
+    expect(deck(mainSub())).toEqual([
+      { key: 'MAIN', receiver: 'MAIN', holds: ['A', 'B'], owns: true },
+      { key: 'SUB', receiver: 'SUB', holds: ['A', 'B'], owns: true },
+    ]);
+  });
+
+  // R58 art direction: a never-produced fact is not drawn. Kills: padding a
+  // one-VFO radio out to two columns with an empty second slot.
+  it.each([
+    ['1/single', single],
+    ['1/ab whose slot identity was never observed', abSlotUnknown],
+  ])('never fabricates a second slot for %s', (_name, build) => {
+    expect(slotsOf((build as () => RadioViewModel)())).toHaveLength(1);
+  });
+
+  it('reports no slots for an empty vfos array', () => {
+    expect(slotsOf({ ...mainSub(), vfos: [] })).toEqual([]);
+  });
+});
+
+describe('forSlot', () => {
+  // Kills: slicing by receiver instead of by slot — both MAIN positions
+  // would then land in every MAIN column.
+  it('keeps only the entries its slot names', () => {
+    const model = abRelative();
+    const [primary, secondary] = slotsOf(model);
+    expect(forSlot(model, primary).vfos).toHaveLength(1);
+    expect(forSlot(model, primary).vfos[0].slot).toEqual({ kind: 'relative', role: 'selected' });
+    expect(forSlot(model, secondary).vfos[0].slot).toEqual({ kind: 'relative', role: 'unselected' });
+  });
+
+  // R58: the 7300's second slot is not a receiver, so it carries no receiver
+  // instruments. `VfoSurface` reads `receiverIndicators`, and its
+  // `indicatorReceiver` prop cannot express "none" — an omitted prop means
+  // "every indicator" there (`semantic/VfoSurface.svelte`, the
+  // `receiverIndicators` $derived) — so the SLICE is what withholds them.
+  // Kills: passing the receiver's indicators through to every slot.
+  it('withholds the receiver indicators from a slot that does not own them', () => {
+    const model = abRelative();
+    const [primary, secondary] = slotsOf(model);
+    expect(model.receiverIndicators?.map((item) => item.receiver)).toEqual(['MAIN']);
+    expect(forSlot(model, primary).receiverIndicators?.map((item) => item.receiver))
+      .toEqual(['MAIN']);
+    expect(forSlot(model, secondary).receiverIndicators).toEqual([]);
+  });
+
+  // Kills: the SUB receiver losing its own S-meter row when the deck strips
+  // by slot — the FTX-1 half of R58.
+  it('keeps each receiver\'s own indicators on a two-receiver deck', () => {
+    const model = abShared();
+    for (const slot of slotsOf(model)) {
+      expect(forSlot(model, slot).receiverIndicators?.map((item) => item.receiver))
+        .toEqual([slot.receiver]);
+    }
+  });
+
+  // Kills: the slice also touching shared/global facts instead of passing
+  // them through verbatim — the same invariant `forReceiver` is held to.
+  it('leaves every field other than vfos and receiverIndicators identical', () => {
+    const model = mainSub();
+    const sliced = forSlot(model, slotsOf(model)[0]);
+    const strip = (m: RadioViewModel) => {
+      const { vfos: _vfos, receiverIndicators: _indicators, ...rest } = m;
+      return rest;
+    };
+    expect(strip(sliced)).toEqual(strip(model));
+  });
+});

--- a/frontend/src/components-v2/wiring/dual-receiver-strips.ts
+++ b/frontend/src/components-v2/wiring/dual-receiver-strips.ts
@@ -1,6 +1,7 @@
 /**
  * Pure per-receiver `RadioViewModel` slicing for the dual-receiver-cockpit's
- * two channel strips (MOR-1067). Carries none of the TX-lease weight
+ * two channel strips (MOR-1067), and — since MOR-2425 / R58 — the per-SLOT
+ * slicing beside it (`slotsOf`/`forSlot`). Carries none of the TX-lease weight
  * `SemanticRadioSurfaces.svelte` owns — filtering only, never touched by or
  * touching TX state, so this is not a second TX code path. `receiversOf`
  * never fabricates a receiver absent from `view.vfos` (MOR-988 §3.2): a
@@ -12,7 +13,7 @@
  * (MOR-977 — the strip renders), but reads back the adapter's per-receiver
  * `disabledReasons` entry to say whether it is also usable right now.
  */
-import type { ReceiverId, RadioViewModel } from '../../semantic/radio-view-model';
+import type { ReceiverId, RadioViewModel, VfoSlot } from '../../semantic/radio-view-model';
 
 export function receiversOf(view: RadioViewModel): readonly ReceiverId[] {
   const seen: ReceiverId[] = [];
@@ -25,6 +26,86 @@ export function receiversOf(view: RadioViewModel): readonly ReceiverId[] {
 /** Every fact except `vfos` stays the shared/global value, unchanged. */
 export function forReceiver(view: RadioViewModel, receiver: ReceiverId): RadioViewModel {
   return { ...view, vfos: view.vfos.filter((vfo) => vfo.receiver === receiver) };
+}
+
+/**
+ * One column of a two-column deck, under owner ruling R58 (2026-09-09): a
+ * deck column is a SLOT, not a receiver. On a two-receiver radio a slot IS a
+ * receiver, so the second slot is SUB and keeps its own instruments. On a
+ * one-receiver radio a slot is one of that receiver's VFO positions, so the
+ * second slot is the unselected VFO — which has no receiver of its own and
+ * therefore no receiver instruments (`ownsReceiverInstruments`).
+ */
+export interface StripSlot {
+  /** Stable `{#each}` key. */
+  readonly key: string;
+  readonly receiver: ReceiverId;
+  /** Indices into `view.vfos`. Like `receiversOf`, this never names a
+   *  position absent from `view.vfos` (MOR-988 §3.2). */
+  readonly entries: readonly number[];
+  /** Whether this is the FIRST slot backed by `receiver`, and so the one
+   *  that carries that receiver's indicator row and S-meter. */
+  readonly ownsReceiverInstruments: boolean;
+}
+
+function slotIdentity(slot: VfoSlot): string {
+  if (slot.kind === 'slotted') return slot.id;
+  if (slot.kind === 'relative') return slot.role;
+  return slot.kind;
+}
+
+/**
+ * The deck slots `view.vfos` actually carries, left column first.
+ *
+ * Two receivers: one slot each, in the model's own order — R58 fixes SUB as
+ * the second slot, so this does not reorder behind the active receiver.
+ * One receiver: one slot per VFO position, the receiver's active/selected
+ * one first (R58: the left column is the active slot). `isActiveSlot` is at
+ * most true once per receiver (`radio-view-model.ts`'s validator), and false
+ * on every position when the slot was never observed — the order is then the
+ * model's own, never a guess.
+ */
+export function slotsOf(view: RadioViewModel): readonly StripSlot[] {
+  const receivers = receiversOf(view);
+  if (receivers.length > 1) {
+    return receivers.map((receiver) => ({
+      key: receiver,
+      receiver,
+      entries: view.vfos.flatMap((vfo, index) => (vfo.receiver === receiver ? [index] : [])),
+      ownsReceiverInstruments: true,
+    }));
+  }
+  const indices = view.vfos.map((_vfo, index) => index);
+  const ordered = [
+    ...indices.filter((index) => view.vfos[index].isActiveSlot),
+    ...indices.filter((index) => !view.vfos[index].isActiveSlot),
+  ];
+  return ordered.map((index, position) => ({
+    key: `${view.vfos[index].receiver}-${slotIdentity(view.vfos[index].slot)}`,
+    receiver: view.vfos[index].receiver,
+    entries: [index],
+    ownsReceiverInstruments: position === 0,
+  }));
+}
+
+/**
+ * `forReceiver`'s per-slot counterpart: every fact except `vfos` and
+ * `receiverIndicators` stays the shared/global value, unchanged.
+ *
+ * The indicators are the exception because `VfoSurface`'s `indicatorReceiver`
+ * prop cannot express "none" — omitting it there means "every indicator" —
+ * so a slot that owns no receiver instruments has to be handed none.
+ */
+export function forSlot(view: RadioViewModel, slot: StripSlot): RadioViewModel {
+  const vfos = slot.entries.map((index) => view.vfos[index]);
+  if (view.receiverIndicators === undefined) return { ...view, vfos };
+  return {
+    ...view,
+    vfos,
+    receiverIndicators: slot.ownsReceiverInstruments
+      ? view.receiverIndicators.filter((indicator) => indicator.receiver === slot.receiver)
+      : [],
+  };
 }
 
 export function isActiveStrip(view: RadioViewModel, receiver: ReceiverId): boolean {

--- a/frontend/src/components-v2/wiring/dual-receiver-strips.ts
+++ b/frontend/src/components-v2/wiring/dual-receiver-strips.ts
@@ -4,9 +4,8 @@
  * slicing beside it (`slotsOf`/`forSlot`). Carries none of the TX-lease weight
  * `SemanticRadioSurfaces.svelte` owns — filtering only, never touched by or
  * touching TX state, so this is not a second TX code path. `receiversOf`
- * never fabricates a receiver absent from `view.vfos` (MOR-988 §3.2): a
- * single-receiver view model yields exactly one strip, an empty one yields
- * none. `isActiveStrip` is true only on a POSITIVELY observed match — an
+ * never fabricates a receiver absent from `view.vfos` (MOR-988 §3.2): an
+ * empty view model yields none. `isActiveStrip` is true only on a POSITIVELY observed match — an
  * `unknown` activeReceiver marks every strip inactive, never a guessed one.
  * `isOperationalStrip` (MOR-1256) is the structural/operational counterpart:
  * a receiver stays in `receiversOf`/`vfos` when only STRUCTURALLY present

--- a/frontend/src/components-v2/wiring/dual-receiver-strips.ts
+++ b/frontend/src/components-v2/wiring/dual-receiver-strips.ts
@@ -46,6 +46,9 @@ export interface StripSlot {
   /** Whether this is the FIRST slot backed by `receiver`, and so the one
    *  that carries that receiver's indicator row and S-meter. */
   readonly ownsReceiverInstruments: boolean;
+  /** Whether another slot of this deck is backed by the same receiver — true
+   *  only where one receiver backs more than one column. */
+  readonly sharesReceiver: boolean;
 }
 
 function slotIdentity(slot: VfoSlot): string {
@@ -73,6 +76,7 @@ export function slotsOf(view: RadioViewModel): readonly StripSlot[] {
       receiver,
       entries: view.vfos.flatMap((vfo, index) => (vfo.receiver === receiver ? [index] : [])),
       ownsReceiverInstruments: true,
+      sharesReceiver: false,
     }));
   }
   const indices = view.vfos.map((_vfo, index) => index);
@@ -85,6 +89,7 @@ export function slotsOf(view: RadioViewModel): readonly StripSlot[] {
     receiver: view.vfos[index].receiver,
     entries: [index],
     ownsReceiverInstruments: position === 0,
+    sharesReceiver: ordered.length > 1,
   }));
 }
 
@@ -106,6 +111,18 @@ export function forSlot(view: RadioViewModel, slot: StripSlot): RadioViewModel {
       ? view.receiverIndicators.filter((indicator) => indicator.receiver === slot.receiver)
       : [],
   };
+}
+
+/**
+ * `isActiveStrip`'s per-slot counterpart: at most ONE column carries the
+ * active mark (R58). A column whose receiver backs no other column keeps
+ * today's rule — the mark follows the active RECEIVER, so a two-receiver deck
+ * is unchanged; where two columns share a receiver, the mark goes to the one
+ * holding that receiver's active position.
+ */
+export function isActiveSlotStrip(view: RadioViewModel, slot: StripSlot): boolean {
+  if (!isActiveStrip(view, slot.receiver)) return false;
+  return !slot.sharesReceiver || slot.entries.some((index) => view.vfos[index].isActiveSlot);
 }
 
 export function isActiveStrip(view: RadioViewModel, receiver: ReceiverId): boolean {

--- a/frontend/src/presentation/layouts/__tests__/flagship-probe-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/flagship-probe-registration.test.ts
@@ -52,9 +52,7 @@ describe('the flagship-probe registration', () => {
     expect(declared.has('memory' as SemanticSurfaceName)).toBe(false);
   });
 
-  // Kills: admitting a single-receiver topology — the arrangement puts two
-  // receivers side by side in both of its arrangements, and there would be
-  // nothing to put in the second.
+  // Kills: admitting a single-receiver topology.
   it('is compatible with the dual-receiver topologies only', () => {
     expect([...flagshipProbeLayout.compatibleTopologies].sort())
       .toEqual(['2/ab_shared', '2/main_sub']);

--- a/frontend/src/presentation/layouts/__tests__/flagship-probe-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/flagship-probe-registration.test.ts
@@ -29,8 +29,8 @@ describe('the flagship-probe registration', () => {
     const placed = new Set(
       [...skinSource.matchAll(/\[data-zone-id='([a-z-]+)'\]/g)].map(([, id]) => id),
     );
-    // The deck's two receiver strips are placed by `data-strip-receiver`, so
-    // their zone ids are the only declared ones the style block does not name.
+    // The deck's two slot strips are placed by `data-strip-slot`, so their
+    // zone ids are the only declared ones the style block does not name.
     const deck = new Set(['primary-vfo', 'secondary-vfo']);
     for (const zone of flagshipProbeLayout.zones) {
       expect(zone.surfaces).toHaveLength(1);

--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -145,7 +145,7 @@ export {
  * Every zone id below is one this repository already uses for that surface:
  * the twelve control zones take `sdr-test`'s and `desktop-v2`'s ids, and the
  * deck takes the cockpit's four. Two of those four are not a free choice —
- * `SemanticRadioSurfaces.svelte: visibleStrips` writes `primary-vfo` and
+ * `SemanticRadioSurfaces.svelte: renderedStrips` writes `primary-vfo` and
  * `secondary-vfo` into the DOM itself.
  *
  * WHY ALL FOURTEEN ARE DECLARED. In the dual composition nine of these
@@ -156,9 +156,7 @@ export {
  * every id the skin's style block places to be a zone declared here.
  * `memory` is the one declarable surface this layout leaves out.
  *
- * `compatibleTopologies` names the two dual-receiver pairs only: the
- * arrangement puts two receivers side by side in both of its arrangements,
- * and a single-receiver radio has no second one to place.
+ * `compatibleTopologies` names the two dual-receiver pairs only.
  */
 export const flagshipProbeLayout: LayoutManifest = {
   schemaVersion: 1,

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -151,6 +151,16 @@
      * once; the radio-wide `showVfoList={false}` mount renders no rows.
      */
     indicatorReceiver?: ReceiverId;
+    /**
+     * MOR-2425 / T207 — a STOPGAP. `true` withholds the "Select VFO A /
+     * Select VFO B" pair. It resolves which of a one-receiver radio's two VFO
+     * POSITIONS is A and which is B: on a deck that gives each position its
+     * own column that is a relation BETWEEN the columns, and drawn inside one
+     * column it reads as that column's own control. The slot-stripped deck
+     * sets this until the relation has a surface of its own (T183). Defaults
+     * to `false`: every other caller renders exactly as before.
+     */
+    suppressIdentitySelectors?: boolean;
     continuitySession?: MeterContinuitySession | null;
     frequencyLifetimeKey?: string;
     receiverInstruments?: ReceiverInstrumentHandles;
@@ -193,6 +203,7 @@
     onTuneFrequency,
     pendingFrequencyHz,
     indicatorReceiver,
+    suppressIdentitySelectors = false,
     continuitySession,
     frequencyLifetimeKey,
     receiverInstruments,
@@ -638,7 +649,7 @@
       </div>
   {/snippet}
   {#snippet identitySelectors()}
-  {#if relativeIdentityUnknown && relativeReceiver !== null}
+  {#if !suppressIdentitySelectors && relativeIdentityUnknown && relativeReceiver !== null}
     {@const absoluteReason = disabled
       ? t('core.vfo.select.receiverUnavailableReason')
       : relativeSelectionPending

--- a/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
+++ b/frontend/src/skins/flagship-probe/FlagshipProbeSkin.svelte
@@ -20,8 +20,12 @@
   that split at the surface, and `__tests__/FlagshipProbe.component.test.ts`
   requires it of the keys this shell mounts.
 
-  ARRANGEMENT. Two receivers side by side in BOTH arrangements, and the
-  panorama always between the two rails, never under one:
+  ARRANGEMENT. Two DECK SLOTS side by side in BOTH arrangements, and the
+  panorama always between the two rails, never under one. `stripBy="slot"`
+  is what makes a column a slot rather than a receiver (owner ruling R58,
+  2026-09-09): on a two-receiver radio a column is still a receiver, and on
+  a single-receiver one the right column holds the unselected VFO —
+  `__tests__/FlagshipProbe.component.test.ts` requires both:
 
     wide   — left rail | (deck over panorama) | right rail
     narrow — deck across the top, then left rail | panorama | right rail
@@ -34,7 +38,7 @@
   requires the rail column, that position and the rail's declared track
   together. The rail's own minimum is the width one key needs — see
   `--flagship-probe-rail-floor` below. Nothing then stands between the two
-  receivers, and the deck's middle track is gone rather than empty: the same
+  slots, and the deck's middle track is gone rather than empty: the same
   test requires every track in both column templates to be a column some area
   names.
 
@@ -75,7 +79,7 @@
 
 <div class="flagship-probe" data-testid="flagship-geometry-probe">
   <div class="probe-stage" data-testid="probe-stage">
-    <SemanticRadioSurfaces strips="dual" bandPermitCaption={false} />
+    <SemanticRadioSurfaces strips="dual" stripBy="slot" bandPermitCaption={false} />
     <!--
       `hideScopeControls`: the fact-backed half of the spectrum toolbar is
       suppressed because the semantic `scopeControls` surface renders it,
@@ -220,8 +224,8 @@
     display: contents;
   }
 
-  .probe-stage :global([data-strip-receiver='MAIN']) { grid-area: rx-main; }
-  .probe-stage :global([data-strip-receiver='SUB']) { grid-area: rx-sub; }
+  .probe-stage :global([data-strip-slot='primary']) { grid-area: rx-main; }
+  .probe-stage :global([data-strip-slot='secondary']) { grid-area: rx-sub; }
   .probe-stage :global([data-zone-id='global']) { grid-area: vfo-ops; }
   .probe-stage :global([data-zone-id='rf-front-end']) { grid-area: rf; }
   .probe-stage :global([data-zone-id='dsp']) { grid-area: dsp; }

--- a/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
+++ b/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
@@ -341,7 +341,7 @@ describe('the arrangement mounts the surfaces the manifest declares', () => {
     const placed = [...source.matchAll(/\[data-zone-id='([a-z-]+)'\]/g)].map(([, id]) => id);
     for (const id of new Set(placed)) expect(qa(`[data-zone-id="${id}"]`)).toHaveLength(1);
     // Total in both directions: the mounted zones are exactly the placed ones
-    // plus the deck's two receiver strips, which this skin places by
+    // plus the deck's two slot strips, which this skin places by
     // `data-strip-slot` instead — so a declared zone that mounts nothing,
     // and a mounted zone this arrangement never places, both fail here.
     expect(qa('[data-zone-id]').map((el) => el.dataset.zoneId).sort())
@@ -366,6 +366,8 @@ describe('the deck is stripped by SLOT, not by receiver (owner ruling R58)', () 
     [...el.querySelectorAll<HTMLElement>('[data-vfo-tile]')].map((tile) => tile.dataset.vfoSlot);
   const indicatorRows = (el: HTMLElement) =>
     [...el.querySelectorAll<HTMLElement>('[data-testid="vfo-indicator-row"]')];
+  const surfaceName = (el: HTMLElement) =>
+    el.querySelector('[data-testid="vfo-surface"]')!.getAttribute('aria-label');
 
   // Kills: the probe left on the default `stripBy="receiver"`, which gives a
   // single-receiver radio ONE strip — both its VFO tiles inside it — and
@@ -408,11 +410,76 @@ describe('the deck is stripped by SLOT, not by receiver (owner ruling R58)', () 
     }
   });
 
+  // R58: the left column IS the active slot, so at most ONE column may say
+  // so. Kills: marking a column from `isActiveStrip(view, receiverId)`, which
+  // is true of BOTH columns here — one receiver, two columns — and paints the
+  // accent border on a column the operator is not working in.
+  it('marks the active slot alone on a one-receiver deck', () => {
+    h.state = abState();
+    h.caps = abCaps();
+    render();
+    expect([slot('primary'), slot('secondary')].map((el) => el.dataset.stripActive))
+      .toEqual(['true', 'false']);
+  });
+
+  // The other half of the same mark: a two-receiver deck's column IS a
+  // receiver, so the mark follows the ACTIVE RECEIVER, as it did before this
+  // ticket. Kills: marking the primary column unconditionally, and reading
+  // the active slot instead of the active receiver — each receiver's only
+  // position is its own active one here.
+  it.each([
+    ['MAIN', ['true', 'false']],
+    ['SUB', ['false', 'true']],
+  ] as const)('follows the active receiver on a two-receiver deck (%s active)', (active, marks) => {
+    h.state = { ...abSharedState(), active } as unknown as ServerState;
+    h.caps = abSharedCaps();
+    render();
+    expect([slot('primary'), slot('secondary')].map((el) => el.dataset.stripActive))
+      .toEqual([...marks]);
+  });
+
+  // `groupLabel` exists so assistive tech can tell the mounted surfaces apart
+  // (`SemanticRadioSurfaces.svelte`, the strip's own comment). Naming a slot
+  // column by its receiver gave a one-receiver deck two identical names.
+  // Kills: taking every slot column's name from its receiver id.
+  it('names the two columns of a one-receiver deck differently', () => {
+    h.state = abState();
+    h.caps = abCaps();
+    render();
+    expect([slot('primary'), slot('secondary')].map(surfaceName))
+      .toEqual(['Receiver MAIN', 'Unselected VFO']);
+  });
+
+  // A column that carries its receiver's instruments keeps the receiver name.
+  // Kills: naming every slot column by its VFO position, which on this deck
+  // gives the two bare receiver ids.
+  it('keeps the receiver name on a two-receiver deck', () => {
+    h.state = abSharedState();
+    h.caps = abSharedCaps();
+    render();
+    expect([slot('primary'), slot('secondary')].map(surfaceName))
+      .toEqual(['Receiver MAIN', 'Receiver SUB']);
+  });
+
+  // T207, STOPGAP: "Select VFO A / Select VFO B" resolves which of the deck's
+  // two columns is A and which is B — a relation BETWEEN the columns, drawn
+  // until now inside each of them, twice. Withheld from the slot path until
+  // the between-columns surface exists (T183): a missing control is honest,
+  // one drawn inside a column reads as belonging to that column. Kills:
+  // leaving the selectors in the slot-stripped deck.
+  it('withholds the A/B identity selectors from a slot-stripped deck', () => {
+    h.state = abState();
+    h.caps = abCaps();
+    render();
+    expect(qa('[data-testid="vfo-identity-selectors"]')).toEqual([]);
+  });
+
   // The control for the claim above: the WIRING still strips by receiver
   // unless a face asks otherwise, so the same one-receiver fixture that gives
   // the probe two slots gives the default deck one strip and no
-  // `data-strip-slot` attribute at all. Kills: a `stripBy` default of
-  // `'slot'`, which would change every shipped `strips="dual"` face.
+  // `data-strip-slot` attribute at all, and its A/B identity selectors —
+  // withheld on the slot path above — still rendered. Kills: a `stripBy`
+  // default of `'slot'`, and a suppression that reaches the default deck.
   it('leaves the wiring default at one strip per receiver', () => {
     h.state = abState();
     h.caps = abCaps();
@@ -428,6 +495,7 @@ describe('the deck is stripped by SLOT, not by receiver (owner ruling R58)', () 
     expect(strips()).toHaveLength(1);
     expect(qa('[data-strip-slot]')).toEqual([]);
     expect(tiles(strips()[0])).toEqual(['selected', 'unselected']);
+    expect(qa('[data-testid="vfo-identity-selectors"]')).toHaveLength(1);
   });
 });
 

--- a/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
+++ b/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
@@ -129,6 +129,7 @@ vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
 });
 
 import FlagshipProbeSkin from '../FlagshipProbeSkin.svelte';
+import SemanticRadioSurfaces from '../../../components-v2/wiring/SemanticRadioSurfaces.svelte';
 // Read through the app-wide registration barrel, never through a direct
 // module import, so the zone ids asserted below are the ids the app registers.
 import { flagshipProbeLayout } from '../../../presentation/layouts/declarations';
@@ -202,6 +203,54 @@ const mainSubCaps = (): Capabilities => ({
   txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
   scopeSource: null, audioFftAvailable: false,
 } as unknown as Capabilities);
+
+/**
+ * IC-7300 shaped: ONE receiver whose A/B identity the radio never confirms,
+ * so the adapter emits a selected and an unselected RELATIVE position on the
+ * single MAIN receiver (`relativeVfoIdentityUnknown` in
+ * `lib/runtime/props/panel-props.ts`). Meter readings for the same reason
+ * `mainSubState` carries them.
+ */
+function abState(): ServerState {
+  const paths = ['split', 'dualWatch', 'txTarget', 'powerMeter', 'swrMeter', 'alcMeter',
+    'main.freqHz', 'main.mode', 'main.filter', 'main.sMeter',
+    'main.unselectedVfo.freqHz', 'main.unselectedVfo.mode', 'main.unselectedVfo.filterNum'];
+  return {
+    split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14250000 },
+    main: {
+      freqHz: 14250000, mode: 'USB', filter: 1, sMeter: 42,
+      unselectedVfo: { freqHz: 14300000, mode: 'LSB', filterNum: 2 },
+    },
+    powerMeter: 0, swrMeter: 0, alcMeter: 0,
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+
+const abCaps = (): Capabilities => ({
+  ...mainSubCaps(),
+  model: 'fixture-1ab', receivers: 1, vfoScheme: 'ab', vfoReadback: 'selected_unselected',
+  capabilities: (mainSubCaps().capabilities as readonly string[])
+    .filter((tag) => tag !== 'dual_rx' && tag !== 'lan_dual_rx_audio_routing'),
+} as unknown as Capabilities);
+
+/** FTX-1 shaped: two receivers, one unslotted VFO each. */
+function abSharedState(): ServerState {
+  const paths = ['active', 'split', 'dualWatch', 'txTarget', 'powerMeter', 'swrMeter', 'alcMeter',
+    'main.freqHz', 'main.mode', 'main.filter', 'main.sMeter',
+    'sub.freqHz', 'sub.mode', 'sub.filter', 'sub.sMeter'];
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14250000 },
+    main: { freqHz: 14250000, mode: 'USB', filter: 1, sMeter: 42 },
+    sub: { freqHz: 7100000, mode: 'LSB', filter: 1, sMeter: 7 },
+    powerMeter: 0, swrMeter: 0, alcMeter: 0,
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+
+const abSharedCaps = (): Capabilities =>
+  ({ ...mainSubCaps(), model: 'fixture-ab-shared', vfoScheme: 'ab_shared' } as unknown as Capabilities);
 
 let target: HTMLDivElement;
 let component: ReturnType<typeof mount> | null = null;
@@ -293,7 +342,7 @@ describe('the arrangement mounts the surfaces the manifest declares', () => {
     for (const id of new Set(placed)) expect(qa(`[data-zone-id="${id}"]`)).toHaveLength(1);
     // Total in both directions: the mounted zones are exactly the placed ones
     // plus the deck's two receiver strips, which this skin places by
-    // `data-strip-receiver` instead — so a declared zone that mounts nothing,
+    // `data-strip-slot` instead — so a declared zone that mounts nothing,
     // and a mounted zone this arrangement never places, both fail here.
     expect(qa('[data-zone-id]').map((el) => el.dataset.zoneId).sort())
       .toEqual([...new Set([...placed, 'primary-vfo', 'secondary-vfo'])].sort());
@@ -307,6 +356,78 @@ describe('the arrangement mounts the surfaces the manifest declares', () => {
     const panorama = q('[data-testid="probe-panorama"]')!;
     expect(panorama).not.toBeNull();
     expect(panorama.querySelector('[data-hide-scope-controls="true"]')).not.toBeNull();
+  });
+});
+
+describe('the deck is stripped by SLOT, not by receiver (owner ruling R58)', () => {
+  const strips = () => qa('[data-testid^="channel-strip-"]');
+  const slot = (position: 'primary' | 'secondary') => q(`[data-strip-slot="${position}"]`)!;
+  const tiles = (el: HTMLElement) =>
+    [...el.querySelectorAll<HTMLElement>('[data-vfo-tile]')].map((tile) => tile.dataset.vfoSlot);
+  const indicatorRows = (el: HTMLElement) =>
+    [...el.querySelectorAll<HTMLElement>('[data-testid="vfo-indicator-row"]')];
+
+  // Kills: the probe left on the default `stripBy="receiver"`, which gives a
+  // single-receiver radio ONE strip — both its VFO tiles inside it — and
+  // leaves the deck's `rx-sub` area with nothing to place.
+  it('gives a one-receiver radio two slots: the selected VFO, then the unselected one', () => {
+    h.state = abState();
+    h.caps = abCaps();
+    render();
+    expect(strips()).toHaveLength(2);
+    expect([slot('primary'), slot('secondary')].map((el) => el.dataset.stripReceiver))
+      .toEqual(['MAIN', 'MAIN']);
+    expect(tiles(slot('primary'))).toEqual(['selected']);
+    expect(tiles(slot('secondary'))).toEqual(['unselected']);
+  });
+
+  // R58: the IC-7300 has ONE receiver, so its second slot carries no receiver
+  // instruments. Kills: handing the second slot the receiver's indicators —
+  // by slicing them in, or by omitting `indicatorReceiver`, which means
+  // "every indicator" to `VfoSurface` rather than none.
+  it('draws the one receiver\'s indicator row once, in the first slot', () => {
+    h.state = abState();
+    h.caps = abCaps();
+    render();
+    expect(indicatorRows(slot('primary'))).toHaveLength(1);
+    expect(indicatorRows(slot('secondary'))).toEqual([]);
+  });
+
+  // R58: on a two-receiver radio the second slot IS the SUB receiver, and it
+  // keeps its own instruments. Kills: the slot path collapsing a
+  // two-receiver deck to one receiver's positions, and SUB losing its row.
+  it('gives a two-receiver radio MAIN then SUB, each with its own indicator row', () => {
+    h.state = abSharedState();
+    h.caps = abSharedCaps();
+    render();
+    expect(strips()).toHaveLength(2);
+    expect([slot('primary'), slot('secondary')].map((el) => el.dataset.stripReceiver))
+      .toEqual(['MAIN', 'SUB']);
+    for (const position of ['primary', 'secondary'] as const) {
+      expect(indicatorRows(slot(position))).toHaveLength(1);
+    }
+  });
+
+  // The control for the claim above: the WIRING still strips by receiver
+  // unless a face asks otherwise, so the same one-receiver fixture that gives
+  // the probe two slots gives the default deck one strip and no
+  // `data-strip-slot` attribute at all. Kills: a `stripBy` default of
+  // `'slot'`, which would change every shipped `strips="dual"` face.
+  it('leaves the wiring default at one strip per receiver', () => {
+    h.state = abState();
+    h.caps = abCaps();
+    target = document.createElement('div');
+    document.body.appendChild(target);
+    const plan = defaultPlan();
+    component = mount(SemanticRadioSurfaces, {
+      target,
+      props: { strips: 'dual' as const },
+      context: new Map<unknown, unknown>([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]),
+    });
+    flushSync();
+    expect(strips()).toHaveLength(1);
+    expect(qa('[data-strip-slot]')).toEqual([]);
+    expect(tiles(strips()[0])).toEqual(['selected', 'unselected']);
   });
 });
 
@@ -488,7 +609,7 @@ describe('no surface may size a track', () => {
   // surface push its own box past its column; and any `width`, `min-width`
   // or `max-width` other than zero in a grid-item rule, each of which is a
   // surface claiming track width again. Scanned over the rules whose
-  // selector names a grid item — `[data-zone-id`, `[data-strip-receiver`,
+  // selector names a grid item — `[data-zone-id`, `[data-strip-slot`,
   // `.probe-panorama` — so a width on `.flagship-probe`, the query
   // container, is out of scope rather than a failure.
   it('caps every grid item at its column: no grid-item rule declares a width, min-width or max-width other than zero', () => {
@@ -497,7 +618,7 @@ describe('no surface may size a track', () => {
     // Innermost rules only: `[^{}]` on both sides skips the `@container`
     // prelude and cannot span a nested block.
     const declared = [...style.matchAll(/([^{}]+)\{([^{}]*)\}/g)]
-      .filter(([, selector]) => /\[data-zone-id|\[data-strip-receiver|\.probe-panorama/.test(selector))
+      .filter(([, selector]) => /\[data-zone-id|\[data-strip-slot|\.probe-panorama/.test(selector))
       .flatMap(([, , body]) => [...body.matchAll(/(?<![-\w(])(?:min-|max-)?width:\s*([^;{}]+)/g)])
       .map(([, value]) => value.trim());
     expect(declared.length).toBeGreaterThan(1);

--- a/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
+++ b/frontend/src/skins/flagship-probe/__tests__/FlagshipProbe.component.test.ts
@@ -513,9 +513,9 @@ describe('the panorama sits between the two rails, in both arrangements', () => 
     expect(Math.max(...panorama)).toBeLessThan(lastColumn);
   });
 
-  // Kills: stacking the receivers, and putting any third area — the transmit
+  // Kills: stacking the slots, and putting any third area — the transmit
   // key's old `rx-mid` track among them — back between them.
-  it.each([[0, 'narrow'], [1, 'wide']])('template %i (%s) keeps the two receivers side by side', (index) => {
+  it.each([[0, 'narrow'], [1, 'wide']])('template %i (%s) keeps the two slots side by side', (index) => {
     const template = templates()[index as number];
     const deckRow = rowOf(template, 'rx-main');
     expect(rowOf(template, 'rx-sub')).toBe(deckRow);


### PR DESCRIPTION
Owner ruling R58 (2026-09-09): a deck column is a SLOT, not a receiver — the left column is the active slot, the right column the second slot, which on a one-receiver radio is the unselected VFO (no receiver instruments, one receiver exists) and on a two-receiver radio is the SUB receiver (its own S-meter).

Two commits: `232a94e0` makes the probe's deck slot-stripped; `22b0b0e6` fixes the class an independent review found in it — per-receiver facts replicated across both columns of a one-receiver deck.

**Soft threshold.** 8 files · 702 changed lines, over the 6/600 threshold and under the 10/1000 ceiling. One unit of work: the second commit exists only because the first one's new code path made a one-receiver deck possible. It touches six files, three of them the first commit's own; the other three are `semantic/VfoSurface.svelte`, which had to grow the suppression prop the withheld control needs, and the two files carrying prose the first commit falsified. Splitting them would ship a deck that marks and names both of its columns as the same receiver.

## The defect, as established

A researcher measured the mounted DOM on a synthetic IC-7300-shaped `1/ab` fixture at `e19d78cb`: `STRIPS COUNT 1`, `vfo tiles: 2`, `SUB STRIPS COUNT 0`. `SemanticRadioSurfaces.svelte`'s `strips="dual"` branch rendered one `.channel-strip` per entry of `visibleStrips`, which maps `receiversOf` — and `receiversOf` de-duplicates `view.vfos` by `.receiver`. On `1/ab` the adapter emits two `vfos` entries **both** with `receiver: 'MAIN'` (`{slot:{kind:'relative',role:'selected'}}` and `…'unselected'`), so `receiversOf` returned `['MAIN']`, one strip was produced with both VFO tiles inside it, and the probe's `rx-sub` grid area — placed by `[data-strip-receiver='SUB']` — had nothing to hold.

## The mechanism

- `dual-receiver-strips.ts` gains `slotsOf(view)` and `forSlot(view, slot)` beside `receiversOf`/`forReceiver`, keeping the file's own rule: a slot never names a position absent from `view.vfos`.
  - More than one receiver in `view.vfos` → one slot per receiver, in the model's order. R58 fixes SUB as the second slot, so this deliberately does **not** reorder behind the active receiver.
  - One receiver → one slot per VFO position, the receiver's `isActiveSlot` one first (R58: the left column is the active slot). `isActiveSlot` is at most true once per receiver (`semantic/radio-view-model.ts`'s validator) and false on every position when the slot was never observed, in which case the order is the model's own.
  - `forSlot` also slices `receiverIndicators`: a slot that does not own its receiver's instruments gets `[]`. This is **not** how the ticket specified it. The spec asked for `indicatorReceiver` to be withheld from the second slot; reading `semantic/VfoSurface.svelte` shows that prop is a *filter* whose omitted value means "every indicator" (`indicatorReceiver === undefined || indicator.receiver === indicatorReceiver`), so withholding it shows the row rather than hiding it. Mutation 2a below confirms it: passing `indicatorReceiver` unconditionally leaves the suite green. The ownership decision therefore lives in the pure slicer, where it is unit-tested, and the component passes `indicatorReceiver={receiverId}` exactly as before.
  - `isActiveSlotStrip(view, slot)` (second commit) is `isActiveStrip`'s per-slot counterpart, keyed on a new `StripSlot.sharesReceiver`: where a receiver backs one column the mark follows the active RECEIVER as before, and where two columns share a receiver it goes to the one holding that receiver's active position.
- `SemanticRadioSurfaces.svelte` gains `stripBy?: 'receiver' | 'slot'`, default `'receiver'`. The `strips="dual"` `{#each}` now walks one `renderedStrips(view)` list; on the `receiver` path its key is the receiver id and `slotPosition` is undefined, so the `data-strip-slot` attribute is absent and the testid, zone id, order and every other attribute are what they were.
- `FlagshipProbeSkin.svelte` passes `stripBy="slot"` and places its two deck columns by `[data-strip-slot='primary'|'secondary']`.

## The class: per-receiver facts on a one-receiver deck

The review's finding, as a class: on the slot path two columns can share one receiver, so every fact the strip derives from `receiverId` alone is drawn twice. Enumerated over the strip's DOM attributes and over every prop it hands `VfoSurface`:

| fact | shared by both columns? | handling |
|---|---|---|
| `receiverIndicators` (indicator row, S-meter) | no — it is the receiver's | withheld from the non-owning slot by `forSlot`, since `indicatorReceiver` cannot express "none" (first commit) |
| `data-strip-active` (accent border, `.channel-strip[data-strip-active='true']`) | no — R58 says the left column IS the active slot | per slot via `isActiveSlotStrip`; **this was the defect** — both columns read `true` on `1/ab` |
| `groupLabel` (`aria-label` on the surface group) | no — its stated purpose is telling the strips apart | the column carrying the receiver's instruments keeps `Receiver MAIN`; a column carrying none is named by its own VFO position (`Unselected VFO`) |
| `vfo-identity-selectors` ("Select VFO A / B") | neither column's — it resolves which COLUMN is A and which is B | **withheld on the slot path (STOPGAP, T207)**. `VfoSurface` gains `suppressIdentitySelectors`, default `false`. The relation's home is *between* the slots (T183); until that surface exists a missing control is honest, while one drawn inside the active column reads as belonging to it |
| `data-strip-operational`, `disabled` | **yes** — a receiver's operational state is genuinely shared by its columns | left reading the slot's receiver, which is what the review asks of them |
| `selectionPoolSize` | **yes** — deliberately radio-wide (MOR-1067) | unchanged |
| `onTuneFrequency`, digit readout | n/a — every consumer is gated on `vfo.isActiveSlot` (`hasDigitReadout`, `hasTunableFrequency`, `tuneFrequency`), so the non-active column is not tunable | unchanged |
| `continuitySession`, `receiverInstruments` | reached only through the gates above and through `receiverIndicators` | unchanged |

**A neighbour checked and found path-independent.** `pendingFrequencyHz` is receiver-keyed and read per tile as `pendingFrequencyHz?.[vfo.receiver]`; the review rendered the 1/ab fixture with a pending MAIN value through both paths and the per-tile results were equal string-for-string, because slicing does not change `vfo.receiver` — on the shipped deck the unselected tile reads the same entry today. The only rule reading `display-unknown` targets `.receiver-instrument`, which does not occur in the probe's mounted DOM. Pre-existing and inert here; not changed.

## Which faces pass `strips="dual"`

Three mount sites, by `git grep -n 'strips="dual"' -- src` at this head: `skins/dual-receiver-cockpit/DualReceiverCockpit.svelte:88`, `skins/segmentline/PeerSplitLayout.svelte:81` (itself mounted by the segmentline and lcd-peer-split skins) and this probe. `git grep -n 'stripBy=' -- src` returns three hits, one of them a mount site: the probe. The other two faces take the `'receiver'` path.

## The default path

At `232a94e0` an independent verifier reproduced the claim directly: the cockpit's mounted DOM is byte-identical across its 14 renders with and without the change. The second commit does not re-run that comparison; it keeps the path identical by construction — on the `receiver` path `active` is the same `isActiveStrip(model, receiverId)` call, `groupLabel` the same `t('core.vfo.receiverGroupLabel', …)` expression, and `suppressIdentitySelectors` is `false`, which is also the prop's default. What pins it: the control test mounting `SemanticRadioSurfaces` with `strips="dual"` and no `stripBy` on the same `1/ab` fixture (one strip, both tiles, no `data-strip-slot`, and the identity selectors still rendered), mutation 11 below, and the 442 tests of the cockpit, peer-split, lcd-peer-split and layout-registration files.

## Topology enumeration

Read out of the adapter's `vfos` flatMap (`lib/runtime/adapters/radio-view-model-adapter.ts`) and pinned as the first `describe` of the new unit test, built through the real adapter from ServerState/Capabilities fixtures:

| topology | `vfos` entries the adapter produces | deck slots |
|---|---|---|
| `1/single` | MAIN unslotted | 1 |
| `1/ab`, relative readback | MAIN selected, MAIN unselected | 2 — selected, then unselected |
| `1/ab`, slot view observed | MAIN A, MAIN B | 2 — the observed active slot first |
| `1/ab`, slot B never observed | MAIN unknown | 1 — the row collapses, no empty box |
| `2/ab_shared` | MAIN unslotted, SUB unslotted | 2 — MAIN, then SUB |
| `2/main_sub` | MAIN A, MAIN B, SUB A, SUB B | 2 — MAIN (A+B), then SUB (A+B) |

The last row is the judgement the ticket left open: one slot per `vfos` entry would give a two-column deck four columns on `2/main_sub`, so on a two-receiver radio a slot is a receiver, which is also what R58 says the FTX-1's second slot is.

## Manifest left alone

`presentation/layouts/declarations.ts` still declares this probe for `2/ab_shared` and `2/main_sub` only. The probe is exercised on `1/ab` here **outside** its declared compatible set; whether the manifest should now list `1/ab` is left to the coordinator. The second commit deletes that declaration's stale rationale ("a single-receiver radio has no second one to place") and corrects its `visibleStrips` citation to `renderedStrips`, leaving `compatibleTopologies` unchanged.

## Tests

New unit file `frontend/src/components-v2/wiring/__tests__/dual-receiver-slots.test.ts` (17 tests) — every view model built by the real `toRadioViewModel`, never by hand.

`FlagshipProbe.component.test.ts`, R58 `describe` (44 tests in the file): two slots on the `1/ab` fixture with the selected tile in `primary` and the unselected in `secondary`; one indicator row, in `primary`; MAIN-then-SUB with a row each on `2/ab_shared`; the control mount described above. Added by the second commit: the active mark is `['true','false']` on `1/ab`; it follows the active receiver on `2/ab_shared` for both MAIN-active and SUB-active; the two `1/ab` columns are named `['Receiver MAIN','Unselected VFO']` and the two `2/ab_shared` columns `['Receiver MAIN','Receiver SUB']`; zero identity-selector groups on the slot path, one on the default path.

### Mutations run

Mutations 1–6 were run against `232a94e0` and reproduced by the reviewing verifier; 7–13 were run against this head, restoring the tree between each.

| # | mutation | result |
|---|---|---|
| 1 | `forSlot` slices by receiver instead of by slot | RED — 4 tests: `slotsOf` "gives a 1/ab radio two slots", "puts the observed active slot first", `forSlot` "keeps only the entries its slot names", and the probe's "gives a one-receiver radio two slots" |
| 2a | `indicatorReceiver` passed unconditionally (the mutation the ticket named) | **GREEN — survives.** The prop is a filter, not the mechanism; see above |
| 2b | `forSlot` ignores `ownsReceiverInstruments` and keeps the receiver's indicators on every slot | RED — 2 tests: `forSlot` "withholds the receiver indicators from a slot that does not own them" and the probe's "draws the one receiver's indicator row once, in the first slot" |
| 3 | the probe left on the default `stripBy` | RED — 3 tests: the probe's "gives a one-receiver radio two slots", "draws the one receiver's indicator row once" and "gives a two-receiver radio MAIN then SUB" |
| 4 | ordering: drop the active-first partition in `slotsOf` | RED — 1 test: "puts the observed active slot first on a slotted single-receiver radio" |
| 5 | `slotPosition` emitted on the `receiver` path too | RED — 1 test: the probe's "leaves the wiring default at one strip per receiver" |
| 6 | behaviour-preserving refactor: the single-receiver ordering rewritten as a stable `sort` by `isActiveSlot` instead of two filters | GREEN, as required |
| 7 | `data-strip-active` back to `isActiveStrip(view, receiverId)` — the defect reinstated | RED — 1 test: "marks the active slot alone on a one-receiver deck" (`['true','true']` vs `['true','false']`) |
| 8 | `slotGroupLabel` always returns the receiver name | RED — 1 test: "names the two columns of a one-receiver deck differently" |
| 9 | `slotGroupLabel` always returns the VFO position label | RED — 2 tests: the same one (`['Selected VFO','Unselected VFO']`) and "keeps the receiver name on a two-receiver deck" (`['MAIN','SUB']`) |
| 10 | `suppressIdentitySelectors={false}` on the slot path | RED — 1 test: "withholds the A/B identity selectors from a slot-stripped deck" |
| 11 | `suppressIdentitySelectors={true}` on both paths | RED — 1 test: "leaves the wiring default at one strip per receiver" (89 of 90 passed across the probe and cockpit files) |
| 12 | `isActiveSlotStrip` drops its active-receiver guard | RED — 2 tests: "follows the active receiver on a two-receiver deck", both MAIN-active and SUB-active |
| 13 | the primary column marked active unconditionally (`active: index === 0`) | RED — 1 test: "follows the active receiver on a two-receiver deck (SUB active)" |
| 14 | benign control: rename the `positionLabel` local throughout | GREEN — 44 tests |

The tree was restored after each; `git diff` at the pushed head carries only the intended change.

### Gate tails at this head

```
npm run check
COMPLETED 4845 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS

npm run lint
(eslint src/ — no output)

npm run lint:boundaries
(eslint src/components-v2/panels/ src/components-v2/layout/ src/presentation/ — no output)

npx vitest run src/skins/flagship-probe/
 Test Files  1 passed (1)
      Tests  44 passed (44)

npx vitest run src/components-v2/wiring/__tests__/dual-receiver-slots.test.ts
 Test Files  1 passed (1)
      Tests  17 passed (17)

npx vitest run src/skins/flagship-probe/ src/presentation/layouts/__tests__/ src/skins/dual-receiver-cockpit/__tests__/ src/components-v2/wiring/__tests__/dual-receiver-slots.test.ts
 Test Files  30 passed (30)
      Tests  485 passed (485)

npx vitest run src/components-v2/wiring/__tests__/ src/semantic/__tests__/
 Test Files  98 passed (98)
      Tests  3156 passed (3156)

npx vitest run src/skins/dual-receiver-cockpit/__tests__/ src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts src/skins/lcd-peer-split/__tests__/ src/presentation/layouts/__tests__/
 Test Files  30 passed (30)
      Tests  442 passed (442)
```

No local run of the whole vitest suite; the pytest/ruff/mypy gates are CI's.

`Census at 22b0b0e6d5cd108744db4d6abdd6a6ee81865889: 8 files, 670+/32- = 702 changed lines` — measured with `git diff --numstat e19d78cb...HEAD` (three-dot; `e19d78cb` is the merge base).

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

