### PR TITLE
feat(ui): open targeted frequency entry from VFO digits (MOR-2446)

### DIFF
--- a/frontend/src/components-v2/vfo/VfoPanel.svelte
+++ b/frontend/src/components-v2/vfo/VfoPanel.svelte
@@ -64,6 +64,8 @@
     layoutProfile?: VfoLayoutProfile;
     onModeClick?: () => void;
     onFreqChange?: (freq: number) => void;
+    /** Opens direct entry for this card; digit arithmetic remains independent. */
+    onFrequencyClick?: (trigger: HTMLElement) => void;
     onSelectSlot?: (key: string) => void;
     /** Selects this VFO from its header; frequency gestures remain independent. */
     onSelectHeader?: () => void;
@@ -79,6 +81,7 @@
     layoutProfile = 'baseline',
     onModeClick,
     onFreqChange,
+    onFrequencyClick,
     onSelectSlot,
     onSelectHeader,
     headerReason,
@@ -98,6 +101,12 @@
     const groups = groupDigitsForDisplay(splitFrequencyToDigits(hz));
     return [groups.mhz, groups.khz, groups.hz]
       .map((group) => group.map((digit) => digit.char).join('')).join('.');
+  }
+
+  function handleFrequencyClick(event: MouseEvent): void {
+    if (onFrequencyClick === undefined || !(event.target instanceof Element)
+      || event.target.closest('.digit') === null) return;
+    if (event.currentTarget instanceof HTMLElement) onFrequencyClick(event.currentTarget);
   }
 </script>
 
@@ -143,6 +152,7 @@
       <div class="freq-row">
         <span class="vfo-freq" data-vfo-freq data-freq-tunable={!frequencyDisabled}
           data-display-state={frequencyState} class:display-unknown={displayHz === null}
+          onclickcapture={handleFrequencyClick}
           >
           {#if frequency}
             {@render frequency()}

--- a/frontend/src/components-v2/vfo/VfoPanel.svelte
+++ b/frontend/src/components-v2/vfo/VfoPanel.svelte
@@ -106,7 +106,8 @@
   function handleFrequencyClick(event: MouseEvent): void {
     if (onFrequencyClick === undefined || !(event.target instanceof Element)
       || event.target.closest('.digit') === null) return;
-    if (event.currentTarget instanceof HTMLElement) onFrequencyClick(event.currentTarget);
+    const readout = event.target.closest('.freq');
+    if (readout instanceof HTMLElement) onFrequencyClick(readout);
   }
 </script>
 

--- a/frontend/src/components-v2/vfo/__tests__/VfoPanel.isolated.test.ts
+++ b/frontend/src/components-v2/vfo/__tests__/VfoPanel.isolated.test.ts
@@ -475,11 +475,11 @@ describe('explicit presentation contract', () => {
     const onFrequencyClick = vi.fn();
     const onFreqChange = vi.fn();
     const t = mountPanel({ ...explicit, onFrequencyClick, onFreqChange });
-    const wrapper = t.querySelector<HTMLElement>('[data-vfo-freq]')!;
+    const readout = t.querySelector<HTMLElement>('[data-vfo-freq] .freq')!;
     const digit = t.querySelectorAll<HTMLElement>('.digit').item(4);
 
     digit.click();
-    expect(onFrequencyClick).toHaveBeenCalledExactlyOnceWith(wrapper);
+    expect(onFrequencyClick).toHaveBeenCalledExactlyOnceWith(readout);
     expect(onFreqChange).not.toHaveBeenCalled();
 
     digit.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true }));

--- a/frontend/src/components-v2/vfo/__tests__/VfoPanel.isolated.test.ts
+++ b/frontend/src/components-v2/vfo/__tests__/VfoPanel.isolated.test.ts
@@ -471,6 +471,23 @@ describe('explicit presentation contract', () => {
     expect(onFreqChange).toHaveBeenCalledExactlyOnceWith(14_074_001);
   });
 
+  it('reports a digit click once without tuning and preserves deliberate wheel tuning', () => {
+    const onFrequencyClick = vi.fn();
+    const onFreqChange = vi.fn();
+    const t = mountPanel({ ...explicit, onFrequencyClick, onFreqChange });
+    const wrapper = t.querySelector<HTMLElement>('[data-vfo-freq]')!;
+    const digit = t.querySelectorAll<HTMLElement>('.digit').item(4);
+
+    digit.click();
+    expect(onFrequencyClick).toHaveBeenCalledExactlyOnceWith(wrapper);
+    expect(onFreqChange).not.toHaveBeenCalled();
+
+    digit.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true }));
+    expect(onFreqChange).toHaveBeenCalledExactlyOnceWith(14_075_000);
+    t.querySelector<HTMLElement>('.sep')?.click();
+    expect(onFrequencyClick).toHaveBeenCalledTimes(1);
+  });
+
   // MOR-2425/R29+R40: a HELD frequency stays tunable. `frequencyState` alone
   // no longer disables the arithmetic control; a display carrying no value
   // ('unknown'/'unsupported') still does, as does `frequencyDisabled`.

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -36,6 +36,8 @@
     PanelChrome,
   } from './instrument-composition';
   import { t } from '$lib/i18n';
+  import { getFieldStatus } from '$lib/state/field-status';
+  import { getCommandLifecycle } from '$lib/stores/commands.svelte';
   import { getScopeSource, hasCapability } from '$lib/stores/capabilities.svelte';
   import { presentationResources, runtime } from '$lib/runtime';
   import * as componentKitActivation from '../../component-kits/activation';
@@ -68,6 +70,7 @@
   import AntennaInstrumentHost from '../../semantic/AntennaInstrumentHost.svelte';
   import BandSurface from '../../semantic/BandSurface.svelte';
   import BandInstrumentHost from '../../semantic/BandInstrumentHost.svelte';
