### PR TITLE
Preserve passband through tuning freshness gaps

### DIFF
--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -1564,7 +1564,7 @@ describe('managed scope projection (MOR-2367)', () => {
     expect(target.querySelector('.passband-resize-zone')).toBeNull();
     expect(handlerHarness.vfo.onFreqChange).not.toHaveBeenCalled();
   });
-  it('keeps projector-produced overlays through five seconds of fresh frames and staggered geometry readback', () => {
+  it('keeps projector-produced overlays through a stale frequency gap and staggered recovery while tuning', () => {
     authorityHarness.state.useProductionSelector = true;
     const state = structuredClone(IC7300_STATE); const caps = structuredClone(IC7300_CAPABILITIES);
     const rx = state.main!;
@@ -1610,6 +1610,41 @@ describe('managed scope projection (MOR-2367)', () => {
       present(5100 + index * 100, 14_075_000);
       expect(result.display.state).toBe(index === 2 ? 'current' : 'stale');
       expect(target.querySelector('.passband-overlay')).not.toBeNull();
+    }
+
+    for (const path of ['main.freqHz', 'main.vfoA.freqHz', 'main.mode', 'main.vfoA.mode']) {
+      Object.assign(state.fieldStatus[path], { freshness: 'stale', availability: 'stale' });
+    }
+    for (let step = 0; step < 10; step += 1) {
+      const frequency = step % 2 === 0 ? 14_076_000 : 14_075_000;
+      rx.freqHz = frequency; rx.vfoA!.freqHz = frequency;
+      state.fieldStatus['main.freqHz'].lastObservedMonotonic = 20 + step;
+      state.fieldStatus['main.vfoA.freqHz'].lastObservedMonotonic = 20 + step;
+      if (step === 3) state.fieldStatus['main.filterWidth'].lastObservedMonotonic = 24;
+      if (step === 7) state.fieldStatus['main.pbtInner'].lastObservedMonotonic = 28;
+      present(6000 + step * 250, frequency);
+      expect(result.display).toMatchObject({ state: 'stale', translated: true,
+        tuple: { frequencyHz: 14_075_000 } });
+      expect(target.querySelectorAll('.tune-line')).toHaveLength(1);
+      expect(target.querySelectorAll('.passband-overlay')).toHaveLength(1);
+      expect(target.querySelector('.passband-resize-zone')).toBeNull();
+    }
+
+    for (const path of ['main.freqHz', 'main.vfoA.freqHz', 'main.mode', 'main.vfoA.mode']) {
+      Object.assign(state.fieldStatus[path], { freshness: 'fresh', availability: 'available',
+        lastObservedMonotonic: 40 });
+    }
+    for (let step = 0; step < 8; step += 1) {
+      const frequency = step % 2 === 0 ? 14_076_000 : 14_075_000;
+      rx.freqHz = frequency; rx.vfoA!.freqHz = frequency;
+      state.fieldStatus['main.freqHz'].lastObservedMonotonic = 41 + step;
+      state.fieldStatus['main.vfoA.freqHz'].lastObservedMonotonic = 41 + step;
+      if (step === 7) state.fieldStatus['main.pbtOuter'].lastObservedMonotonic = 48;
+      present(9000 + step * 250, frequency);
+      expect(result.display.state).toBe(step === 7 ? 'current' : 'stale');
+      expect(target.querySelectorAll('.tune-line')).toHaveLength(1);
+      expect(target.querySelectorAll('.passband-overlay')).toHaveLength(1);
+      if (step < 7) expect(target.querySelector('.passband-resize-zone')).toBeNull();
     }
     expect(handlerHarness.vfo.onFreqChange).not.toHaveBeenCalled();
     expect(handlerHarness.filter.onFilterWidthCommit).not.toHaveBeenCalled();

--- a/frontend/src/lib/runtime/adapters/__tests__/scope-passband-display.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scope-passband-display.test.ts
@@ -105,6 +105,55 @@ function tune(input: ScopePassbandDisplayInput, frequency: number, marker: numbe
 }
 
 describe('confirmed tuning display continuity (MOR-2437)', () => {
+  it('holds the last qualified tuple through a stale frequency gap and recovers while tuning continues', () => {
+    const input = banded();
+    let result = project(input);
+    tune(input, 14_100_000, 11);
+    receipt(input, 2, { startFreq: 14_050_000, endFreq: 14_150_000 });
+    result = project(input, result);
+    renew(input, 16, 3);
+    result = project(input, result);
+    expect(result.display.state).toBe('current');
+    expect(tuple(result).frequencyHz).toBe(14_100_000);
+
+    for (const path of ['main.freqHz', 'main.vfoA.freqHz', 'main.mode', 'main.vfoA.mode']) stale(input, path);
+    let sequence = 3;
+    let holdFloors: ScopePassbandDisplayState['floors'] = null;
+    for (let step = 0; step < 10; step += 1) {
+      const frequency = step % 2 === 0 ? 14_101_000 : 14_100_000;
+      tune(input, frequency, 20 + step);
+      if (step === 3) status(input, 'main.filterWidth', { lastObservedMonotonic: 24 });
+      if (step === 7) status(input, 'main.pbtInner', { lastObservedMonotonic: 28 });
+      receipt(input, ++sequence, { startFreq: frequency - 50_000, endFreq: frequency + 50_000 });
+      result = project(input, result);
+      expect(result.display).toMatchObject({ state: 'stale', translated: true,
+        tuple: { frequencyHz: 14_100_000, startHz: frequency - 50_000, endHz: frequency + 50_000 } });
+      if (step === 0) {
+        holdFloors = result.floors;
+        const disconnected = structuredClone(input);
+        disconnected.session = { state: 'disconnected', epoch: 1 };
+        expect(project(disconnected, result).display.state).toBe('unknown');
+        const frameLost = structuredClone(input); frameLost.frame = null;
+        expect(project(frameLost, result).display.state).toBe('unknown');
+      } else expect(result.floors).toEqual(holdFloors);
+    }
+
+    for (const path of ['main.freqHz', 'main.vfoA.freqHz', 'main.mode', 'main.vfoA.mode']) {
+      status(input, path, { freshness: 'fresh', availability: 'available', lastObservedMonotonic: 40 });
+    }
+    for (let step = 0; step < 8; step += 1) {
+      const frequency = step % 2 === 0 ? 14_101_000 : 14_100_000;
+      tune(input, frequency, 41 + step);
+      if (step === 7) status(input, 'main.pbtOuter', { lastObservedMonotonic: 48 });
+      receipt(input, ++sequence, { startFreq: frequency - 50_000, endFreq: frequency + 50_000 });
+      result = project(input, result);
+      expect(result.display.state).toBe(step === 7 ? 'current' : 'stale');
+      expect(tuple(result).frequencyHz).toBe(frequency);
+      if (step < 7) expect(result.floors).toEqual(holdFloors);
+    }
+    expect(result.floors).toBeNull();
+  });
+
   it('keeps one translated stale shape through repeated steps and staggered 5s geometry observations', () => {
     const input = banded(); let result = project(input);
     for (const [frequency, marker] of [[14_075_000, 11], [14_076_000, 12]]) {
@@ -133,12 +182,14 @@ describe('confirmed tuning display continuity (MOR-2437)', () => {
     expect(result.display.state).toBe('stale'); expect(tuple(result).frequencyHz).toBe(14_075_000);
     renew(input, 16, 3); expect(project(input, result).display.state).toBe('current');
   });
-  it('does not use pending targets or stale frequency observations to translate', () => {
+  it('ignores pending targets and holds rather than follows a stale frequency observation', () => {
     const input = banded(); const current = project(input);
     Object.assign(input.state!, { pending: { frequencyHz: 14_090_000 } });
     expect(tuple(project(input, current)).frequencyHz).toBe(14_074_000);
     tune(input, 14_075_000, 11); stale(input, 'main.vfoA.freqHz');
-    expect(project(input, current).display.state).toBe('unknown');
+    const held = project(input, current);
+    expect(held.display).toMatchObject({ state: 'stale', translated: true });
+    expect(tuple(held).frequencyHz).toBe(14_074_000);
   });
   const hard: [string, (i: ScopePassbandDisplayInput) => void][] = [
     ['provider', (i) => { i.state!.providerGeneration = 2; i.caps!.providerGeneration = 2; receipt(i, 3); }],
@@ -155,7 +206,6 @@ describe('confirmed tuning display continuity (MOR-2437)', () => {
     ['band', (i) => tune(i, 18_100_000, 12)],
     ['outside profile bands', (i) => tune(i, 15_000_000, 12)],
     ['band definitions', (i) => { i.caps!.freqRanges[0].bands![5].end += 100; }],
-    ['stale frequency', (i) => stale(i, 'main.vfoA.freqHz')],
     ['null frame', (i) => { i.frame = null; }],
     ['500ms frame silence', (i) => { i.frame = { ...i.frame!, authority: { ...i.frame!.authority, nowMonotonic: 500 } }; }],
     ['off', (i) => { i.frame = { ...i.frame!, authority: { ...i.frame!.authority, demanded: false } }; }],

--- a/frontend/src/lib/runtime/adapters/scope-passband-display.ts
+++ b/frontend/src/lib/runtime/adapters/scope-passband-display.ts
@@ -33,6 +33,8 @@ export interface ScopePassbandDisplayState {
   readonly geometryPaths: readonly string[];
   readonly receipt: number;
   readonly floors: Readonly<{ domain: string | null; geometry: Markers; receipt: number }> | null;
+  /** Keeps one hold-entry evidence floor pinned until fresh frequency recovery completes. */
+  readonly frequencyHoldRecovery: boolean;
 }
 export interface ScopePassbandDisplayInput {
   state: ServerState | null;
@@ -46,7 +48,7 @@ const EMPTY_PATHS: readonly string[] = Object.freeze([]);
 export const EMPTY_SCOPE_PASSBAND_DISPLAY: ScopePassbandDisplayState = Object.freeze({
   display: Object.freeze({ state: 'unknown', reason: 'not-observed' }),
   identity: null, continuityIdentity: null, domain: null, observations: EMPTY_OBSERVATIONS,
-  geometryPaths: EMPTY_PATHS, receipt: 0, floors: null,
+  geometryPaths: EMPTY_PATHS, receipt: 0, floors: null, frequencyHoldRecovery: false,
 });
 const nonnegative = (n: unknown): n is number => typeof n === 'number' && Number.isFinite(n) && n >= 0;
 const positive = (n: unknown): n is number => typeof n === 'number' && Number.isFinite(n) && n > 0;
@@ -245,17 +247,25 @@ export function projectScopePassbandDisplay(
   const receiptRegression = candidate !== null && next.receipt < previous.receipt;
   const hasTuple = active(previous.display);
   const wasTranslated = hasTuple && previous.display.translated === true;
+  const holdingFrequency = hasTuple && candidate !== null && candidate.continuityIdentity !== null
+    && candidate.continuityIdentity === previous.continuityIdentity
+    && !candidate.frequencyCurrent && candidate.frequencyAligned
+    && !regression && !receiptRegression && !changedGeometry;
   const invalid = !candidate || regression || receiptRegression || (!candidate.stale && !candidate.strict)
-    || ((candidate.stale || wasTranslated) && changedGeometry) || (wasTranslated && !candidate.frequencyCurrent);
+    || ((candidate.stale || wasTranslated) && changedGeometry)
+    || (wasTranslated && !candidate.frequencyCurrent && !holdingFrequency);
   const canTranslate = hasTuple && candidate !== null && candidate.continuityIdentity !== null
     && candidate.continuityIdentity === previous.continuityIdentity
     && candidate.frequencyCurrent && !regression && !receiptRegression && !changedGeometry
     && (candidate.stale || candidate.strict || !candidate.frequencyAligned);
   const translating = canTranslate && (changedIdentity || wasTranslated);
   const domainChange = previous.floors !== null && next.domain !== null && previous.floors.domain !== next.domain;
-  const retire = ((hasTuple && (invalid || changedIdentity)) || changedIdentity) && !translating || domainChange;
+  const retire = (((hasTuple && (invalid || changedIdentity)) || changedIdentity)
+    && !translating && !holdingFrequency) || domainChange;
   let floors = previous.floors;
-  if (retire || (translating && (!wasTranslated || candidate.tuple.frequencyHz !== tupleOf(previous.display).frequencyHz))) {
+  if (retire || (holdingFrequency && !previous.frequencyHoldRecovery)
+    || (translating && !previous.frequencyHoldRecovery
+      && (!wasTranslated || candidate.tuple.frequencyHz !== tupleOf(previous.display).frequencyHz))) {
     const domain = next.domain ?? previous.domain;
     floors = Object.freeze({ domain, receipt: Math.max(previous.receipt, next.receipt),
       geometry: mergeMarkers(
@@ -272,7 +282,12 @@ export function projectScopePassbandDisplay(
   const canRetain = hasTuple && !retire && !invalid && !translating;
   const canCapture = candidate && !candidate.stale && candidate.strict && !regression
     && !receiptRegression && !retire && crossedFloors;
-  const display: ScopePassbandDisplay = translating
+  const display: ScopePassbandDisplay = holdingFrequency
+    ? { state: 'stale', translated: true, tuple: {
+      ...tupleOf(previous.display), frameMode: candidate!.tuple.frameMode,
+      startHz: candidate!.tuple.startHz, endHz: candidate!.tuple.endHz,
+    } }
+    : translating
     ? crossedFloors && axisAligned && !candidate.stale && candidate.strict
       ? { state: 'current', tuple: candidate.tuple }
       : { state: 'stale', tuple: candidate.tuple, translated: true }
@@ -295,6 +310,8 @@ export function projectScopePassbandDisplay(
     observations: Object.freeze(observations),
     geometryPaths: Object.freeze([...next.geometryPaths]), receipt: Math.max(previous.receipt, next.receipt),
     floors: active(display) && !display.translated ? null : floors,
+    frequencyHoldRecovery: (holdingFrequency || previous.frequencyHoldRecovery)
+      && active(display) && display.translated === true,
   });
 }
 function tupleOf(display: ScopePassbandDisplay): ScopePassbandTuple {


### PR DESCRIPTION
Rapid alternating tuning could make a confirmed passband disappear when the relative VFO tuple briefly became stale, then keep recovery geometry floors moving after freshness returned. The projector now holds the last qualified same-context tuple on each fresh hardware frame axis, keeps it explicitly stale and non-resizable, and pins the hold-entry evidence floor until strict frequency evidence and staggered geometry recover.

Provider/session/receiver/slot/mode/filter/DATA/band/span changes, invalid frames, marker conflicts, geometry changes, and regressions still retire the display. Held stale values never retarget the frequency, grant resize authority, invoke command callbacks, or become current. This does not change backend retention, polling, command, or TX authority; the producer readback gap remains MOR-2439.

Linear: MOR-2437

Validation:

- Focused projector + mounted SpectrumPanel: 302/302 passed
- `npm run check` (0 errors, 0 warnings)
- scoped ESLint
- `git diff --check`
