### PR TITLE
docs: name the model in every serial example now that the factory refuses to guess

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ from rigplane import create_radio, LanBackendConfig
 async def main():
     async with create_radio(LanBackendConfig(host="192.168.1.100",
                                              username="user",
-                                             password="pass")) as radio:
+                                             password="pass",
+                                             model="IC-7610")) as radio:
         await radio.set_frequency(14_074_000)
         await radio.set_mode("USB")
         print(await radio.get_s_meter())

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Tested in production against WSJT-X, fldigi, and JS8Call.
 
 ```bash
 pip install rigplane
-rigplane web                # auto-discovers a radio on the LAN
+rigplane --model IC-7610 web   # discovers the radio's IP on the LAN
 # open http://localhost:8080
 ```
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -97,17 +97,17 @@ rigplane --backend lan status
 
 ```bash
 # Auto-discover serial port
-rigplane --backend serial status
+rigplane --backend serial --model IC-7610 status
 
 # Explicit port (--backend serial is inferred)
-rigplane --serial-port /dev/tty.usbmodem-IC7610 status
+rigplane --serial-port /dev/tty.usbmodem-IC7610 --model IC-7610 status
 ```
 
 Set via environment variable to avoid repeating:
 
 ```bash
 export ICOM_SERIAL_DEVICE=/dev/tty.usbmodem-IC7610
-rigplane status    # auto-infers --backend serial
+rigplane --model IC-7610 status    # auto-infers --backend serial
 ```
 
 ### Yaesu CAT backend
@@ -152,13 +152,13 @@ rigplane --list-audio-devices
 rigplane --list-audio-devices --json
 
 # Specify explicit devices
-rigplane --backend serial --serial-port /dev/tty.usbmodem-IC7610 \
+rigplane --backend serial --model IC-7610 --serial-port /dev/tty.usbmodem-IC7610 \
     --rx-device "IC-7610 USB Audio" \
     --tx-device "IC-7610 USB Audio" \
     audio rx --out rx.wav --seconds 10
 
 # Specify an ALSA hardware id from --list-audio-devices --json
-rigplane --backend serial --serial-port /dev/ttyACM0 \
+rigplane --backend serial --model IC-7610 --serial-port /dev/ttyACM0 \
     --rx-device "hw:3,0" \
     --tx-device "hw:3,0" \
     audio rx --out rx.wav --seconds 10

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -39,8 +39,8 @@ rigplane supports two backends selected via `--backend`:
 ```bash
 # Serial backend quick start
 export ICOM_SERIAL_DEVICE=/dev/tty.usbmodem-IC7610
-rigplane --backend serial status
-rigplane --backend serial freq 14.074m
+rigplane --backend serial --model IC-7610 status
+rigplane --backend serial --model IC-7610 freq 14.074m
 
 # List available USB audio devices
 rigplane --list-audio-devices

--- a/docs/guide/ic7300-usb-setup.md
+++ b/docs/guide/ic7300-usb-setup.md
@@ -171,7 +171,7 @@ Use macOS BlackHole (or Loopback) to bridge rigplane audio to WSJT-X:
    - Add "IC-7300" input + "BlackHole 2ch" output
 3. **Start audio bridge**:
    ```bash
-   rigplane audio bridge --serial-port ic-7300-usb-in --loopback "BlackHole 2ch"
+   rigplane --model IC-7300 audio bridge --serial-port ic-7300-usb-in --loopback "BlackHole 2ch"
    ```
 4. **WSJT-X settings**:
    - Input Device: "IC-7300 Bridge"

--- a/docs/guide/ic7610-usb-setup.md
+++ b/docs/guide/ic7610-usb-setup.md
@@ -138,9 +138,9 @@ export ICOM_SERIAL_DEVICE=/dev/cu.usbserial-111120
 export ICOM_SERIAL_BAUDRATE=115200
 
 # Test basic control
-rigplane --backend serial status
-rigplane --backend serial freq
-rigplane --backend serial mode
+rigplane --backend serial --model IC-7610 status
+rigplane --backend serial --model IC-7610 freq
+rigplane --backend serial --model IC-7610 mode
 ```
 
 Expected output:
@@ -156,7 +156,7 @@ Power:        50
 
 ```bash
 # Capture 10 seconds of RX audio to WAV
-rigplane --backend serial \
+rigplane --backend serial --model IC-7610 \
     --rx-device "IC-7610 USB Audio" \
     audio rx --out test_rx.wav --seconds 10
 
@@ -169,33 +169,33 @@ rigplane --backend serial \
 
 ```bash
 # Status check
