### PR TITLE
fix(ui): restore passband promptly after VFO selection

### DIFF
--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -1704,6 +1704,18 @@ describe('managed scope projection (MOR-2367)', () => {
     expect(result.display).toMatchObject({ state: 'current', tuple: { frequencyHz: 14_090_000, mode: 'LSB', widthHz: 1800 } });
     expect(target.querySelectorAll('.passband-overlay')).toHaveLength(1);
     expect(target.querySelector<HTMLElement>('.tune-line')!.style.left).toBe('50%');
+    Object.assign(state.fieldStatus['main.activeSlot'], {
+      lastObservedMonotonic: 30, source: { source: 'command_response' },
+    });
+    present(14_090_000);
+    expect(result.display.state).toBe('unknown');
+    expect(target.querySelector('.passband-overlay')).toBeNull();
+    for (const [index, leaf] of ['filterWidth', 'pbtInner', 'pbtOuter'].entries()) {
+      state.fieldStatus[`main.${leaf}`].lastObservedMonotonic = 30.1 + index / 10;
+      present(14_090_000);
+    }
+    expect(result.display).toMatchObject({ state: 'current', tuple: { frequencyHz: 14_090_000, widthHz: 1800 } });
+    expect(target.querySelectorAll('.passband-overlay')).toHaveLength(1);
     expect(handlerHarness.vfo.onFreqChange).not.toHaveBeenCalled();
     expect(handlerHarness.filter.onFilterWidthCommit).not.toHaveBeenCalled();
   });

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -11,6 +11,7 @@ import { resolve } from 'node:path';
 import type { ScopeDisplayProjection } from '$lib/runtime/adapters/scope-display-projection';
 import { EMPTY_SCOPE_PASSBAND_DISPLAY, projectScopePassbandDisplay,
   type ScopePassbandDisplayInput } from '$lib/runtime/adapters/scope-passband-display';
+import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
 import { qualifyScopeFrameEnvelope, toScopeDisplayFrame } from '$lib/runtime/adapters/scope-adapter';
 import { resolveLcdSpectrumFrame } from '../../../skins/segmentline/lcd-display-contract';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
@@ -1646,6 +1647,63 @@ describe('managed scope projection (MOR-2367)', () => {
       expect(target.querySelectorAll('.passband-overlay')).toHaveLength(1);
       if (step < 7) expect(target.querySelector('.passband-resize-zone')).toBeNull();
     }
+    expect(handlerHarness.vfo.onFreqChange).not.toHaveBeenCalled();
+    expect(handlerHarness.filter.onFilterWidthCommit).not.toHaveBeenCalled();
+  });
+  it('recovers selected-slot geometry through canonical alias hydration without a second width reading', () => {
+    authorityHarness.state.useProductionSelector = true;
+    const state = structuredClone(IC7300_STATE); const caps = structuredClone(IC7300_CAPABILITIES);
+    const rx = state.main!;
+    Object.assign(rx, { freqHz: 14_074_000, mode: 'USB', filter: 1, activeSlot: 'A',
+      filterWidth: 2400, pbtInner: 128, pbtOuter: 128, dataMode: 0,
+      vfoA: { freqHz: 14_074_000, mode: 'USB', filterNum: 1, dataMode: 0 },
+      vfoB: { freqHz: 14_090_000, mode: 'LSB', filterNum: 2, dataMode: 1 } });
+    const paths = ['main', ...Object.keys(rx).map((leaf) => `main.${leaf}`),
+      ...['vfoA', 'vfoB'].flatMap(slot => Object.keys(rx.vfoA!).map(leaf => `main.${slot}.${leaf}`))];
+    state.fieldStatus = Object.fromEntries(paths.map(path => [path, { storePath: path,
+      observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 10 }]));
+    runtimeHarness.state.currentState = state; runtimeHarness.state.currentCaps = caps;
+    const input: ScopePassbandDisplayInput = { state, caps, selection: null,
+      session: { state: 'connected', epoch: 1 }, frame: null };
+    const { target, props } = managed(null); let result = EMPTY_SCOPE_PASSBAND_DISPLAY; let sequence = 0;
+    function present(center: number): void {
+      const active = toRadioViewModel(state, caps)!.vfos.filter(vfo => vfo.isActive);
+      const vfo = active.length === 1 ? active[0] : null;
+      input.selection = vfo?.slot.kind === 'slotted' ? { receiver: vfo.receiver, slot: vfo.slot.id } : null;
+      const envelope = qualifyScopeFrameEnvelope({ receiver: 0, mode: 0,
+        startFreq: center - 50_000, endFreq: center + 50_000, pixels: new Uint8Array([10, 100, 200]) },
+      { source: 'hardware', receiver: 0, providerGeneration: 1, transportEpoch: 1,
+        receivedAt: 0, acceptedSequence: ++sequence }, 1)!;
+      const authority = { source: 'hardware' as const, receiver: 0 as const, providerGeneration: 1,
+        transportEpoch: 1, demanded: true, transport: 'connected' as const, nowMonotonic: 0 };
+      const frame = toScopeDisplayFrame(envelope, authority);
+      input.frame = { envelope, authority, resolution: resolveLcdSpectrumFrame(frame, { source: 'hardware', receiver: 'MAIN' }) };
+      result = projectScopePassbandDisplay(result, input);
+      props.set('projection', { frame, frameMode: 0, acceptedSequence: sequence, passband: result.display }); flushSync();
+    }
+    present(14_074_000); expect(result.display.state).toBe('current');
+    rx.activeSlot = 'B'; state.fieldStatus['main.activeSlot'].lastObservedMonotonic = 20;
+    for (const leaf of Object.keys(rx.vfoB!)) state.fieldStatus[`main.vfoB.${leaf}`].observed = false;
+    rx.filterWidth = 1800; state.fieldStatus['main.filterWidth'].lastObservedMonotonic = 20.1;
+    present(14_074_000);
+    expect(input.selection).toEqual({ receiver: 'MAIN', slot: 'B' });
+    expect(result.display.state).toBe('unknown');
+    expect(target.querySelector('.passband-overlay')).toBeNull();
+    expect(target.querySelector('.passband-resize-zone')).toBeNull();
+    Object.assign(rx, { freqHz: 14_090_000, mode: 'LSB', filter: 2, dataMode: 1 });
+    for (const path of [...Object.keys(rx.vfoB!).map(leaf => `main.vfoB.${leaf}`),
+      'main.freqHz', 'main.mode', 'main.filter', 'main.dataMode']) {
+      Object.assign(state.fieldStatus[path], { observed: true, lastObservedMonotonic: 20.2 });
+    }
+    present(14_090_000); expect(result.display.state).toBe('unknown');
+    for (const [index, leaf] of ['pbtInner', 'pbtOuter'].entries()) {
+      state.fieldStatus[`main.${leaf}`].lastObservedMonotonic = 20.3 + index / 10;
+      present(14_090_000);
+      if (index === 0) expect(target.querySelector('.passband-overlay')).toBeNull();
+    }
+    expect(result.display).toMatchObject({ state: 'current', tuple: { frequencyHz: 14_090_000, mode: 'LSB', widthHz: 1800 } });
+    expect(target.querySelectorAll('.passband-overlay')).toHaveLength(1);
+    expect(target.querySelector<HTMLElement>('.tune-line')!.style.left).toBe('50%');
     expect(handlerHarness.vfo.onFreqChange).not.toHaveBeenCalled();
     expect(handlerHarness.filter.onFilterWidthCommit).not.toHaveBeenCalled();
   });

