### PR TITLE
feat(ui): add compact semantic HAM tab to Standard BANDS (MOR-2445)

### DIFF
--- a/frontend/src/components-v2/controls/BandSelector.svelte
+++ b/frontend/src/components-v2/controls/BandSelector.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { HardwareButton } from '$lib/Button';
   import { getCapabilities } from '$lib/stores/capabilities.svelte';
   import { flattenBands, findActiveBand } from './band-utils';
@@ -22,12 +23,18 @@
    * only production consumer of. Suppressing the whole component would delete
    * that affordance with no remaining host.
    *
-   * Hence a prop, not a mount gate: hosts pass `hamBands={!declared.has('band')}`
-   * and keep mounting the component unconditionally. `true` by default, so
-   * every caller that does not know about the split (LCD, mobile, tests)
-   * renders exactly the pre-split three-tab component.
+   * Hence props, not a mount gate: hosts keep mounting the component
+   * unconditionally. Standard supplies `semanticHamBands`, which restores the
+   * HAM tab through the retained semantic instrument authority; settings keeps
+   * only the two broadcast tabs. `hamBands` remains true by default, so every
+   * older caller (LCD, mobile, tests) renders the pre-split three-tab component.
    */
-  let { hamBands = true }: { hamBands?: boolean } = $props();
+  let {
+    hamBands = true, semanticHamBands,
+  }: {
+    hamBands?: boolean;
+    semanticHamBands?: Snippet<[compact?: boolean]>;
+  } = $props();
 
   const bandH = getBandHandlers();
   const presetH = getPresetHandlers();
@@ -39,13 +46,14 @@
   const onFreqPreset = presetH.onFreqPreset;
 
   let bandMode = $state<'ham' | 'broadcast' | 'lwmw'>('ham');
+  let hasHamBands = $derived(hamBands || semanticHamBands !== undefined);
 
   // S10 §4a explicitly gates the DEFAULT too, not just the tab: with the HAM
   // tab gone there would be no control able to leave a `'ham'` selection, so
   // the component would open on an empty grid and stay there. Derived rather
   // than baked into `$state`'s initialiser so the fallback also holds if a host
   // flips the prop after mount.
-  let shownMode = $derived(!hamBands && bandMode === 'ham' ? 'lwmw' : bandMode);
+  let shownMode = $derived(!hasHamBands && bandMode === 'ham' ? 'lwmw' : bandMode);
 
   let bands = $derived(flattenBands(getCapabilities()?.freqRanges ?? []));
   let activeBand = $derived(findActiveBand(currentFreq, getCapabilities()?.freqRanges ?? []));
@@ -65,7 +73,7 @@
 </script>
 
 <div class="band-tabs">
