### PR TITLE
fix(MOR-1895): release bounded acknowledged command bookkeeping

### DIFF
--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -64,6 +64,8 @@ _UNSET = object()
 _MAX_ACTIVE_COMMANDS = 128
 _MAX_READBACK_EXPECTATIONS = 128
 _READBACK_EXPECTATION_GRACE_SECONDS = 2.0
+# ACK stays dispatchable for late queue callbacks. Its active bookkeeping uses
+# the existing overlay/readback windows, without implying terminal success.
 _DISPATCHABLE_LIFECYCLE_STATES = ("accepted", "queued", "sent", "acknowledged")
 _NORMALIZED_LEVEL_EXPECTATION_COMMANDS = {
     "set_af_level": "af_level",
@@ -457,6 +459,7 @@ class CommandService:
     ) -> CommandLifecycleEvent:
         """Record and publish a lifecycle event for an intent."""
 
+        self._purge_expired()
         payload_details = dict(details or {})
         if "session_id" in intent.params:
             payload_details["session_id"] = _session_id(intent)
@@ -474,14 +477,26 @@ class CommandService:
             while key not in self._active_commands and (
                 len(self._active_commands) >= _MAX_ACTIVE_COMMANDS
             ):
-                oldest = next(iter(self._active_commands))
-                self.fail_command(
-                    oldest[2],
-                    source=oldest[0],
-                    session_id=oldest[1],
-                    message="active command capacity exceeded",
+                acknowledged = next(
+                    (
+                        item
+                        for item, active in self._active_commands.items()
+                        if active.state == "acknowledged"
+                    ),
+                    None,
                 )
+                oldest = acknowledged or next(iter(self._active_commands))
+                self._active_commands.pop(oldest)
+                if acknowledged is None:
+                    self.fail_command(
+                        oldest[2],
+                        source=oldest[0],
+                        session_id=oldest[1],
+                        message="active command capacity exceeded",
+                    )
             self._active_commands[key] = event
+            if state == "acknowledged":
+                self._purge_expired()
         else:
             self._active_commands.pop(key, None)
         self._events.append(event)
@@ -851,6 +866,13 @@ class CommandService:
             for overlay in self._readback_expectations
             if not overlay.is_expired(now)
         ]
