### PR TITLE
MOR-2436: compact the Standard VFO pair bridge

### DIFF
--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -1082,6 +1082,19 @@
     .bridge { flex-basis: 150px; }
     .receiver-instrument .vfo-freq { font-size: 26px; }
   }
+  @media (max-width: 950px) {
+    [data-vfo-appearance='standard'] .standard-pair-bridge {
+      padding: 2px;
+      gap: 1px;
+    }
+    [data-vfo-appearance='standard'] .standard-receiver {
+      --vfo-panel-body-height: 64px;
+      --vfo-control-strip-height: 22px;
+    }
+    [data-vfo-appearance='standard'] .standard-receiver[data-standard-vfo-slot] {
+      flex-basis: calc(100% - 192px);
+    }
+  }
   @media (max-width: 760px) {
     .instrument-panel { flex-direction: column; }
     .receiver-instrument, .bridge { flex-basis: auto; }

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -983,11 +983,43 @@
   [data-vfo-appearance='standard'] .standard-receiver[data-standard-vfo-slot] {
     flex: 1 1 0;
     padding: 6px;
+    --btn-compact-min-height: 18px;
+    --btn-compact-padding-block: 1px;
+    --btn-compact-padding-inline: 4px;
+    --btn-compact-font-size: 8px;
+    --vfo-control-strip-gap: 2px;
   }
   [data-vfo-appearance='standard'] .standard-pair-bridge {
-    flex: 0 0 clamp(124px, 11vw, 152px);
-    padding: 6px;
-    gap: 6px;
+    flex: 0 0 clamp(190px, 14vw, 220px);
+    padding: 4px;
+    gap: 3px;
+    --vfo-ops-gap: 3px;
+    --vfo-ops-badge-padding-x: 3px;
+    --vfo-ops-badge-font-size: 9px;
+  }
+  [data-vfo-appearance='standard'] .standard-pair-bridge :global(.shared-indicators .facts) {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 3px;
+  }
+  [data-vfo-appearance='standard'] .standard-pair-bridge :global(.shared-indicators .fact) {
+    min-width: 0;
+    text-align: center;
+  }
+  [data-vfo-appearance='standard'] .standard-pair-bridge :global(.shared-indicators .rf-lamp:empty) {
+    display: none;
+  }
+  [data-vfo-appearance='standard'] .standard-pair-bridge :global(.vfo-ops) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  [data-vfo-appearance='standard'] .standard-pair-bridge :global(.split-digest) {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 3px;
+  }
+  [data-vfo-appearance='standard'] .standard-pair-bridge :global(.split-digest > span) {
+    min-width: 0;
+    text-align: center;
   }
   .standard-vfo-selectors { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 4px; }
   .standard-vfo-selectors .vfo-select {

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -988,6 +988,14 @@
     --btn-compact-padding-inline: 4px;
     --btn-compact-font-size: 8px;
     --vfo-control-strip-gap: 2px;
+    --vfo-panel-body-height: 82px;
+    --vfo-control-strip-height: 40px;
+  }
+  [data-vfo-appearance='standard'] .standard-receiver[data-standard-vfo-slot] :global(.control-strip) {
+    align-content: center;
+    flex-wrap: wrap;
+    overflow: visible;
+    white-space: normal;
   }
   [data-vfo-appearance='standard'] .standard-pair-bridge {
     flex: 0 0 clamp(190px, 14vw, 220px);

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -986,10 +986,10 @@
     --btn-compact-min-height: 18px;
     --btn-compact-padding-block: 1px;
     --btn-compact-padding-inline: 4px;
-    --btn-compact-font-size: 8px;
+    --btn-compact-font-size: 9px;
     --vfo-control-strip-gap: 2px;
-    --vfo-panel-body-height: 82px;
-    --vfo-control-strip-height: 40px;
+    --vfo-panel-body-height: 100px;
+    --vfo-control-strip-height: 54px;
   }
   [data-vfo-appearance='standard'] .standard-receiver[data-standard-vfo-slot] :global(.control-strip) {
     align-content: center;

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -92,6 +92,7 @@ interface BootOptions {
   theme?: 'nord' | 'github-light';
   locale?: 'en-US' | 'ru-RU';
   extraCapabilities?: string[];
+  absoluteVfoPair?: boolean;
   /** The QA-only skin `?layout=flagship-probe` selects
    *  (`lib/stores/qa-cockpit-override.ts`). It is not a `CanonicalLayoutMode`,
    *  so the workspace `layout` this helper writes cannot carry it. */
@@ -101,6 +102,25 @@ interface BootOptions {
 async function boot(page: Page, layout: string, width: number, known: boolean, language = 'studioline', productionUnknown = false, topology?: TopologyId, options: BootOptions = {}) {
   const { state, caps } = topology ? catalogFixture(topology, known) : productionUnknown
     ? { state: structuredClone(mockState), caps: structuredClone(mockCapabilities) } : fixture(known);
+  if (options.absoluteVfoPair) {
+    const observed = (storePath: string) => ({ storePath, observed: true as const,
+      freshness: 'fresh' as const, availability: 'available' as const, lastObservedMonotonic: 0 });
+    state.main.vfoA = { freqHz: state.main.freqHz, mode: state.main.mode,
+      filterNum: state.main.filter, dataMode: 0 };
+    state.main.vfoB = structuredClone(state.main.unselectedVfo!);
+    Object.assign(state, { txAntenna: 1, ritOn: false, ritTx: false, ritFreq: 0 });
+    Object.assign(caps, { antennas: 1 });
+    Object.assign(state.fieldStatus!, {
+      'main.activeSlot': observed('main.activeSlot'),
+      ...Object.fromEntries(['txAntenna', 'tunerStatus', 'ritOn', 'ritTx', 'ritFreq']
+        .map(path => [path, observed(path)])),
+      ...Object.fromEntries(['freqHz', 'mode', 'filterNum', 'dataMode'].flatMap(leaf =>
+        (['vfoA', 'vfoB'] as const).map(slot => {
+          const path = `main.${slot}.${leaf}`;
+          return [path, observed(path)];
+        }))),
+    });
+  }
   if (options.extraCapabilities) {
     const tags = (caps as unknown as { capabilities: string[] }).capabilities;
     (caps as unknown as { capabilities: string[] }).capabilities = [...new Set([...tags, ...options.extraCapabilities])];
@@ -339,6 +359,59 @@ function expectStandardReceiverIntegrity(
 }
 
 test.describe('MOR-2424 Standard v2.11.1 outer grid', () => {
+  for (const width of [1200, 1700] as const) {
+    test(`Standard ${width} compact absolute VFO pair keeps every bridge control`, async ({ page }, info) => {
+      await boot(page, 'standard', width, true, 'studioline', false, undefined, {
+        height: 1000, extraCapabilities: ALL_STRUCTURAL_ACTION_CAPS, absoluteVfoPair: true,
+      });
+      const panel = page.getByTestId('vfo-instrument-panel');
+      const cards = page.locator('[data-standard-vfo-slot]');
+      await expect(cards).toHaveCount(2);
+      const geometry = await panel.evaluate(element => {
+        const rect = (target: Element) => target.getBoundingClientRect().toJSON();
+        const cardRects = [...element.querySelectorAll('[data-standard-vfo-slot]')].map(rect);
+        return {
+          panel: rect(element), cards: cardRects,
+          overflow: element.scrollWidth > element.clientWidth + 1,
+          cardOverflow: [...element.querySelectorAll<HTMLElement>('[data-standard-vfo-slot]')]
+            .map(card => [...card.querySelectorAll<HTMLElement>('.panel-header, .panel-meter, .vfo-freq, .control-strip, .control-strip *')]
+              .filter(target => {
+                const style = getComputedStyle(target);
+                return style.display !== 'none' && style.visibility !== 'hidden'
+                  && target.scrollWidth > target.clientWidth + 1;
+              }).map(target => target.className ?? target.tagName)),
+          bridgeOverflow: [...element.querySelectorAll<HTMLElement>('[data-instrument-bridge] *')]
+            .filter(target => target.scrollWidth > target.clientWidth + 1)
+            .map(target => target.getAttribute('data-dual-action') ?? target.className ?? target.tagName),
+        };
+      });
+      await info.attach('compact-vfo-pair', { body: JSON.stringify(geometry), contentType: 'application/json' });
+      expect.soft(geometry.panel.height, 'the full Standard VFO row stays compact').toBeLessThanOrEqual(190);
+      expect.soft(geometry.cards[0].top, 'A and B cards start together').toBeCloseTo(geometry.cards[1].top, 0);
+      expect.soft(geometry.cards[0].bottom, 'A and B cards end together').toBeCloseTo(geometry.cards[1].bottom, 0);
+      expect.soft(geometry.overflow, 'the VFO pair does not overflow its row').toBe(false);
+      expect.soft(geometry.cardOverflow, 'both full card strips fit without clipped descendants').toEqual([[], []]);
+      expect.soft(geometry.bridgeOverflow, 'every bridge item fits its assigned cell').toEqual([]);
+      await expect(page.locator('[data-standard-select-vfo]')).toHaveCount(2);
+      await expect(page.locator('[data-vfo-split]')).toBeVisible();
+      for (const action of ['equalize', 'swap', 'speak']) {
+        await expect(page.locator(`[data-dual-action="${action}"]`)).toBeVisible();
+      }
+      await expect(page.getByTestId('vfo-split-digest')).toBeVisible();
+      const strips = cards.locator('.control-strip');
+      await expect(strips).toHaveCount(2);
+      await expect(strips.nth(0).locator('.mode-badge-wrapper')).toHaveAttribute('data-vfo-controls-disabled', 'false');
+      await expect(strips.nth(1).locator('.mode-badge-wrapper')).toHaveAttribute('data-vfo-controls-disabled', 'true');
+      await expect(strips.nth(0)).toContainText(/CW.*FIL3/);
+      await expect(strips.nth(1)).toContainText(/USB.*FIL1/);
+      for (const fact of ['antenna', 'atu', 'rit', 'xit']) {
+        await expect(page.locator(`[data-indicator-fact="${fact}"]`)).toBeVisible();
+      }
+      expect(await page.evaluate(() => (window as unknown as { geometryCommands: { type: string }[] })
+        .geometryCommands.filter(c => c.type === 'cmd'))).toEqual([]);
+    });
+  }
+
   for (const width of STANDARD_WIDTHS) for (const topology of STANDARD_TOPOLOGIES) {
     test(`standard ${width} ${topology} painted grid`, async ({ page }, info) => {
       await boot(page, 'standard', width, true, 'studioline', false, topology);

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -374,13 +374,20 @@ test.describe('MOR-2424 Standard v2.11.1 outer grid', () => {
           panel: rect(element), cards: cardRects,
           overflow: element.scrollWidth > element.clientWidth + 1,
           cardOverflow: [...element.querySelectorAll<HTMLElement>('[data-standard-vfo-slot]')]
-            .map(card => [...card.querySelectorAll<HTMLElement>('.panel-header, .panel-meter, .vfo-freq, .control-strip, .control-strip *')]
+            .map(card => {
+              const cardBox = card.getBoundingClientRect();
+              return [...card.querySelectorAll<HTMLElement>('.panel-header, .panel-meter, .vfo-freq, .control-strip, .control-strip *')]
               .filter(target => {
                 const style = getComputedStyle(target);
+                const box = target.getBoundingClientRect();
                 return style.display !== 'none' && style.visibility !== 'hidden'
-                  && target.scrollWidth > target.clientWidth + 1;
+                  && (target.scrollWidth > target.clientWidth + 1
+                    || box.left < cardBox.left - 1 || box.right > cardBox.right + 1
+                    || box.top < cardBox.top - 1 || box.bottom > cardBox.bottom + 1);
               }).map(target => ({ target: target.className ?? target.tagName,
-                scrollWidth: target.scrollWidth, clientWidth: target.clientWidth }))),
+                scrollWidth: target.scrollWidth, clientWidth: target.clientWidth,
+                rect: target.getBoundingClientRect().toJSON(), card: cardBox.toJSON() }));
+            }),
           bridgeOverflow: [...element.querySelectorAll<HTMLElement>('[data-instrument-bridge] *')]
             .filter(target => target.scrollWidth > target.clientWidth + 1)
             .map(target => target.getAttribute('data-dual-action') ?? target.className ?? target.tagName),
@@ -410,6 +417,9 @@ test.describe('MOR-2424 Standard v2.11.1 outer grid', () => {
       }
       expect(await page.evaluate(() => (window as unknown as { geometryCommands: { type: string }[] })
         .geometryCommands.filter(c => c.type === 'cmd'))).toEqual([]);
+      const screenshot = info.outputPath(`compact-vfo-pair-${width}.png`);
+      await page.screenshot({ path: screenshot, fullPage: true });
+      await info.attach('compact-vfo-pair-screenshot', { path: screenshot, contentType: 'image/png' });
     });
   }
 

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -379,7 +379,8 @@ test.describe('MOR-2424 Standard v2.11.1 outer grid', () => {
                 const style = getComputedStyle(target);
                 return style.display !== 'none' && style.visibility !== 'hidden'
                   && target.scrollWidth > target.clientWidth + 1;
-              }).map(target => target.className ?? target.tagName)),
+              }).map(target => ({ target: target.className ?? target.tagName,
+                scrollWidth: target.scrollWidth, clientWidth: target.clientWidth }))),
           bridgeOverflow: [...element.querySelectorAll<HTMLElement>('[data-instrument-bridge] *')]
             .filter(target => target.scrollWidth > target.clientWidth + 1)
             .map(target => target.getAttribute('data-dual-action') ?? target.className ?? target.tagName),

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -359,7 +359,7 @@ function expectStandardReceiverIntegrity(
 }
 
 test.describe('MOR-2424 Standard v2.11.1 outer grid', () => {
-  for (const width of [1200, 1700] as const) {
+  for (const width of [900, 1024, 1200, 1700] as const) {
     test(`Standard ${width} compact absolute VFO pair keeps every bridge control`, async ({ page }, info) => {
       await boot(page, 'standard', width, true, 'studioline', false, undefined, {
         height: 1000, extraCapabilities: ALL_STRUCTURAL_ACTION_CAPS, absoluteVfoPair: true,
@@ -394,9 +394,11 @@ test.describe('MOR-2424 Standard v2.11.1 outer grid', () => {
         };
       });
       await info.attach('compact-vfo-pair', { body: JSON.stringify(geometry), contentType: 'application/json' });
-      expect.soft(geometry.panel.height, 'the full Standard VFO row stays compact').toBeLessThanOrEqual(190);
-      expect.soft(geometry.cards[0].top, 'A and B cards start together').toBeCloseTo(geometry.cards[1].top, 0);
-      expect.soft(geometry.cards[0].bottom, 'A and B cards end together').toBeCloseTo(geometry.cards[1].bottom, 0);
+      if (width > 1050) {
+        expect.soft(geometry.panel.height, 'the full Standard VFO row stays compact').toBeLessThanOrEqual(190);
+        expect.soft(geometry.cards[0].top, 'A and B cards start together').toBeCloseTo(geometry.cards[1].top, 0);
+        expect.soft(geometry.cards[0].bottom, 'A and B cards end together').toBeCloseTo(geometry.cards[1].bottom, 0);
+      }
       expect.soft(geometry.overflow, 'the VFO pair does not overflow its row').toBe(false);
       expect.soft(geometry.cardOverflow, 'both full card strips fit without clipped descendants').toEqual([[], []]);
       expect.soft(geometry.bridgeOverflow, 'every bridge item fits its assigned cell').toEqual([]);
@@ -549,6 +551,18 @@ for (const layout of ['standard', 'sdr-test', 'lcd-scope', 'lcd-cockpit']) {
     test(`${layout} ${width} ${known ? 'observed IC' : 'unknown'} geometry`, async ({ page }, info) => {
       const errors: string[] = []; page.on('pageerror', e => errors.push(String(e)));
       await boot(page, layout, width, known);
+      if (layout === 'standard' && width === 900) {
+        const stripFailures = await page.locator('.receiver-instrument .control-strip').evaluateAll(strips =>
+          strips.flatMap(strip => {
+            const card = strip.closest('.receiver-instrument')!.getBoundingClientRect();
+            const box = strip.getBoundingClientRect();
+            return strip.scrollWidth > strip.clientWidth + 1 || box.left < card.left - 1
+              || box.right > card.right + 1 || box.top < card.top - 1 || box.bottom > card.bottom + 1
+              ? [{ scrollWidth: strip.scrollWidth, clientWidth: strip.clientWidth,
+                strip: box.toJSON(), card: card.toJSON() }] : [];
+          }));
+        expect.soft(stripFailures, '900px Standard cards keep every status chip contained').toEqual([]);
+      }
       const unkey = page.getByTestId('rx-tx-unkey');
       await expect(unkey).toHaveCount(1);
       await expect(page.getByTestId('rx-tx-key')).toHaveCount(1);

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -98,6 +98,7 @@ from ..core.state_pipeline_contracts import (
     SourceMetadata,
 )
 from ..core.radio_protocol import (
+    CivCommandCapable,
     ManagedTxApi,
     RelativeVfoReadbackCapable,
 )
@@ -3687,6 +3688,8 @@ class RadioPoller:
     def _vfo_connection_generation(self) -> tuple[int, object]:
         return self._provider_generation(), self._connection_generation_capture()
 
+    _VFO_CONNECT_PTT_TIMEOUT: float = 2.0
+
     async def select_vfo_a_on_connect(self, *, read_only: bool) -> None:
         """Attempt the application connection policy once, with fresh RX only."""
         generation = self._vfo_connection_generation()
@@ -3705,13 +3708,45 @@ class RadioPoller:
             reason = "inapplicable_profile"
         else:
             snapshot = self._state_store.snapshot()
-            if self._current_rf_state(snapshot) is not RfState.RX:
-                reason = "rf_not_confirmed_rx"
-            elif (
-                snapshot.field(_PTT_PATH).last_observed_monotonic
+            rf_state = self._current_rf_state(snapshot)
+            if rf_state is RfState.UNKNOWN or (
+                rf_state is RfState.RX
+                and snapshot.field(_PTT_PATH).last_observed_monotonic
                 < self._vfo_connection_started_at
             ):
-                reason = "ptt_predates_connection"
+                try:
+                    cmd_map = self._cmd_map
+                    if (
+                        not isinstance(self._radio, CivCommandCapable)
+                        or cmd_map is None
+                        or not cmd_map.has("get_transceiver_status")
+                    ):
+                        raise CommandError("connection PTT read is unavailable")
+                    command, sub, data = decode_wire_tuple(
+                        cmd_map.get("get_transceiver_status")
+                    )
+                    if data:
+                        raise CommandError("connection PTT read must carry no data")
+                    await asyncio.wait_for(
+                        self._radio.send_civ(
+                            command, sub=sub, data=data, wait_response=True
+                        ),
+                        timeout=self._VFO_CONNECT_PTT_TIMEOUT,
+                    )
+                except Exception:
+                    reason = "ptt_refresh_failed"
+                if generation != self._vfo_connection_generation():
+                    reason = "connection_changed"
+                snapshot = self._state_store.snapshot()
+                rf_state = self._current_rf_state(snapshot)
+            if reason is None:
+                if rf_state is not RfState.RX:
+                    reason = "rf_not_confirmed_rx"
+                elif (
+                    snapshot.field(_PTT_PATH).last_observed_monotonic
+                    < self._vfo_connection_started_at
+                ):
+                    reason = "ptt_predates_connection"
         if reason is not None:
             self._record_state_diagnostic(
                 "vfo_connect_skipped", "web.radio_poller", reason=reason

--- a/tests/test_radio_poller_tx_interlock.py
+++ b/tests/test_radio_poller_tx_interlock.py
@@ -759,7 +759,11 @@ async def test_application_connect_refuses_without_fresh_rx(state: str) -> None:
         )
     if state == "old_generation":
         store.begin_provider_generation()
+    if state in ("read_only", "tx"):
+        radio.send_civ = AsyncMock()
     await poller.select_vfo_a_on_connect(read_only=state == "read_only")
+    if state in ("read_only", "tx"):
+        radio.send_civ.assert_not_awaited()
     _observe_ptt(store, False)
     await poller._send_query()
     assert radio.wire.sent_frames == []
@@ -777,8 +781,10 @@ async def test_application_connect_leaves_other_topologies_alone(
 
     poller, radio, store = connect_vfo_poller()
     poller._profile = replace(poller._profile, **overrides)
+    radio.send_civ = AsyncMock()
     _observe_ptt(store, False)
     await poller.select_vfo_a_on_connect(read_only=False)
+    radio.send_civ.assert_not_awaited()
     assert radio.wire.sent_frames == []
 
 
@@ -822,6 +828,72 @@ async def test_connection_reset_requires_new_rx_and_allows_one_new_select() -> N
     await poller.select_vfo_a_on_connect(read_only=False)
     assert len(radio.wire.sent_frames) == 10
     assert store.snapshot().field(FieldPath.active_slot("0")).value == "A"
+
+
+async def observe_connect_ptt_read(radio: ConnectVfoRadio, value: bool | None) -> None:
+    from rigplane.core.civ import CivFrame
+    from rigplane.commands import build_civ_frame
+
+    await radio.wire.send(build_civ_frame(0x94, 0xE0, 0x1C, sub=0))
+    if value is not None:
+        await radio._civ_runtime._route_civ_frame(
+            CivFrame(0xE0, 0x94, 0x1C, sub=0, data=bytes([int(value)])),
+            generation=radio._civ_epoch,
+            store_provider_generation=radio.state_store.provider_generation,
+        )
+
+
+@pytest.mark.parametrize("value", (False, True, None))
+@pytest.mark.parametrize("stale_ptt", (False, True))
+async def test_connect_rechecks_genuine_ptt_after_one_bounded_read(
+    value: bool | None,
+    stale_ptt: bool,
+) -> None:
+    poller, radio, store = connect_vfo_poller()
+    _observe_ptt(store, stale_ptt, observed_at=time.monotonic() - 5.0)
+
+    async def read(command: int, **kwargs: object) -> bool:
+        assert command == 0x1C
+        assert kwargs == {"sub": 0, "data": b"", "wait_response": True}
+        await observe_connect_ptt_read(radio, value)
+        return False
+
+    radio.send_civ = AsyncMock(side_effect=read)
+    await poller.select_vfo_a_on_connect(read_only=False)
+    await poller.select_vfo_a_on_connect(read_only=False)
+    radio.send_civ.assert_awaited_once()
+    assert radio.wire.sent_frames[0] == bytes.fromhex("fefe94e01c00fd")
+    assert len(radio.wire.sent_frames) == (6 if value is False else 1)
+    assert (str(FieldPath.active_slot("0")) in store.snapshot().as_dict()) is (
+        value is False
+    )
+
+
+@pytest.mark.parametrize("outcome", ("timeout", "new_generation"))
+async def test_connect_read_timeout_or_epoch_change_never_selects(outcome: str) -> None:
+    poller, radio, store = connect_vfo_poller()
+    entered, release = asyncio.Event(), asyncio.Event()
+    radio.send_civ = AsyncMock()
+
+    async def read(*args: object, **kwargs: object) -> None:
+        entered.set()
+        if outcome == "timeout":
+            await asyncio.Event().wait()
+        await release.wait()
+        radio._civ_epoch += 1
+        store.begin_provider_generation()
+        await observe_connect_ptt_read(radio, False)
+
+    radio.send_civ.side_effect = read
+    poller._VFO_CONNECT_PTT_TIMEOUT = 0.01
+    task = asyncio.create_task(poller.select_vfo_a_on_connect(read_only=False))
+    await asyncio.wait_for(entered.wait(), timeout=0.5)
+    await poller.select_vfo_a_on_connect(read_only=False)
+    release.set()
+    await task
+    radio.send_civ.assert_awaited_once()
+    assert all(frame[4] != 0x07 for frame in radio.wire.sent_frames)
+    assert str(FieldPath.active_slot("0")) not in store.snapshot().as_dict()
 
 
 async def test_teardown_drain_unkey_stays_outside_the_execute_seat() -> None:

--- a/tests/test_web_recovery_durable_off.py
+++ b/tests/test_web_recovery_durable_off.py
@@ -744,3 +744,43 @@ async def test_explicit_disconnect_connect_uses_the_same_new_epoch_policy() -> N
     assert len(radio.wire.sent_frames) == 5
     assert radio.selected == "A"
     assert radio.refetches == 1
+
+
+async def test_reconnect_with_ptt_aged_by_refetch_reads_rx_before_selecting_a() -> None:
+    from unittest.mock import AsyncMock
+    from test_radio_poller_tx_interlock import (
+        connect_vfo_poller,
+        _observe_ptt,
+        observe_connect_ptt_read,
+    )
+    from rigplane.core.state_pipeline_contracts import FieldPath
+
+    poller, radio, store = connect_vfo_poller()
+    server = WebServer(radio)
+    server._radio_poller = poller
+    radio._civ_epoch += 1
+    store.begin_provider_generation()
+
+    async def refetch() -> None:
+        _observe_ptt(store, False, observed_at=time.monotonic() - 2.0)
+
+    async def read(*args: object, **kwargs: object) -> None:
+        await observe_connect_ptt_read(radio, False)
+
+    radio._fetch_initial_state = refetch
+    radio.send_civ = AsyncMock(side_effect=read)
+    await _recover(server)
+    assert store.snapshot().field(FieldPath.active_slot("0")).value == "A"
+    assert radio.wire.sent_frames == [
+        bytes.fromhex(frame)
+        for frame in (
+            "fefe94e01c00fd",
+            "fefe94e00700fd",
+            "fefe94e02500fd",
+            "fefe94e02600fd",
+            "fefe94e02501fd",
+            "fefe94e02601fd",
+        )
+    ]
+    await _recover(server)
+    radio.send_civ.assert_awaited_once()


### PR DESCRIPTION
The installed Standard VFO pair grew to 246px when the complete IC-7300 shared facts and operations were present, leaving a large empty strip below both receiver cards. This compacts the center bridge into bounded grids and lets the active status strip wrap inside the card's reserved second line. The production-shaped browser regression measures a 185px row with 183px aligned cards at 1200px and 1700px, with every selector, SPLIT, A=B, A↔B, SPEAK, RX/TX digest, and card chip visible without overflow. At 900px the pair reflows while preserving every chip and leaves a measured 1.75px gap before the station meters.

This PR also carries the reviewed MOR-2426 reconnect correction. The original 51-query connection refresh could age the PTT observation until there was no admissible confirmed-RX proof for the select-A policy. When RX proof is stale or unavailable, the connection policy performs one bounded passive PTT refresh before selecting VFO A; fresh confirmed RX skips that read, and fresh TX skips the selection policy. Selection still fails closed unless the available observation reaches canonical ingress as confirmed RX.

Linear: MOR-2436, MOR-2426

Validation:
- `npm run check`
- `npm run lint`
- `npm run build`
- `npm run test:e2e:i18n -- tests/e2e/i18n/desktop-geometry.spec.ts` (46/46)
- focused 900/1024/1200/1700 compact-pair and 900 observed/unknown geometry cases (6/6)
- Backend slice: 269 focused tests plus mypy, ruff, and import checks (reviewed exact source commit `1db7a8c4bc0dc352087bff8602bffe099c9d4033`)
