### PR TITLE
fix(ui): complete Standard band migration and VFO frequency entry

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -202,6 +202,11 @@
   // Reactive state + capabilities — via runtime
   let radioState = $derived(runtime.state);
   let caps = $derived(runtime.caps);
+  let directFrequencyEntrySupported = $derived(
+    caps?.capabilities.includes('vfo_freq_direct') === true
+      && caps.receivers === 1
+      && caps.vfoScheme === 'ab',
+  );
 
   // MOR-1235. The meters dock's TX chrome takes its truth from the App-owned
   // TX controller — the SAME source as the authoritative global lamp
@@ -483,7 +488,7 @@
       undefined, filterFiniteLayout, panelChrome(owner, 'semantic-filter'),
     )}
   {/if}
-  {#if owner.order.includes('semantic-band')}
+  {#if owner.order.includes('semantic-band') && !directFrequencyEntrySupported}
     {@render instruments.band(
       undefined, bandControlLayout, panelChrome(owner, 'semantic-band'),
     )}

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -1051,6 +1051,11 @@
     -ms-overflow-style: none; /* IE/Edge */
   }
 
+  .radio-layout.desktop-control-face.standard-face {
+    scrollbar-width: none;
+  }
+
+  .radio-layout.desktop-control-face.standard-face::-webkit-scrollbar,
   .content-left::-webkit-scrollbar,
   .content-right::-webkit-scrollbar,
   .desktop-control-face.standard-face :global(.desktop-controls-left)::-webkit-scrollbar,

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -2387,13 +2387,9 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
     expect(t.querySelector('[data-testid="antenna-control-grid"]')).not.toBeNull();
   });
 
-  /**
-   * MOR-2445 stage A keeps both selectors mounted, restores HAM only in the
-   * upper Standard panel through the semantic instrument handle, and leaves
-   * settings on the two broadcast tabs. The lower semantic block is retained
-   * until the separate owner-present acceptance gate.
-   */
-  it('moves semantic HAM choices into the upper BAND selector and keeps settings broadcast-only', () => {
+  /** Unsupported profiles retain the generic lower entry surface because
+   * their active-frequency command is still the only available route. */
+  it('keeps the generic lower entry on unsupported profiles while moving HAM into BANDS', () => {
     const t = renderAll('desktop-v2');
     const upper = t.querySelector('.left-sidebar [data-panel-id="band"]');
     const settings = t.querySelector('[data-panel-id="desktop-vfo-ops"]');
@@ -2402,8 +2398,30 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
     expect(upper?.querySelector('[data-testid="band-choices-compact"]')).not.toBeNull();
     expect(texts(settings, '.band-tab')).toEqual(['LW/MW', 'SWL']);
     expect(texts(settings, '.grid button')).toEqual(LW_MW_PRESETS);
-    // Stage A deliberately retains the lower semantic block until owner acceptance.
     expect(t.querySelector('[data-testid="band-surface"] [data-testid="band-choices"]')).not.toBeNull();
+  });
+
+  it('retires the complete lower BAND panel for direct Standard entry without freshness resurrection', () => {
+    h.caps = {
+      ...(h.caps as object),
+      capabilities: [...(h.caps as Capabilities).capabilities, 'vfo_freq_direct'],
+      receivers: 1,
+      vfoScheme: 'ab',
+    } as Capabilities;
+    const t = renderAll('desktop-v2');
+
+    const upper = t.querySelector('.left-sidebar [data-panel-id="band"]');
+    expect(texts(upper, '.band-tab')).toEqual(['HAM', 'LW/MW', 'SWL']);
+    expect(upper?.querySelector('[data-testid="band-choices-compact"]')).not.toBeNull();
+    expect(t.querySelector('[data-testid="band-surface"]')).toBeNull();
+    expect(t.querySelector('[data-panel-id="semantic-band"]')).toBeNull();
+
+    h.state = { ...(h.state as object), fieldStatus: {} };
+    const stale = renderAll('desktop-v2');
+
+    expect(stale.querySelector('[data-testid="band-surface"]')).toBeNull();
+    expect(stale.querySelector('[data-panel-id="semantic-band"]')).toBeNull();
+    expect(stale.querySelector('.left-sidebar [data-panel-id="band"]')).not.toBeNull();
   });
 
   // PRESET SURVIVAL. Both broadcast tabs remain reachable and every preset is
@@ -2449,7 +2467,7 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
     ]) {
       expect(t.querySelectorAll(selector).length, selector).toBe(0);
     }
