### PR TITLE
fix(MOR-2437): keep panorama overlays during confirmed tuning

### DIFF
--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -157,17 +157,19 @@
     spectrumAuthority !== null && spectrumAuthority.frequencyHz !== null && spanHz > 0,
   );
   let scopeMode = $derived(frameScopeMode);
-  // Tuning indicator: center for CTR/SCROLL-C, proportional for FIX/SCROLL-F
   let isFixedScope = $derived(isFixedScopeFn(scopeMode));
   let displayTuple = $derived(!managedUnavailable && scopeProjection
     && (scopeProjection.passband.state === 'current' || scopeProjection.passband.state === 'stale')
     ? scopeProjection.passband.tuple : null);
   let displayStale = $derived(displayTuple !== null && scopeProjection?.passband.state === 'stale');
+  let translatedStale = $derived(scopeProjection?.passband.state === 'stale'
+    && scopeProjection.passband.translated === true);
+  let proportionalIndicator = $derived(isFixedScope || translatedStale);
   let displayFrequencyHz = $derived(managed ? displayTuple?.frequencyHz : spectrumAuthority?.frequencyHz);
   let tuneVisible = $derived(
     displayFrequencyHz !== null
       && displayFrequencyHz !== undefined
-      && (!isFixedScope || (
+      && (!proportionalIndicator || (
         displayFrequencyHz >= startFreq
         && displayFrequencyHz <= endFreq
       )),
@@ -217,7 +219,7 @@
       && canResizeFromRightEdge(spectrumAuthority.mode!),
   );
   let tuneLinePct = $derived(
-    isFixedScope && spanHz > 0 && tuneVisible
+    proportionalIndicator && spanHz > 0 && tuneVisible
       ? ((tuneHz - startFreq) / spanHz) * 100
       : 50
   );
@@ -238,7 +240,7 @@
     passbandShiftHz,
     refLevel,
     mode: rxMode,
-    scopeMode,
+    scopeMode: translatedStale ? 1 : scopeMode,
   });
 
   let waterfallOptions = $derived<WaterfallOptions>({
@@ -264,10 +266,9 @@
     : deriveFreqTicks(spanHz));
 
   // Passband overlay position derived from the same geometry as the spectrum renderer.
-  // In FIX mode pass tuneLinePct so passband follows the carrier indicator.
   let passbandOverlay = $derived(
     getPassbandGeometry(rxMode, passbandHz, passbandShiftHz, spanHz, 100,
-      isFixedScope ? tuneLinePct : undefined),
+      proportionalIndicator ? tuneLinePct : undefined),
   );
   let pbWidthPct = $derived(passbandOverlay?.widthPx ?? 0);
   let pbLeftPct = $derived(passbandOverlay?.leftPx ?? 0);

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -9,6 +9,10 @@ import { SvelteMap } from 'svelte/reactivity';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { ScopeDisplayProjection } from '$lib/runtime/adapters/scope-display-projection';
+import { EMPTY_SCOPE_PASSBAND_DISPLAY, projectScopePassbandDisplay,
+  type ScopePassbandDisplayInput } from '$lib/runtime/adapters/scope-passband-display';
+import { qualifyScopeFrameEnvelope, toScopeDisplayFrame } from '$lib/runtime/adapters/scope-adapter';
+import { resolveLcdSpectrumFrame } from '../../../skins/segmentline/lcd-display-contract';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
 
 // ---------------------------------------------------------------------------
