### PR TITLE
fix: dispatch a continuous control's candidate only when it changed

### DIFF
--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.test.ts
@@ -13,6 +13,7 @@ import {
   createDiscreteContinuousScalarPolicy,
   createHBarContinuousScalarPolicy,
   createKnobContinuousScalarPolicy,
+  createRenderedNativeRangeContinuousScalarPolicy,
 } from '../../../../primitives/scalar/continuous-scalar.svelte';
 
 let components: ReturnType<typeof mount>[] = [];
@@ -410,6 +411,44 @@ describe('HBarRenderer', () => {
     const slider = getSlider(target);
     slider?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
     expect(onchange).toHaveBeenCalledWith(60);
+  });
+
+  it('sends one command per distinct value while a drag jitters inside one step', () => {
+    const request = vi.fn<(value: number) => void>();
+    const binding = createContinuousScalar(
+      () => ({
+        evidence: 'reading' as const,
+        reading: { status: 'known' as const, value: 100 },
+        ownerKey: 'nb-level',
+        domain: { min: 0, max: 255, step: 1, defaultValue: null, fineStepDivisor: 1 },
+        enabled: true,
+        request,
+      }),
+      createRenderedNativeRangeContinuousScalarPolicy(),
+    );
+    const target = mountControl({ binding, label: 'NB level', renderer: 'hbar' });
+    const slider = getSlider(target);
+    const container = target.querySelector('.vc-hbar') as HTMLDivElement;
+    vi.spyOn(container, 'getBoundingClientRect')
+      .mockReturnValue({ left: 0, width: 255 } as DOMRect);
+    Object.assign(slider, {
+      setPointerCapture: vi.fn(),
+      releasePointerCapture: vi.fn(),
+      hasPointerCapture: () => false,
+    });
+
+    slider.dispatchEvent(new PointerEvent('pointerdown', {
+      pointerId: 1, clientX: 138, bubbles: true,
+    }));
+    for (const clientX of [138.1, 137.9, 138.4, 138.05, 137.6]) {
+      slider.dispatchEvent(new PointerEvent('pointermove', {
+        pointerId: 1, clientX, bubbles: true,
+      }));
+    }
+    slider.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1, bubbles: true }));
+
+    expect(request.mock.calls).toEqual([[138]]);
+    binding.destroy();
   });
 });
 

--- a/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
+++ b/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
@@ -554,7 +554,7 @@ describe('continuous scalar source policies', () => {
     const pendingToken = pendingLease.beginPointer()!;
     pendingLease.pointer(pendingToken, 2_700);
     pendingLease.pointer(pendingToken, 2_700);
-    expect(pending.request.mock.calls).toEqual([[2_700], [2_700]]);
+    expect(pending.request.mock.calls).toEqual([[2_700]]);
     pendingLease.dispose();
   });
 
@@ -1560,4 +1560,122 @@ describe('continuous scalar renderer leases and cleanup', () => {
     expect(scalar.attachRenderer().beginPointer()).toBeNull();
     vi.useRealTimers();
   });
