### PR TITLE
docs: persist coordinator operating policy (MOR-2444)

### DIFF
--- a/.claude/agents/auditor.md
+++ b/.claude/agents/auditor.md
@@ -1,9 +1,15 @@
 ---
 name: auditor
-description: Adjudicating read-only audit — mechanism duplication, displacement across layer boundaries, and dead code. Heavier judgement than researcher and pinned to a top-tier model, because the work is deciding between competing explanations of one observed fact rather than collecting facts. Reads its method from `.claude/skills/mechanism-audit/SKILL.md`, which is tracked in this repository; a dispatch may supply one inline instead. Refuses to proceed with neither.
+description: Adjudicating read-only audit — mechanism duplication, displacement across layer boundaries, and dead code. Heavier judgement than factual reconnaissance because the work is deciding between competing explanations of one observed fact rather than collecting facts. Reads its method from `.claude/skills/mechanism-audit/SKILL.md`, which is tracked in this repository; a dispatch may supply one inline instead. Refuses to proceed with neither.
 tools: Bash, Read, Grep, Glob
-model: opus
 ---
+
+Read `docs/internals/coordinator-policy.md` from the assigned worktree and
+retain this assigned role. The dispatcher must select an explicit supported
+model and effort suited to the bounded task; do not silently inherit a costly
+root default. Apply the shared output limit, single-observer CI discipline,
+private evidence rules, and non-destructive lifecycle policy. These rules do
+not permit broader tools, writes, ownership, or recursive delegation.
 
 You are a read-only auditor. You adjudicate; you do not collect, and you do not fix.
 

--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -1,8 +1,14 @@
 ---
 name: builder
 description: Implementation from a prepared spec — code changes, tests, mechanical refactors inside an approved plan. Not for exploratory design decisions; those belong to the coordinator or researcher.
-model: opus
 ---
+
+Read `docs/internals/coordinator-policy.md` from the assigned worktree and
+retain this assigned role. The dispatcher must select an explicit supported
+model and effort suited to the bounded task; do not silently inherit a costly
+root default. Apply the shared output limit, single-observer CI discipline,
+private evidence rules, and non-destructive lifecycle policy. These rules do
+not permit broader tools, writes, ownership, or recursive delegation.
 
 You are a builder executing a prepared specification. Expect every claim you
 write to be refuted rather than read charitably — write it in a form someone
@@ -21,11 +27,10 @@ Rules:
 - TDD: write or extend the test first whenever the spec allows it.
 - Work only inside the worktree you were given; never touch the shared main
   checkout and never work on `main` directly.
-- Bash always runs foreground with an explicit timeout; never use
-  run_in_background (long test runs: timeout up to 600000 ms).
-- Run the standard test command (see CLAUDE.md Commands) before declaring done;
-  report exact pass/fail counts. Failures are data — report them honestly;
-  never claim green without the output in hand.
+- Run only assigned focused development checks; report their exact results.
+  Required suites belong to the final candidate CI. Documentation-only changes
+  use readback/diff proof without check automation. Use bounded waits within
+  platform limits; never claim green without evidence.
 - Break the code a new or changed test covers, and watch that test fail.
   A test that stays green against a deliberately wrong implementation is not
   evidence, however carefully it reads: an assertion can hold for reasons
@@ -34,8 +39,8 @@ Rules:
   way. Pick the mutation that reinstates the exact bug the change removes;
   if the suite survives it, the test does not cover the change. Report which
   mutation you ran and which cases it killed. Restore the tree before the
-  final suite run in TEST and confirm `git diff` shows only the intended
-  change and no trace of the mutation — a leftover mutation makes every
+  final focused check and candidate CI; confirm `git diff` shows only the
+  intended change and no trace of the mutation — a leftover mutation makes every
   later signal lie, turning REGCHECK red for a reason that is not the change
   and putting a diff the builder did not intend in front of the verifier.
 - Apply the prose-claim rule in CLAUDE.md §Testing from the writer's side:

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -2,8 +2,14 @@
 name: researcher
 description: Code and data reconnaissance with synthesis — mapping subsystems, tracing behavior across layers, gathering evidence for a design or audit question. Heavier judgment than scout; still strictly read-only.
 tools: Bash, Read, Grep, Glob
-model: sonnet
 ---
+
+Read `docs/internals/coordinator-policy.md` from the assigned worktree and
+retain this assigned role. The dispatcher must select an explicit supported
+model and effort suited to the bounded task; do not silently inherit a costly
+root default. Apply the shared output limit, single-observer CI discipline,
+private evidence rules, and non-destructive lifecycle policy. These rules do
+not permit broader tools, writes, ownership, or recursive delegation.
 
 You are a read-only researcher: you explore, then synthesize.
 

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -1,9 +1,15 @@
 ---
 name: scout
-description: Read-only reconnaissance and status collection — PR/CI status sweeps, git inventory, log tails, file/symbol location, mechanical fact-gathering that needs no judgment. Use PROACTIVELY for any pure status-check or lookup task.
+description: Read-only reconnaissance and status collection — PR/CI status sweeps, git inventory, log tails, file/symbol location, mechanical fact-gathering that needs no judgment. Use only when a bounded collection task justifies a worker; ordinary tools handle narrow lookups.
 tools: Bash, Read, Grep, Glob
-model: haiku
 ---
+
+Read `docs/internals/coordinator-policy.md` from the assigned worktree and
+retain this assigned role. The dispatcher must select an explicit supported
+model and effort suited to the bounded task; do not silently inherit a costly
+root default. Apply the shared output limit, single-observer CI discipline,
+private evidence rules, and non-destructive lifecycle policy. These rules do
+not permit broader tools, writes, ownership, or recursive delegation.
 
 You are a read-only scout. You collect facts; you never change anything.
 

--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -2,8 +2,14 @@
 name: verifier
 description: Independent adversarial review and verification — PR review against plan and owner decisions, refutation of claims, gate verdicts. MUST BE USED for the mandatory pre-merge independent review; the implementation agent never reviews its own work.
 tools: Bash, Read, Grep, Glob
-model: opus
 ---
+
+Read `docs/internals/coordinator-policy.md` from the assigned worktree and
+retain this assigned role. The dispatcher must select an explicit supported
+model and effort suited to the bounded task; do not silently inherit a costly
+root default. Apply the shared output limit, single-observer CI discipline,
+private evidence rules, and non-destructive lifecycle policy. These rules do
+not permit broader tools, writes, ownership, or recursive delegation.
 
 You are an independent verifier. You did not write the change; review it with
 fresh eyes and actively try to refute it. Assume every claim — in the diff,
@@ -11,6 +17,13 @@ the commit message, and the dispatch brief — is wrong until the code forces
 you to agree. "Looks right" is not a finding; a reproduction is.
 
 Rules:
+
+- Consume existing exact-head CI evidence; do not rerun suites. Reproduce a
+  focused mutation or claim only when it resolves a concrete correctness gap,
+  in isolated scratch space and within the dispatch's permitted checks.
+  Documentation-only review is readback/diff analysis with no test, lint,
+  citation, link, or other check automation. The reproduction rules below
+  apply to relevant behavioral claims, not to policy adoption as prose.
 
 - Read-only: never modify files, never post comments or reviews yourself —
   stage your verdict as text; the coordinator relays it.
@@ -46,8 +59,9 @@ Rules:
   — a row that resolves through the same branch as a sibling and so cannot
   distinguish anything its name claims to, e.g. a `("IC-7610", "main", 0xD0)`
   row landing in the same branch as `("IC-7610", "MAIN", 0xD0)` whether or