-  {#if hamBands}
+  {#if hasHamBands}
     <button
       class="band-tab"
       class:active={shownMode === 'ham'}
@@ -86,19 +94,23 @@
 
 {#if shownMode === 'ham'}
   <div class="grid">
-    {#each bands as band (band.name)}
-      {@const isActive = activeBand === band.name}
-      <HardwareButton
-        active={isActive}
-        indicator="edge-left"
-        color="cyan"
-        title={bandShortcut(band.bsrCode)}
-        shortcutHint={bandShortcut(band.bsrCode)}
-        onclick={() => handleClick(band.name, band.defaultFreq, band.bsrCode)}
-      >
-        {band.name}
-      </HardwareButton>
-    {/each}
+    {#if semanticHamBands}
+      {@render semanticHamBands(true)}
+    {:else}
+      {#each bands as band (band.name)}
+        {@const isActive = activeBand === band.name}
+        <HardwareButton
+          active={isActive}
+          indicator="edge-left"
+          color="cyan"
+          title={bandShortcut(band.bsrCode)}
+          shortcutHint={bandShortcut(band.bsrCode)}
+          onclick={() => handleClick(band.name, band.defaultFreq, band.bsrCode)}
+        >
+          {band.name}
+        </HardwareButton>
+      {/each}
+    {/if}
   </div>
 {:else if shownMode === 'lwmw'}
   <div class="grid">
@@ -181,6 +193,14 @@
   }
 
   .grid > :global(button) {
+    min-width: 0;
+  }
+
+  .grid > :global([data-testid='band-choices-compact']) {
+    display: contents;
+  }
+
+  .grid > :global([data-testid='band-choices-compact']) > :global(button) {
     min-width: 0;
   }
 </style>

--- a/frontend/src/components-v2/controls/__tests__/BandSelector.isolated.test.ts
+++ b/frontend/src/components-v2/controls/__tests__/BandSelector.isolated.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mount, unmount, flushSync } from 'svelte';
+import { createRawSnippet, mount, unmount, flushSync, type Snippet } from 'svelte';
 import { flattenBands, findActiveBand } from '../band-utils';
 import type { FreqRange } from '$lib/types/capabilities';
 
@@ -57,7 +57,10 @@ import BandSelector from '../BandSelector.svelte';
 
 let components: ReturnType<typeof mount>[] = [];
 
-function mountPanel(overrides?: Partial<typeof mockProps>, props?: { hamBands?: boolean }) {
+function mountPanel(
+  overrides?: Partial<typeof mockProps>,
+  props?: { hamBands?: boolean; semanticHamBands?: Snippet<[compact?: boolean]> },
+) {
   if (overrides) Object.assign(mockProps, overrides);
   const target = document.createElement('div');
   document.body.appendChild(target);
@@ -238,8 +241,8 @@ describe('BandSelector component', () => {
  * and this component is their only production consumer, so they are permanent
  * on every manifest. Hence a prop, and hosts that never unmount the component.
  *
- * The composed-tree half of this contract (both hosts, the real desktop-v2
- * manifest) lives in
+ * MOR-2445 adds a semantic snippet that can restore HAM without reviving the
+ * legacy command path. The composed-tree contract lives in
  * `components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts`.
  */
 describe('BandSelector HAM/broadcast split (hamBands prop)', () => {
@@ -262,6 +265,20 @@ describe('BandSelector HAM/broadcast split (hamBands prop)', () => {
     const t = mountPanel(undefined, { hamBands: false });
     expect(tabs(t)).toEqual(['LW/MW', 'SWL']);
     expect(grid(t)).not.toContain('20m');
+  });
+
+  it('hosts semantic HAM controls in the compact grid without reviving the legacy path', () => {
+    let compact: boolean | undefined;
+    const semanticHamBands = createRawSnippet<[compact?: boolean]>((requestedCompact) => {
+      compact = requestedCompact?.();
+      return { render: () => '<button data-testid="semantic-ham">20m</button>' };
+    });
+    const t = mountPanel(undefined, { hamBands: false, semanticHamBands });
+    expect(tabs(t)).toEqual(['HAM', 'LW/MW', 'SWL']);
+    expect(grid(t)).toEqual(['20m']);
+    expect(compact).toBe(true);
+    (t.querySelector('[data-testid="semantic-ham"]') as HTMLElement).click();
+    expect(mockBandHandlers.onBandSelect).not.toHaveBeenCalled();
   });
 
   // Kills: gating the tab/grid but leaving `bandMode`'s `'ham'` initial value

--- a/frontend/src/components-v2/layout/LeftSidebar.svelte
+++ b/frontend/src/components-v2/layout/LeftSidebar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { untrack } from 'svelte';
+  import { untrack, type Snippet } from 'svelte';
   import { runtime } from '$lib/runtime';
   import { hasCapability } from '$lib/stores/capabilities.svelte';
   import RfFrontEnd from '../panels/RfFrontEnd.svelte';
@@ -46,11 +46,13 @@
     declared = new Set<SemanticSurfaceName>(),
     dragOwner,
     showReset = true,
+    semanticHamBands,
   }: {
     hideTxPanel?: boolean;
     declared?: ReadonlySet<SemanticSurfaceName>;
     dragOwner?: PanelDragOwner;
     showReset?: boolean;
+    semanticHamBands?: Snippet<[compact?: boolean]>;
   } = $props();
 
   // Reactive state + capabilities — via runtime
@@ -108,19 +110,16 @@
     </CollapsiblePanel>
   {/if}
 
-  <!-- MOR-1367 (S8): the BAND twin joins the channel by PROP, not by mount.
-       `BandSelector` hosts three tabs (HAM / LW-MW / SWL) and 16 broadcast
-       presets; only the HAM half is duplicated by `BandSurface`, and the
-       broadcast presets are deliberately NOT facts
-       (`semantic/radio-view-model.ts:494-496`) and have no other production
-       host. So the panel keeps mounting unconditionally and the component
-       drops only its HAM half (S10 §4a) — a `{#if !declared.has('band')}` here
-       would orphan the presets. -->
+  <!-- MOR-2445: Standard supplies `semanticHamBands`, placing the retained
+       semantic choice authority beside the 16 broadcast presets. Other
+       declared layouts keep the MOR-1367 suppression behavior; undeclared
+       layouts keep the legacy HAM fallback. The panel remains unconditional
+       because no semantic vocabulary owns the broadcast presets. -->
   {#if drag.order.includes('band')}
-    <CollapsiblePanel title="BAND" panelId="band"
+    <CollapsiblePanel title="BANDS" panelId="band"
       draggable={true} onDragStart={drag.handleDragStart}
       style={drag.dragStyle('band')}>
-      <BandSelector hamBands={!declared.has('band')} />
+      <BandSelector hamBands={!declared.has('band')} {semanticHamBands} />
     </CollapsiblePanel>
   {/if}
 

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -919,8 +919,8 @@
     min-height: 320px;
   }
   .desktop-control-face :global(.desktop-controls-right) { grid-area: 4 / 3 / 5 / 4; }
-  .desktop-control-face.standard-face :global(.desktop-controls-left),
-  .desktop-control-face.standard-face :global(.desktop-controls-right) {
+  .desktop-control-face :global(.desktop-controls-left),
+  .desktop-control-face :global(.desktop-controls-right) {
     overflow-y: auto; min-height: 0;
     /* Scrollable sidebars must not contribute their full content height. */
     contain: size;
@@ -1039,8 +1039,8 @@
 
   .content-left,
   .content-right,
-  .desktop-control-face :global(.desktop-controls-left),
-  .desktop-control-face :global(.desktop-controls-right) {
+  .desktop-control-face.standard-face :global(.desktop-controls-left),
+  .desktop-control-face.standard-face :global(.desktop-controls-right) {
     min-height: 0;
     max-height: 100%;
     overflow-y: auto;

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -530,6 +530,7 @@
   <div class="content-left">
     <LeftSidebar
       hideTxPanel={semanticRxTx} {declared} dragOwner={owner} {showReset}
+      semanticHamBands={instruments.bandInstruments?.bandChoice}
     />
   </div>
   <div class="content-right">

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -1038,7 +1038,9 @@
   }
 
   .content-left,
-  .content-right {
+  .content-right,
+  .desktop-control-face :global(.desktop-controls-left),
+  .desktop-control-face :global(.desktop-controls-right) {
     min-height: 0;
     max-height: 100%;
     overflow-y: auto;
@@ -1050,7 +1052,9 @@
   }
 
   .content-left::-webkit-scrollbar,
-  .content-right::-webkit-scrollbar {
+  .content-right::-webkit-scrollbar,
+  .desktop-control-face :global(.desktop-controls-left)::-webkit-scrollbar,
+  .desktop-control-face :global(.desktop-controls-right)::-webkit-scrollbar {
     display: none; /* Chrome/Safari/Opera */
   }
 

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -919,8 +919,8 @@
     min-height: 320px;
   }
   .desktop-control-face :global(.desktop-controls-right) { grid-area: 4 / 3 / 5 / 4; }
-  .desktop-control-face :global(.desktop-controls-left),
-  .desktop-control-face :global(.desktop-controls-right) {
+  .desktop-control-face.standard-face :global(.desktop-controls-left),
+  .desktop-control-face.standard-face :global(.desktop-controls-right) {
     overflow-y: auto; min-height: 0;
     /* Scrollable sidebars must not contribute their full content height. */
     contain: size;
@@ -1053,8 +1053,8 @@
 
   .content-left::-webkit-scrollbar,
   .content-right::-webkit-scrollbar,
-  .desktop-control-face :global(.desktop-controls-left)::-webkit-scrollbar,
-  .desktop-control-face :global(.desktop-controls-right)::-webkit-scrollbar {
+  .desktop-control-face.standard-face :global(.desktop-controls-left)::-webkit-scrollbar,
+  .desktop-control-face.standard-face :global(.desktop-controls-right)::-webkit-scrollbar {
     display: none; /* Chrome/Safari/Opera */
   }
 

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
@@ -648,6 +648,18 @@ describe('Band instrument placement', () => {
     expect(choices[0]!.compareDocumentPosition(entries[0]!) & Node.DOCUMENT_POSITION_FOLLOWING)
       .toBeTruthy();
   });
+
+  it('places semantic HAM controls in the Standard upper BAND selector', () => {
+    rt.state = structuredClone(stateFixture);
+    rt.caps = structuredClone(capsFixture);
+    const t = mountLayout('desktop-v2');
+    const upper = t.querySelector('.left-sidebar [data-panel-id="band"]');
+    expect(upper).not.toBeNull();
+    expect([...upper!.querySelectorAll('.band-tab')].map((tab) => tab.textContent?.trim()))
+      .toEqual(['HAM', 'LW/MW', 'SWL']);
+    expect(upper!.querySelector('[data-testid="band-choices-compact"]')).not.toBeNull();
+    expect(t.querySelector('[data-testid="band-surface"]')).not.toBeNull();
+  });
 });
 
 // MOR-1369 (v3-rework S6b-1) — the SpectrumPanel `hideScopeControls`

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -2388,30 +2388,22 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
   });
 
   /**
-   * THE SPLIT (S10 §4a, rows 6 and 10) — the one asymmetric retirement in the
-   * wave. `BandSelector` keeps its mount in BOTH hosts; only its HAM tab and
-   * HAM grid go, because `BandSurface` duplicates those and nothing duplicates
-   * the broadcast presets (`semantic/radio-view-model.ts:494-496` excludes them
-   * from the vocabulary BY NAME) and `BandSelector` is their only production
-   * consumer.
+   * MOR-2445 stage A keeps both selectors mounted, restores HAM only in the
+   * upper Standard panel through the semantic instrument handle, and leaves
+   * settings on the two broadcast tabs. The lower semantic block is retained
+   * until the separate owner-present acceptance gate.
    */
-  it('retires the HAM half of BandSelector in BOTH hosts and keeps the broadcast half', () => {
+  it('moves semantic HAM choices into the upper BAND selector and keeps settings broadcast-only', () => {
     const t = renderAll('desktop-v2');
-    for (const [host, root] of [
-      ['left sidebar', t.querySelector('.left-sidebar [data-panel-id="band"]')],
-      ['settings modal', t.querySelector('[data-panel-id="desktop-vfo-ops"]')],
-    ] as const) {
-      expect(root, `${host} still hosts BandSelector`).not.toBeNull();
-      // The HAM tab is gone; the two broadcast tabs are not.
-      expect(texts(root, '.band-tab'), `${host} tabs`).toEqual(['LW/MW', 'SWL']);
-      // …and so is the HAM grid's content — the default landed on LW/MW, which
-      // is the other half of §4a's instruction ("gate the `bandMode === 'ham'`
-      // DEFAULT too"): without it the component would open on an empty grid.
-      expect(texts(root, '.grid button'), `${host} grid`).toEqual(LW_MW_PRESETS);
-      expect(texts(root, '.grid button')).not.toContain('20m');
-    }
-    // The semantic replacement really is on screen where the HAM grid went.
-    expect(t.querySelector('[data-testid="band-choices"]')).not.toBeNull();
+    const upper = t.querySelector('.left-sidebar [data-panel-id="band"]');
+    const settings = t.querySelector('[data-panel-id="desktop-vfo-ops"]');
+    expect(texts(upper, '.band-tab')).toEqual(['HAM', 'LW/MW', 'SWL']);
+    expect(texts(upper, '.grid button')).toEqual(['40m', '20m']);
+    expect(upper?.querySelector('[data-testid="band-choices-compact"]')).not.toBeNull();
+    expect(texts(settings, '.band-tab')).toEqual(['LW/MW', 'SWL']);
+    expect(texts(settings, '.grid button')).toEqual(LW_MW_PRESETS);
+    // Stage A deliberately retains the lower semantic block until owner acceptance.
+    expect(t.querySelector('[data-testid="band-surface"] [data-testid="band-choices"]')).not.toBeNull();
   });
 
   // PRESET SURVIVAL. Both broadcast tabs remain reachable and every preset is
@@ -2422,10 +2414,10 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
   it('keeps all 16 broadcast presets reachable after the split', () => {
     const t = renderAll('desktop-v2');
     const panel = t.querySelector('.left-sidebar [data-panel-id="band"]')!;
+    (panel.querySelectorAll('.band-tab')[1] as HTMLElement).click();
+    flushSync();
     expect(texts(panel, '.grid button')).toEqual(LW_MW_PRESETS);
-    (texts(panel, '.band-tab').indexOf('SWL') >= 0
-      ? (panel.querySelectorAll('.band-tab')[1] as HTMLElement)
-      : null)?.click();
+    (panel.querySelectorAll('.band-tab')[2] as HTMLElement).click();
     flushSync();
     expect(texts(panel, '.grid button')).toEqual(SW_PRESETS);
     expect(LW_MW_PRESETS.length + SW_PRESETS.length).toBe(16);
@@ -2457,11 +2449,11 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
     ]) {
       expect(t.querySelectorAll(selector).length, selector).toBe(0);
     }
-    // The band family's "exactly once" is tab-shaped, not panel-shaped: one
-    // semantic band grid, and zero HAM tabs anywhere on the flagship skin.
+    // Stage A has one retained lower semantic grid plus the compact upper host.
     expect(t.querySelectorAll('[data-testid="band-choices"]').length).toBe(1);
+    expect(t.querySelectorAll('[data-testid="band-choices-compact"]').length).toBe(1);
     expect([...t.querySelectorAll('.band-tab')].filter((b) => b.textContent?.trim() === 'HAM').length)
-      .toBe(0);
+      .toBe(1);
   });
 
   // R9, over the real manifest rather than a probe: three more declared zones

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -2457,6 +2457,7 @@
       filter: hostedFilter,
       dsp: hostedDsp,
       band: hostedBand,
+      bandInstruments,
       antenna: hostedAntenna,
       antennaInstruments,
       antennaLayout,

--- a/frontend/src/components-v2/wiring/instrument-composition.ts
+++ b/frontend/src/components-v2/wiring/instrument-composition.ts
@@ -13,7 +13,7 @@ import type { DspFiniteLayout } from '../../semantic/dsp-instruments';
 import type { DspScalarLayout } from '../../semantic/dsp-scalars';
 import type { VfoOperationHandles } from '../../semantic/VfoOperationSeatHost.svelte';
 import type { FilterFiniteLayout } from '../../semantic/filter-instruments';
-import type { BandControlLayout } from '../../semantic/band-instruments';
+import type { BandControlLayout, BandInstrumentHandles } from '../../semantic/band-instruments';
 import type { CwKeyerInstrumentHandles } from '../../semantic/CwKeyerInstrumentHost.svelte';
 import type {
   AntennaInstrumentHandles, AntennaInstrumentLayout,
@@ -70,6 +70,7 @@ export interface InstrumentComposition {
   readonly band: Snippet<[
     allowBare?: boolean, controlLayout?: BandControlLayout, chrome?: PanelChrome,
   ]>;
+  readonly bandInstruments?: BandInstrumentHandles;
   readonly antenna: Snippet<[
     allowBare?: boolean, controlLayout?: Snippet, chrome?: PanelChrome,
   ]>;

--- a/frontend/src/semantic/BandInstrumentHost.svelte
+++ b/frontend/src/semantic/BandInstrumentHost.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onDestroy, type Component, type Snippet } from 'svelte';
+  import { HardwareButton } from '$lib/Button';
   import { t } from '$lib/i18n';
   import { bindAbsoluteChoiceInstrument } from '../primitives/control-instruments/control-instrument-behavior';
   import ControlInstrumentRendererHost from '../primitives/control-instruments/ControlInstrumentRendererHost.svelte';
@@ -158,9 +159,28 @@
   {/if}
 {/snippet}
 
-{#snippet bandChoice()}
+{#snippet bandChoice(compact = false)}
   {#if band?.bandChoices.length}
-    {#if finiteAppearance}{@render externalChoice()}{:else}
+    {#if compact}
+      <div role="group" aria-label="Band select" data-testid="band-choices-compact">
+        {#each band.bandChoices as choice, index (choice.name)}
+          {@const permit = defaultPermitLabel(choice)}
+          {@const descriptionId = `band-choice-compact-permit-${index}`}
+          <HardwareButton
+            active={bandChoiceBehavior.isSelected(choice.name)}
+            disabled={!bandChoiceBehavior.available}
+            indicator="edge-left"
+            color="cyan"
+            title={permit}
+            describedBy={descriptionId}
+            onclick={() => bandChoiceBehavior.invoke(choice.name)}
+          >{choice.name}</HardwareButton>
+          <span id={descriptionId} class="visually-hidden" data-default-permit={choice.defaultHzTxPermit.status}>
+            {permit}
+          </span>
+        {/each}
+      </div>
+    {:else if finiteAppearance}{@render externalChoice()}{:else}
       <div class="band-row" role="group" aria-label="Band select" data-testid="band-choices">
         {#each band.bandChoices as choice (choice.name)}
           <button
@@ -193,4 +213,15 @@
   .band-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin: 0; }
   .band-choice[aria-pressed='true'] { font-weight: 700; }
   button:disabled { cursor: not-allowed; }
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
 </style>

--- a/frontend/src/semantic/band-instruments.ts
+++ b/frontend/src/semantic/band-instruments.ts
@@ -3,7 +3,7 @@ import { t } from '$lib/i18n';
 import type { BandChoice } from './radio-view-model';
 
 export interface BandInstrumentHandles {
-  readonly bandChoice: Snippet;
+  readonly bandChoice: Snippet<[compact?: boolean]>;
   readonly frequencyEntry: Snippet;
 }
 


### PR DESCRIPTION
Standard now exposes HAM alongside LW/MW and SWL in the BANDS panel. HAM uses the retained semantic band-selection behavior and compact hardware buttons matching broadcast presets. Side-rail scrollbars are hidden while scrolling remains enabled.

This is the transfer stage of MOR-2445. The lower semantic BAND panel remains until the VFO frequency-entry overlay in MOR-2446 is accepted. Other layouts and settings keep their existing band behavior.

Validation: 288 focused component/wiring tests passed on Mac Mini; svelte-check reported 0 errors/0 warnings; scoped ESLint and production build passed. Browser preview verified 11 HAM, 6 LW/MW and 10 SWL choices, with equal 28px button heights. No live band-selection command acceptance is claimed.

Linear: https://linear.app/morozsm/issue/MOR-2445
