### PR TITLE
fix(ui): restore capability-driven RF front end layout

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -387,8 +387,8 @@
 
 {#snippet rfFrontEndFiniteLayout(rfFrontEndInstruments: RfFrontEndFiniteHandles)}
   <div class="rf-front-end-finite-grid">
-    <div class="rf-front-end-finite-seat" data-field="preamp">{@render rfFrontEndInstruments.preamp()}</div>
     <div class="rf-front-end-finite-seat" data-field="attenuator">{@render rfFrontEndInstruments.attenuator()}</div>
+    <div class="rf-front-end-finite-seat" data-field="preamp">{@render rfFrontEndInstruments.preamp()}</div>
     <div class="rf-front-end-finite-seat" data-field="digiSel">{@render rfFrontEndInstruments.digiSel()}</div>
     <div class="rf-front-end-finite-seat" data-field="ipPlus">{@render rfFrontEndInstruments.ipPlus()}</div>
   </div>
@@ -961,7 +961,8 @@
   .standard-bottom-dock > .content-right { display: contents; }
   .tx-aux-finite-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
   .dsp-finite-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
-  .rf-front-end-finite-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+  .rf-front-end-finite-grid { display: flex; flex-direction: column; gap: 0.5rem; min-width: 0; }
+  .rf-front-end-finite-seat { display: contents; }
   /* The `.filter-finite-*` shape, not the siblings' wrap row: a wrap row let
      each seat shrink to its content, and the desktop-v2 skin stretches
      `.rx-audio-row` buttons with `flex: 1 1 0`, which needs the row to span

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -675,7 +675,7 @@ describe('each finite control has exactly one owner in the composed tree', () =>
     renderHostedFace('desktop-v2');
     const seats = [...target.querySelectorAll<HTMLElement>('.rf-front-end-finite-seat')]
       .map((seat) => seat.dataset.field);
-    expect(seats).toEqual(['preamp', 'attenuator', 'digiSel', 'ipPlus']);
+    expect(seats).toEqual(['attenuator', 'preamp', 'digiSel', 'ipPlus']);
   });
 
   it('has no Standard seat grid on sdr-test — the grouped surface owns placement there', () => {

--- a/frontend/src/semantic/RfFrontEndInstrumentHost.svelte
+++ b/frontend/src/semantic/RfFrontEndInstrumentHost.svelte
@@ -338,18 +338,11 @@
       ?? view.canonical;
   }
   function status(view: Readonly<ContinuousScalarView>): string {
-    if (view.evidence !== 'command-feedback' || view.phase === 'idle') return '';
-    const target = view.feedback.target ?? view.feedback.requestedTarget;
-    return `${view.phase.replaceAll('-', ' ')}${target === null ? '' : `; requested ${valueText(target)}`}`
-      + `; confirmed ${valueText(view.canonical)}${view.error === null ? '' : `; ${view.error}`}`;
+    return view.evidence === 'command-feedback' ? view.error ?? '' : '';
   }
   function pairStatus(view: Readonly<ContinuousPairView>, lane: DualParamLane): string {
     const laneView = view.lanes[lane];
-    if (laneView.evidence !== 'command-feedback' || laneView.phase === 'idle') return '';
-    const target = laneView.feedback.target ?? laneView.feedback.requestedTarget;
-    return `${laneView.phase.replaceAll('-', ' ')}${target === null ? '' : `; requested ${valueText(target)}`}`
-      + `; confirmed ${valueText(laneView.canonical)}`
-      + `${laneView.error === null ? '' : `; ${laneView.error}`}`;
+    return laneView.evidence === 'command-feedback' ? laneView.error ?? '' : '';
   }
 
   const preampChoices = (): readonly number[] => rf?.preValues ?? [];

--- a/frontend/src/semantic/RfFrontEndInstrumentHost.svelte
+++ b/frontend/src/semantic/RfFrontEndInstrumentHost.svelte
@@ -354,6 +354,8 @@
 
   const preampChoices = (): readonly number[] => rf?.preValues ?? [];
   const attenuatorChoices = (): readonly number[] => rf?.attValues ?? [];
+  const preampChoiceText = (value: number): string => value === 0 ? 'OFF' : `P${value}`;
+  const attenuatorChoiceText = (value: number): string => value === 0 ? 'OFF' : `${value} dB`;
   const preampBehavior = bindChoiceInstrument<number>(() => ({
     field: rf?.preamp, choices: preampChoices(), blocked: preMutex !== null,
     invoke: (level) => onPreChange?.(level),
@@ -374,7 +376,7 @@
   const preampSeat = createChoiceRendererSeat<number>(() => ({
     context: rendererContext ?? null, field: rf?.preamp, label: 'Preamp', blocked: preMutex !== null,
     options: preampChoices().map((value) => ({
-      value, label: String(value),
+      value, label: preampChoiceText(value),
       ...(preampMutexReason() === undefined ? {} : { disabledReason: preampMutexReason() }),
     })),
     ...(pendingPreamp === null ? {} : {
@@ -384,7 +386,7 @@
   }));
   const attenuatorSeat = createChoiceRendererSeat<number>(() => ({
     context: rendererContext ?? null, field: rf?.attenuator, label: 'Attenuator',
-    options: attenuatorChoices().map((value) => ({ value, label: `${value} dB` })),
+    options: attenuatorChoices().map((value) => ({ value, label: attenuatorChoiceText(value) })),
     invoke: (db) => onAttChange?.(db),
   }));
   const digiSelSeat = createToggleRendererSeat(() => ({
@@ -438,14 +440,16 @@
     data-sql-command-phase={view.lanes.sql.phase ?? undefined}
     aria-busy={view.busy}
   >
-    <span class="rf-front-end-name">RF/SQL</span>
-    {#key rendererEpoch}
-      <DualParamRenderer binding={pair} showValues={false}
-        issuedStatusPresentation={pairIssuedStatus} />
-    {/key}
-    <output data-testid="rf-front-end-rf-sql-rf-value">{valueText(pairLaneValue(view, 'rf'))}</output>
-    /
-    <output data-testid="rf-front-end-rf-sql-sql-value">{valueText(pairLaneValue(view, 'sql'))}</output>
+    <div class="rf-front-end-heading">
+      <span class="rf-front-end-reading">RF <output data-testid="rf-front-end-rf-sql-rf-value">{valueText(pairLaneValue(view, 'rf'))}</output></span>
+      <span class="rf-front-end-reading">SQL <output data-testid="rf-front-end-rf-sql-sql-value">{valueText(pairLaneValue(view, 'sql'))}</output></span>
+    </div>
+    <div class="rf-front-end-slider">
+      {#key rendererEpoch}
+        <DualParamRenderer binding={pair} showValues={false}
+          issuedStatusPresentation={pairIssuedStatus} />
+      {/key}
+    </div>
     {#each PAIR_LANES as lane (lane)}
       {@const currentStatus = pairStatus(view, lane)}
       {#if currentStatus !== ''}
@@ -469,15 +473,18 @@
       data-command-phase={view.phase ?? undefined}
       aria-busy={view.busy}
     >
-      <span class="rf-front-end-name">{label}</span>
-      {#key rendererEpoch}
-        <ValueControl
-          {...feedbackIntegratedControl}
-          binding={binding} {label} renderer="hbar" showLabel={false} showValue={false} compact={true}
-          displayFn={valueText} issuedStatusPresentation={scalarIssuedStatuses[field]}
-        />
-      {/key}
-      <output>{valueText(scalarValue(view))}</output>
+      <div class="rf-front-end-heading">
+        <span class="rf-front-end-reading">{label} <output>{valueText(scalarValue(view))}</output></span>
+      </div>
+      <div class="rf-front-end-slider">
+        {#key rendererEpoch}
+          <ValueControl
+            {...feedbackIntegratedControl}
+            binding={binding} {label} renderer="hbar" showLabel={false} showValue={false} compact={true}
+            displayFn={valueText} issuedStatusPresentation={scalarIssuedStatuses[field]}
+          />
+        {/key}
+      </div>
       {#if currentStatus !== ''}
         <output data-testid={`rf-front-end-${field}-status`}>{currentStatus}</output>
       {/if}
@@ -503,17 +510,24 @@
         data-preamp-status={pendingPreamp !== null ? 'pending' : 'confirmed'}
         aria-describedby={pendingPreamp !== null ? pendingPreampId : undefined}
       >
-        {#each rf.preValues as value (value)}
-          <button
-            type="button" role="radio" class="rf-front-end-choice"
-            data-testid={`rf-front-end-preamp-${value}`}
-            aria-checked={preampBehavior.isSelected(value)}
-            data-pending={pendingPreamp === value}
-            disabled={!preampBehavior.available}
-            onclick={() => preampBehavior.invoke(value)}
-          >{value}</button>
-        {/each}
-        <output data-testid="rf-front-end-preamp-value">{finiteText(rf.preamp)}</output>
+        <span class="rf-front-end-row-label">PRE</span>
+        <div class="rf-front-end-choices">
+          {#each rf.preValues as value (value)}
+            <button
+              type="button" role="radio" class="rf-front-end-choice"
+              data-testid={`rf-front-end-preamp-${value}`}
+              aria-checked={preampBehavior.isSelected(value)}
+              data-pending={pendingPreamp === value}
+              disabled={!preampBehavior.available}
+              onclick={() => preampBehavior.invoke(value)}
+            >{preampChoiceText(value)}</button>
+          {/each}
+        </div>
+        {#if rf.preamp.reading.status !== 'known'}
+          <output class="rf-front-end-unknown" aria-label="PRE value" data-testid="rf-front-end-preamp-value">?</output>
+        {:else}
+          <output class="sr-only" aria-label="PRE value" data-testid="rf-front-end-preamp-value">{preampChoiceText(rf.preamp.reading.value)}</output>
+        {/if}
         {#if preMutex}
           <p data-testid="rf-front-end-preamp-mutex-reason">{DISABLED_REASON_LABEL[preMutex.code]}</p>
         {/if}
@@ -536,16 +550,23 @@
         class="rf-front-end-row" role="radiogroup" aria-label="Attenuator"
         data-testid="rf-front-end-attenuator" data-observed={usable(rf.attenuator)}
       >
-        {#each rf.attValues as value (value)}
-          <button
-            type="button" role="radio" class="rf-front-end-choice"
-            data-testid={`rf-front-end-attenuator-${value}`}
-            aria-checked={attenuatorBehavior.isSelected(value)}
-            disabled={!attenuatorBehavior.available}
-            onclick={() => attenuatorBehavior.invoke(value)}
-          >{value} dB</button>
-        {/each}
-        <output data-testid="rf-front-end-attenuator-value">{finiteText(rf.attenuator)}</output>
+        <span class="rf-front-end-row-label">ATT</span>
+        <div class="rf-front-end-choices">
+          {#each rf.attValues as value (value)}
+            <button
+              type="button" role="radio" class="rf-front-end-choice"
+              data-testid={`rf-front-end-attenuator-${value}`}
+              aria-checked={attenuatorBehavior.isSelected(value)}
+              disabled={!attenuatorBehavior.available}
+              onclick={() => attenuatorBehavior.invoke(value)}
+            >{attenuatorChoiceText(value)}</button>
+          {/each}
+        </div>
+        {#if rf.attenuator.reading.status !== 'known'}
+          <output class="rf-front-end-unknown" aria-label="ATT value" data-testid="rf-front-end-attenuator-value">?</output>
+        {:else}
+          <output class="sr-only" aria-label="ATT value" data-testid="rf-front-end-attenuator-value">{attenuatorChoiceText(rf.attenuator.reading.value)}</output>
+        {/if}
       </div>
     {/if}
   {/if}
@@ -588,11 +609,18 @@
 {/each}
 
 <style>
-  .rf-front-end-level { display: flex; align-items: baseline; gap: 0.5rem; }
-  .rf-front-end-name { min-width: 6ch; }
+  .rf-front-end-level { display: grid; grid-template-columns: minmax(0, 1fr); gap: 0.25rem; min-width: 0; }
+  .rf-front-end-heading { grid-column: 1 / -1; display: flex; justify-content: space-between; gap: 1rem; min-width: 0; }
+  .rf-front-end-reading { color: var(--v2-text-dim); font-size: 9px; text-transform: uppercase; }
+  .rf-front-end-reading output { color: var(--v2-text-primary); font-size: 10px; }
+  .rf-front-end-slider { grid-column: 1 / -1; width: 100%; min-width: 0; }
   .rf-front-end-level :global(.vc-hbar),
   .rf-front-end-level :global(.vc-dual) { width: 100%; min-width: 0; }
-  .rf-front-end-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin: 0; }
+  .rf-front-end-row { display: grid; grid-template-columns: 34px minmax(0, 1fr); align-items: center; gap: 0.5rem; margin: 0; min-width: 0; }
+  .rf-front-end-row-label { color: var(--v2-text-dim); font-size: 11px; font-weight: 700; letter-spacing: 0.06em; }
+  .rf-front-end-choices { display: flex; flex-wrap: wrap; gap: 4px; min-width: 0; }
+  .rf-front-end-choices > button { flex: 1 1 4.5ch; }
+  .rf-front-end-unknown { grid-column: 2; color: var(--v2-text-primary); }
   .rf-front-end-choice[aria-checked='true'] { font-weight: 700; }
   [data-observed='false'] { font-style: italic; }
   button:disabled { cursor: not-allowed; }

--- a/frontend/src/semantic/RfFrontEndInstrumentHost.svelte
+++ b/frontend/src/semantic/RfFrontEndInstrumentHost.svelte
@@ -523,10 +523,10 @@
             >{preampChoiceText(value)}</button>
           {/each}
         </div>
-        {#if rf.preamp.reading.status !== 'known'}
-          <output class="rf-front-end-unknown" aria-label="PRE value" data-testid="rf-front-end-preamp-value">?</output>
-        {:else}
+        {#if rf.preamp.reading.status === 'known' && rf.preValues.includes(rf.preamp.reading.value)}
           <output class="sr-only" aria-label="PRE value" data-testid="rf-front-end-preamp-value">{preampChoiceText(rf.preamp.reading.value)}</output>
+        {:else}
+          <output class="rf-front-end-unknown" aria-label="PRE value" data-testid="rf-front-end-preamp-value">{rf.preamp.reading.status === 'known' ? preampChoiceText(rf.preamp.reading.value) : '?'}</output>
         {/if}
         {#if preMutex}
           <p data-testid="rf-front-end-preamp-mutex-reason">{DISABLED_REASON_LABEL[preMutex.code]}</p>
@@ -562,10 +562,10 @@
             >{attenuatorChoiceText(value)}</button>
           {/each}
         </div>
-        {#if rf.attenuator.reading.status !== 'known'}
-          <output class="rf-front-end-unknown" aria-label="ATT value" data-testid="rf-front-end-attenuator-value">?</output>
-        {:else}
+        {#if rf.attenuator.reading.status === 'known' && rf.attValues.includes(rf.attenuator.reading.value)}
           <output class="sr-only" aria-label="ATT value" data-testid="rf-front-end-attenuator-value">{attenuatorChoiceText(rf.attenuator.reading.value)}</output>
+        {:else}
+          <output class="rf-front-end-unknown" aria-label="ATT value" data-testid="rf-front-end-attenuator-value">{rf.attenuator.reading.status === 'known' ? attenuatorChoiceText(rf.attenuator.reading.value) : '?'}</output>
         {/if}
       </div>
     {/if}

--- a/frontend/src/semantic/RfFrontEndSurface.svelte
+++ b/frontend/src/semantic/RfFrontEndSurface.svelte
@@ -49,13 +49,6 @@
 
 {#if rf}
   <section class="rf-front-end-surface" data-testid="rf-front-end-surface" aria-label="RF front end">
-    {#if finiteLayout}
-      {@render finiteLayout(levelHandles)}
-    {:else}
-      {@render levelHandles.preamp()}
-      {@render levelHandles.attenuator()}
-    {/if}
-
     {#if levelHandles.kind === 'combined'}
       {@render levelHandles.rfSql()}
     {:else}
@@ -63,7 +56,11 @@
       {#if rf.squelch.availability.structural}{@render levelHandles.squelch()}{/if}
     {/if}
 
-    {#if !finiteLayout}
+    {#if finiteLayout}
+      {@render finiteLayout(levelHandles)}
+    {:else}
+      {@render levelHandles.attenuator()}
+      {@render levelHandles.preamp()}
       {@render levelHandles.digiSel()}
       {@render levelHandles.ipPlus()}
     {/if}

--- a/frontend/src/semantic/__tests__/RfFrontEndInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/RfFrontEndInstrumentHost.isolated.test.ts
@@ -402,8 +402,7 @@ describe('RfFrontEndInstrumentHost', () => {
     const statuses = () => target.querySelectorAll<HTMLElement>('[data-control-feedback-status]');
     expect(statuses()).toHaveLength(1);
     expect(statuses()[0].textContent).toContain('Awaiting confirmation: 0.75');
-    expect(target.querySelector('[data-testid="rf-front-end-rf-sql-rf-status"]')?.textContent)
-      .toContain('requested 75%; confirmed 50%');
+    expect(target.querySelector('[data-testid="rf-front-end-rf-sql-rf-status"]')).toBeNull();
 
     r.props.layout = 'independent'; flushSync();
     expect(statuses()).toHaveLength(1);
@@ -423,7 +422,7 @@ describe('RfFrontEndInstrumentHost', () => {
     expect(statuses()).toHaveLength(1);
     expect(statuses()[0].textContent).toContain('Failed: 0.4: denied');
     expect(target.querySelector('[data-testid="rf-front-end-rfGain-status"]')?.textContent)
-      .toContain('requested 40%; confirmed 50%; denied');
+      .toBe('denied');
 
     r.props.layout = 'independent'; flushSync();
     expect(statuses()).toHaveLength(1);

--- a/frontend/src/semantic/__tests__/RfFrontEndInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/RfFrontEndInstrumentHost.isolated.test.ts
@@ -372,16 +372,19 @@ describe('RfFrontEndInstrumentHost', () => {
     const slider = () => group().querySelector<HTMLElement>('[role="slider"]')!;
     expect(group().dataset.feedbackIntegration).toBe('compatibility-reading');
     expect(group().textContent).toContain('100%');
+    expect(slider().closest('.rf-front-end-slider')).not.toBeNull();
     expect(slider().getAttribute('aria-disabled')).toBe('false');
 
     r.setFeedback(null); flushSync();
     expect(group().dataset.feedbackIntegration).toBe('authority-unresolved');
-    expect(group().textContent).toContain('? / ?');
+    expect(group().textContent).toContain('RF ?');
+    expect(group().textContent).toContain('SQL ?');
     expect(slider().getAttribute('aria-disabled')).toBe('true');
 
     r.setFeedback(commandFeedback()); flushSync();
     expect(group().dataset.feedbackIntegration).toBe('command-feedback');
-    expect(group().textContent).toContain('50% / 20%');
+    expect(group().textContent).toContain('RF 50%');
+    expect(group().textContent).toContain('SQL 20%');
     expect(slider().getAttribute('aria-disabled')).toBe('false');
 
     r.setFeedback(commandFeedback({ rf: { availability: 'unavailable' } })); flushSync();
@@ -546,6 +549,15 @@ describe('RfFrontEndInstrumentHost finite handles (MOR-2425 RF-B)', () => {
     },
   );
 
+  it('presents capability-derived preamp and attenuator choices with operator labels', () => {
+    const r = renderFinite(finiteBase());
+    expect(r.el('preamp-0')?.textContent).toBe('OFF');
+    expect(r.el('preamp-1')?.textContent).toBe('P1');
+    expect(r.el('preamp-2')?.textContent).toBe('P2');
+    expect(r.el('attenuator-0')?.textContent).toBe('OFF');
+    expect(r.el('attenuator-6')?.textContent).toBe('6 dB');
+  });
+
   it.each([0, 6, 12, 18] as const)(
     'sends attenuator step %s dB exactly once, from a fresh mount, independent of the other buttons',
     (value) => {
@@ -675,15 +687,15 @@ describe('RfFrontEndInstrumentHost finite handles (MOR-2425 RF-B)', () => {
   /**
    * MOR-2425 review fix (non-blocking order note) — `RfFrontEndSurface
    * .svelte`'s grouped (non-`finiteLayout`) placement must keep the
-   * pre-existing `origin/main` order: preamp and attenuator before the
-   * level controls, DIGI-SEL/IP+ after. Exercises the REAL surface
+   * Standard panel order: the continuous RF/SQL controls first, followed by
+   * ATT, PRE, then the remaining capability-derived finite controls. Exercises the REAL surface
    * component via the fixture's `renderSurface` flag, not a bare mock.
    */
   it('renders the grouped surface controls in the documented order', () => {
     renderFinite(finiteBase(), { renderSurface: true });
     const documented = [
-      'rf-front-end-preamp', 'rf-front-end-attenuator', 'rf-front-end-rfGain',
-      'rf-front-end-squelch', 'rf-front-end-digiSel', 'rf-front-end-ipPlus',
+      'rf-front-end-rfGain', 'rf-front-end-squelch', 'rf-front-end-attenuator',
+      'rf-front-end-preamp', 'rf-front-end-digiSel', 'rf-front-end-ipPlus',
     ];
     const order = [...target.querySelectorAll<HTMLElement>('[data-testid]')]
       .map((node) => node.dataset.testid)

--- a/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
@@ -297,7 +297,7 @@ describe('preamp and attenuator render as choice groups from the capability-deri
     for (const value of [0, 1, 2]) {
       expect(r.el(`preamp-${value}`)!.getAttribute('aria-checked')).toBe(String(value === 2));
     }
-    expect(r.text('preamp-value')).toBe('2');
+    expect(r.text('preamp-value')).toBe('P2');
     r.dispose();
   });
 
@@ -314,7 +314,9 @@ describe('preamp and attenuator render as choice groups from the capability-deri
     const onPreampChange = vi.fn();
     const r = render(withRf({ preamp: known(3) }), { onPreampChange });
     for (const value of [0, 1, 2]) expect(r.el(`preamp-${value}`)!.getAttribute('aria-checked')).toBe('false');
-    expect(r.text('preamp-value')).toBe('3');
+    const unmatched = r.el('preamp-value')!;
+    expect(unmatched.textContent).toBe('P3');
+    expect(unmatched.classList.contains('sr-only')).toBe(false);
     r.el('preamp-1')!.click();
     flushSync();
     expect(onPreampChange).toHaveBeenCalledExactlyOnceWith(1);
@@ -329,6 +331,17 @@ describe('preamp and attenuator render as choice groups from the capability-deri
     r.el('attenuator-18')!.click();
     flushSync();
     expect(onAttenuatorChange).toHaveBeenCalledExactlyOnceWith(18);
+    r.dispose();
+  });
+
+  it('keeps a known out-of-offered attenuator reading visible without selecting an offered step', () => {
+    const r = render(withRf({ attenuator: known(30) }));
+    for (const value of [0, 6, 12, 18]) {
+      expect(r.el(`attenuator-${value}`)!.getAttribute('aria-checked')).toBe('false');
+    }
+    const unmatched = r.el('attenuator-value')!;
+    expect(unmatched.textContent).toBe('30 dB');
+    expect(unmatched.classList.contains('sr-only')).toBe(false);
     r.dispose();
   });
 });
