### PR TITLE
feat(MOR-2436): render fixed Standard VFO peers

### DIFF
--- a/frontend/src/components-v2/vfo/VfoPanel.svelte
+++ b/frontend/src/components-v2/vfo/VfoPanel.svelte
@@ -45,6 +45,7 @@
     frequencyState?: 'current' | 'stale' | 'unknown' | 'unsupported';
     contextKey?: string;
     frequencyDisabled?: boolean;
+    controlsDisabled?: boolean;
     mode: string | null;
     filter: string | null;
     sMeter?: Snippet;
@@ -58,22 +59,29 @@
     bandText?: string | null;
     rit?: { active: boolean; offset: number };
     slotChoices?: readonly VfoPanelSlotChoice[];
+    /** Keep peer cards aligned while only the active VFO owns the real meter. */
+    reserveMeterSpace?: boolean;
     layoutProfile?: VfoLayoutProfile;
     onModeClick?: () => void;
     onFreqChange?: (freq: number) => void;
     onSelectSlot?: (key: string) => void;
+    /** Selects this VFO from its header; frequency gestures remain independent. */
+    onSelectHeader?: () => void;
+    headerReason?: string;
   }
 
   let {
     receiver, receiverLabel, slotTag, frequency, freq, displayHz, pendingDisplayHz = null,
-    frequencyState = 'current', contextKey, frequencyDisabled = false,
+    frequencyState = 'current', contextKey, frequencyDisabled = false, controlsDisabled = false,
     mode, filter, sMeter, sValue, meterPresent = true, meterOperational, meterSource, continuitySession,
     isActive,
-    badgeItems, bandText, rit, slotChoices = [],
+    badgeItems, bandText, rit, slotChoices = [], reserveMeterSpace = false,
     layoutProfile = 'baseline',
     onModeClick,
     onFreqChange,
     onSelectSlot,
+    onSelectHeader,
+    headerReason,
   }: Props = $props();
 
   let meterVariant = $derived(layoutProfile === 'wide' ? 'vfo-wide' : 'vfo');
@@ -99,18 +107,24 @@
   data-layout-profile={layoutProfile}
   style={Object.entries(receiverChromeVars).map(([key, value]) => `${key}:${value}`).join(';')}
 >
-  <div class="panel-header">
+  <button
+    type="button" class="panel-header" disabled={onSelectHeader === undefined}
+    aria-label={onSelectHeader ? `Select ${receiverLabel}` : undefined}
+    title={headerReason}
+    onclick={onSelectHeader}
+  >
     <div class="header-title-group">
       <span class="vfo-label">{receiverLabel}</span>
     </div>
 
     <div class="header-badges">