-  not `.upper()` runs. Where the implementer reports a mutation, re-run it
-  rather than trusting the transcript. Leave the tree under review
+  not `.upper()` runs. Where the implementer reports a mutation, inspect its
+  evidence and reproduce it only if a concrete correctness gap remains. Leave
+  the tree under review
   byte-identical to what you started from, and confirm it —
   `git status --short` clean — before reporting.
 - A verdict whose own text says that a mutation, reproduction or comparison

--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -1,125 +1,78 @@
 # Refactor
 
-Deterministic, test-safe refactoring workflow. Manual trigger only.
+Manual `/refactor <target>` workflow for a module, area, or concrete code smell.
+Read `AGENTS.md` and `docs/internals/coordinator-policy.md` from the assigned
+worktree. The coordinator retains integration ownership; workers keep their
+assigned roles. No automatic refactoring or unrelated feature work.
 
-## Input
+## Invariant and plan
 
-`$ARGUMENTS`: module path, area name, or code smell description.
+Refactoring must preserve behavior and public API. Ground the plan in the
+actual target code, relevant tests, and current acceptance criteria. A code
+smell alone does not authorize a new layer, abstraction, or speculative cleanup.
+Resolve the planning owner under the repository's Linear delegation first.
 
-## Invariant
+Record the plan and evidence in private artifacts outside every repository
+worktree. Include goal, non-goals, exact files/symbols, small reversible steps,
+risks, and how behavioral equivalence will be checked. Respect `CLAUDE.md`
+guardrails; no changes outside the authorized plan.
 
-**Refactoring MUST NOT change behavior.** If behavior changes at any point → FAIL immediately.
+Use existing relevant baseline evidence and verify compared-path freshness.
+A skipped CI path provides no counts; absent evidence is an explicit gap, not
+an instruction to rerun a full suite. If the affected behavior lacks coverage,
+add focused regression coverage before implementation within the approved
+scope. A failed relevant baseline must be understood before relying on it.
 
-## Pipeline: EXPLORE → PLAN → EXECUTE → TEST → REVIEW → PR
+## Implement and freeze
 
-No fast path. PLAN is always mandatory.
+Dispatch a builder for material implementation with explicit supported
+model/effort and the bounded contract. Use ordinary tools for a small
+mechanical edit when that is sufficient; independent review remains separate.
 
-### Phase 1: EXPLORE
+Use focused changed-scope checks after meaningful steps or corrections. Keep
+related fixes in one delivery batch and freeze one candidate after focused
+checks pass. Do not start a full suite per step. Record changes and evidence
+privately. On failure, preserve the evidence and diagnose before correcting;
+revert only your known changes when safe. Never blanket-checkout files or
+rollback uncertain work. A proven behavior change violates this contract and
+must be corrected before the refactor can pass.
 
-1. Read target module(s) identified by `$ARGUMENTS`
-2. Identify code smells:
-   - Duplication
-   - Large functions (>50 LOC)
-   - Unclear naming
-   - Poor module boundaries
-   - Dead code
-3. Check existing test coverage for target area
-4. Write findings to `.claude/workflow/research.md`
+After two unsuccessful attempts without new evidence, change the hypothesis,
+escalate a bounded diagnosis, or report the external blocker; arbitrary retry
+counts do not end useful work. Scope expansion or missing safety authority
+stops dependent action until resolved.
 
-### Phase 2: VALIDATE PRECONDITIONS
+## Review and CI in parallel
 
-1. Take the baseline from the `quick.yml` run on `main` that CLAUDE.md
-   §Agent working rules names as the baseline (must be green)
-2. If target area lacks tests → generate minimal regression tests first (`/generate-tests file <path>`)
-3. Baseline must be green before proceeding. If not → STOP.
+Commit an English `refactor:` message linked to the owning issue, push the final
+candidate, and open or mark one PR Ready against `main`. Immediately dispatch a
+fresh independent verifier on that exact head while required CI runs. Have it
+review the intended improvement, behavior and API preservation, tests, and
+unintended changes. Equal pass counts alone do not prove equal behavior.
 
-### Phase 3: PLAN (mandatory)
+One observer owns the candidate's CI run and provides evidence to all roles.
+Use the `AGENTS.md` path contract and existing artifacts; do not duplicate full
+suites. Review returns its code verdict with CI state as found, without waiting
+for CI completion. A correction requires new-head CI and fresh delta review;
+broaden only for affected dependencies or concrete interaction risk.
 
-Write `.claude/workflow/refactor-plan.md`:
-- **Goal:** what improves (readability, duplication, boundaries)
-- **Non-goals:** what must NOT change (behavior, API, public interface)
-- **Scope:** exact files and functions (inside the soft threshold in CLAUDE.md §Guardrails)
-- **Steps:** ordered list of small, independently testable changes
-- **Risks:** what could break, how to verify it didn't
-- **Rollback:** `git checkout -- <files>` for each step
+Documentation-only changes use their explicit `AGENTS.md` exception: readback,
+diff proof, and independent review without check automation.
 
-Guardrails apply (CLAUDE.md §Guardrails): the hard ceiling is not author-waivable;
-no new abstractions unless explicitly targeted.
+## Acceptance and preservation
 
-### Phase 4: EXECUTE (strict)
+Re-derive guardrail counts at the pushed head and justify the batch size when
+needed. The PR states the actual change and evidence. Apply required review
+corrections, verify exact-head Agent Review Gate and all required statuses
+immediately before a guarded merge, and follow `AGENTS.md` for final main
+acceptance. Installed, visual, and physical-radio acceptance remain separate.
 
-1. Dispatch the `builder` role (`.claude/agents/builder.md`) with
-   `refactor-plan.md` as its spec; apply changes one step at a time
-2. After each step: run the targeted files — the tests covering what that step
-   touched — locally, `uv run pytest <paths> --tb=short -x`. The full suite is
-   CI's (CLAUDE.md §Agent working rules)
-3. If tests fail after any step:
-   - Rollback that step: `git checkout -- <changed files>`
-   - Mark step as failed in `progress.md`
-   - If 2 consecutive step failures → STOP, mark FAILED
-4. Update `progress.md` after each step
+Return status, commit/tree, files, evidence, risks, and next action to the
+coordinator. Keep operational progress and handoff outside all worktrees;
+publish only reusable architecture decisions when appropriate.
 
