### PR TITLE
fix: refuse a layout override whose manifest excludes the live topology

### DIFF
--- a/frontend/src/__tests__/design-language-activation.component.test.ts
+++ b/frontend/src/__tests__/design-language-activation.component.test.ts
@@ -81,7 +81,15 @@ vi.mock('../lib/runtime/frontend-runtime', () => ({
   runtime: {
     onTxAudioDied: () => () => {},
     get state() { return { stateRevision: 1, freshnessRevision: 1, observationSeq: 1, ptt: false }; },
-    get caps() { return { tx: true, capabilities: ['tx'] }; },
+    // T198: `peer-split`'s manifest declares only the two dual-receiver
+    // topology classes, and `resolveSkinId` now refuses the preference on a
+    // radio outside them — so this stub has to name one. `2/main_sub` is the
+    // FTX-1's MAIN/SUB pair, the radio `peer-split` exists for.
+    get caps() {
+      return {
+        tx: true, capabilities: ['tx', 'dual_rx'], receivers: 2, vfoScheme: 'main_sub',
+      };
+    },
     bootstrap: h.bootstrap,
   },
   presentationResources: {

--- a/frontend/src/__tests__/design-language-activation.component.test.ts
+++ b/frontend/src/__tests__/design-language-activation.component.test.ts
@@ -83,11 +83,12 @@ vi.mock('../lib/runtime/frontend-runtime', () => ({
     get state() { return { stateRevision: 1, freshnessRevision: 1, observationSeq: 1, ptt: false }; },
     // T198: `peer-split`'s manifest declares only the two dual-receiver
     // topology classes, and `resolveSkinId` now refuses the preference on a
-    // radio outside them — so this stub has to name one. `2/main_sub` is the
-    // FTX-1's MAIN/SUB pair, the radio `peer-split` exists for.
+    // radio outside them — so this stub has to name one. `ab_shared` is the
+    // scheme `rigs/ftx1.toml` declares under `[vfo]`, and the FTX-1 is the
+    // radio `peer-split` exists for.
     get caps() {
       return {
-        tx: true, capabilities: ['tx', 'dual_rx'], receivers: 2, vfoScheme: 'main_sub',
+        tx: true, capabilities: ['tx', 'dual_rx'], receivers: 2, vfoScheme: 'ab_shared',
       };
     },
     bootstrap: h.bootstrap,

--- a/frontend/src/lib/stores/qa-cockpit-override.ts
+++ b/frontend/src/lib/stores/qa-cockpit-override.ts
@@ -31,6 +31,12 @@
  * as "the param is broken" rather than "this viewport is mobile" — most
  * often on an ordinary narrow/short desktop window, not an actual phone.
  * `console.warn` makes that non-obvious no-op self-explaining.
+ *
+ * The param no-ops a second way: when the layout manifest registered under
+ * the id it names excludes the live receiver topology, `resolveSkinId`
+ * mounts that manifest's declared fallback instead and reports it on this
+ * same `console.warn` channel (T198 — `skins/__tests__/registry.test.ts`,
+ * "layout-manifest topology gate").
  */
 const QA_COCKPIT_QUERY_PARAM = 'layout';
 export type QaLayoutOverride = 'dual-receiver-cockpit' | 'flagship-probe';

--- a/frontend/src/presentation/workspace/__tests__/selection-adoption.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/selection-adoption.test.ts
@@ -27,8 +27,18 @@ import {
   getTheme, hasExplicitTheme, setTheme, setThemeUserChoice,
 } from '../../../components-v2/theme/theme-switcher';
 import { resolveSkinId } from '../../../skins/registry';
+import type { Capabilities } from '../../../lib/types/capabilities';
 import { fieldline, studioline } from '../../languages/declarations';
 import { validManifest } from '../../languages/__tests__/fixtures';
+
+/** T198: `dual-receiver-cockpit`'s manifest declares only the two dual
+ *  topology classes, and `resolveSkinId` now refuses the preference on any
+ *  other radio — so the QA-override case below has to name one. Only the
+ *  three fields `derivePresentationCapabilities` reads for its topology are
+ *  populated. */
+const MAIN_SUB_CAPABILITIES = {
+  vfoScheme: 'main_sub', receivers: 2, capabilities: ['dual_rx'],
+} as unknown as Capabilities;
 
 const LEGACY_LAYOUT_KEY = 'rigplane-layout';
 const LEGACY_SKIN_KEY = 'rigplane-skin';
@@ -233,7 +243,7 @@ describe('MOR-1257 — the ?layout= QA override survives adoption byte-exactly',
 
     // App's own expression: the override wins for RESOLUTION only.
     expect(resolveSkinId({
-      capabilities: null,
+      capabilities: MAIN_SUB_CAPABILITIES,
       layoutPreference: override ?? getLayoutMode(),
       isMobile: false,
       hasAnyScope: true,
@@ -241,7 +251,7 @@ describe('MOR-1257 — the ?layout= QA override survives adoption byte-exactly',
 
     // …and mobile still wins under 640px.
     expect(resolveSkinId({
-      capabilities: null,
+      capabilities: MAIN_SUB_CAPABILITIES,
       layoutPreference: override ?? getLayoutMode(),
       isMobile: true,
       hasAnyScope: true,

--- a/frontend/src/skins/__tests__/registry.test.ts
+++ b/frontend/src/skins/__tests__/registry.test.ts
@@ -5,16 +5,22 @@ import type { HostedFaceComponentV1 } from '../../../component-kit-api/src/index
 import type { SkinId } from '../registry';
 
 // MOR-2074: which SkinId is QA-gated, read off `resolveSkinId`'s actual
-// early-return branch in `../registry.ts` (`if (ctx.layoutPreference ===
-// 'X') return 'X';`, checked on the RAW `ctx.layoutPreference` before
-// `normalizeLayoutMode` runs — the regex requires the `ctx.` prefix
-// specifically so it does not also match the normal forced-preference
-// branches further down, which check the normalized local instead) rather
-// than hand-copied, so this list cannot silently drift from the production
-// branch that actually makes an id reachable only through the QA-only param.
+// early-return branch in `../registry.ts`, checked on the RAW
+// `ctx.layoutPreference` before `normalizeLayoutMode` runs — the regex
+// requires the `ctx.` prefix specifically so it does not also match the
+// normal forced-preference branches further down, which check the normalized
+// local instead — rather than hand-copied, so this list cannot silently
+// drift from the production branch that actually makes an id reachable only
+// through the QA-only param.
+//
+// T198 extended the matched branch shape with the topology gate's own term
+// (`&& admitsLiveTopology('X', ctx.capabilities)`). Both QA-only ids stay
+// derivable here only while both branches still carry that term: drop the
+// gate from one and this list loses that id, which the "pins a lazy-load
+// case for every skin" completeness test below then fails on.
 const registrySource = readFileSync('src/skins/registry.ts', 'utf8');
 const QA_GATED_LAZY_LOAD_IDS = [...registrySource.matchAll(
-  /if \(ctx\.layoutPreference === '([a-z0-9-]+)'\) return '\1';/g,
+  /if \(ctx\.layoutPreference === '([a-z0-9-]+)'\s+&& admitsLiveTopology\('\1', ctx\.capabilities\)\) return '\1';/g,
 )].map((m) => m[1]) as SkinId[];
 
 // MOR-2074: keyed by the literal `SkinId` itself (not an arbitrary local
@@ -76,6 +82,21 @@ import {
   type ExternalPresentationRecord,
   type PresentationHostMode,
 } from '../registry';
+// T198: the real manifest registry. `../registry` pulls
+// `presentation/layouts/declarations` in for its side effect, so these
+// resolve the shipped declarations rather than a fixture.
+import { getLayout, TOPOLOGY_CLASSES } from '../../presentation/layouts/contract';
+import type { LayoutMode } from '$lib/runtime/adapters/layout-mode-adapter';
+import type { Capabilities, VfoScheme } from '$lib/types/capabilities';
+
+/** Only `vfoScheme`/`receivers`/`capabilities` reach the topology half of
+ *  `derivePresentationCapabilities`; the rest of `Capabilities` only feeds
+ *  its scope/audio diagnostics, which this gate never reads. */
+const capsFor = (vfoScheme: VfoScheme, receivers: 1 | 2): Capabilities =>
+  ({ vfoScheme, receivers, capabilities: ['dual_rx'] }) as unknown as Capabilities;
+const SINGLE_AB = capsFor('ab', 1);
+const AB_SHARED = capsFor('ab_shared', 2);
+const MAIN_SUB = capsFor('main_sub', 2);
 
 const resolve = (overrides: Partial<Parameters<typeof resolveSkinId>[0]> = {}) =>
   resolveSkinId({
@@ -126,7 +147,22 @@ describe('skin registry', () => {
     ['panadapter-first', 'panadapter-first'],
     ['dual-sdr-face', 'dual-sdr-face'],
   ] as const)('resolves forced %s preference to %s', (layoutPreference, skinId) => {
-    expect(resolve({ layoutPreference, hasAnyScope: false })).toBe(skinId);
+    expect(resolve({ layoutPreference, hasAnyScope: false, capabilities: MAIN_SUB })).toBe(skinId);
+  });
+
+  // T198: the same table minus the three `segmentline` preferences, whose
+  // manifests exclude a single-receiver radio. Every preference here resolves
+  // with no live capabilities at all, because the manifest registered under
+  // its id (or, for `dual-sdr-face`, the absence of one) excludes nothing.
+  it.each([
+    ['standard', 'desktop-v2'],
+    ['lcd', 'lcd-cockpit'],
+    ['lcd-cockpit', 'lcd-cockpit'],
+    ['lcd-scope', 'lcd-scope'],
+    ['sdr-test', 'sdr-test'],
+    ['dual-sdr-face', 'dual-sdr-face'],
+  ] as const)('resolves forced %s preference to %s before capabilities arrive', (layoutPreference, skinId) => {
+    expect(resolve({ layoutPreference, capabilities: null })).toBe(skinId);
   });
 
   it.each([
@@ -194,15 +230,19 @@ describe('QA-only layout reachability', () => {
   // which resolves to 'desktop-v2' unconditionally (MOR-1097 cutover) —
   // never the cockpit.
   it('resolves the QA-only preference to the cockpit skin', () => {
-    expect(resolve({ layoutPreference: 'dual-receiver-cockpit' })).toBe('dual-receiver-cockpit');
-    expect(resolve({ layoutPreference: 'dual-receiver-cockpit', hasAnyScope: true })).toBe('dual-receiver-cockpit');
+    expect(resolve({ layoutPreference: 'dual-receiver-cockpit', capabilities: MAIN_SUB })).toBe('dual-receiver-cockpit');
+    expect(resolve({
+      layoutPreference: 'dual-receiver-cockpit', hasAnyScope: true, capabilities: MAIN_SUB,
+    })).toBe('dual-receiver-cockpit');
   });
 
   // Kill-test: removing the T160 branch leaves 'flagship-probe' falling
   // through `normalizeLayoutMode` to 'auto', hence to 'desktop-v2'.
   it('resolves the QA-only preference to the flagship geometry probe', () => {
-    expect(resolve({ layoutPreference: 'flagship-probe' })).toBe('flagship-probe');
-    expect(resolve({ layoutPreference: 'flagship-probe', hasAnyScope: true })).toBe('flagship-probe');
+    expect(resolve({ layoutPreference: 'flagship-probe', capabilities: MAIN_SUB })).toBe('flagship-probe');
+    expect(resolve({
+      layoutPreference: 'flagship-probe', hasAnyScope: true, capabilities: MAIN_SUB,
+    })).toBe('flagship-probe');
   });
 
   // Default-path pin (ticket acceptance): every OTHER forced preference is
@@ -430,5 +470,80 @@ describe('external presentation records share the built-in catalog', () => {
     expect(registrySource.match(/export async function loadSkin/g)).toHaveLength(1);
     expect(registrySource).not.toContain('EXTERNAL_SKIN_LOADERS');
     expect(registrySource).not.toContain('EXTERNAL_PRESENTATION_CATALOG');
+  });
+});
+
+// T198 — a layout manifest's `compatibleTopologies` is a restriction on which
+// radios its skin may mount, and until this block it was validated, documented
+// and read by nothing. `resolveSkinId` now refuses a layout preference whose
+// registered manifest excludes the live receiver topology class.
+describe('layout-manifest topology gate', () => {
+  /** Read off the shipped manifests, not hand-listed: a skin id is gated iff
+   *  a manifest is registered under it AND that manifest leaves at least one
+   *  class out of `TOPOLOGY_CLASSES`. */
+  const GATED = (Object.keys(entrypoints) as SkinId[]).filter((id) => {
+    const manifest = getLayout(id);
+    return manifest !== undefined
+      && !TOPOLOGY_CLASSES.every((c) => manifest.compatibleTopologies.includes(c));
+  });
+
+  // Runs first in this block: the refusal report is throttled per (layout,
+  // live class), and the cases below consume the pairs it counts.
+  it('reports a refusal once per layout and live topology class', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(resolve({ layoutPreference: 'flagship-probe', capabilities: SINGLE_AB })).toBe('desktop-v2');
+      expect(resolve({ layoutPreference: 'flagship-probe', capabilities: SINGLE_AB })).toBe('desktop-v2');
+      expect(warn).toHaveBeenCalledTimes(1);
+      const [message] = warn.mock.calls[0] as [string];
+      expect(message).toContain('flagship-probe');
+      expect(message).toContain('1/ab');
+      expect(message).toContain('2/ab_shared, 2/main_sub');
+      // Same layout, a class not yet reported.
+      expect(resolve({ layoutPreference: 'flagship-probe', capabilities: capsFor('single', 1) })).toBe('desktop-v2');
+      expect(warn).toHaveBeenCalledTimes(2);
+      // Same class, a layout not yet reported.
+      expect(resolve({ layoutPreference: 'peer-split', capabilities: SINGLE_AB })).toBe('desktop-v2');
+      expect(warn).toHaveBeenCalledTimes(3);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('gates exactly the loadable skins whose manifest excludes a topology class', () => {
+    expect([...GATED].sort()).toEqual([
+      'dual-receiver-cockpit', 'flagship-probe', 'panadapter-first', 'peer-split',
+      'unified-instrument',
+    ]);
+  });
+
+  // The defect this block exists for: the probe mounted on an IC-7300 (1/ab),
+  // a radio its own manifest excludes.
+  it.each(GATED)('refuses the %s preference on a 1/ab radio', (skinId) => {
+    expect(resolve({ layoutPreference: skinId as LayoutMode, capabilities: SINGLE_AB })).toBe('desktop-v2');
+  });
+
+  it.each(GATED)('admits the %s preference on both topology classes it declares', (skinId) => {
+    expect(resolve({ layoutPreference: skinId as LayoutMode, capabilities: AB_SHARED })).toBe(skinId);
+    expect(resolve({ layoutPreference: skinId as LayoutMode, capabilities: MAIN_SUB })).toBe(skinId);
+  });
+
+  it.each(GATED)('never admits %s while the live topology is underivable', (skinId) => {
+    expect(resolve({ layoutPreference: skinId as LayoutMode, capabilities: null })).toBe('desktop-v2');
+    expect(resolve({
+      layoutPreference: skinId as LayoutMode, capabilities: undefined as unknown as null,
+    })).toBe('desktop-v2');
+    // `receivers` disagreeing with `vfoScheme` is what
+    // `derivePresentationCapabilities` reports as `invalid-topology`, and it
+    // yields no class either.
+    expect(resolve({
+      layoutPreference: skinId as LayoutMode, capabilities: capsFor('main_sub', 1),
+    })).toBe('desktop-v2');
+  });
+
+  it('leaves a preference with no registered manifest unaffected', () => {
+    expect(getLayout('dual-sdr-face')).toBeUndefined();
+    expect(resolve({ layoutPreference: 'dual-sdr-face', capabilities: SINGLE_AB })).toBe('dual-sdr-face');
+    expect(resolve({ layoutPreference: 'dual-sdr-face', capabilities: null })).toBe('dual-sdr-face');
   });
 });

--- a/frontend/src/skins/__tests__/registry.test.ts
+++ b/frontend/src/skins/__tests__/registry.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AppResource } from '$lib/runtime/resource-demand';
 import type { HostedFaceComponentV1 } from '../../../component-kit-api/src/index';
 import type { SkinId } from '../registry';
@@ -13,14 +13,14 @@ import type { SkinId } from '../registry';
 // drift from the production branch that actually makes an id reachable only
 // through the QA-only param.
 //
-// T198 extended the matched branch shape with the topology gate's own term
-// (`&& admitsLiveTopology('X', ctx.capabilities)`). Both QA-only ids stay
-// derivable here only while both branches still carry that term: drop the
-// gate from one and this list loses that id, which the "pins a lazy-load
-// case for every skin" completeness test below then fails on.
+// T198 replaced the matched branch's bare `return 'X'` with the topology
+// gate's own call (`return resolveWithFallback('X', ctx.capabilities)`). Both
+// QA-only ids stay derivable here only while both branches still carry that
+// call: drop the gate from one and this list loses that id, which the "pins a
+// lazy-load case for every skin" completeness test below then fails on.
 const registrySource = readFileSync('src/skins/registry.ts', 'utf8');
 const QA_GATED_LAZY_LOAD_IDS = [...registrySource.matchAll(
-  /if \(ctx\.layoutPreference === '([a-z0-9-]+)'\s+&& admitsLiveTopology\('\1', ctx\.capabilities\)\) return '\1';/g,
+  /if \(ctx\.layoutPreference === '([a-z0-9-]+)'\) return resolveWithFallback\('\1', ctx\.capabilities\);/g,
 )].map((m) => m[1]) as SkinId[];
 
 // MOR-2074: keyed by the literal `SkinId` itself (not an arbitrary local
@@ -86,6 +86,7 @@ import {
 // `presentation/layouts/declarations` in for its side effect, so these
 // resolve the shipped declarations rather than a fixture.
 import { getLayout, TOPOLOGY_CLASSES } from '../../presentation/layouts/contract';
+import type { LayoutManifest } from '../../presentation/layouts/contract';
 import type { LayoutMode } from '$lib/runtime/adapters/layout-mode-adapter';
 import type { Capabilities, VfoScheme } from '$lib/types/capabilities';
 
@@ -474,9 +475,11 @@ describe('external presentation records share the built-in catalog', () => {
 });
 
 // T198 — a layout manifest's `compatibleTopologies` is a restriction on which
-// radios its skin may mount, and until this block it was validated, documented
+// radios its skin may mount, and its `fallbackLayoutId` names where a refused
+// preference goes instead. Until this block both were validated, documented
 // and read by nothing. `resolveSkinId` now refuses a layout preference whose
-// registered manifest excludes the live receiver topology class.
+// registered manifest excludes the live receiver topology class, and mounts
+// the first hop down that manifest's fallback chain which admits it.
 describe('layout-manifest topology gate', () => {
   /** Read off the shipped manifests, not hand-listed: a skin id is gated iff
    *  a manifest is registered under it AND that manifest leaves at least one
@@ -487,24 +490,56 @@ describe('layout-manifest topology gate', () => {
       && !TOPOLOGY_CLASSES.every((c) => manifest.compatibleTopologies.includes(c));
   });
 
+  /** What each gated preference mounts on a radio its own manifest excludes.
+   *  Hand-written: this is the outcome the walk owes, not a second copy of
+   *  the walk. The completeness case below pins the key set against `GATED`
+   *  and pins that every value here declares all four topology classes —
+   *  which is why the same expectation holds for `1/ab`, for no capabilities
+   *  at all, and for an invalid topology. */
+  const MOUNTED_WHEN_REFUSED: Record<string, SkinId> = {
+    'dual-receiver-cockpit': 'sdr-test',
+    'flagship-probe': 'sdr-test',
+    'peer-split': 'lcd-cockpit',
+    // `peer-split` is the declared fallback of both, and is itself refused on
+    // the same radio, so the walk continues to ITS fallback.
+    'unified-instrument': 'lcd-cockpit',
+    'panadapter-first': 'lcd-cockpit',
+  };
+
   // Runs first in this block: the refusal report is throttled per (layout,
   // live class), and the cases below consume the pairs it counts.
   it('reports a refusal once per layout and live topology class', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
-      expect(resolve({ layoutPreference: 'flagship-probe', capabilities: SINGLE_AB })).toBe('desktop-v2');
-      expect(resolve({ layoutPreference: 'flagship-probe', capabilities: SINGLE_AB })).toBe('desktop-v2');
+      expect(resolve({ layoutPreference: 'flagship-probe', capabilities: SINGLE_AB })).toBe('sdr-test');
+      expect(resolve({ layoutPreference: 'flagship-probe', capabilities: SINGLE_AB })).toBe('sdr-test');
       expect(warn).toHaveBeenCalledTimes(1);
       const [message] = warn.mock.calls[0] as [string];
       expect(message).toContain('flagship-probe');
       expect(message).toContain('1/ab');
       expect(message).toContain('2/ab_shared, 2/main_sub');
       // Same layout, a class not yet reported.
-      expect(resolve({ layoutPreference: 'flagship-probe', capabilities: capsFor('single', 1) })).toBe('desktop-v2');
+      expect(resolve({ layoutPreference: 'flagship-probe', capabilities: capsFor('single', 1) })).toBe('sdr-test');
       expect(warn).toHaveBeenCalledTimes(2);
       // Same class, a layout not yet reported.
-      expect(resolve({ layoutPreference: 'peer-split', capabilities: SINGLE_AB })).toBe('desktop-v2');
+      expect(resolve({ layoutPreference: 'peer-split', capabilities: SINGLE_AB })).toBe('lcd-cockpit');
       expect(warn).toHaveBeenCalledTimes(3);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  // The refusal has to say what the user is looking at instead, or the report
+  // explains a blank change of face with the name of a skin that is NOT on
+  // screen. `unified-instrument` on `1/single` is a (layout, class) pair no
+  // other case in this file consumes, so the throttle above cannot swallow it.
+  it('names the layout the walk actually mounted', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(resolve({ layoutPreference: 'unified-instrument', capabilities: capsFor('single', 1) }))
+        .toBe('lcd-cockpit');
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect((warn.mock.calls[0] as [string])[0]).toContain('mounting "lcd-cockpit" instead');
     } finally {
       warn.mockRestore();
     }
@@ -515,12 +550,20 @@ describe('layout-manifest topology gate', () => {
       'dual-receiver-cockpit', 'flagship-probe', 'panadapter-first', 'peer-split',
       'unified-instrument',
     ]);
+    expect(Object.keys(MOUNTED_WHEN_REFUSED).sort()).toEqual([...GATED].sort());
+    for (const mounted of new Set(Object.values(MOUNTED_WHEN_REFUSED))) {
+      const manifest = getLayout(mounted);
+      expect(manifest, `${mounted} is a registered layout`).toBeDefined();
+      expect(TOPOLOGY_CLASSES.every((c) => manifest!.compatibleTopologies.includes(c)),
+        `${mounted} declares every topology class`).toBe(true);
+    }
   });
 
   // The defect this block exists for: the probe mounted on an IC-7300 (1/ab),
   // a radio its own manifest excludes.
-  it.each(GATED)('refuses the %s preference on a 1/ab radio', (skinId) => {
-    expect(resolve({ layoutPreference: skinId as LayoutMode, capabilities: SINGLE_AB })).toBe('desktop-v2');
+  it.each(GATED)('routes the refused %s preference to its declared fallback', (skinId) => {
+    expect(resolve({ layoutPreference: skinId as LayoutMode, capabilities: SINGLE_AB }))
+      .toBe(MOUNTED_WHEN_REFUSED[skinId]);
   });
 
   it.each(GATED)('admits the %s preference on both topology classes it declares', (skinId) => {
@@ -528,22 +571,80 @@ describe('layout-manifest topology gate', () => {
     expect(resolve({ layoutPreference: skinId as LayoutMode, capabilities: MAIN_SUB })).toBe(skinId);
   });
 
-  it.each(GATED)('never admits %s while the live topology is underivable', (skinId) => {
-    expect(resolve({ layoutPreference: skinId as LayoutMode, capabilities: null })).toBe('desktop-v2');
+  it.each(GATED)('never mounts %s while the live topology is underivable', (skinId) => {
+    const fallback = MOUNTED_WHEN_REFUSED[skinId];
+    expect(resolve({ layoutPreference: skinId as LayoutMode, capabilities: null })).toBe(fallback);
     expect(resolve({
       layoutPreference: skinId as LayoutMode, capabilities: undefined as unknown as null,
-    })).toBe('desktop-v2');
+    })).toBe(fallback);
     // `receivers` disagreeing with `vfoScheme` is what
     // `derivePresentationCapabilities` reports as `invalid-topology`, and it
     // yields no class either.
     expect(resolve({
       layoutPreference: skinId as LayoutMode, capabilities: capsFor('main_sub', 1),
-    })).toBe('desktop-v2');
+    })).toBe(fallback);
   });
 
   it('leaves a preference with no registered manifest unaffected', () => {
     expect(getLayout('dual-sdr-face')).toBeUndefined();
     expect(resolve({ layoutPreference: 'dual-sdr-face', capabilities: SINGLE_AB })).toBe('dual-sdr-face');
     expect(resolve({ layoutPreference: 'dual-sdr-face', capabilities: null })).toBe('dual-sdr-face');
+  });
+});
+
+// T198 — the ends of the fallback walk, which no shipped chain reaches: every
+// shipped chain terminates on a layout declaring all four topology classes.
+describe('layout fallback chain terminates', () => {
+  // Each case refuses a preference, so each reports one refusal.
+  beforeEach(() => { vi.spyOn(console, 'warn').mockImplementation(() => {}); });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  /** A fresh module graph. `../registry` pulls `presentation/layouts/
+   *  declarations` in for its side effect, so each call gets its own layout
+   *  registry — one a test-only manifest can register into under
+   *  `dual-sdr-face`, the one loadable skin id the shipped declarations leave
+   *  free (pinned by the case above). Static bindings elsewhere in this file
+   *  keep pointing at the first instance, so earlier suites are untouched. */
+  async function freshRegistry() {
+    vi.resetModules();
+    const contract = await import('../../presentation/layouts/contract');
+    const registry = await import('../registry');
+    /** A test-only manifest: a shipped one cloned wholesale, with only the id,
+     *  the topology restriction and the fallback replaced. `2/main_sub` alone
+     *  is what makes `SINGLE_AB` a refusal, so the walk runs. Cloned rather
+     *  than written out as a literal because a literal here would have to name
+     *  the manifest's stage sizing-policy field, which
+     *  `presentation/layouts/__tests__/stage-sizing-boundary.test.ts` forbids
+     *  any file outside `presentation/layouts/` from naming. */
+    const base = contract.getLayout('lcd-cockpit');
+    expect(base, 'lcd-cockpit is registered in the fresh graph').toBeDefined();
+    const register = (id: string, fallbackLayoutId: string | null) =>
+      contract.registerLayout({
+        ...(base as LayoutManifest),
+        id,
+        displayName: id,
+        compatibleTopologies: ['2/main_sub'],
+        fallbackLayoutId,
+      });
+    return {
+      register,
+      resolve: (layoutPreference: LayoutMode) => registry.resolveSkinId({
+        capabilities: SINGLE_AB, layoutPreference, isMobile: false, hasAnyScope: false,
+      }),
+    };
+  }
+
+  it('stops at the default when the chain names an id already visited', async () => {
+    const { register, resolve: resolveFresh } = await freshRegistry();
+    register('dual-sdr-face', 'fallback-hop-one');
+    register('fallback-hop-one', 'fallback-hop-two');
+    register('fallback-hop-two', 'fallback-hop-one');
+    expect(resolveFresh('dual-sdr-face')).toBe('desktop-v2');
+  });
+
+  it('stops at the default when the chain names no registered layout', async () => {
+    const { register, resolve: resolveFresh } = await freshRegistry();
+    register('dual-sdr-face', 'fallback-absent');
+    expect(resolveFresh('dual-sdr-face')).toBe('desktop-v2');
   });
 });

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -22,6 +22,17 @@ import {
   normalizeLayoutMode,
   type LayoutMode,
 } from '$lib/runtime/adapters/layout-mode-adapter';
+import {
+  derivePresentationCapabilities,
+} from '$lib/runtime/adapters/presentation-capabilities';
+import { getLayout, TOPOLOGY_CLASSES } from '../presentation/layouts/contract';
+// Side-effect import, the same idiom `App.svelte` uses for the same registry:
+// it populates the layout manifests `getLayout` resolves against. Imported
+// here as well so `admitsLiveTopology` below cannot depend on the composition
+// root having pulled the barrel in first — an unregistered id is admitted, so
+// without this the gate would silently disappear wherever the barrel was not
+// already loaded.
+import '../presentation/layouts/declarations';
 
 export type SkinId =
   | 'desktop-v2' | 'dual-receiver-cockpit' | 'lcd-cockpit' | 'lcd-scope' | 'mobile' | 'peer-split'
@@ -83,6 +94,54 @@ export interface SkinResolutionContext {
   hasAnyScope: boolean;
 }
 
+/** Layout id + live topology class pairs already reported, so a repeated
+ *  resolution (every capability revision re-runs `App.svelte`'s `$derived`)
+ *  reports once rather than per evaluation. Report state only: never read by
+ *  `admitsLiveTopology`, so it cannot change which preferences are refused. */
+const reportedRefusals = new Set<string>();
+
+/**
+ * T198 — whether the layout manifest registered under `id` accepts the radio
+ * `capabilities` describes.
+ *
+ * `compatibleTopologies` was validated (`presentation/layouts/contract.ts:
+ * validateLayoutManifest`) and documented as a restriction, but no runtime
+ * path read it: `?layout=flagship-probe` mounted the probe on an IC-7300,
+ * whose `1/ab` class that manifest does not declare.
+ *
+ * The live class is `${structuralCount}/${scheme}` — the same string
+ * `lib/runtime/adapters/radio-view-model-adapter.ts` composes for its
+ * `topologyId`, over the same `TOPOLOGY_CLASSES` vocabulary a manifest
+ * declares against.
+ *
+ * Two shapes are admitted without deriving anything: an id with no registered
+ * manifest, and a manifest that declares every class in `TOPOLOGY_CLASSES`.
+ * Neither can exclude a radio, so neither needs to see one — which is what
+ * keeps an unrestricted preference resolving before capabilities arrive. A
+ * manifest that DOES exclude a class must see its own: an underivable
+ * topology (no capabilities yet, or a `vfoScheme`/`receivers` pair
+ * `derivePresentationCapabilities` reports as `invalid-topology`) is refused,
+ * because nothing establishes that the manifest covers it.
+ */
+function admitsLiveTopology(id: SkinId, capabilities: Capabilities | null): boolean {
+  const manifest = getLayout(id);
+  if (manifest === undefined) return true;
+  const declared = manifest.compatibleTopologies;
+  if (TOPOLOGY_CLASSES.every((topologyClass) => declared.includes(topologyClass))) return true;
+  const topology = capabilities ? derivePresentationCapabilities(capabilities).topology : null;
+  const live = topology === null ? null : `${topology.structuralCount}/${topology.scheme}`;
+  if (live !== null && declared.some((topologyClass) => topologyClass === live)) return true;
+  const key = `${id} ${live ?? ''}`;
+  if (!reportedRefusals.has(key)) {
+    reportedRefusals.add(key);
+    console.warn(
+      `[rigplane] layout "${id}" declares compatibleTopologies [${declared.join(', ')}], and the `
+      + `live receiver topology is ${live ?? 'not derivable yet'} — not selecting that skin.`,
+    );
+  }
+  return false;
+}
+
 /**
  * Determine which skin to use based on context.
  *
@@ -100,6 +159,12 @@ export interface SkinResolutionContext {
  * - User forced 'peer-split' → peer-split
  * - Auto: use desktop-v2 (the v3 default); explicit LCD choices are the
  *   recoverable compatibility-window opt-out
+ * - T198: each forced branch above requires `admitsLiveTopology` for the
+ *   skin it would return, and a refused preference falls through to the
+ *   default exactly as an unrecognised one does. The 'standard' branch and
+ *   the auto default are the two that do not carry the term: both return
+ *   'desktop-v2', which is what a refusal falls through TO, so refusing it
+ *   could only report a refusal and then return it anyway
  */
 export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
   if (ctx.isMobile) return 'mobile';
@@ -109,19 +174,28 @@ export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
   // `CanonicalLayoutMode` (lib/stores/layout.svelte.ts), so
   // `normalizeLayoutMode` below would fall it straight through to 'auto'.
   // Checked here, before normalization, for that reason.
-  if (ctx.layoutPreference === 'dual-receiver-cockpit') return 'dual-receiver-cockpit';
+  if (ctx.layoutPreference === 'dual-receiver-cockpit'
+    && admitsLiveTopology('dual-receiver-cockpit', ctx.capabilities)) return 'dual-receiver-cockpit';
   // T160 PR-1: the geometry probe is gated the same way and checked here for
   // the same reason — it is not a `CanonicalLayoutMode` either.
-  if (ctx.layoutPreference === 'flagship-probe') return 'flagship-probe';
+  if (ctx.layoutPreference === 'flagship-probe'
+    && admitsLiveTopology('flagship-probe', ctx.capabilities)) return 'flagship-probe';
   const layoutPreference = normalizeLayoutMode(ctx.layoutPreference);
-  if (layoutPreference === 'sdr-test') return 'sdr-test';
-  if (layoutPreference === 'lcd-cockpit') return 'lcd-cockpit';
-  if (layoutPreference === 'lcd-scope') return 'lcd-scope';
+  if (layoutPreference === 'sdr-test'
+    && admitsLiveTopology('sdr-test', ctx.capabilities)) return 'sdr-test';
+  if (layoutPreference === 'lcd-cockpit'
+    && admitsLiveTopology('lcd-cockpit', ctx.capabilities)) return 'lcd-cockpit';
+  if (layoutPreference === 'lcd-scope'
+    && admitsLiveTopology('lcd-scope', ctx.capabilities)) return 'lcd-scope';
   if (layoutPreference === 'standard') return 'desktop-v2';
-  if (layoutPreference === 'peer-split') return 'peer-split';
-  if (layoutPreference === 'unified-instrument') return 'unified-instrument';
-  if (layoutPreference === 'panadapter-first') return 'panadapter-first';
-  if (layoutPreference === 'dual-sdr-face') return 'dual-sdr-face';
+  if (layoutPreference === 'peer-split'
+    && admitsLiveTopology('peer-split', ctx.capabilities)) return 'peer-split';
+  if (layoutPreference === 'unified-instrument'
+    && admitsLiveTopology('unified-instrument', ctx.capabilities)) return 'unified-instrument';
+  if (layoutPreference === 'panadapter-first'
+    && admitsLiveTopology('panadapter-first', ctx.capabilities)) return 'panadapter-first';
+  if (layoutPreference === 'dual-sdr-face'
+    && admitsLiveTopology('dual-sdr-face', ctx.capabilities)) return 'dual-sdr-face';
   // MOR-1097 cutover: every non-mobile auto start uses the reworked
   // desktop-v2 composition. Scope availability remains presentation data, not
   // default-selection policy; explicit LCD preferences stay selectable.

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -94,11 +94,26 @@ export interface SkinResolutionContext {
   hasAnyScope: boolean;
 }
 
-/** Layout id + live topology class pairs already reported, so a repeated
+/** Refused layout + live topology class pairs already reported, so a repeated
  *  resolution (every capability revision re-runs `App.svelte`'s `$derived`)
- *  reports once rather than per evaluation. Report state only: never read by
- *  `admitsLiveTopology`, so it cannot change which preferences are refused. */
+ *  reports once rather than per evaluation. */
 const reportedRefusals = new Set<string>();
+
+/** The skin an unresolvable preference lands on (MOR-1097 cutover). */
+const DEFAULT_SKIN_ID: SkinId = 'desktop-v2';
+
+/**
+ * The live receiver topology class, `${structuralCount}/${scheme}` — the same
+ * string `lib/runtime/adapters/radio-view-model-adapter.ts` composes for its
+ * `topologyId`, over the same `TOPOLOGY_CLASSES` vocabulary a manifest
+ * declares against. `null` when nothing establishes one: no capabilities yet,
+ * or a `vfoScheme`/`receivers` pair `derivePresentationCapabilities` reports
+ * as `invalid-topology`.
+ */
+function liveTopologyClass(capabilities: Capabilities | null): string | null {
+  const topology = capabilities ? derivePresentationCapabilities(capabilities).topology : null;
+  return topology === null ? null : `${topology.structuralCount}/${topology.scheme}`;
+}
 
 /**
  * T198 — whether the layout manifest registered under `id` accepts the radio
@@ -109,37 +124,67 @@ const reportedRefusals = new Set<string>();
  * path read it: `?layout=flagship-probe` mounted the probe on an IC-7300,
  * whose `1/ab` class that manifest does not declare.
  *
- * The live class is `${structuralCount}/${scheme}` — the same string
- * `lib/runtime/adapters/radio-view-model-adapter.ts` composes for its
- * `topologyId`, over the same `TOPOLOGY_CLASSES` vocabulary a manifest
- * declares against.
- *
  * Two shapes are admitted without deriving anything: an id with no registered
  * manifest, and a manifest that declares every class in `TOPOLOGY_CLASSES`.
  * Neither can exclude a radio, so neither needs to see one — which is what
  * keeps an unrestricted preference resolving before capabilities arrive. A
  * manifest that DOES exclude a class must see its own: an underivable
- * topology (no capabilities yet, or a `vfoScheme`/`receivers` pair
- * `derivePresentationCapabilities` reports as `invalid-topology`) is refused,
- * because nothing establishes that the manifest covers it.
+ * topology is refused, because nothing establishes that the manifest covers
+ * it.
  */
-function admitsLiveTopology(id: SkinId, capabilities: Capabilities | null): boolean {
+function admitsLiveTopology(id: string, capabilities: Capabilities | null): boolean {
   const manifest = getLayout(id);
   if (manifest === undefined) return true;
   const declared = manifest.compatibleTopologies;
   if (TOPOLOGY_CLASSES.every((topologyClass) => declared.includes(topologyClass))) return true;
-  const topology = capabilities ? derivePresentationCapabilities(capabilities).topology : null;
-  const live = topology === null ? null : `${topology.structuralCount}/${topology.scheme}`;
-  if (live !== null && declared.some((topologyClass) => topologyClass === live)) return true;
+  const live = liveTopologyClass(capabilities);
+  return live !== null && declared.some((topologyClass) => topologyClass === live);
+}
+
+function reportRefusal(id: SkinId, capabilities: Capabilities | null, mounted: SkinId): void {
+  const live = liveTopologyClass(capabilities);
   const key = `${id} ${live ?? ''}`;
-  if (!reportedRefusals.has(key)) {
-    reportedRefusals.add(key);
-    console.warn(
-      `[rigplane] layout "${id}" declares compatibleTopologies [${declared.join(', ')}], and the `
-      + `live receiver topology is ${live ?? 'not derivable yet'} — not selecting that skin.`,
-    );
+  if (reportedRefusals.has(key)) return;
+  reportedRefusals.add(key);
+  const declared = getLayout(id)?.compatibleTopologies ?? [];
+  console.warn(
+    `[rigplane] layout "${id}" declares compatibleTopologies [${declared.join(', ')}], and the `
+    + `live receiver topology is ${live ?? 'not derivable yet'} — mounting "${mounted}" instead.`,
+  );
+}
+
+/**
+ * T198 — the skin actually mounted for a preferred `id`: `id` itself when its
+ * manifest admits the live topology, otherwise the first hop down the
+ * `fallbackLayoutId` chain that is a built-in skin admitting it, and
+ * `DEFAULT_SKIN_ID` when the chain runs out. `LayoutManifest.fallbackLayoutId`
+ * was declared and validated but read by no runtime path before this.
+ *
+ * A hop is taken only when it is both a built-in skin and admitted; any other
+ * candidate — an id no manifest is registered under, one registered but not
+ * loadable, one whose own manifest also excludes the radio — continues down
+ * that candidate's own chain. `visited` bounds the walk: a chain that names an
+ * id already seen stops there instead of looping.
+ *
+ * One report per refused (preference, live class) pair, naming the skin the
+ * walk actually mounted — `console.warn`, the channel
+ * `lib/stores/qa-cockpit-override.ts` already uses to explain its own no-op.
+ */
+function resolveWithFallback(id: SkinId, capabilities: Capabilities | null): SkinId {
+  if (admitsLiveTopology(id, capabilities)) return id;
+  const visited = new Set<string>([id]);
+  let mounted: SkinId = DEFAULT_SKIN_ID;
+  let candidate = getLayout(id)?.fallbackLayoutId ?? null;
+  while (candidate !== null && !visited.has(candidate)) {
+    visited.add(candidate);
+    if (BUILT_IN_SKIN_IDS.has(candidate) && admitsLiveTopology(candidate, capabilities)) {
+      mounted = candidate as SkinId;
+      break;
+    }
+    candidate = getLayout(candidate)?.fallbackLayoutId ?? null;
   }
-  return false;
+  reportRefusal(id, capabilities, mounted);
+  return mounted;
 }
 
 /**
@@ -159,12 +204,12 @@ function admitsLiveTopology(id: SkinId, capabilities: Capabilities | null): bool
  * - User forced 'peer-split' → peer-split
  * - Auto: use desktop-v2 (the v3 default); explicit LCD choices are the
  *   recoverable compatibility-window opt-out
- * - T198: each forced branch above requires `admitsLiveTopology` for the
- *   skin it would return, and a refused preference falls through to the
- *   default exactly as an unrecognised one does. The 'standard' branch and
- *   the auto default are the two that do not carry the term: both return
- *   'desktop-v2', which is what a refusal falls through TO, so refusing it
- *   could only report a refusal and then return it anyway
+ * - T198: a forced preference resolves through `resolveWithFallback`, which
+ *   returns the preferred skin only while its manifest admits the live
+ *   receiver topology and otherwise walks that manifest's `fallbackLayoutId`
+ *   chain, ending at `DEFAULT_SKIN_ID`. The 'standard' branch returns
+ *   'desktop-v2' directly — the walk's own endpoint, so routing it through
+ *   the walker could only report a refusal and return the same id
  */
 export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
   if (ctx.isMobile) return 'mobile';
@@ -174,32 +219,23 @@ export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
   // `CanonicalLayoutMode` (lib/stores/layout.svelte.ts), so
   // `normalizeLayoutMode` below would fall it straight through to 'auto'.
   // Checked here, before normalization, for that reason.
-  if (ctx.layoutPreference === 'dual-receiver-cockpit'
-    && admitsLiveTopology('dual-receiver-cockpit', ctx.capabilities)) return 'dual-receiver-cockpit';
+  if (ctx.layoutPreference === 'dual-receiver-cockpit') return resolveWithFallback('dual-receiver-cockpit', ctx.capabilities);
   // T160 PR-1: the geometry probe is gated the same way and checked here for
   // the same reason — it is not a `CanonicalLayoutMode` either.
-  if (ctx.layoutPreference === 'flagship-probe'
-    && admitsLiveTopology('flagship-probe', ctx.capabilities)) return 'flagship-probe';
+  if (ctx.layoutPreference === 'flagship-probe') return resolveWithFallback('flagship-probe', ctx.capabilities);
   const layoutPreference = normalizeLayoutMode(ctx.layoutPreference);
-  if (layoutPreference === 'sdr-test'
-    && admitsLiveTopology('sdr-test', ctx.capabilities)) return 'sdr-test';
-  if (layoutPreference === 'lcd-cockpit'
-    && admitsLiveTopology('lcd-cockpit', ctx.capabilities)) return 'lcd-cockpit';
-  if (layoutPreference === 'lcd-scope'
-    && admitsLiveTopology('lcd-scope', ctx.capabilities)) return 'lcd-scope';
+  if (layoutPreference === 'sdr-test') return resolveWithFallback('sdr-test', ctx.capabilities);
+  if (layoutPreference === 'lcd-cockpit') return resolveWithFallback('lcd-cockpit', ctx.capabilities);
+  if (layoutPreference === 'lcd-scope') return resolveWithFallback('lcd-scope', ctx.capabilities);
   if (layoutPreference === 'standard') return 'desktop-v2';
-  if (layoutPreference === 'peer-split'
-    && admitsLiveTopology('peer-split', ctx.capabilities)) return 'peer-split';
-  if (layoutPreference === 'unified-instrument'
-    && admitsLiveTopology('unified-instrument', ctx.capabilities)) return 'unified-instrument';
-  if (layoutPreference === 'panadapter-first'
-    && admitsLiveTopology('panadapter-first', ctx.capabilities)) return 'panadapter-first';
-  if (layoutPreference === 'dual-sdr-face'
-    && admitsLiveTopology('dual-sdr-face', ctx.capabilities)) return 'dual-sdr-face';
+  if (layoutPreference === 'peer-split') return resolveWithFallback('peer-split', ctx.capabilities);
+  if (layoutPreference === 'unified-instrument') return resolveWithFallback('unified-instrument', ctx.capabilities);
+  if (layoutPreference === 'panadapter-first') return resolveWithFallback('panadapter-first', ctx.capabilities);
+  if (layoutPreference === 'dual-sdr-face') return resolveWithFallback('dual-sdr-face', ctx.capabilities);
   // MOR-1097 cutover: every non-mobile auto start uses the reworked
   // desktop-v2 composition. Scope availability remains presentation data, not
   // default-selection policy; explicit LCD preferences stay selectable.
-  return 'desktop-v2';
+  return DEFAULT_SKIN_ID;
 }
 
 /**
@@ -299,6 +335,11 @@ const SKIN_LOADERS = {
     resources: ['hardware-scope'],
   },
 } satisfies BuiltInPresentationCatalog;
+
+/** The catalog's built-in ids, captured before `commitExternalPresentationBatch`
+ *  can add an externally authored presentation to the same object: a fallback
+ *  hop must land on a `SkinId`, which an external presentation id is not. */
+const BUILT_IN_SKIN_IDS: ReadonlySet<string> = new Set(Object.keys(SKIN_LOADERS));
 
 const hasOwn = (value: object, key: PropertyKey): boolean =>
   Object.prototype.hasOwnProperty.call(value, key);

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -580,7 +580,11 @@ test.describe('T185 transmit key pair', () => {
 
   test('stacks when its column is narrower than the pair', async ({ page }, info) => {
     // `layout` is the workspace value; `qaLayout` is what actually selects the skin.
-    await boot(page, 'standard', 1440, true, 'studioline', false, undefined,
+    // The probe's manifest declares only the two dual-receiver topology classes
+    // and `resolveSkinId` refuses the preference outside them (T198), so both
+    // cases boot the two-receiver catalog fixture: on the single-receiver
+    // default the probe never mounts and its transmit zone never appears.
+    await boot(page, 'standard', 1440, true, 'studioline', false, 'topology-2-main-sub',
       { qaLayout: 'flagship-probe' });
     // Both cases set the rail column they measure in, rather than inheriting
     // whatever the skin declares: the two custom properties its grid templates
@@ -604,7 +608,7 @@ test.describe('T185 transmit key pair', () => {
   });
 
   test('stays on one line when its column is wider than the pair', async ({ page }, info) => {
-    await boot(page, 'standard', 1440, true, 'studioline', false, undefined,
+    await boot(page, 'standard', 1440, true, 'studioline', false, 'topology-2-main-sub',
       { qaLayout: 'flagship-probe' });
     // The mirror of the case above: 400px is wider than the pair. The skin's
     // own rail is one key wide, so this column has to be set here too.


### PR DESCRIPTION
## The defect

`LayoutManifest.compatibleTopologies` was validated by `validateLayoutManifest`
and documented as a restriction on which radios a layout's skin may mount, but
no runtime path read it. `resolveSkinId` returned the preferred skin id
straight from `ctx.layoutPreference`, so `?layout=flagship-probe` mounted the
geometry probe on an IC-7300 — live class `1/ab` — although the probe's
manifest declares only `2/ab_shared` and `2/main_sub`.

`LayoutManifest.fallbackLayoutId` was in the same state: declared by six
shipped manifests, validated, and read by no runtime path.

## The gate

`admitsLiveTopology(id, capabilities)` reads the manifest registered under the
skin id and compares its declared classes against `${structuralCount}/${scheme}`
derived from `ctx.capabilities` — the same string
`lib/runtime/adapters/radio-view-model-adapter.ts` composes for its
`topologyId`, over the same `TOPOLOGY_CLASSES` vocabulary a manifest declares
against.

Two shapes are admitted without deriving anything: an id with no registered
manifest, and a manifest that declares every class in `TOPOLOGY_CLASSES`.
Neither can exclude a radio, so an unrestricted preference still resolves
before capabilities arrive. A manifest that does exclude a class must see its
own: an underivable topology (no capabilities yet, or a `vfoScheme`/`receivers`
pair `derivePresentationCapabilities` reports as `invalid-topology`) is
refused.

## The fallback chain

A refused preference no longer drops straight to the default. `resolveWithFallback`
walks `fallbackLayoutId` and takes the first hop that is both a built-in skin
and admitted; a hop that is unregistered, registered but not loadable, or
itself refused continues down that hop's own chain. A `visited` set bounds the
walk: a chain naming an id already seen stops there. The endpoint when the walk
finds nothing is `desktop-v2`.

Where each gated preference lands on a radio its manifest excludes:

| preference | walk | mounted |
|---|---|---|
| `dual-receiver-cockpit` | → `sdr-test` | `sdr-test` |
| `flagship-probe` | → `sdr-test` | `sdr-test` |
| `peer-split` | → `lcd-cockpit` | `lcd-cockpit` |
| `unified-instrument` | → `peer-split` (refused) → `lcd-cockpit` | `lcd-cockpit` |
| `panadapter-first` | → `peer-split` (refused) → `lcd-cockpit` | `lcd-cockpit` |

`sdr-test` and `lcd-cockpit` each declare all four topology classes, which is
why the same table holds for `1/ab`, for no capabilities at all, and for an
invalid topology. A test asserts that property of both endpoints rather than
assuming it.

## Gated skins and what the user sees

The gated ids are the five whose registered manifest leaves a class out:
`dual-receiver-cockpit`, `flagship-probe`, `panadapter-first`, `peer-split`,
`unified-instrument` — read off the shipped manifests by the test, not
hand-listed. Three of them (`peer-split`, `unified-instrument`,
`panadapter-first`) are options in `components-v2/layout/StatusBar.svelte`'s
skin picker; the other two are reachable only through `?layout=<id>`.

On a single-receiver radio, picking one of those three now renders the
fallback instead. The persisted preference is not touched — `resolveSkinId` is
pure and writes nothing — so the picker still shows the chosen value while a
different skin is on screen, and the only signal is one `console.warn` naming
the layout actually mounted. Surfacing the refusal in the picker itself is
T209.

## The e2e fixture change

`frontend/tests/e2e/i18n/desktop-geometry.spec.ts`'s two T185 cases booted the
probe on `fixture()`'s default caps (IC-7300, `receivers: 1`, `vfoScheme: 'ab'`
→ class `1/ab`), which the gate refuses, so
`[data-testid="flagship-geometry-probe"]` never appeared and the i18n visual
smoke step failed on the previous head (2 failed / 87 passed). Both now pass
`'topology-2-main-sub'` as `boot()`'s 7th parameter.

No assertion in those two cases carries a geometry literal, and both already
pin the rail column they measure (200px narrow, 400px wide) with their own
`addStyleTag`, so nothing had to be re-tuned. Measured on the two-receiver
deck, from the cases' own attachments: `key.width` 131.12, `unkey.width`
130.83, `columnGap` 8 → pair 269.95 in both cases; `actions.width` 200.00
(narrow, buttons stacked) and 400.00 (wide, one line).

## Tests and mutations

Gates run locally at the pre-merge head `277b399d`, before `origin/main` was merged into the branch (kept as the record of that head; the current head's evidence is under "CI at this head"):

- `npx vitest run src/skins/__tests__/ src/presentation/ src/__tests__/design-language-activation.component.test.ts` — 66 files, 1390 tests, 0 failed
- `npm run check` — `COMPLETED 4844 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`
- `npm run lint` — no output (clean)
- `npm run lint:boundaries` — no output (clean)
- `npm run build` then `npx playwright test -c ./playwright.i18n.config.ts tests/e2e/i18n/desktop-geometry.spec.ts` — 42 passed (45.2s)

Mutations, each applied to the restored tree and reverted afterwards:

1. **Fallback ignored.** Inserted `reportRefusal(id, capabilities, DEFAULT_SKIN_ID); return DEFAULT_SKIN_ID;` immediately after the admit check in `resolveWithFallback`, so a refusal never walks the chain. `src/skins/__tests__/registry.test.ts`: 12 failed / 81 passed — every "routes the refused X preference to its declared fallback" case, every "never mounts X while the live topology is underivable" case, "names the layout the walk actually mounted", and the once-per-pair report case.
2. **Chain unbounded.** Replaced `while (candidate !== null && !visited.has(candidate)) { visited.add(candidate);` with `while (candidate !== null) {`. The run never produced a result: the cycle registered by "stops at the default when the chain names an id already visited" spins the resolver forever, and the vitest worker had to be killed after >600s with no test output. That is the failure mode the bound exists to prevent.
3. **Control.** Renamed the walker's local `candidate` to `hop` (9 occurrences inside `resolveWithFallback`), a behaviour-preserving edit: 93 passed / 0 failed, unchanged from the unmutated file.
4. **E2E fixture reverted.** Put `undefined` back as `boot()`'s topology argument in both T185 cases: both fail at `boot`'s
   `await expect(page.locator('[data-testid="flagship-geometry-probe"]').first()).toBeVisible()` — the exact CI red this PR fixes.

Class sweep for the fixture defect: `qaLayout` / `?layout=<gated id>` appears in
`tests/e2e/i18n/desktop-geometry.spec.ts` only. `presentation-switch-resources.
component.test.ts` and `presentation-switch-tx.component.test.ts` mention
`?layout=flagship-probe` in comments but select skins through their own
`widthToSkin` table, not the resolver; the visual specs mount fixtures
directly. No other site reaches a gated skin through `resolveSkinId`.

## Review fixes carried in this head

- `design-language-activation.component.test.ts`: the stub caps said
  `vfoScheme: 'main_sub'` under a comment calling `2/main_sub` "the FTX-1's
  MAIN/SUB pair". `rigs/ftx1.toml` declares `scheme = "ab_shared"` under
  `[vfo]`; the stub and the sentence now say `ab_shared`.
- `skins/registry.ts`: the `reportedRefusals` docstring claimed it was "never
  read by `admitsLiveTopology`" while that function read it for the throttle.
  Reporting now lives in its own `reportRefusal`, and the clause is deleted.
- `skins/registry.ts`: the `resolveSkinId` bullet claiming "the two that do not
  carry the term" is replaced — it did not count the `isMobile` branch.
- `lib/stores/qa-cockpit-override.ts`: one sentence recording the topology
  refusal as a second way `?layout=` no-ops, tied to
  `skins/__tests__/registry.test.ts`'s "layout-manifest topology gate".

## Size

Census at `6793ca0940d17da0b3e80e0a838d1104de87ca8e`, the head after `origin/main` (`6d7e712f`) was merged into the branch and two untrue comment claims were deleted: 6 files, 388+/29- = 417 changed lines, re-measured with `git diff --numstat origin/main...HEAD`.
At the 6-file soft threshold, under the 600-line one. One unit of work: the
gate and the fallback it falls to are the same decision in `resolveSkinId`, the
two test files pin that decision, and the e2e fixture and the
`qa-cockpit-override.ts` sentence are the two places the gate's own effect
shows up elsewhere. Splitting would land a gate whose e2e is red.

## CI at this head

At the current head `6793ca09`: `Agent Review Gate` — pass, bound to this head; `quick` — run 35039192901 (the comment-only delta's own run). The pre-delta head `32df3bfa` had `quick` pass in 5m45s, run 35038270578. The paragraph below records the earlier run 34362092289 (4m59s) at the pre-merge head, whose selection reasoning still applies. Its own selection step reports
`Core checks selected: false` / `Frontend checks selected: true`: this PR
touches only `frontend/`, so `quick.yml`'s `core` filter skipped the pytest and
ruff block and the frontend block ran. Frontend vitest: 470 files, 11651 tests,
all passed. Frontend i18n visual smoke: 89 passed (previous head: 2 failed / 87
passed). `visual` — pass. `Agent Review Gate` — red pending the independent
review directive.

internal-identifier self-check — empty

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)