+});
+
+const NB_LEVEL_DOMAIN: ScalarDomain = {
+  min: 0,
+  max: 255,
+  step: 1,
+  defaultValue: null,
+  fineStepDivisor: 1,
+};
+
+const DEDUPE_FIXTURES = [
+  [
+    'rendered-native-range command feedback'
+    + ' (DspScalarHost, RfFrontEndInstrumentHost, CwKeyerInstrumentHost)',
+    () => {
+      const setup = commandSetup(createRenderedNativeRangeContinuousScalarPolicy(), {
+        domain: NB_LEVEL_DOMAIN,
+        feedback: feedback('idle', { confirmed: 100 }),
+      });
+      return {
+        scalar: setup.scalar,
+        request: setup.request,
+        setCanonical: (value: number) =>
+          setup.update({ feedback: feedback('idle', { confirmed: value }) }),
+      };
+    },
+  ],
+  [
+    'hbar-optimistic reading (RxAudioInstrumentHost, TxAuxScalarHost)',
+    () => {
+      const setup = readingSetup(
+        createHBarContinuousScalarPolicy({ preview: 'optimistic', debounceMs: 0 }),
+        { domain: NB_LEVEL_DOMAIN, reading: { status: 'known', value: 100 } },
+      );
+      return {
+        scalar: setup.scalar,
+        request: setup.request,
+        setCanonical: (value: number) => setup.update({ reading: { status: 'known', value } }),
+      };
+    },
+  ],
+] as const;
+
+describe('continuous scalar dispatch deduplication', () => {
+  it.each(DEDUPE_FIXTURES)('sends one command per distinct pointer value with %s', (_name, make) => {
+    const { scalar, request } = make();
+    const lease = scalar.attachRenderer();
+    const token = lease.beginPointer()!;
+
+    for (let index = 0; index < 25; index += 1) lease.pointer(token, 138);
+    expect(request.mock.calls).toEqual([[138]]);
+
+    for (let index = 0; index < 3; index += 1) lease.pointer(token, 139);
+    expect(request.mock.calls).toEqual([[138], [139]]);
+
+    lease.pointer(token, 138);
+    expect(request.mock.calls).toEqual([[138], [139], [138]]);
+  });
+
+  it.each(DEDUPE_FIXTURES)('re-sends a repeated value in a later gesture with %s', (_name, make) => {
+    const { scalar, request } = make();
+    const lease = scalar.attachRenderer();
+    const first = lease.beginPointer()!;
+    lease.pointer(first, 138);
+    lease.pointer(first, 138);
+    lease.endPointer(first);
+    const second = lease.beginPointer()!;
+    lease.pointer(second, 138);
+
+    expect(request.mock.calls).toEqual([[138], [138]]);
+  });
+
+  it.each(DEDUPE_FIXTURES)(
+    're-sends a repeated value after the canonical value changes from outside with %s',
+    (_name, make) => {
+      const { scalar, request, setCanonical } = make();
+      const lease = scalar.attachRenderer();
+      const token = lease.beginPointer()!;
+      lease.pointer(token, 138);
+      lease.pointer(token, 138);
+      setCanonical(140);
+      lease.pointer(token, 138);
+
+      expect(request.mock.calls).toEqual([[138], [138]]);
+    },
+  );
+
+  it.each(DEDUPE_FIXTURES)(
+    're-sends a repeated value after another source dispatched a different one with %s',
+    (_name, make) => {
+      const { scalar, request } = make();
+      const lease = scalar.attachRenderer();
+      const token = lease.beginPointer()!;
+      lease.pointer(token, 138);
+      lease.wheel({ direction: 1, fine: false });
+      lease.pointer(token, 138);
+
+      expect(request).toHaveBeenCalledTimes(3);
+      expect(request.mock.calls[1]![0]).not.toBe(138);
+      expect(request).toHaveBeenLastCalledWith(138);
+      lease.dispose();
+    },
+  );
+
+  it('keeps the first gesture candidate equal to canonical dispatching under dispatchesCanonical',
+    () => {
+      const setup = commandSetup(createRenderedNativeRangeContinuousScalarPolicy(), {
+        domain: NB_LEVEL_DOMAIN,
+        feedback: feedback('idle', { confirmed: 100 }),
+      });
+      const lease = setup.scalar.attachRenderer();
+      const token = lease.beginPointer()!;
+
+      lease.pointer(token, 100);
+      expect(setup.request.mock.calls).toEqual([[100]]);
+      lease.pointer(token, 100);
+      expect(setup.request.mock.calls).toEqual([[100]]);
+    });
 });