@@ -1531,6 +1535,83 @@ describe('managed scope projection (MOR-2367)', () => {
     props.set('projection', projection('stale')); flushSync();
     pointer(window, 'pointerup', 84, 130);
     expect(target.querySelector('.passband-resize-zone')).toBeNull();
+    expect(handlerHarness.filter.onFilterWidthCommit).not.toHaveBeenCalled();
+  });
+  it('positions translated stale CENTER geometry on the live axis through frame lag and cancels resize', async () => {
+    const { target, props } = managed(projection()); const { waterfall } = prepareGeometry(target);
+    pointer(waterfall.querySelector('.passband-resize-zone')!, 'pointerdown', 89, 100);
+    pointer(waterfall, 'pointermove', 89, 130);
+    const initial = projection('stale');
+    if (initial.passband.state !== 'stale') throw new Error('stale fixture required');
+    const translated = { ...initial, passband: { ...initial.passband, translated: true,
+      tuple: { ...initial.passband.tuple, frequencyHz: 14_051_000 } } };
+    props.set('projection', translated); flushSync();
+    expect(target.querySelector<HTMLElement>('.tune-line')!.style.left).toBe('51%');
+    expect(target.querySelector<HTMLElement>('.passband-overlay')!.style.left).toBe('39%');
+    expect(target.querySelector<HTMLElement>('.passband-overlay')!.style.width).toBe('24%');
+    await vi.waitFor(() => expect(spectrumRendererHarness.lastOptions).toMatchObject({
+      tuneHz: 14_051_000, centerHz: 14_050_000, scopeMode: 1, passbandHz: 2400,
+    }));
+    pointer(window, 'pointerup', 89, 130);
+    expect(target.querySelector('.passband-resize-zone')).toBeNull();
+    expect(handlerHarness.filter.onFilterWidthCommit).not.toHaveBeenCalled();
+    props.set('projection', { ...translated, acceptedSequence: 2,
+      frame: { ...translated.frame, startHz: 14_001_000, endHz: 14_101_000 },
+      passband: { ...translated.passband, tuple: { ...translated.passband.tuple, startHz: 14_001_000, endHz: 14_101_000 } } });
+    flushSync();
+    expect(target.querySelector<HTMLElement>('.tune-line')!.style.left).toBe('50%');
+    expect(target.querySelector('.passband-overlay')).not.toBeNull();
+    expect(target.querySelector('.passband-resize-zone')).toBeNull();
+    expect(handlerHarness.vfo.onFreqChange).not.toHaveBeenCalled();
+  });
+  it('keeps projector-produced overlays through five seconds of fresh frames and staggered geometry readback', () => {
+    authorityHarness.state.useProductionSelector = true;
+    const state = structuredClone(IC7300_STATE); const caps = structuredClone(IC7300_CAPABILITIES);
+    const rx = state.main!;
+    Object.assign(rx, { freqHz: 14_074_000, mode: 'USB', filter: 1, activeSlot: 'A',
+      filterWidth: 2400, pbtInner: 128, pbtOuter: 128, dataMode: 0,
+      vfoA: { freqHz: 14_074_000, mode: 'USB', filterNum: 1, dataMode: 0 } });
+    const paths = ['main', ...Object.keys(rx).map((leaf) => `main.${leaf}`),
+      ...Object.keys(rx.vfoA!).map((leaf) => `main.vfoA.${leaf}`)];
+    state.fieldStatus = Object.fromEntries(paths.map((path) => [path, { storePath: path,
+      observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 10 }]));
+    runtimeHarness.state.currentState = state; runtimeHarness.state.currentCaps = caps;
+    const input: ScopePassbandDisplayInput = { state, caps, selection: { receiver: 'MAIN', slot: 'A' },
+      session: { state: 'connected', epoch: 1 }, frame: null };
+    let result = EMPTY_SCOPE_PASSBAND_DISPLAY; let sequence = 0;
+    const { target, props } = managed(null);
+    function present(now: number, center: number): void {
+      const envelope = qualifyScopeFrameEnvelope({ receiver: 0, mode: 0,
+        startFreq: center - 50_000, endFreq: center + 50_000, pixels: new Uint8Array([10, 100, 200]) },
+      { source: 'hardware', receiver: 0, providerGeneration: 1, transportEpoch: 1,
+        receivedAt: now, acceptedSequence: ++sequence }, 1)!;
+      const authority = { source: 'hardware' as const, receiver: 0 as const, providerGeneration: 1,
+        transportEpoch: 1, demanded: true, transport: 'connected' as const, nowMonotonic: now };
+      const frame = toScopeDisplayFrame(envelope, authority);
+      const resolution = resolveLcdSpectrumFrame(frame, { source: 'hardware', receiver: 'MAIN' });
+      input.frame = { envelope, authority, resolution }; result = projectScopePassbandDisplay(result, input);
+      props.set('projection', { frame, frameMode: 0, acceptedSequence: sequence, passband: result.display }); flushSync();
+    }
+    present(0, 14_074_000); expect(result.display.state).toBe('current');
+    rx.vfoA!.freqHz = 14_075_000; state.fieldStatus['main.vfoA.freqHz'].lastObservedMonotonic = 11;
+    present(100, 14_074_000);
+    expect(result.display.state).toBe('stale');
+    expect(target.querySelector<HTMLElement>('.tune-line')!.style.left).toBe('51%');
+    rx.freqHz = 14_075_000; state.fieldStatus['main.freqHz'].lastObservedMonotonic = 11.1;
+    for (let now = 200; now <= 5000; now += 100) {
+      present(now, 14_075_000);
+      expect(result.display.state).toBe('stale');
+      expect(target.querySelectorAll('.tune-line')).toHaveLength(1);
+      expect(target.querySelectorAll('.passband-overlay')).toHaveLength(1);
+      expect(target.querySelector('.passband-resize-zone')).toBeNull();
+    }
+    for (const [index, leaf] of ['filterWidth', 'pbtInner', 'pbtOuter'].entries()) {
+      state.fieldStatus[`main.${leaf}`].lastObservedMonotonic = 15.1 + index / 10;
+      present(5100 + index * 100, 14_075_000);
+      expect(result.display.state).toBe(index === 2 ? 'current' : 'stale');
+      expect(target.querySelector('.passband-overlay')).not.toBeNull();
+    }
+    expect(handlerHarness.vfo.onFreqChange).not.toHaveBeenCalled();
     expect(handlerHarness.filter.onFilterWidthCommit).not.toHaveBeenCalled();
   });
   it('pushes normalized managed frames through existing waterfall registrations on mount and recovery', () => {

--- a/frontend/src/lib/runtime/adapters/__tests__/scope-passband-display.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scope-passband-display.test.ts
@@ -6,6 +6,7 @@ import { getPassbandEdgesHz } from '../../../../components/spectrum/passband-geo
 import { resolveLcdSpectrumFrame } from '../../../../skins/segmentline/lcd-display-contract';
 import { qualifyScopeFrameEnvelope, toScopeDisplayFrame, toSpectrumAuthority } from '../scope-adapter';
 import { toRadioViewModel } from '../radio-view-model-adapter';
+import { IC7300_CAPABILITIES } from './fixtures/ic7300-profile';
 import { EMPTY_SCOPE_PASSBAND_DISPLAY, projectScopePassbandDisplay,
   type ScopePassbandDisplayInput, type ScopePassbandDisplayState } from '../scope-passband-display';
 
@@ -87,6 +88,114 @@ function pbt(input: ScopePassbandDisplayInput): void {
 function slotted(input: ScopePassbandDisplayInput): void {
   input.caps!.vfoScheme = 'ab'; input.selection = { receiver: 'MAIN', slot: 'A' };
 }
+
+function banded(): ScopePassbandDisplayInput {
+  const input = fixture(); slotted(input); pbt(input);
+  input.caps!.freqRanges = structuredClone(IC7300_CAPABILITIES.freqRanges);
+  receipt(input, 1, { startFreq: 14_024_000, endFreq: 14_124_000 });
+  return input;
+}
+function tune(input: ScopePassbandDisplayInput, frequency: number, marker: number, mirror = true): void {
+  input.state!.main!.vfoA!.freqHz = frequency;
+  status(input, 'main.vfoA.freqHz', { lastObservedMonotonic: marker });
+  if (mirror) {
+    input.state!.main!.freqHz = frequency;
+    status(input, 'main.freqHz', { lastObservedMonotonic: marker });
+  }
+}
+
+describe('confirmed tuning display continuity (MOR-2437)', () => {
+  it('keeps one translated stale shape through repeated steps and staggered 5s geometry observations', () => {
+    const input = banded(); let result = project(input);
+    for (const [frequency, marker] of [[14_075_000, 11], [14_076_000, 12]]) {
+      tune(input, frequency, marker); result = project(input, result);
+      expect(result.display.state).toBe('stale');
+      expect(tuple(result)).toMatchObject({ frequencyHz: frequency, widthHz: 2400, shiftHz: 0 });
+      receipt(input, marker, { startFreq: frequency - 50_000, endFreq: frequency + 50_000 });
+      result = project(input, result); expect(result.display.state).toBe('stale');
+    }
+    for (const [path, marker] of [['main.filterWidth', 15], ['main.pbtInner', 15.1], ['main.pbtOuter', 15.2]] as const) {
+      status(input, path, { lastObservedMonotonic: marker }); result = project(input, result);
+      expect(result.display.state).toBe(path === 'main.pbtOuter' ? 'current' : 'stale');
+      expect(tuple(result)).toMatchObject({ frequencyHz: 14_076_000, widthHz: 2400, shiftHz: 0 });
+    }
+    expect(result.floors).toBeNull();
+  });
+  it.each(['slot-first', 'active-first'])('survives %s frequency acknowledgments and lagging CENTER frames', (order) => {
+    const input = banded(); let result = project(input);
+    if (order === 'slot-first') tune(input, 14_075_000, 11, false);
+    else { input.state!.main!.freqHz = 14_075_000; status(input, 'main.freqHz', { lastObservedMonotonic: 11 }); }
+    result = project(input, result);
+    expect(result.display.state).toBe('stale'); expect(tuple(result).frequencyHz).toBe(14_075_000);
+    tune(input, 14_075_000, 12); result = project(input, result);
+    expect(result.display.state).toBe('stale');
+    receipt(input, 2, { startFreq: 14_025_000, endFreq: 14_125_000 }); result = project(input, result);
+    expect(result.display.state).toBe('stale'); expect(tuple(result).frequencyHz).toBe(14_075_000);
+    renew(input, 16, 3); expect(project(input, result).display.state).toBe('current');
+  });
+  it('does not use pending targets or stale frequency observations to translate', () => {
+    const input = banded(); const current = project(input);
+    Object.assign(input.state!, { pending: { frequencyHz: 14_090_000 } });
+    expect(tuple(project(input, current)).frequencyHz).toBe(14_074_000);
+    tune(input, 14_075_000, 11); stale(input, 'main.vfoA.freqHz');
+    expect(project(input, current).display.state).toBe('unknown');
+  });
+  const hard: [string, (i: ScopePassbandDisplayInput) => void][] = [
+    ['provider', (i) => { i.state!.providerGeneration = 2; i.caps!.providerGeneration = 2; receipt(i, 3); }],
+    ['caps', (i) => { i.caps!.filterWidthMax = 9000; }],
+    ['control epoch', (i) => { i.session!.epoch = 2; }],
+    ['scope epoch', (i) => { i.frame = { ...i.frame!, authority: { ...i.frame!.authority, transportEpoch: 2 } }; }],
+    ['receiver', (i) => { i.state!.active = 'SUB'; }],
+    ['slot', (i) => { i.selection!.slot = 'B'; i.state!.main!.activeSlot = 'B'; status(i, 'main.activeSlot', { lastObservedMonotonic: 12 }); }],
+    ['mode', (i) => { i.state!.main!.mode = 'LSB'; i.state!.main!.vfoA!.mode = 'LSB'; status(i, 'main.mode', { lastObservedMonotonic: 12 }); status(i, 'main.vfoA.mode', { lastObservedMonotonic: 12 }); }],
+    ['filter', (i) => { i.state!.main!.filter = 2; i.state!.main!.vfoA!.filterNum = 2; status(i, 'main.filter', { lastObservedMonotonic: 12 }); status(i, 'main.vfoA.filterNum', { lastObservedMonotonic: 12 }); }],
+    ['DATA', (i) => { i.state!.main!.dataMode = 1; status(i, 'main.dataMode', { lastObservedMonotonic: 12 }); }],
+    ['frame mode', (i) => receipt(i, 3, { mode: 1 })],
+    ['span', (i) => receipt(i, 3, { endFreq: 14_200_000 })],
+    ['band', (i) => tune(i, 18_100_000, 12)],
+    ['outside profile bands', (i) => tune(i, 15_000_000, 12)],
+    ['band definitions', (i) => { i.caps!.freqRanges[0].bands![5].end += 100; }],
+    ['stale frequency', (i) => stale(i, 'main.vfoA.freqHz')],
+    ['null frame', (i) => { i.frame = null; }],
+    ['500ms frame silence', (i) => { i.frame = { ...i.frame!, authority: { ...i.frame!.authority, nowMonotonic: 500 } }; }],
+    ['off', (i) => { i.frame = { ...i.frame!, authority: { ...i.frame!.authority, demanded: false } }; }],
+  ];
+  it.each(hard)('retires a translated tuple on %s without replay after return', (_name, change) => {
+    const input = banded(); let result = project(input); tune(input, 14_075_000, 11); result = project(input, result);
+    expect(result.display.state).toBe('stale');
+    const saved = structuredClone(input); change(input); result = project(input, result);
+    expect(result.display.state).toBe('unknown');
+    result = project(saved, result); expect(result.display.state).toBe('unknown');
+    result = project(saved, result); expect(result.display.state).toBe('unknown');
+    renew(saved, 20, 4); expect(project(saved, result).display.state).toBe('current');
+  });
+  it.each(['filterWidth', 'pbtInner', 'pbtOuter'] as const)('never mixes a partial changed %s with retained shape', (leaf) => {
+    const input = banded(); let result = project(input); tune(input, 14_075_000, 11); result = project(input, result);
+    input.state!.main![leaf]! += 10; status(input, `main.${leaf}`, { lastObservedMonotonic: 15 });
+    result = project(input, result); expect(result.display.state).toBe('unknown');
+    receipt(input, 3); result = project(input, result); expect(result.display.state).toBe('unknown');
+    renew(input, 16, 4); expect(project(input, result).display.state).toBe('current');
+  });
+  it.each([0, 1, 2, 3])('waits for matching CENTER axis but allows observed frequency within fixed mode %s', (mode) => {
+    const input = banded(); receipt(input, 1, { mode, startFreq: 14_024_000, endFreq: 14_124_000 });
+    let result = project(input); tune(input, 14_075_000, 11); result = project(input, result);
+    renew(input, 16, 2); result = project(input, result);
+    expect(result.display.state).toBe(mode === 1 || mode === 3 ? 'current' : 'stale');
+    if (mode === 0 || mode === 2) {
+      receipt(input, 3, { mode, startFreq: 14_025_000, endFreq: 14_125_000 });
+      result = project(input, result); expect(result.display.state).toBe('current');
+    }
+  });
+  it('keeps frequency source-backed when the next CENTER frame precedes both frequency acknowledgments', () => {
+    const input = banded(); let result = project(input);
+    receipt(input, 2, { startFreq: 14_025_000, endFreq: 14_125_000 }); result = project(input, result);
+    expect(result.display.state).toBe('stale'); expect(tuple(result).frequencyHz).toBe(14_074_000);
+    tune(input, 14_075_000, 11, false); result = project(input, result);
+    expect(result.display.state).toBe('stale'); expect(tuple(result).frequencyHz).toBe(14_075_000);
+    tune(input, 14_075_000, 12); result = project(input, result); expect(result.display.state).toBe('stale');
+    renew(input, 16, 3); expect(project(input, result).display.state).toBe('current');
+  });
+});
 
 describe('coherent RF passband display', () => {
   it.each(['USB', 'LSB', 'AM'])('retains complete %s edges through leaf/ancestor stale and equal current', (mode) => {

--- a/frontend/src/lib/runtime/adapters/scope-passband-display.ts
+++ b/frontend/src/lib/runtime/adapters/scope-passband-display.ts
@@ -1,6 +1,7 @@
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import { deriveIfShift, pbtRangeFromCaps, pbtRawToHz } from '$lib/radio/filter-controls';
+import { findActiveBand, flattenBands } from '$lib/radio/band-plan';
 import type { ScopeFramePresentation } from '../scope-frame-host';
 import { qualifyDisplayObservation, qualifyRadioDisplayObservation } from './display-observation';
 import { derivePresentationCapabilities, type ReceiverId } from './presentation-capabilities';
@@ -20,12 +21,13 @@ export interface ScopePassbandTuple {
   readonly endHz: number;
 }
 export type ScopePassbandDisplay =
-  | Readonly<{ state: 'current' | 'stale'; tuple: ScopePassbandTuple }>
+  | Readonly<{ state: 'current' | 'stale'; tuple: ScopePassbandTuple; translated?: true }>
   | Readonly<{ state: 'unknown'; reason: string }>
   | Readonly<{ state: 'unsupported' }>;
 export interface ScopePassbandDisplayState {
   readonly display: ScopePassbandDisplay;
   readonly identity: string | null;
+  readonly continuityIdentity: string | null;
   readonly domain: string | null;
   readonly observations: Observations;
   readonly geometryPaths: readonly string[];
@@ -43,7 +45,7 @@ const EMPTY_OBSERVATIONS: Observations = Object.freeze({});
 const EMPTY_PATHS: readonly string[] = Object.freeze([]);
 export const EMPTY_SCOPE_PASSBAND_DISPLAY: ScopePassbandDisplayState = Object.freeze({
   display: Object.freeze({ state: 'unknown', reason: 'not-observed' }),
-  identity: null, domain: null, observations: EMPTY_OBSERVATIONS,
+  identity: null, continuityIdentity: null, domain: null, observations: EMPTY_OBSERVATIONS,
   geometryPaths: EMPTY_PATHS, receipt: 0, floors: null,
 });
 const nonnegative = (n: unknown): n is number => typeof n === 'number' && Number.isFinite(n) && n >= 0;
@@ -61,13 +63,16 @@ function capabilityIdentity(caps: Capabilities): string {
   return JSON.stringify(canonical({
     scheme: caps.vfoScheme, receivers: caps.receivers, readback: caps.vfoReadback,
     tags: tags.filter((tag) => caps.capabilities.includes(tag)),
-    modes: caps.modes, filters: caps.filters, config: caps.filterConfig,
+    modes: caps.modes, filters: caps.filters, config: caps.filterConfig, bands: caps.freqRanges,
     min: caps.filterWidthMin, max: caps.filterWidthMax,
     pbt: caps.capabilities.includes('if_shift') ? undefined : caps.controls?.pbt_inner,
     shift: caps.capabilities.includes('if_shift') ? caps.controls?.if_shift : undefined,
   }));
 }
-interface Candidate { identity: string; tuple: ScopePassbandTuple; stale: boolean; strict: boolean }
+interface Candidate {
+  identity: string; continuityIdentity: string | null; tuple: ScopePassbandTuple;
+  stale: boolean; strict: boolean; frequencyCurrent: boolean; frequencyAligned: boolean;
+}
 interface Inspection {
   candidate: Candidate | null;
   domain: string | null;
@@ -110,12 +115,14 @@ function inspect(input: ScopePassbandDisplayInput): Inspection {
   result.geometryPaths = geometryFields.map((leaf) => `${key}.${leaf}`);
   let invalid = false;
   let stale = false;
+  const currentPaths = new Set<string>();
   function read<T extends Scalar>(path: string, value: T | undefined, radio = false): T | undefined {
     const args = { state, caps, path, value, structural: true };
     const observation = radio ? qualifyRadioDisplayObservation(args)
       : qualifyDisplayObservation({ ...args, receiver: selection!.receiver });
     if (observation.state !== 'current' && observation.state !== 'stale') { invalid = true; return undefined; }
     stale ||= observation.state === 'stale';
+    if (observation.state === 'current') currentPaths.add(path);
     result.observations[path] = Object.freeze({ value: observation.value,
       marker: state!.fieldStatus![path].lastObservedMonotonic! });
     for (let prefix = path; prefix.includes('.');) {
@@ -139,14 +146,25 @@ function inspect(input: ScopePassbandDisplayInput): Inspection {
   } else if (selection.slot !== 'single') return result;
   const position = slotted ? (selection.slot === 'A' ? rx.vfoA : rx.vfoB) : rx;
   const base = slotted ? `${key}.${selection.slot === 'A' ? 'vfoA' : 'vfoB'}` : key;
-  const frequency = read(`${base}.freqHz`, position?.freqHz);
+  let frequency = read(`${base}.freqHz`, position?.freqHz);
+  let frequencyAligned = true;
+  let frequencyCurrent = currentPaths.has(`${base}.freqHz`);
   const mode = modeName(read(`${base}.mode`, position?.mode));
   const filter = read(`${base}.${slotted ? 'filterNum' : 'filter'}`,
     slotted ? (selection.slot === 'A' ? rx.vfoA?.filterNum : rx.vfoB?.filterNum) ?? undefined : rx.filter ?? undefined);
   if (slotted) {
     if (modeName(read(`${key}.mode`, rx.mode)) !== mode
-      || read(`${key}.filter`, rx.filter ?? undefined) !== filter
-      || read(`${key}.freqHz`, rx.freqHz) !== frequency) invalid = true;
+      || read(`${key}.filter`, rx.filter ?? undefined) !== filter) invalid = true;
+    const mirror = read(`${key}.freqHz`, rx.freqHz);
+    frequencyAligned = mirror === frequency;
+    frequencyCurrent &&= currentPaths.has(`${key}.freqHz`);
+    if (!frequencyAligned) {
+      const selectedMarker = result.observations[`${base}.freqHz`]?.marker;
+      const mirrorMarker = result.observations[`${key}.freqHz`]?.marker;
+      if (!positive(mirror) || selectedMarker === undefined || mirrorMarker === undefined
+        || selectedMarker === mirrorMarker) invalid = true;
+      else if (mirrorMarker > selectedMarker) frequency = mirror;
+    }
   }
   const data = has('data_mode') ? read(`${key}.dataMode`, rx.dataMode) : 'structurally-unsupported';
   const shiftHz = native ? shift : validScale && inner !== undefined && outer !== undefined
@@ -178,11 +196,18 @@ function inspect(input: ScopePassbandDisplayInput): Inspection {
   const tuple = Object.freeze({ frequencyHz: frequency, mode, widthHz: width, shiftHz,
     frameMode: frame.mode, startHz: frame.startFreq, endHz: frame.endFreq });
   const strict = stale ? null : toSpectrumAuthority(state, caps);
+  const band = findActiveBand(frequency, caps.freqRanges ?? []);
+  const partition = flattenBands(caps.freqRanges ?? []).find((entry) =>
+    entry.name === band && frequency >= entry.start && frequency <= entry.end);
+  const context = [state.providerGeneration, capabilityIdentity(caps), session.epoch,
+    selection.receiver, selection.slot, mode, filter, data, 'hardware',
+    envelope.transportEpoch, frame.mode];
   result.candidate = {
-    tuple, stale, identity: JSON.stringify([state.providerGeneration, capabilityIdentity(caps), session.epoch,
-      selection.receiver, selection.slot, frequency, mode, filter, data, 'hardware',
-      envelope.transportEpoch, frame.mode, frame.startFreq, frame.endFreq]),
-    strict: !!strict && strict.receiver === receiver && strict.frequencyHz === frequency
+    tuple, stale, frequencyCurrent, frequencyAligned,
+    identity: JSON.stringify([...context, frequency, frame.startFreq, frame.endFreq]),
+    continuityIdentity: !partition ? null
+      : JSON.stringify([...context, partition.name, partition.start, partition.end, frame.endFreq - frame.startFreq]),
+    strict: frequencyAligned && !!strict && strict.receiver === receiver && strict.frequencyHz === frequency
       && modeName(strict.mode ?? undefined) === mode && strict.filter === `FIL${filter}`
       && strict.filterWidthHz === width && strict.ifShiftHz === shiftHz
       && (!has('data_mode') || strict.dataMode === data),
@@ -218,13 +243,19 @@ export function projectScopePassbandDisplay(
   const changedGeometry = next.geometryPaths.some((path) =>
     next.observations[path]?.value !== previous.observations[path]?.value);
   const receiptRegression = candidate !== null && next.receipt < previous.receipt;
-  const invalid = !candidate || regression || receiptRegression || (!candidate.stale && !candidate.strict)
-    || (candidate.stale && changedGeometry);
   const hasTuple = active(previous.display);
+  const wasTranslated = hasTuple && previous.display.translated === true;
+  const invalid = !candidate || regression || receiptRegression || (!candidate.stale && !candidate.strict)
+    || ((candidate.stale || wasTranslated) && changedGeometry) || (wasTranslated && !candidate.frequencyCurrent);
+  const canTranslate = hasTuple && candidate !== null && candidate.continuityIdentity !== null
+    && candidate.continuityIdentity === previous.continuityIdentity
+    && candidate.frequencyCurrent && !regression && !receiptRegression && !changedGeometry
+    && (candidate.stale || candidate.strict || !candidate.frequencyAligned);
+  const translating = canTranslate && (changedIdentity || wasTranslated);
   const domainChange = previous.floors !== null && next.domain !== null && previous.floors.domain !== next.domain;
-  const retire = (hasTuple && (invalid || changedIdentity)) || changedIdentity || domainChange;
+  const retire = ((hasTuple && (invalid || changedIdentity)) || changedIdentity) && !translating || domainChange;
   let floors = previous.floors;
-  if (retire) {
+  if (retire || (translating && (!wasTranslated || candidate.tuple.frequencyHz !== tupleOf(previous.display).frequencyHz))) {
     const domain = next.domain ?? previous.domain;
     floors = Object.freeze({ domain, receipt: Math.max(previous.receipt, next.receipt),
       geometry: mergeMarkers(
@@ -236,10 +267,16 @@ export function projectScopePassbandDisplay(
   const crossedFloors = !floors || (floors.domain === next.domain && next.receipt > floors.receipt
     && next.geometryPaths.every((path) => next.observations[path]
       && next.observations[path].marker > (floors.geometry[path] ?? -1)));
-  const canRetain = hasTuple && !retire && !invalid;
+  const axisAligned = candidate && (candidate.tuple.frameMode === 1 || candidate.tuple.frameMode === 3
+    || candidate.tuple.frequencyHz === (candidate.tuple.startHz + candidate.tuple.endHz) / 2);
+  const canRetain = hasTuple && !retire && !invalid && !translating;
   const canCapture = candidate && !candidate.stale && candidate.strict && !regression
     && !receiptRegression && !retire && crossedFloors;
-  const display: ScopePassbandDisplay = canRetain || canCapture
+  const display: ScopePassbandDisplay = translating
+    ? crossedFloors && axisAligned && !candidate.stale && candidate.strict
+      ? { state: 'current', tuple: candidate.tuple }
+      : { state: 'stale', tuple: candidate.tuple, translated: true }
+    : canRetain || canCapture
     ? { state: candidate!.stale ? 'stale' : 'current',
       tuple: canRetain && !changedGeometry ? tupleOf(previous.display) : candidate!.tuple }
     : next.unsupported ? { state: 'unsupported' }
@@ -253,10 +290,11 @@ export function projectScopePassbandDisplay(
   }
   return Object.freeze({
     display: Object.freeze(display), identity: candidate?.identity ?? previous.identity,
+    continuityIdentity: candidate?.continuityIdentity ?? null,
     domain: next.domain ?? previous.domain,
     observations: Object.freeze(observations),
     geometryPaths: Object.freeze([...next.geometryPaths]), receipt: Math.max(previous.receipt, next.receipt),
-    floors: active(display) ? null : floors,
+    floors: active(display) && !display.translated ? null : floors,
   });
 }
 function tupleOf(display: ScopePassbandDisplay): ScopePassbandTuple {


### PR DESCRIPTION
Keyboard tuning could remove the panorama frequency marker and filter passband until the next geometry readback. Preserve a coherent display-only stale tuple across confirmed frequency and CENTER-axis translations within the same profile band and unchanged radio/scope context. Position both canvas and DOM overlays against the live axis while CENTER frames catch up.

Geometry and frame observation floors remain required for current promotion; changed width/PBT, hard context changes, expired/off/null frames and lost frequency freshness retire the tuple. Existing stale resize guards and canonical RF authority remain unchanged.

Linear: MOR-2437 (child MOR-2367).

Validation: 302 focused projector/component tests pass, including a production-projector-to-mounted-panel sequence with five seconds of fresh frames and staggered geometry readback; npm run check passes with 0 errors/0 warnings; focused ESLint and git diff --check pass. Initial continuity/DOM RED reproduction produced 21 failures; additional frame-lag and stale-frequency regressions were also reproduced before their fixes.

Independent exact-head review PASS; required quick and visual checks PASS. Repository ruff check also PASS. Installed owner-present acceptance remains pending; this PR does not claim hardware acceptance.
