### PR TITLE
fix(MOR-2426): select VFO A once per application connection

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -544,7 +544,7 @@ class RadioPoller:
         # so the map never leaks.
         self._acquisition_healthy_grace_started: dict[str, float] = {}
         self._queue = queue
-        self._connection_generation_capture = lambda: getattr(
+        self._connection_generation_capture: Callable[[], int | None] = lambda: getattr(
             self._radio, "_civ_epoch", None
         )
         self._connection_generation_bound = False
@@ -597,6 +597,9 @@ class RadioPoller:
         self._scope_session_state: tuple[bool, bool] | None = None
         self._scope_session_active = False
         self._vfo_binding_generation = 0
+        self._vfo_connect_attempt: tuple[int, object] | None = None
+        self._vfo_recovery_generation: tuple[int, object] | None = None
+        self._vfo_connection_started_at = 0.0
         # MOR-615: (main, sub) data_mode pair seen at the last MOD-input fetch;
         # a change triggers a refetch of the per-DATA-group MOD-input sources.
         self._mod_input_data_modes: tuple[int, int] | None = None
@@ -3681,9 +3684,63 @@ class RadioPoller:
             )
         return tuple(paths)
 
-    def reset_vfo_session(self) -> None:
+    def _vfo_connection_generation(self) -> tuple[int, object]:
+        return self._provider_generation(), self._connection_generation_capture()
+
+    async def select_vfo_a_on_connect(self, *, read_only: bool) -> None:
+        """Attempt the application connection policy once, with fresh RX only."""
+        generation = self._vfo_connection_generation()
+        if self._vfo_connect_attempt == generation:
+            return
+        self._vfo_connect_attempt = generation
+        self._vfo_recovery_generation = generation
+        reason: str | None = None
+        if read_only:
+            reason = "read_only"
+        elif (
+            self._profile.receiver_count != 1
+            or self._profile.vfo_scheme != "ab"
+            or self._profile.vfo_readback != "selected_unselected"
+        ):
+            reason = "inapplicable_profile"
+        else:
+            snapshot = self._state_store.snapshot()
+            if self._current_rf_state(snapshot) is not RfState.RX:
+                reason = "rf_not_confirmed_rx"
+            elif (
+                snapshot.field(_PTT_PATH).last_observed_monotonic
+                < self._vfo_connection_started_at
+            ):
+                reason = "ptt_predates_connection"
+        if reason is not None:
+            self._record_state_diagnostic(
+                "vfo_connect_skipped", "web.radio_poller", reason=reason
+            )
+            logger.info("radio-poller: VFO A connection selection skipped: %s", reason)
+            return
+        try:
+            await self._execute(SelectVfo("A"), source="internal_policy")
+        except Exception:
+            self._record_state_diagnostic(
+                "vfo_connect_failed",
+                "web.radio_poller",
+                reason="selection_or_readback_failed",
+            )
+            logger.warning(
+                "radio-poller: VFO A connection selection failed", exc_info=True
+            )
+
+    def reset_vfo_session(self, *, connection_recovery: bool = False) -> None:
         """Invalidate connection-epoch A/B proof without touching TX facts."""
 
+        if connection_recovery:
+            generation = self._vfo_connection_generation()
+            if self._vfo_recovery_generation == generation:
+                return
+            self._vfo_recovery_generation = generation
+            self._vfo_connection_started_at = (
+                self._state_store.snapshot().generated_at_monotonic
+            )
         self._vfo_binding_generation += 1
         relative_reset = self._state_store.reset_relative_vfo_retention(
             generation=self._provider_generation()

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -2425,7 +2425,7 @@ class WebServer:
         # them before any new-epoch read can arrive; the topology-derived MAIN
         # fact is independently valid and is reasserted without touching TX.
         if isinstance(self._radio_poller, RadioPoller):
-            self._radio_poller.reset_vfo_session()
+            self._radio_poller.reset_vfo_session(connection_recovery=True)
         self._publish_single_receiver_topology()
         # Clear poller readiness so scope waits for refetch to complete
         if self._radio_poller is not None:
@@ -2448,6 +2448,10 @@ class WebServer:
                         self._radio, "_fetch_initial_state"
                     ):
                         await self._radio._fetch_initial_state()
+                    if isinstance(self._radio_poller, RadioPoller):
+                        await self._radio_poller.select_vfo_a_on_connect(
+                            read_only=self._config.read_only
+                        )
                 except Exception:
                     logger.warning("reconnect: refetch failed", exc_info=True)
             finally:
@@ -5186,7 +5190,18 @@ class WebServer:
                 await radio.disconnect()
                 resp = {"status": "disconnected"}
             elif path == "/api/v1/radio/connect":
+                poller = self._radio_poller
+                generation = (
+                    poller._vfo_connection_generation()
+                    if isinstance(poller, RadioPoller)
+                    else None
+                )
                 await radio.connect()
+                if (
+                    isinstance(poller, RadioPoller)
+                    and generation != poller._vfo_connection_generation()
+                ):
+                    self._on_radio_reconnect()
                 resp = {"status": "connecting"}
             elif path == "/api/v1/radio/power":
                 # Read JSON body for power state

--- a/src/rigplane/web/web_startup.py
+++ b/src/rigplane/web/web_startup.py
@@ -429,6 +429,10 @@ async def _start_web_server(
         server._state_freshness_service.run(), name="web-state-freshness"
     )
     await _await_initial_state_acquisition(server, sweep=startup_sweep)
+    if startup_sweep and server._radio_poller is not None:
+        await server._radio_poller.select_vfo_a_on_connect(
+            read_only=server._config.read_only
+        )
 
     server._server = await asyncio.start_server(
         server._accept_client,

--- a/tests/test_radio_poller_tx_interlock.py
+++ b/tests/test_radio_poller_tx_interlock.py
@@ -35,6 +35,7 @@ from rigplane.runtime._poller_types import (
     VfoSwap,
     validate_command_queue_entry_currency,
 )
+from rigplane.runtime.radio import CoreRadio
 from rigplane.runtime.tx_interlock import (
     RfState,
     TxInterlockCommandFamily,
@@ -658,13 +659,169 @@ async def test_vfo_selection_is_not_observed_rf_gated() -> None:
     assert "VFO selection" in str(dispatched.value)
 
 
-def test_connection_epoch_bootstrap_exemption_is_absent_from_production() -> None:
-    from pathlib import Path
+class ConnectVfoRadio(CoreRadio):
+    connected = True
+    radio_ready = True
+    control_connected = True
 
-    import rigplane.web.radio_poller as radio_poller_module
+    def __init__(self, *, selected: str = "B") -> None:
+        from serial_stub import DeterministicSerialCivLink
 
-    source = Path(radio_poller_module.__file__).read_text()
-    assert "connection_epoch_bootstrap" not in source
+        super().__init__("127.0.0.1", model="IC-7300")
+        self.wire = DeterministicSerialCivLink()
+        self.selected = selected
+        self.ack = asyncio.Event()
+        self.ack.set()
+        self.reject = False
+        self.refetches = 0
+
+    def _check_connected(self) -> None:
+        pass
+
+    async def _send_civ_expect(self, frame: bytes, **kwargs: object) -> object:
+        from rigplane.core.civ import CivFrame
+        from rigplane.core.types import bcd_encode
+
+        await self.wire.send(frame)
+        command, data = frame[4], frame[5:-1]
+        if command == 0x07:
+            await self.ack.wait()
+            if self.reject:
+                return CivFrame(0xE0, 0x94, 0xFA)
+            self.selected = "A" if data == b"\x00" else "B"
+            return CivFrame(0xE0, 0x94, 0xFB)
+        slot = self.selected if data[0] == 0 else ("B" if self.selected == "A" else "A")
+        if command == 0x25:
+            payload = data + bcd_encode(14_200_000 if slot == "A" else 7_100_000)
+        elif command == 0x26:
+            payload = data + (b"\x01\x00\x01" if slot == "A" else b"\x00\x00\x02")
+        else:
+            raise AssertionError(f"Unexpected write/read: {frame.hex()}")
+        return CivFrame(0xE0, 0x94, command, data=payload)
+
+    async def _fetch_initial_state(self) -> None:
+        self.refetches += 1
+        _observe_ptt(self.state_store, False)
+
+
+def connect_vfo_poller(
+    *, selected: str = "B"
+) -> tuple[RadioPoller, ConnectVfoRadio, StateStore]:
+    radio = ConnectVfoRadio(selected=selected)
+    store = radio.state_store
+    store.begin_provider_generation()
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+    return poller, radio, store
+
+
+@pytest.mark.parametrize("selected", ("A", "B"))
+async def test_application_connect_selects_a_once_and_binds_real_wire(
+    selected: str,
+) -> None:
+    poller, radio, store = connect_vfo_poller(selected=selected)
+    _observe_ptt(store, False)
+    await poller.select_vfo_a_on_connect(read_only=False)
+    await poller.select_vfo_a_on_connect(read_only=False)
+    await poller._send_query()
+    assert radio.wire.sent_frames == [
+        bytes.fromhex(frame)
+        for frame in (
+            "fefe94e00700fd",
+            "fefe94e02500fd",
+            "fefe94e02600fd",
+            "fefe94e02501fd",
+            "fefe94e02601fd",
+        )
+    ]
+    assert radio.selected == "A"
+    snapshot = store.snapshot()
+    assert snapshot.field(FieldPath.active_slot("0")).value == "A"
+    assert (
+        snapshot.field(FieldPath.vfo_slot("0", "A", "freq_mode", "freq_hz")).value
+        == 14_200_000
+    )
+    assert (
+        snapshot.field(FieldPath.vfo_slot("0", "B", "freq_mode", "freq_hz")).value
+        == 7_100_000
+    )
+
+
+@pytest.mark.parametrize(
+    "state", ("read_only", "tx", "unknown", "stale", "old_generation")
+)
+async def test_application_connect_refuses_without_fresh_rx(state: str) -> None:
+    poller, radio, store = connect_vfo_poller()
+    if state != "unknown":
+        _observe_ptt(
+            store,
+            state == "tx",
+            observed_at=time.monotonic() - (5 if state == "stale" else 0),
+        )
+    if state == "old_generation":
+        store.begin_provider_generation()
+    await poller.select_vfo_a_on_connect(read_only=state == "read_only")
+    _observe_ptt(store, False)
+    await poller._send_query()
+    assert radio.wire.sent_frames == []
+    assert str(FieldPath.active_slot("0")) not in store.snapshot().as_dict()
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    ({"receiver_count": 2}, {"vfo_scheme": "main_sub"}, {"vfo_readback": "absolute"}),
+)
+async def test_application_connect_leaves_other_topologies_alone(
+    overrides: dict,
+) -> None:
+    from dataclasses import replace
+
+    poller, radio, store = connect_vfo_poller()
+    poller._profile = replace(poller._profile, **overrides)
+    _observe_ptt(store, False)
+    await poller.select_vfo_a_on_connect(read_only=False)
+    assert radio.wire.sent_frames == []
+
+
+@pytest.mark.parametrize("reject", (False, True))
+async def test_application_connect_ack_is_honest_and_inflight_calls_do_not_resend(
+    reject: bool,
+) -> None:
+    poller, radio, store = connect_vfo_poller()
+    _observe_ptt(store, False)
+    radio.ack.clear()
+    radio.reject = reject
+    task = asyncio.create_task(poller.select_vfo_a_on_connect(read_only=False))
+    await asyncio.sleep(0)
+    await poller.select_vfo_a_on_connect(read_only=False)
+    assert str(FieldPath.active_slot("0")) not in store.snapshot().as_dict()
+    assert len(radio.wire.sent_frames) == 1
+    radio.ack.set()
+    await task
+    await poller.select_vfo_a_on_connect(read_only=False)
+    assert sum(frame[4] == 0x07 for frame in radio.wire.sent_frames) == 1
+    assert (str(FieldPath.active_slot("0")) in store.snapshot().as_dict()) is not reject
+
+
+async def test_connection_reset_requires_new_rx_and_allows_one_new_select() -> None:
+    poller, radio, store = connect_vfo_poller()
+    _observe_ptt(store, False)
+    await poller.select_vfo_a_on_connect(read_only=False)
+    radio._civ_epoch += 1
+    poller.reset_vfo_session(connection_recovery=True)
+    await poller.select_vfo_a_on_connect(read_only=False)
+    assert len(radio.wire.sent_frames) == 5
+    # An unsafe connection attempt has no automatic retry, even after RX arrives.
+    _observe_ptt(store, False)
+    await poller.select_vfo_a_on_connect(read_only=False)
+    assert len(radio.wire.sent_frames) == 5
+    radio._civ_epoch += 1
+    poller.reset_vfo_session(connection_recovery=True)
+    _observe_ptt(store, False)
+    await poller.select_vfo_a_on_connect(read_only=False)
+    poller.reset_vfo_session(connection_recovery=True)
+    await poller.select_vfo_a_on_connect(read_only=False)
+    assert len(radio.wire.sent_frames) == 10
+    assert store.snapshot().field(FieldPath.active_slot("0")).value == "A"
 
 
 async def test_teardown_drain_unkey_stays_outside_the_execute_seat() -> None:

--- a/tests/test_startup_state_gate.py
+++ b/tests/test_startup_state_gate.py
@@ -551,7 +551,9 @@ async def test_civ_startup_binds_only_after_the_predicate_is_satisfied() -> None
     radio = _CivRadio(scheduler)
     server = WebServer(radio, _gated_config())
     binds: list[dict[str, object]] = []
-    fake_poller = MagicMock(drain_tx_safety_commands=AsyncMock())
+    fake_poller = MagicMock(
+        drain_tx_safety_commands=AsyncMock(), select_vfo_a_on_connect=AsyncMock()
+    )
     started_when_primed: list[bool] = []
     scheduler.on_prime = lambda: started_when_primed.append(fake_poller.start.called)
 
@@ -975,3 +977,43 @@ def test_ftx1_drain_meters_hold_the_gate_open_until_they_are_observed() -> None:
     observed = _ftx1_outstanding(StateStore(), FTX1_DRAIN_PATHS)
 
     assert set(FTX1_DRAIN_PATHS).isdisjoint(observed)
+
+
+@pytest.mark.parametrize("read_only", (False, True))
+async def test_application_connection_selection_follows_acquisition_before_listener(
+    read_only: bool,
+) -> None:
+    from test_radio_poller_tx_interlock import ConnectVfoRadio, _observe_ptt
+    from rigplane.web.radio_poller import RadioPoller
+
+    radio = ConnectVfoRadio()
+    config = _gated_config()
+    config.read_only = read_only
+    server = WebServer(radio, config)
+    events: list[str] = []
+
+    async def acquire(*args: object, **kwargs: object) -> None:
+        assert radio.wire.sent_frames == []
+        events.append("acquire")
+        _observe_ptt(server.command_state_store, False)
+
+    async def bind(*args: object, **kwargs: object) -> _FakeAsyncServer:
+        events.append("bind")
+        assert len(radio.wire.sent_frames) == (0 if read_only else 5)
+        if not read_only:
+            assert (
+                server.command_state_store.snapshot()
+                .field(FieldPath.active_slot("0"))
+                .value
+                == "A"
+            )
+        return _FakeAsyncServer()
+
+    with (
+        patch.object(RadioPoller, "start"),
+        patch.object(web_startup, "_await_initial_state_acquisition", new=acquire),
+        patch.object(web_startup.asyncio, "start_server", new=bind),
+    ):
+        await server.start()
+        await server.stop()
+    assert events == ["acquire", "bind"]

--- a/tests/test_web_recovery_durable_off.py
+++ b/tests/test_web_recovery_durable_off.py
@@ -685,3 +685,62 @@ async def test_a_re_arm_that_raises_does_not_fail_the_reconnect(
     assert order == ["on_reconnect"]
     assert host._civ_transport is not None
     assert _warned(caplog, "re-arm failed")
+
+
+@pytest.mark.parametrize("read_only", (False, True))
+async def test_reconnect_selects_a_after_refetch_once_per_real_epoch(
+    read_only: bool,
+) -> None:
+    from test_radio_poller_tx_interlock import connect_vfo_poller, _observe_ptt
+    from rigplane.core.state_pipeline_contracts import FieldPath
+
+    poller, radio, store = connect_vfo_poller()
+    server = WebServer(radio)
+    server._radio_poller = poller
+    server._config.read_only = read_only
+    _observe_ptt(store, False)
+    await poller.select_vfo_a_on_connect(read_only=read_only)
+    for iteration in (1, 2):
+        radio._civ_epoch += 1
+        store.begin_provider_generation()
+        radio.selected = "B"
+        radio.wire.sent_frames.clear()
+        server._on_radio_reconnect()
+        server._on_radio_reconnect()
+        await asyncio.gather(*list(server._bg_tasks))
+        assert radio.refetches == iteration * 3 - 1
+        assert poller._initial_fetch_done.is_set()
+        assert len(radio.wire.sent_frames) == (0 if read_only else 5)
+        if not read_only:
+            assert store.snapshot().field(FieldPath.active_slot("0")).value == "A"
+        await _recover(server)
+        assert len(radio.wire.sent_frames) == (0 if read_only else 5)
+        if not read_only:
+            assert store.snapshot().field(FieldPath.active_slot("0")).value == "A"
+
+
+async def test_explicit_disconnect_connect_uses_the_same_new_epoch_policy() -> None:
+    from unittest.mock import AsyncMock, MagicMock
+    from test_radio_poller_tx_interlock import connect_vfo_poller, _observe_ptt
+
+    poller, radio, store = connect_vfo_poller()
+    server = WebServer(radio)
+    server._radio_poller = poller
+    _observe_ptt(store, False)
+    await poller.select_vfo_a_on_connect(read_only=False)
+
+    async def connect() -> None:
+        radio._civ_epoch += 1
+        store.begin_provider_generation()
+        radio.selected = "B"
+
+    radio.connect = connect
+    radio.disconnect = AsyncMock()
+    writer = MagicMock(drain=AsyncMock())
+    radio.wire.sent_frames.clear()
+    await server._handle_radio_control("/api/v1/radio/disconnect", writer)
+    await server._handle_radio_control("/api/v1/radio/connect", writer)
+    await asyncio.gather(*list(server._bg_tasks))
+    assert len(radio.wire.sent_frames) == 5
+    assert radio.selected == "A"
+    assert radio.refetches == 1

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -348,7 +348,9 @@ async def test_start_and_stop_with_radio_sets_callbacks() -> None:
     fake_server = _FakeAsyncServer()
     # MOR-1181: stop_web_server now awaits a final TX-safety drain on the
     # poller it stopped, so the stand-in has to answer that call too.
-    fake_poller = MagicMock(drain_tx_safety_commands=AsyncMock())
+    fake_poller = MagicMock(
+        drain_tx_safety_commands=AsyncMock(), select_vfo_a_on_connect=AsyncMock()
+    )
 
     srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
     with (
@@ -389,7 +391,9 @@ async def test_start_attaches_shared_state_model_service_for_acquisition_profile
     radio.radio_ready = True
     radio.control_connected = True
     fake_server = _FakeAsyncServer()
-    fake_poller = MagicMock(drain_tx_safety_commands=AsyncMock())  # MOR-1181
+    fake_poller = MagicMock(
+        drain_tx_safety_commands=AsyncMock(), select_vfo_a_on_connect=AsyncMock()
+    )  # MOR-1181
 
     srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
     with (
@@ -750,7 +754,9 @@ async def test_stop_handles_disconnect_failure_and_cancels_client_tasks() -> Non
     radio.disconnect = AsyncMock(side_effect=RuntimeError("disconnect failed"))
     srv = WebServer(radio)
     srv._server = _FakeAsyncServer()
-    srv._radio_poller = MagicMock(drain_tx_safety_commands=AsyncMock())
+    srv._radio_poller = MagicMock(
+        drain_tx_safety_commands=AsyncMock(), select_vfo_a_on_connect=AsyncMock()
+    )
 
     blocker = asyncio.Event()
 


### PR DESCRIPTION
Application connections to single-receiver A/B rigs with selected/unselected readback now select VFO A once when fresh RX is observed. This implements the latest owner decision in [MOR-2426](https://linear.app/morozsm/issue/MOR-2426): a rig left on B switches to A, and the existing typed selection path publishes absolute A/B identity only after ACK.

The initial call follows state acquisition and precedes the HTTP listener. Soft recovery and an explicit Disconnect/Connect use the same policy after refetch. Connection-generation dedup prevents duplicate recovery callbacks from invalidating/reselecting an already bound slot. Strict read-only mode, passive polling, other topologies, and unknown/stale/TX observations emit no selection; skipped or failed attempts are logged and are not retried automatically in that connection.

This is one connection-policy change across three production entry points and four test files; the seventh file only updates existing startup async doubles.

Validation: 260 focused tests passed, including production CoreRadio command construction over DeterministicSerialCivLink, exact A-select/read sequence for starting A/B, ACK pending/failure, read-only/RF guards, duplicate/new recovery epochs, startup ordering and explicit Connect. Ruff check/format, strict web mypy (27 files), and all five import contracts passed. The first standard full run found two outdated startup doubles (16,205 passed); those fixtures are fixed. The final local Python 3.14 / 10-worker full run had 16,203 passed, 224 skipped, 15 xfailed and four timing/worker failures (Vitest 5s timeout, CI-V 50ms timeout, batch command timeout, and one crashed rigctld worker). All four failed cases passed unchanged in a serial targeted rerun (2.42s); local full validation remains partial. Exact-head Python 3.11 CI must pass before merge. Hardware and installed-candidate acceptance remain separate.