--- a/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
+++ b/frontend/src/primitives/scalar/__tests__/continuous-scalar.test.ts
@@ -1604,6 +1604,78 @@ const DEDUPE_FIXTURES = [
 ] as const;
 
 describe('continuous scalar dispatch deduplication', () => {
+  it.each(['replaced', 'lost'] as const)(
+    'reoffers the pointer candidate before pointerup when its pending lifecycle is %s',
+    (change) => {
+      const { scalar, request, update } = commandSetup(
+        createRenderedNativeRangeContinuousScalarPolicy(), {
+          domain: NB_LEVEL_DOMAIN,
+          feedback: feedback('idle', { confirmed: 100 }),
+        },
+      );
+      const lease = scalar.attachRenderer();
+      const token = lease.beginPointer()!;
+      lease.pointer(token, 138);
+      update({ feedback: feedback('queued', {
+        confirmed: 100, target: 138, requestedTarget: 138, lifecycleId: 'A',
+      }) });
+      lease.pointer(token, 138);
+      expect(request.mock.calls).toEqual([[138]]);
+
+      update({ feedback: change === 'replaced'
+        ? feedback('queued', {
+          confirmed: 100, target: 140, requestedTarget: 140, lifecycleId: 'B',
+        })
+        : feedback('idle', { confirmed: 100 }) });
+      lease.pointer(token, 138);
+      lease.pointer(token, 138);
+      lease.endPointer(token);
+      lease.pointer(token, 140);
+
+      expect(request.mock.calls).toEqual([[138], [138]]);
+      expect(scalar.view.canonical).toBe(100);
+      expect(scalar.view.interaction).toBe('idle');
+    },
+  );
+
+  it('keeps pointer deduplication through own lifecycle progress and delayed older feedback', () => {
+    const older = feedback('queued', {
+      confirmed: 100, target: 120, requestedTarget: 120, lifecycleId: 'older',
+    });
+    const { scalar, request, update } = commandSetup(
+      createRenderedNativeRangeContinuousScalarPolicy(), {
+        domain: NB_LEVEL_DOMAIN, feedback: older,
+      },
+    );
+    const lease = scalar.attachRenderer();
+    const token = lease.beginPointer()!;
+    lease.pointer(token, 138);
+
+    for (const phase of ['queued', 'dispatched', 'awaiting-confirmation'] as const) {
+      update({ feedback: feedback(phase, {
+        confirmed: 100, target: 138, requestedTarget: 138, lifecycleId: 'A',
+      }) });
+      lease.pointer(token, 138);
+      update({ feedback: older });
+      lease.pointer(token, 138);
+    }
+    update({ feedback: feedback('failed', {
+      ...older, phase: 'failed', busy: false, outcome: { phase: 'failed' },
+    }) });
+    lease.pointer(token, 138);
+    update({ feedback: feedback('confirmed', {
+      confirmed: 138, requestedTarget: 138, lifecycleId: 'A',
+      outcome: { phase: 'confirmed' },
+    }) });
+    lease.pointer(token, 138);
+    update({ feedback: feedback('idle', { confirmed: 138 }) });
+    lease.pointer(token, 138);
+    lease.endPointer(token);
+
+    expect(request.mock.calls).toEqual([[138]]);
+    expect(scalar.view.canonical).toBe(138);
+  });
+
   it.each(DEDUPE_FIXTURES)('sends one command per distinct pointer value with %s', (_name, make) => {
     const { scalar, request } = make();
     const lease = scalar.attachRenderer();

--- a/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
+++ b/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
@@ -577,6 +577,7 @@ export function createContinuousScalar(
         || (feedback.lifecycleId !== null
           && feedback.lifecycleId !== representedLifecycle
           && feedback.lifecycleId !== representedRequest?.observedLifecycleId));
+    if (representedLifecycleIsGone) lastDispatch = null;
     const representationRetiresDraft = representedRequest !== null
       && representedRequest.representedLifecycleId !== null
       && (representedRequest.source === 'native-input'
@@ -695,8 +696,6 @@ export function createContinuousScalar(
       if (source !== 'pointer') interaction = 'idle';
       return true;
     }
-    // A drag re-offers the same candidate on every pointermove; our own standing
-    // dispatch already put it on the radio.
     if (source === 'pointer' && lastDispatch !== null
       && Object.is(normalized, lastDispatch.value)) return true;
     localCommandRequest = input.evidence === 'command-feedback'

--- a/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
+++ b/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
@@ -511,6 +511,7 @@ export function createContinuousScalar(
     announcedTransitionIds: [],
   };
   let localCommandRequest: LocalCommandRequest | null = null;
+  let lastDispatch: Readonly<{ value: number; canonical: number }> | null = null;
   let destroyed = false;
 
   function clearTimers(): void {
@@ -528,6 +529,7 @@ export function createContinuousScalar(
     interaction = 'idle';
     activeGesture = null;
     localCommandRequest = null;
+    lastDispatch = null;
   }
 
   function reconcile(input: Readonly<ContinuousScalarInput>): void {
@@ -538,6 +540,14 @@ export function createContinuousScalar(
       presentationState = { announcedTransitionIds: [] };
     }
     lastAuthority = authority;
+    if (lastDispatch !== null) {
+      const canonical = canonicalOf(input);
+      if (!Object.is(canonical, lastDispatch.canonical)) {
+        lastDispatch = Object.is(canonical, lastDispatch.value)
+          ? { value: lastDispatch.value, canonical: lastDispatch.value }
+          : null;
+      }
+    }
     const requestSnapshot = localCommandRequest;
     const representedLifecycleId = requestSnapshot !== null
       && requestSnapshot.dispatched
@@ -647,6 +657,8 @@ export function createContinuousScalar(
           representedLifecycleId: null,
         }
         : null;
+      const canonical = canonicalOf(input);
+      if (canonical !== null) lastDispatch = { value: candidate, canonical };
       input.request(candidate);
     }
   }
@@ -673,14 +685,6 @@ export function createContinuousScalar(
     draft = normalized;
     draftCanonical = canonical;
     interaction = source;
-    localCommandRequest = input.evidence === 'command-feedback'
-      ? {
-        source,
-        observedLifecycleId: input.feedback.lifecycleId,
-        dispatched: false,
-        representedLifecycleId: null,
-      }
-      : null;
     if (!policy.dispatchesCanonical(source, {
       canonical,
       interactionBase: base,
@@ -691,6 +695,18 @@ export function createContinuousScalar(
       if (source !== 'pointer') interaction = 'idle';
       return true;
     }
+    // A drag re-offers the same candidate on every pointermove; our own standing
+    // dispatch already put it on the radio.
+    if (source === 'pointer' && lastDispatch !== null
+      && Object.is(normalized, lastDispatch.value)) return true;
+    localCommandRequest = input.evidence === 'command-feedback'
+      ? {
+        source,
+        observedLifecycleId: input.feedback.lifecycleId,
+        dispatched: false,
+        representedLifecycleId: null,
+      }
+      : null;
     const mode = policy.dispatch(source);
     if (mode === 'immediate') {
       dispatch(normalized, source, authority, generation, renderer, isCurrent);
@@ -764,6 +780,7 @@ export function createContinuousScalar(
         const input = current();
         if (!rendererIsCurrent(renderer, isCurrent) || !editable(input)) return null;
         localCommandRequest = null;
+        lastDispatch = null;
         const token = ++gestureSequence;
         activeGesture = { renderer, token };
         interaction = 'pointer';


### PR DESCRIPTION
Dragging a continuous scalar repeatedly within one numeric step could issue the same request on every pointer movement. This change suppresses a repeated pointer candidate while its previous request remains valid, and permits the candidate again when that pending lifecycle is replaced or disappears.

Owner: [MOR-2425](https://linear.app/morozsm/issue/MOR-2425), T217.

## Behavior

`createContinuousScalar` records the last dispatched value and canonical value. Duplicate pointer candidates in one gesture are skipped. A fresh gesture, a different dispatch, an external canonical change, or transient-state invalidation retires that record. Own confirmation rebases it. The correction following independent review also retires it when `representedLifecycleIsGone` detects pending replacement or loss; initial representation, own pending/confirmation progression, and delayed observed older lifecycle feedback preserve suppression.

For example, with canonical 100, pointer candidate 138 sends request A once. If queued B at 140 replaces A while canonical remains 100, another pointer candidate 138 sends again, including when pointerup immediately follows. Issuing a request does not establish that the radio applied it.

The equality check is scoped to pointer input. Existing wheel/keyboard behavior, including intentional boundary resends under `dispatchesCanonical`, remains part of the policy contract. The first candidate in a fresh gesture may equal canonical when that policy allows it. Ending a gesture invalidates its token. No renderer, tuning accumulator, or command-store implementation changes are included.

## Validation at 7fa3efdde44c784e9a325c30d8966e0fb72b6a34

Independent review reproduced pending replacement failure at the prior head `3aeb2d1c70d734f9b918aca586c60097100a00e2`; the correction builder reproduced the unchanged supplied test with 6 passing cases and 1 failing case before editing production source.

After correction, focused Vitest passed 161 tests across the following three permanent files plus the unchanged temporary reviewer reproduction (7 tests):

- `src/primitives/scalar/__tests__/continuous-scalar.test.ts`
- `src/components-v2/controls/value-control/__tests__/ValueControl.test.ts`
- `src/semantic/__tests__/DspScalarHost.isolated.test.ts`

The permanent regression covers replacement/loss with unchanged canonical and pointerup, plus own lifecycle progression and delayed older feedback. Existing tests cover repeated pointer values, new gestures, canonical changes, other dispatch sources, wheel/keyboard semantics, and renderer jitter. The temporary reproduction was removed after validation. Changed-file ESLint and `git diff --check` passed. Dependencies were installed with a real isolated `npm ci`.

## Historical evidence and remaining gates

The initial implementation report recorded an owner-present IC-7300 observation on 2026-09-09: 25 `set_nb_level` requests carried three values over eleven seconds (138 x11, 140 x10, 139 x4), with 20 coalesced requests. It also reported type/lint checks, mutation checks, and Vitest totals of 267, 571, and 4027 for its respective commands. These are prior-head reports; they were not rerun or independently re-established for this correction and are not new-head acceptance evidence.

Final required CI and independent exact-head delta review remain separate gates. This software correction has no new installed-candidate or hardware acceptance evidence; reconnect diagnosis is outside this PR.