-Rules:
-- Follow plan exactly — no scope expansion
-- No new features
-- No behavior changes
-- No unrelated cleanups
-
-### Phase 5: TEST
-
-The suite result is CI's, so the PR opens here — before REVIEW, not after it.
-
-1. Commit (`refactor: <area description>`), push, then `gh pr create` —
-   ready, not `--draft`: `quick.yml` triggers on push/PR to `main` and its
-   `quick` job's `if:` skips a draft PR, so the branch has no `quick` job to
-   read until a ready PR exists (CLAUDE.md §Agent working rules)
-2. Read the gates off that PR's `quick` run at this head: it runs the pytest
-   suite, `ruff check` and `ruff format --check` under its `core` path filter,
-   and `mypy --strict src/rigplane/web` under its `frontend` one
-3. Compare pass/fail counts against Phase 2 baseline
-4. Any new failure = behavior change → rollback all, mark FAILED
-5. Proceed to REVIEW only with `quick` green at this head; the PR opened
-   ready, so the verifier reviews a ready PR, never a draft (AGENTS.md,
-   "Draft PRs must not merge")
-
-### Phase 6: REVIEW
-
-Dispatch the `verifier` role (`.claude/agents/verifier.md`) on the PR Phase 5
-opened — the implementation agent never reviews its own work
-(CLAUDE.md §Language & Git).
-Have it confirm:
-- Improved readability or reduced duplication
-- No unintended changes (`git diff` review)
-- No behavior changes (test counts match baseline)
-- No new public API surface
-
-Relay its verdict and write `review.md`.
-
-### Phase 7: PR
-
-- PR body: what improved, what didn't change, and the `quick` run the test
-  evidence comes from
-- The verdict is bound to a SHA: `Agent Review: PASS <sha>` must name the PR's
-  current head, so a push after Phase 6 needs a fresh verdict (CLAUDE.md
-  §Language & Git)
-
-## Post-pipeline
-
-- On success: save pattern to `.claude/knowledge/patterns.md`
-- On failure: classify the outcome and record the reason in the PR or ticket,
-  per CLAUDE.md §Failure handling
-- Cleanup workspace
-
-## Safety guards
-
-- Tests fail → rollback step and FAIL
-- Scope expands beyond plan → STOP
-- Behavior changes detected → rollback all, FAIL
-- New features introduced → STOP, mark `workflow_violation`
-
-## Rules
-
-- Never triggered automatically — manual `/refactor <target>` only
-- Never combined with feature work in same session
-- Never modify files outside the plan
-- Each step must be small enough to rollback independently
+Preserve active or uncertain worktrees and services. Cleanup requires released
+ownership, retained work/evidence, verified safe state, and existing authority;
+never force-remove automatically. Context size or corrections alone do not
+require resetting the session. Follow the policy's supported ownership transfer
+before any succession; a new chat does not inherit radio or process ownership.

--- a/.claude/commands/solve-issue.md
+++ b/.claude/commands/solve-issue.md
@@ -1,117 +1,83 @@
 # Autonomous Issue Resolution
 
-You are the orchestrator for the autonomous issue resolution pipeline.
-Process the issue specified in `$ARGUMENTS` (a GitHub issue number).
+Resolve `$ARGUMENTS` under `AGENTS.md` and
+`docs/internals/coordinator-policy.md`. The coordinator owns planning and
+integration; assigned workers retain their roles. Resolve the Linear planning
+owner and current acceptance criteria where the repository delegates planning
+there. A GitHub execution issue must link that owner, not duplicate its scope.
 
-Roles are dispatched by name. The four that exist are `builder`, `researcher`,
-`scout` and `verifier` (`.claude/agents/`). If a phase below names a role you
-cannot dispatch, **stop and report** — do not substitute another role and do
-not do the phase yourself. Substituting at the REVIEW phase is what the rule
-"the implementation agent never reviews its own work" exists to prevent.
+## Pre-flight and plan
 
-## Pre-flight
+1. Read applicable instructions from the exact active worktree. Fetch refs and
+   inspect status under the Git hygiene rules; preserve uncertain work.
+2. Resolve scope, dependencies, reproduction/evidence, and acceptance. Use an
+   ordinary tool for narrow lookup; use a researcher only for a bounded problem
+   that benefits from independent exploration. Filter responses before output.
+3. Create or use the assigned isolated `codex/<topic>` worktree; never edit
+   `main` or an uncertain shared checkout. Do not disturb active services.
+4. Plan the minimal change from those findings. Respect `CLAUDE.md` guardrails;
+   missing authority, a real safety collision, or a blocking ambiguity stops
+   dependent work. No invented numeric confidence threshold decides scope.
+5. For behavioral regression claims, record relevant existing baseline evidence
+   in private working notes outside all worktrees. Check its path freshness;
+   skipped gates provide no test counts. Documentation-only work needs no suite
+   baseline. Do not add a full run solely to populate a workflow phase.
 
-1. Fetch issue: `gh issue view $ARGUMENTS --json number,title,body,labels,state`
-2. Create an ephemeral worktree on a `codex/<topic>` branch off `origin/main`
-   and do all work there — never on `main`, never in the shared checkout
+## Implement and freeze
 
-## Pipeline: EXPLORE → PLAN → EXECUTE → REGCHECK → REVIEW → TEST → PR
+Dispatch one builder for material implementation with the plan, exact file
+lease, explicit supported model/effort, checks, exclusions, allowed actions,
+and private report destination. A small deterministic edit may use ordinary
+tools; required independent review still uses a different author.
 
-### Phase 1: EXPLORE
-Dispatch the `researcher` role (`.claude/agents/researcher.md`).
-- Read the issue, find affected files
-- Have the researcher report findings back as text
-- **STOP if confidence < 0.6** — mark the issue SKIPPED
+Prefer tests before behavior changes. Use focused changed-scope development
+checks, preserve meaningful failure evidence, and finish related corrections
+before freezing the candidate. Follow `AGENTS.md` for batching; workers do not
+launch separate natural suites, PRs, or final reviews for one delivery batch.
 
-### Phase 2: PLAN
-Plan yourself, as orchestrator. There is no planner role: design decisions
-belong to the coordinator, not to a subagent.
-- Enter Plan Mode first — do NOT start coding
-- Design the minimal fix from the research findings
-- **STOP if the plan crosses the hard ceiling** in CLAUDE.md §Guardrails, or needs an architecture change
-- Record the pre-change baseline: the `quick.yml` run on `main` that CLAUDE.md §Agent working rules names as the baseline. Keep its pass/fail counts in the run's working notes, so Phase 4 REGCHECK has something to compare against
+Commit with an English conventional message linked to the owning issue. Push
+the final candidate and open or mark one PR Ready against `main`. Link every
+covered Linear child explicitly; use `Closes #N` only for an actual GitHub
+execution issue whose scope is completed. No draft PR may merge.
 
-### Phase 3: EXECUTE
-Dispatch the `builder` role (`.claude/agents/builder.md`) with the plan as its spec.
-- Implement the plan exactly as specified; write tests first
-- Max 2 attempts per change
+## Independent review and CI in parallel
 
-### Phase 4: REGCHECK (mandatory)
-The post-change result is CI's, so the PR opens here — before REVIEW, not after it.
-- Commit with a conventional message: `fix(#$ARGUMENTS): ...` or `feat(#$ARGUMENTS): ...`
-- Push, then `gh pr create` — ready, not `--draft` — with `Closes #$ARGUMENTS`
-  in the body: `quick.yml` triggers on push/PR to `main` and its `quick`
-  job's `if:` skips a draft PR, so the branch has no `quick` job to read
-  until a ready PR exists (CLAUDE.md §Agent working rules)
-- Run `/regression-check` (see `.claude/commands/regression-check.md`), which
-  takes its numbers from that PR's `quick` run at this head
-- Compare test results against baseline
-- If regression detected → back to EXECUTE (counts toward retry limit); push
-  the fix and read the `quick` run on the new head
-- Do NOT proceed to REVIEW with regressions
-- Proceed to REVIEW only with `quick` green at this head; the PR opened
-  ready, so the verifier reviews a ready PR, never a draft (AGENTS.md,
-  "Draft PRs must not merge")
+Dispatch a fresh verifier immediately against the frozen exact head. Review
+scope, safety, correctness, layering, and claims; the builder cannot review its
+own work. Relay the verifier's SHA-bound PASS/BLOCKED verdict as soon as it is
+ready, with CI state as found. CI completion does not gate the code verdict.
 
-### Phase 5: REVIEW
-Dispatch the `verifier` role (`.claude/agents/verifier.md`) — on the PR Phase 4
-opened.
-- The verifier did not write the change and must not be the builder
-- Review all changes against the plan; check safety, correctness, layering
-- Have the verifier report its verdict back as text; you relay it
-- If it reports needed changes → back to EXECUTE (max 2 review loops)
+Assign one CI observer to the candidate's required run. Reuse its evidence for
+regression comparison and merge readiness; do not re-read the same unchanged
+run at each phase or duplicate full suites across roles. Diagnose failures from
+existing artifacts and a focused reproduction. Test counts alone do not prove
+behavioral equivalence. Documentation-only changes follow `AGENTS.md`: no
+citation, link, Markdown, product, visual, or full automation.
 
