### PR TITLE
Fix managed TX refresh continuity

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -302,7 +302,7 @@
       state?.active, state?.main?.dataMode, state?.sub?.dataMode, state?.txTarget, state?.fieldStatus,
       caps?.tx, caps?.audioTx, caps?.audioTxRequiredModInputSource, caps?.capabilities, caps?.vfoScheme, caps?.txBands,
     ]);
-    if (txAuthorityReady) txHost.refreshAuthority();
+    if (txAuthorityReady) txHost.refreshAuthority(state?.providerGeneration ?? null);
   });
 
   onMount(() => {

--- a/frontend/src/lib/runtime/tx-controller/__tests__/app-host.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/app-host.test.ts
@@ -77,6 +77,7 @@ describe('managed App TX host', () => {
   it('registers one lifecycle owner, refreshes on connect, and unregisters exactly once', async () => {
     const host = provideManagedAppTxHost(bindings());
     expect([h.session, h.lifecycle, h.barrier].every(Boolean)).toBe(true);
+    host.refreshAuthority(3);
     h.session!({ state: 'connected', epoch: 4 });
     await flush();
     expect(h.refresh).toHaveBeenCalledTimes(1);
@@ -125,7 +126,7 @@ describe('managed App TX host', () => {
     getManagedAppTxController().transmitOn();
     await vi.waitFor(() => expect(h.submit).toHaveBeenCalledWith('transmit_on'));
     h.state = { ...idle(), phase: 'active', intent: 'latched', radioTx: 'on', releaseRequired: true };
-    host.refreshAuthority();
+    host.refreshAuthority(3);
     await flush();
     if (release === 'lifecycle') h.lifecycle!();
     if (release === 'pre-disconnect') await h.barrier!();
@@ -164,10 +165,108 @@ describe('managed App TX host', () => {
       .map((mock) => mock.mock.calls.length);
     h.session!({ state: 'connected', epoch: 6 }); h.lifecycle!(); await h.barrier!();
     facade.pttOn(); facade.pttOff(); facade.transmitOn(); facade.forceOff();
-    await facade.setTot(240); host.refreshAuthority();
+    await facade.setTot(240); host.refreshAuthority(3);
     await flush();
     expect([h.refresh, h.sendPtt, h.submit, h.setTot, h.startAudio]
       .map((mock) => mock.mock.calls.length)).toEqual(counts);
+  });
+
+  it('invalidates immediately across provider and control-session boundaries', async () => {
+    const host = provideManagedAppTxHost(bindings());
+    host.refreshAuthority(3);
+    expect(h.invalidate).toHaveBeenCalledTimes(1);
+    expect(h.refresh).not.toHaveBeenCalled();
+
+    h.session!({ state: 'connected', epoch: 4 });
+    await flush();
+    expect(h.invalidate).toHaveBeenCalledTimes(2);
+    expect(h.refresh).toHaveBeenCalledTimes(1);
+
+    host.refreshAuthority(3);
+    await flush();
+    expect(h.invalidate).toHaveBeenCalledTimes(2);
+    expect(h.refresh).toHaveBeenCalledTimes(2);
+
+    host.refreshAuthority(5);
+    await flush();
+    expect(h.invalidate).toHaveBeenCalledTimes(3);
+    expect(h.refresh).toHaveBeenCalledTimes(3);
+
+    h.session!({ state: 'connected', epoch: 6 });
+    await flush();
+    expect(h.invalidate).toHaveBeenCalledTimes(4);
+    expect(h.refresh).toHaveBeenCalledTimes(4);
+    host.dispose();
+  });
+
+  it('dispatches one explicit TRANSMIT intent while a background refresh is pending', async () => {
+    let resolveRefresh!: () => void;
+    h.refresh.mockImplementationOnce(() => new Promise<void>((resolve) => { resolveRefresh = resolve; }));
+    h.submit.mockResolvedValueOnce('rejected');
+    const host = provideManagedAppTxHost(bindings());
+    host.refreshAuthority(3);
+    h.session!({ state: 'connected', epoch: 4 });
+    await flush();
+
+    expect(h.refresh).toHaveBeenCalledTimes(1);
+    expect(h.submit).not.toHaveBeenCalled();
+    getManagedAppTxController().transmitOn();
+    await vi.waitFor(() => expect(h.submit).toHaveBeenCalledExactlyOnceWith('transmit_on'));
+    expect(h.sendPtt).not.toHaveBeenCalled();
+    expect(getManagedAppTxController().snapshot()).toMatchObject({ phase: 'idle', fresh: true });
+
+    resolveRefresh();
+    await flush();
+    expect(h.submit).toHaveBeenCalledTimes(1);
+    host.dispose();
+  });
+
+  it('coalesces repeated background refresh requests and performs one trailing read', async () => {
+    let resolveRefresh!: () => void;
+    h.refresh.mockImplementationOnce(() => new Promise<void>((resolve) => { resolveRefresh = resolve; }));
+    const host = provideManagedAppTxHost(bindings());
+    host.refreshAuthority(3);
+    h.session!({ state: 'connected', epoch: 4 });
+    host.refreshAuthority(3);
+    host.refreshAuthority(3);
+    expect(h.refresh).toHaveBeenCalledTimes(1);
+
+    resolveRefresh();
+    await flush();
+    expect(h.refresh).toHaveBeenCalledTimes(2);
+    host.dispose();
+  });
+
+  it('does not launch a queued refresh after disposal', async () => {
+    let resolveRefresh!: () => void;
+    h.refresh.mockImplementationOnce(() => new Promise<void>((resolve) => { resolveRefresh = resolve; }));
+    const host = provideManagedAppTxHost(bindings());
+    host.refreshAuthority(3);
+    h.session!({ state: 'connected', epoch: 4 });
+    host.refreshAuthority(3);
+    expect(h.refresh).toHaveBeenCalledTimes(1);
+
+    host.dispose();
+    resolveRefresh();
+    await flush();
+    expect(h.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates disconnect synchronously and fences its late cleanup after reconnect', async () => {
+    const host = provideManagedAppTxHost(bindings());
+    host.refreshAuthority(3);
+    h.session!({ state: 'connected', epoch: 4 });
+    await flush();
+    expect(h.invalidate).toHaveBeenCalledTimes(2);
+
+    h.session!({ state: 'disconnected', epoch: 5 });
+    expect(h.invalidate).toHaveBeenCalledTimes(3);
+    h.session!({ state: 'connected', epoch: 6 });
+    expect(h.invalidate).toHaveBeenCalledTimes(4);
+    await flush();
+    expect(h.invalidate).toHaveBeenCalledTimes(4);
+    expect(h.refresh).toHaveBeenCalledTimes(2);
+    host.dispose();
   });
 
   it('routes fractional and disabled TOT edits through the stable facade', async () => {

--- a/frontend/src/lib/runtime/tx-controller/__tests__/app-host.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/app-host.test.ts
@@ -291,15 +291,36 @@ describe('managed App TX host', () => {
     const facade = getManagedAppTxController();
     let published: ManagedTxState | undefined;
     facade.subscribe((state) => { published = state; });
-    h.setTot.mockRejectedValueOnce(new Error('write failed'));
-    h.invalidate.mockImplementationOnce(() => {
+    h.setTot.mockImplementationOnce(async () => {
       h.state = { ...h.state, fresh: false, configuredSeconds: null };
+      h.invalidate();
+      throw new Error('write failed');
     });
 
     await expect(facade.setTot(240)).rejects.toThrow('write failed');
 
     expect(h.invalidate).toHaveBeenCalledTimes(1);
     expect(published).toMatchObject({ fresh: false, configuredSeconds: null });
+    host.dispose();
+    await flush();
+  });
+
+  it('does not retire a newer projection after the TOT dependency reports its handled failure', async () => {
+    const host = provideManagedAppTxHost(bindings());
+    const facade = getManagedAppTxController();
+    h.setTot.mockImplementationOnce(async () => {
+      h.invalidate();
+      h.state = { ...h.state, fresh: false, configuredSeconds: null };
+      queueMicrotask(() => {
+        h.state = { ...idle(), configuredSeconds: 300 };
+      });
+      throw new Error('old context write failed');
+    });
+
+    await expect(facade.setTot(240)).rejects.toThrow('old context write failed');
+
+    expect(h.invalidate).toHaveBeenCalledTimes(1);
+    expect(facade.snapshot()).toMatchObject({ fresh: true, configuredSeconds: 300 });
     host.dispose();
     await flush();
   });

--- a/frontend/src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts
@@ -11,7 +11,7 @@ const h = vi.hoisted(() => ({
   initMedia: vi.fn(),
   destroyMedia: vi.fn(),
   resolveSkin: vi.fn(),
-  radio: null as { stateRevision: number; freshnessRevision: number; observationSeq: number; ptt: boolean } | null,
+  radio: null as { stateRevision: number; freshnessRevision: number; observationSeq: number; ptt: boolean; providerGeneration: number } | null,
   caps: null as { tx: boolean; capabilities: string[] } | null,
   notifyRuntime: () => {},
   barrier: undefined as (() => Promise<void>) | undefined,
@@ -88,7 +88,7 @@ beforeEach(() => {
   h.barrier = undefined;
   h.host = undefined;
   h.inFlight = null;
-  h.radio = { stateRevision: 1, freshnessRevision: 1, observationSeq: 1, ptt: false };
+  h.radio = { stateRevision: 1, freshnessRevision: 1, observationSeq: 1, ptt: false, providerGeneration: 3 };
   h.caps = { tx: true, capabilities: ['tx'] };
   document.body.innerHTML = '';
   Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1200 });
@@ -137,6 +137,7 @@ describe('App TX lifecycle', () => {
     await settle();
     expect(h.provide).toHaveBeenCalledOnce();
     expect(h.host!.refreshAuthority).toHaveBeenCalledOnce();
+    expect(h.host!.refreshAuthority).toHaveBeenLastCalledWith(3);
     // MOR-2425 C1 PR-2 follow-up: the loaded presentation (SpectrumPanelStub,
     // via `loadSkin`) must actually be in the mounted tree, not merely
     // implied by the TX-host assertions above — AppGlobalHost and

--- a/frontend/src/lib/runtime/tx-controller/managed-app-host.ts
+++ b/frontend/src/lib/runtime/tx-controller/managed-app-host.ts
@@ -14,7 +14,7 @@ export type ManagedAppTxController = Readonly<{
   setTot(configuredSeconds: number | null): Promise<void>;
 }>;
 export type ManagedAppTxHost = Readonly<{
-  refreshAuthority(): void;
+  refreshAuthority(providerGeneration: number | null): void;
   release(): Promise<void>;
   dispose(): void;
 }>;
@@ -39,7 +39,39 @@ export function provideManagedAppTxHost(bindings: ManagedAppTxHostBindings): Man
   const browser = createManagedBrowserDependencies();
   const controller = new ManagedTxController(browser.dependencies);
   let disposed = false;
-  const refreshAuthority = () => { if (!disposed) void controller.refresh(); };
+  let controlSessionEpoch: number | null = null;
+  let providerGeneration: number | null = null;
+  let contextRevision = 0;
+  let refreshInFlight: { revision: number; promise: Promise<void>; queued: boolean } | null = null;
+  let sessionBoundaryRevision = 0;
+  const startRefresh = () => {
+    if (disposed) return;
+    if (controlSessionEpoch === null || providerGeneration === null) return;
+    if (refreshInFlight?.revision === contextRevision) {
+      refreshInFlight.queued = true;
+      return;
+    }
+    const revision = contextRevision;
+    const promise = controller.refresh().finally(() => {
+      if (refreshInFlight?.promise !== promise) return;
+      const rerun = refreshInFlight.queued && contextRevision === revision;
+      refreshInFlight = null;
+      if (rerun) startRefresh();
+    });
+    refreshInFlight = { revision, promise, queued: false };
+  };
+  const refreshAuthority = (nextProviderGeneration: number | null) => {
+    if (disposed) return;
+    const next = Number.isSafeInteger(nextProviderGeneration) && nextProviderGeneration! >= 0
+      ? nextProviderGeneration
+      : null;
+    if (providerGeneration !== next) {
+      providerGeneration = next;
+      contextRevision++;
+      controller.invalidate();
+    }
+    startRefresh();
+  };
   const release = async () => { if (!disposed) await controller.releaseSession(); };
   const facade = Object.freeze<ManagedAppTxController>({
     snapshot: () => controller.snapshot(),
@@ -66,8 +98,24 @@ export function provideManagedAppTxHost(bindings: ManagedAppTxHostBindings): Man
   };
   try {
     offSession = browser.subscribeSession((session) => {
-      if (session.state === 'connected') refreshAuthority();
-      else void controller.releaseSession().finally(() => controller.abandonSession());
+      const boundary = ++sessionBoundaryRevision;
+      if (session.state === 'connected') {
+        if (controlSessionEpoch !== session.epoch) {
+          controlSessionEpoch = session.epoch;
+          contextRevision++;
+          controller.invalidate();
+        }
+        startRefresh();
+      } else {
+        controlSessionEpoch = null;
+        contextRevision++;
+        controller.invalidate();
+        void controller.releaseSession().finally(() => {
+          if (sessionBoundaryRevision === boundary && controlSessionEpoch === null) {
+            controller.abandonSession();
+          }
+        });
+      }
     });
     offBarrier = bindings.registerPreDisconnectBarrier(release);
     offLifecycle = bindings.lifecycleReleaseSource(() => { void release(); });

--- a/frontend/src/lib/runtime/tx-controller/managed-controller.ts
+++ b/frontend/src/lib/runtime/tx-controller/managed-controller.ts
@@ -10,6 +10,7 @@ export interface ManagedTxDependencies {
   invalidate(): void;
   sendPtt(operation: PttOperation): Promise<Outcome>;
   submit(operation: ManagedOperation): Promise<Outcome>;
+  /** Persists TOT and owns canonical projection invalidation on failure. */
   setTot(configuredSeconds: number | null): Promise<void>;
   /** Browser-only presentation clock; never a TX or transport authority. */
   onPresentationTick?(handler: () => void): () => void;
@@ -95,7 +96,6 @@ export class ManagedTxController {
     try {
       await this.dependencies.setTot(configuredSeconds);
     } catch (error) {
-      this.dependencies.invalidate();
       this.#publish();
       throw error;
     }

--- a/frontend/src/lib/stores/__tests__/managed-transmit.test.ts
+++ b/frontend/src/lib/stores/__tests__/managed-transmit.test.ts
@@ -82,6 +82,42 @@ describe('managed transmit store', () => {
     }
   });
 
+  it('ignores a late setTot success after a new context snapshot is accepted', async () => {
+    const store = await import('../managed-transmit.svelte');
+    store.receiveManagedTransmitSnapshot(document(180));
+    let resolvePut!: (value: ManagedTransmitDocument) => void;
+    const client = { setTot: vi.fn(() => new Promise<ManagedTransmitDocument>((resolve) => { resolvePut = resolve; })) };
+
+    const pending = store.setManagedTransmitTot(240, client);
+    store.invalidateManagedTransmit();
+    store.receiveManagedTransmitSnapshot(document(300, '2026-09-04T00:00:01Z'));
+    resolvePut(document(240, '2026-09-04T00:00:02Z'));
+    await pending;
+
+    expect(store.managedTransmitIsStale()).toBe(false);
+    const snapshot = store.managedTransmitSnapshot();
+    expect(snapshot?.sampledAt).toBe('2026-09-04T00:00:01Z');
+    if (snapshot?.managedTransmit.status === 'available') {
+      expect(snapshot.managedTransmit.tot.configuredSeconds).toBe(300);
+    }
+  });
+
+  it('ignores a late setTot rejection after a new context snapshot is accepted', async () => {
+    const store = await import('../managed-transmit.svelte');
+    store.receiveManagedTransmitSnapshot(document(180));
+    let rejectPut!: (error: Error) => void;
+    const client = { setTot: vi.fn(() => new Promise<ManagedTransmitDocument>((_resolve, reject) => { rejectPut = reject; })) };
+
+    const pending = store.setManagedTransmitTot(240, client);
+    store.invalidateManagedTransmit();
+    store.receiveManagedTransmitSnapshot(document(300, '2026-09-04T00:00:01Z'));
+    rejectPut(new Error('old context failed'));
+    await expect(pending).resolves.toBeUndefined();
+
+    expect(store.managedTransmitIsStale()).toBe(false);
+    expect(store.managedTransmitSnapshot()?.sampledAt).toBe('2026-09-04T00:00:01Z');
+  });
+
   it('keeps an available projection fresh while a background refresh is pending', async () => {
     const store = await import('../managed-transmit.svelte');
     store.receiveManagedTransmitSnapshot(document(180));
@@ -125,8 +161,7 @@ describe('managed transmit store', () => {
     const store = await import('../managed-transmit.svelte');
     store.receiveManagedTransmitSnapshot(document(180));
     const pending = store.refreshManagedTransmit({ snapshot });
-    if (_label === 'HTTP failure') await expect(pending).rejects.toThrow('read failed');
-    else await pending;
+    await pending;
     expect(store.managedTransmitIsStale()).toBe(true);
   });
 });

--- a/frontend/src/lib/stores/__tests__/managed-transmit.test.ts
+++ b/frontend/src/lib/stores/__tests__/managed-transmit.test.ts
@@ -81,4 +81,52 @@ describe('managed transmit store', () => {
       expect(snapshot.managedTransmit.tot.configuredSeconds).toBe(180);
     }
   });
+
+  it('keeps an available projection fresh while a background refresh is pending', async () => {
+    const store = await import('../managed-transmit.svelte');
+    store.receiveManagedTransmitSnapshot(document(180));
+    let resolveRead!: (value: ManagedTransmitDocument) => void;
+    const client = { snapshot: vi.fn(() => new Promise<ManagedTransmitDocument>((resolve) => { resolveRead = resolve; })) };
+
+    const pending = store.refreshManagedTransmit(client);
+
+    expect(store.managedTransmitIsStale()).toBe(false);
+    expect(store.managedTransmitSnapshot()?.txObservation.observedPtt).toBe('off');
+    expect(client.snapshot).toHaveBeenCalledTimes(1);
+    resolveRead(document(180, '2026-09-04T00:00:01Z'));
+    await pending;
+    expect(store.managedTransmitIsStale()).toBe(false);
+  });
+
+  it('fences a late refresh after hard invalidation', async () => {
+    const store = await import('../managed-transmit.svelte');
+    store.receiveManagedTransmitSnapshot(document(180));
+    let resolveRead!: (value: ManagedTransmitDocument) => void;
+    const client = { snapshot: vi.fn(() => new Promise<ManagedTransmitDocument>((resolve) => { resolveRead = resolve; })) };
+
+    const pending = store.refreshManagedTransmit(client);
+    store.invalidateManagedTransmit();
+    resolveRead(document(240, '2026-09-04T00:00:01Z'));
+    await pending;
+
+    expect(store.managedTransmitIsStale()).toBe(true);
+    expect(store.managedTransmitSnapshot()?.managedTransmit.status).toBe('available');
+    expect(store.managedTransmitSnapshot()?.sampledAt).toBe('2026-09-04T00:00:00Z');
+  });
+
+  it.each([
+    ['HTTP failure', async () => { throw new Error('read failed'); }],
+    ['unavailable document', async (): Promise<ManagedTransmitDocument> => ({
+      schemaVersion: 1 as const, sampledAt: '2026-09-04T00:00:01Z',
+      managedTransmit: { status: 'unavailable' as const, reason: 'authority_not_composed' },
+      txObservation: { observedPtt: 'unknown' as const },
+    })],
+  ])('%s retires the cached available projection', async (_label, snapshot) => {
+    const store = await import('../managed-transmit.svelte');
+    store.receiveManagedTransmitSnapshot(document(180));
+    const pending = store.refreshManagedTransmit({ snapshot });
+    if (_label === 'HTTP failure') await expect(pending).rejects.toThrow('read failed');
+    else await pending;
+    expect(store.managedTransmitIsStale()).toBe(true);
+  });
 });

--- a/frontend/src/lib/stores/managed-transmit.svelte.ts
+++ b/frontend/src/lib/stores/managed-transmit.svelte.ts
@@ -2,6 +2,8 @@ import { ManagedTransmitClient } from '../transport/managed-transmit-client';
 import { startManagedTransmitCountdown, readManagedTransmitCountdown, type ManagedTransmitCountdown } from '../runtime/managed-transmit-countdown';
 import type { ManagedTransmitDocument } from '../types/managed-transmit';
 let document = $state<ManagedTransmitDocument | null>(null); let countdown = $state<ManagedTransmitCountdown | null>(null); let stale = $state(true);
+let invalidationRevision = 0;
+let refreshRevision = 0;
 const clock = () => globalThis.performance.now();
 const applyManagedTransmitSnapshot = (value: ManagedTransmitDocument, receivedAt = clock()): void => {
   document = value;
@@ -9,14 +11,34 @@ const applyManagedTransmitSnapshot = (value: ManagedTransmitDocument, receivedAt
   countdown = tot === null || tot.remainingMs === null
     ? null
     : startManagedTransmitCountdown(tot.remainingMs, receivedAt);
-  stale = false;
+  stale = value.managedTransmit.status !== 'available';
 };
 export function managedTransmitSnapshot(): ManagedTransmitDocument | null { return document; }
 export function managedTransmitIsStale(): boolean { return stale; }
 export function managedTransmitRemainingMs(now = clock()): number | null { return !stale && countdown ? readManagedTransmitCountdown(countdown, now) : null; }
 export function receiveManagedTransmitSnapshot(value: ManagedTransmitDocument, receivedAt = clock()): void { if (document !== null && Date.parse(value.sampledAt) < Date.parse(document.sampledAt)) return; applyManagedTransmitSnapshot(value, receivedAt); }
-export function invalidateManagedTransmit(): void { stale = true; countdown = null; }
-export async function refreshManagedTransmit(client = new ManagedTransmitClient()): Promise<void> { invalidateManagedTransmit(); receiveManagedTransmitSnapshot(await client.snapshot()); }
+export function invalidateManagedTransmit(): void {
+  invalidationRevision++;
+  refreshRevision++;
+  stale = true;
+  countdown = null;
+}
+export async function refreshManagedTransmit(
+  client: Pick<ManagedTransmitClient, 'snapshot'> = new ManagedTransmitClient(),
+): Promise<void> {
+  const invalidationAtStart = invalidationRevision;
+  const refresh = ++refreshRevision;
+  let value: ManagedTransmitDocument;
+  try {
+    value = await client.snapshot();
+  } catch (error) {
+    if (refresh !== refreshRevision || invalidationAtStart !== invalidationRevision) return;
+    invalidateManagedTransmit();
+    throw error;
+  }
+  if (refresh !== refreshRevision || invalidationAtStart !== invalidationRevision) return;
+  receiveManagedTransmitSnapshot(value);
+}
 export async function submitManagedTransmit(operation: 'transmit_on' | 'force_off', client = new ManagedTransmitClient()): Promise<'accepted' | 'rejected'> { const outcome = await client.command(operation); await refreshManagedTransmit(client); return outcome; }
 export async function setManagedTransmitTot(
   configuredSeconds: number | null,

--- a/frontend/src/lib/stores/managed-transmit.svelte.ts
+++ b/frontend/src/lib/stores/managed-transmit.svelte.ts
@@ -5,6 +5,7 @@ let document = $state<ManagedTransmitDocument | null>(null); let countdown = $st
 let invalidationRevision = 0;
 let refreshRevision = 0;
 const clock = () => globalThis.performance.now();
+const contextIsCurrent = (revision: number): boolean => revision === invalidationRevision;
 const applyManagedTransmitSnapshot = (value: ManagedTransmitDocument, receivedAt = clock()): void => {
   document = value;
   const tot = value.managedTransmit.status === 'available' ? value.managedTransmit.tot : null;
@@ -31,12 +32,12 @@ export async function refreshManagedTransmit(
   let value: ManagedTransmitDocument;
   try {
     value = await client.snapshot();
-  } catch (error) {
-    if (refresh !== refreshRevision || invalidationAtStart !== invalidationRevision) return;
+  } catch {
+    if (refresh !== refreshRevision || !contextIsCurrent(invalidationAtStart)) return;
     invalidateManagedTransmit();
-    throw error;
+    return;
   }
-  if (refresh !== refreshRevision || invalidationAtStart !== invalidationRevision) return;
+  if (refresh !== refreshRevision || !contextIsCurrent(invalidationAtStart)) return;
   receiveManagedTransmitSnapshot(value);
 }
 export async function submitManagedTransmit(operation: 'transmit_on' | 'force_off', client = new ManagedTransmitClient()): Promise<'accepted' | 'rejected'> { const outcome = await client.command(operation); await refreshManagedTransmit(client); return outcome; }
@@ -44,9 +45,13 @@ export async function setManagedTransmitTot(
   configuredSeconds: number | null,
   client: Pick<ManagedTransmitClient, 'setTot'> = new ManagedTransmitClient(),
 ): Promise<void> {
+  const invalidationAtStart = invalidationRevision;
   try {
-    receiveManagedTransmitSnapshot(await client.setTot(configuredSeconds));
+    const value = await client.setTot(configuredSeconds);
+    if (!contextIsCurrent(invalidationAtStart)) return;
+    receiveManagedTransmitSnapshot(value);
   } catch (error) {
+    if (!contextIsCurrent(invalidationAtStart)) return;
     invalidateManagedTransmit();
     throw error;
   }


### PR DESCRIPTION
The Standard TX panel briefly disabled and dimmed `KEY TRANSMITTER` whenever a background managed-authority GET started, even while the last document still belonged to the same provider and control session. The store now keeps that projection while a same-context read is pending, and the existing App-root host invalidates it synchronously when provider generation or control-session epoch changes.

All async managed-document ingress is context-fenced. Failed or unavailable current reads retire the projection; late GET or TOT success/failure from an invalidated context cannot publish or invalidate newer state. The store owns production refresh and TOT failure invalidation, while the controller continues to publish and return the real TOT error. Explicit TRANSMIT still reaches the existing server admission path exactly once during a pending refresh. No PTT freshness gate, timer, backend API, or second TX authority is added.

Linear: MOR-2438

Validation:

- Focused Vitest: 5 files, 44 tests passed
- `npm run check`
- scoped ESLint and `git diff --check`
- `uv run --frozen ruff check .`