@@ -879,10 +892,12 @@ describe('pending-target affordance (MOR-1441 leg 2)', () => {
 
   it('renders a screen-reader announcement only while pending', () => {
     const pending = render(base(), { pendingPreamp: 1 });
-    expect(pending.el('preamp')!.querySelector('.sr-only')).not.toBeNull();
+    const describedBy = pending.el('preamp')!.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(pending.el('preamp')!.querySelector(`#${describedBy}`)).not.toBeNull();
     pending.dispose();
     const confirmed = render(base());
-    expect(confirmed.el('preamp')!.querySelector('.sr-only')).toBeNull();
+    expect(confirmed.el('preamp')!.getAttribute('aria-describedby')).toBeNull();
     confirmed.dispose();
   });
 

--- a/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
@@ -434,6 +434,7 @@ describe('RF gain and squelch render as 0..1 sliders, no rescale', () => {
     expect(rfInput.value()).toBe(0.5);
     expect(rfInput.range()).toEqual(['0', '1']);
     expect(rfGroup.querySelector('output')?.textContent).toBe('75%');
+    expect(r.el('rfGain-status')).toBeNull();
     expect(rfInput.disabled()).toBe(false);
     expect(sqlGroup.dataset.commandPhase).toBe('unavailable');
     expect(sqlGroup.dataset.observed).toBe('false');
@@ -627,7 +628,7 @@ describe('the combined RF/SQL knob (controlModel="combined")', () => {
     r.dispose();
   });
 
-  it('renders independent lane phases, errors, busy state, and announcements', () => {
+  it('keeps routine lane phases out of view while showing concise failures and announcements', () => {
     const values = new SvelteMap<string, PairFeedback>([['feedback', pairFeedback()]]);
     const publication = rfTestAuthorityPublication('combined');
     target = document.createElement('div'); document.body.appendChild(target);
@@ -652,12 +653,12 @@ describe('the combined RF/SQL knob (controlModel="combined")', () => {
     expect(group.dataset.rfCommandPhase).toBe('confirmed');
     expect(group.dataset.sqlCommandPhase).toBe('failed');
     expect(group.getAttribute('aria-busy')).toBe('false');
-    expect(group.querySelector('[data-testid="rf-front-end-rf-sql-rf-status"]')?.textContent)
-      .toContain('confirmed; requested 50%; confirmed 50%');
+    expect(group.querySelector('[data-testid="rf-front-end-rf-sql-rf-status"]')).toBeNull();
     expect(group.querySelector('[data-testid="rf-front-end-rf-sql-sql-status"]')?.textContent)
-      .toContain('failed; requested 40%; confirmed 20%');
+      .toBe('denied');
     expect(target.querySelectorAll('[data-control-feedback-status]')).toHaveLength(2);
-    expect(group.textContent).toContain('denied');
+    expect(group.textContent).not.toContain('requested');
+    expect(group.textContent).not.toContain('confirmed;');
     unmount(component); target.remove();
   });
 
@@ -668,8 +669,7 @@ describe('the combined RF/SQL knob (controlModel="combined")', () => {
     } });
     const r = render(base(), { controlModel: 'combined', rfSqlFeedback: feedback });
     expect(r.text('rf-sql-rf-value')).toBe('75%');
-    expect(r.text('rf-sql-rf-status'))
-      .toContain('awaiting confirmation; requested 75%; confirmed 50%');
+    expect(r.el('rf-sql-rf-status')).toBeNull();
     expect(r.el('rf-sql')!.getAttribute('aria-busy')).toBe('true');
     r.dispose();
   });


### PR DESCRIPTION
Fixes MOR-2448. Standard's RF/SQL slider was squeezed into a narrow grid column, after unlabeled ATT/PRE controls and duplicate raw readings. The panel now puts full-width levels first, followed by labeled ATT and PRE rows with OFF/dB and OFF/Pn choices. Choices and control presence still come from radio capabilities; supported unknown readings remain visibly unknown and disabled. Known readings outside the offered choices remain visible without selecting a false match.

Routine requested/confirmed status prose no longer appears below RF controls; actual error text and accessible lifecycle announcements remain.

The existing instrument bindings, command ownership, pending feedback and preamp mutex are unchanged. IP+ acquisition on IC-7300 is tracked separately as MOR-2449.

Validation: 195 focused tests across four files passed on Mac mini, as did Svelte/TypeScript check, changed-file ESLint and production build. Browser preview against the live IC-7300 backend confirmed the narrow sidebar layout, RF/SQL values, ATT OFF/20 dB, PRE OFF/P1/P2, disabled unknown IP+ and absent DIGI-SEL. No radio control commands were issued during visual verification.
