### PR TITLE
fix(ui): preserve rapid tuning intent across delayed echoes

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/focus-mode-race.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/focus-mode-race.isolated.test.ts
@@ -5,7 +5,10 @@ vi.mock('$lib/transport/ws-client', () => ({
 }));
 vi.mock('$lib/runtime/commands/radio-intents', async () => {
   const { sendCommand } = await import('$lib/transport/ws-client');
-  return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
+  return {
+    dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params),
+    currentControlSessionEpoch: () => 0,
+  };
 });
 
 vi.mock('$lib/stores/radio.svelte', () => ({

--- a/frontend/src/components-v2/wiring/__tests__/keyboard-wiring.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/keyboard-wiring.isolated.test.ts
@@ -45,6 +45,7 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
 }));
 
 vi.mock('$lib/state/field-status', () => ({
+  getFieldStatus: vi.fn(() => undefined),
   isFieldAvailable: vi.fn(() => true),
 }));
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -139,7 +139,10 @@ import {
   resetRetainedInvocations, retainedInvocations,
 } from '../../../primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte';
 
-const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const fresh = {
+  storePath: 'x', observed: true, freshness: 'fresh', availability: 'available',
+  lastObservedMonotonic: 1,
+};
 const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
 
 /** MAIN sits at 14.250 (inside the 20m TX segment), SUB at 7.100 (inside 40m). */