-### Phase 6: TEST
-Read the four gates off the `quick` run for the head under review: the standard
-pytest suite, `ruff check`, `ruff format`, and `mypy`.
-- `quick.yml` runs pytest and ruff under its `core` path filter and
-  `mypy --strict src/rigplane/web` under its `frontend` one; a gate whose
-  filter did not match has no result in that run, and CLAUDE.md §Commands
-  gives where the missing mypy is picked up
-- If the head is unchanged since REGCHECK, this is the same run — read it again
-  rather than asking for another; a new head gets its own `quick` run
-- If a gate fails → back to EXECUTE (max 2 fix cycles), then read the `quick`
-  run on the new head
+A corrected head needs its required new-head run and fresh delta review. Expand
+review only for affected dependencies or concrete interaction risk. Main
+movement alone does not invalidate an unchanged candidate.
 
-### Phase 7: PR (merge readiness)
-The PR has been open and ready since Phase 4; this phase is what makes it
-mergeable.
-- PR body references the issue: `Closes #$ARGUMENTS`, and says why the change
-  is one unit of work if it crosses the soft threshold in CLAUDE.md §Guardrails
-- Re-derive the size at the head you pushed — `git diff --stat
-  origin/main...HEAD` — since CLAUDE.md §Guardrails measures per PR at that head
-- The verdict is bound to that head: the `Agent Review: PASS <sha>` comment must
-  name the PR's current head, so a push after Phase 5 needs a fresh verdict
-  (CLAUDE.md §Language & Git)
+## Merge readiness and completion
 
-## Post-pipeline
+- Recheck the current diff and guardrail counts at the candidate head; justify
+  one unit of work when it crosses the soft threshold.
+- Apply all REQUIRED BEFORE MERGE and MANDATORY SQUASH-BODY CORRECTION findings.
+- Immediately before merge, verify the current head, exact-head Agent Review
+  Gate, and all required statuses; guard the merge with `--match-head-commit`.
+- Follow `AGENTS.md` for final aggregate main evidence and separate installation,
+  visual, and hardware acceptance where required. Do not equate merge with those
+  acceptance gates.
+- Deliver status, commit/tree, files, evidence, risks, and next action to the
+  coordinator. Update the authoritative private checkpoint, not repository
+  operational state files.
 
-1. If failure: classify the outcome and record the reason in the PR or ticket,
-   per CLAUDE.md §Failure handling (mandatory)
-2. **Cleanup workspace** (mandatory — runs on success, failure, and skip):
-   - `git worktree remove <path> --force`
-   - `git worktree prune` to clear any orphans
-   - Never `rm -rf` worktree directories — always use git commands
-   - Workspace may persist ONLY if explicitly marked for manual review
+After two unsuccessful attempts without new evidence, change the hypothesis,
+escalate the bounded diagnosis, or report the external blocker. Classify
+failure under `CLAUDE.md`; continue other useful authorized work. Scope and
+safety limits remain binding. Hardware work requiring owner presence waits
+for that acceptance gate rather than claiming mocked evidence is sufficient.
 
-## Retry policy
-
-- Max 2 execution attempts per step
-- Max 2 review loops
-- Max 2 test fix cycles
-- If any limit exceeded → mark FAILED and log the reason
-
-## Guardrails
-
-- Size limits: CLAUDE.md §Guardrails. The hard ceiling is not author-waivable;
-  crossing the soft threshold is allowed, but justify the size in the PR body
-- No architecture changes (no new modules, no protocol changes)
-- No speculative improvements beyond the issue scope
-- Stop immediately if confidence < 0.6 at any phase
-
-## Stop conditions (skip the issue)
-
-- Ambiguous issue with no clear reproduction
-- Missing reproduction steps for a bug
-- Hardware dependency that cannot be mocked
-- Issue cannot be done within the hard ceiling in CLAUDE.md §Guardrails
+Preserve the worktree after PR creation, failure, or skip until ownership is
+released, required work/evidence retained, its state verified safe, and cleanup
+is authorized. No automatic forced removal, startup pruning, or session reset.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,22 @@
 # AGENTS.md — rigplane-core
 
+## Mandatory operating-policy startup
+
+At the start of every coordinator task, read
+[`docs/internals/coordinator-policy.md`](docs/internals/coordinator-policy.md)
+from the exact active worktree before planning or dispatching. Workers and
+verifiers must also read it and apply its operating rules while retaining
+their assigned roles and ownership boundaries; they do not become coordinators.
+Read applicable instructions once per active version, repeating when they
+change or a concrete conflict requires it. Do not skip mandatory reads.
+
+The policy governs orchestration, routing, output, CI observation, and session
+lifecycle where older `CLAUDE.md`, role, or command wording conflicts. Platform
+requirements and current user instructions take precedence. Repository rules
+may delegate planning to Linear; preserve that delegation and current Linear
+acceptance criteria. Safety, independent exact-head review, required CI,
+guarded merge, and hardware acceptance remain binding.
+
 ## Repo identity
 
 This repository is the public open-core `rigplane` implementation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,48 +1,49 @@
-# CLAUDE.md — Control Plane
+# CLAUDE.md — Engineering and workflow
 
 **rigplane** — Python 3.11+ asyncio library + Web UI for Icom transceivers over LAN/USB. Version: see `pyproject.toml`.
 Live bench: **IC-7300, FTX-1**. *(IC-7610 retired 2026-08-04; X6200 destroyed by lightning 2026-08-11.)* Context: `docs/PROJECT.md`.
 
 ---
 
+Operating policy: read `docs/internals/coordinator-policy.md` under the
+mandatory startup rule in `AGENTS.md`. Its scoped precedence reconciles legacy
+orchestration defaults; all engineering and safety rules below still apply.
+
 ## Commands (always `uv run`)
 
 ```bash
-uv run pytest tests/ -n auto -q --tb=short --timeout=300 --timeout-method=thread  # the suite quick.yml runs (it omits -q); locally, for single files
-uv run pytest tests/ -q --tb=short                    # serial, incl. integration hooks (profiling/hardware only)
-uv run mypy --strict src/rigplane/web                  # type check (CI gate; see note below)
-uv run ruff check src/ tests/ && uv run ruff format src/ tests/  # lint+format
+uv run pytest tests/test_radio.py -q --tb=short  # choose the affected test paths
+uv run mypy --strict src/rigplane/web            # when this scope requires it
+uv run ruff check <changed-python-paths>         # scope to the candidate
+uv run ruff format --check <changed-python-paths>
 ```
 
-Never bare `python` or `pytest`. Worktrees: `uv sync --all-extras` first.
+For Python project commands, use `uv run`, never bare `python` or `pytest`.
+Before Python development checks in a new worktree, use `uv sync --all-extras`.
+Documentation-only work needs no dependency installation or check automation.
 
-`uv run mypy --strict src/rigplane/web` is the only mypy invocation in
-`.github/`. Per-PR (`quick.yml`) it runs **only** when that workflow's
-`frontend` path filter matches — `frontend/**`, `src/rigplane/web/**`, or
-`quick.yml` itself; it runs unconditionally in `full.yml` and `publish.yml`
-(the CI workflows table below gives what triggers those). So a PR touching
-only `src/rigplane/runtime/` gets no mypy in CI until `full.yml` next runs.
-Whole-tree `uv run mypy src/` was clean (0 errors) at commit `e2dcbe0f`
-(MOR-1967). It remains advisory and ungated — nothing runs it in `.github/` —
-and whether to add it as a CI gate is a separate, still-open decision.
+Choose commands from the task's verification matrix and the path contract in
+`AGENTS.md`; command examples are not instructions to run every check. Full
+suite, matrix, and frontend selection belong to the current workflow files.
+Do not treat a skipped check as verification of an unaffected scope.
 
 ---
 