+  import FrequencyEntryDialog from '../../semantic/FrequencyEntryDialog.svelte';
   import type { BandControlLayout } from '../../semantic/band-instruments';
   import DspSurface, {
     type DspLevelField, type DspToggleField,
@@ -338,6 +341,80 @@
 
   const semanticHandlers = bindSemanticSurfaceHandlers();
   const vfo = semanticHandlers.vfo;
+
+  type FrequencyEntryCapture = Readonly<{
+    target: { receiver: 'MAIN'; slot: 'A' | 'B' };
+    expectedActiveSlot: 'A' | 'B';
+    providerGeneration: number;
+    sessionEpoch: number;
+    topologyId: string;
+    trigger: HTMLElement;
+  }>;
+  let frequencyEntryCapture = $state<FrequencyEntryCapture | null>(null);
+  let frequencyEntryLifecycle = $state<{ id: string; epoch: number } | null>(null);
+
+  function directFrequencyAuthorityMatches(capture: FrequencyEntryCapture): boolean {
+    const state = runtime.state, caps = runtime.caps, session = runtime.controlSession;
+    const activeSlot = state?.main?.activeSlot;
+    const slotStatus = state ? getFieldStatus(state, 'main.activeSlot') : undefined;
+    const model = toRadioViewModel(state, caps);
+    return session.state === 'connected' && session.epoch === capture.sessionEpoch
+      && state?.providerGeneration === capture.providerGeneration
+      && caps?.providerGeneration === capture.providerGeneration
+      && caps.capabilities.includes('vfo_freq_direct')
+      && caps.receivers === 1 && caps.vfoScheme === 'ab'
+      && model?.topologyId === capture.topologyId
+      && slotStatus?.observed === true && slotStatus.freshness === 'fresh'
+      && slotStatus.availability === 'available'
+      && activeSlot === capture.expectedActiveSlot
+      && model.vfos.some((candidate) => candidate.receiver === capture.target.receiver
+        && candidate.slot.kind === 'slotted' && candidate.slot.id === capture.target.slot);
+  }
+
+  function openFrequencyEntry(target: VfoSelection, trigger: HTMLElement): void {
+    if (target.receiver !== 'MAIN' || target.slot.kind !== 'slotted') return;
+    const state = runtime.state, caps = runtime.caps, session = runtime.controlSession;
+    const stateGeneration = state?.providerGeneration;
+    const model = toRadioViewModel(state, caps);
+    const activeSlot = state?.main?.activeSlot;
+    const slotStatus = state ? getFieldStatus(state, 'main.activeSlot') : undefined;
+    if (session.state !== 'connected' || !Number.isSafeInteger(stateGeneration)
+      || stateGeneration !== caps?.providerGeneration
+      || !caps?.capabilities.includes('vfo_freq_direct')
+      || caps.receivers !== 1 || caps.vfoScheme !== 'ab' || model === null
+      || slotStatus?.observed !== true || slotStatus.freshness !== 'fresh'
+      || slotStatus.availability !== 'available'
+      || (activeSlot !== 'A' && activeSlot !== 'B')) return;
+    frequencyEntryLifecycle = null;
+    const capture = Object.freeze<FrequencyEntryCapture>({
+      target: { receiver: 'MAIN', slot: target.slot.id }, expectedActiveSlot: activeSlot,
+      providerGeneration: stateGeneration as number, sessionEpoch: session.epoch,
+      topologyId: model.topologyId, trigger,
+    });
+    frequencyEntryCapture = capture;
+  }
+
+  let frequencyEntryAuthorityValid = $derived(
+    frequencyEntryCapture !== null && directFrequencyAuthorityMatches(frequencyEntryCapture),
+  );
+  let frequencyEntryCommand = $derived(frequencyEntryLifecycle === null ? undefined
+    : getCommandLifecycle(frequencyEntryLifecycle.id, frequencyEntryLifecycle.epoch));
+  let frequencyEntryStatus = $derived.by(() => {
+    if (frequencyEntryCapture !== null && !frequencyEntryAuthorityValid) {
+      return 'Radio authority changed. Close this dialog and open it again.';
+    }
+    const command = frequencyEntryCommand;
+    if (command?.status === 'pending') return 'Sending frequency…';
+    if (command?.status === 'acknowledged') return 'Waiting for the selected VFO readback…';
+    if (command?.status === 'confirmed') return 'Frequency confirmed.';
+    if (command?.status === 'failed' || command?.status === 'timed-out'
+      || command?.status === 'cancelled') return command.error ?? 'Frequency change was not confirmed.';
+    return undefined;
+  });
+  let frequencyEntrySubmitEnabled = $derived(frequencyEntryAuthorityValid
+    && frequencyEntryCommand?.status !== 'pending'
+    && frequencyEntryCommand?.status !== 'acknowledged'
+    && frequencyEntryCommand?.status !== 'confirmed');
   const systemIntents = getSystemHandlers();
   /** MOR-1307: the shipped band vocabulary, composed rather than forked. */
   const band = semanticHandlers.band;
@@ -1546,13 +1623,27 @@
     const state = runtime.state, caps = runtime.caps, session = runtime.controlSession;
     const model = toRadioViewModel(state, caps);
     const authority = bandFiniteAuthority(state, caps, session);
-    const active = model?.activeReceiver;
     const currentBand = model?.band;
-    if (authority === null || active?.status !== 'known'
-      || authority.activeReceiver !== active.receiver || currentBand === undefined
+    if (currentBand === undefined
       || currentBand.tuneMinHz === null || currentBand.tuneMaxHz === null
       || !Number.isFinite(frequencyHz)
       || frequencyHz < currentBand.tuneMinHz || frequencyHz > currentBand.tuneMaxHz) return;
+    const capture = frequencyEntryCapture;
+    if (capture !== null) {
+      if (!directFrequencyAuthorityMatches(capture)) return;
+      const lifecycle = vfo.onDirectFrequencyChange({
+        frequencyHz, receiver: capture.target.receiver, slot: capture.target.slot,
+        expectedActiveSlot: capture.expectedActiveSlot,
+        providerGeneration: capture.providerGeneration, sessionEpoch: capture.sessionEpoch,
+      });
+      if (lifecycle !== null) frequencyEntryLifecycle = {
+        id: lifecycle.id, epoch: lifecycle.originalEpoch,
+      };
+      return;
+    }
+    const active = model?.activeReceiver;
+    if (authority === null || active?.status !== 'known'
+      || authority.activeReceiver !== active.receiver) return;
     // MOR-1425 review round 2 (B1 residual): a typed frequency is the most
     // explicitly ABSOLUTE gesture in the UI — 'jump', same reasoning as
     // `selectBand` above.
@@ -1656,9 +1747,26 @@
   <BandInstrumentHost
     {...bandFiniteRendererSelection} {view} entryRendererContext={bandFiniteRendererContext}
     onSelectBand={selectBand} onEnterFrequency={enterFrequency}
+    frequencyEntryEnabled={frequencyEntryCapture === null || frequencyEntrySubmitEnabled}
+    frequencyEntryUnavailableReason={frequencyEntryCapture !== null && !frequencyEntryAuthorityValid
+      ? frequencyEntryStatus : undefined}
     showPermitCaption={bandPermitCaption}
   >
   {#snippet children(bandInstruments)}
+  <FrequencyEntryDialog
+    open={frequencyEntryCapture !== null}
+    targetLabel={frequencyEntryCapture
+      ? `${frequencyEntryCapture.target.receiver} VFO ${frequencyEntryCapture.target.slot}` : ''}
+    returnFocus={frequencyEntryCapture?.trigger}
+    status={frequencyEntryStatus}
+    onclose={() => {
+      bandInstruments.cancelFrequencyEntry();
+      frequencyEntryCapture = null;
+      frequencyEntryLifecycle = null;
+    }}
+  >
+    {#snippet children()}{@render bandInstruments.frequencyEntry()}{/snippet}
+  </FrequencyEntryDialog>
   <AntennaInstrumentHost
     {view} tx={txState} readTx={() => tx.snapshot()}
     subscribeControlAuthority={(handler) => runtime.subscribeControlAuthority(handler)}
@@ -1750,6 +1858,7 @@
               {groupLabel}
               onSelectVfo={selectVfo}
               onTuneFrequency={tuneFrequency}
+              onOpenFrequencyEntry={openFrequencyEntry}
               disabled={!isOperationalStrip(view, receiverId)}
               indicatorReceiver={receiverId}
               suppressIdentitySelectors={stripBy === 'slot'}
@@ -1803,6 +1912,7 @@
         {operationControls}
         onSelectVfo={selectVfo}
         onTuneFrequency={tuneFrequency}
+        onOpenFrequencyEntry={openFrequencyEntry}
         {hasDualReceiver}
         {receiverInstruments}
         continuitySession={meterContinuitySession}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -245,23 +245,25 @@ beforeEach(() => {
 });
 
 describe('fixed-slot frequency entry overlay', () => {
-  function directState(): ServerState {
+  function directState(withDisplayContract = false): ServerState {
     const current = liveState();
-    return { ...current, sub: undefined, main: {
+    return { ...current, ...(withDisplayContract ? { stateContractVersion: 1 as const } : {}),
+      sub: undefined, main: {
       ...current.main!, activeSlot: 'A',
       vfoA: slot(14_250_000), vfoB: slot(7_074_000),
     } } as unknown as ServerState;
   }
-  function directCaps(): Capabilities {
+  function directCaps(withDisplayContract = false): Capabilities {
     return { ...liveCaps(BAND_PLAN), capabilities: ['audio', 'tx', 'vfo_freq_direct'],
+      ...(withDisplayContract ? { stateContractVersion: 1 as const } : {}),
       receivers: 1, vfoScheme: 'ab' };
   }
 
   it('opens from inactive B digits and dispatches B without selecting it', () => {
-    h.state = directState(); h.caps = directCaps();
+    h.state = directState(true); h.caps = directCaps(true);
     render({ vfoAppearance: 'standard' });
-    const digit = document.createElement('span'); digit.className = 'digit';
-    q<HTMLElement>('[data-vfo-slot="B"] [data-vfo-freq]')!.append(digit);
+    const digit = q<HTMLElement>('[data-vfo-slot="B"] [data-vfo-freq] .digit')!;
+    expect(digit).not.toBeNull();
     digit.click();
     flushSync();
     const dialog = q<HTMLElement>('[data-testid="frequency-entry-dialog-panel"]')!;
@@ -276,11 +278,43 @@ describe('fixed-slot frequency entry overlay', () => {
     expect(vi.mocked(sendCommand).mock.calls.some(([name]) => name === 'set_vfo')).toBe(false);
   });
 
+  it.each(['Escape', 'backdrop'] as const)(
+    'restores focus to the real inactive B readout after %s close without commands',
+    async (closeWith) => {
+      h.state = directState(true); h.caps = directCaps(true);
+      render({ vfoAppearance: 'standard' });
+      const readout = q<HTMLElement>('[data-vfo-slot="B"] [data-vfo-freq] .freq')!;
+      const digit = readout.querySelector<HTMLElement>('.digit')!;
+
+      expect(readout).not.toBeNull();
+      expect(digit).not.toBeNull();
+      digit.click();
+      flushSync();
+      await Promise.resolve();
+      const input = q<HTMLInputElement>('[data-testid="band-entry-input"]')!;
+      expect(document.activeElement).toBe(input);
+
+      if (closeWith === 'Escape') {
+        input.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'Escape', bubbles: true, cancelable: true,
+        }));
+      } else {
+        q<HTMLElement>('[data-testid="frequency-entry-dialog-backdrop"]')!.click();
+      }
+      flushSync();
+      await Promise.resolve();
+
+      expect(q<HTMLElement>('[role="dialog"]')).toBeNull();
+      expect(document.activeElement).toBe(readout);
+      expect(vi.mocked(sendCommand)).not.toHaveBeenCalled();
+    },
+  );
+
   it('keeps an open draft inert after the captured session changes', () => {
     h.state = directState(); h.caps = directCaps();
     render({ vfoAppearance: 'standard' });
     const digit = document.createElement('span'); digit.className = 'digit';
-    q<HTMLElement>('[data-vfo-slot="B"] [data-vfo-freq]')!.append(digit);
+    q<HTMLElement>('[data-vfo-slot="B"] [data-vfo-freq] .freq')!.append(digit);
     digit.click();
     flushSync();
     h.controlSession = { state: 'connected', epoch: 2 };

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -65,8 +65,11 @@ vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
 vi.mock('$lib/runtime/commands/radio-intents', async () => {
   const { sendCommand } = await import('$lib/transport/ws-client');
   return {
-    dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params),
-    currentControlSessionEpoch: () => 0,
+    dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => {
+      sendCommand(name, params);
+      return { id: `test-${name}`, name, params, originalEpoch: h.controlSession.epoch, status: 'pending' };
+    },
+    currentControlSessionEpoch: () => h.controlSession.epoch,
   };
 });
 vi.mock('$lib/stores/radio.svelte', () => ({
@@ -209,6 +212,7 @@ function publishAuthority(): void {
 
 function render(props: {
   strips?: 'single' | 'dual'; bandPermitCaption?: boolean;
+  vfoAppearance?: 'semantic' | 'sdr' | 'standard';
 } = {}): void {
   target = document.createElement('div');
   document.body.appendChild(target);
@@ -220,6 +224,7 @@ const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T
 const el = (id: string) => q<HTMLElement>(`[data-testid="band-${id}"]`);
 const btn = (id: string) => q<HTMLButtonElement>(`[data-testid="band-${id}"]`);
 const setFreqCalls = () => vi.mocked(sendCommand).mock.calls.filter(([n]) => n === 'set_freq');
+const setDirectFreqCalls = () => vi.mocked(sendCommand).mock.calls.filter(([n]) => n === 'set_vfo_freq');
 
 function typeFrequency(value: string): void {
   const input = q<HTMLInputElement>('[data-testid="band-entry-input"]')!;
@@ -237,6 +242,58 @@ beforeEach(() => {
   h.finiteAppearance = false;
   resetRetainedInvocations();
   vi.mocked(sendCommand).mockClear();
+});
+
+describe('fixed-slot frequency entry overlay', () => {
+  function directState(): ServerState {
+    const current = liveState();
+    return { ...current, sub: undefined, main: {
+      ...current.main!, activeSlot: 'A',
+      vfoA: slot(14_250_000), vfoB: slot(7_074_000),
+    } } as unknown as ServerState;
+  }
+  function directCaps(): Capabilities {
+    return { ...liveCaps(BAND_PLAN), capabilities: ['audio', 'tx', 'vfo_freq_direct'],
+      receivers: 1, vfoScheme: 'ab' };
+  }
+
+  it('opens from inactive B digits and dispatches B without selecting it', () => {
+    h.state = directState(); h.caps = directCaps();
+    render({ vfoAppearance: 'standard' });
+    const digit = document.createElement('span'); digit.className = 'digit';
+    q<HTMLElement>('[data-vfo-slot="B"] [data-vfo-freq]')!.append(digit);
+    digit.click();
+    flushSync();
+    const dialog = q<HTMLElement>('[data-testid="frequency-entry-dialog-panel"]')!;
+    expect(dialog.textContent).toContain('MAIN VFO B');
+    const input = dialog.querySelector<HTMLInputElement>('[data-testid="band-entry-input"]')!;
+    input.value = '7.075'; input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    dialog.querySelector<HTMLButtonElement>('[data-testid="band-entry-set"]')!.click();
+    expect(setDirectFreqCalls()).toEqual([['set_vfo_freq', {
+      freq: 7_075_000, receiver: 0, slot: 'B', expected_active_slot: 'A', provider_generation: 1,
+    }]]);
+    expect(vi.mocked(sendCommand).mock.calls.some(([name]) => name === 'set_vfo')).toBe(false);
+  });
+
+  it('keeps an open draft inert after the captured session changes', () => {
+    h.state = directState(); h.caps = directCaps();
+    render({ vfoAppearance: 'standard' });
+    const digit = document.createElement('span'); digit.className = 'digit';
+    q<HTMLElement>('[data-vfo-slot="B"] [data-vfo-freq]')!.append(digit);
+    digit.click();
+    flushSync();
+    h.controlSession = { state: 'connected', epoch: 2 };
+    h.state = { ...(h.state as ServerState), providerGeneration: 2 };
+    h.caps = { ...(h.caps as Capabilities), providerGeneration: 2 };
+    publishAuthority(); flushSync();
+    const dialog = q<HTMLElement>('[data-testid="frequency-entry-dialog-panel"]')!;
+    const input = dialog.querySelector<HTMLInputElement>('[data-testid="band-entry-input"]')!;
+    input.value = '7.075'; input.dispatchEvent(new Event('input', { bubbles: true })); flushSync();
+    dialog.querySelector<HTMLButtonElement>('[data-testid="band-entry-set"]')!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(setDirectFreqCalls()).toEqual([]);
+  });
 });
 
 afterEach(() => {

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -67,6 +67,7 @@ import {
 } from '../panel-adapters';
 import {
   BREAK_IN_DELAY_COMMAND_DESCRIPTOR, CW_PITCH_COMMAND_DESCRIPTOR, FILTER_WIDTH_COMMAND_DESCRIPTOR,
+  DIRECT_VFO_FREQUENCY_COMMAND_DESCRIPTOR,
   DSP_COMMAND_DESCRIPTORS, IF_SHIFT_COMMAND_DESCRIPTOR, KEY_SPEED_COMMAND_DESCRIPTOR,
   PBT_INNER_COMMAND_DESCRIPTOR, PBT_OUTER_COMMAND_DESCRIPTOR,
   RF_GAIN_COMMAND_DESCRIPTOR, SQUELCH_COMMAND_DESCRIPTOR,
@@ -112,8 +113,9 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
   it('shares one canonical registered Filter Width descriptor and exact paths', () => {
     expect(FILTER_WIDTH_FEEDBACK_DESCRIPTOR).toBe(FILTER_WIDTH_COMMAND_DESCRIPTOR);
     expect(getStateBackedCommandDescriptor('set_filter_width')).toBe(FILTER_WIDTH_COMMAND_DESCRIPTOR);
+    expect(getStateBackedCommandDescriptor('set_vfo_freq')).toBe(DIRECT_VFO_FREQUENCY_COMMAND_DESCRIPTOR);
     expect([...STATE_BACKED_COMMAND_DESCRIPTORS.keys()]).toEqual([
-      'set_filter_width', 'set_break_in_delay', 'set_rf_gain', 'set_squelch',
+      'set_filter_width', 'set_vfo_freq', 'set_break_in_delay', 'set_rf_gain', 'set_squelch',
       'set_cw_pitch', 'set_key_speed', 'set_mic_gain', 'set_drive_gain',
       'set_vox_gain', 'set_anti_vox_gain', 'set_vox_delay',
       'set_compressor_level', 'set_monitor_gain', 'set_nb_level', 'set_nb_width',
@@ -129,6 +131,23 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     expect(FILTER_WIDTH_COMMAND_DESCRIPTOR.scope(command({ params: { width: 3000, receiver: 2 } }))).toBeNull();
     expect(FILTER_WIDTH_COMMAND_DESCRIPTOR.target(command({ params: { width: 3000.5 } }))).toBeNull();
     expect(FILTER_WIDTH_COMMAND_DESCRIPTOR.repeatPolicy).toBe('latest-target-wins');
+    const fixedB = DIRECT_VFO_FREQUENCY_COMMAND_DESCRIPTOR.scope(command({
+      name: 'set_vfo_freq', params: {
+        freq: 7_074_000, receiver: 0, slot: 'B', expected_active_slot: 'A', provider_generation: 3,
+      },
+    }))!;
+    expect(fixedB).toEqual({ control: 'vfo-frequency', receiver: 0, slot: 'B' });
+    expect(DIRECT_VFO_FREQUENCY_COMMAND_DESCRIPTOR.fieldPath(fixedB)).toBe('main.vfoB.freqHz');
+    expect(DIRECT_VFO_FREQUENCY_COMMAND_DESCRIPTOR.target(command({
+      name: 'set_vfo_freq', params: {
+        freq: 7_074_000, receiver: 0, slot: 'B', expected_active_slot: 'A', provider_generation: 3,
+      },
+    }))).toBe(7_074_000);
+    expect(DIRECT_VFO_FREQUENCY_COMMAND_DESCRIPTOR.scope(command({
+      name: 'set_vfo_freq', params: {
+        freq: 7_074_000, receiver: 0, slot: 'selected', expected_active_slot: 'A', provider_generation: 3,
+      },
+    }))).toBeNull();
   });
   it('stays unavailable rather than fabricating a pending or confirmed value without observed width', () => {
     runtimeState.state = state({ main: {} });
@@ -598,6 +617,7 @@ describe('Break-in Delay ControlFeedback projection (MOR-1744)', () => {
     expect(getStateBackedCommandDescriptor('set_break_in_delay')).toBe(BREAK_IN_DELAY_COMMAND_DESCRIPTOR);
     expect([...STATE_BACKED_COMMAND_DESCRIPTORS.entries()]).toEqual([
       ['set_filter_width', FILTER_WIDTH_COMMAND_DESCRIPTOR],
+      ['set_vfo_freq', DIRECT_VFO_FREQUENCY_COMMAND_DESCRIPTOR],
       ['set_break_in_delay', BREAK_IN_DELAY_COMMAND_DESCRIPTOR],
       ['set_rf_gain', RF_GAIN_COMMAND_DESCRIPTOR],
       ['set_squelch', SQUELCH_COMMAND_DESCRIPTOR],

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands-completeness.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands-completeness.test.ts
@@ -90,6 +90,9 @@ import {
 const PANEL_COMMANDS_PATH = resolve(process.cwd(), 'src/lib/runtime/commands/panel-commands.ts');
 const SOURCE = readFileSync(PANEL_COMMANDS_PATH, 'utf8');
 
+/** Exact fixed-slot lifecycle conformance is pinned by the descriptor inventory test. */
+const EXACT_TARGET_INTENTS = new Set(['set_vfo_freq']);
+
 /** Every `dispatchRadioIntent({ name: '<literal>', ... })` call site. */
 const INTENT_CALL_RE = /dispatchRadioIntent\(\s*\{\s*name:\s*(['"])([A-Za-z0-9_]+)\1/g;
 
@@ -207,10 +210,10 @@ function completenessSuite(opts: {
 completenessSuite({
   label: 'panel-commands.ts intent completeness ledger (MOR-1556)',
   sourceNames: extractSourceIntents(SOURCE),
-  claimed: CLAIMED_INTENTS,
+  claimed: new Set([...CLAIMED_INTENTS, ...EXACT_TARGET_INTENTS]),
   waived: WAIVED_INTENTS,
   waivedCount: WAIVED_INTENTS_COUNT,
-  claimedCount: CLAIMED_INTENTS_COUNT,
+  claimedCount: CLAIMED_INTENTS_COUNT + EXACT_TARGET_INTENTS.size,
 });
 
 completenessSuite({

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
@@ -1205,6 +1205,59 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(getCommandLifecycles()).toHaveLength(0);
   });
 
+  it('writes the captured fixed A/B slot without selecting it', () => {
+    h.state = oneReceiverAbState();
+    h.state.fieldStatus = {
+      ...h.state.fieldStatus,
+      'main.activeSlot': { ...freshStatus, storePath: 'main.activeSlot' },
+    };
+    h.caps = {
+      capabilities: ['vfo_freq_direct'], receivers: 1, vfoScheme: 'ab',
+      stateContractVersion: 1, providerGeneration: 31,
+      freqRanges: [{ start: 30_000, end: 74_800_000, label: 'HF' }],
+    };
+
+    const lifecycle = makeVfoHandlers().onDirectFrequencyChange({
+      frequencyHz: 7_075_000, receiver: 'MAIN', slot: 'B', expectedActiveSlot: 'A',
+      providerGeneration: 31, sessionEpoch: 31,
+    });
+
+    expect(lifecycle).toMatchObject({ name: 'set_vfo_freq', status: 'pending' });
+    expect(exactCalls()).toEqual([['set_vfo_freq', {
+      freq: 7_075_000, receiver: 0, slot: 'B', expected_active_slot: 'A', provider_generation: 31,
+    }]]);
+    expect(h.patchActiveReceiver).not.toHaveBeenCalled();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+    expect(h.patchReceiver).not.toHaveBeenCalled();
+  });
+
+  it('refuses direct slot writes after any captured authority changes', () => {
+    const request = {
+      frequencyHz: 7_075_000, receiver: 'MAIN' as const, slot: 'B' as const,
+      expectedActiveSlot: 'A' as const, providerGeneration: 31, sessionEpoch: 31,
+    };
+    const reset = () => {
+      h.state = oneReceiverAbState();
+      h.state.fieldStatus = { ...h.state.fieldStatus,
+        'main.activeSlot': { ...freshStatus, storePath: 'main.activeSlot' } };
+      h.caps = { capabilities: ['vfo_freq_direct'], receivers: 1, vfoScheme: 'ab',
+        stateContractVersion: 1, providerGeneration: 31,
+        freqRanges: [{ start: 30_000, end: 74_800_000, label: 'HF' }] };
+      h.sendCommand.mockClear(); resetCommandLifecycle(); h.unavailable.clear();
+    };
+    const refuse = (mutate: () => void) => {
+      reset(); mutate();
+      expect(makeVfoHandlers().onDirectFrequencyChange(request)).toBeNull();
+      expect(h.sendCommand).not.toHaveBeenCalled();
+    };
+    refuse(() => { h.state!.main!.activeSlot = 'B'; });
+    refuse(() => { h.state = { ...h.state!, providerGeneration: 32 }; });
+    refuse(() => { h.caps = { ...h.caps!, capabilities: [] }; });
+    refuse(() => { h.unavailable.add('main.activeSlot'); });
+    refuse(() => { h.caps = { ...h.caps!, vfoScheme: 'main_sub' }; });
+    refuse(() => { h.caps = { ...h.caps!, receivers: 2 }; });
+  });
+
   it('MOR-1425: a burst of rapid steps within one round trip accumulates onto the pending target, not the stale confirmed value', () => {
     const vfo = makeVfoHandlers();
     const confirmed = h.state!.main!.freqHz; // 14_074_000, unchanged for the whole burst

--- a/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
@@ -146,6 +146,26 @@ describe('typed non-PTT radio intents', () => {
     expect(lifecycle.getCommandLifecycle('freq-1', 7)?.status).toBe('pending');
   });
 
+  it('accepts only the exact fixed-slot frequency envelope', () => {
+    const params = {
+      freq: 14_074_000, receiver: 0 as const, slot: 'B' as const,
+      expected_active_slot: 'A' as const, provider_generation: 31,
+    };
+    intents.dispatchRadioIntent({ id: 'slot-freq', name: 'set_vfo_freq', params });
+    expect(harness.sendCommand).toHaveBeenCalledExactlyOnceWith('set_vfo_freq', params, 'slot-freq');
+
+    for (const malformed of [
+      { ...params, slot: 'MAIN' },
+      { ...params, expected_active_slot: 'SUB' },
+      { ...params, provider_generation: 31.5 },
+      { ...params, receiver: 2 },
+      { ...params, extra: true },
+    ]) expect(() => intents.dispatchRadioIntent({
+      name: 'set_vfo_freq', params: malformed,
+    } as unknown as RadioIntent)).toThrow(/invalid radio intent/i);
+    expect(harness.sendCommand).toHaveBeenCalledTimes(1);
+  });
+
   it('correlates delivery without turning acknowledgement into radio truth', () => {
     intents.dispatchRadioIntent({ id: 'mode-1', name: 'set_mode', params: { mode: 'CW', receiver: 1 } });
     harness.delivery?.({
@@ -465,8 +485,9 @@ describe('typed non-PTT radio intents', () => {
       const invalidRit: RadioIntent = { name: 'set_rit_frequency', params: { value: 300 } };
       expect(invalidRit).toBeDefined();
     }
-    expect(intents.RADIO_INTENT_NAMES).toHaveLength(91);
-    expect(new Set(intents.RADIO_INTENT_NAMES).size).toBe(91);
+    expect(intents.RADIO_INTENT_NAMES).toHaveLength(92);
+    expect(new Set(intents.RADIO_INTENT_NAMES).size).toBe(92);
+    expect(intents.RADIO_INTENT_NAMES).toContain('set_vfo_freq');
     expect(intents.RADIO_INTENT_NAMES).toContain('set_data3_mod_input');
     expect(intents.RADIO_INTENT_NAMES).not.toContain('ptt');
     expect(intents.RADIO_INTENT_NAMES).not.toContain('ptt_on');

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -45,6 +45,15 @@ import {
 
 type Receiver = 0 | 1;
 
+export interface DirectVfoFrequencyRequest {
+  readonly frequencyHz: number;
+  readonly receiver: 'MAIN' | 'SUB';
+  readonly slot: 'A' | 'B';
+  readonly expectedActiveSlot: 'A' | 'B';
+  readonly providerGeneration: number;
+  readonly sessionEpoch: number;
+}
+
 function knownActiveReceiver(
   field?: string, target?: 'MAIN' | 'SUB', receiverCount?: number | null,
 ): Receiver | null {
@@ -1269,6 +1278,37 @@ export function makeVfoHandlers() {
       tuningAccumulator().cancel(receiver === 'SUB' ? 1 : 0);
       if (active !== receiver && !activateReceiver(receiver, context)) return;
       if (slot !== null) dispatchRadioIntent({ name: 'set_vfo', params: { vfo: slot } });
+    },
+    onDirectFrequencyChange: (request: DirectVfoFrequencyRequest) => {
+      const context = currentA03cContext();
+      const generation = context?.state.providerGeneration;
+      const activeSlot = context?.state.main?.activeSlot;
+      if (!context || request.receiver !== 'MAIN' || context.caps.receivers !== 1
+        || context.caps.vfoScheme !== 'ab'
+        || !context.caps.capabilities.includes('vfo_freq_direct')
+        || request.sessionEpoch !== currentControlSessionEpoch()
+        || !Number.isSafeInteger(request.providerGeneration) || request.providerGeneration < 0
+        || generation !== request.providerGeneration
+        || context.caps.providerGeneration !== request.providerGeneration
+        || !observedAvailableField(context.state, 'main.activeSlot')
+        || (activeSlot !== 'A' && activeSlot !== 'B')
+        || activeSlot !== request.expectedActiveSlot
+        || (request.slot !== 'A' && request.slot !== 'B')
+        || !Number.isSafeInteger(request.frequencyHz) || request.frequencyHz <= 0
+        || !context.caps.freqRanges.some(
+          (range) => request.frequencyHz >= range.start && request.frequencyHz <= range.end,
+        )) return null;
+      tuningAccumulator().cancel(0);
+      return dispatchRadioIntent({
+        name: 'set_vfo_freq',
+        params: {
+          freq: request.frequencyHz,
+          receiver: 0,
+          slot: request.slot,
+          expected_active_slot: request.expectedActiveSlot,
+          provider_generation: request.providerGeneration,
+        },
+      });
     },
     onMainModeClick: () => { tuningAccumulator().cancel(); focusModePanel('MAIN'); },
     onSubModeClick: () => { tuningAccumulator().cancel(); focusModePanel('SUB'); },

--- a/frontend/src/lib/runtime/commands/radio-intents.ts
+++ b/frontend/src/lib/runtime/commands/radio-intents.ts
@@ -3,7 +3,7 @@ import { makeCommandId } from '$lib/types/protocol';
 import * as controlTransport from '$lib/transport/ws-client';
 import { getControlSession, onCommandDelivery, onControlSessionTransition, sendCommand } from '$lib/transport/ws-client';
 
-type FieldKind = 'boolean' | 'integer' | 'normalized' | 'normalized-unit' | 'number' | 'receiver' | 'string' | 'vfo';
+type FieldKind = 'boolean' | 'integer' | 'normalized' | 'normalized-unit' | 'number' | 'receiver' | 'string' | 'vfo' | 'vfo-slot';
 type FieldSpec = FieldKind | `${FieldKind}?`;
 type IntentSpec = { names: readonly string[]; params: Readonly<Record<string, FieldSpec>> };
 
@@ -38,6 +38,10 @@ const intentSpecs = [
   { names: ['set_filter_shape'], params: { shape: 'integer', receiver: 'receiver' } },
   { names: ['set_filter_width'], params: { width: 'integer', receiver: 'receiver?' } },
   { names: ['set_freq'], params: { freq: 'integer', receiver: 'receiver?' } },
+  { names: ['set_vfo_freq'], params: {
+    freq: 'integer', receiver: 'receiver', slot: 'vfo-slot',
+    expected_active_slot: 'vfo-slot', provider_generation: 'integer',
+  } },
   { names: ['set_if_shift'], params: { offset: 'integer', receiver: 'receiver' } },
   { names: ['set_mode'], params: { mode: 'string', filter: 'integer?', receiver: 'receiver?' } },
   { names: ['set_rit_frequency'], params: { freq: 'integer' } },
@@ -53,7 +57,8 @@ const intentSpecs = [
 
 type Spec = (typeof intentSpecs)[number];
 type KindValue<K extends FieldKind> = K extends 'boolean' ? boolean : K extends 'normalized-unit' ? 'normalized' : K extends 'receiver' ? 0 | 1
-  : K extends 'string' ? string : K extends 'vfo' ? 'A' | 'B' | 'MAIN' | 'SUB' : number;
+  : K extends 'string' ? string : K extends 'vfo-slot' ? 'A' | 'B'
+    : K extends 'vfo' ? 'A' | 'B' | 'MAIN' | 'SUB' : number;
 type RequiredKeys<S extends Readonly<Record<string, FieldSpec>>> = {
   [K in keyof S]-?: S[K] extends `${FieldKind}?` ? never : K
 }[keyof S];
@@ -82,6 +87,7 @@ function matchesValue(kind: FieldKind, value: unknown): boolean {
   if (kind === 'number') return typeof value === 'number' && Number.isFinite(value);
   if (kind === 'boolean') return typeof value === 'boolean';
   if (kind === 'receiver') return value === 0 || value === 1;
+  if (kind === 'vfo-slot') return value === 'A' || value === 'B';
   if (kind === 'vfo') return value === 'A' || value === 'B' || value === 'MAIN' || value === 'SUB';
   return typeof value === 'string' && value.length > 0;
 }

--- a/frontend/src/lib/stores/__tests__/commands.test.ts
+++ b/frontend/src/lib/stores/__tests__/commands.test.ts
@@ -304,6 +304,47 @@ describe('command lifecycle store', () => {
     expect(store.getCommandLifecycle('overflow', 9)).toBeUndefined();
   });
 
+  describe('direct VFO frequency state-backed descriptor', () => {
+    const params = (slot: 'A' | 'B', freq: number) => ({
+      freq, receiver: 0, slot, expected_active_slot: 'A', provider_generation: 31,
+    });
+    const radio = (a: number, b: number, aObserved: number, bObserved: number) => ({
+      providerGeneration: 31,
+      main: { vfoA: { freqHz: a }, vfoB: { freqHz: b } },
+      fieldStatus: {
+        'main.vfoA.freqHz': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: aObserved },
+        'main.vfoB.freqHz': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: bObserved },
+      },
+    } as unknown as ServerState);
+
+    it('keys supersession and confirmation by exact receiver slot', () => {
+      acceptedState = radio(14_074_000, 7_074_000, 1, 1);
+      const a = store.beginCommand({ id: 'a', name: 'set_vfo_freq', params: params('A', 14_075_000), originalEpoch: 7 });
+      const b = store.beginCommand({ id: 'b', name: 'set_vfo_freq', params: params('B', 7_075_000), originalEpoch: 7 });
+      expect(a.locallyObsolete).toBeUndefined();
+      expect(b.locallyObsolete).toBeUndefined();
+      store.acknowledgeCommand(a.id, 7, 7);
+      store.acknowledgeCommand(b.id, 7, 7);
+
+      emitState(radio(14_075_000, 7_075_000, 2, 2));
+      expect(store.getCommandLifecycle(a.id, 7)?.status).toBe('confirmed');
+      expect(store.getCommandLifecycle(b.id, 7)?.status).toBe('confirmed');
+    });
+
+    it('does not confirm from acknowledgement or the other slot readback', () => {
+      acceptedState = radio(14_074_000, 7_074_000, 1, 1);
+      const command = store.beginCommand({
+        id: 'target-b', name: 'set_vfo_freq', params: params('B', 7_075_000), originalEpoch: 7,
+      });
+      store.acknowledgeCommand(command.id, 7, 7);
+      expect(store.getCommandLifecycle(command.id, 7)?.status).toBe('acknowledged');
+      emitState(radio(14_075_000, 7_074_000, 2, 1));
+      expect(store.getCommandLifecycle(command.id, 7)?.status).toBe('acknowledged');
+      emitState(radio(14_075_000, 7_073_000, 2, 2));
+      expect(store.getCommandLifecycle(command.id, 7)?.status).toBe('acknowledged');
+    });
+  });
+
   describe('RF/SQL state-backed descriptors', () => {
     it('uses exact receiver scopes and normalized 0..1 targets', () => {
       const rfMain = store.RF_GAIN_COMMAND_DESCRIPTOR.scope({ params: { level: 128, receiver: 0 } })!;
@@ -312,7 +353,7 @@ describe('command lifecycle store', () => {
       const sqlSub = store.SQUELCH_COMMAND_DESCRIPTOR.scope({ params: { level: 64, receiver: 1 } })!;
 
       expect([...store.STATE_BACKED_COMMAND_DESCRIPTORS.keys()]).toEqual([
-        'set_filter_width', 'set_break_in_delay', 'set_rf_gain', 'set_squelch',
+        'set_filter_width', 'set_vfo_freq', 'set_break_in_delay', 'set_rf_gain', 'set_squelch',
         'set_cw_pitch', 'set_key_speed', 'set_mic_gain', 'set_drive_gain',
         'set_vox_gain', 'set_anti_vox_gain', 'set_vox_delay',
         'set_compressor_level', 'set_monitor_gain', 'set_nb_level', 'set_nb_width',
@@ -450,7 +491,7 @@ describe('command lifecycle store', () => {
   describe('global CW state-backed descriptors', () => {
     it('registers exact global scopes, fields, targets, and canonical values', () => {
       expect([...store.STATE_BACKED_COMMAND_DESCRIPTORS.keys()]).toEqual([
-        'set_filter_width', 'set_break_in_delay', 'set_rf_gain', 'set_squelch',
+        'set_filter_width', 'set_vfo_freq', 'set_break_in_delay', 'set_rf_gain', 'set_squelch',
         'set_cw_pitch', 'set_key_speed', 'set_mic_gain', 'set_drive_gain',
         'set_vox_gain', 'set_anti_vox_gain', 'set_vox_delay',
         'set_compressor_level', 'set_monitor_gain', 'set_nb_level', 'set_nb_width',

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -58,6 +58,8 @@ export type StateBackedRepeatPolicy = 'latest-target-wins';
 export interface StateBackedCommandDescriptor<T> {
   readonly intentName: RadioIntentName;
   readonly repeatPolicy: StateBackedRepeatPolicy;
+  /** Keep awaiting radio truth when a post-ack observation reports another value. */
+  readonly requireTargetMatch?: boolean;
   scope(command: Pick<CommandLifecycle, 'params'>): ControlFeedbackScope | null;
   fieldPath(scope: ControlFeedbackScope): string;
   target(command: Pick<CommandLifecycle, 'params'>): T | null;
@@ -142,6 +144,43 @@ export const FILTER_WIDTH_COMMAND_DESCRIPTOR: StateBackedCommandDescriptor<numbe
   ),
   matches: (confirmed: number, target: number) => confirmed === target,
 });
+
+type DirectVfoFrequencyCommand = Readonly<{
+  receiver: 0 | 1;
+  slot: 'A' | 'B';
+  target: number;
+}>;
+function directVfoFrequencyCommand(
+  command: Pick<CommandLifecycle, 'params'>,
+): DirectVfoFrequencyCommand | null {
+  const params = command.params;
+  if (Reflect.ownKeys(params).length !== 5) return null;
+  const target = safeInteger(params.freq);
+  const receiver = params.receiver;
+  const slot = params.slot;
+  const expected = params.expected_active_slot;
+  const generation = providerGeneration(params.provider_generation);
+  return target !== null && target > 0 && (receiver === 0 || receiver === 1)
+    && (slot === 'A' || slot === 'B') && (expected === 'A' || expected === 'B')
+    && generation !== null
+    ? Object.freeze({ receiver, slot, target }) : null;
+}
+
+export const DIRECT_VFO_FREQUENCY_COMMAND_DESCRIPTOR: StateBackedCommandDescriptor<number> = Object.freeze({
+  intentName: 'set_vfo_freq', repeatPolicy: 'latest-target-wins', requireTargetMatch: true,
+  scope: (command) => {
+    const parsed = directVfoFrequencyCommand(command);
+    return parsed === null ? null : Object.freeze({
+      control: 'vfo-frequency', receiver: parsed.receiver, slot: parsed.slot,
+    });
+  },
+  fieldPath: (scope) => `${scope.receiver === 1 ? 'sub' : 'main'}.vfo${scope.slot}.freqHz`,
+  target: (command) => directVfoFrequencyCommand(command)?.target ?? null,
+  confirmed: (state, scope) => safeInteger(
+    (scope.receiver === 1 ? state.sub : state.main)?.[scope.slot === 'B' ? 'vfoB' : 'vfoA']?.freqHz,
+  ),
+  matches: (confirmed, target) => confirmed === target,
+} satisfies StateBackedCommandDescriptor<number>);
 
 const breakInDelayTarget = (command: Pick<CommandLifecycle, 'params'>): number | null =>
   Reflect.ownKeys(command.params).length === 1
@@ -376,6 +415,7 @@ export const IF_SHIFT_COMMAND_DESCRIPTOR: StateBackedCommandDescriptor<number> =
 export const STATE_BACKED_COMMAND_DESCRIPTORS: ReadonlyMap<RadioIntentName, StateBackedCommandDescriptor<unknown>> =
   new Map([
     [FILTER_WIDTH_COMMAND_DESCRIPTOR.intentName, FILTER_WIDTH_COMMAND_DESCRIPTOR],
+    [DIRECT_VFO_FREQUENCY_COMMAND_DESCRIPTOR.intentName, DIRECT_VFO_FREQUENCY_COMMAND_DESCRIPTOR],
     [BREAK_IN_DELAY_COMMAND_DESCRIPTOR.intentName, BREAK_IN_DELAY_COMMAND_DESCRIPTOR],
     [RF_GAIN_COMMAND_DESCRIPTOR.intentName, RF_GAIN_COMMAND_DESCRIPTOR],
     [SQUELCH_COMMAND_DESCRIPTOR.intentName, SQUELCH_COMMAND_DESCRIPTOR],
@@ -550,7 +590,7 @@ function reconcileStateBackedCommands(state: ServerState | null): void {
       command.ackFieldObservationTimes = { ...boundaries, [path]: marker };
       continue;
     }
-    if (marker > boundary) {
+    if (marker > boundary && (!descriptor.requireTargetMatch || descriptor.matches(confirmed, target))) {
       transition(command.id, command.originalEpoch, 'confirmed', command.eventEpoch ?? command.originalEpoch);
     }
   }

--- a/frontend/src/semantic/BandInstrumentHost.svelte
+++ b/frontend/src/semantic/BandInstrumentHost.svelte
@@ -26,6 +26,8 @@
     onEnterFrequency?: (frequencyHz: number) => void;
     entryRendererContext?: FiniteRendererContext | null;
     entryRenderer?: Component<FrequencyEntryRendererProps>;
+    frequencyEntryEnabled?: boolean;
+    frequencyEntryUnavailableReason?: string;
     /** Whether the fallback key PRINTS its permit sentence. Its accessible name
      *  carries that sentence, and `data-default-permit` the status, either way. */
     showPermitCaption?: boolean;
@@ -39,7 +41,8 @@
 
   let {
     view, onSelectBand, onEnterFrequency, finiteAppearance, rendererContext,
-    entryRendererContext, entryRenderer, showPermitCaption = true, children,
+    entryRendererContext, entryRenderer, frequencyEntryEnabled = true,
+    frequencyEntryUnavailableReason, showPermitCaption = true, children,
   }: Props = $props();
   let band = $derived(view?.band);
   let receiverKnown = $derived(view?.activeReceiver.status === 'known');
@@ -54,19 +57,19 @@
       ? interpretFrequencyEntry(entryText, band.tuneMinHz, band.tuneMaxHz) : null,
   );
   let entryReady = $derived(
-    entryAuthorityAvailable && receiverKnown && boundsKnown && interpretedHz !== null,
+    entryAuthorityAvailable && frequencyEntryEnabled && receiverKnown && boundsKnown && interpretedHz !== null,
   );
   let entryValidation = $derived(
-    !entryAuthorityAvailable || !receiverKnown || !boundsKnown ? 'unavailable' as const
+    !entryAuthorityAvailable || !frequencyEntryEnabled || !receiverKnown || !boundsKnown ? 'unavailable' as const
       : entryText.trim() === '' ? 'empty' as const
         : interpretedHz === null ? 'rejected' as const : 'accepted' as const,
   );
   let entryHint = $derived(entryReady && interpretedHz !== null ? `→ ${mhz(interpretedHz)}` : '');
   let entryRangeText = $derived(boundsKnown && band?.tuneMinHz != null && band?.tuneMaxHz != null
     ? `${mhz(band.tuneMinHz)} … ${mhz(band.tuneMaxHz)}` : UNKNOWN_TEXT);
-  let entryUnavailableReason = $derived(!boundsKnown
+  let entryUnavailableReason = $derived(frequencyEntryUnavailableReason ?? (!boundsKnown
     ? t('core.band.entry.reason.boundsUnknown')
-    : !receiverKnown ? t('core.band.entry.reason.receiverUnconfirmed') : undefined);
+    : !receiverKnown ? t('core.band.entry.reason.receiverUnconfirmed') : undefined));
 
   $effect(() => {
     const present = band !== undefined;
@@ -104,7 +107,7 @@
     view: {
       label: 'FREQ', draft: entryText, validation: entryValidation,
       boundsAvailable: boundsKnown, interpretedHz,
-      inputAvailable: entryAuthorityAvailable && receiverKnown && boundsKnown,
+      inputAvailable: entryAuthorityAvailable && frequencyEntryEnabled && receiverKnown && boundsKnown,
       submitAvailable: entryReady,
       hint: entryHint, rangeText: entryRangeText,
       ...(entryUnavailableReason === undefined ? {} : { unavailableReason: entryUnavailableReason }),
@@ -121,7 +124,7 @@
 
   function entryIsAvailable(): boolean {
     const currentBand = view?.band;
-    return entryRendererContext !== null && view?.activeReceiver.status === 'known'
+    return entryRendererContext !== null && frequencyEntryEnabled && view?.activeReceiver.status === 'known'
       && currentBand !== undefined
       && currentBand.tuneMinHz !== null && currentBand.tuneMaxHz !== null;
   }
@@ -207,7 +210,7 @@
   {/if}
 {/snippet}
 
-{@render children({ bandChoice, frequencyEntry })}
+{@render children({ bandChoice, frequencyEntry, cancelFrequencyEntry: cancelEntry })}
 
 <style>
   .band-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin: 0; }

--- a/frontend/src/semantic/FrequencyEntryDialog.svelte
+++ b/frontend/src/semantic/FrequencyEntryDialog.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    open: boolean;
+    targetLabel: string;
+    returnFocus?: HTMLElement | null;
+    onclose?: () => void;
+    children: Snippet;
+  }
+
+  let { open, targetLabel, returnFocus = null, onclose, children }: Props = $props();
+  const titleId = $props.id();
+  let panel: HTMLElement | undefined = $state();
+  let wasOpen = false;
+  let restoreTarget: HTMLElement | null = null;
+
+  const focusable = () => panel?.querySelectorAll<HTMLElement>(
+    'input:not([disabled]), button:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+  ) ?? [];
+  const initialFocus = () => panel?.querySelector<HTMLElement>(
+    '.content input:not([disabled]), .content select:not([disabled]), .content textarea:not([disabled]), .content button:not([disabled])',
+  ) ?? focusable()[0] ?? panel;
+
+  $effect(() => {
+    if (open && !wasOpen) {
+      restoreTarget = returnFocus ?? (document.activeElement instanceof HTMLElement
+        ? document.activeElement : null);
+      queueMicrotask(() => initialFocus()?.focus());
+    } else if (!open && wasOpen) {
+      const target = restoreTarget;
+      queueMicrotask(() => target?.focus());
+    }
+    wasOpen = open;
+  });
+
+  function requestClose(event?: Event): void {
+    event?.preventDefault();
+    event?.stopPropagation();
+    onclose?.();
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      requestClose(event);
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    const nodes = [...focusable()];
+    if (nodes.length === 0) {
+      event.preventDefault();
+      panel?.focus();
+      return;
+    }
+    const first = nodes[0], last = nodes[nodes.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault(); last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault(); first.focus();
+    }
+  }
+
+  function handleBackdrop(event: MouseEvent): void {
+    if (event.target === event.currentTarget) requestClose(event);
+  }
+</script>
+
+{#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+  <div class="frequency-entry-backdrop" data-testid="frequency-entry-dialog-backdrop" role="presentation"
+    onclick={handleBackdrop} onkeydowncapture={handleKeydown}>
+    <div class="frequency-entry-dialog" data-testid="frequency-entry-dialog-panel"
+      role="dialog" aria-modal="true" aria-labelledby={titleId} tabindex="-1" bind:this={panel}>
+      <header>
+        <h2 id={titleId}>Set frequency — {targetLabel}</h2>
+        <button type="button" class="close" aria-label="Close frequency entry"
+          onclick={requestClose}>×</button>
+      </header>
+      <div class="content">{@render children()}</div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .frequency-entry-backdrop {
+    position: fixed; inset: 0; z-index: 1200; display: grid; place-items: center;
+    padding: 20px; background: rgba(0, 0, 0, 0.62); backdrop-filter: blur(3px);
+  }
+  .frequency-entry-dialog {
+    width: min(480px, 100%); border: 1px solid var(--v2-border-cyan);
+    border-radius: 12px; background: var(--v2-panel-bg, #12141b);
+    color: var(--v2-text-primary, #f4f6fa); box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  }
+  header { display: flex; align-items: center; justify-content: space-between; gap: 16px;
+    padding: 14px 16px; border-bottom: 1px solid var(--v2-border-panel, #333); }
+  h2 { margin: 0; font: 700 15px/1.3 'IBM Plex Sans', sans-serif; }
+  .close { border: 0; background: transparent; color: inherit; padding: 4px 8px;
+    font-size: 22px; cursor: pointer; }
+  .content { padding: 16px; }
+</style>

--- a/frontend/src/semantic/FrequencyEntryDialog.svelte
+++ b/frontend/src/semantic/FrequencyEntryDialog.svelte
@@ -5,11 +5,12 @@
     open: boolean;
     targetLabel: string;
     returnFocus?: HTMLElement | null;
+    status?: string;
     onclose?: () => void;
     children: Snippet;
   }
 
-  let { open, targetLabel, returnFocus = null, onclose, children }: Props = $props();
+  let { open, targetLabel, returnFocus = null, status, onclose, children }: Props = $props();
   const titleId = $props.id();
   let panel: HTMLElement | undefined = $state();
   let wasOpen = false;
@@ -77,6 +78,7 @@
           onclick={requestClose}>×</button>
       </header>
       <div class="content">{@render children()}</div>
+      {#if status}<p class="status" role="status">{status}</p>{/if}
     </div>
   </div>
 {/if}
@@ -97,4 +99,5 @@
   .close { border: 0; background: transparent; color: inherit; padding: 4px 8px;
     font-size: 22px; cursor: pointer; }
   .content { padding: 16px; }
+  .status { margin: 0; padding: 0 16px 16px; color: var(--v2-text-muted, #aeb5c2); }
 </style>

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -62,6 +62,8 @@
     viewModel: RadioViewModel;
     appearance?: 'semantic' | 'sdr' | 'standard';
     onSelectVfo?: (target: VfoSelection) => void;
+    /** Standard-face digit activation with exact VFO identity and focus return node. */
+    onOpenFrequencyEntry?: (target: VfoSelection, trigger: HTMLElement) => void;
     onToggleSplit?: () => void;
     onToggleDualWatch?: () => void;
     /**
@@ -194,6 +196,7 @@
   let {
     viewModel, appearance = 'semantic',
     onSelectVfo,
+    onOpenFrequencyEntry,
     onToggleSplit,
     onToggleDualWatch,
     selectionPoolSize,
@@ -843,6 +846,9 @@
           reserveMeterSpace={fixed !== undefined && !fixed.isActiveSlot}
           onFreqChange={receiverInstruments === undefined && dominant
             ? (hz) => tuneFrequency(dominant, hz) : undefined}
+          onFrequencyClick={dominant && onOpenFrequencyEntry
+            ? (trigger) => onOpenFrequencyEntry({ receiver: dominant.receiver, slot: dominant.slot }, trigger)
+            : undefined}
           onSelectSlot={(key) => {
             const choice = viewModel.vfos[Number(key)];
             if (choice) selectVfo(choice);

--- a/frontend/src/semantic/__tests__/FrequencyEntryDialog.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/FrequencyEntryDialog.isolated.test.ts
@@ -56,4 +56,17 @@ describe('FrequencyEntryDialog', () => {
     expect(onclose).toHaveBeenCalledOnce();
     unmount(component);
   });
+
+  it('announces command lifecycle feedback', () => {
+    const props = proxy({
+      open: true, targetLabel: 'VFO B', status: 'Waiting for readback', children: content,
+    });
+    const component = mount(FrequencyEntryDialog, { target, props });
+    flushSync();
+    expect(target.querySelector('[role="status"]')?.textContent).toBe('Waiting for readback');
+    props.status = 'Frequency confirmed.';
+    flushSync();
+    expect(target.querySelector('[role="status"]')?.textContent).toBe('Frequency confirmed.');
+    unmount(component);
+  });
 });

--- a/frontend/src/semantic/__tests__/FrequencyEntryDialog.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/FrequencyEntryDialog.isolated.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRawSnippet, flushSync, mount, unmount } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
+import FrequencyEntryDialog from '../FrequencyEntryDialog.svelte';
+
+const content = createRawSnippet(() => ({
+  render: () => '<div><input data-dialog-input><button type="button">Set</button></div>',
+}));
+
+let target: HTMLDivElement;
+let trigger: HTMLButtonElement;
+beforeEach(() => {
+  target = document.createElement('div');
+  trigger = document.createElement('button');
+  document.body.append(trigger, target);
+});
+afterEach(() => {
+  target.remove();
+  trigger.remove();
+});
+
+describe('FrequencyEntryDialog', () => {
+  it('autofocuses its entry and Escape cancels, closes, and restores trigger focus', async () => {
+    const onclose = vi.fn();
+    const props = proxy({ open: true, targetLabel: 'VFO B', returnFocus: trigger, onclose, children: content });
+    trigger.focus();
+    const component = mount(FrequencyEntryDialog, { target, props });
+    flushSync();
+    await Promise.resolve();
+    const dialog = target.querySelector<HTMLElement>('[role="dialog"]')!;
+    const input = target.querySelector<HTMLInputElement>('[data-dialog-input]')!;
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+    expect(dialog.textContent).toContain('VFO B');
+    expect(document.activeElement).toBe(input);
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+    expect(onclose).toHaveBeenCalledOnce();
+    props.open = false;
+    flushSync();
+    await Promise.resolve();
+    expect(target.querySelector('[role="dialog"]')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+    unmount(component);
+  });
+
+  it('cancels only a direct backdrop click', () => {
+    const onclose = vi.fn();
+    const component = mount(FrequencyEntryDialog, {
+      target, props: { open: true, targetLabel: 'VFO A', onclose, children: content },
+    });
+    flushSync();
+    target.querySelector<HTMLElement>('[data-testid="frequency-entry-dialog-panel"]')?.click();
+    expect(onclose).not.toHaveBeenCalled();
+    target.querySelector<HTMLElement>('[data-testid="frequency-entry-dialog-backdrop"]')?.click();
+    expect(onclose).toHaveBeenCalledOnce();
+    unmount(component);
+  });
+});

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -2544,6 +2544,29 @@ describe('MOR-2342 historical instrument presentations', () => {
     expect(onSelectVfo).not.toHaveBeenCalled();
   });
 
+  it('reports the exact Standard A/B record clicked without selecting or tuning either slot', () => {
+    const onOpenFrequencyEntry = vi.fn();
+    const onSelectVfo = vi.fn();
+    const onTuneFrequency = vi.fn();
+    const model = withReceiverIndicators('1/ab');
+    const root = mountSurface({
+      viewModel: model, appearance: 'standard', onOpenFrequencyEntry, onSelectVfo,
+      onTuneFrequency,
+    });
+
+    for (const id of ['A', 'B'] as const) {
+      root.querySelector<HTMLElement>(`[data-standard-vfo-slot="${id}"] .digit`)?.click();
+    }
+    expect(onOpenFrequencyEntry).toHaveBeenCalledTimes(2);
+    expect(onOpenFrequencyEntry.mock.calls.map(([target]) => target)).toEqual([
+      { receiver: 'MAIN', slot: { kind: 'slotted', id: 'A' } },
+      { receiver: 'MAIN', slot: { kind: 'slotted', id: 'B' } },
+    ]);
+    expect(onOpenFrequencyEntry.mock.calls.every(([, trigger]) => trigger instanceof HTMLElement)).toBe(true);
+    expect(onSelectVfo).not.toHaveBeenCalled();
+    expect(onTuneFrequency).not.toHaveBeenCalled();
+  });
+
   it('puts persistent A/B selection and shared operations in the center of the Standard pair', () => {
     const onSelectVfo = vi.fn();
     const root = mountSurface({

--- a/frontend/src/semantic/band-instruments.ts
+++ b/frontend/src/semantic/band-instruments.ts
@@ -5,6 +5,7 @@ import type { BandChoice } from './radio-view-model';
 export interface BandInstrumentHandles {
   readonly bandChoice: Snippet<[compact?: boolean]>;
   readonly frequencyEntry: Snippet;
+  readonly cancelFrequencyEntry: () => void;
 }
 
 export type BandControlLayout = Snippet<[BandInstrumentHandles]>;


### PR DESCRIPTION
File-count exception: 18 code + 0 regenerated baselines = 18 files; coordinator-authorized for the shared entry host, VFO presentation, command lifecycle and their focused tests. The 707 added/deleted lines remain below the 1000-line ceiling.

Clicking Standard VFO digits opens a frequency-entry overlay for the captured A/B target. The existing Band entry parser, range checks and Enter submission are reused. Direct writes use `set_vfo_freq` with connection and active-slot context; authority changes disable submission rather than redirecting it. ACK and target readback remain distinct.

The direct capability is initially IC-7300-only and depends on backend PR #3442. There is no implicit selection or active-frequency fallback. Unsupported/unbound contexts retain the lower entry surface. The lower BAND panel remains pending acceptance of both HAM transfer and this overlay.

Validation on Mac Mini: 266 isolated checks and 275 store/VFO checks passed; Svelte/TypeScript check reported 0 errors/0 warnings; scoped ESLint passed. Correction validation: 174 checks across four affected suites passed, including real inactive-B Escape/backdrop focus restoration and command registry coverage; scoped ESLint and typecheck passed. Installed dialog and physical-radio acceptance remain pending.

Linear: https://linear.app/morozsm/issue/MOR-2446
