### PR TITLE
fix(ui): prevent Standard side panels from shrinking below their headers

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -942,6 +942,11 @@
     outline: 2px solid var(--v2-accent, #4af);
     outline-offset: -2px;
   }
+  .standard-panel-owner :global(.semantic-control-panel),
+  .standard-panel-owner :global(.left-sidebar > .collapsible-panel),
+  .standard-panel-owner :global(.right-sidebar > .collapsible-panel) {
+    flex-shrink: 0;
+  }
   .standard-panel-owner > :global(.surface-zone),
   .standard-bottom-dock > :global(.surface-zone),
   .standard-panel-owner > .content-left,

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -487,6 +487,32 @@ test.describe('MOR-2424 Standard v2.11.1 outer grid', () => {
     });
   }
 
+  test('keeps legacy side-panel headers inside their scrollable panel boxes', async ({ page }) => {
+    await boot(page, 'standard', 1440, true, 'studioline', false, undefined, {
+      height: 800,
+    });
+
+    for (const [ownerClass, panelId] of [
+      ['standard-panel-owner-left', 'band'],
+      ['standard-panel-owner-right', 'audio-scope'],
+    ] as const) {
+      const panel = page.locator(`.${ownerClass} [data-panel-id="${panelId}"]`);
+      await expect(panel).toHaveCount(1);
+      const geometry = await panel.evaluate(element => {
+        const panelRect = element.getBoundingClientRect();
+        const headerRect = element.querySelector('.panel-header-row')!.getBoundingClientRect();
+        return { panel: panelRect.toJSON(), header: headerRect.toJSON() };
+      });
+
+      expect(geometry.panel.height, `${panelId} panel contains its header`)
+        .toBeGreaterThanOrEqual(geometry.header.height);
+      expect(geometry.header.top, `${panelId} header starts inside its panel`)
+        .toBeGreaterThanOrEqual(geometry.panel.top - 1);
+      expect(geometry.header.bottom, `${panelId} header ends inside its panel`)
+        .toBeLessThanOrEqual(geometry.panel.bottom + 1);
+    }
+  });
+
   test('crosses the 1200 and 1024 Standard thresholds without changing routes', async ({ page }) => {
     await boot(page, 'standard', 1201, true, 'studioline', false, 'topology-1-single');
     const root = page.locator('.desktop-control-face.standard-face');


### PR DESCRIPTION
When Standard side panels were expanded, the legacy BAND and AUDIO SCOPE flex items could shrink to a 2px border box. Their headers were clipped and pointer clicks hit the container instead of the collapse button. Prevent shrinking for semantic wrappers and injected legacy panel roots within Standard side owners.

The Chromium regression checks that both legacy panels contain their headers. Pointer collapse/reopen is checked separately during installed acceptance. On the isolated test host, the focused test failed before the fix with a 2px panel versus a 24px header, then passed after the fix. Production build and diff check passed. Required CI and independent exact-head review provide the final source gates; installed browser acceptance remains separate.

Follow-up to #3438 under [MOR-2443](https://linear.app/morozsm/issue/MOR-2443). Two files, 31 added lines. The CSS scope is limited to Standard side owners.