-rigplane --backend serial status
+rigplane --backend serial --model IC-7610 status
 
 # Set frequency
-rigplane --backend serial freq 7.074m
+rigplane --backend serial --model IC-7610 freq 7.074m
 
 # Set mode
-rigplane --backend serial mode USB
+rigplane --backend serial --model IC-7610 mode USB
 
 # PTT test: key for 3 seconds, then unkey automatically (exits 0)
-rigplane --backend serial ptt --for 3
+rigplane --backend serial --model IC-7610 ptt --for 3
 
 # rigplane ptt on (no --for) keys and blocks until you press Ctrl-C —
 # use that form instead when you want to hold the key down by hand
 # ptt off unkeys immediately: the recovery command if a crash or an
 # older rigplane build left the rig transmitting
-rigplane --backend serial ptt off
+rigplane --backend serial --model IC-7610 ptt off
 
 # CW keying
-rigplane --backend serial cw "CQ CQ DE KN4KYD K"
+rigplane --backend serial --model IC-7610 cw "CQ CQ DE KN4KYD K"
 
 # Attenuator (uses Command29 for IC-7610)
-rigplane --backend serial att 18
-rigplane --backend serial att 0
+rigplane --backend serial --model IC-7610 att 18
+rigplane --backend serial --model IC-7610 att 0
 
 # Preamp
-rigplane --backend serial preamp 1
-rigplane --backend serial preamp 0
+rigplane --backend serial --model IC-7610 preamp 1
+rigplane --backend serial --model IC-7610 preamp 0
 ```
 
 ### Python API
@@ -245,7 +245,7 @@ asyncio.run(main())
 
 ```bash
 # Start web UI on serial backend
-rigplane --backend serial \
+rigplane --backend serial --model IC-7610 \
     --rx-device "IC-7610 USB Audio" \
     --tx-device "IC-7610 USB Audio" \
     web
@@ -263,7 +263,7 @@ The web UI will show:
 
 ```bash
 # Start rigctld server on serial backend
-rigplane --backend serial serve
+rigplane --backend serial --model IC-7610 serve
 
 # Then configure WSJT-X:
 # Radio: Hamlib NET rigctl
@@ -380,7 +380,7 @@ usb-audio-resolve: /dev/cu.usbserial-201410 → prefix 0x2014 → RX device [2],
 
 If you see `"topology resolution not supported"` (Linux), specify device indices explicitly:
 ```bash
-rigplane --backend serial --rx-device 2 --tx-device 3 status
+rigplane --backend serial --model IC-7610 --rx-device 2 --tx-device 3 status
 ```
 
 Use `rigplane --list-audio-devices` to find the correct indices.
@@ -438,7 +438,7 @@ export ICOM_USB_RX_DEVICE="IC-7610 USB Audio"
 export ICOM_USB_TX_DEVICE="IC-7610 USB Audio"
 
 # Then simply:
-rigplane --backend serial status
+rigplane --backend serial --model IC-7610 status
 ```
 
 ## Migration from LAN to Serial
@@ -465,7 +465,7 @@ If you're currently using the LAN backend and want to switch to serial:
    rigplane status
    
    # After (Serial)
-   rigplane --backend serial status
+   rigplane --backend serial --model IC-7610 status
    ```
 
 3. **Capability check**: scope/waterfall requires ≥115200 baud (see table above)

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -533,7 +533,7 @@ pip install rigplane
 2. **Override** (use with caution for debugging only):
    ```bash
    export ICOM_SERIAL_SCOPE_ALLOW_LOW_BAUD=1
-   rigplane --backend serial --serial-baud 19200 scope
+   rigplane --backend serial --model IC-7610 --serial-baud 19200 scope
    ```
    Python API:
    ```python
@@ -553,7 +553,7 @@ pip install rigplane
 ```bash
 # Increase serial CI-V pacing interval (default 50 ms)
 export ICOM_SERIAL_CIV_MIN_INTERVAL_MS=80
-rigplane --backend serial status
+rigplane --backend serial --model IC-7610 status
 
 # Or use higher baud rate (radio setting)
 # Menu → Set → Connectors → CI-V → CI-V USB Baud Rate → 115200
@@ -577,7 +577,7 @@ rigplane --backend serial status
 rigplane --list-audio-devices
 
 # Explicitly set TX device
-rigplane --backend serial --tx-device "IC-7610 USB Audio" audio tx --in test.wav
+rigplane --backend serial --model IC-7610 --tx-device "IC-7610 USB Audio" audio tx --in test.wav
 
 # Ensure PTT is active during TX (library handles this automatically for audio tx)
 ```