+        retained = {
+            (overlay.source, overlay.session_id, overlay.command_id)
+            for overlay in (*self._overlays, *self._readback_expectations)
+        }
+        for key, event in tuple(self._active_commands.items()):
+            if event.state == "acknowledged" and key not in retained:
+                self._active_commands.pop(key)
 
     def _last_event(
         self,

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -111,6 +111,148 @@ def _states(events: Sequence[CommandLifecycleEvent]) -> list[str]:
     return [event.state for event in events]
 
 
+@pytest.mark.parametrize("source", ["websocket", "rigctld", "public_api", "http"])
+async def test_successful_acknowledgments_release_existing_confirmation_window(
+    source: str,
+) -> None:
+    clock = FreshnessClock(start=10.0)
+    service = CommandService(
+        executor=FakeExecutor(), state_store=StateStore(), clock=clock.now
+    )
+    for index in range(260):
+        await service.execute(_intent(command_id=str(index), source=source))
+        assert len(service._active_commands) <= 1  # noqa: SLF001
+        clock.advance(10)
+        assert (
+            service.pending_overlays(
+                source=cast(CommandSource, source), session_id="ws-a"
+            )
+            == ()
+        )
+        assert service._active_commands == {}  # noqa: SLF001
+    assert not [
+        event for event in service.lifecycle_events() if event.state == "failed"
+    ]
+
+
+async def test_ack_without_readback_expectations_releases_bookkeeping_without_terminal_claim() -> (
+    None
+):
+    service = CommandService(executor=FakeExecutor(), state_store=StateStore())
+    result = await service.execute(
+        replace(_intent(), pending_policy="none", expected_observations=())
+    )
+    assert _states(result.lifecycle_events) == [
+        "accepted",
+        "queued",
+        "sent",
+        "acknowledged",
+    ]
+    assert service._active_commands == {}  # noqa: SLF001
+    assert (
+        service.retain_readback_expectations_for_dispatch(
+            source="websocket", session_id="ws-a", command_id="cmd-1"
+        )
+        == ()
+    )
+    assert service.fail_command(
+        "cmd-1", source="websocket", session_id="ws-a", message="late queue NAK"
+    )
+    assert service.lifecycle_events()[-1].message == "late queue NAK"
+
+
+async def test_next_admission_purges_expired_ack_without_a_metadata_reader() -> None:
+    clock = FreshnessClock(start=10.0)
+    service = CommandService(
+        executor=FakeExecutor(), state_store=StateStore(), clock=clock.now
+    )
+    for index in range(260):
+        await service.execute(_intent(command_id=str(index)))
+        assert len(service._active_commands) == 1  # noqa: SLF001
+        clock.advance(10)
+    assert not [
+        event for event in service.lifecycle_events() if event.state == "failed"
+    ]
+
+
+async def test_capacity_sheds_ack_bookkeeping_but_preserves_late_failure_and_correlated_readback() -> (
+    None
+):
+    clock = FreshnessClock(start=10.0)
+    service = CommandService(
+        executor=FakeExecutor(), state_store=StateStore(), clock=clock.now
+    )
+    for index in range(130):
+        await service.execute(_intent(command_id=str(index)))
+    assert len(service._active_commands) <= 128  # noqa: SLF001
+    assert not [
+        event for event in service.lifecycle_events() if event.state == "failed"
+    ]
+    assert ("websocket", "ws-a", "0") not in service._active_commands  # noqa: SLF001
+    assert service.fail_command(
+        "0", source="websocket", session_id="ws-a", message="actual queue failure"
+    )
+    service.apply_observation(
+        _observation(_freq_path(), 14_074_000, at=10.1, correlation_id="1")
+    )
+    assert [
+        (event.command_id, event.state) for event in service.lifecycle_events()[-2:]
+    ] == [("0", "failed"), ("1", "reconciled")]
+
+
+@pytest.mark.parametrize("timeout", [0.0, 2.0, 10.0])
+async def test_ack_retention_uses_existing_expectation_expiry_including_dispatch_refresh(
+    timeout: float,
+) -> None:
+    clock = FreshnessClock(start=10.0)
+    service = CommandService(
+        executor=FakeExecutor(), state_store=StateStore(), clock=clock.now
+    )
+    await service.execute(replace(_intent(), timeout=timeout))
+    key = ("websocket", "ws-a", "cmd-1")
+    scope = {"source": "websocket", "session_id": "ws-a", "command_id": "cmd-1"}
+    expectations = service.readback_expectations(**scope)
+    deadline = max(item.expires_at_monotonic for item in expectations)
+    clock.advance(deadline - clock.now() - 0.01)
+    assert service.readback_expectations(**scope)
+    assert key in service._active_commands  # noqa: SLF001
+    retained = service.retain_readback_expectations_for_dispatch(**scope)
+    assert retained
+    clock.advance(max(item.expires_at_monotonic for item in retained) - clock.now())
+    assert service.readback_expectations(**scope) == ()
+    assert key not in service._active_commands  # noqa: SLF001
+    assert service.lifecycle_events()[-1].state == "acknowledged"
+
+
+async def test_ack_window_keeps_same_id_issuers_separate_and_poll_value_is_not_confirmation() -> (
+    None
+):
+    clock = FreshnessClock(start=10.0)
+    service = CommandService(
+        executor=FakeExecutor(), state_store=StateStore(), clock=clock.now
+    )
+    for source, session in [
+        ("websocket", "ws-a"),
+        ("websocket", "ws-b"),
+        ("rigctld", "ws-a"),
+    ]:
+        await service.execute(_intent(source=source, session_id=session))
+    service.apply_observation(
+        _observation(_freq_path(), 14_074_000, at=10.1, correlation_id=None)
+    )
+    assert len(service._active_commands) == 3  # noqa: SLF001
+    assert (
+        service.terminate_active_commands(
+            "session invalidated", source="websocket", session_id="ws-a"
+        )
+        == 1
+    )
+    assert len(service._active_commands) == 2  # noqa: SLF001
+    clock.advance(10)
+    service.pending_overlays(source="websocket", session_id="ws-b")
+    assert service._active_commands == {}  # noqa: SLF001
+
+
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_execute_emits_lifecycle_events_and_applies_response_observations() -> (
     None

--- a/tests/test_command_service_lifecycle_invalidation.py
+++ b/tests/test_command_service_lifecycle_invalidation.py
@@ -10,6 +10,8 @@ from rigplane.core.command_service import (
 )
 from rigplane.core.state_pipeline_contracts import (
     CommandIntent,
+    CommandLifecycleEvent,
+    CommandLifecycleState,
     CommandSource,
     FieldPath,
     Observation,
@@ -79,7 +81,16 @@ def _intent(
 
 def test_terminate_active_commands_is_exact_scoped_and_idempotent() -> None:
     service, _ = _service()
-    emit = service.emit_lifecycle
+
+    def emit(
+        intent: CommandIntent,
+        state: CommandLifecycleState,
+        *,
+        details: dict[str, str] | None = None,
+    ) -> CommandLifecycleEvent:
+        service._record_intent_overlay(intent)  # noqa: SLF001
+        return service.emit_lifecycle(intent, state, details=details)
+
     terminate = service.terminate_active_commands
     states = ("accepted", "queued", "sent", "acknowledged")
     for command_id, state in zip("aqsk", states, strict=True):
@@ -201,7 +212,7 @@ def test_active_command_registry_is_bounded_and_terminal_entries_do_not_leak() -
     service, _ = _service()
     for index in range(128):
         service.emit_lifecycle(_intent(str(index), "websocket", "ws-a"), "accepted")
-    service.emit_lifecycle(_intent("0", "websocket", "ws-a"), "acknowledged")
+    service.emit_lifecycle(_intent("0", "websocket", "ws-a"), "sent")
 
     def refill(event: object) -> None:
         if getattr(event, "message", None) == "active command capacity exceeded":
@@ -214,3 +225,25 @@ def test_active_command_registry_is_bounded_and_terminal_entries_do_not_leak() -
     assert [event.command_id for event in evicted] == ["0", "1"]
     service.terminate_active_commands("shutdown")
     assert service._active_commands == {}  # noqa: SLF001
+
+
+def test_capacity_removes_stale_registry_entry_even_when_failure_cannot_be_emitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _ = _service()
+    for index in range(128):
+        service.emit_lifecycle(_intent(str(index), "websocket", "ws-a"), "sent")
+    calls = 0
+
+    def already_terminal(*args: object, **kwargs: object) -> bool:
+        nonlocal calls
+        calls += 1
+        assert calls <= 1, (
+            "capacity loop retried an entry whose history is already terminal"
+        )
+        return False
+
+    monkeypatch.setattr(CommandService, "fail_command", already_terminal)
+    service.emit_lifecycle(_intent("next", "websocket", "ws-a"), "accepted")
+    assert calls == 1
+    assert len(service._active_commands) == 128  # noqa: SLF001


### PR DESCRIPTION
Long-lived command service sessions kept acknowledged commands in the active registry after their confirmation metadata expired. At 128 entries, each new command published an `active command capacity exceeded` failure for an old acknowledged command, even while the new command proceeded.

Bound ACK bookkeeping to existing overlay/readback expectation windows and release ACKs without expectations immediately. Capacity pressure sheds ACK bookkeeping without inventing failure or confirmed success. Lifecycle history and readback expectations remain available for genuine late queue failures and correlated readback; in-progress sent-event invalidation and pressure failures remain intact.

Linear: MOR-1895.

Validation: 1137 focused Web/rigctld/runtime seat tests pass, including long-running success, late failure/readback after ACK shedding, exact issuer scoping, existing reentrant pressure and MOR1882 invalidation/ERJCTED coverage. Initial retention RED: 10 failures; separate false-retirement retry RED reproduced. Ruff, import contracts and standard web mypy pass. Extra strict core-file mypy retains 8 pre-existing diagnostics in untouched helpers, verified against the baseline source.

Independent exact-head code review and mechanism-audit PASS; required quick PASS. Installed acceptance is a separate gate; no hardware or service actions performed by this builder.