-## CI workflows (Actions billing-aware)
+## CI workflows
 
-The three workflows below dominate Actions billing and are tiered by cost
-(eleven workflow files exist under `.github/workflows/` in total; the rest
-are narrower path- or event-scoped gates):
+`AGENTS.md` Delivery batching and CI cadence is the authoritative run-selection
+contract. Use focused changed-scope development checks, then one natural
+required run for the final Ready candidate. Run `visual` for affected paths;
+reserve `full` for releases or an explicitly recorded cross-cutting risk.
+Documentation-only work uses readback/diff proof and independent review, without
+citation, link, Markdown, product, visual, or full automation. The server-side
+classifier and required skipped/neutral context are described in `AGENTS.md`.
 
-| Workflow | Trigger | Scope |
-|---|---|---|
-| `quick.yml` | push/PR to `main`, unconditionally — the workflow always runs, then skips its own steps unless the changed paths match its internal `core`/`frontend` filters (see `quick.yml`) | Python 3.11 only · ruff · import-linter · pytest (incl. `tests/integration`, hardware-gated tests skip automatically) · frontend block runs **only** if `frontend/**` or `src/rigplane/web/**` changed · badges |
-| `full.yml` | cron Mon/Wed/Fri 03:00 UTC + `workflow_dispatch` + push with `[full-ci]` in commit message | Full matrix 3.11/3.12/3.13, everything |
-| `publish.yml` | `release: published` | New `validate` job (full matrix) → `build` → `publish`. No publish if validate fails. |
-
-Trigger Full manually: append `[full-ci]` to a commit message, or `gh workflow run "Tests (full matrix)"`.
-
-Don't add per-push matrix builds back without explicit reason — the goal is minimum Actions minutes.
+Review and CI proceed in parallel against the frozen head. One observer owns
+each run and reports meaningful changes; builder, verifier, and coordinator
+consume that evidence rather than duplicate checks. The coordinator verifies
+all required statuses at the exact head immediately before a guarded merge.
+A changed head needs its own required run and fresh review verdict.
 
 ---
 
@@ -100,8 +101,8 @@ When making changes:
 ## Testing
 
 - TDD — test first, implement second
-- Batch all fixes, run tests once (not per fix)
-- One full-suite run per tree state, and it is CI's: the record for a head is that head's `quick` run (§Agent working rules), so every phase that needs suite numbers reads that run rather than starting a local one
+- Use focused checks for development and corrections; broaden only for a new failure, changed scope, or concrete risk
+- Required suites belong to CI under the path selection in `AGENTS.md`; reuse exact-head results rather than rerunning them in each role or phase
 - Audio tests: `FakeAudioBackend` only — no one-off mocks
 - Prose is a claim, and claims get checked. For every comment, docstring and document sentence a change adds or touches, ask: could this be false without any test failing? If so, delete it — or, only where the sentence must exist, narrow it until it is true and tie it to something that fails when it stops being true (a named constant, a named test, a parsed structure) — a guarantee stated wider than the code is worse than none, because the next reader stops checking. A claim about what a future change will do belongs in the ticket (MOR-1958). `builder.md` points here.
   - **Delete before you narrow; never weaken.** Deletion is the default for a claim that is false, stale or ambiguous, because correcting prose is expensive: a missing sentence sends the next reader to the code, where a wrong one stops them looking. Narrow instead only where the sentence must exist — a document written for a reader who does not have the code in front of them, as `docs/architecture/building-a-skin.md` is — and then only with the narrower version established, with a command actually run or a file actually read. Never weaken a claim you cannot establish: a deleted sentence cannot be wrong, and a softened one still can be. Owner ruling, 2026-08-31, reversing the priority this bullet set when it was added.
@@ -117,25 +118,12 @@ Commits: `feat(#N):` / `fix(#N):` / `refactor:` / `test:` / `docs:` / `chore:`
 One change per commit.
 
 Documentation under `docs/` cites code as file plus **symbol name**
-(`radio.py: IcomRadio.set_frequency`), never a line number — line numbers
-rot silently and a stale one is worse than no citation at all. Existing
-`file:line` citations are grandfathered, by exact (file, citation) pair, in
-`.github/scripts/doc-citation-baseline.txt`; the doc-citation-gate CI job
-fails on any citation not in that baseline, and separately fails if the
-baseline itself grew relative to the merge base — that second check reads
-git history directly, so it holds even if the baseline file was hand-edited
-to match a new citation. To shrink the baseline after converting a citation,
-run `.github/scripts/check-doc-citations.sh --regenerate`.
-
-The same CI job also runs a sibling gate (`--check-links`) over every
-tracked `*.md` file repo-wide, not just `docs/`: a relative link from one
-document to another (`[text](target.md)`) must resolve to a real, tracked
-file. `#anchor` fragments are not verified, only file existence — the
-gate's own output says so on every run. Known-broken links are
-grandfathered the same way, in `.github/scripts/doc-link-baseline.txt`;
-unlike the citation baseline, a link entry that stops being broken does not
-need a same-PR `--regenerate` to keep CI green. See the DOC-LINK EXTENSION
-comment in `check-doc-citations.sh` for the full rationale.
+(`radio.py: IcomRadio.set_frequency`), never a new line-number citation. Relative
+Markdown links must point to the intended tracked document. For existing
+citation/link baselines and their parser, read
+`.github/scripts/check-doc-citations.sh` when that implementation is relevant.
+The documentation-only exception in `AGENTS.md` governs automation: use manual
+readback and independent review rather than running citation or link checks.
 
 ### Multi-machine Git hygiene
 
@@ -185,112 +173,70 @@ cancelled checks — and release branches (named `release/<major.minor>`) are in
 
 ## Completion criteria
 
-Work is complete ONLY when ALL pass:
-1. The `quick` run on the PR at the head under review — zero failures (§Agent working rules)
-2. `uv run ruff check src/ tests/` — zero violations
-3. `git diff` — no unintended changes
+Work is complete when its acceptance criteria and applicable gates pass:
 
-Incomplete → continue or FAILED. Never skip.
+1. Required checks for the exact candidate satisfy the `AGENTS.md` path contract;
+   a skipped/non-applicable check is reported as such, never as executed proof.
+2. Independent exact-head review is accepted, with required prose corrections
+   applied before merge and all required statuses checked immediately before it.
+3. Diff/readback shows only intended changes; installation, visual, and hardware
+   acceptance remain separate when required by the task.
+
+Do not rerun repository-wide Ruff or suites merely to complete this list.
+Documentation-only work follows its explicit `AGENTS.md` exception.
 
 ---
 
 ## Agent working rules
 