--- a/docs/radio-protocol.md
+++ b/docs/radio-protocol.md
@@ -335,7 +335,7 @@ rigplane freq 14.074m
 rigplane --backend lan status
 
 # New: Serial backend
-rigplane --backend serial --serial-port /dev/cu.usbserial-111120 status
+rigplane --backend serial --model IC-7610 --serial-port /dev/cu.usbserial-111120 status
 ```
 
 ### Web UI and rigctld
@@ -347,13 +347,13 @@ Web UI and rigctld now support backend selection via CLI flags. Default is LAN f
 rigplane web
 
 # Web UI: Serial backend
-rigplane --backend serial --serial-port /dev/cu.usbserial-111120 web
+rigplane --backend serial --model IC-7610 --serial-port /dev/cu.usbserial-111120 web
 
 # rigctld: LAN backend (default)
 rigplane serve
 
 # rigctld: Serial backend
-rigplane --backend serial --serial-port /dev/cu.usbserial-111120 serve
+rigplane --backend serial --model IC-7610 --serial-port /dev/cu.usbserial-111120 serve
 ```
 
 ### Consumer Code (Web/rigctld/CLI)

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -581,12 +581,12 @@ def _build_parser() -> argparse.ArgumentParser:
         allow_abbrev=False,
         epilog=(
             "examples:\n"
-            "  rigplane web                          # auto-discover radio, start web UI\n"
-            "  rigplane web --radio-host 192.168.55.40  # explicit radio IP\n"
-            "  rigplane web --preset digimode        # bridge + rigctld + WSJT-X compat\n"
-            "  rigplane web --bridge                 # web UI + audio bridge\n"
-            "  rigplane serve                        # rigctld server only\n"
-            "  rigplane discover                     # find radios on the network\n"
+            "  rigplane --model IC-7610 web                    # discover radio IP, start web UI\n"
+            "  rigplane --model IC-7610 web --radio-host 192.168.55.40  # explicit radio IP\n"
+            "  rigplane --model IC-7610 web --preset digimode  # bridge + rigctld + WSJT-X compat\n"
+            "  rigplane --model IC-7610 web --bridge           # web UI + audio bridge\n"
+            "  rigplane --model IC-7610 serve                  # rigctld server only\n"
+            "  rigplane discover                               # find radios on the network\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -432,10 +432,11 @@ def _print_common_cli_hint(argv: list[str]) -> None:
     if "discover" in argv and "web" in argv:
         print(
             "\nHint: do not combine 'discover' and 'web'. "
-            "'web' can auto-discover the radio, or you can pass the radio explicitly:\n"
-            "  rigplane web\n"
-            "  rigplane web --radio-host 192.168.55.40 --radio-user USER "
-            "--radio-pass-file /path/to/password\n",
+            "'web' can discover the radio's IP, but the model must be named; "
+            "you can also pass the radio explicitly:\n"
+            "  rigplane --model IC-7610 web\n"
+            "  rigplane --model IC-7610 web --radio-host 192.168.55.40 "
+            "--radio-user USER --radio-pass-file /path/to/password\n",
             file=sys.stderr,
         )
         return
@@ -443,11 +444,11 @@ def _print_common_cli_hint(argv: list[str]) -> None:
     if _has_global_connection_options_after_command(argv):
         print(
             "\nHint: radio connection options normally go before the command:\n"
-            "  rigplane --backend lan --host 192.168.55.40 --user USER "
-            "--pass-file /path/to/password web\n\n"
+            "  rigplane --model IC-7610 --backend lan --host 192.168.55.40 "
+            "--user USER --pass-file /path/to/password web\n\n"
             "For the web UI, the more readable form is also supported:\n"
-            "  rigplane web --radio-host 192.168.55.40 --radio-user USER "
-            "--radio-pass-file /path/to/password\n",
+            "  rigplane --model IC-7610 web --radio-host 192.168.55.40 "
+            "--radio-user USER --radio-pass-file /path/to/password\n",
             file=sys.stderr,
         )
 

--- a/src/rigplane/profiles/LAYER.md
+++ b/src/rigplane/profiles/LAYER.md
@@ -56,7 +56,8 @@ types. **Do not hoist it to module top-level** (plan §6.2 no-touch list).
   `tests/test_rig_loader*.py`.
 - **Change the registry resolution policy** → edit `resolve_radio_profile`
   in `profiles/__init__.py`; the docstring documents the precedence
-  order (explicit > model > civ_addr > IC-7610 default).
+  order (explicit profile > model > radio_addr), and the `ValueError`
+  raised when none of the three identifies the radio.
 
 ## See also
 

--- a/src/rigplane/profiles/LAYER.md
+++ b/src/rigplane/profiles/LAYER.md
@@ -55,9 +55,10 @@ types. **Do not hoist it to module top-level** (plan §6.2 no-touch list).
   extend the TOML schema in `rig_loader.py`, add a test fixture under
   `tests/test_rig_loader*.py`.
 - **Change the registry resolution policy** → edit `resolve_radio_profile`
-  in `profiles/__init__.py`; the docstring documents the precedence
-  order (explicit profile > model > radio_addr), and the `ValueError`
-  raised when none of the three identifies the radio.
+  in `profiles/__init__.py`; the docstring states that an explicit
+  profile or model name is a caller override that wins over
+  `radio_addr`, and that `ValueError` is raised when none of the three
+  identifies the radio.
 
 ## See also
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -467,7 +467,7 @@ class TestPasswordResolution:
 
         err = mock_stderr.getvalue()
         assert "do not combine 'discover' and 'web'" in err
-        assert "rigplane web --radio-host 192.168.55.40" in err
+        assert "rigplane --model IC-7610 web --radio-host 192.168.55.40" in err
 
     def test_web_help_does_not_print_error_hint(self):
         p = _build_parser()


### PR DESCRIPTION
2 code (cli hint + its test) + 8 docs = 10 files, at the hard file ceiling and not over it (the coordinating session records this under the owner's 2026-09-03 delegation: every documented serial invocation and the CLI's own printed examples are one change)

## Why

Owner ruling R59 (PR #3411) removes the serial backend's implicit `IC-7610`
default: `create_radio` on a `SerialBackendConfig` with no model refuses
instead of guessing. Every serial invocation documented without `--model`
therefore stops working the moment #3411 lands. This PR names the radio in all
of them, ahead of that merge.

Three already-broken LAN cases are fixed in the same pass, because they are the
same defect — a documented invocation that identifies no radio: `README.md`'s
shell quickstart, `README.md`'s Python quickstart, and the CLI parser's own
printed examples (`_build_parser`'s epilog and `_print_common_cli_hint`).
Those never worked on the LAN path either. Measured on this branch's base
(`695e56d87`), `create_radio(LanBackendConfig(host=…, username=…, password=…))`
with no `model=`:

```
ValueError: Cannot resolve a radio profile: no profile, model, or matching
radio_addr identifies the radio. ...
```

`_auto_discover_lan` (`cli/__init__.py`) returns only the host IP — it never
supplies a model — and `_run` catches that `ValueError` and returns 1.

## Grep, before and after

```
grep -rn "rigplane .*\(--backend serial\|--serial-port\)" docs/ README.md \
  | grep -v -- "--model" | grep -v yaesu-cat
```

Both numbers re-derived at head `3b724c15a` (the "before" via `git grep` at the
merge base):

- before (`695e56d87`): **37** lines
- after: **4** lines, all in `docs/guide/ic705-usb-setup.md` (147, 151, 239, 260)

Those four are false positives of a line-based grep, not defects: each is the
first line of a backslash-continued invocation whose `--model IC-705` sits on
the *next* line (read at head). Left untouched deliberately — see "Not fixed".

## Files

| File | Change |
|---|---|
| `docs/guide/cli.md` | 5 serial examples gain `--model IC-7610` |
| `docs/guide/configuration.md` | 2 serial quick-start examples |
| `docs/guide/ic7300-usb-setup.md` | 1 `audio bridge` example gains `--model IC-7300` |
| `docs/guide/ic7610-usb-setup.md` | 19 serial examples |
| `docs/guide/troubleshooting.md` | 3 serial examples |
| `docs/radio-protocol.md` | 3 serial examples |
| `README.md` | shell quickstart gains `--model IC-7610`; the Python quickstart's `LanBackendConfig(...)` gains `model="IC-7610"` |
| `src/rigplane/cli/__init__.py` | `_build_parser`'s epilog and `_print_common_cli_hint`: the printed `web`/`serve` examples gain `--model IC-7610`, and the hint's sentence narrows from "`web` can auto-discover the radio" to discovery finding the IP with the model still named. Both are help/hint strings; no behaviour |
| `tests/test_cli.py` | `TestPasswordResolution::test_discover_web_common_mistake_gets_human_hint` asserts the new hint string |
| `src/rigplane/profiles/LAYER.md` | the bullet said the `resolve_radio_profile` docstring documents a precedence order ranking profile against model. It does not: it says a `RadioProfile` or a non-blank profile/model name is a caller override that wins over `radio_addr`, and that `ValueError` is raised when none of the three identifies the radio. The bullet now says that |

## Verification

- **34** rewritten markdown invocations at head (an added line whose stripped
  form starts with `rigplane `, joined across backslash continuations);
  **33 parse** under `_build_parser().parse_args(...)`. The one failure is
  `docs/guide/ic7300-usb-setup.md:174`, for a pre-existing reason this PR does
  not introduce: the global `--serial-port` sits after the subcommand, and
  `audio bridge` has no `--loopback`. Each cause was confirmed on its own —
  `rigplane audio bridge --serial-port X` and `rigplane audio bridge --loopback Y`
  each give `error: unrecognized arguments` — and `git show
  origin/main:docs/guide/ic7300-usb-setup.md` shows the base line already had
  both.
- Each of the **3** distinct invocations `_print_common_cli_hint` prints was
  scraped from the hint's own stderr (not transcribed) and driven through
  `cli._run`, with `_auto_discover_lan` stubbed to return a host and
  `create_radio` wrapped to stop the run the moment it returns. All three get
  past `create_radio`. Control: the same three with `--model` removed each
  return 1 with the resolve `ValueError`.
- The README Python quickstart's `create_radio(LanBackendConfig(...))` call was
  extracted from the file and executed — construction only, nothing connects:
  it returns an `IcomRadio`. The same extraction against the pre-fix block
  raised the resolve `ValueError`.
- `uv run pytest tests/test_cli.py tests/test_cli_model.py tests/test_cli_coverage.py -q --tb=short --timeout=300 --timeout-method=thread`
  — **245 passed, 0 failed**.
- `uv run ruff check src/ tests/` — All checks passed.
  `uv run ruff format --check src/ tests/` — 742 files already formatted.
- Mutations. (a) The hint invocation strings reverted to their modelless form →
  `tests/test_cli.py:470` fails (1 failed, 244 passed). (b) `model="IC-7610"`
  removed from the README block → the extraction check raises the resolve
  `ValueError`. Both reversed; `git diff` before the final gate run showed only
  the intended change.
- **The doc-citation gate did not run on this PR.** Its workflow
  (`.github/workflows/doc-citation-gate.yml`) triggers only on changes to
  `.github/scripts/check-doc-citations.sh` or to itself, and this PR touches
  neither. The script would not run locally either — it uses `declare -A` and
  this machine has bash 3.2. Verified by hand instead:
  `git diff 695e56d87...HEAD -- '*.md'` adds no relative markdown link and no
  `file:line` citation, so neither gate's input changed.

## Not fixed — reported instead

The earlier sweep of the class "documented `rigplane` invocation that
identifies no radio" was **markdown-only**. Re-run over Python sources, the
class has these members in `src/rigplane/cli/__init__.py`:

- `_print_common_cli_hint` — **fixed in this PR**, see above.
- The **module docstring usage synopsis** (the `Usage:` block at the top of
  the file): 17 lines, every one
  modelless (`rigplane status [--host HOST] …`). Not fixed — it belongs with
  the LAN-docs follow-up (T213). Two of its forms were measured as real
  subprocesses at head: `rigplane --host <ip> status` and
  `rigplane --host <ip> audio rx --out … --seconds 1` each exit 1 with the
  resolve error.
- `_warn_web_host_ambiguity` quotes three forms in its warning text.
  As subprocesses, the two it recommends (`rigplane web --radio-host <ip>`,
  `rigplane --host <ip> web`) exit 1 with the resolve error; the third is the
  form it warns *against*, and on this machine it fails earlier, at LAN
  discovery. Same follow-up.
- The four `Example: rigplane audio …` strings in the `audio` subparser
  descriptions (`rx`, `tx`, `loopback`, `bridge`) are modelless. Same
  follow-up.

Not a member: the epilog's `rigplane discover` line needs no model — `discover`
is dispatched in `main()` and never reaches `_run`, so `create_radio` is never
called.

Markdown members remaining:

1. **LAN-path invocations with no `--model`/`--radio-addr`.**
   `git grep -nE '^\s*rigplane ' -- '*.md'`, minus lines matching `--model` or
   `--radio-addr`, minus the commands that never reach `create_radio`
   (`discover`, `proxy`, `diagnose`, `validate`, `radio-validate`, `convert`,
   `--list-audio-devices`, `--version`, `--help`, `audio caps`,
   `audio probe-profile`), leaves **147 lines across 19 files**, 104 of them in
   `docs/guide/cli.md`. That is a line count — a backslash-continued
   invocation counts once, on its first line — and I did not execute them.
   Ticket T213.
2. **`docs/PROJECT.md`** — the 2026-03-23 architecture note describes
   `IC-7610 → Icom7610SerialRadio (default)`; the parenthetical goes stale with
   #3411.
3. **`docs/guide/ic705-usb-setup.md` CLI section** — broken for an unrelated
   reason: its examples use `--device`, `--baudrate`, `--rx-audio-device`,
   `--tx-audio-device` and the subcommands `repl` and `rigctld`, none of which
   the parser defines. Different class, left untouched — which is also why the
   four residual grep lines above stay.
4. **`docs/guide/ic7300-usb-setup.md:174`** — see Verification. The model fix
   is correct and independent of the two parse defects, and is kept.

Different class, reported only: **`src/rigplane/profiles/LAYER.md`** says
"adding a new radio is a TOML file plus zero Python changes" (Charter) and
"No Python changes required" (Common operations, "Add a new radio"). That is
false for
serial. `backends/factory.py` dispatches on five model names and raises
otherwise; `rigs/x6100.toml` and `rigs/tx500.toml` exist with no branch.
Measured:

```
create_radio(SerialBackendConfig(device=…, model='X6100'))
  -> ValueError: Unsupported serial model 'X6100'; supported: IC-705, IC-7300,
     IC-7610, IC-9700, X6200, and Yaesu FT-series (FTX-1, FT-710, ...).
create_radio(SerialBackendConfig(device=…, model='TX-500'))  -> same ValueError
create_radio(SerialBackendConfig(device=…, model='IC-7300')) -> Ic7300SerialRadio
```

## Guardrails

Census at `3b724c15a0dcf525bf01874a1cd5c224a0db5321`
(`git diff --numstat origin/main...HEAD`): **10 files, 64+/57- = 121 changed
lines**.

Over the 6-file soft threshold and at the 10-file hard ceiling; under both line
limits. One unit of work: a single mechanical substitution driven by one owner
ruling, applied to every place the removed default was relied on, plus the two
blocks of the same class that review found in files this PR had already
touched.

internal-identifier self-check — empty.

Linear: MOR-2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Correction after review (`c407b902`)

The first review found the sweep incomplete: `docs/guide/ic7610-usb-setup.md` and `docs/radio-protocol.md` still built a `SerialBackendConfig` with no model, and both would have broken the moment #3411 lands. `c407b902` names `IC-7610` in each — the radio both documents are about — and in four adjacent `allow_low_baud_scope` / migration fragments, which live in `docs/guide/ic7610-usb-setup.md` and `docs/guide/troubleshooting.md`.

`23ac194e` then fixed a regression `c407b902` introduced: it had written `SerialBackendConfig(model="IC-7610", ..., …)`, and in Python a bare `...` after a keyword argument is a positional argument, so three snippets that compiled before stopped compiling. All abbreviated calls now put the placeholder first — `SerialBackendConfig(..., model="IC-7610", …)` — including one `LanBackendConfig` call in `ic7610-usb-setup.md` that had the same defect before this PR. Verified at the head by compiling every one-line backend-config snippet in `docs/**` and `README.md`: 24 checked, 0 broken. Docs-only edits; the file count stays at 10.

**Not fixed here, and not because they work.** Of the thirty `LanBackendConfig(...)` constructions in `docs/**` and `README.md`, twenty-three pass neither a model nor an address and two pass `radio_addr=0x42`; all twenty-five refuse today, before #3411 changes anything — measured at `0a5bd7f6`:

```
create_radio(LanBackendConfig(host="192.0.2.1", username="u", password="p"))
→ ValueError: Cannot resolve a radio profile: no profile, model, or matching
  radio_addr identifies the radio. … rigplane no longer guesses a default rig.
```

One example resolves by address (`radio_addr=0xA4` → IC-705) and two pass a variable address. That path is not a substitute for naming the radio: those addresses are factory defaults and the operator can change them in the radio's own menu, which is exactly what the two `0x42` examples document.

They are left out because this PR is already at the 10-file hard ceiling, and they are recorded as follow-up work on MOR-2425.