-    // Stage A has one retained lower semantic grid plus the compact upper host.
+    // This unsupported fixture retains the generic lower grid plus the compact upper host.
     expect(t.querySelectorAll('[data-testid="band-choices"]').length).toBe(1);
     expect(t.querySelectorAll('[data-testid="band-choices-compact"]').length).toBe(1);
     expect([...t.querySelectorAll('.band-tab')].filter((b) => b.textContent?.trim() === 'HAM').length)

--- a/frontend/src/components-v2/vfo/VfoPanel.svelte
+++ b/frontend/src/components-v2/vfo/VfoPanel.svelte
@@ -107,10 +107,12 @@
   }
 
   function handleFrequencyClick(event: MouseEvent): void {
-    if (onFrequencyClick === undefined || !(event.target instanceof Element)
-      || event.target.closest('.digit') === null) return;
+    if (onFrequencyClick === undefined || !(event.target instanceof Element)) return;
+    const readout = event.target.closest('.freq');
+    if (readout === null || !(event.currentTarget instanceof HTMLElement)
+      || !event.currentTarget.contains(readout)) return;
     const trigger = frequencyEntryButton
-      ? event.currentTarget : event.target.closest('.freq');
+      ? event.currentTarget : readout;
     if (trigger instanceof HTMLElement) {
       if (frequencyEntryButton) event.stopPropagation();
       onFrequencyClick(trigger);

--- a/frontend/src/components-v2/vfo/VfoPanel.svelte
+++ b/frontend/src/components-v2/vfo/VfoPanel.svelte
@@ -88,6 +88,9 @@
   }: Props = $props();
 
   let meterVariant = $derived(layoutProfile === 'wide' ? 'vfo-wide' : 'vfo');
+  let frequencyEntryButton = $derived(onFrequencyClick !== undefined && controlsDisabled
+    && (frequencyState === 'current' || frequencyState === 'stale')
+    && freq !== null && freq !== undefined && Number.isFinite(freq));
   const staleId = `vfo-panel-stale-${++sequence}`;
   let receiverChromeVars = $derived({
     '--receiver-accent': `var(--v2-receiver-${receiver}-accent)`,
@@ -106,8 +109,21 @@
   function handleFrequencyClick(event: MouseEvent): void {
     if (onFrequencyClick === undefined || !(event.target instanceof Element)
       || event.target.closest('.digit') === null) return;
-    const readout = event.target.closest('.freq');
-    if (readout instanceof HTMLElement) onFrequencyClick(readout);
+    const trigger = frequencyEntryButton
+      ? event.currentTarget : event.target.closest('.freq');
+    if (trigger instanceof HTMLElement) {
+      if (frequencyEntryButton) event.stopPropagation();
+      onFrequencyClick(trigger);
+    }
+  }
+
+  function handleFrequencyKeydown(event: KeyboardEvent): void {
+    if (!frequencyEntryButton || onFrequencyClick === undefined
+      || (event.key !== 'Enter' && event.key !== ' ')
+      || !(event.currentTarget instanceof HTMLElement)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    onFrequencyClick(event.currentTarget);
   }
 </script>
 
@@ -151,22 +167,29 @@
   <div class="panel-body">
     <div class="display-row">
       <div class="freq-row">
+        <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
         <span class="vfo-freq" data-vfo-freq data-freq-tunable={!frequencyDisabled}
           data-display-state={frequencyState} class:display-unknown={displayHz === null}
+          role={frequencyEntryButton ? 'button' : undefined}
+          aria-label={frequencyEntryButton ? `Set frequency — ${receiverLabel}` : undefined}
+          tabindex={frequencyEntryButton ? 0 : undefined}
           onclickcapture={handleFrequencyClick}
+          onkeydowncapture={handleFrequencyKeydown}
           >
-          {#if frequency}
-            {@render frequency()}
-          {:else if freq !== null && freq !== undefined && Number.isFinite(freq)}
-            <FrequencyDisplayInteractive
-              {freq} {displayHz} {pendingDisplayHz} {contextKey}
-              disabled={frequencyDisabled
-                || (frequencyState !== 'current' && frequencyState !== 'stale')}
-              active={isActive} {receiver} {onFreqChange} vfoFreqHook={false}
-            />
-          {:else}
-            <span class="freq unknown-frequency">{formatFrequency(pendingDisplayHz ?? displayHz)}</span>
-          {/if}
+          <span class="frequency-readout-content" aria-hidden={frequencyEntryButton ? 'true' : undefined}>
+            {#if frequency}
+              {@render frequency()}
+            {:else if freq !== null && freq !== undefined && Number.isFinite(freq)}
+              <FrequencyDisplayInteractive
+                {freq} {displayHz} {pendingDisplayHz} {contextKey}
+                disabled={frequencyDisabled
+                  || (frequencyState !== 'current' && frequencyState !== 'stale')}
+                active={isActive} {receiver} {onFreqChange} vfoFreqHook={false}
+              />
+            {:else}
+              <span class="freq unknown-frequency">{formatFrequency(pendingDisplayHz ?? displayHz)}</span>
+            {/if}
+          </span>
         </span>
       </div>
 
@@ -417,6 +440,15 @@
     max-inline-size: 100%;
     font-size: var(--vfo-frequency-size, 24px);
     letter-spacing: var(--vfo-frequency-letter-spacing, 0.03em);
+  }
+
+  .frequency-readout-content { display: contents; }
+
+  .vfo-freq[role='button'], .vfo-freq[role='button'] :global(.digit) { cursor: pointer; }
+  .vfo-freq[role='button']:focus-visible {
+    outline: 2px solid var(--v2-accent-cyan-bright);
+    outline-offset: 3px;
+    border-radius: 4px;
   }
 
   .vfo-freq :global(.freq.interactive) {

--- a/frontend/src/components-v2/vfo/__tests__/VfoPanel.isolated.test.ts
+++ b/frontend/src/components-v2/vfo/__tests__/VfoPanel.isolated.test.ts
@@ -471,7 +471,7 @@ describe('explicit presentation contract', () => {
     expect(onFreqChange).toHaveBeenCalledExactlyOnceWith(14_074_001);
   });
 
-  it('reports a digit click once without tuning and preserves deliberate wheel tuning', () => {
+  it('opens from the whole readout without tuning and preserves deliberate wheel tuning', () => {
     const onFrequencyClick = vi.fn();
     const onFreqChange = vi.fn();
     const t = mountPanel({ ...explicit, onFrequencyClick, onFreqChange });
@@ -485,7 +485,9 @@ describe('explicit presentation contract', () => {
     digit.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true }));
     expect(onFreqChange).toHaveBeenCalledExactlyOnceWith(14_075_000);
     t.querySelector<HTMLElement>('.sep')?.click();
-    expect(onFrequencyClick).toHaveBeenCalledTimes(1);
+    readout.click();
+    expect(onFrequencyClick).toHaveBeenCalledTimes(3);
+    expect(onFreqChange).toHaveBeenCalledOnce();
   });
 
   it.each(['Enter', ' '] as const)(

--- a/frontend/src/components-v2/vfo/__tests__/VfoPanel.isolated.test.ts
+++ b/frontend/src/components-v2/vfo/__tests__/VfoPanel.isolated.test.ts
@@ -488,6 +488,61 @@ describe('explicit presentation contract', () => {
     expect(onFrequencyClick).toHaveBeenCalledTimes(1);
   });
 
+  it.each(['Enter', ' '] as const)(
+    'exposes inactive direct entry as an enabled button and opens with %s without tuning',
+    (key) => {
+      const onFrequencyClick = vi.fn();
+      const onFreqChange = vi.fn();
+      const t = mountPanel({
+        ...explicit, receiverLabel: 'MAIN B', isActive: false,
+        frequencyDisabled: true, controlsDisabled: true,
+        onFrequencyClick, onFreqChange,
+      });
+      const trigger = t.querySelector<HTMLElement>('[data-vfo-freq]')!;
+      const readout = trigger.querySelector<HTMLElement>('.freq')!;
+
+      expect(trigger.getAttribute('role')).toBe('button');
+      expect(trigger.getAttribute('aria-label')).toBe('Set frequency — MAIN B');
+      expect(trigger.getAttribute('aria-disabled')).toBeNull();
+      expect(trigger.getAttribute('tabindex')).toBe('0');
+      expect(readout.parentElement?.getAttribute('aria-hidden')).toBe('true');
+      trigger.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+
+      expect(onFrequencyClick).toHaveBeenCalledExactlyOnceWith(trigger);
+      expect(onFreqChange).not.toHaveBeenCalled();
+    },
+  );
+
+  it('opens inactive direct entry by pointer without digit selection or wheel and arrow tuning', () => {
+    const onFrequencyClick = vi.fn();
+    const onFreqChange = vi.fn();
+    const t = mountPanel({
+      ...explicit, receiverLabel: 'MAIN B', isActive: false,
+      frequencyDisabled: true, controlsDisabled: true,
+      onFrequencyClick, onFreqChange,
+    });
+    const trigger = t.querySelector<HTMLElement>('[data-vfo-freq]')!;
+    const readout = trigger.querySelector<HTMLElement>('.freq')!;
+    const digit = readout.querySelector<HTMLElement>('.digit')!;
+
+    digit.click();
+    expect(onFrequencyClick).toHaveBeenCalledExactlyOnceWith(trigger);
+    expect(digit.classList.contains('selected')).toBe(false);
+    digit.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true }));
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    expect(onFreqChange).not.toHaveBeenCalled();
+  });
+
+  it('does not expose unsupported inactive frequency as an entry button', () => {
+    const t = mountPanel({
+      ...explicit, isActive: false, frequencyDisabled: true, controlsDisabled: true,
+    });
+    const wrapper = t.querySelector<HTMLElement>('[data-vfo-freq]')!;
+    expect(wrapper.getAttribute('role')).toBeNull();
+    expect(wrapper.getAttribute('tabindex')).toBeNull();
+    expect(wrapper.querySelector('.freq')?.parentElement?.getAttribute('aria-hidden')).toBeNull();
+  });
+
   // MOR-2425/R29+R40: a HELD frequency stays tunable. `frequencyState` alone
   // no longer disables the arithmetic control; a display carrying no value
   // ('unknown'/'unsupported') still does, as does `frequencyDisabled`.

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -342,6 +342,12 @@
   const semanticHandlers = bindSemanticSurfaceHandlers();
   const vfo = semanticHandlers.vfo;
 
+  let directFrequencyEntrySupported = $derived(
+    runtime.caps?.capabilities.includes('vfo_freq_direct') === true
+      && runtime.caps.receivers === 1
+      && runtime.caps.vfoScheme === 'ab',
+  );
+
   type FrequencyEntryCapture = Readonly<{
     target: { receiver: 'MAIN'; slot: 'A' | 'B' };
     expectedActiveSlot: 'A' | 'B';
@@ -1858,7 +1864,7 @@
               {groupLabel}
               onSelectVfo={selectVfo}
               onTuneFrequency={tuneFrequency}
-              onOpenFrequencyEntry={openFrequencyEntry}
+              onOpenFrequencyEntry={directFrequencyEntrySupported ? openFrequencyEntry : undefined}
               disabled={!isOperationalStrip(view, receiverId)}
               indicatorReceiver={receiverId}
               suppressIdentitySelectors={stripBy === 'slot'}
@@ -1912,7 +1918,7 @@
         {operationControls}
         onSelectVfo={selectVfo}
         onTuneFrequency={tuneFrequency}
-        onOpenFrequencyEntry={openFrequencyEntry}
+        onOpenFrequencyEntry={directFrequencyEntrySupported ? openFrequencyEntry : undefined}
         {hasDualReceiver}
         {receiverInstruments}
         continuitySession={meterContinuitySession}

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -421,6 +421,11 @@
     && frequencyEntryCommand?.status !== 'pending'
     && frequencyEntryCommand?.status !== 'acknowledged'
     && frequencyEntryCommand?.status !== 'confirmed');
+  $effect(() => {
+    if (frequencyEntryCommand?.status !== 'confirmed') return;
+    frequencyEntryCapture = null;
+    frequencyEntryLifecycle = null;
+  });
   const systemIntents = getSystemHandlers();
   /** MOR-1307: the shipped band vocabulary, composed rather than forked. */
   const band = semanticHandlers.band;

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -74,6 +74,7 @@ vi.mock('$lib/runtime/commands/radio-intents', async () => {
 });
 vi.mock('$lib/stores/radio.svelte', () => ({
   getRadioState: vi.fn(() => h.state),
+  subscribeRadioState: vi.fn(() => () => {}),
   getActiveReceiver: vi.fn(() => {
     const state = h.state as ServerState | null;
     return state?.active === 'SUB' ? state.sub ?? null : state?.main ?? null;
@@ -141,6 +142,9 @@ import { makeBandHandlers, makeVfoHandlers } from '$lib/runtime/commands/panel-c
 import {
   resetRetainedInvocations, retainedInvocations,
 } from '../../../primitives/control-instruments/__tests__/support/FiniteControlRendererFixture.svelte';
+import {
+  acknowledgeCommand, beginCommand, confirmCommand, failCommand, resetCommandLifecycle,
+} from '$lib/stores/commands.svelte';
 
 const fresh = {
   storePath: 'x', observed: true, freshness: 'fresh', availability: 'available',
@@ -241,6 +245,7 @@ beforeEach(() => {
   h.controlSession = { state: 'connected', epoch: 1 };
   h.finiteAppearance = false;
   resetRetainedInvocations();
+  resetCommandLifecycle();
   vi.mocked(sendCommand).mockClear();
 });
 
@@ -259,13 +264,23 @@ describe('fixed-slot frequency entry overlay', () => {
       receivers: 1, vfoScheme: 'ab' };
   }
 
-  it('opens from inactive B digits and dispatches B without selecting it', () => {
+  function beginSubmittedDirectCommand() {
+    const [, params] = setDirectFreqCalls().at(-1)!;
+    if (params === undefined) throw new Error('direct frequency params missing');
+    return beginCommand({
+      id: 'test-set_vfo_freq', name: 'set_vfo_freq', params,
+      originalEpoch: h.controlSession.epoch,
+    });
+  }
+
+  it('opens from inactive B separator and dispatches B without selecting it', () => {
     h.state = directState(true); h.caps = directCaps(true);
     render({ vfoAppearance: 'standard' });
-    const digit = q<HTMLElement>('[data-vfo-slot="B"] [data-vfo-freq] .digit')!;
-    expect(digit).not.toBeNull();
-    digit.click();
+    const separator = q<HTMLElement>('[data-vfo-slot="B"] [data-vfo-freq] .sep')!;
+    expect(separator).not.toBeNull();
+    separator.click();
     flushSync();
+    expect(vi.mocked(sendCommand)).not.toHaveBeenCalled();
     const dialog = q<HTMLElement>('[data-testid="frequency-entry-dialog-panel"]')!;
     expect(dialog.textContent).toContain('MAIN VFO B');
     const input = dialog.querySelector<HTMLInputElement>('[data-testid="band-entry-input"]')!;
@@ -312,6 +327,44 @@ describe('fixed-slot frequency entry overlay', () => {
       expect(vi.mocked(sendCommand)).not.toHaveBeenCalled();
     },
   );
+
+  it('closes and restores focus only after exact-readback confirmation', async () => {
+    h.state = directState(true); h.caps = directCaps(true);
+    render({ vfoAppearance: 'standard' });
+    const trigger = q<HTMLElement>('[data-vfo-slot="B"] [data-vfo-freq]')!;
+    trigger.querySelector<HTMLElement>('.freq')!.click();
+    flushSync();
+    typeFrequency('7.075');
+    btn('entry-set')!.click();
+    const command = beginSubmittedDirectCommand();
+    flushSync();
+
+    expect(q<HTMLElement>('[role="dialog"]')).not.toBeNull();
+    acknowledgeCommand(command.id, command.originalEpoch, command.originalEpoch);
+    flushSync();
+    expect(q<HTMLElement>('[role="dialog"]')?.textContent)
+      .toContain('Waiting for the selected VFO readback');
+
+    confirmCommand(command.id, command.originalEpoch, command.originalEpoch);
+    flushSync();
+    await Promise.resolve();
+    expect(q<HTMLElement>('[role="dialog"]')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('keeps a failed submission open with its error', () => {
+    h.state = directState(true); h.caps = directCaps(true);
+    render({ vfoAppearance: 'standard' });
+    q<HTMLElement>('[data-vfo-slot="B"] [data-vfo-freq] .freq')!.click();
+    flushSync();
+    typeFrequency('7.075');
+    btn('entry-set')!.click();
+    const command = beginSubmittedDirectCommand();
+    failCommand(command.id, command.originalEpoch, command.originalEpoch, 'Radio rejected frequency');
+    flushSync();
+
+    expect(q<HTMLElement>('[role="dialog"]')?.textContent).toContain('Radio rejected frequency');
+  });
 
   it.each(['Enter', ' '] as const)(
     'opens real inactive B entry with %s without tuning or selecting',
@@ -374,6 +427,7 @@ afterEach(() => {
   expect(h.authoritySubscribers.size).toBe(0);
   expect(txHarness.listenerCount()).toBe(0);
   expect(txHarness.trace()).toEqual([]);
+  resetCommandLifecycle();
   document.body.innerHTML = '';
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -283,9 +283,12 @@ describe('fixed-slot frequency entry overlay', () => {
     async (closeWith) => {
       h.state = directState(true); h.caps = directCaps(true);
       render({ vfoAppearance: 'standard' });
-      const readout = q<HTMLElement>('[data-vfo-slot="B"] [data-vfo-freq] .freq')!;
+      const trigger = q<HTMLElement>('[data-vfo-slot="B"] [data-vfo-freq]')!;
+      const readout = trigger.querySelector<HTMLElement>('.freq')!;
       const digit = readout.querySelector<HTMLElement>('.digit')!;
 
+      expect(trigger.getAttribute('role')).toBe('button');
+      expect(trigger.getAttribute('aria-label')).toBe('Set frequency — MAIN B');
       expect(readout).not.toBeNull();
       expect(digit).not.toBeNull();
       digit.click();
@@ -305,8 +308,25 @@ describe('fixed-slot frequency entry overlay', () => {
       await Promise.resolve();
 
       expect(q<HTMLElement>('[role="dialog"]')).toBeNull();
-      expect(document.activeElement).toBe(readout);
+      expect(document.activeElement).toBe(trigger);
       expect(vi.mocked(sendCommand)).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['Enter', ' '] as const)(
+    'opens real inactive B entry with %s without tuning or selecting',
+    async (key) => {
+      h.state = directState(true); h.caps = directCaps(true);
+      render({ vfoAppearance: 'standard' });
+      const trigger = q<HTMLElement>('[data-vfo-slot="B"] [data-vfo-freq]')!;
+      trigger.focus();
+      trigger.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+      flushSync();
+      await Promise.resolve();
+
+      expect(q<HTMLElement>('[data-testid="frequency-entry-dialog-panel"]')).not.toBeNull();
+      expect(vi.mocked(sendCommand)).not.toHaveBeenCalled();
+      expect(q<HTMLElement>('[data-vfo-slot="B"]')?.getAttribute('data-vfo-active-slot')).toBe('false');
     },
   );
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -330,6 +330,24 @@ describe('fixed-slot frequency entry overlay', () => {
     },
   );
 
+  it('leaves unsupported inactive B on its original non-entry digit path', () => {
+    h.state = directState(true);
+    h.caps = { ...directCaps(true), capabilities: ['audio', 'tx'] };
+    render({ vfoAppearance: 'standard' });
+    const wrapper = q<HTMLElement>('[data-vfo-slot="B"] [data-vfo-freq]')!;
+    const digit = wrapper.querySelector<HTMLElement>('.digit')!;
+    const bubbled = vi.fn();
+    wrapper.addEventListener('click', bubbled);
+
+    expect(wrapper.getAttribute('role')).toBeNull();
+    expect(wrapper.getAttribute('tabindex')).toBeNull();
+    digit.click();
+
+    expect(bubbled).toHaveBeenCalledOnce();
+    expect(q<HTMLElement>('[role="dialog"]')).toBeNull();
+    expect(vi.mocked(sendCommand)).not.toHaveBeenCalled();
+  });
+
   it('keeps an open draft inert after the captured session changes', () => {
     h.state = directState(); h.caps = directCaps();
     render({ vfoAppearance: 'standard' });


### PR DESCRIPTION
Standard radios supporting direct A/B frequency entry now use the compact HAM / LW/MW / SWL selector and the VFO dialog, so the duplicate lower BAND panel and its movable shell are removed after owner acceptance. Unsupported radios retain their existing entry surface. The removal uses structural capability, so stale frequency data does not resurrect the panel.

The whole frequency readout opens the dialog, including separators and gaps. Supported inactive VFOs expose an enabled named action with Enter/Space activation and focus restoration; inactive wheel/arrow tuning remains inert. The dialog closes only when target readback confirms the command; pending, ACK-only and failure states remain visible. Standard outer and sidebar scrollbars are hidden while scrolling remains available.

Validation: 271 focused Mini tests passed across VFO, composed wiring and desktop migration suites; scoped ESLint, Svelte/TypeScript check and production build passed. Earlier installed direct-B write/restore preserved selected A, A frequency and PTT off. Final installed acceptance remains pending.

Linear: https://linear.app/morozsm/issue/MOR-2446 and https://linear.app/morozsm/issue/MOR-2445

Final scope: 6 files, 257 additions and 35 deletions (292 A+D). The exact-head review body correction is applied: final UX scope and 271 focused tests are recorded above.