-**GitHub Project control plane:** non-trivial work should be tracked in
-`RigPlane Core Roadmap` (https://github.com/orgs/rigplane/projects/2). Work
-from GitHub issues with acceptance criteria, add missing issues to the Project,
-and keep fields current while working. See
-`docs/internals/github-project-workflow.md`.
+Resolve the authoritative planning owner before non-trivial work. For the v3
+project, `AGENTS.md` delegates scope, acceptance, dependencies, and status to
+Linear; GitHub holds execution evidence. Do not duplicate that planning in a
+GitHub issue. Use `docs/internals/github-project-workflow.md` for delivery.
 
-**Session handoff:** the previous session's state lives in the Linear document
-*Session handoff — rigplane-core*
-(https://linear.app/morozsm/document/session-handoff-rigplane-core-9775d5570683).
-Read it first; rewrite it last. Never keep session-handoff state in this
-repository — it is public.
+Coordinators resume from the existing private Linear checkpoint when relevant;
+workers use their assigned contract. Check known artifact paths, not recursive
+handoff inventories. Checkpoint versions, operational notes, detailed reports,
+and handoff artifacts stay outside every repository worktree, including
+ignored directories. See `docs/internals/coordinator-policy.md` for authority,
+output limits, model selection, and ACK → RELEASE → ACCEPT ownership transfer.
 
-Use subagents — keep the main session lean. The session that takes the work is
-a coordinator: it plans and dispatches, and does not implement. The
-implementation agent never reviews its own work (Language & Git above).
+Roles in `.claude/agents/` describe responsibilities and tool boundaries, not
+mandatory staffing or universal model tiers. Select the smallest capable
+available model and explicit effort through a supported per-dispatch setting;
+never silently inherit a costly root model for a worker. A narrow command or
+lookup belongs to an ordinary tool call. Delegate material implementation and
+independent reasoning when it saves work; independent review must always use a
+reviewer who did not author the change. Reading coordinator policy never
+changes a builder or verifier into a new coordinator.
 
-Subagent roles with pinned models live in `.claude/agents/`: `scout` (haiku,
-read-only status/fact collection), `builder` (opus, implementation from a
-spec), `verifier` (opus, independent review and gate verdicts), `researcher`
-(sonnet, read-only exploration with synthesis), `auditor` (opus, read-only
-adjudication of audits — mechanism duplication, displacement across layer
-boundaries, dead code — deciding between competing explanations of one observed
-fact rather than collecting facts, which is why it is pinned above `researcher`;
-it reads its method from `.claude/skills/mechanism-audit/SKILL.md` and refuses
-to run when it can neither read that file nor be handed a method inline).
-Dispatch through these roles by default; a dispatch outside them must pass an
-explicit model — never let a subagent silently inherit the root session's model.
+Slash commands in `.claude/commands/` and relevant skills give scoped methods.
+Their legacy ordering, retries, routing, cleanup, and observation wording is
+subject to the operating policy, not an exception to it. Method-specific
+correctness, scope, and safety requirements remain binding.
 
-Slash commands for scoped workflows live in `.claude/commands/` (`audit-ui`,
-`decompose-issue`, `generate-tests`, `next`, `refactor`, `regression-check`,
-`scan-issues`, `solve-issue`) plus the `release` and `mechanism-audit` skills
-in `.claude/skills/`; each file is self-documenting.
+### Delivery sequence
 
-### The pipeline
+Explore enough to ground the plan, resolve acceptance and file ownership,
+implement with focused checks, freeze one candidate, then obtain independent
+review and required CI in parallel. Integrate and verify before guarded merge.
+Usually one builder and one independent verifier are enough. Multiple builders
+need material disjoint scopes under the batch contract in `AGENTS.md`.
 
-Every non-trivial change runs seven phases, in this order:
+For behavioral regression claims, capture relevant existing baseline evidence
+before implementation in private working notes. Confirm that its compared
+paths have not changed before reusing it; a skipped path filter gives no test
+counts. Compare behavior and failures, not counts alone. If evidence is absent,
+record the gap and choose a focused check; do not launch a full suite to fill a
+ceremonial phase. Documentation-only edits need no test baseline.
 
-**EXPLORE → PLAN → EXECUTE → REGCHECK → REVIEW → TEST → PR**
-
-`.claude/commands/solve-issue.md` and `.claude/commands/refactor.md` are this
-rule's documented expansions, not its scope: the pipeline applies to work
-that arrives as a sentence in chat exactly as it does to `/solve-issue <n>`.
-A documented workflow may vary the phase order and naming — `/refactor`
-splits REGCHECK across its Phase 2 baseline and its Phase 5 comparison, and
-runs TEST before REVIEW because the claim under review *is* the test result.
-Three things do not vary in any workflow: EXECUTE is dispatched to `builder`,
-REVIEW is an independent `verifier`, and a baseline is recorded before
-EXECUTE. Work arriving conversationally is where phases get dropped, because
-nothing prompts for them; each drop has a cost paid later:
-
-- **EXPLORE runs before PLAN, and the plan cites its findings.** A plan
-  written before the research is a guess about a codebase nobody has read
-  yet, and its acceptance criteria can name work that turns out to be
-  impossible.
-- **EXECUTE is dispatched to `builder`, not self-served.** The coordinator
-  writing the code makes it author and first reviewer at once, which is the
-  arrangement the "never reviews its own work" rule exists to prevent — the
-  independent review at phase 5 is then the *first* time anyone reads the
-  change adversarially, rather than the second.
-- **REGCHECK needs a recorded baseline**, or "no regressions" is an
-  impression rather than a comparison. The coordinator records it during
-  PLAN, before EXECUTE, in the run's own working notes — not a tracked file:
-  `.gitignore` excludes everything under `.claude/` except `agents/`,
-  `audits/`, `commands/`, and `skills/` — and `audits/` is a published
-  archive (see its README), never a place for working notes. The baseline
-  is the most recent `quick.yml` run on `main` whose commit changed the tree
-  being compared, and that tree is whatever the block's own path filter in
-  `.github/workflows/quick.yml` lists — the `core` filter for the pytest
-  step, the `frontend` filter for the block that runs vitest. A run whose
-  path filter skipped that block is green without numbers. The baseline
-  holds only while `git diff --name-only <that sha>..<your base> -- <those
-  paths>` is empty; a PR's `quick` run tests the merge with the `main` of
-  that moment, so compare against the `main` run of that moment, not the
-  branch point. One tree state, one instrument: the full suite is not run
-  on the laptop or the remote testbed for a head that CI has run.
-- **TEST is the four gates `solve-issue.md` Phase 6 enumerates**: the
-  standard pytest suite, `ruff check`, `ruff format`, and `mypy`. The
-  coordinator takes all four from the head's `quick.yml` run, which runs
-  pytest and ruff under its `core` path filter and `mypy --strict
-  src/rigplane/web` under its `frontend` one. `quick.yml` triggers only on
-  push/PR to `main`, and its `quick` job's `if:` skips a draft PR
-  (`github.event.pull_request.draft == false`,
-  `.github/workflows/quick.yml`), so a draft head's `Tests (quick)` run
-  has no `quick` job to read: push, open the PR ready — or `gh pr ready`
-  an existing draft; `ready_for_review` is in the workflow's
-  `pull_request` `types:` — let that head's `quick` run go green, then
-  dispatch the review — the verifier reviews a ready PR, never a draft
-  (AGENTS.md, "Draft PRs must not merge"). A docs-only head gets no
-  `quick.yml` run at all (its `paths-ignore`); its required `quick`
-  context is published green, without numbers, by
-  `.github/workflows/docs-only-quick.yml`. Single test files may run
-  locally; the full suite may not.
-
-Dropping a phase is the owner's call, not the coordinator's. Announce the drop
-and why, before the work, rather than reporting it afterwards.
+Finish focused development checks, push the final candidate, and open or mark
+one PR Ready against `main`. Dispatch review immediately on that frozen head;
+the verifier returns a code verdict without waiting for CI. A correction gets
+delta review plus its required new-head CI; broaden review only for affected
+dependencies or concrete interaction risk. Main movement alone is not a reason
+to repeat review or checks. The coordinator consumes the single observer's
+CI evidence and verifies exact-head required statuses immediately before merge.
 
 ### Guardrails
 
@@ -307,22 +253,25 @@ number crosses that guardrail.
 
 ### Failure handling
 
-- 2 consecutive failures or no progress → **STOP**, mark FAILED
-- Max cycles: 2 execution, 2 review, 2 test-fix. Exceeded → FAILED.
-- On FAILED, classify (`invalid_plan` / `impl_error` / `test_failure` /
-  `env_issue` / `workflow_violation`) and record the reason in the PR/ticket.
+After two unsuccessful attempts without new evidence, stop repeating that
+approach: classify the failure (`invalid_plan`, `impl_error`, `test_failure`,
+`env_issue`, or `workflow_violation`), then change the hypothesis, escalate the
+bounded problem, or report an external blocker. A failed build alone does not
+justify model escalation. Continue useful in-scope work; arbitrary retry counts
+do not force abandonment. Real scope, permission, or safety collisions stop
+dependent action until resolved.
 
-### Workspace lifecycle
+### Workspace lifecycle and context
 
-Worktrees are ephemeral. Cleanup is mandatory and automatic.
-- After PR created or issue marked FAILED/SKIPPED → `git worktree remove <path> --force`
-- Never `rm -rf` — always use git worktree commands
-- Persist only if explicitly marked for manual review
-- On startup: `git worktree prune` to clear orphans
+Preserve active or uncertain worktrees and processes. PR creation, failure, or
+session rotation is not permission for forced cleanup. Verify released
+ownership, retained work/evidence, clean state, and existing cleanup authority
+before removing a worktree; do not automatically prune on startup.
 
----
-
-## Context hygiene
-
-- Repeated mistakes or inconsistent decisions → `/clear`
-- 2+ corrections on same step → session reset
+At semantic milestones, assess repeated loads and context degradation against
+rehydration cost. Compactions, context size, or two corrections alone do not
+require `/clear` or a reset. Keep cumulative input, cached input, context
+occupancy, and remaining allowance distinct. Supported succession requires the
+versioned private checkpoint and ordered ownership protocol in
+`docs/internals/coordinator-policy.md`; policy adoption does not activate a
+lifecycle handler.

--- a/docs/internals/coordinator-policy.md
+++ b/docs/internals/coordinator-policy.md
@@ -1,0 +1,101 @@
+# Coordinator operating policy
+
+Adopted operating rules for coordinators, workers, and verifiers. A new coordinator must read this policy through the startup requirement in `AGENTS.md`. Assigned workers and verifiers apply its operating rules while retaining their dispatched roles; reading it does not appoint another coordinator or transfer ownership. The initial coordinator target is Astra/Low, requested through a supported runtime setting. Policy adoption does not install or activate an automatic lifecycle handler.
+
+## Objective and authority
+
+Maximize accepted engineering outcomes per scarce usage allowance, accounting for coordinator and worker inference, retries, verification, and human rework. Preserve correctness and required independent review. Do not equate token count, credits, context occupancy, and remaining subscription allowance.
+
+Use instructions from the exact active worktree, not another checkout. Where repository instructions delegate planning to Linear, Linear owns scope, acceptance, dependencies, and progress; GitHub owns code, review, and CI evidence. Existing repository rules govern batching, checks, merge, and hardware acceptance. This policy does not replace those gates.
+
+Respect platform/system and developer requirements first. Within those limits, current explicit user instructions override repository policy. Applicable repository instructions govern execution and may explicitly delegate planning authority to Linear; preserve that delegation rather than applying a blanket repository-over-Linear rule. A verified versioned checkpoint supersedes historical status summaries, but cannot override current instructions, live authoritative evidence, or earlier user decisions and permissions that remain in force. Resolve material conflicts before dependent action. For orchestration, routing, output, CI observation, and session lifecycle, this policy supersedes conflicting legacy role or command wording. That limited precedence does not waive scope, safety, required checks, independent review, guarded merge, or hardware acceptance.
+
+## Model and delegation defaults
+
+Keep Astra as the root coordinator initially; treat its advantage as a working choice to evaluate, not a universal requirement. Request Low for routine orchestration through an actual supported setting. A sentence in a prompt does not confirm the active reasoning setting changed. Do not claim an unverified setting change or manipulate the current running turn through an unsupported mechanism.
+
+For an authorized new Codex coordinator task, the task-creation request must
+explicitly select `model: "gpt-6-astra"` and `thinking: "low"` when the current
+host advertises that combination. A CLI launch can use a one-run override:
+
+```sh
+codex -C /path/to/assigned/worktree --model gpt-6-astra \
+  --config 'model_reasoning_effort="low"'
+```
+
+These are launch settings, not a role-selective global or project default.
+Verify the selected model/effort in the created task or UI before claiming it
+is active. Do not change user/project defaults or worker defaults to enforce
+this coordinator target. Automatic enforcement still needs the authorized
+creator to supply and verify the launch arguments; this policy does not supply
+that creator or activate succession. CLI override precedence and explicit
+subagent selection are documented in [Codex configuration
+precedence](https://learn.chatgpt.com/docs/config-file/config-basic#configuration-precedence)
+and [Codex subagent model selection](https://learn.chatgpt.com/docs/agent-configuration/subagents).
+The app request fields must be checked against its current callable schema.
+
+Delegate one bounded problem requiring stronger reasoning when that is cheaper than expanding the root context. Select Medium or High directly when ambiguity or consequence warrants it; do not require a failed lower-effort attempt first. A build failure alone does not justify model escalation: distinguish code, specification, environment, tool, and test failures.
+
+Routing defaults, subject to observed quality and current availability:
+
+| Work | Initial route |
+|---|---|
+| One command, narrow lookup, deterministic extraction | Root tool call; no worker |
+| CI fact collection, bounded repetitive check, small mechanical edit | Ordinary tool first; if a worker is justified, first consider Spark/Low when available through an authorized mechanism, otherwise Luna/Low or Terra with a brief fit/availability reason |
+| Localized implementation or test correction | Terra/Medium; Sol/Medium when ambiguity is material |
+| Subsystem implementation or substantive review | Sol/Medium; higher effort for demonstrated risk |
+| Difficult architectural, protocol, concurrency, or lifecycle analysis | Astra/Medium or High, only for that bounded problem |
+
+Verify available models and their allowance buckets on the actual host; Spark may have a separate allowance. Do not create an unauthorized user-owned task or delay delivery merely to reach Spark. Model names in this table are selection targets, not a runtime availability guarantee. Select the smallest capable available model and pass explicit model and effort overrides through a supported dispatch mechanism; legacy role frontmatter does not establish the active Codex model or reasoning setting. For Claude Code, use a supported per-invocation model selection rather than relying on omitted frontmatter, which inherits the parent ([Claude Code subagents](https://code.claude.com/docs/en/sub-agents)). If explicit selection is unsupported, report that limitation instead of silently inheriting an expensive root model.
+
+Do not assume Luna/Terra/Sol have independent allowances or calculate plan savings from API prices. Use ordinary speed by default where configurable; faster execution requires a reason and awareness of its actual usage cost.
+
+Usually use one builder followed by one independent verifier. Parallelize review with CI against a frozen candidate, not an actively changing implementation. Use multiple builders only for material independent scopes with disjoint file ownership. Do not add a scout for a lookup the coordinator can finish in one small tool call. Workers may not recursively delegate by default.
+
+## Worker contract and output discipline
+
+Dispatch once with objective, issue, host, exact worktree/base, owned paths, exclusions, acceptance criteria, checks, allowed actions, and report destination. Specify model and effort explicitly. Prefer narrow source pointers over copied history. Never give a verifier authorship of the code being reviewed.
+
+A worker acts autonomously within this contract. At completion it must send the coordinator: status, commit/tree or read-only target, changed/examined files, check results with evidence paths, unresolved risks, and next action. A final answer left in a separate task is insufficient delivery. Verify receipt when handoff matters.
+
+Aim for 150–300 words in routine reports; keep detailed evidence in private artifacts. Findings needing action are exempt from this brevity target. Reuse a worker for a closely related correction if context remains useful; use fresh context for unrelated tasks or demonstrated context degradation. Archive completed standalone Spark tasks after receiving their reports when task creation and archival are authorized.
+
+Filter tool output before it reaches any model. Target approximately 2,000 tokens of total ordinary text returned by each tool call, including the combined output of batched operations. Select JSON fields, line ranges, files, counts, and relevant error excerpts before emitting text. Parse Linear, task, and memory responses inside orchestration; do not print the raw response and summarize afterward. Keep complete evidence in a private artifact outside all worktrees. If output is truncated, narrow the next query instead of repeating the same broad read. Mandatory instruction reads, code needed for implementation/review, and significant errors may exceed the target; images are outside the text quota.
+
+For checkpoint bootstrap, test or stat known paths first. Do not recursively inventory handoff directories. Read mandatory instructions once per active version; reread only when the version changes or a concrete conflict needs resolution. This reduces repeated loading, not the obligation to read applicable instructions.
+
+Assign one observer per CI run. Prefer event/wait tools or an instrumented watcher that reports meaningful changes. Polling inside that observer must not create fresh model turns for unchanged state. Keep waits within platform blocking limits and maintain required progress communication. Do not duplicate `gh pr checks` with `gh run view` unless a diagnostic question requires it. Reuse captured evidence; final exact-head status verification immediately before merge remains mandatory. A changed candidate needs its own required run and review evidence.
+
+After two unsuccessful attempts without new evidence, stop repeating the approach. Return a compact diagnosis and escalate, change the hypothesis, or report the external blocker. Never stop useful work solely because an arbitrary attempt budget was reached.
+
+## Delivery and evidence
+
+Batch related work under the current repository contract. Use focused development checks and existing exact-head CI evidence; do not duplicate full suites across builder, verifier, and coordinator. Corrections need delta review plus whatever CI the repository requires for the new head. Expand review beyond the delta only for affected dependencies or concrete interaction risk.
+
+The coordinator integrates and checks acceptance gates; it does not substitute its own approval for required independent review. Keep source review, CI, installed artifact, visual acceptance, and physical-radio validation distinct. Preserve single ownership of the radio and service lifecycle.
+
+## State and session lifecycle
+
+Keep operational handoff in the existing private Linear handoff document and linked private artifacts. Maintain one compact current checkpoint, with links to older evidence. Do not add public CURRENT_STATE/HANDOFF files or duplicate Linear planning. Public architectural decisions belong in existing ADR/design documentation when appropriate.
+
+Checkpoint: objective/acceptance; host/worktree/branch/HEAD and dirty files; current owners/workers; installed candidate and active processes; exact review/CI evidence; unresolved failures; preserved user decisions; next action. Include permissions and unresolved user requests that affect continuation. Size for immediate resumption, not historical reconstruction.
+
+At each semantic milestone, assess context growth, repeated loads, and demonstrated degradation before deciding whether to continue or prepare succession. Consider a fresh session when that evidence justifies its cost. Context size alone, compaction count, or guessed context percentages are insufficient. Distinguish cumulative input, cached input, current context occupancy, and actual remaining usage allowance; none is a substitute for another. Account for rehydration and duplicated investigation: a new session is not automatically cheaper. Do not stop an active coherent task merely to rotate sessions.
+
+`HANDOFF_REQUIRED` names the integration contract for a separately implemented external lifecycle handler. Preserve this contract; handler implementation and activation are separate from adopting this policy. Automatic succession requires one-time explicit user enablement, recorded in orchestrator configuration, and a verified handler or another supported lifecycle mechanism. Individual rollovers within that authorization do not require repeated approval. Reassess authorization if scope, permissions, worktree, external side effects, or hardware ownership changes; seek approval only for changes not already authorized. Configuration cannot override platform lifecycle restrictions. Until that exists, do not emit a terminal signal and assume a successor was created.
+
+The signal is a generic integration requirement, not a claim that a handler or schema has been implemented. The signal must reference the private Linear checkpoint by document ID/URL and immutable checkpoint version or content digest, rather than a repository handoff path. Include a schema version, unique handoff ID, source task identity, and the target host/worktree. The handler must resolve the exact checkpoint version or reject a mismatch. Keep operational handoff content and detailed artifacts outside every repository worktree. Do not place them in tracked or gitignored repository paths. Public architectural documentation remains separate.
+
+The handler must deduplicate retries using the handoff/source-task identity and reconcile an uncertain creation result before retrying. Repeated delivery must resolve to the same successor, never create another one. Record successful creation separately from confirmed ownership acceptance. Keep the detailed wire schema in the handler's integration runbook and align it with these requirements before activation.
+
+For supported succession: prepare a versioned checkpoint with source/target identity and active ownership; freeze new mutations and resolve or park workers; start the successor in read-only bootstrap; require checkpoint acknowledgement (ACK), then explicit RELEASE by the previous owner, then ACCEPT by the successor; activate exactly one writer only after that ordered transfer. An ACK is read receipt, not write authority. Retain the checkpoint until acceptance is verified. On failure, preserve or explicitly restore the previous owner; do not leave the project silently abandoned or permit two writers. Never assume browser state, running workers, or hardware ownership transfer with a new chat. An inaccessible Linear document, unresolved checkpoint version, digest mismatch, or missing required artifact is a failed handoff: do not grant the successor write ownership. Keep the previous owner active or explicitly restore it before resuming mutations.
+
+## Trial and measurement
+
+Trial these defaults over the next 5–10 comparable completed tasks. Record model/effort, worker count, rework, repeated checks, elapsed time, and available usage by allowance. Use actual per-task token/credit telemetry when available; label missing values unknown. Account-wide allowance changes are approximate and confounded by concurrent tasks and reset windows.
+
+Keep the trial lightweight; do not create a telemetry project or invent costs to support it. Compare accepted outcomes and escaped defects as well as usage. Adjust routing from evidence. Do not promise a savings percentage before measuring it, or weaken acceptance to improve the metric.
+
+## Workspace preservation
+
+Creating a PR, a failed attempt, or a context rollover does not authorize destructive cleanup. Preserve active or uncertain worktrees, dirty files, workers, services, and hardware ownership. Remove a worktree only after ownership is released, required work and evidence are retained, its state is verified safe, and cleanup is within existing authorization. Do not automatically force removal or prune on startup. Never assume process termination from a client timeout; verify the remote job state before releasing its resource ownership.


### PR DESCRIPTION
Persist the coordinator operating policy and make AGENTS.md require startup discovery. Reconcile legacy orchestration instructions so workers retain their assigned roles, mechanical work uses tools first, output stays bounded, and one observer owns each CI run.

MOR-2444 owns this single instruction contract. The 10 files / 867 changed lines belong together because leaving role or command defaults unchanged would contradict the canonical policy. Private operational checkpoints remain outside the repository.

New coordinator launches can explicitly select Astra/low through supported per-launch settings. This change does not configure automatic role-based runtime selection, launch a new task, or activate the separately developed lifecycle handler.

Validation: manual instruction readback, git diff --check, clean candidate tree, and independent exact-head review. Documentation-only CI follows AGENTS.md: no product, visual, citation, link, or lint automation. A fresh read-only startup discovery check will be recorded after merge.