--- a/frontend/src/components-v2/wiring/__tests__/vfo-ops-command-bus.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/vfo-ops-command-bus.isolated.test.ts
@@ -30,7 +30,10 @@ const h = vi.hoisted(() => ({
 vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
 vi.mock('$lib/runtime/commands/radio-intents', async () => {
   const { sendCommand } = await import('$lib/transport/ws-client');
-  return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
+  return {
+    dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params),
+    currentControlSessionEpoch: () => 0,
+  };
 });
 vi.mock('$lib/stores/radio.svelte', () => ({
   getActiveReceiver: vi.fn(() => null),

--- a/frontend/src/components-v2/wiring/__tests__/vfo-wiring.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/vfo-wiring.isolated.test.ts
@@ -5,7 +5,10 @@ vi.mock('$lib/transport/ws-client', () => ({
 }));
 vi.mock('$lib/runtime/commands/radio-intents', async () => {
   const { sendCommand } = await import('$lib/transport/ws-client');
-  return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
+  return {
+    dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params),
+    currentControlSessionEpoch: () => 0,
+  };
 });
 
 vi.mock('$lib/stores/radio.svelte', () => ({

--- a/frontend/src/lib/radio/pending-focus.isolated.test.ts
+++ b/frontend/src/lib/radio/pending-focus.isolated.test.ts
@@ -17,7 +17,10 @@ vi.mock('$lib/transport/ws-client', () => ({
 }));
 vi.mock('$lib/runtime/commands/radio-intents', async () => {
   const { sendCommand } = await import('$lib/transport/ws-client');
-  return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
+  return {
+    dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params),
+    currentControlSessionEpoch: () => 0,
+  };
 });
 
 vi.mock('$lib/stores/radio.svelte', () => ({

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
@@ -117,10 +117,17 @@ import {
   makeKeyboardHandlers,
   dispatchKeyboardRadioAction,
 } from '../panel-commands';
-import { getCommandLifecycles, resetCommandLifecycle } from '$lib/stores/commands.svelte';
+import {
+  acknowledgeCommand,
+  failCommand,
+  getCommandLifecycles,
+  resetCommandLifecycle,
+} from '$lib/stores/commands.svelte';
 import { setPendingFocus } from '$lib/radio/pending-focus';
 
-const freshStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const freshStatus = {
+  storePath: 'x', observed: true, freshness: 'fresh', availability: 'available',
+} as const;
 
 function state(active: 'MAIN' | 'SUB' = 'MAIN'): ServerState {
   const receiver = {
@@ -195,6 +202,8 @@ function state(active: 'MAIN' | 'SUB' = 'MAIN'): ServerState {
     scanResumeMode: 2,
     fieldStatus: {
       active: freshStatus,
+      'main.freqHz': { ...freshStatus, storePath: 'main.freqHz', lastObservedMonotonic: 1 },
+      'sub.freqHz': { ...freshStatus, storePath: 'sub.freqHz', lastObservedMonotonic: 1 },
       'main.dataMode': freshStatus,
       'sub.dataMode': freshStatus,
       data1ModInput: freshStatus,
@@ -1252,6 +1261,153 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     // The pre-reset paced flush must never fire and emit a stray 3rd call.
     vi.advanceTimersByTime(60);
     expect(h.sendCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it('MOR-1864: associates delayed accepted echoes by exact target and marker across a reversal', () => {
+    const vfo = makeVfoHandlers();
+    const start = h.state!.main!.freqHz;
+    const setObservation = (frequency: number, marker: number) => {
+      h.state = {
+        ...h.state!,
+        main: { ...h.state!.main!, freqHz: frequency },
+        fieldStatus: {
+          ...h.state!.fieldStatus,
+          'main.freqHz': {
+            ...freshStatus, storePath: 'main.freqHz', lastObservedMonotonic: marker,
+          },
+        },
+      };
+    };
+    const acknowledgeLatest = () => {
+      const command = getCommandLifecycles().at(-1)!;
+      acknowledgeCommand(command.id, command.originalEpoch, command.originalEpoch);
+    };
+
+    vfo.onMainFreqChange(start + 1_000); // R -> S+1
+    expect(getCommandLifecycles()[0]?.params).toEqual({ freq: start + 1_000, receiver: 0 });
+    acknowledgeLatest();
+    vi.advanceTimersByTime(250);
+    vfo.onMainFreqChange(start - 1_000); // L -> net S
+    vi.advanceTimersByTime(0);
+    acknowledgeLatest();
+
+    setObservation(start + 1_000, 2); // delayed echo of the older, obsolete R
+    vi.advanceTimersByTime(250);
+    vfo.onMainFreqChange(start + 2_000); // R -> net S+1, never S+2
+    vi.advanceTimersByTime(0);
+    acknowledgeLatest();
+
+    setObservation(start, 3); // delayed echo of L
+    vi.advanceTimersByTime(250);
+    vfo.onMainFreqChange(start - 1_000); // L -> net S
+    vi.advanceTimersByTime(0);
+
+    expect(exactCalls().filter(([name]) => name === 'set_freq')).toEqual([
+      ['set_freq', { freq: start + 1_000, receiver: 0 }],
+      ['set_freq', { freq: start, receiver: 0 }],
+      ['set_freq', { freq: start + 1_000, receiver: 0 }],
+      ['set_freq', { freq: start, receiver: 0 }],
+    ]);
+    expect(getCommandLifecycles()[0]?.locallyObsolete).toBe(true);
+  });
+
+  it('MOR-1864: preserves all 70 delayed alternating pairs without target drift', () => {
+    const vfo = makeVfoHandlers();
+    const start = h.state!.main!.freqHz;
+    const observed = (frequency: number, marker: number) => {
+      h.state = {
+        ...h.state!, main: { ...h.state!.main!, freqHz: frequency },
+        fieldStatus: { ...h.state!.fieldStatus, 'main.freqHz': {
+          ...freshStatus, storePath: 'main.freqHz', lastObservedMonotonic: marker,
+        } },
+      };
+    };
+
+    for (let index = 0; index < 140; index++) {
+      if (index > 0) vi.advanceTimersByTime(250);
+      if (index >= 2) observed(index % 2 === 0 ? start + 1_000 : start, index);
+      const shown = h.state!.main!.freqHz;
+      vfo.onMainFreqChange(shown + (index % 2 === 0 ? 1_000 : -1_000));
+      vi.advanceTimersByTime(0);
+      const command = getCommandLifecycles().at(-1)!;
+      acknowledgeCommand(command.id, command.originalEpoch, command.originalEpoch);
+    }
+
+    expect(exactCalls().filter(([name]) => name === 'set_freq').map(([, params]) => params.freq))
+      .toEqual(Array.from({ length: 140 }, (_, index) => index % 2 === 0 ? start + 1_000 : start));
+  });
+
+  it('MOR-1864: stale TTL preserves a known marker, while pending targets cannot explain changed truth', () => {
+    const vfo = makeVfoHandlers();
+    const start = h.state!.main!.freqHz;
+    vfo.onMainFreqChange(start + 1_000);
+    h.state = { ...h.state!, fieldStatus: { ...h.state!.fieldStatus, 'main.freqHz': {
+      ...freshStatus, storePath: 'main.freqHz', freshness: 'stale', availability: 'stale',
+      lastObservedMonotonic: 1, quality: ['confirmed'],
+    } } };
+    vfo.onMainFreqChange(start + 1_000);
+    vi.advanceTimersByTime(60);
+    expect(exactCalls().at(-1)).toEqual(['set_freq', { freq: start + 2_000, receiver: 0 }]);
+
+    // The latest target is still merely pending. A changed field value cannot
+    // be attributed to it and therefore starts cold, immediately.
+    h.state = { ...h.state!, main: { ...h.state!.main!, freqHz: start + 2_000 }, fieldStatus: {
+      ...h.state!.fieldStatus, 'main.freqHz': {
+        ...freshStatus, storePath: 'main.freqHz', lastObservedMonotonic: 2,
+      },
+    } };
+    const count = h.sendCommand.mock.calls.length;
+    vfo.onMainFreqChange(start + 3_000);
+    expect(h.sendCommand).toHaveBeenCalledTimes(count + 1);
+    expect(exactCalls().at(-1)).toEqual(['set_freq', { freq: start + 3_000, receiver: 0 }]);
+  });
+
+  it('MOR-1864: explicit A/B selection fences an already queued old-slot flush', () => {
+    h.state = oneReceiverAbState();
+    h.state = { ...h.state, fieldStatus: { ...h.state.fieldStatus,
+      'main.freqHz': { ...freshStatus, storePath: 'main.freqHz', lastObservedMonotonic: 1 },
+      'main.activeSlot': { ...freshStatus, storePath: 'main.activeSlot', lastObservedMonotonic: 1 },
+    } };
+    h.caps = { ...h.caps!, receivers: 1, vfoScheme: 'ab' };
+    const vfo = makeVfoHandlers();
+    const start = h.state!.main!.freqHz;
+    vfo.onMainFreqChange(start + 1_000);
+    vfo.onMainFreqChange(start + 1_000);
+    vfo.onVfoSelect('MAIN', 'B');
+    vi.advanceTimersByTime(60);
+    expect(exactCalls()).toEqual([
+      ['set_freq', { freq: start + 1_000, receiver: 0 }],
+      ['set_vfo', { vfo: 'B' }],
+    ]);
+  });
+
+  it('MOR-1864: excludes pre-burst, pending, and failed records from changed-value association', () => {
+    const vfo = makeVfoHandlers();
+    const start = h.state!.main!.freqHz;
+    const setObservation = (frequency: number, marker: number) => {
+      h.state = { ...h.state!, main: { ...h.state!.main!, freqHz: frequency }, fieldStatus: {
+        ...h.state!.fieldStatus, 'main.freqHz': {
+          ...freshStatus, storePath: 'main.freqHz', lastObservedMonotonic: marker,
+        },
+      } };
+    };
+
+    // Same fake-clock millisecond as the later burst anchor: registry order,
+    // not timestamp alone, keeps this accepted historical target out.
+    vfo.onFreqChange(start + 500, 0, 'jump');
+    let record = getCommandLifecycles().at(-1)!;
+    acknowledgeCommand(record.id, record.originalEpoch, record.originalEpoch);
+    vfo.onMainFreqChange(start + 1_000);
+    setObservation(start + 500, 2);
+    vfo.onMainFreqChange(start + 1_500);
+    expect(exactCalls().at(-1)).toEqual(['set_freq', { freq: start + 1_500, receiver: 0 }]);
+
+    // A failed current record is equally unable to explain a later change.
+    record = getCommandLifecycles().at(-1)!;
+    failCommand(record.id, record.originalEpoch, record.originalEpoch, 'NAK');
+    setObservation(start + 1_500, 3);
+    vfo.onMainFreqChange(start + 2_500);
+    expect(exactCalls().at(-1)).toEqual(['set_freq', { freq: start + 2_500, receiver: 0 }]);
   });
 
   it("MOR-1425 review B1: onFreqChange(freq, receiver, 'step') opts a relative gesture into the accumulate path instead of the 'jump' default", () => {

--- a/frontend/src/lib/runtime/commands/__tests__/tuning-accumulator.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/tuning-accumulator.test.ts
@@ -18,11 +18,14 @@ describe('MOR-1425 tuning accumulator', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     emit = vi.fn((_receiver: number, _freq: number) => ({ status: 'pending' }));
-    acc = createTuningAccumulator({ emit, paceMs: 60, quietWindowMs: 4_000 });
+    acc = createTuningAccumulator({
+      emit, paceMs: 60, quietWindowMs: 4_000,
+      acceptedTarget: ({ frequency }) => emit.mock.calls.some(([, target]) => target === frequency),
+    });
   });
 
   it('(f) emits an isolated single step immediately, unpaced', () => {
-    acc.step(0, 14_074_000, 14_075_000);
+    acc.step(0, 14_074_000, 14_075_000, 1);
     expect(emit).toHaveBeenCalledExactlyOnceWith(0, 14_075_000);
   });
 
@@ -33,7 +36,7 @@ describe('MOR-1425 tuning accumulator', () => {
     for (let i = 1; i <= N; i++) {
       // Each gesture computes target = displayed (still-stale confirmed) +
       // step — exactly the operator-captured mechanism from MOR-1425.
-      acc.step(0, confirmed, confirmed + step);
+      acc.step(0, confirmed, confirmed + step, 1);
     }
     // First (cold) step emitted immediately; the rest are paced.
     expect(emit).toHaveBeenCalledTimes(1);
@@ -44,17 +47,17 @@ describe('MOR-1425 tuning accumulator', () => {
 
   it('(b) paced emissions during a sustained burst are at least ~60ms apart', () => {
     const confirmed = 14_074_000;
-    acc.step(0, confirmed, confirmed + 1_000); // cold, immediate
+    acc.step(0, confirmed, confirmed + 1_000, 1); // cold, immediate
     expect(emit).toHaveBeenCalledTimes(1);
 
-    acc.step(0, confirmed, confirmed + 2_000); // hot, schedules a flush
+    acc.step(0, confirmed, confirmed + 2_000, 1); // hot, schedules a flush
     expect(emit).toHaveBeenCalledTimes(1);
     vi.advanceTimersByTime(59);
     expect(emit).toHaveBeenCalledTimes(1); // not yet — under the pace window
     vi.advanceTimersByTime(1);
     expect(emit).toHaveBeenCalledTimes(2); // paced flush fires at >=60ms
 
-    acc.step(0, confirmed, confirmed + 3_000); // hot again, schedules another
+    acc.step(0, confirmed, confirmed + 3_000, 1); // hot again, schedules another
     vi.advanceTimersByTime(59);
     expect(emit).toHaveBeenCalledTimes(2);
     vi.advanceTimersByTime(1);
@@ -63,14 +66,14 @@ describe('MOR-1425 tuning accumulator', () => {
 
   it('(c) a contradictory confirmed observation resets accumulation — the next step bases on the new truth', () => {
     const confirmed = 14_074_000;
-    acc.step(0, confirmed, confirmed + 1_000); // cold, immediate: target 14_075_000
-    acc.step(0, confirmed, confirmed + 2_000); // hot: target 14_076_000, paced
+    acc.step(0, confirmed, confirmed + 1_000, 1); // cold, immediate: target 14_075_000
+    acc.step(0, confirmed, confirmed + 2_000, 1); // hot: target 14_076_000, paced
 
     // The operator turned the physical knob: a confirmed freq that matches
     // neither our frozen baseline (14_074_000) nor our pending target
     // (14_076_000).
     const physical = 14_200_000;
-    acc.step(0, physical, physical + 1_000);
+    acc.step(0, physical, physical + 1_000, 2);
 
     // The reset step is itself a cold start: immediate, unpaced, and its
     // delta is measured from the NEW physical truth, not the old baseline.
@@ -79,23 +82,23 @@ describe('MOR-1425 tuning accumulator', () => {
 
   it('(c) a confirmed observation that matches our own predicted target is NOT a contradiction', () => {
     const confirmed = 14_074_000;
-    acc.step(0, confirmed, confirmed + 1_000); // cold, immediate: target 14_075_000
+    acc.step(0, confirmed, confirmed + 1_000, 1); // cold, immediate: target 14_075_000
     // Our own first write lands mid-burst — confirmed truth now equals what
     // we predicted. This must rebase, not reset: the next step's delta is
     // measured from the new (matching) baseline and continues accumulating.
-    acc.step(0, confirmed + 1_000, confirmed + 1_000 + 1_000);
+    acc.step(0, confirmed + 1_000, confirmed + 1_000 + 1_000, 2);
     vi.advanceTimersByTime(60);
     expect(emit).toHaveBeenLastCalledWith(0, confirmed + 2_000);
   });
 
   it('(d) the accumulator expires after the quiet window and the next step is a fresh cold start', () => {
     const confirmed = 14_074_000;
-    acc.step(0, confirmed, confirmed + 1_000);
+    acc.step(0, confirmed, confirmed + 1_000, 1);
     expect(emit).toHaveBeenCalledTimes(1);
 
     vi.advanceTimersByTime(4_001); // past quietWindowMs with no further activity
 
-    acc.step(0, confirmed, confirmed + 1_000);
+    acc.step(0, confirmed, confirmed + 1_000, 1);
     // A fresh cold start emits immediately again — no pacing delay, and
     // the target is not double-accumulated from the expired burst.
     expect(emit).toHaveBeenCalledTimes(2);
@@ -111,13 +114,13 @@ describe('MOR-1425 tuning accumulator', () => {
     const lifecycle = { status: 'pending' };
     emit.mockReturnValueOnce(lifecycle);
     const confirmed = 14_074_000;
-    acc.step(0, confirmed, confirmed + 1_000); // cold, immediate — still pending
+    acc.step(0, confirmed, confirmed + 1_000, 1); // cold, immediate — still pending
 
     // The async failure arrives later by mutating the SAME retained object,
     // exactly like `failCommand`/`acknowledgeCommand` do in production.
     lifecycle.status = 'failed';
 
-    acc.step(0, confirmed, confirmed + 2_000);
+    acc.step(0, confirmed, confirmed + 2_000, 1);
     // Treated as a fresh cold start (the prior burst is dead), not an
     // accumulation onto a target that will never be retried. If the
     // accumulator had snapshotted `.status` at emit time instead of
@@ -128,16 +131,16 @@ describe('MOR-1425 tuning accumulator', () => {
   });
 
   it('tracks receivers independently', () => {
-    acc.step(0, 14_074_000, 14_075_000);
-    acc.step(1, 7_100_000, 7_101_000);
+    acc.step(0, 14_074_000, 14_075_000, 1);
+    acc.step(1, 7_100_000, 7_101_000, 1);
     expect(emit).toHaveBeenNthCalledWith(1, 0, 14_075_000);
     expect(emit).toHaveBeenNthCalledWith(2, 1, 7_101_000);
   });
 
   it('(g) jump(receiver, freq) clears accumulator state and emits the exact frequency immediately, unpaced — even mid-burst (review B1)', () => {
     const confirmed = 14_074_000;
-    acc.step(0, confirmed, confirmed + 1_000); // cold, immediate
-    acc.step(0, confirmed, confirmed + 1_000); // hot, accumulates, paced flush pending
+    acc.step(0, confirmed, confirmed + 1_000, 1); // cold, immediate
+    acc.step(0, confirmed, confirmed + 1_000, 1); // hot, accumulates, paced flush pending
     expect(emit).toHaveBeenCalledTimes(1);
 
     acc.jump(0, 18_100_000); // absolute target — must land EXACTLY, not accumulate
@@ -151,7 +154,7 @@ describe('MOR-1425 tuning accumulator', () => {
 
     // The next step is a fresh cold start off the jumped-to frequency, not
     // a continuation of the pre-jump burst.
-    acc.step(0, 18_100_000, 18_101_000);
+    acc.step(0, 18_100_000, 18_101_000, 1);
     expect(emit).toHaveBeenCalledTimes(3);
     expect(emit).toHaveBeenLastCalledWith(0, 18_101_000);
   });
@@ -160,19 +163,19 @@ describe('MOR-1425 tuning accumulator', () => {
     const confirmed = 14_074_000;
     const step = 1_000;
 
-    acc.step(0, confirmed, confirmed + step); // cold, immediate: target C+1_000
-    acc.step(0, confirmed, confirmed + step); // hot: target C+2_000, paced
-    acc.step(0, confirmed, confirmed + step); // hot: target C+3_000, same paced flush
+    acc.step(0, confirmed, confirmed + step, 1); // cold, immediate: target C+1_000
+    acc.step(0, confirmed, confirmed + step, 1); // hot: target C+2_000, paced
+    acc.step(0, confirmed, confirmed + step, 1); // hot: target C+3_000, same paced flush
     vi.advanceTimersByTime(60); // flush carries the latest target: C+3_000
 
-    acc.step(0, confirmed, confirmed + step); // hot, still no echo yet: target C+4_000, paced
+    acc.step(0, confirmed, confirmed + step, 1); // hot, still no echo yet: target C+4_000, paced
     vi.advanceTimersByTime(60); // flush: C+4_000 already sent to the radio
 
     // The echo of the VERY FIRST write (C+1_000 — long superseded by the
     // C+4_000 already in flight) finally lands: an INTERMEDIATE target, not
     // the frozen baseline (C) and not the current pending target either —
     // exactly the failure mode from the live capture (review B2).
-    acc.step(0, confirmed + step, confirmed + 2 * step);
+    acc.step(0, confirmed + step, confirmed + 2 * step, 2);
     vi.advanceTimersByTime(60);
 
     const targets = emit.mock.calls.map(([, freq]) => freq);
@@ -191,11 +194,11 @@ describe('MOR-1425 tuning accumulator', () => {
     let epoch = 1;
     const local = createTuningAccumulator({ emit, paceMs: 60, quietWindowMs: 4_000, epoch: () => epoch });
     const confirmed = 14_074_000;
-    local.step(0, confirmed, confirmed + 1_000); // cold, immediate
-    local.step(0, confirmed, confirmed + 1_000); // hot, paced
+    local.step(0, confirmed, confirmed + 1_000, 1); // cold, immediate
+    local.step(0, confirmed, confirmed + 1_000, 1); // hot, paced
 
     epoch = 2; // reconnect — a NEW control session
-    local.step(0, confirmed, confirmed + 1_000);
+    local.step(0, confirmed, confirmed + 1_000, 1);
 
     // Treated as a fresh cold start under the new epoch, not a continuation
     // of the pre-reconnect accumulation.
@@ -207,14 +210,73 @@ describe('MOR-1425 tuning accumulator', () => {
     let generation: number | null = 7;
     const local = createTuningAccumulator({ emit, paceMs: 60, quietWindowMs: 4_000, generation: () => generation });
     const confirmed = 14_074_000;
-    local.step(0, confirmed, confirmed + 1_000); // cold, immediate
-    local.step(0, confirmed, confirmed + 1_000); // hot, paced
+    local.step(0, confirmed, confirmed + 1_000, 1); // cold, immediate
+    local.step(0, confirmed, confirmed + 1_000, 1); // hot, paced
 
     generation = 8; // radio switch / re-negotiated capabilities
-    local.step(0, confirmed, confirmed + 1_000);
+    local.step(0, confirmed, confirmed + 1_000, 1);
 
     expect(emit).toHaveBeenCalledTimes(2);
     expect(emit).toHaveBeenLastCalledWith(0, confirmed + 1_000);
+  });
+
+  it('MOR-1864 fails closed on missing, regressed, or contradictory marker evidence', () => {
+    for (const [marker, frequency] of [[null, 14_074_000], [0, 14_074_000], [1, 14_080_000]] as const) {
+      emit.mockClear();
+      const local = createTuningAccumulator({ emit, paceMs: 60 });
+      local.step(0, 14_074_000, 14_075_000, 1);
+      local.step(0, frequency, frequency + 1_000, marker);
+      expect(emit).toHaveBeenCalledTimes(2);
+      expect(emit).toHaveBeenLastCalledWith(0, frequency + 1_000);
+    }
+  });
+
+  it('MOR-1864 preserves a repolled equal value, but requires association for a changed value', () => {
+    const acceptedTarget = vi.fn(() => false);
+    const local = createTuningAccumulator({ emit, paceMs: 60, acceptedTarget });
+    local.step(0, 14_074_000, 14_075_000, 1);
+    local.step(0, 14_074_000, 14_075_000, 2); // newer field marker, same value
+    vi.advanceTimersByTime(60);
+    expect(emit).toHaveBeenLastCalledWith(0, 14_076_000);
+    expect(acceptedTarget).not.toHaveBeenCalled();
+
+    local.step(0, 14_075_000, 14_076_000, 3); // changed, unmatched value
+    expect(emit).toHaveBeenLastCalledWith(0, 14_076_000);
+    expect(acceptedTarget).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+      frequency: 14_075_000, observationMarker: 3,
+    }));
+  });
+
+  it.each([14_074_500, 14_200_000])(
+    'MOR-1864 treats unmatched physical value %i as cold regardless of numeric segment',
+    (physical) => {
+      const local = createTuningAccumulator({ emit, paceMs: 60, acceptedTarget: () => false });
+      local.step(0, 14_074_000, 14_076_000, 1);
+      local.step(0, physical, physical + 1_000, 2);
+      expect(emit).toHaveBeenCalledTimes(2);
+      expect(emit).toHaveBeenLastCalledWith(0, physical + 1_000);
+    },
+  );
+
+  it('MOR-1864 rechecks selected identity and terminal/quiet fences at paced flush', () => {
+    let context = 'ab:main:A';
+    const lifecycle = { status: 'pending' };
+    emit.mockReturnValue(lifecycle);
+    const local = createTuningAccumulator({
+      emit, paceMs: 60, quietWindowMs: 4_000, context: () => context,
+    });
+    local.step(0, 14_074_000, 14_075_000, 1);
+    local.step(0, 14_074_000, 14_075_000, 1);
+    context = 'ab:main:B';
+    vi.advanceTimersByTime(60);
+    expect(emit).toHaveBeenCalledTimes(1);
+
+    context = 'ab:main:A';
+    local.step(0, 14_074_000, 14_075_000, 2);
+    local.step(0, 14_074_000, 14_075_000, 2);
+    lifecycle.status = 'failed';
+    vi.advanceTimersByTime(60);
+    expect(emit).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -233,13 +295,13 @@ describe('MOR-1425 getSharedTuningAccumulator (review B5)', () => {
 
     const confirmed = 14_074_000;
     const step = 1_000;
-    first.step(0, confirmed, confirmed + step); // cold, immediate
+    first.step(0, confirmed, confirmed + step, 1); // cold, immediate
     expect(sharedEmit).toHaveBeenCalledTimes(1);
 
     // If `second` tracked independent state, this would ALSO be a cold,
     // immediate start (on `second`'s own emit spy). Because it shares
     // `first`'s pending burst instead, it accumulates and paces.
-    second.step(0, confirmed, confirmed + step);
+    second.step(0, confirmed, confirmed + step, 1);
     expect(sharedEmit).toHaveBeenCalledTimes(1);
     vi.advanceTimersByTime(60);
     expect(sharedEmit).toHaveBeenCalledTimes(2);

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -35,7 +35,11 @@ import {
 import { audioManager } from '$lib/audio/audio-manager';
 import { adjustTuningStep, getTuningStep } from '$lib/stores/tuning.svelte';
 import { currentControlSessionEpoch, dispatchRadioIntent, isNormalizedLevel } from './radio-intents';
-import { getSharedTuningAccumulator } from './tuning-accumulator';
+import { getCommandLifecycles } from '$lib/stores/commands.svelte';
+import {
+  getSharedTuningAccumulator,
+  type AcceptedTargetQuery,
+} from './tuning-accumulator';
 
 /* ── Shared helpers ──────────────────────────────────────────────── */
 
@@ -1133,6 +1137,80 @@ function supportsVfoSlot(
   return context.caps.vfoScheme === 'ab' || context.caps.vfoScheme === 'main_sub';
 }
 
+function tuningReceiverPath(receiver: number): 'main' | 'sub' | null {
+  return receiver === 0 ? 'main' : receiver === 1 ? 'sub' : null;
+}
+
+/** Identity of the physical receiver's currently selected VFO. Relative A/B
+ * providers remain relative; an A/B label is used only when observed. */
+function currentTuningContext(receiver: number): string | null {
+  const context = currentA03cContext();
+  const receiverPath = tuningReceiverPath(receiver);
+  if (!context || receiverPath === null) return null;
+  if (knownA03cReceiver(context, receiverPath === 'main' ? 'MAIN' : 'SUB', 'freqHz') !== receiver) return null;
+  if (context.caps.vfoScheme === 'single' || context.caps.vfoScheme === 'ab_shared') {
+    return `${context.caps.vfoScheme}:${receiverPath}`;
+  }
+  if (context.caps.vfoScheme === 'ab'
+    && relativeVfoIdentityUnknown(context.state, context.caps, receiverPath)) {
+    return `ab-relative:${receiverPath}`;
+  }
+  const selected = context.state[receiverPath]?.activeSlot;
+  const status = getFieldStatus(context.state, `${receiverPath}.activeSlot`);
+  if (context.caps.vfoScheme === 'main_sub' && (status?.observed !== true
+    || (selected !== 'A' && selected !== 'B'))) return `main_sub:${receiverPath}`;
+  return status?.observed === true && status.freshness !== 'unknown'
+    && status.availability !== 'missing' && (selected === 'A' || selected === 'B')
+    ? `${context.caps.vfoScheme}:${receiverPath}:${selected}` : null;
+}
+
+function currentTuningMarker(receiver: number): number | null {
+  const context = currentA03cContext();
+  const receiverPath = tuningReceiverPath(receiver);
+  if (!context || receiverPath === null) return null;
+  const status = getFieldStatus(context.state, `${receiverPath}.freqHz`);
+  const marker = status?.lastObservedMonotonic;
+  return status?.observed === true && status.freshness !== 'unknown'
+    && status.availability !== 'missing' && status.availability !== 'unavailable'
+    && status.availability !== 'undeclared'
+    && status.source !== null
+    && (!Array.isArray(status.quality) || status.quality.includes('confirmed'))
+    && typeof marker === 'number' && Number.isFinite(marker) && marker >= 0
+    ? marker : null;
+}
+
+function acceptedTuningTarget(query: AcceptedTargetQuery): boolean {
+  // Practical association, not causal proof: a changed radio observation may
+  // continue this burst only when it exactly equals an accepted local target
+  // and advances that command's frequency-field ACK marker. A physical move
+  // to the same still-relevant target is intrinsically indistinguishable and
+  // is intentionally treated as the local echo.
+  if (currentTuningContext(query.receiver) !== query.context) return false;
+  const receiverPath = tuningReceiverPath(query.receiver);
+  if (receiverPath === null) return false;
+  const path = `${receiverPath}.freqHz`;
+  const records = getCommandLifecycles();
+  const anchorIndex = query.anchor.id === null ? -1 : records.findIndex((record) =>
+    record.id === query.anchor.id && record.createdAt === query.anchor.createdAt);
+  return records.some((record, index) => {
+    const inBurst = anchorIndex >= 0
+      ? index >= anchorIndex
+      : record.createdAt > query.anchor.createdAt;
+    const params = record.params;
+    const boundary = record.ackFieldObservationTimes?.[path];
+    return inBurst
+      && record.name === 'set_freq'
+      && (record.status === 'acknowledged' || record.status === 'confirmed')
+      && record.originalEpoch === currentControlSessionEpoch()
+      && record.providerGeneration === getCapabilities()?.providerGeneration
+      && Reflect.ownKeys(params).length === 2
+      && params.receiver === query.receiver
+      && params.freq === query.frequency
+      && typeof boundary === 'number' && Number.isFinite(boundary)
+      && query.observationMarker > boundary;
+  });
+}
+
 export function makeVfoHandlers() {
   // MOR-1425: rapid-tuning-step accumulator, shared module-wide (review
   // B5) — NOT per-instance: `panel-adapters.ts` holds both a singleton
@@ -1149,6 +1227,8 @@ export function makeVfoHandlers() {
         const value = getCapabilities()?.providerGeneration;
         return typeof value === 'number' ? value : null;
       },
+      context: currentTuningContext,
+      acceptedTarget: acceptedTuningTarget,
     });
   }
 
@@ -1156,11 +1236,13 @@ export function makeVfoHandlers() {
     onSwap: () => {
       const context = currentA03cContext();
       if (!context || !context.caps.capabilities.includes('vfo_swap')) return;
+      tuningAccumulator().cancel();
       dispatchRadioIntent({ name: 'vfo_swap', params: {} });
     },
     onEqual: () => {
       const context = currentA03cContext();
       if (!context || !context.caps.capabilities.includes('vfo_equalize')) return;
+      tuningAccumulator().cancel();
       dispatchRadioIntent({ name: 'vfo_equalize', params: {} });
     },
     onSplitToggle: () => {
@@ -1170,8 +1252,8 @@ export function makeVfoHandlers() {
         || !knownA03cTopLevelField(context, 'split') || typeof current !== 'boolean') return;
       dispatchRadioIntent({ name: 'set_split', params: { on: !current } });
     },
-    onMainVfoClick: () => { activateReceiver('MAIN'); },
-    onSubVfoClick: () => { activateReceiver('SUB'); },
+    onMainVfoClick: () => { tuningAccumulator().cancel(); activateReceiver('MAIN'); },
+    onSubVfoClick: () => { tuningAccumulator().cancel(); activateReceiver('SUB'); },
     onVfoSelect: (receiver: 'MAIN' | 'SUB', slot: 'A' | 'B' | null) => {
       const context = currentA03cContext();
       // MOR-1423: same single-receiver `active` bypass as knownActiveReceiver
@@ -1184,24 +1266,25 @@ export function makeVfoHandlers() {
       if (!context || (active !== 'MAIN' && active !== 'SUB')
         || knownA03cReceiver(context, receiver) === null
         || !supportsVfoSlot(context, slot)) return;
+      tuningAccumulator().cancel(receiver === 'SUB' ? 1 : 0);
       if (active !== receiver && !activateReceiver(receiver, context)) return;
       if (slot !== null) dispatchRadioIntent({ name: 'set_vfo', params: { vfo: slot } });
     },
-    onMainModeClick: () => focusModePanel('MAIN'),
-    onSubModeClick: () => focusModePanel('SUB'),
+    onMainModeClick: () => { tuningAccumulator().cancel(); focusModePanel('MAIN'); },
+    onSubModeClick: () => { tuningAccumulator().cancel(); focusModePanel('SUB'); },
     onMainFreqChange: (freq: number) => {
       const context = currentA03cContext();
       const main = context?.state.main;
       if (!context || knownA03cReceiver(context, 'MAIN', 'freqHz') !== 0
         || !Number.isSafeInteger(freq) || !main) return;
-      tuningAccumulator().step(0, main.freqHz, freq);
+      tuningAccumulator().step(0, main.freqHz, freq, currentTuningMarker(0));
     },
     onSubFreqChange: (freq: number) => {
       const context = currentA03cContext();
       const sub = context?.state.sub;
       if (!context || knownA03cReceiver(context, 'SUB', 'freqHz') !== 1
         || !Number.isSafeInteger(freq) || !sub) return;
-      tuningAccumulator().step(1, sub.freqHz, freq);
+      tuningAccumulator().step(1, sub.freqHz, freq, currentTuningMarker(1));
     },
     // MOR-1425 review B1: callers mix ABSOLUTE targets (spectrum click/
     // drag, EiBi/QSY recall) and RELATIVE steps (spectrum scroll, media
@@ -1216,7 +1299,7 @@ export function makeVfoHandlers() {
       if (kind === 'jump') { tuningAccumulator().jump(receiver, freq); return; }
       const confirmed = receiver === 1 ? context.state.sub : context.state.main;
       if (!confirmed) return;
-      tuningAccumulator().step(receiver, confirmed.freqHz, freq);
+      tuningAccumulator().step(receiver, confirmed.freqHz, freq, currentTuningMarker(receiver));
     },
     onModeChange: (mode: string, receiver?: Receiver) => {
       const context = currentA03cContext();

--- a/frontend/src/lib/runtime/commands/tuning-accumulator.ts
+++ b/frontend/src/lib/runtime/commands/tuning-accumulator.ts
@@ -1,122 +1,76 @@
-/**
- * MOR-1425 — rapid tuning-step accumulator.
- *
- * Digit-tuning gestures (wheel ticks, arrow presses) compute their target as
- * `displayed value + step`, but the displayed value is last-confirmed radio
- * truth and only advances after a full `set_freq` round trip (~0.5-2s on
- * live hardware). A burst inside one round trip all computes the SAME
- * target off the same stale display, so N steps net one write — the
- * collapse this module fixes by holding an ephemeral PENDING TARGET per
- * receiver: while a burst is "hot" (within `quietWindowMs` of the last
- * step), each gesture's delta from the FROZEN baseline accumulates onto the
- * target instead. Emission is paced just above the server's 50ms
- * same-command coalescing window (MOR-1427).
- *
- * `step()` is for RELATIVE gestures only (wheel/arrow, one fixed increment
- * per call). ABSOLUTE targets (click-to-tune, station/QSY recall) go
- * through `jump()` instead (review B1): a burst delta computed against an
- * absolute target is meaningless, so `jump()` clears any in-flight burst
- * for the receiver and emits the exact frequency immediately, unpaced.
- *
- * Invariants:
- *  - this module never patches a store — it only calls the injected `emit`.
- *  - a confirmed observation on the CLOSED SEGMENT between the frozen
- *    baseline and the current target (direction of travel) is one of our
- *    own writes landing mid-burst — including an INTERMEDIATE target
- *    already superseded by further accumulation, not just the final one
- *    (review B2) — and rebases the baseline without discarding the target.
- *    Off-segment is a genuine contradiction (the operator moved the
- *    physical dial): reset, and rebuild the baseline from the new truth.
- *  - the burst expires after `quietWindowMs` of inactivity, immediately on
- *    a terminal (failed/cancelled/timed-out) lifecycle — the lifecycle
- *    OBJECT is retained and `.status` read fresh each step/flush, since
- *    it's mutated in place after `emit` returns, not replaced (review B3) —
- *    or on a control-session epoch / capabilities-generation change (review
- *    B4), so a burst never carries across a reconnect or radio switch.
- *  - the first step of a cold window emits immediately, unpaced.
- *  - ONE accumulator per receiver, globally (review B5): `createTuningAccumulator`
- *    stays a plain per-call factory (used by tests); production code goes
- *    through `getSharedTuningAccumulator`, a module singleton so every
- *    caller shares the same pending-burst state per receiver.
- */
+/** Rapid relative-tuning accumulator (MOR-1425, MOR-1864). */
 
-const DEFAULT_PACE_MS = 60; // just above the server's 50ms coalescing window
-const DEFAULT_QUIET_WINDOW_MS = 4_000; // ~2x the observed confirm round trip
-
+const DEFAULT_PACE_MS = 60;
+const DEFAULT_QUIET_WINDOW_MS = 4_000;
 const TERMINAL_STATUSES = new Set(['failed', 'cancelled', 'timed-out']);
 
-/** Structural — matches `CommandLifecycle` without importing it (this
- *  module stays store/transport-free; see the file-level invariants). */
-interface EmittedLifecycle { status: string }
+export interface EmittedLifecycle {
+  status: string;
+  id?: string;
+  createdAt?: number;
+}
+
+export interface BurstAnchor {
+  readonly id: string | null;
+  readonly createdAt: number;
+}
+
+export interface AcceptedTargetQuery {
+  readonly receiver: number;
+  readonly context: string;
+  readonly frequency: number;
+  readonly observationMarker: number;
+  readonly anchor: BurstAnchor;
+}
 
 interface PendingTuning {
-  /** Confirmed radio truth this burst's deltas are measured against. */
-  baseline: number;
-  /** Latest accumulated target — the honest prediction of where we're heading. */
   target: number;
-  /** Wall-clock deadline; no further activity past this and the burst expires. */
   quietUntil: number;
-  /** Non-null while a paced flush is scheduled. */
   flushTimer: ReturnType<typeof setTimeout> | null;
-  /** Wall-clock time the last frame was actually emitted, for pacing. */
   lastEmitAt: number;
-  /** Last emitted lifecycle OBJECT, mutated in place by the caller — read
-   *  fresh, never snapshotted (review B3). */
   lastLifecycle: EmittedLifecycle | null;
-  /** Session epoch / capabilities generation this burst started under; a
-   *  mismatch at any later step/flush expires it (review B4). */
   epoch: number;
   generation: number | null;
+  context: string;
+  lastObservationMarker: number;
+  lastObservedFrequency: number;
+  anchor: BurstAnchor;
 }
 
 export interface TuningAccumulatorOptions {
-  /** Sends one `set_freq` for `receiver` at `freq`; returns its lifecycle
-   *  object when known, so a NAK/failure can expire the burst early. */
   emit: (receiver: number, freq: number) => EmittedLifecycle | void;
   now?: () => number;
   paceMs?: number;
   quietWindowMs?: number;
-  /** Current control-session epoch / capabilities generation (review B4);
-   *  default to a constant so options that omit them never force a reset. */
   epoch?: () => number;
   generation?: () => number | null;
+  /** Selected-VFO identity, read at every step and again at paced flush. */
+  context?: (receiver: number) => string | null;
+  /** Exact accepted-target association for a changed frequency observation. */
+  acceptedTarget?: (query: AcceptedTargetQuery) => boolean;
 }
 
 export interface TuningAccumulator {
-  /** Feed one RELATIVE gesture: `confirmedFreq` is the current confirmed
-   *  radio truth for `receiver`, `requestedFreq` the absolute target the
-   *  presentation layer computed off its own (possibly stale) display. */
-  step(receiver: number, confirmedFreq: number, requestedFreq: number): void;
-  /** Feed one ABSOLUTE-target gesture (click-to-tune, station/QSY recall):
-   *  clears any in-flight burst and emits `freq` unpaced (review B1). */
+  step(receiver: number, confirmedFreq: number, requestedFreq: number, observationMarker?: number | null): void;
   jump(receiver: number, freq: number): void;
+  /** Retire queued relative intent before an explicit VFO identity command. */
+  cancel(receiver?: number): void;
 }
 
-/** True when `observed` lies on the closed segment between `baseline` and
- *  `target`, in the direction of travel (review B2) — covers both
- *  endpoints and every intermediate target a burst has already emitted. */
-function isOnSegment(baseline: number, target: number, observed: number): boolean {
-  return target >= baseline
-    ? observed >= baseline && observed <= target
-    : observed <= baseline && observed >= target;
+function validMarker(value: number | null): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
 }
 
 export function createTuningAccumulator(options: TuningAccumulatorOptions): TuningAccumulator {
   const {
     emit,
-    // A plain `now = Date.now` default would capture a reference to
-    // whatever `Date.now` IS AT CONSTRUCTION TIME. `makeVfoHandlers()` is
-    // called once at module import for the singleton accessor
-    // (`getVfoHandlers()` in `panel-adapters.ts`) — well before any test's
-    // `vi.useFakeTimers()` swaps the global — so a captured reference would
-    // silently keep reading real wall-clock time forever. Looking up
-    // `Date.now` fresh on every call instead tracks whatever is currently
-    // installed as the global, faked or not.
     now = () => Date.now(),
     paceMs = DEFAULT_PACE_MS,
     quietWindowMs = DEFAULT_QUIET_WINDOW_MS,
     epoch: getEpoch = () => 0,
     generation: getGeneration = () => null,
+    context: getContext = (receiver) => `receiver:${receiver}`,
+    acceptedTarget = () => false,
   } = options;
   const pending = new Map<number, PendingTuning>();
 
@@ -126,16 +80,25 @@ export function createTuningAccumulator(options: TuningAccumulatorOptions): Tuni
     pending.delete(receiver);
   }
 
-  function sessionChanged(state: PendingTuning): boolean {
-    return state.epoch !== getEpoch() || state.generation !== getGeneration();
+  function contextChanged(receiver: number, state: PendingTuning): boolean {
+    return state.epoch !== getEpoch()
+      || state.generation !== getGeneration()
+      || state.context !== getContext(receiver);
+  }
+
+  function stillLive(receiver: number, state: PendingTuning, t: number): boolean {
+    return t < state.quietUntil
+      && !contextChanged(receiver, state)
+      && !TERMINAL_STATUSES.has(state.lastLifecycle?.status ?? '');
   }
 
   function flush(receiver: number): void {
     const state = pending.get(receiver);
     if (!state) return;
-    if (sessionChanged(state)) { clear(receiver); return; }
+    const t = now();
+    if (!stillLive(receiver, state, t)) { clear(receiver); return; }
     state.flushTimer = null;
-    state.lastEmitAt = now();
+    state.lastEmitAt = t;
     state.lastLifecycle = emit(receiver, state.target) ?? null;
   }
 
@@ -146,71 +109,90 @@ export function createTuningAccumulator(options: TuningAccumulatorOptions): Tuni
     state.flushTimer = setTimeout(() => flush(receiver), wait);
   }
 
-  function beginFresh(receiver: number, t: number, baseline: number, target: number): PendingTuning {
+  function beginFresh(
+    receiver: number,
+    t: number,
+    confirmedFreq: number,
+    requestedFreq: number,
+    observationMarker: number | null,
+  ): void {
     clear(receiver);
-    const fresh: PendingTuning = {
-      baseline,
-      target,
+    const context = getContext(receiver);
+    const lifecycle = emit(receiver, requestedFreq) ?? null;
+    if (context === null || !validMarker(observationMarker)) return;
+    pending.set(receiver, {
+      target: requestedFreq,
       quietUntil: t + quietWindowMs,
       flushTimer: null,
       lastEmitAt: t,
-      lastLifecycle: null,
+      lastLifecycle: lifecycle,
       epoch: getEpoch(),
       generation: getGeneration(),
-    };
-    pending.set(receiver, fresh);
-    return fresh;
+      context,
+      lastObservationMarker: observationMarker,
+      lastObservedFrequency: confirmedFreq,
+      anchor: {
+        id: typeof lifecycle?.id === 'string' ? lifecycle.id : null,
+        createdAt: typeof lifecycle?.createdAt === 'number' ? lifecycle.createdAt : t,
+      },
+    });
+  }
+
+  function observationContinues(
+    receiver: number,
+    state: PendingTuning,
+    frequency: number,
+    marker: number | null,
+  ): boolean {
+    if (!validMarker(marker) || marker < state.lastObservationMarker) return false;
+    if (marker === state.lastObservationMarker) return frequency === state.lastObservedFrequency;
+    if (frequency !== state.lastObservedFrequency && !acceptedTarget({
+      receiver,
+      context: state.context,
+      frequency,
+      observationMarker: marker,
+      anchor: state.anchor,
+    })) return false;
+    state.lastObservationMarker = marker;
+    state.lastObservedFrequency = frequency;
+    return true;
   }
 
   return {
-    step(receiver, confirmedFreq, requestedFreq) {
+    step(receiver, confirmedFreq, requestedFreq, observationMarker = null) {
       const t = now();
       const state = pending.get(receiver);
-      let hot = state !== undefined
-        && t < state.quietUntil
-        && !sessionChanged(state)
-        && !TERMINAL_STATUSES.has(state.lastLifecycle?.status ?? '');
-
-      if (hot) {
-        if (isOnSegment(state!.baseline, state!.target, confirmedFreq)) {
-          // Our own write landing mid-burst — the frozen baseline or any
-          // intermediate target we already emitted — rebase and continue.
-          state!.baseline = confirmedFreq;
-        } else {
-          // Off the segment: a physical observation we did not cause.
-          hot = false;
-        }
-      }
+      const hot = state !== undefined
+        && stillLive(receiver, state, t)
+        && observationContinues(receiver, state, confirmedFreq, observationMarker);
 
       if (!hot) {
-        const fresh = beginFresh(receiver, t, confirmedFreq, requestedFreq);
-        fresh.lastLifecycle = emit(receiver, requestedFreq) ?? null;
+        beginFresh(receiver, t, confirmedFreq, requestedFreq, observationMarker);
         return;
       }
 
-      state!.target += requestedFreq - state!.baseline;
-      state!.quietUntil = t + quietWindowMs;
+      state.target += requestedFreq - confirmedFreq;
+      state.quietUntil = t + quietWindowMs;
       scheduleFlush(receiver);
     },
     jump(receiver, freq) {
-      // No pending burst to leave behind: an absolute target carries no
-      // "baseline" a future relative step could honestly accumulate from.
       clear(receiver);
       emit(receiver, freq);
+    },
+    cancel(receiver) {
+      if (receiver !== undefined) { clear(receiver); return; }
+      for (const key of [...pending.keys()]) clear(key);
     },
   };
 }
 
 let singleton: TuningAccumulator | null = null;
 
-/** Module-level singleton (review B5): options are captured from the FIRST
- *  caller only — every real caller wires functionally identical ones, so
- *  every `makeVfoHandlers()` instance shares one pending-burst state. */
 export function getSharedTuningAccumulator(options: TuningAccumulatorOptions): TuningAccumulator {
   return singleton ??= createTuningAccumulator(options);
 }
 
-/** Test-only: clears the shared singleton for a clean slate between tests. */
 export function resetSharedTuningAccumulatorForTests(): void {
+  singleton?.cancel();
   singleton = null;
 }

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -1943,7 +1943,7 @@ describe('pending-target affordance (MOR-1441)', () => {
         let requested: number | null = null;
         const onTuneFrequency = (_receiver: 'MAIN' | 'SUB', hz: number) => {
           requested = hz;
-          accumulator.step(0, CONFIRMED, hz);
+          accumulator.step(0, CONFIRMED, hz, 1);
         };
         const el = document.createElement('div');
         document.body.appendChild(el);


### PR DESCRIPTION
11 code + 0 regenerated baselines = 11 files

MOR-1864 tracks rapid relative tuning as signed intent across delayed radio echoes. The accumulator now associates a changed field observation with an exact accepted same-burst target and ACK marker, preserves older locally-obsolete acknowledgements, and fences queued work across selected-VFO, session, provider, terminal, quiet, and absolute-command boundaries.

This is practical association rather than causal protocol proof. A physical move exactly equal to a still-relevant accepted target remains indistinguishable and follows the local-echo policy. No transport, backend, timeout, producer freshness, or hardware command contract changes.

The 637-line patch is one atomic accumulator correction: 2 production files and 9 tests. The tests include focused accumulator/registry behavior, directly coupled marker fixtures, and five legacy mocks that must expose the imported session/field-status seams for full CI.

Validation:
- pristine-base regression: 1 expected failure, commands 3/4 drifted to S+2000/S-1000
- final focused candidate: 469/469 passed across the five mechanism suites and five formerly failing CI fixtures
- frontend check: 0 errors, 0 warnings
- ESLint on all touched files: passed across production/mechanism and final fixture delta runs
- diff check: passed

Linear: MOR-1864