--- a/frontend/src/lib/runtime/adapters/__tests__/scope-passband-display.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scope-passband-display.test.ts
@@ -104,6 +104,112 @@ function tune(input: ScopePassbandDisplayInput, frequency: number, marker: numbe
   }
 }
 
+describe('confirmed VFO selection recovery (MOR-2441)', () => {
+  function select(input: ScopePassbandDisplayInput, slot: 'A' | 'B', marker: number): void {
+    input.selection!.slot = slot; input.state!.main!.activeSlot = slot;
+    status(input, 'main.activeSlot', { lastObservedMonotonic: marker });
+  }
+  it.each(['batched', 'width-first', 'tuple-first'])(
+    'captures the first complete post-selection geometry: %s', (order) => {
+      const input = banded(); let result = project(input);
+      select(input, 'B', 20);
+      const rx = input.state!.main!;
+      rx.vfoB!.freqHz = 14_090_000;
+      status(input, 'main.vfoB.freqHz', { observed: false });
+      if (order !== 'tuple-first') {
+        rx.filterWidth = 1800; status(input, 'main.filterWidth', { lastObservedMonotonic: 20.1 });
+      }
+      if (order !== 'batched') {
+        receipt(input, 2); result = project(input, result);
+        expect(result.display.state).toBe('unknown');
+      }
+      rx.freqHz = rx.vfoB!.freqHz;
+      status(input, 'main.vfoB.freqHz', { observed: true, lastObservedMonotonic: 20.2 });
+      status(input, 'main.freqHz', { lastObservedMonotonic: 20.2 });
+      if (order === 'batched') {
+        for (const leaf of ['pbtInner', 'pbtOuter']) status(input, `main.${leaf}`, { lastObservedMonotonic: 20.3 });
+      }
+      receipt(input, 3, { startFreq: 14_040_000, endFreq: 14_140_000 });
+      result = project(input, result);
+      if (order !== 'batched') {
+        expect(result.display.state).toBe('unknown');
+        status(input, 'main.activeSlot', { lastObservedMonotonic: 21 });
+        rx.filterWidth = 1800;
+        if (order === 'tuple-first') status(input, 'main.filterWidth', { lastObservedMonotonic: 20.4 });
+        for (const [index, leaf] of ['pbtInner', 'pbtOuter'].entries()) {
+          status(input, `main.${leaf}`, { lastObservedMonotonic: 20.5 + index / 10 });
+          receipt(input, 4 + index, { startFreq: 14_040_000, endFreq: 14_140_000 });
+          result = project(input, result);
+          if (index === 0) expect(result.display.state).toBe('unknown');
+        }
+      }
+      expect(result.display.state).toBe('current');
+      expect(tuple(result)).toMatchObject({ frequencyHz: 14_090_000, widthHz: 1800 });
+    });
+  it.each(['mode', 'filter', 'DATA', 'session', 'provider', 'band', 'frame', 'regression'])(
+    'retires an interrupted selection recovery on %s change', (change) => {
+      const input = banded(); let result = project(input);
+      select(input, 'B', 20); receipt(input, 2); result = project(input, result);
+      status(input, 'main.filterWidth', { lastObservedMonotonic: 20.1 });
+      receipt(input, 3); result = project(input, result);
+      const rx = input.state!.main!;
+      if (change === 'mode') { rx.mode = rx.vfoB!.mode = 'LSB'; status(input, 'main.mode', { lastObservedMonotonic: 21 }); status(input, 'main.vfoB.mode', { lastObservedMonotonic: 21 }); }
+      if (change === 'filter') { rx.filter = rx.vfoB!.filterNum = 2; status(input, 'main.filter', { lastObservedMonotonic: 21 }); status(input, 'main.vfoB.filterNum', { lastObservedMonotonic: 21 }); }
+      if (change === 'DATA') { rx.dataMode = 1; status(input, 'main.dataMode', { lastObservedMonotonic: 21 }); }
+      if (change === 'session') input.session!.epoch = 2;
+      if (change === 'provider') { input.state!.providerGeneration = 2; input.caps!.providerGeneration = 2; }
+      if (change === 'band') { rx.freqHz = rx.vfoB!.freqHz = 7_100_000; status(input, 'main.freqHz', { lastObservedMonotonic: 21 }); status(input, 'main.vfoB.freqHz', { lastObservedMonotonic: 21 }); }
+      if (change === 'regression') status(input, 'main.activeSlot', { lastObservedMonotonic: 19 });
+      receipt(input, 4, change === 'frame' ? { mode: 1 } : {});
+      result = project(input, result); expect(result.display.state).toBe('unknown');
+      expect(result.selectionRecovery).toBeNull();
+      for (const leaf of ['pbtInner', 'pbtOuter']) status(input, `main.${leaf}`, { lastObservedMonotonic: 22 });
+      receipt(input, 5, change === 'frame' ? { mode: 1 } : {});
+      expect(project(input, result).display.state).toBe('unknown');
+    });
+  it('requires the selected axis and retires invalid frames during recovery', () => {
+    const input = banded(); let result = project(input);
+    select(input, 'B', 20);
+    input.state!.main!.freqHz = input.state!.main!.vfoB!.freqHz = 14_090_000;
+    for (const path of ['main.freqHz', 'main.vfoB.freqHz', 'main.filterWidth', 'main.pbtInner', 'main.pbtOuter']) {
+      status(input, path, { lastObservedMonotonic: 20.1 });
+    }
+    receipt(input, 2); result = project(input, result);
+    expect(result.display.state).toBe('unknown');
+    input.frame = { ...input.frame!, resolution: { state: 'ghost', reason: 'stale' } };
+    result = project(input, result); expect(result.selectionRecovery).toBeNull();
+    receipt(input, 3, { startFreq: 14_040_000, endFreq: 14_140_000 });
+    result = project(input, result); expect(result.display.state).toBe('unknown');
+    for (const leaf of ['filterWidth', 'pbtInner', 'pbtOuter']) status(input, `main.${leaf}`, { lastObservedMonotonic: 21 });
+    receipt(input, 4, { startFreq: 14_040_000, endFreq: 14_140_000 });
+    expect(project(input, result).display.state).toBe('current');
+  });
+  it('does not let a contradicted slot marker replace the accepted selection boundary', () => {
+    const input = banded(); let result = project(input);
+    select(input, 'B', 10); receipt(input, 2); result = project(input, result);
+    expect(result.selection?.slot).toBe('A');
+    for (const leaf of ['filterWidth', 'pbtInner', 'pbtOuter']) status(input, `main.${leaf}`, { lastObservedMonotonic: 11 });
+    select(input, 'B', 12); receipt(input, 3, { startFreq: 14_024_000, endFreq: 14_124_000 });
+    result = project(input, result); expect(result.display.state).toBe('unknown');
+    for (const leaf of ['filterWidth', 'pbtInner', 'pbtOuter']) status(input, `main.${leaf}`, { lastObservedMonotonic: 13 });
+    receipt(input, 4, { startFreq: 14_024_000, endFreq: 14_124_000 });
+    expect(project(input, result).display.state).toBe('current');
+  });
+  it('rejects pre-selection geometry and geometry from a superseded selection', () => {
+    const input = banded(); let result = project(input);
+    select(input, 'B', 20); receipt(input, 2); result = project(input, result);
+    expect(result.display.state).toBe('unknown');
+    for (const leaf of ['filterWidth', 'pbtInner', 'pbtOuter']) status(input, `main.${leaf}`, { lastObservedMonotonic: 20.1 });
+    select(input, 'A', 21); receipt(input, 3); result = project(input, result);
+    expect(result.display.state).toBe('unknown');
+    receipt(input, 4); result = project(input, result);
+    expect(result.display.state).toBe('unknown');
+    for (const leaf of ['filterWidth', 'pbtInner', 'pbtOuter']) status(input, `main.${leaf}`, { lastObservedMonotonic: 21.1 });
+    receipt(input, 5, { startFreq: 14_024_000, endFreq: 14_124_000 }); result = project(input, result);
+    expect(result.display.state).toBe('current');
+  });
+});
+
 describe('confirmed tuning display continuity (MOR-2437)', () => {
   it('holds the last qualified tuple through a stale frequency gap and recovers while tuning continues', () => {
     const input = banded();
@@ -217,7 +323,12 @@ describe('confirmed tuning display continuity (MOR-2437)', () => {
     expect(result.display.state).toBe('unknown');
     result = project(saved, result); expect(result.display.state).toBe('unknown');
     result = project(saved, result); expect(result.display.state).toBe('unknown');
-    renew(saved, 20, 4); expect(project(saved, result).display.state).toBe('current');
+    renew(saved, 20, 4);
+    if (_name === 'slot') {
+      status(saved, 'main.activeSlot', { lastObservedMonotonic: 19 });
+      receipt(saved, 4, { startFreq: 14_025_000, endFreq: 14_125_000 });
+    }
+    expect(project(saved, result).display.state).toBe('current');
   });
   it.each(['filterWidth', 'pbtInner', 'pbtOuter'] as const)('never mixes a partial changed %s with retained shape', (leaf) => {
     const input = banded(); let result = project(input); tune(input, 14_075_000, 11); result = project(input, result);
@@ -331,7 +442,12 @@ describe('coherent RF passband display', () => {
     const current = project(input); expect(current.display.state).toBe('current'); change(input);
     const retired = project(input, current); expect(retired.display.state).toBe('unknown');
     expect(project(input, retired).display.state).toBe('unknown');
-    const oldFrame = input.frame; renew(input, 11, 3); const nextFrame = input.frame; input.frame = oldFrame;
+    const oldFrame = input.frame; renew(input, 11, 3);
+    if (name === 'slot') {
+      status(input, 'main.activeSlot', { lastObservedMonotonic: 10.5 });
+      receipt(input, 3, { startFreq: 14_024_000, endFreq: 14_124_000 });
+    }
+    const nextFrame = input.frame; input.frame = oldFrame;
     expect(project(input, retired).display.state).toBe('unknown');
     input.frame = nextFrame; expect(project(input, retired).display.state).toBe('current');
   });
@@ -574,6 +690,7 @@ describe('coherent RF passband display', () => {
     expect(previous.display.state).toBe('unknown');
     expect(previous.observations[path]).toEqual(current.observations[path]);
     renew(input, 13, 4); status(input, path, { lastObservedMonotonic: 11 });
+    if (field === 'slot') receipt(input, 4, { startFreq: 14_024_000, endFreq: 14_124_000 });
     expect(project(input, previous).display.state).toBe('current');
   });
 

--- a/frontend/src/lib/runtime/adapters/__tests__/scope-passband-display.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scope-passband-display.test.ts
@@ -460,6 +460,32 @@ describe('coherent RF passband display', () => {
     expect(project(input, back).display.state).toBe('unknown');
     renew(input, 11, 4); expect(project(input, back).display.state).toBe('current');
   });
+  it.each([
+    ['command_response', 'unknown'],
+    ['poll_response', 'current'],
+  ] as const)('treats a same-slot %s refresh as %s', (source, expected) => {
+    const input = banded(); const current = project(input); const rx = input.state!.main!;
+    rx.filterWidth = 1800;
+    for (const leaf of ['filterWidth', 'pbtInner', 'pbtOuter']) {
+      status(input, `main.${leaf}`, { lastObservedMonotonic: 20.1 });
+    }
+    status(input, 'main.activeSlot', { lastObservedMonotonic: 21, source: { source } });
+    for (const path of ['main.freqHz', 'main.mode', 'main.filter', 'main.dataMode',
+      'main.vfoA.freqHz', 'main.vfoA.mode', 'main.vfoA.filterNum']) {
+      status(input, path, { lastObservedMonotonic: 21.2 });
+    }
+    receipt(input, 2, { startFreq: 14_024_000, endFreq: 14_124_000 });
+    const boundary = project(input, current); expect(boundary.display.state).toBe(expected);
+    if (source === 'command_response') {
+      for (const leaf of ['filterWidth', 'pbtInner', 'pbtOuter']) {
+        status(input, `main.${leaf}`, { lastObservedMonotonic: 21.3 });
+      }
+      receipt(input, 3, { startFreq: 14_024_000, endFreq: 14_124_000 });
+      const recovered = project(input, boundary);
+      expect(recovered.display).toMatchObject({ state: 'current', tuple: { widthHz: 1800 } });
+      expect(project(input, recovered).display.state).toBe('current');
+    }
+  });
   it('rejects partial width updates and regressing leaf/ancestor markers', () => {
     for (const path of ['main.ifShift', 'main']) {
       const input = fixture(); const current = project(input); status(input, path, { lastObservedMonotonic: 9 });

--- a/frontend/src/lib/runtime/adapters/scope-passband-display.ts
+++ b/frontend/src/lib/runtime/adapters/scope-passband-display.ts
@@ -11,6 +11,7 @@ type Scalar = number | string | boolean;
 type Observation = Readonly<{ value: Scalar; marker: number }>;
 type Observations = Readonly<Record<string, Observation>>;
 type Markers = Readonly<Record<string, number>>;
+type SelectionObservation = Readonly<{ context: string; slot: 'A' | 'B'; marker: number }>;
 export interface ScopePassbandTuple {
   readonly frequencyHz: number;
   readonly mode: string;
@@ -35,6 +36,8 @@ export interface ScopePassbandDisplayState {
   readonly floors: Readonly<{ domain: string | null; geometry: Markers; receipt: number }> | null;
   /** Keeps one hold-entry evidence floor pinned until fresh frequency recovery completes. */
   readonly frequencyHoldRecovery: boolean;
+  readonly selection: SelectionObservation | null;
+  readonly selectionRecovery: Readonly<{ context: string | null }> | null;
 }
 export interface ScopePassbandDisplayInput {
   state: ServerState | null;
@@ -49,6 +52,7 @@ export const EMPTY_SCOPE_PASSBAND_DISPLAY: ScopePassbandDisplayState = Object.fr
   display: Object.freeze({ state: 'unknown', reason: 'not-observed' }),
   identity: null, continuityIdentity: null, domain: null, observations: EMPTY_OBSERVATIONS,
   geometryPaths: EMPTY_PATHS, receipt: 0, floors: null, frequencyHoldRecovery: false,
+  selection: null, selectionRecovery: null,
 });
 const nonnegative = (n: unknown): n is number => typeof n === 'number' && Number.isFinite(n) && n >= 0;
 const positive = (n: unknown): n is number => typeof n === 'number' && Number.isFinite(n) && n > 0;
@@ -83,13 +87,14 @@ interface Inspection {
   receipt: number;
   reason: string;
   unsupported: boolean;
+  selection: SelectionObservation | null;
 }
 function inspect(input: ScopePassbandDisplayInput): Inspection {
   const { state, caps, selection, session, frame: presentation } = input;
   const envelope = presentation?.envelope;
   const result: Inspection = { candidate: null, domain: null, observations: {}, geometryPaths: [],
     receipt: integer(envelope?.acceptedSequence) ? envelope.acceptedSequence : 0,
-    reason: 'identity-unresolved', unsupported: false };
+    reason: 'identity-unresolved', unsupported: false, selection: null };
   if (!state || !caps || !selection || state.stateContractVersion !== 1 || caps.stateContractVersion !== 1
     || !integer(state.providerGeneration) || state.providerGeneration !== caps.providerGeneration
     || (selection.receiver !== 'MAIN' && selection.receiver !== 'SUB')) return result;
@@ -145,6 +150,12 @@ function inspect(input: ScopePassbandDisplayInput): Inspection {
     const slot = read(`${key}.activeSlot`, rx.activeSlot);
     if ((selection.slot !== 'A' && selection.slot !== 'B') || slot !== selection.slot
       || !slots?.includes(selection.slot)) return result;
+    if (session?.state === 'connected' && integer(session.epoch) && session.epoch > 0) {
+      result.selection = Object.freeze({ slot: selection.slot,
+        marker: result.observations[`${key}.activeSlot`].marker,
+        context: JSON.stringify([state.providerGeneration, capabilityIdentity(caps), session.epoch, selection.receiver]),
+      });
+    }
   } else if (selection.slot !== 'single') return result;
   const position = slotted ? (selection.slot === 'A' ? rx.vfoA : rx.vfoB) : rx;
   const base = slotted ? `${key}.${selection.slot === 'A' ? 'vfoA' : 'vfoB'}` : key;
@@ -245,6 +256,20 @@ export function projectScopePassbandDisplay(
   const changedGeometry = next.geometryPaths.some((path) =>
     next.observations[path]?.value !== previous.observations[path]?.value);
   const receiptRegression = candidate !== null && next.receipt < previous.receipt;
+  const selectionChanged = next.selection !== null && previous.selection !== null
+    && next.selection.context === previous.selection.context && next.selection.slot !== previous.selection.slot
+    && next.selection.marker > previous.selection.marker && !regression && !receiptRegression;
+  const recoveryContext = candidate?.continuityIdentity ?? candidate?.identity ?? null;
+  let selectionRecovery = selectionChanged ? { context: recoveryContext } : previous.selectionRecovery;
+  if (selectionRecovery && (regression || receiptRegression || !next.selection
+    || (!selectionChanged && next.selection.context !== previous.selection?.context)
+    || (selectionRecovery.context !== null && recoveryContext !== selectionRecovery.context))) {
+    selectionRecovery = null;
+  }
+  if (selectionRecovery && selectionRecovery.context === null && recoveryContext !== null) {
+    selectionRecovery = { context: recoveryContext };
+  }
+  const recoveryCancelled = previous.selectionRecovery !== null && selectionRecovery === null;
   const hasTuple = active(previous.display);
   const wasTranslated = hasTuple && previous.display.translated === true;
   const holdingFrequency = hasTuple && candidate !== null && candidate.continuityIdentity !== null
@@ -260,10 +285,14 @@ export function projectScopePassbandDisplay(
     && (candidate.stale || candidate.strict || !candidate.frequencyAligned);
   const translating = canTranslate && (changedIdentity || wasTranslated);
   const domainChange = previous.floors !== null && next.domain !== null && previous.floors.domain !== next.domain;
-  const retire = (((hasTuple && (invalid || changedIdentity)) || changedIdentity)
-    && !translating && !holdingFrequency) || domainChange;
+  const retire = !selectionRecovery && ((((hasTuple && (invalid || changedIdentity)) || changedIdentity)
+    && !translating && !holdingFrequency) || domainChange || recoveryCancelled);
   let floors = previous.floors;
-  if (retire || (holdingFrequency && !previous.frequencyHoldRecovery)
+  if (selectionChanged) {
+    floors = Object.freeze({ domain: next.domain, receipt: previous.receipt,
+      geometry: Object.freeze(Object.fromEntries(next.geometryPaths.map((path) => [path, next.selection!.marker]))),
+    });
+  } else if (retire || (holdingFrequency && !previous.frequencyHoldRecovery)
     || (translating && !previous.frequencyHoldRecovery
       && (!wasTranslated || candidate.tuple.frequencyHz !== tupleOf(previous.display).frequencyHz))) {
     const domain = next.domain ?? previous.domain;
@@ -279,9 +308,9 @@ export function projectScopePassbandDisplay(
       && next.observations[path].marker > (floors.geometry[path] ?? -1)));
   const axisAligned = candidate && (candidate.tuple.frameMode === 1 || candidate.tuple.frameMode === 3
     || candidate.tuple.frequencyHz === (candidate.tuple.startHz + candidate.tuple.endHz) / 2);
-  const canRetain = hasTuple && !retire && !invalid && !translating;
+  const canRetain = hasTuple && !selectionRecovery && !retire && !invalid && !translating;
   const canCapture = candidate && !candidate.stale && candidate.strict && !regression
-    && !receiptRegression && !retire && crossedFloors;
+    && !receiptRegression && !retire && crossedFloors && (!selectionRecovery || axisAligned);
   const display: ScopePassbandDisplay = holdingFrequency
     ? { state: 'stale', translated: true, tuple: {
       ...tupleOf(previous.display), frameMode: candidate!.tuple.frameMode,
@@ -312,6 +341,9 @@ export function projectScopePassbandDisplay(
     floors: active(display) && !display.translated ? null : floors,
     frequencyHoldRecovery: (holdingFrequency || previous.frequencyHoldRecovery)
       && active(display) && display.translated === true,
+    selection: regression ? previous.selection : next.selection ?? previous.selection,
+    selectionRecovery: active(display) && !display.translated ? null
+      : selectionRecovery && Object.freeze(selectionRecovery),
   });
 }
 function tupleOf(display: ScopePassbandDisplay): ScopePassbandTuple {

--- a/frontend/src/lib/runtime/adapters/scope-passband-display.ts
+++ b/frontend/src/lib/runtime/adapters/scope-passband-display.ts
@@ -88,13 +88,14 @@ interface Inspection {
   reason: string;
   unsupported: boolean;
   selection: SelectionObservation | null;
+  explicitSelectionBind: boolean;
 }
 function inspect(input: ScopePassbandDisplayInput): Inspection {
   const { state, caps, selection, session, frame: presentation } = input;
   const envelope = presentation?.envelope;
   const result: Inspection = { candidate: null, domain: null, observations: {}, geometryPaths: [],
     receipt: integer(envelope?.acceptedSequence) ? envelope.acceptedSequence : 0,
-    reason: 'identity-unresolved', unsupported: false, selection: null };
+    reason: 'identity-unresolved', unsupported: false, selection: null, explicitSelectionBind: false };
   if (!state || !caps || !selection || state.stateContractVersion !== 1 || caps.stateContractVersion !== 1
     || !integer(state.providerGeneration) || state.providerGeneration !== caps.providerGeneration
     || (selection.receiver !== 'MAIN' && selection.receiver !== 'SUB')) return result;
@@ -155,6 +156,7 @@ function inspect(input: ScopePassbandDisplayInput): Inspection {
         marker: result.observations[`${key}.activeSlot`].marker,
         context: JSON.stringify([state.providerGeneration, capabilityIdentity(caps), session.epoch, selection.receiver]),
       });
+      result.explicitSelectionBind = state.fieldStatus?.[`${key}.activeSlot`]?.source?.source === 'command_response';
     }
   } else if (selection.slot !== 'single') return result;
   const position = slotted ? (selection.slot === 'A' ? rx.vfoA : rx.vfoB) : rx;
@@ -259,10 +261,14 @@ export function projectScopePassbandDisplay(
   const selectionChanged = next.selection !== null && previous.selection !== null
     && next.selection.context === previous.selection.context && next.selection.slot !== previous.selection.slot
     && next.selection.marker > previous.selection.marker && !regression && !receiptRegression;
+  const selectionRebound = next.explicitSelectionBind && next.selection !== null && previous.selection !== null
+    && next.selection.context === previous.selection.context && next.selection.slot === previous.selection.slot
+    && next.selection.marker > previous.selection.marker && !regression && !receiptRegression;
+  const selectionBoundary = selectionChanged || selectionRebound;
   const recoveryContext = candidate?.continuityIdentity ?? candidate?.identity ?? null;
-  let selectionRecovery = selectionChanged ? { context: recoveryContext } : previous.selectionRecovery;
+  let selectionRecovery = selectionBoundary ? { context: recoveryContext } : previous.selectionRecovery;
   if (selectionRecovery && (regression || receiptRegression || !next.selection
-    || (!selectionChanged && next.selection.context !== previous.selection?.context)
+    || (!selectionBoundary && next.selection.context !== previous.selection?.context)
     || (selectionRecovery.context !== null && recoveryContext !== selectionRecovery.context))) {
     selectionRecovery = null;
   }
@@ -288,7 +294,7 @@ export function projectScopePassbandDisplay(
   const retire = !selectionRecovery && ((((hasTuple && (invalid || changedIdentity)) || changedIdentity)
     && !translating && !holdingFrequency) || domainChange || recoveryCancelled);
   let floors = previous.floors;
-  if (selectionChanged) {
+  if (selectionBoundary) {
     floors = Object.freeze({ domain: next.domain, receipt: previous.receipt,
       geometry: Object.freeze(Object.fromEntries(next.geometryPaths.map((path) => [path, next.selection!.marker]))),
     });

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1391,7 +1391,9 @@ class RadioPoller:
         except Exception:
             logger.debug("radio-poller: %s reconfirm failed", label, exc_info=True)
 
-    def _request_post_write_readback(self, cmd: Command) -> None:
+    def _request_post_write_readback(
+        self, cmd: Command, *, selected_receiver: int | None = None
+    ) -> None:
         """Read back whatever the dispatched command just set (MOR-1484).
 
         A ``CommandIntent`` carries its ``expected_observations``; a legacy
@@ -1410,6 +1412,8 @@ class RadioPoller:
             return
         if isinstance(cmd, CommandIntent):
             expected = cmd.expected_observations
+        elif type(cmd) is SelectVfo and selected_receiver is not None:
+            expected = ()
         else:
             name = LEGACY_COMMAND_NAMES.get(type(cmd))
             if name is None:
@@ -1421,6 +1425,21 @@ class RadioPoller:
             params.setdefault("receiver", 0)
             expected = expected_observations_for_command(name, params)
         paths = tuple(observable_field_path(path) for path in expected)
+        if type(cmd) is SelectVfo and selected_receiver is not None:
+            receiver_id = str(selected_receiver)
+            geometry = (
+                FieldPath.active(receiver_id, "freq_mode", "filter_width"),
+                *(
+                    FieldPath.receiver(receiver_id, "operator_controls", leaf)
+                    for leaf in ("if_shift", "pbt_inner", "pbt_outer")
+                ),
+            )
+            paths = tuple(
+                path
+                for path in (*paths, *geometry)
+                if (capability := scheduler._profile.capability_for(path)).can_poll
+                or capability.command_response_observable
+            )
         if type(cmd) is SetMode and CAP_FILTER_WIDTH in self._caps:
             filter_width = FieldPath.active(
                 _post_write_receiver_id(cmd), "freq_mode", "filter_width"
@@ -4064,6 +4083,9 @@ class RadioPoller:
                         else FieldPath.unselected(receiver_id, "freq_mode", name)
                     )
                     apply(relative_path, value)
+            self._request_post_write_readback(
+                SelectVfo(slot), selected_receiver=receiver
+            )
             logger.info(
                 "radio-poller: confirmed VFO slot=%s receiver=%d generation=%d",
                 slot,

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -2249,6 +2249,82 @@ async def test_single_receiver_vfo_b_selects_slot_without_sub_receiver() -> None
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("native_shift", [False, True])
+async def test_confirmed_vfo_selection_requests_supported_geometry(
+    native_shift: bool,
+) -> None:
+    radio = _make_radio(model="IC-7300")
+    radio._radio_state = RadioState()
+    width = FieldPath.active("0", "freq_mode", "filter_width")
+    inner = FieldPath.receiver("0", "operator_controls", "pbt_inner")
+    outer = FieldPath.receiver("0", "operator_controls", "pbt_outer")
+    shift = FieldPath.receiver("0", "operator_controls", "if_shift")
+    paths = (width, shift) if native_shift else (width, inner, outer)
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(*paths))
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue())
+    with patch.object(
+        AcquisitionScheduler, "ensure_fresh", wraps=scheduler.ensure_fresh
+    ) as request:
+        await poller._execute(SelectVfo("B"))  # noqa: SLF001
+    request.assert_called_once()
+    assert set(request.call_args.args[0]) == set(paths)
+    assert request.call_args.kwargs["require_fresh_dispatch"] is True
+    assert request.call_args.kwargs["priority"] == AcquisitionPriority.USER
+    radio._set_vfo_slot_confirmed.assert_awaited_once_with("B", receiver=0)
+    assert radio.read_relative_vfo.await_count == 2
+
+    pending = scheduler.pending_requests()
+    radio.read_relative_vfo.side_effect = (
+        RelativeVfoState(7_100_000, "LSB", 2, 0),
+        RelativeVfoState(14_200_000, "USB", 1, 0),
+    )
+    await poller._execute(SelectVfo("A"))  # noqa: SLF001
+    assert len(scheduler.pending_requests()) == len(pending)
+    assert {
+        path for item in scheduler.pending_requests() for path in item.paths
+    } == set(paths)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "interruption", ["select", "readback", "provider", "selection"]
+)
+async def test_interrupted_vfo_selection_does_not_request_geometry(
+    interruption: str,
+) -> None:
+    radio = _make_radio(model="IC-7300")
+    scheduler = AcquisitionScheduler(
+        profile=_acquisition_profile(FieldPath.active("0", "freq_mode", "filter_width"))
+    )
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue())
+    if interruption == "select":
+        radio._set_vfo_slot_confirmed.side_effect = CommandError("selection rejected")
+    else:
+
+        async def interrupted_read(*, selected: bool) -> RelativeVfoState:
+            if interruption == "readback":
+                raise CommandError("readback failed")
+            if interruption == "provider":
+                poller._state_store.begin_provider_generation()  # noqa: SLF001
+            else:
+                poller._vfo_binding_generation += 1  # noqa: SLF001
+            return RelativeVfoState(14_200_000, "USB", 1, 0)
+
+        radio.read_relative_vfo.side_effect = interrupted_read
+    with patch.object(
+        AcquisitionScheduler, "ensure_fresh", wraps=scheduler.ensure_fresh
+    ) as request:
+        if interruption in ("select", "readback"):
+            with pytest.raises(CommandError):
+                await poller._execute(SelectVfo("B"))  # noqa: SLF001
+        else:
+            await poller._execute(SelectVfo("B"))  # noqa: SLF001
+    request.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_relative_vfo_ack_maps_selected_and_complement_then_rebinds() -> None:
     state = RadioState()
     state.active = "MAIN"


### PR DESCRIPTION
Switching VFO A/B can leave the panorama marker and passband blank for 5–6 seconds after the selected frequency has updated. Request supported filter geometry through the existing acquisition scheduler after a successful selection, and let the display consume the first complete post-selection observation set instead of waiting for a second poll.

Recovery uses the accepted selection boundary and an aligned frame. It rejects old-slot geometry and superseded or malformed observations, and retains the existing context and frame fences. Existing same-VFO tuning continuity and command authority are preserved.

Validation at `7e514c4e07187bf083e9d31b6f0722a8d84ac1d0`: 319 projector/component tests, frontend check and targeted ESLint passed. The unchanged Python code passed 18 VFO-selection tests, 65 post-write tests, Ruff and strict web mypy at `57d7e60b`. Regressions cover batched/staggered geometry, the canonical-view-to-SpectrumPanel path, interrupted selection and a coalesced A→B→A snapshot. Explicit same-slot binding uses command-response provenance; ordinary poll refresh does not restart recovery. Restoring the original implementations makes the targeted regressions fail. Full-suite evidence is owned by this PR's CI.

Linear: [MOR-2441](https://linear.app/morozsm/issue/MOR-2441/scope-remove-multi-second-passband-blank-after-confirmed-vfo-ab). The completed scope mechanism audit assigns mobile composition adoption to separate MOR-2442; this change leaves the current mobile wiring intact. Installed RX acceptance remains a separate gate after source review and CI.
