### PR TITLE
Support shared panel dragging across registered drop zones

### DIFF
--- a/frontend/src/lib/__tests__/DragReorderFixture.svelte
+++ b/frontend/src/lib/__tests__/DragReorderFixture.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { createDragReorder } from '../drag-reorder.svelte';
+
+  const left = createDragReorder({
+    storageKey: 'test:drag:left',
+    defaults: ['alpha', 'beta'],
+    containerSelector: '.test-drag-left',
+  });
+  const bottom = createDragReorder({
+    storageKey: 'test:drag:bottom',
+    defaults: [],
+    containerSelector: '.test-drag-bottom',
+  });
+  const right = createDragReorder({
+    storageKey: 'test:drag:right',
+    defaults: ['gamma', 'delta'],
+    containerSelector: '.test-drag-right',
+  });
+</script>
+
+{#snippet dock(name: string, drag: typeof left)}
+  <section
+    class={`test-drag-${name}`}
+    data-zone={name}
+    data-drop-target={drag.isDropTarget}
+  >
+    {#each drag.order as panelId (panelId)}
+      <article data-panel-id={panelId} style={drag.dragStyle(panelId)}>
+        <button
+          data-drag-handle={panelId}
+          onpointerdown={(event) => drag.handleDragStart(panelId, event)}
+        >{panelId}</button>
+      </article>
+    {/each}
+  </section>
+{/snippet}
+
+{@render dock('left', left)}
+{@render dock('bottom', bottom)}
+{@render dock('right', right)}
+<button data-reset-all onclick={() => left.resetAll()}>reset</button>

--- a/frontend/src/lib/__tests__/drag-reorder.component.test.ts
+++ b/frontend/src/lib/__tests__/drag-reorder.component.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import DragReorderFixture from './DragReorderFixture.svelte';
+
+const KEYS = {
+  left: 'test:drag:left',
+  bottom: 'test:drag:bottom',
+  right: 'test:drag:right',
+} as const;
+
+const rects = {
+  left: { left: 0, top: 0, right: 100, bottom: 180, width: 100, height: 180 },
+  bottom: { left: 150, top: 200, right: 250, bottom: 300, width: 100, height: 100 },
+  right: { left: 300, top: 0, right: 400, bottom: 180, width: 100, height: 180 },
+} as const;
+
+let component: ReturnType<typeof mount> | undefined;
+let target: HTMLElement;
+
+function domRect(rect: Omit<DOMRect, 'x' | 'y' | 'toJSON'>): DOMRect {
+  return { ...rect, x: rect.left, y: rect.top, toJSON: () => ({}) };
+}
+
+function panelIds(zone: keyof typeof KEYS): string[] {
+  return [...target.querySelectorAll(`[data-zone="${zone}"] [data-panel-id]`)]
+    .map((panel) => panel.getAttribute('data-panel-id')!);
+}
+
+function zone(zoneName: keyof typeof KEYS): HTMLElement {
+  return target.querySelector(`[data-zone="${zoneName}"]`)!;
+}
+
+function handle(panelId: string): HTMLElement {
+  return target.querySelector(`[data-drag-handle="${panelId}"]`)!;
+}
+
+function pointer(element: HTMLElement, type: string, clientX: number, clientY: number): void {
+  element.dispatchEvent(new PointerEvent(type, {
+    bubbles: true,
+    pointerId: 1,
+    clientX,
+    clientY,
+  }));
+  flushSync();
+}
+
+function prepareRects(): void {
+  for (const zoneName of Object.keys(KEYS) as (keyof typeof KEYS)[]) {
+    const zoneElement = zone(zoneName);
+    zoneElement.getBoundingClientRect = () => domRect(rects[zoneName]);
+    [...zoneElement.querySelectorAll<HTMLElement>('[data-panel-id]')].forEach((panel, index) => {
+      const container = rects[zoneName];
+      panel.getBoundingClientRect = () => domRect({
+        left: container.left,
+        right: container.right,
+        top: container.top + index * 50,
+        bottom: container.top + (index + 1) * 50,
+        width: container.width,
+        height: 50,
+      });
+    });
+  }
+}
+
+function render(): void {
+  component = mount(DragReorderFixture, { target });
+  flushSync();
+  prepareRects();
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  Object.defineProperty(HTMLElement.prototype, 'setPointerCapture', {
+    configurable: true,
+    value: vi.fn(),
+  });
+  if (!globalThis.PointerEvent) {
+    vi.stubGlobal('PointerEvent', class extends MouseEvent {
+      pointerId: number;
+
+      constructor(type: string, init: PointerEventInit = {}) {
+        super(type, init);
+        this.pointerId = init.pointerId ?? 0;
+      }
+    });
+  }
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = undefined;
+  target.remove();
+  Reflect.deleteProperty(HTMLElement.prototype, 'setPointerCapture');
+  vi.unstubAllGlobals();
+});
+
+describe('three-zone panel drag', () => {
+  it('tracks left to bottom to right and transfers only to the active target', () => {
+    render();
+    const alpha = handle('alpha');
+
+    pointer(alpha, 'pointerdown', 10, 25);
+    pointer(alpha, 'pointermove', 200, 250);
+    expect(zone('bottom').dataset.dropTarget).toBe('true');
+
+    pointer(alpha, 'pointermove', 350, 75);
+    expect(zone('bottom').dataset.dropTarget).toBe('false');
+    expect(zone('right').dataset.dropTarget).toBe('true');
+
+    pointer(alpha, 'pointerup', 350, 75);
+    expect(panelIds('left')).toEqual(['beta']);
+    expect(panelIds('bottom')).toEqual([]);
+    expect(panelIds('right')).toEqual(['gamma', 'alpha', 'delta']);
+    expect(zone('right').dataset.dropTarget).toBe('false');
+  });
+
+  it('inserts at index zero when the active target dock is empty', () => {
+    render();
+    const alpha = handle('alpha');
+
+    pointer(alpha, 'pointerdown', 10, 25);
+    pointer(alpha, 'pointermove', 200, 250);
+    pointer(alpha, 'pointerup', 200, 250);
+
+    expect(panelIds('left')).toEqual(['beta']);
+    expect(panelIds('bottom')).toEqual(['alpha']);
+    expect(JSON.parse(localStorage.getItem(KEYS.bottom)!)).toEqual(['alpha']);
+  });
+
+  it('resets all three registered zones', () => {
+    localStorage.setItem(KEYS.left, JSON.stringify(['beta']));
+    localStorage.setItem(KEYS.bottom, JSON.stringify(['alpha']));
+    localStorage.setItem(KEYS.right, JSON.stringify(['delta', 'gamma']));
+    render();
+
+    target.querySelector<HTMLElement>('[data-reset-all]')!.click();
+    flushSync();
+
+    expect(panelIds('left')).toEqual(['alpha', 'beta']);
+    expect(panelIds('bottom')).toEqual([]);
+    expect(panelIds('right')).toEqual(['gamma', 'delta']);
+  });
+
+  it('does not duplicate an id already present in the target and persists the transfer', () => {
+    localStorage.setItem(KEYS.right, JSON.stringify(['gamma', 'alpha', 'delta']));
+    render();
+    const alpha = handle('alpha');
+
+    pointer(alpha, 'pointerdown', 10, 25);
+    pointer(alpha, 'pointermove', 350, 75);
+    pointer(alpha, 'pointerup', 350, 75);
+
+    expect(panelIds('right').filter((id) => id === 'alpha')).toHaveLength(1);
+    expect(JSON.parse(localStorage.getItem(KEYS.left)!)).toEqual(['beta']);
+    expect(JSON.parse(localStorage.getItem(KEYS.right)!))
+      .toEqual(['gamma', 'alpha', 'delta']);
+  });
+});

--- a/frontend/src/lib/__tests__/drag-reorder.test.ts
+++ b/frontend/src/lib/__tests__/drag-reorder.test.ts
@@ -136,6 +136,13 @@ describe('loadPanelOrder', () => {
     expect(r1).toEqual(afterDrag);
     expect(r2).toEqual(afterDrag);
   });
+
+  it('keeps a known-default zone empty after its final panel moves away', () => {
+    localStorage.setItem(KEY, JSON.stringify([]));
+    localStorage.setItem(KNOWN_KEY, JSON.stringify(DEFAULTS));
+
+    expect(loadPanelOrder(KEY, DEFAULTS)).toEqual([]);
+  });
 });
 
 describe('reorderPanels', () => {

--- a/frontend/src/lib/drag-reorder.svelte.ts
+++ b/frontend/src/lib/drag-reorder.svelte.ts
@@ -10,8 +10,8 @@
  *   });
  *
  * Cross-sidebar linking happens automatically via module-level registry.
