### PR TITLE
fix(MOR-1675): format Standard level readouts

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
@@ -361,11 +361,11 @@ describe('the composed tree owns no audio lifetime', () => {
 describe('AF level: 0..100 becomes 0..1 exactly once, at the adapter seam', () => {
   // MUTATION KILLED: a second `/ 100` (renders 0.0042) or a missing one
   // (renders 42, clamped by the range to 1).
-  it('renders a browser volume of 42 as an AF level of 0.42', () => {
+  it('renders a browser volume of 42 as 42% while keeping an AF control value of 0.42', () => {
     render();
     expect(Number(afSlider()!.getAttribute('aria-valuenow')))
       .toBeCloseTo(0.42, 10);
-    expect(text('af-value')).toBe('0.42');
+    expect(text('af-value')).toBe('42%');
   });
 
   it.each([0, 7, 50, 100])('renders a browser volume of %i on the 0..1 scale', (volume) => {

--- a/frontend/src/semantic/RxAudioSurface.svelte
+++ b/frontend/src/semantic/RxAudioSurface.svelte
@@ -36,6 +36,7 @@
 -->
 <script module lang="ts">
   import type { RxAudioField } from './radio-view-model';
+  import { formatKnownLevel } from './format-level';
   import { UNKNOWN_TEXT } from './rx-audio-instruments';
 
   export {
@@ -48,6 +49,8 @@
   /** Honest text: an unread fact reads as unknown, never as a default. */
   export const textOf = (f: RxAudioField<unknown>): string =>
     f.reading.status === 'known' ? String(f.reading.value) : UNKNOWN_TEXT;
+  const afText = (f: RxAudioField<number>): string =>
+    f.reading.status === 'known' ? formatKnownLevel(f.reading.value, 0, 1) : UNKNOWN_TEXT;
 </script>
 
 <script lang="ts">
@@ -91,7 +94,7 @@
         <!-- 0..1 — the contract's OWN unit. No rescale in either
              direction: the value in is the fact, the value out is the intent. -->
         {@render handles.afLevel()}
-        <output data-testid="rx-audio-af-value">{textOf(rx.afLevel)}</output>
+        <output data-testid="rx-audio-af-value">{afText(rx.afLevel)}</output>
       </label>
     {/if}
 

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -44,6 +44,8 @@
   import VfoPanel from '../components-v2/vfo/VfoPanel.svelte';
   import VfoIndicatorRow from './VfoIndicatorRow.svelte';
   import VfoOperationGroup from './VfoOperationGroup.svelte';
+  import { formatKnownLevel } from './format-level';
+  import { RF_FRONT_END_LEVELS } from './rf-front-end-instruments';
   import {
     invokeVfoOperation,
     projectVfoOperations,
@@ -482,7 +484,10 @@
     toggle('IP+', indicator.ipPlus); toggle('DIGI-SEL', indicator.digiSel);
     if (indicator.rfGain.availability.structural && indicator.rfGain.display?.state !== 'unsupported') {
       const shown = displayValue(indicator.rfGain.display, indicator.rfGain.reading.status === 'known' ? indicator.rfGain.reading.value : null);
-      badges.push({ label: `RFG ${shown ?? '—'}`, active: shown !== null, color: shown === null ? 'muted' : 'cyan', state: indicator.rfGain.display?.state ?? indicator.rfGain.reading.status });
+      const text = shown === null
+        ? '—'
+        : formatKnownLevel(shown, RF_FRONT_END_LEVELS[0][2], RF_FRONT_END_LEVELS[0][3]);
+      badges.push({ label: `RFG ${text}`, active: shown !== null, color: shown === null ? 'muted' : 'cyan', state: indicator.rfGain.display?.state ?? indicator.rfGain.reading.status });
     }
     return badges;
   }

--- a/frontend/src/semantic/__tests__/RxAudioSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RxAudioSurface.test.ts
@@ -40,6 +40,7 @@ import type {
 import type { RxAudioAuthorityPublication } from '../rx-audio-instruments';
 
 const SOURCE = readFileSync('src/semantic/RxAudioSurface.svelte', 'utf8');
+const FORMAT_LEVEL_SOURCE = readFileSync('src/semantic/format-level.ts', 'utf8');
 /** Comments stripped, so the file's own doctrine prose can never be what a
  *  source-scanning test matches. */
 const CODE = SOURCE
@@ -113,10 +114,13 @@ describe('the RX-audio surface owns no audio lifetime (MOR-972 P0 / MOR-1058)', 
   /** The whole static import closure of the file, allow-listed. Kills: adding
    *  ANY import that could reach transport or the audio manager — including
    *  through a relative specifier, which a `$lib/...` regex would miss. */
-  it('imports only facts and the RxAudioInstrumentHost handle contract', () => {
+  it('imports only facts, the level formatter and the RxAudioInstrumentHost handle contract', () => {
     const specifiers = [...CODE.matchAll(/from\s+'([^']+)'/g)].map((m) => m[1]);
     expect(specifiers.length).toBeGreaterThan(0);
-    expect([...new Set(specifiers)].sort()).toEqual(['./radio-view-model', './rx-audio-instruments']);
+    expect([...new Set(specifiers)].sort()).toEqual([
+      './format-level', './radio-view-model', './rx-audio-instruments',
+    ]);
+    expect(FORMAT_LEVEL_SOURCE).not.toMatch(/\b(?:import|require)\b/);
   });
 
   // Kills: `onMount(() => audioManager.startRx())` and every relative of it.
@@ -389,16 +393,16 @@ describe('every unread fact renders honestly, never as the v2 default', () => {
 describe('AF level is 0..1 end to end — converted exactly once, in the adapter', () => {
   // Kills: `value / 100` or `value * 100` on the way IN. 0.42 is the fixture's
   // level, i.e. an RxAudioSnapshot volume of 42 already divided by the adapter.
-  it('renders the fact verbatim, with no second scaling', () => {
-    const r = render(base());
-    expect(Number(r.slider()!.getAttribute('aria-valuenow'))).toBeCloseTo(0.42, 10);
-    expect(r.text('af-value')).toBe('0.42');
-    r.dispose();
-  });
-
-  it.each([0, 0.01, 0.5, 1])('renders the level %s verbatim', (value) => {
+  it.each([
+    [0, '0%'],
+    [0.42, '42%'],
+    [1, '100%'],
+    [0.24705882352941178, '25%'],
+  ] as const)('renders the level %s as %s while preserving its control value', (value, text) => {
     const r = render(withRx({ afLevel: known(value) }));
     expect(Number(r.slider()!.getAttribute('aria-valuenow'))).toBe(value);
+    expect(r.text('af-value')).toBe(text);
+    expect(r.text('af-value')).not.toBe(String(value));
     r.dispose();
   });
 

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -331,6 +331,25 @@ describe('receiver-addressed indicator composition (MOR-2299 slice 1)', () => {
       expect(badge.textContent).not.toBe(`RFG ${rfGainValue}`);
     },
   );
+
+  it('omits the Standard RFG badge when display support is unavailable despite a known reading', () => {
+    const base = withReceiverIndicators('1/single');
+    const indicator = base.receiverIndicators![0];
+    const viewModel = validateRadioViewModel({
+      ...base,
+      receiverIndicators: [{
+        ...indicator,
+        rfGain: {
+          ...indicator.rfGain,
+          reading: { status: 'known' as const, value: 0.75 },
+          display: { state: 'unsupported' },
+        },
+      }],
+    });
+
+    const target = mountSurface({ viewModel, appearance: 'standard' });
+    expect(target.querySelector('[data-indicator-fact="rfg"]')).toBeNull();
+  });
 });
 
 function withRadioWide(

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -298,25 +298,39 @@ describe('receiver-addressed indicator composition (MOR-2299 slice 1)', () => {
     expect(target.querySelectorAll('[data-indicator-fact="antenna"], [data-indicator-fact="tune"], [data-indicator-fact="rit"], [data-indicator-fact="xit"]')).toHaveLength(0);
   });
 
-  it('MOR-2425/R41: the Standard RFG badge holds a stale value with no dagger cue', () => {
-    const base = withReceiverIndicators('1/single');
-    const indicator = base.receiverIndicators![0];
-    const rfGainReading = indicator.rfGain.reading;
-    if (rfGainReading.status !== 'known') throw new Error('fixture must have a known rfGain reading');
-    const rfGainValue = rfGainReading.value;
-    const staleViewModel = validateRadioViewModel({
-      ...base,
-      receiverIndicators: [{
-        ...indicator,
-        rfGain: { ...indicator.rfGain, display: { state: 'stale' as const, value: rfGainValue } },
-      }],
-    });
-    const target = mountSurface({ viewModel: staleViewModel, appearance: 'standard' });
-    const badge = target.querySelector('[data-indicator-fact="rfg"]')!;
-    expect(badge).not.toBeNull();
-    expect(badge.textContent).not.toContain('†');
-    expect(badge.textContent).toContain(String(rfGainValue));
-  });
+  it.each([
+    ['current', 0, '0%'],
+    ['current', 0.4823529411764706, '48%'],
+    ['current', 0.5333333333333333, '53%'],
+    ['current', 1, '100%'],
+    ['stale', 0, '0%'],
+    ['stale', 0.4823529411764706, '48%'],
+    ['stale', 0.5333333333333333, '53%'],
+    ['stale', 1, '100%'],
+  ] as const)(
+    'MOR-2425/R41: the Standard %s RFG badge formats %s as %s without a dagger cue',
+    (displayState, rfGainValue, expected) => {
+      const base = withReceiverIndicators('1/single');
+      const indicator = base.receiverIndicators![0];
+      const viewModel = validateRadioViewModel({
+        ...base,
+        receiverIndicators: [{
+          ...indicator,
+          rfGain: {
+            ...indicator.rfGain,
+            reading: { status: 'known' as const, value: rfGainValue },
+            display: { state: displayState, value: rfGainValue },
+          },
+        }],
+      });
+      const target = mountSurface({ viewModel, appearance: 'standard' });
+      const badge = target.querySelector('[data-indicator-fact="rfg"]')!;
+      expect(badge).not.toBeNull();
+      expect(badge.textContent).not.toContain('†');
+      expect(badge.textContent).toContain(`RFG ${expected}`);
+      expect(badge.textContent).not.toBe(`RFG ${rfGainValue}`);
+    },
+  );
 });
 
 function withRadioWide(


### PR DESCRIPTION
## Problem and result

An owner-present Standard IC-7300 capture on installed `b7eb7b78` showed normalized control facts as raw text: `RFG 0.5333333333333333` and `AF 0.24705882352941178`. Standard RF Gain and AF now use the existing declared-domain `formatKnownLevel` formatter, rendering those values as `RFG 53%` and `AF 25%`.

This changes readout strings only. AF and RF Gain facts, slider attributes, write-command values, current/stale state, unknown em dash, unsupported omission, receiver composition, frequency/mode presentation, and authority ownership are unchanged.

Linear owners:

- [MOR-1675](https://linear.app/morozsm/issue/MOR-1675) — AF percent readout without rescaling its control domain
- [MOR-2425](https://linear.app/morozsm/issue/MOR-2425) — companion Standard RF Gain badge presentation

PR #3321 recorded the same defect class on an older tree. This fresh current-main change carries forward only its relevant formatter intent; it does not close or revive that broader conflicting PR.

## Scope

Five files: two semantic surfaces and their three directly coupled tests. No backend, command, view-model, layout, meter, TX auxiliary, non-Standard VFO indicator, or visual-baseline changes.

## Validation

- RED: focused tests produced 7 expected failures and 296 passes: four AF endpoint/captured-fraction cases, two Standard RF Gain current/stale cases, and one real AF wiring case. Failures showed the original raw decimals.
- GREEN: `npm run test -- VfoSurface RxAudioSurface semantic-rx-audio-wiring` — 303 passed.
- Expanded Standard RF Gain table after early review input: current and stale `0`, `0.4823529411764706`, `0.5333333333333333`, and `1`; `npm run test -- VfoSurface` — 184 passed.
- `npm run check` — 0 errors, 0 warnings.
- `npm run lint` — passed.
- `npm run build` — passed with the existing chunk-size/dynamic-import warnings.

Hardware/browser acceptance and independent exact-head review remain separate coordinator gates.

Final validation: independent exact-head PASS at 29e87d62fa28c27a9c48ce2aafb15fab8bc3de3c; final quick 34423259315 and visual 34423259308 SUCCESS. Required Standard unsupported-omission test added; final focused VfoSurface suite 185/185 PASS with guard-restoration mutation proof. Installed-browser verification is the subsequent deployment gate.