-      <span class="header-tag meter-tag">BAR</span>
+      {#if sMeter || meterPresent}<span class="header-tag meter-tag">BAR</span>{/if}
       <span class="header-tag slot-tag">{slotTag}</span>
     </div>
-  </div>
+  </button>
 
-  <div class="smeter-row panel-meter">
+  <div class="smeter-row panel-meter"
+    data-meter-space={!sMeter && !meterPresent && reserveMeterSpace ? 'reserved' : undefined}>
     {#if sMeter}
       <div data-testid="receiver-s-meter" data-receiver={receiver}>
         {@render sMeter()}
@@ -158,8 +172,14 @@
       <!-- svelte-ignore a11y_click_events_have_key_events -->
       <div
         class="mode-badge-wrapper"
-        onclick={(e) => { e.stopPropagation(); onModeClick?.(); }}
-        title={`Change mode (current: ${mode})`}
+        class:mode-disabled={controlsDisabled || onModeClick === undefined}
+        data-vfo-controls-disabled={controlsDisabled}
+        aria-disabled={controlsDisabled || onModeClick === undefined}
+        onclick={(e) => {
+          e.stopPropagation();
+          if (!controlsDisabled) onModeClick?.();
+        }}
+        title={!controlsDisabled && onModeClick ? `Change mode (current: ${mode})` : undefined}
       >
         <StatusIndicator
           label={mode ?? '—'}
@@ -252,7 +272,17 @@
       var(--vfo-panel-pad-x, 10px)
       0;
     border-bottom: none;
+    width: 100%;
+    border-top: 0;
+    border-inline: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: inherit;
+    cursor: pointer;
   }
+
+  .panel-header:disabled { cursor: default; }
 
   .header-title-group {
     display: flex;
@@ -335,6 +365,8 @@
     cursor: pointer;
     display: inline-flex;
   }
+
+  .mode-badge-wrapper.mode-disabled { cursor: default; }
 
   .mode-badge-wrapper:hover :global(.v2-status-indicator) {
     filter: brightness(1.15);

--- a/frontend/src/components-v2/vfo/__tests__/VfoPanel.isolated.test.ts
+++ b/frontend/src/components-v2/vfo/__tests__/VfoPanel.isolated.test.ts
@@ -251,6 +251,51 @@ describe('panel structure', () => {
 });
 
 describe('active/inactive state', () => {
+  it('lets an inactive panel header select its VFO without making the frequency area a selector', () => {
+    const onSelectHeader = vi.fn();
+    const t = mountPanel({
+      receiver: 'main', receiverLabel: 'VFO B', slotTag: 'B', freq: 7150000,
+      mode: 'LSB', filter: 'NARROW', sValue: null, meterPresent: false,
+      isActive: false, badgeItems: [], onSelectHeader,
+    });
+
+    t.querySelector<HTMLButtonElement>('.panel-header')?.click();
+    expect(onSelectHeader).toHaveBeenCalledOnce();
+    t.querySelector<HTMLElement>('[data-vfo-freq]')?.click();
+    t.querySelector<HTMLElement>('[data-vfo-freq]')?.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true }));
+    t.querySelector<HTMLElement>('[data-vfo-freq]')?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    expect(onSelectHeader).toHaveBeenCalledOnce();
+  });
+
+  it('keeps inactive mode and frequency controls inert while the header remains selectable', () => {
+    const onModeClick = vi.fn();
+    const t = mountPanel({
+      receiver: 'main', receiverLabel: 'VFO B', slotTag: 'B', freq: 7150000,
+      mode: 'LSB', filter: 'NARROW', sValue: null, meterPresent: false,
+      isActive: false, badgeItems: [], frequencyDisabled: true, controlsDisabled: true,
+      onModeClick, onSelectHeader: vi.fn(),
+    });
+    const mode = t.querySelector<HTMLElement>('.mode-badge-wrapper')!;
+    mode.click();
+    mode.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(onModeClick).not.toHaveBeenCalled();
+    expect(mode.getAttribute('aria-disabled')).toBe('true');
+    expect(mode.getAttribute('title')).toBeNull();
+    expect(t.querySelector('[data-vfo-freq]')?.getAttribute('data-freq-tunable')).toBe('false');
+  });
+
+  it('reserves the meter row for an inactive peer without painting a second meter', () => {
+    const t = mountPanel({
+      receiver: 'main', receiverLabel: 'VFO B', slotTag: 'B', freq: 7150000,
+      mode: 'LSB', filter: 'NARROW', sValue: null, meterPresent: false,
+      isActive: false, badgeItems: [], reserveMeterSpace: true,
+    });
+
+    expect(t.querySelector('[data-meter-space="reserved"]')).not.toBeNull();
+    expect(t.querySelector('[data-testid="receiver-s-meter"]')).toBeNull();
+    expect(Array.from(t.querySelectorAll('.header-tag')).some((tag) => tag.textContent === 'BAR')).toBe(false);
+  });
+
   it('panel has active class when isActive=true', () => {
     const t = mountPanel(baseProps);
     expect(t.querySelector('.panel')?.classList.contains('active')).toBe(true);

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -448,6 +448,17 @@
     return slot?.kind === 'slotted' ? slot.id : '—';
   }
   let instrumentReceivers = $derived([...new Set(viewModel.vfos.map((vfo) => vfo.receiver))]);
+  let standardPair = $derived.by(() => {
+    if (appearance !== 'standard' || instrumentReceivers.length !== 1) return null;
+    const receiver = instrumentReceivers[0];
+    const records = viewModel.vfos.filter((vfo) => vfo.receiver === receiver);
+    const a = records.find((vfo) => vfo.slot.kind === 'slotted' && vfo.slot.id === 'A');
+    const b = records.find((vfo) => vfo.slot.kind === 'slotted' && vfo.slot.id === 'B');
+    if (records.length !== 2) return null;
+    return a && b
+      ? { receiver, left: a, right: b, absolute: true }
+      : { receiver, left: records[0], right: records[1], absolute: false };
+  });
   let receiverIndicators = $derived(
     (viewModel.receiverIndicators ?? []).filter(
       (indicator) => indicatorReceiver === undefined || indicator.receiver === indicatorReceiver,
@@ -707,6 +718,30 @@
   {/if}
   {/snippet}
 
+  {#snippet standardPairSelectors(pair: { receiver: ReceiverId; left: VfoViewModel; right: VfoViewModel; absolute: boolean })}
+    {#if pair.absolute}
+    <div class="standard-vfo-selectors" aria-label="Select VFO">
+      {#each [pair.left, pair.right] as vfo (slotKey(vfo.slot))}
+        {@const slot = vfo.slot.kind === 'slotted' ? vfo.slot.id : '—'}
+        <button type="button" class="vfo-select" data-standard-select-vfo={slot}
+          data-active={vfo.isActiveSlot} disabled={disabled || vfo.isActiveSlot}
+          onclick={() => selectVfo(vfo)}>SELECT {slot}</button>
+      {/each}
+    </div>
+    {:else}
+      {@render identitySelectors()}
+    {/if}
+  {/snippet}
+
+  {#snippet standardTxTargetStatus()}
+    <span class="standard-tx-target" data-vfo-tx-target-status>
+      {t('core.vfo.txTarget.label')}
+      {viewModel.txTarget.status === 'known'
+        ? ` ${viewModel.txTarget.slot.kind === 'slotted' ? viewModel.txTarget.slot.id : roleLabel(viewModel.vfos.find((vfo) => vfo.isTxTarget) ?? viewModel.vfos[0])}`
+        : ' —'}
+    </span>
+  {/snippet}
+
   {#snippet receiverInstrument(receiver: ReceiverId)}
     {@const meterHandle = receiver === 'MAIN'
       ? receiverInstruments?.mainSMeter : receiverInstruments?.subSMeter}
@@ -732,10 +767,10 @@
     </section>
   {/snippet}
 
-  {#snippet standardInstrument(receiver: ReceiverId)}
+  {#snippet standardInstrument(receiver: ReceiverId, fixed: VfoViewModel | undefined)}
     {@const records = viewModel.vfos.filter((item) => item.receiver === receiver)}
     {@const activeSlot = records.find((item) => item.isActiveSlot)}
-    {@const dominant = activeSlot ?? (records.length === 1 ? records[0] : undefined)}
+    {@const dominant = fixed ?? activeSlot ?? (records.length === 1 ? records[0] : undefined)}
     {@const indicator = receiverIndicators.find((item) => item.receiver === receiver)}
     {@const frequencyHandle = receiver === 'MAIN'
       ? receiverInstruments?.mainFrequency : receiverInstruments?.subFrequency}
@@ -752,7 +787,7 @@
     {#snippet hostedMeter()}
       {#if meterHandle}{@render meterHandle(hostedMeterFrame)}{/if}
     {/snippet}
-    {@const choices = viewModel.vfos.flatMap((choice, index) =>
+    {@const choices = fixed ? [] : viewModel.vfos.flatMap((choice, index) =>
         choice.receiver === receiver && choice !== dominant
           ? [{
               key: String(index), receiver: choice.receiver === 'SUB' ? 'sub' as const : 'main' as const,
@@ -764,6 +799,7 @@
             }]
           : [])}
     <section class="receiver-instrument standard-receiver" data-receiver-instrument={receiver}
+      data-standard-vfo-slot={fixed?.slot.kind === 'slotted' ? fixed.slot.id : undefined}
       data-testid="vfo-indicator-row" data-indicator-receiver={receiver}
       data-indicator-operational={indicator?.availability.operational}
       aria-label={`${receiver} receiver indicators`}>
@@ -774,12 +810,14 @@
         data-vfo-active={dominant?.isActive} data-vfo-active-slot={dominant?.isActiveSlot}
         data-vfo-tx-target={dominant?.isTxTarget}>
         <VfoPanel
-          receiver={receiver === 'SUB' ? 'sub' : 'main'} receiverLabel={receiver}
+          receiver={receiver === 'SUB' ? 'sub' : 'main'} receiverLabel={fixed ? roleLabel(fixed) : receiver}
           slotTag={dominant ? (dominant.slot.kind === 'slotted' ? dominant.slot.id : roleLabel(dominant)) : '—'}
           frequency={receiverInstruments !== undefined && dominant && frequencyHandle
+            && (fixed === undefined || fixed.isActiveSlot)
             ? hostedFrequency : undefined}
-          freq={receiverInstruments === undefined ? dominant?.frequencyHz ?? null : undefined}
-          displayHz={receiverInstruments === undefined && dominant
+          freq={receiverInstruments === undefined || (fixed !== undefined && !fixed.isActiveSlot)
+            ? dominant?.frequencyHz ?? null : undefined}
+          displayHz={(receiverInstruments === undefined || (fixed !== undefined && !fixed.isActiveSlot)) && dominant
             ? displayValue(dominant.display?.frequencyHz, dominant.frequencyHz) : undefined}
           pendingDisplayHz={receiverInstruments === undefined && dominant
             ? pendingFrequencyHz?.[receiver] ?? null : undefined}
@@ -787,25 +825,33 @@
           contextKey={receiverInstruments === undefined
             ? `${frequencyLifetimeKey ?? 'unscoped'}:${viewModel.topologyId}:${receiver}:${dominant ? slotKey(dominant.slot) : 'unknown'}`
             : undefined}
-          frequencyDisabled={!dominant || readoutDisabled(dominant)}
+          frequencyDisabled={!dominant || (fixed !== undefined && !fixed.isActiveSlot) || readoutDisabled(dominant)}
+          controlsDisabled={fixed !== undefined && !fixed.isActiveSlot}
           mode={dominant ? displayValue(dominant.display?.mode, dominant.mode) : null}
           filter={dominant ? displayValue(dominant.display?.filter, dominant.filter) : null}
           sValue={indicator?.sMeter.availability.operational && indicator.sMeter.reading.status === 'known'
             && Number.isFinite(indicator.sMeter.reading.value) ? indicator.sMeter.reading.value : null}
-          sMeter={receiverInstruments === undefined ? undefined : hostedMeter}
-          meterPresent={indicator?.sMeter.availability.structural ?? false}
+          sMeter={receiverInstruments === undefined || (fixed && !fixed.isActiveSlot) ? undefined : hostedMeter}
+          meterPresent={(fixed === undefined || fixed.isActiveSlot) && (indicator?.sMeter.availability.structural ?? false)}
           meterOperational={indicator?.sMeter.availability.operational ?? false}
           meterSource={indicator?.sMeter.source}
           {continuitySession}
-          isActive={dominant?.isActive ?? false} badgeItems={standardBadges(indicator)}
+          isActive={dominant?.isActive ?? false}
+          badgeItems={fixed === undefined || fixed.isActiveSlot ? standardBadges(indicator) : []}
           bandText={dominant ? standardBand(dominant) : null}
           rit={dominant ? standardRit(dominant) : undefined} slotChoices={choices}
+          reserveMeterSpace={fixed !== undefined && !fixed.isActiveSlot}
           onFreqChange={receiverInstruments === undefined && dominant
             ? (hz) => tuneFrequency(dominant, hz) : undefined}
           onSelectSlot={(key) => {
             const choice = viewModel.vfos[Number(key)];
             if (choice) selectVfo(choice);
           }}
+          onSelectHeader={fixed?.slot.kind === 'slotted' && isSelectable(fixed) && !disabled
+            ? () => selectVfo(fixed) : undefined}
+          headerReason={fixed?.slot.kind === 'unknown'
+            ? selectReasonText(fixed)
+            : fixed?.slot.kind === 'relative' ? identityOnlyReasonText() : undefined}
         />
       </div>
     </section>
@@ -813,8 +859,17 @@
 
   {#if appearance !== 'semantic' && showVfoList}
     <div class="instrument-panel" data-testid="vfo-instrument-panel">
+      {#if standardPair}
+        {@render standardInstrument(standardPair.receiver, standardPair.left)}
+        <div class="bridge standard-pair-bridge" data-instrument-bridge>
+          {@render standardPairSelectors(standardPair)}
+          {@render radioWideContent()}
+          {@render standardTxTargetStatus()}
+        </div>
+        {@render standardInstrument(standardPair.receiver, standardPair.right)}
+      {:else}
       {#if instrumentReceivers[0]}
-        {#if appearance === 'standard'}{@render standardInstrument(instrumentReceivers[0])}
+        {#if appearance === 'standard'}{@render standardInstrument(instrumentReceivers[0], undefined)}
         {:else}{@render receiverInstrument(instrumentReceivers[0])}{/if}
       {/if}
       {#if showRadioWideFacts}
@@ -825,9 +880,10 @@
         </div>
       {/if}
       {#each instrumentReceivers.slice(1) as receiver (receiver)}
-        {#if appearance === 'standard'}{@render standardInstrument(receiver)}
+        {#if appearance === 'standard'}{@render standardInstrument(receiver, undefined)}
         {:else}{@render receiverInstrument(receiver)}{/if}
       {/each}
+      {/if}
     </div>
   {:else}
     {#if appearance !== 'semantic' && !showVfoList}{@render activeReceiverStatus()}{/if}
@@ -924,6 +980,27 @@
     box-shadow: 0 0 6px rgba(0,212,255,.3), inset 0 0 16px rgba(0,212,255,.06);
   }
   [data-vfo-appearance='standard'] .bridge { flex-basis: 136px; }
+  [data-vfo-appearance='standard'] .standard-receiver[data-standard-vfo-slot] {
+    flex: 1 1 0;
+    padding: 6px;
+  }
+  [data-vfo-appearance='standard'] .standard-pair-bridge {
+    flex: 0 0 clamp(124px, 11vw, 152px);
+    padding: 6px;
+    gap: 6px;
+  }
+  .standard-vfo-selectors { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 4px; }
+  .standard-vfo-selectors .vfo-select {
+    min-width: 0; padding: 4px 3px; font-size: 9px; font-weight: 700;
+  }
+  .standard-vfo-selectors .vfo-select[data-active='true'] {
+    border-color: var(--v2-accent-cyan, #00d4ff); color: var(--v2-accent-cyan, #00d4ff);
+  }
+  .standard-tx-target {
+    display: block; padding: 3px 5px; border: 1px solid var(--v2-accent-red, #ff2020);
+    border-radius: 3px; color: var(--v2-accent-red, #ff2020); font-size: 9px;
+    font-weight: 700; text-align: center;
+  }
   [data-vfo-appearance='standard'] .receiver-instrument :where(.vfo-tile) {
     grid-template-columns: auto minmax(0, 1fr) auto;
     grid-template-rows: auto auto;

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -2450,8 +2450,7 @@ describe('MOR-2342 historical instrument presentations', () => {
     expect(panel).toMatch(/meterSource=\{indicator\?\.sMeter\.source\}/);
     expect(panel).toMatch(/\{continuitySession\}/);
     expect(source.match(/receiverInstruments\?\.(?:mainSMeter|subSMeter)/g)).toHaveLength(6);
-    expect(source.match(/sMeter=\{receiverInstruments === undefined \? undefined : hostedMeter\}/g))
-      .toHaveLength(3);
+    expect(source.match(/sMeter=\{receiverInstruments === undefined/g)).toHaveLength(3);
   });
 
   it.each(['semantic', 'sdr', 'standard'] as const)(
@@ -2499,18 +2498,67 @@ describe('MOR-2342 historical instrument presentations', () => {
     expect(root.querySelectorAll('[data-vfo-tile]')).toHaveLength(2);
     expect(root.querySelectorAll('[data-testid="receiver-s-meter"]')).toHaveLength(1);
   });
-  it('keeps the Standard active frequency dominant over its secondary memory', () => {
-    const root = mountSurface({ viewModel: withReceiverIndicators('1/ab'), appearance: 'standard' });
-    const primary = root.querySelector<HTMLElement>('[data-vfo-active-slot="true"] .vfo-freq')!;
-    const secondary = root.querySelector<HTMLElement>('[data-vfo-active-slot="false"] .vfo-freq')!;
-    expect(primary).not.toBeNull();
-    expect(secondary).not.toBeNull();
-    const source = readFileSync('src/semantic/VfoSurface.svelte', 'utf8');
-    expect(source).toContain('grid-template-columns: auto minmax(0, 1fr) auto;');
-    expect(source).toContain('grid-template-rows: auto auto;');
-    expect(source).toContain('grid-template-columns: auto auto minmax(0, 1fr) auto;');
-    expect(source).toContain('font-size: clamp(34px, 3vw, 44px)');
-    expect(source).toContain('.secondary-slot .vfo-freq { font-size: 18px;');
+  it('keeps Standard VFO A left and VFO B right while the confirmed active highlight moves', () => {
+    const base = withReceiverIndicators('1/ab');
+    const aActive = mountSurface({ viewModel: base, appearance: 'standard' });
+    expect(Array.from(aActive.querySelectorAll('[data-standard-vfo-slot]')).map((node) =>
+      node.getAttribute('data-standard-vfo-slot'))).toEqual(['A', 'B']);
+    expect(aActive.querySelector('[data-standard-vfo-slot="A"] .panel')?.classList.contains('active')).toBe(true);
+    expect(aActive.querySelector('[data-standard-vfo-slot="B"] .panel')?.classList.contains('active')).toBe(false);
+    expect(aActive.querySelectorAll('[data-testid="receiver-s-meter"]')).toHaveLength(1);
+    expect(aActive.querySelector('[data-standard-vfo-slot="B"] [data-meter-space="reserved"]')).not.toBeNull();
+
+    const bModel: RadioViewModel = {
+      ...base,
+      vfos: base.vfos.map((vfo) => ({
+        ...vfo,
+        isActive: vfo.slot.kind === 'slotted' && vfo.slot.id === 'B',
+        isActiveSlot: vfo.slot.kind === 'slotted' && vfo.slot.id === 'B',
+      })),
+    };
+    const bActive = mountSurface({ viewModel: bModel, appearance: 'standard' });
+    expect(Array.from(bActive.querySelectorAll('[data-standard-vfo-slot]')).map((node) =>
+      node.getAttribute('data-standard-vfo-slot'))).toEqual(['A', 'B']);
+    expect(bActive.querySelector('[data-standard-vfo-slot="A"] .panel')?.classList.contains('active')).toBe(false);
+    expect(bActive.querySelector('[data-standard-vfo-slot="B"] .panel')?.classList.contains('active')).toBe(true);
+    expect(bActive.querySelector('[data-standard-vfo-slot="A"] [data-vfo-freq]')?.textContent?.replace(/\s/g, '')).toBe('7.100.000');
+    expect(bActive.querySelector('[data-standard-vfo-slot="B"] [data-vfo-freq]')?.textContent?.replace(/\s/g, '')).toBe('7.150.000');
+  });
+
+  it('keeps the inactive Standard peer on its own slot frequency when the active receiver uses a hosted readout', () => {
+    const onTuneFrequency = vi.fn();
+    const onSelectVfo = vi.fn();
+    const root = mountSurface({
+      viewModel: withReceiverIndicators('1/ab'), appearance: 'standard',
+      receiverInstruments: hostedReceiverInstruments(), onTuneFrequency, onSelectVfo,
+    });
+    expect(root.querySelector('[data-standard-vfo-slot="A"] [data-hosted-frequency="MAIN"]')).not.toBeNull();
+    expect(root.querySelector('[data-standard-vfo-slot="B"] [data-vfo-freq]')?.textContent?.replace(/\s/g, '')).toBe('7.150.000');
+    expect(root.querySelector('[data-standard-vfo-slot="B"] [data-hosted-frequency]')).toBeNull();
+    const inactiveFrequency = root.querySelector<HTMLElement>('[data-standard-vfo-slot="B"] [data-vfo-freq]')!;
+    expect(inactiveFrequency.getAttribute('data-freq-tunable')).toBe('false');
+    inactiveFrequency.click();
+    inactiveFrequency.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true }));
+    inactiveFrequency.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    expect(onTuneFrequency).not.toHaveBeenCalled();
+    expect(onSelectVfo).not.toHaveBeenCalled();
+  });
+
+  it('puts persistent A/B selection and shared operations in the center of the Standard pair', () => {
+    const onSelectVfo = vi.fn();
+    const root = mountSurface({
+      viewModel: withReceiverIndicators('1/ab'), appearance: 'standard', onSelectVfo,
+    });
+    const bridge = root.querySelector('[data-instrument-bridge]')!;
+    expect(bridge.previousElementSibling?.getAttribute('data-standard-vfo-slot')).toBe('A');
+    expect(bridge.nextElementSibling?.getAttribute('data-standard-vfo-slot')).toBe('B');
+    expect(bridge.querySelectorAll('[data-standard-select-vfo]')).toHaveLength(2);
+    bridge.querySelector<HTMLButtonElement>('[data-standard-select-vfo="B"]')?.click();
+    expect(onSelectVfo).toHaveBeenCalledExactlyOnceWith({ receiver: 'MAIN', slot: { kind: 'slotted', id: 'B' } });
+    expect(bridge.querySelector('[data-vfo-split]')).not.toBeNull();
+    expect(bridge.querySelector('[data-vfo-equalize]')).not.toBeNull();
+    expect(bridge.querySelector('[data-vfo-swap]')).not.toBeNull();
+    expect(bridge.querySelector('[data-vfo-tx-target-status]')).not.toBeNull();
   });
 
   it('mounts the surviving Standard VfoPanel with honest meter states', () => {
@@ -2546,7 +2594,7 @@ describe('MOR-2342 historical instrument presentations', () => {
     expect(onSelectVfo).toHaveBeenCalledExactlyOnceWith({ receiver: 'SUB', slot: { kind: 'slotted', id: 'B' } });
   });
 
-  it('retains a structural receiver and both records when active-slot identity is unknown', () => {
+  it('retains both fixed cards without an optimistic highlight when the active slot is unknown', () => {
     const base = withReceiverIndicators('1/ab');
     const onSelectVfo = vi.fn();
     const viewModel: RadioViewModel = {
@@ -2555,11 +2603,12 @@ describe('MOR-2342 historical instrument presentations', () => {
       vfos: base.vfos.map((vfo) => ({ ...vfo, isActive: false, isActiveSlot: false })),
     };
     const root = mountSurface({ viewModel, appearance: 'standard', onSelectVfo });
-    expect(root.querySelectorAll('[data-receiver-instrument="MAIN"]')).toHaveLength(1);
-    expect(root.querySelector('[data-vfo-dominant="unknown"] [data-vfo-freq]')?.textContent?.trim()).toBe('—');
+    expect(root.querySelectorAll('[data-receiver-instrument="MAIN"]')).toHaveLength(2);
+    expect(root.querySelectorAll('[data-standard-vfo-slot]')).toHaveLength(2);
+    expect(root.querySelectorAll('.panel.active')).toHaveLength(0);
     expect(root.querySelectorAll('[data-vfo-tile]')).toHaveLength(2);
     expect(Array.from(root.querySelectorAll('[data-vfo-slot]')).map((node) => node.getAttribute('data-vfo-slot'))).toEqual(['A', 'B']);
-    root.querySelector<HTMLButtonElement>('[data-vfo-slot="B"]')?.click();
+    root.querySelector<HTMLButtonElement>('[data-standard-select-vfo="B"]')?.click();
     expect(onSelectVfo).toHaveBeenCalledExactlyOnceWith({ receiver: 'MAIN', slot: { kind: 'slotted', id: 'B' } });
   });
 
@@ -2572,11 +2621,12 @@ describe('MOR-2342 historical instrument presentations', () => {
     };
     const root = mountSurface({ viewModel, appearance: 'standard', onSelectVfo });
     expect(root.querySelectorAll('[data-vfo-tile]')).toHaveLength(2);
-    const unknown = root.querySelector<HTMLButtonElement>('[data-vfo-slot="unknown"]')!;
+    const unknown = root.querySelector<HTMLElement>('[data-vfo-slot="unknown"]')!;
     expect(unknown).not.toBeNull();
-    expect(unknown.disabled).toBe(true);
-    expect(unknown.title).toContain("has not confirmed this VFO's A/B identity");
-    unknown.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const unknownHeader = unknown.querySelector<HTMLButtonElement>('.panel-header')!;
+    expect(unknownHeader.disabled).toBe(true);
+    expect(unknownHeader.title).toContain("has not confirmed this VFO's A/B identity");
+    unknownHeader.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(onSelectVfo).not.toHaveBeenCalled();
   });
 
@@ -2592,11 +2642,11 @@ describe('MOR-2342 historical instrument presentations', () => {
     };
     const root = mountSurface({ viewModel, appearance: 'standard', onSelectVfo });
     expect(root.querySelectorAll('[data-vfo-tile]')).toHaveLength(2);
-    const relative = root.querySelector<HTMLButtonElement>('[data-vfo-slot="unselected"]')!;
+    const relative = root.querySelector<HTMLElement>('[data-vfo-slot="unselected"]')!;
     expect(relative).not.toBeNull();
-    expect(relative.disabled).toBe(true);
-    expect(relative.title).toContain('has not confirmed which VFO is A and which is B');
-    relative.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(relative.querySelector('.panel-header')?.getAttribute('disabled')).not.toBeNull();
+    expect(root.querySelectorAll('[data-vfo-select-absolute]')).toHaveLength(2);
+    relative.querySelector<HTMLElement>('.panel-header')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(onSelectVfo).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Standard currently promotes the active A/B memory into one large receiver card and compresses the other memory into a small inline choice. This change renders a one-receiver A/B radio as two stable, equal peer cards with VFO A fixed left, VFO B fixed right, and shared selection/split/copy/swap controls in the center.

Only the confirmed active peer owns the receiver S-meter and receiver-wide facts. The inactive peer keeps its own observed frequency/mode/filter visible, remains non-tunable, and can be selected from its header. Relative or unknown slot identity keeps truthful labels and uses the existing A/B identity resolver without inventing a mapping. The TX target remains a separate center status.

Linear: MOR-2436 (parent MOR-2425; related MOR-2426)

Validation:
- `cd frontend && npm test -- --run src/components-v2/vfo/__tests__/VfoPanel.isolated.test.ts src/semantic/__tests__/VfoSurface.test.ts` (250 passed)
- `cd frontend && npm run check`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- Offline Standard fixture inspected at 1200, 1440, and 1700 CSS widths; fixed A/B and active-B states showed no horizontal overflow. This is fixture geometry evidence; installed IC-7300 acceptance remains a separate gate.