- * When two instances exist, dragging a panel over the peer sidebar
- * triggers cross-sidebar drop detection and panel transfer.
+ * Dragging a panel over another registered container triggers cross-container
+ * drop detection and panel transfer.
  */
 
 // --- Pure helpers (exported for testing) ---
@@ -164,7 +164,7 @@ export function createDragReorder(options: DragReorderOptions): DragInstance {
   }
 
   function _acceptPanel(panelId: string, atIndex: number) {
-    const newOrder = [...order];
+    const newOrder = order.filter((id) => id !== panelId);
     newOrder.splice(Math.min(atIndex, newOrder.length), 0, panelId);
     order = newOrder;
   }
@@ -207,61 +207,63 @@ export function createDragReorder(options: DragReorderOptions): DragInstance {
       rects.set(p.dataset.panelId!, p.getBoundingClientRect());
     }
 
-    // Find peer from registry and cache its rects
-    const peer = _registry.find((r) => r !== instance);
-    let peerRect: DOMRect | null = null;
-    let peerRects: Map<string, DOMRect> | null = null;
-    if (peer) {
+    // Cache every registered peer container and its panel rects.
+    const peers: Array<{
+      instance: DragInstance;
+      rect: DOMRect;
+      panelRects: Map<string, DOMRect>;
+    }> = [];
+    for (const peer of _registry) {
+      if (peer === instance) continue;
       const peerEl = document.querySelector(peer.containerSelector) as HTMLElement;
       if (peerEl) {
-        peerRect = peerEl.getBoundingClientRect();
-        peerRects = new Map();
+        const panelRects = new Map<string, DOMRect>();
         for (const p of peerEl.querySelectorAll<HTMLElement>('[data-panel-id]')) {
-          peerRects.set(p.dataset.panelId!, p.getBoundingClientRect());
+          panelRects.set(p.dataset.panelId!, p.getBoundingClientRect());
         }
+        peers.push({ instance: peer, rect: peerEl.getBoundingClientRect(), panelRects });
       }
     }
 
-    let isOverPeer = false;
+    let activePeer: (typeof peers)[number] | null = null;
 
     function onMove(e: PointerEvent) {
-      if (
-        peer &&
-        peerRect &&
-        peerRects &&
-        e.clientX >= peerRect.left &&
-        e.clientX <= peerRect.right &&
-        e.clientY >= peerRect.top &&
-        e.clientY <= peerRect.bottom
-      ) {
-        // Cursor is over peer sidebar
-        if (!isOverPeer) {
+      const target = peers.find(({ rect }) =>
+        e.clientX >= rect.left &&
+        e.clientX <= rect.right &&
+        e.clientY >= rect.top &&
+        e.clientY <= rect.bottom
+      ) ?? null;
+
+      if (target) {
+        if (activePeer?.instance !== target.instance) {
+          activePeer?.instance._setIncoming(null, -1);
           dropTargetIndex = -1;
         }
-        isOverPeer = true;
-        const peerOrder = peer.order;
-        const idx = peerOrder.length === 0 ? 0 : findDropIndex(peerOrder, peerRects, e.clientY);
-        peer._setIncoming(panelId, idx);
+        activePeer = target;
+        const targetOrder = target.instance.order;
+        const idx = targetOrder.length === 0
+          ? 0
+          : findDropIndex(targetOrder, target.panelRects, e.clientY);
+        target.instance._setIncoming(panelId, idx);
       } else {
-        // Cursor is over own sidebar (or between)
-        if (isOverPeer && peer) {
-          peer._setIncoming(null, -1);
-        }
-        isOverPeer = false;
+        activePeer?.instance._setIncoming(null, -1);
+        activePeer = null;
         dropTargetIndex = findDropIndex(order, rects, e.clientY);
       }
     }
 
     function onUp() {
-      if (isOverPeer && peer && dragPanelId) {
-        const targetIdx = peer._incomingDropIndex;
-        peer._acceptPanel(dragPanelId, targetIdx >= 0 ? targetIdx : 0);
+      if (activePeer && dragPanelId) {
+        const targetIdx = activePeer.instance._incomingDropIndex;
+        activePeer.instance._acceptPanel(dragPanelId, targetIdx >= 0 ? targetIdx : 0);
         _removePanel(dragPanelId);
-        peer._setIncoming(null, -1);
       } else if (dragPanelId && dropTargetIndex >= 0) {
         const newOrder = reorderPanels(order, dragPanelId, dropTargetIndex);
         if (newOrder !== order) order = newOrder;
       }
+      activePeer?.instance._setIncoming(null, -1);
+      activePeer = null;
       dragPanelId = null;
       dropTargetIndex = -1;
       handle.removeEventListener('pointermove', onMove);

--- a/frontend/src/lib/drag-reorder.svelte.ts
+++ b/frontend/src/lib/drag-reorder.svelte.ts
@@ -52,7 +52,7 @@ export function loadPanelOrder(storageKey: string, defaults: string[]): string[]
     const stored = localStorage.getItem(storageKey);
     if (stored) {
       const parsed = JSON.parse(stored);
-      if (Array.isArray(parsed) && parsed.length > 0) {
+      if (Array.isArray(parsed)) {
         // Accept variable-length orders (cross-sidebar moves change panel count).
         // Filter to strings only, deduplicate, ignore unknowns at render time.
         const seen = new Set<string>();
@@ -63,22 +63,20 @@ export function loadPanelOrder(storageKey: string, defaults: string[]): string[]
             unique.push(id);
           }
         }
-        if (unique.length > 0) {
-          // Append ONLY defaults that the app has never presented to this
-          // sidebar before (i.e. newly introduced panels). Defaults that are
-          // already in `known` but absent from the stored order were
-          // deliberately removed by the user (e.g. dragged to the peer
-          // sidebar) — re-adding them would duplicate the panel across both
-          // sidebars. Unknown (peer-owned) ids stay untouched.
-          for (const id of defaults) {
-            if (!seen.has(id) && !known.has(id)) {
-              seen.add(id);
-              unique.push(id);
-            }
+        // Append ONLY defaults that the app has never presented to this
+        // sidebar before (i.e. newly introduced panels). Defaults that are
+        // already in `known` but absent from the stored order were
+        // deliberately removed by the user (e.g. dragged to the peer
+        // sidebar) — re-adding them would duplicate the panel across both
+        // sidebars. Unknown (peer-owned) ids stay untouched.
+        for (const id of defaults) {
+          if (!seen.has(id) && !known.has(id)) {
+            seen.add(id);
+            unique.push(id);
           }
-          saveKnownDefaults(storageKey, nextKnown);
-          return unique;
         }
+        saveKnownDefaults(storageKey, nextKnown);
+        return unique;
       }
     }
   } catch {


### PR DESCRIPTION
Panel dragging previously considered only the first peer container. Extend the existing `createDragReorder` implementation to select among registered containers, clear the previous target when moving between them, and avoid duplicate ids on acceptance.

Also preserve a stored empty panel order. Moving the only panel out of a zone previously caused its defaults to return on reload, duplicating the moved panel.

This is the prerequisite for making all Standard hybrid service panels interactive while keeping STATION METERS in its full-width bottom row by default. Panel composition follows separately; the existing two sidebars keep their API and preference keys.

Part of [MOR-2443](https://linear.app/morozsm/issue/MOR-2443), under MOR-2425.

Validation:
- 20 focused drag and persistence tests pass, including transfers across three containers, empty-target insertion, reset, target cleanup, duplicate acceptance, and preservation of an emptied zone.
- Restoring first-peer-only selection fails two component regressions; restoring duplicate acceptance fails its regression; the empty-order regression failed before its fix.
- Frontend type check, lint, and production build pass.
- Independent base review and delta review pass at `1233939385d4102c242a029880743ba72fa3a8e8`.

Verification caveat: the coordinator mistakenly used the older checkout's testing instructions and started unnecessary local full runs. One hit a timing assertion in `test_managed_tx_effect_lane`; that file then passed all 30 focused tests. Another lost a worker in unchanged `test_rigctld_server_coverage::test_max_clients_rejected`. Four frontend files also failed during concurrent full-suite/build load, then all 117 focused tests passed. These local runs are not the acceptance record. The current `CLAUDE.md` assigns full-suite evidence to the exact-head `quick` run with its path filters; that rule governs this PR. No backend/Python files changed.

No hardware commands or server behavior change in this prerequisite.
