### PR TITLE
fix(web): queue VFO geometry reads with canonical receiver paths

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1426,7 +1426,11 @@ class RadioPoller:
             expected = expected_observations_for_command(name, params)
         paths = tuple(observable_field_path(path) for path in expected)
         if type(cmd) is SelectVfo and selected_receiver is not None:
-            receiver_id = str(selected_receiver)
+            # Scheduler/profile paths use the canonical receiver names, not
+            # the command API's integer receiver index.  A numeric spelling
+            # makes every real-profile capability lookup below unsupported,
+            # silently leaving geometry on its ordinary cadence after A/B.
+            receiver_id = "sub" if selected_receiver == 1 else "main"
             geometry = (
                 FieldPath.active(receiver_id, "freq_mode", "filter_width"),
                 *(

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -2255,10 +2255,10 @@ async def test_confirmed_vfo_selection_requests_supported_geometry(
 ) -> None:
     radio = _make_radio(model="IC-7300")
     radio._radio_state = RadioState()
-    width = FieldPath.active("0", "freq_mode", "filter_width")
-    inner = FieldPath.receiver("0", "operator_controls", "pbt_inner")
-    outer = FieldPath.receiver("0", "operator_controls", "pbt_outer")
-    shift = FieldPath.receiver("0", "operator_controls", "if_shift")
+    width = FieldPath.active("main", "freq_mode", "filter_width")
+    inner = FieldPath.receiver("main", "operator_controls", "pbt_inner")
+    outer = FieldPath.receiver("main", "operator_controls", "pbt_outer")
+    shift = FieldPath.receiver("main", "operator_controls", "if_shift")
     paths = (width, shift) if native_shift else (width, inner, outer)
     scheduler = AcquisitionScheduler(profile=_acquisition_profile(*paths))
     radio._acquisition_scheduler = scheduler
@@ -2284,6 +2284,53 @@ async def test_confirmed_vfo_selection_requests_supported_geometry(
     assert {
         path for item in scheduler.pending_requests() for path in item.paths
     } == set(paths)
+
+
+@pytest.mark.asyncio
+async def test_confirmed_vfo_selection_dispatches_real_ic7300_geometry() -> None:
+    """A/B selection jumps the shipped geometry reads ahead of 5 s cadence."""
+
+    radio = _make_radio(model="IC-7300")
+    radio._radio_state = RadioState()
+    profile = resolve_radio_profile(model="IC-7300")
+    assert profile.state_acquisition is not None
+    scheduler = AcquisitionScheduler(profile=profile.state_acquisition)
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue())
+    expected = {
+        FieldPath.active("main", "freq_mode", "filter_width"),
+        FieldPath.receiver("main", "operator_controls", "pbt_inner"),
+        FieldPath.receiver("main", "operator_controls", "pbt_outer"),
+    }
+    scheduler.ensure_fresh(
+        expected,
+        max_age=5.0,
+        priority=AcquisitionPriority.BACKGROUND,
+        reason="policy-cadence",
+    )
+    await poller._send_scheduler_requests()  # noqa: SLF001
+    cadence_frames = tuple(
+        (call_.args[0], call_.kwargs["sub"]) for call_ in radio.send_civ.await_args_list
+    )
+    assert set(cadence_frames) == {(0x14, 0x07), (0x14, 0x08), (0x1A, 0x03)}
+
+    await poller._execute(SelectVfo("B"))  # noqa: SLF001
+
+    assert {
+        path for request in scheduler.pending_requests() for path in request.paths
+    } == expected
+    assert all(
+        request.priority is AcquisitionPriority.USER
+        for request in scheduler.pending_requests()
+    )
+
+    await poller._send_scheduler_requests()  # noqa: SLF001
+
+    readback_frames = tuple(
+        (call_.args[0], call_.kwargs["sub"])
+        for call_ in radio.send_civ.await_args_list[len(cadence_frames) :]
+    )
+    assert readback_frames == cadence_frames
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
VFO A/B selection still left the passband blank for seconds on the installed IC-7300 after #3435. Its post-selection geometry request used numeric receiver paths (`receiver.0.*`), but the shipped acquisition profile declares `receiver.main.*`; capability filtering therefore discarded every requested field before the scheduler could accelerate the readback.

Map the captured receiver index to the canonical `main`/`sub` name. A regression test uses the shipped IC-7300 profile, the real acquisition scheduler and web drain: it first dispatches cadence reads, selects VFO B, then verifies that width and both PBT reads are reissued at USER priority. The frontend recovery policy is unchanged.

Validation: RED before the fix; 81 focused Python tests, Ruff check/format and strict web mypy passed. Independent coordinator review repeated seven selection tests. Exact PR quick34497764214 and merged-main quick34498552419 passed (16241 pytest and11810 Vitest tests in the PR run). Installed IC-7300 desktop acceptance: six A/B switches restored the overlay911–1384ms after click, versus6018–6834ms baseline. A short transition remains.22 keyboard presses and10 wheel gestures retained the marker/passband in all91 sampled DOM states, with32 correct alternating frequency targets and no command errors. Scope: two files,61 changed lines; mobile adoption remains separate.

Owner: [MOR-2441](https://linear.app/morozsm/issue/MOR-2441/scope-remove-multi-second-passband-blank-after-confirmed-vfo-ab). Mobile composition remains separately owned by MOR-2442.
