### PR TITLE
fix: quiet remaining RF indicator seats

### DIFF
--- a/frontend/src/components-v2/panels/TxPanel.svelte
+++ b/frontend/src/components-v2/panels/TxPanel.svelte
@@ -243,7 +243,7 @@
   <div class="tx-panel" bind:this={modalAnchor}>
     <!-- TX indicator strip -->
     <div class="tx-strip" class:tx-active={rf === 'on'} data-testid="tx-strip" data-rf={rf}>
-      {rf === 'on' ? '● TX' : rf === 'off' ? '○ RX' : '○ ---'}
+      {rf === 'on' ? '● TX' : ''}
     </div>
 
     <button

--- a/frontend/src/components-v2/panels/__tests__/TxPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/TxPanel.isolated.test.ts
@@ -204,14 +204,16 @@ describe('panel structure', () => {
     tx.emitStale();
     const t = mountPanel();
     const strip = t.querySelector('.tx-strip');
-    expect(strip?.textContent?.trim()).toBe('○ ---');
+    expect(strip?.getAttribute('data-rf')).toBe('unknown');
+    expect(strip?.textContent?.trim()).toBe('');
   });
 
   it('does not source TX ACTIVE from legacy txActive', () => {
     tx.emitStale();
     const t = mountPanel({ txActive: true });
     const strip = t.querySelector('.tx-strip');
-    expect(strip?.textContent?.trim()).toBe('○ ---');
+    expect(strip?.getAttribute('data-rf')).toBe('unknown');
+    expect(strip?.textContent?.trim()).toBe('');
   });
 
   it('renders Mic Gain slider', () => {
@@ -482,10 +484,14 @@ describe('PTT via the App TX controller (MOR-1011)', () => {
 
     tx.emitServerSnapshot({ intent: 'rx', observedPtt: 'off' });
     t = mountPanel({ txActive: true, txActiveAvailable: true });
-    expect(t.querySelector('.tx-strip')!.getAttribute('data-rf')).toBe('off');
+    let strip = t.querySelector('.tx-strip')!;
+    expect(strip.getAttribute('data-rf')).toBe('off');
+    expect(strip.textContent?.trim()).toBe('');
     tx.emitServerSnapshot({ intent: 'ptt', observedPtt: 'on', releaseRequired: true });
     flushSync();
-    expect(t.querySelector('.tx-strip')!.getAttribute('data-rf')).toBe('on');
+    strip = t.querySelector('.tx-strip')!;
+    expect(strip.getAttribute('data-rf')).toBe('on');
+    expect(strip.textContent?.trim()).toBe('● TX');
   });
 
   describe('two mounted panels', () => {

--- a/frontend/src/semantic/TxAuxSurface.svelte
+++ b/frontend/src/semantic/TxAuxSurface.svelte
@@ -30,6 +30,7 @@
   }: Props = $props();
   let txAux = $derived(view.txAux);
   let tuneBlocked = $derived(keyBlockedReasons(view, tx));
+  let visibleTuneBlocked = $derived(tuneBlocked.filter((code) => code !== 'rf-state-unknown'));
 </script>
 
 {#if txAux}
@@ -51,7 +52,7 @@
 
     {#if txAux.atu.availability.structural}
       <ul class="tx-aux-blocked" data-testid="tx-aux-tune-blocked">
-        {#each tuneBlocked as code (code)}<li data-reason={code}>{blockedLabel(code)}</li>{/each}
+        {#each visibleTuneBlocked as code (code)}<li data-reason={code}>{blockedLabel(code)}</li>{/each}
       </ul>
     {/if}
   </section>

--- a/frontend/src/semantic/VfoIndicatorRow.svelte
+++ b/frontend/src/semantic/VfoIndicatorRow.svelte
@@ -28,9 +28,8 @@
 
   const rfLabel = (state: RadioWideIndicatorsViewModel['rfState']): string =>
     state === 'transmitting' ? 'TX'
-      : state === 'receiving' ? 'RX'
-        : state === 'uncertain' ? 'TX?'
-          : 'RF ?';
+      : state === 'uncertain' ? 'TX?'
+        : '';
 
   function numeric(field: ReceiverIndicatorField<number>): string {
     return field.reading.status === 'known' ? String(field.reading.value) : '—';
@@ -181,7 +180,6 @@
     <div class="facts" aria-label="Radio-wide facts">
       <span
         class:tx={radioWide.rfState === 'transmitting'}
-        class:rx={radioWide.rfState === 'receiving'}
         class="rf-lamp"
         data-indicator-fact="rf-authority"
         data-indicator-rf={radioWide.rfState}
@@ -230,8 +228,8 @@
     font-size: 10px;
     line-height: 1.4;
   }
+  .rf-lamp { min-inline-size: 3ch; box-sizing: content-box; }
   .rf-lamp.tx { color: var(--v2-accent-red, #ff4545); border-color: currentColor; }
-  .rf-lamp.rx { color: var(--v2-accent-cyan, #00d4ff); border-color: currentColor; }
   .fact[data-state='on'], .fact[data-state='known'] { color: var(--v2-text-primary, #e8e8e8); }
   .fact[data-state='off'], .fact[data-state='unknown'] { color: var(--v2-text-subdued, rgba(255, 255, 255, 0.55)); }
   .s-meter { min-width: 0; overflow: hidden; }

--- a/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
+++ b/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
@@ -347,6 +347,8 @@ const BLOCKING: readonly (readonly [string, Partial<TxAuthoritySnapshot>])[] = [
   ['TX risk is uncertain', { txRisk: 'uncertain' }],
   ['TX risk is confirmed-on', { txRisk: 'confirmed-on' }],
 ];
+const visibleTuneReasons = (view: RadioViewModel, tx: TxAuthoritySnapshot) =>
+  keyBlockedReasons(view, tx).filter((code) => code !== 'rf-state-unknown');
 
 describe('ATU TUNE is gated by the server TX projection, exactly like the key intent', () => {
   it('offers TUNE when the authority is idle and the permit allows', () => {
@@ -357,16 +359,15 @@ describe('ATU TUNE is gated by the server TX projection, exactly like the key in
     });
   });
 
-  // MUTATION KILLED: gating TUNE on anything weaker than the key intent's own
-  // predicate (or on nothing at all). Asserted against the SHARED
-  // `keyBlockedReasons` so the two can never drift apart.
+  // The shared predicate still gates TUNE. Its passive list omits only RF
+  // unknown so observation churn cannot move the surrounding layout.
   it.each(BLOCKING)('disables TUNE while %s', (_label, over) => {
     const view = base();
     const tx = snap(over);
     expect(keyBlockedReasons(view, tx).length).toBeGreaterThan(0);
     withSurface(view, tx, (s) => {
       expect(s.tune()!.disabled).toBe(true);
-      expect(s.tuneReasons()).toEqual([...keyBlockedReasons(view, tx)]);
+      expect(s.tuneReasons()).toEqual(visibleTuneReasons(view, tx));
     });
   });
 

--- a/frontend/src/semantic/__tests__/VfoIndicatorRow.test.ts
+++ b/frontend/src/semantic/__tests__/VfoIndicatorRow.test.ts
@@ -161,10 +161,12 @@ describe('radio-wide singleton indicators (MOR-2309)', () => {
     expect(root.querySelector('[data-indicator-fact="atu"]')?.textContent).toContain('TUNE OFF');
     expect(root.querySelector('[data-indicator-fact="rit"]')?.textContent).toContain('RIT OFF 0 Hz');
     expect(root.querySelector('[data-indicator-fact="xit"]')?.textContent).toContain('XIT ON 0 Hz');
-    expect(root.querySelector('[data-indicator-fact="rf-authority"]')?.textContent).toContain('RX');
+    const rf = root.querySelector('[data-indicator-fact="rf-authority"]');
+    expect(rf?.getAttribute('data-indicator-rf')).toBe('receiving');
+    expect(rf?.textContent).toBe('');
   });
 
-  it('keeps missing/unobserved shared leaves visibly unknown and omits unsupported facts', () => {
+  it('keeps RF unknown quiet while retaining its state and omits unsupported facts', () => {
     const root = render({
       radioWide: {
         ...shared(), rfState: 'unknown', antenna: unknown(false), atu: unknown(),
@@ -172,10 +174,19 @@ describe('radio-wide singleton indicators (MOR-2309)', () => {
       },
     });
     expect(root.querySelector('[data-indicator-fact="antenna"]')).toBeNull();
-    expect(root.querySelector('[data-indicator-fact="rf-authority"]')?.textContent).toContain('RF ?');
+    const rf = root.querySelector('[data-indicator-fact="rf-authority"]');
+    expect(rf?.getAttribute('data-indicator-rf')).toBe('unknown');
+    expect(rf?.textContent).toBe('');
     for (const fact of ['atu', 'rit', 'xit']) {
       expect(root.querySelector(`[data-indicator-fact="${fact}"]`)?.textContent).toContain('—');
     }
+  });
+
+  it.each([
+    ['transmitting', 'TX'], ['uncertain', 'TX?'],
+  ] as const)('keeps %s RF authority visible as %s', (rfState, label) => {
+    const root = render({ radioWide: { ...shared(), rfState } });
+    expect(root.querySelector('[data-indicator-fact="rf-authority"]')?.textContent).toBe(label);
   });
 
   it('marks RIT/XIT aggregate state unknown when either constituent is unknown', () => {


### PR DESCRIPTION
The Standard receiver-center indicator, legacy TX panel, and passive ATU-TUNE reason list still changed size or copy when RF observation moved between receiving and unknown. Those passive seats now keep the same reserved quiet footprint for both states. Confirmed `TX` and uncertain `TX?` remain visible, and the underlying state attributes, managed TX source, TUNE gate, action title/description, and command paths are unchanged.

Linear: [MOR-2435](https://linear.app/morozsm/issue/MOR-2435/remove-flickering-rf-unknown-presentation-from-normal-hybrid-ui)

Validation:

- `npm test -- --run src/semantic/__tests__/VfoIndicatorRow.test.ts src/components-v2/panels/__tests__/TxPanel.isolated.test.ts src/semantic/__tests__/TxAuxSurface.test.ts` — 224 passed
- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — passed
- `npm run build` — passed

This is PR B of the MOR-2435 presentation cleanup and is independently based on `main`.
