### PR TITLE
fix(ui): restore capability-driven MOD IN selector (MOR-2451)

### DIFF
--- a/frontend/fixtures/stubs/panel-adapters.ts
+++ b/frontend/fixtures/stubs/panel-adapters.ts
@@ -136,6 +136,10 @@ export function getDataModeArmed(): { armed: false; value: null } {
   return { armed: false, value: null };
 }
 
+export function getModInputArmed(): { armed: false; value: null } {
+  return { armed: false, value: null };
+}
+
 /**
  * MOR-2425 — `SemanticRadioSurfaces.svelte` now also imports
  * `deriveMemoryPanelProps`/`getMemoryHandlers` unconditionally (same

--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
@@ -299,6 +299,7 @@ describe('MobileRadioLayout structure', () => {
     vi.mocked(getCapabilities).mockReturnValue({
       ...oldCaps, model: 'fixture', receivers: 1, vfoScheme: 'ab',
       capabilities: ['mod_input_routing'],
+      dataModeCount: 1,
       dataModeInputs: MOD_INPUT_SOURCES.map(({ value, label }) => ({ value, label })),
     } as Capabilities);
     const fresh = { storePath: 'fixture', observed: true, freshness: 'fresh', availability: 'available' };

--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
@@ -299,6 +299,7 @@ describe('MobileRadioLayout structure', () => {
     vi.mocked(getCapabilities).mockReturnValue({
       ...oldCaps, model: 'fixture', receivers: 1, vfoScheme: 'ab',
       capabilities: ['mod_input_routing'],
+      dataModeInputs: MOD_INPUT_SOURCES.map(({ value, label }) => ({ value, label })),
     } as Capabilities);
     const fresh = { storePath: 'fixture', observed: true, freshness: 'fresh', availability: 'available' };
     (radio as unknown as { current: ServerState | null }).current = {

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -2510,6 +2510,7 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
   it('restores capability-driven MODE hardware keys and keeps FILTER in a sibling panel', () => {
     const renderModePanel = (
       modes: string[], dataModeCount?: number, dataModeLabels?: Record<string, string>, observed = true,
+      dataModeInputs?: { value: number; label: string }[], dataMode = 0,
     ) => {
       h.caps = {
         ...(capsFor('2/main_sub') as object), modes, filters: ['FIL1', 'FIL2', 'FIL3'],
@@ -2517,17 +2518,21 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
           'scope', 'audio', 'tx', 'dual_rx', 'filter_shape',
           ...(dataModeCount === undefined ? [] : ['data_mode']),
         ],
-        ...(dataModeCount === undefined ? {} : { dataModeCount, dataModeLabels }),
+        ...(dataModeCount === undefined ? {} : { dataModeCount, dataModeLabels, dataModeInputs }),
       } as Capabilities;
       const state = liveState() as { main: Record<string, unknown>; fieldStatus: Record<string, unknown> };
-      const fieldStatus: Record<string, unknown> = { ...state.fieldStatus, 'main.dataMode': fresh };
+      const modInputKey = ['dataOffModInput', 'data1ModInput', 'data2ModInput', 'data3ModInput'][dataMode]!;
+      const fieldStatus: Record<string, unknown> = {
+        ...state.fieldStatus, 'main.dataMode': fresh, [modInputKey]: fresh,
+      };
       if (!observed) {
         const missing = { storePath: 'x', observed: false, freshness: 'unknown', availability: 'missing' };
         fieldStatus['main.mode'] = missing;
         fieldStatus['main.dataMode'] = missing;
+        fieldStatus[modInputKey] = missing;
       }
       h.state = {
-        ...state, main: { ...state.main, dataMode: 0 },
+        ...state, main: { ...state.main, dataMode }, [modInputKey]: 0,
         fieldStatus,
       };
       const target = render('desktop-v2');
@@ -2535,12 +2540,24 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
       const filter = target.querySelector('[data-panel-id="semantic-filter-controls"]')!;
       return { mode, filter,
         modes: texts(mode, '[data-testid="standard-mode-choices"] button'),
-        data: texts(mode, '[data-testid="standard-data-mode"] button') };
+        data: texts(mode, '[data-testid="standard-data-mode"] button'),
+        modInputs: texts(mode, '[data-testid="mod-input-select"] option') };
     };
+
+    const ic7300Inputs = [
+      { value: 0, label: 'MIC' }, { value: 1, label: 'ACC' },
+      { value: 2, label: 'MIC+ACC' }, { value: 3, label: 'USB' },
+      { value: 4, label: 'MIC+USB' },
+    ];
+    const ic7610Inputs = [
+      { value: 0, label: 'MIC' }, { value: 1, label: 'ACC' },
+      { value: 3, label: 'USB' }, { value: 5, label: 'LAN' },
+      { value: 2, label: 'MIC+ACC' }, { value: 4, label: 'MIC+USB' },
+    ];
 
     const ic7610 = renderModePanel(
       ['FM', 'PSK-R', 'RTTY', 'LSB', 'CW-R', 'AM', 'USB', 'PSK', 'CW', 'RTTY-R'],
-      3, { '0': 'OFF', '1': 'D1', '2': 'D2', '3': 'D3' },
+      3, { '0': 'OFF', '1': 'D1', '2': 'D2', '3': 'D3' }, true, ic7610Inputs, 3,
     );
     expect(ic7610.mode.querySelector('.panel-header .title')?.textContent).toBe('MODE');
     expect(ic7610.filter.querySelector('.panel-header .title')?.textContent).toBe('FILTER');
@@ -2548,6 +2565,7 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
       'USB', 'LSB', 'CW', 'CW-R', 'RTTY', 'RTTY-R', 'PSK', 'PSK-R', 'AM', 'FM',
     ]);
     expect(ic7610.data).toEqual(['OFF', 'D1', 'D2', 'D3']);
+    expect(ic7610.modInputs).toEqual(['MIC', 'ACC', 'USB', 'LAN', 'MIC+ACC', 'MIC+USB']);
     expect(ic7610.mode.querySelectorAll('[data-surface="hardware"]')).toHaveLength(14);
     for (const id of ['filter-select', 'filter-shape', 'filter-width', 'filter-pbtInner']) {
       expect(ic7610.mode.querySelector(`[data-testid="${id}"]`), id).toBeNull();
@@ -2566,11 +2584,12 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
 
     const ic7300 = renderModePanel(
       ['USB', 'LSB', 'CW', 'CW-R', 'RTTY', 'RTTY-R', 'AM', 'FM'],
-      1, { '0': 'OFF', '1': 'DATA' },
+      1, { '0': 'OFF', '1': 'DATA' }, true, ic7300Inputs, 1,
     );
     expect(ic7300.modes).not.toContain('PSK');
     expect(ic7300.modes).not.toContain('PSK-R');
     expect(ic7300.data).toEqual(['OFF', 'DATA']);
+    expect(ic7300.modInputs).toEqual(['MIC', 'ACC', 'MIC+ACC', 'USB', 'MIC+USB']);
 
     const yaesu = renderModePanel([
       'FM-N', 'DATA-FM', 'RTTY-U', 'CW-L', 'USB', 'LSB', 'CW-U', 'RTTY-L',
@@ -2581,13 +2600,19 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
       'DATA-U', 'DATA-L', 'DATA-FM', 'AM', 'FM', 'FM-N',
     ]);
     expect(yaesu.mode.querySelector('[data-testid="standard-data-mode"]')).toBeNull();
+    expect(yaesu.mode.querySelector('[data-testid="mod-input-select"]')).toBeNull();
 
-    const unknown = renderModePanel(['USB', 'LSB'], 1, { '0': 'OFF', '1': 'DATA' }, false);
+    const unknown = renderModePanel(
+      ['USB', 'LSB'], 1, { '0': 'OFF', '1': 'DATA' }, false, ic7300Inputs,
+    );
     expect(unknown.mode.querySelectorAll('[data-testid="standard-mode-choices"] button:not(:disabled)'), 'mode')
       .toHaveLength(0);
     expect(unknown.mode.querySelectorAll('[data-testid="standard-data-mode"] button:not(:disabled)'), 'data')
       .toHaveLength(0);
     expect(unknown.mode.querySelector('[aria-pressed="true"]')).toBeNull();
+    const unknownInput = unknown.mode.querySelector<HTMLSelectElement>('[data-testid="mod-input-select"]')!;
+    expect(unknownInput.disabled).toBe(true);
+    expect(unknownInput.value).toBe('');
   });
 
   it('groups both bare CW instruments inside the one movable CW shell', () => {

--- a/frontend/src/components-v2/panels/ModePanel.svelte
+++ b/frontend/src/components-v2/panels/ModePanel.svelte
@@ -4,7 +4,6 @@
   import {
     deriveModeProps, getModeHandlers, getModeArmed, getDataModeArmed,
   } from '$lib/runtime/adapters/panel-adapters';
-  import { MOD_INPUT_SOURCES } from '$lib/radio/mod-input';
   import { t } from '$lib/i18n';
 
   const handlers = getModeHandlers();
@@ -43,6 +42,7 @@
   let dataModeLabels = $derived(p.dataModeLabels ?? { '0': 'OFF', '1': 'D1', '2': 'D2', '3': 'D3' });
   // MOR-616: MOD-input source of the active DATA group (null until read).
   let modInputSource = $derived(p.modInputSource ?? null);
+  let modInputChoices = $derived(p.modInputChoices ?? []);
   let hasModInput = $derived(p.hasModInput ?? false);
   const onModeChange = handlers.onModeChange;
   const onDataModeChange = handlers.onDataModeChange;
@@ -161,12 +161,13 @@
           aria-label={t('core.modePanel.modInputAria')}
           title={t('core.modePanel.modInputAria')}
           value={modInputSource === null ? '' : String(modInputSource)}
+          disabled={modInputSource === null}
           onchange={(e) => onModInputChange(Number(e.currentTarget.value))}
         >
           {#if modInputSource === null}
             <option value="" disabled>—</option>
           {/if}
-          {#each MOD_INPUT_SOURCES as option (option.value)}
+          {#each modInputChoices as option (option.value)}
             <option value={String(option.value)}>{option.label}</option>
           {/each}
         </select>

--- a/frontend/src/components-v2/panels/__tests__/ModePanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/ModePanel.isolated.test.ts
@@ -37,6 +37,11 @@ const mockProps = {
   dataModeCount: 3,
   dataModeLabels: { '0': 'OFF', '1': 'D1', '2': 'D2', '3': 'D3' } as Record<string, string>,
   modInputSource: null as number | null,
+  modInputChoices: [
+    { value: 0, label: 'MIC' }, { value: 1, label: 'ACC' },
+    { value: 2, label: 'MIC+ACC' }, { value: 3, label: 'USB' },
+    { value: 4, label: 'MIC+USB' }, { value: 5, label: 'LAN' },
+  ],
   hasModInput: false,
 };
 
@@ -89,6 +94,11 @@ beforeEach(() => {
   mockProps.dataModeCount = 3;
   mockProps.dataModeLabels = { '0': 'OFF', '1': 'D1', '2': 'D2', '3': 'D3' };
   mockProps.modInputSource = null;
+  mockProps.modInputChoices = [
+    { value: 0, label: 'MIC' }, { value: 1, label: 'ACC' },
+    { value: 2, label: 'MIC+ACC' }, { value: 3, label: 'USB' },
+    { value: 4, label: 'MIC+USB' }, { value: 5, label: 'LAN' },
+  ];
   mockProps.hasModInput = false;
   mockHandlers.onModeChange = vi.fn();
   mockHandlers.onDataModeChange = vi.fn();
@@ -317,11 +327,20 @@ describe('ModePanel', () => {
       expect(labels).toEqual(['MIC', 'ACC', 'MIC+ACC', 'USB', 'MIC+USB', 'LAN']);
     });
 
+    it('renders only the declared IC-7300 domain and hides when it is absent', () => {
+      const choices = mockProps.modInputChoices.slice(0, 5);
+      const target = mountPanel({ hasModInput: true, modInputSource: 4, modInputChoices: choices });
+      expect(Array.from(modInputSelect(target)!.options).map(option => option.text))
+        .toEqual(['MIC', 'ACC', 'MIC+ACC', 'USB', 'MIC+USB']);
+      expect(modInputSelect(mountPanel({ hasModInput: false, modInputChoices: [] }))).toBeNull();
+    });
+
     it('shows an empty placeholder before the first readback', () => {
       const target = mountPanel({ hasModInput: true, modInputSource: null });
       const select = modInputSelect(target);
       expect(select).not.toBeNull();
       expect(select!.value).toBe('');
+      expect(select!.disabled).toBe(true);
     });
 
     it('is hidden when the radio does not expose MOD-input routing', () => {

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -57,7 +57,7 @@
     getTxAuxControlFeedback, type TxAuxControlFeedbackField,
     getPendingFrequencyHz,
     getPendingFilterSelection, getPendingNbOn, getPendingNrOn, getPendingPreampLevel,
-    getSystemHandlers, getDataModeArmed,
+    getSystemHandlers, getDataModeArmed, getModInputArmed,
     deriveMemoryPanelProps, getMemoryHandlers,
   } from '$lib/runtime/adapters/panel-adapters';
   import { toRitXitProps } from '$lib/runtime/props/panel-props';
@@ -1530,6 +1530,8 @@
   ) as unknown as TxAuxLevelFeedback);
   let dataModeArmed = $derived(getDataModeArmed());
   let pendingDataMode = $derived(dataModeArmed.armed ? dataModeArmed.value : null);
+  let modInputArmed = $derived(getModInputArmed());
+  let pendingModInput = $derived(modInputArmed.armed ? modInputArmed.value : null);
   let pendingPreamp = $derived(
     activeReceiverIndex === null ? null : getPendingPreampLevel(activeReceiverIndex),
   );
@@ -1749,11 +1751,12 @@
   {#snippet children(rfFrontEndInstruments)}
   {#snippet vfoInstrumentComposition(vfoOperations: VfoOperationHandles)}
   <FilterInstrumentHost
-    {...filterFiniteRendererSelection} {view} {pendingFilter} {pendingDataMode}
+    {...filterFiniteRendererSelection} {view} {pendingFilter} {pendingDataMode} {pendingModInput}
     onModeChange={filterIntents.onModeChange}
     onFilterChange={filterIntents.onFilterChange}
     onFilterShapeChange={filterIntents.onFilterShapeChange}
     onDataModeChange={filterIntents.onDataModeChange}
+    onModInputChange={filterIntents.onModInputChange}
   >
   {#snippet children(filterInstruments)}
   <BandInstrumentHost

--- a/frontend/src/components-v2/wiring/__tests__/mod-input-wiring.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/mod-input-wiring.isolated.test.ts
@@ -11,6 +11,11 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+const h = vi.hoisted(() => ({
+  caps: { receivers: 1, dataModeCount: 3,
+    dataModeInputs: [0, 1, 2, 3, 4, 5].map(value => ({ value, label: String(value) })) },
+}));
+
 vi.mock('$lib/transport/ws-client', () => ({
   sendCommand: vi.fn(),
 }));
@@ -22,6 +27,10 @@ vi.mock('$lib/runtime/commands/radio-intents', async () => {
 vi.mock('$lib/stores/radio.svelte', () => ({
   getActiveReceiver: vi.fn(() => null),
   getRadioState: vi.fn(() => null),
+}));
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  capabilitiesMatchGeneration: vi.fn(() => true),
+  getCapabilities: vi.fn(() => h.caps),
 }));
 
 vi.mock('$lib/audio/audio-manager', () => ({
@@ -47,6 +56,8 @@ describe.each(factories)('%s onModInputChange (MOR-616)', (_name, makeHandlers) 
     vi.mocked(sendCommand).mockClear();
     vi.mocked(getActiveReceiver).mockReturnValue(null);
     vi.mocked(getRadioState).mockReturnValue(null);
+    h.caps = { receivers: 1, dataModeCount: 3,
+      dataModeInputs: [0, 1, 2, 3, 4, 5].map(value => ({ value, label: String(value) })) };
   });
 
   it('emits set_data_off_mod_input when DATA is off', () => {
@@ -78,6 +89,17 @@ describe.each(factories)('%s onModInputChange (MOR-616)', (_name, makeHandlers) 
   it('fails closed when no receiver state exists', () => {
     makeHandlers().onModInputChange(0);
 
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('rejects a source or DATA group outside the active profile domain', () => {
+    h.caps = { receivers: 1, dataModeCount: 1,
+      dataModeInputs: [0, 1, 2, 3, 4].map(value => ({ value, label: String(value) })) };
+    vi.mocked(getRadioState).mockReturnValue({ active: 'MAIN', main: {} } as never);
+    vi.mocked(getActiveReceiver).mockReturnValue({ dataMode: 0 } as never);
+    makeHandlers().onModInputChange(5);
+    vi.mocked(getActiveReceiver).mockReturnValue({ dataMode: 2 } as never);
+    makeHandlers().onModInputChange(3);
     expect(sendCommand).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
@@ -35,6 +35,7 @@ import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import type { ManagedAppTxController } from '$lib/runtime/tx-controller/managed-app-host';
 import type { RxAudioTargetSnapshot } from '$lib/stores/audio.svelte';
+import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
 
 
 const h = vi.hoisted(() => ({
@@ -232,10 +233,13 @@ const liveCaps = (tags: readonly string[]): Capabilities => ({
   model: 'fixture', scope: false, audio: tags.includes('audio'), tx: true,
   capabilities: tags, audioTxRequiredModInputSource: 5,
   receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: [], filters: [],
+  dataModeCount: 3,
+  dataModeInputs: MOD_INPUT_SOURCES.map(({ value, label }) => ({ value, label })),
   audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
   webrtc: { available: false, enabled: false },
   txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
   scopeSource: null, audioFftAvailable: false,
+  stateContractVersion: 1,
   providerGeneration: 1,
 } as unknown as Capabilities);
 
@@ -312,6 +316,7 @@ beforeEach(() => {
   h.txController = txHarness.controller;
   h.state = liveState();
   h.caps = liveCaps(AUDIO_TAGS);
+  expect(setCapabilities(h.caps as Capabilities)).toBe(true);
   h.audio = { muted: false, rxEnabled: true, volume: 42 };
   h.audioConnected = true;
   h.rxEnabled = true;
@@ -326,6 +331,7 @@ afterEach(() => {
   if (component) unmount(component);
   component = null;
   expect(h.authoritySubscribers.size).toBe(0);
+  clearCapabilities();
   expect(txHarness.listenerCount()).toBe(0);
   expect(txHarness.trace()).toEqual([]);
   document.body.innerHTML = '';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-vfo-indicator-wiring.component.test.ts
@@ -77,6 +77,7 @@ vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
     : group }),
   getSystemHandlers: () => ({ onSpeak: h.speak }),
   getDataModeArmed: () => ({ armed: false, value: null }),
+  getModInputArmed: () => ({ armed: false, value: null }),
   getBreakInDelayControlFeedback: () => null,
   getFilterWidthControlFeedback: h.filterWidthFeedback,
   getCwPitchControlFeedback: h.cwPitchFeedback,

--- a/frontend/src/lib/runtime/adapters/__tests__/mod-input-tx-guard.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mod-input-tx-guard.isolated.test.ts
@@ -46,7 +46,7 @@ import { sendCommand } from '$lib/transport/ws-client';
 import { dispatchRadioIntent } from '$lib/runtime/commands/radio-intents';
 import { runtime } from '$lib/runtime/frontend-runtime';
 import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
-import { setCapabilities } from '$lib/stores/capabilities.svelte';
+import { getCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
 import {
   armModInputTxGuard,
   deriveModInputTxGuardProps,
@@ -113,6 +113,8 @@ function setState(overrides: Record<string, unknown> = {}): void {
 function useDualReceiverCapabilities(): void {
   setCapabilities({
     capabilities: ['data_mode'],
+    dataModeCount: 3,
+    dataModeInputs: [0, 1, 2, 3, 4, 5].map(value => ({ value, label: String(value) })),
     receivers: 2,
     vfoScheme: 'main_sub',
     audioTx: true,
@@ -145,6 +147,8 @@ beforeEach(() => {
   resetRadioState();
   setCapabilities({
     capabilities: ['data_mode'],
+    dataModeCount: 3,
+    dataModeInputs: [0, 1, 2, 3, 4, 5].map(value => ({ value, label: String(value) })),
     audioTx: true,
     audioTxRoute: 'lan',
     audioTxRequiredModInputSource: 5,
@@ -345,6 +349,8 @@ describe('one-click Set LAN (MOR-617)', () => {
   it('dispatches the active group SET intent with source=5', () => {
     setState({ main: receiver(1), data1ModInput: 0 });
     armModInputTxGuard();
+
+    expect(getCapabilities()?.dataModeInputs?.some(option => option.value === 5)).toBe(true);
 
     getModInputTxGuardHandlers().onSetLan();
 

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1536-armed-adoption.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1536-armed-adoption.isolated.test.ts
@@ -69,7 +69,7 @@ vi.mock('$lib/runtime/adapters/radio-view-model-adapter', () => ({
 
 import {
   getAgcArmed, getFilterArmed, getPreampArmed, getAttenuatorArmed,
-  getDataModeArmed, getAutoNotchArmed, getManualNotchArmed,
+  getDataModeArmed, getModInputArmed, getAutoNotchArmed, getManualNotchArmed,
 } from '../panel-adapters';
 
 const actualCommandStore = await vi.importActual<typeof import('$lib/stores/commands.svelte')>(
@@ -104,6 +104,19 @@ const fixtures: Fixture[] = [
   { label: 'getAutoNotchArmed', accessor: getAutoNotchArmed, intentName: 'set_auto_notch', paramKey: 'on', confirmedField: 'autoNotch', target: true, otherTarget: false },
   { label: 'getManualNotchArmed', accessor: getManualNotchArmed, intentName: 'set_manual_notch', paramKey: 'on', confirmedField: 'manualNotch', target: true, otherTarget: false },
 ];
+
+describe('active DATA-group MOD input armed signal', () => {
+  it.each([
+    [0, 'set_data_off_mod_input', 'dataOffModInput'],
+    [3, 'set_data3_mod_input', 'data3ModInput'],
+  ] as const)('tracks DATA %i without inventing a receiver parameter', (dataMode, name, field) => {
+    runtimeState.state = { active: 'MAIN', main: { dataMode }, sub: {}, [field]: 0 } as FakeState;
+    state.commands = [{ name, status: 'pending', createdAt: 1, updatedAt: 1, params: { source: 3 } }];
+    expect(getModInputArmed()).toEqual({ armed: true, value: 3 });
+    state.commands[0]!.status = 'failed';
+    expect(getModInputArmed()).toEqual({ armed: false, value: null });
+  });
+});
 
 // MOR-1541: pin `ControlButton.svelte`'s import of the shared armed-state
 // CSS seat by its literal source string — a regression here (import

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1567-remainder-sweeper-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1567-remainder-sweeper-conformance.isolated.test.ts
@@ -95,11 +95,11 @@
  * real, fixture-relevant, mixed reading, not a hypothetical. The 4-case
  * table below mutates only `h.state.main.dataMode` (never the underlying
  * fixture file) to walk all four DATA groups' observation state through the
- * real handler, covering every group this fixture can reach — group 0's
- * refusal is the ACTUAL current-state behavior; groups 1-3's dispatches
- * confirm the handler resolves the right per-group command
- * (`set_data1_mod_input`/`set_data2_mod_input`/`set_data3_mod_input`) once
- * observed. This coverage is ADDITIVE — it claims no new name in
+ * real handler, covering every stored group while respecting the IC-7300's
+ * one-DATA-group capability — group 0's refusal is the ACTUAL current-state
+ * behavior; group 1 dispatches once observed; groups 2-3 refuse even when
+ * observed because this radio does not expose those DATA groups. This
+ * coverage is ADDITIVE — it claims no new name in
  * `claimed.ts` and changes no count, since these 4 names live outside the
  * 87-name universe by design (see header cited above).
  */
@@ -197,6 +197,8 @@ describe('IC-7300 fixture — remainder-sweeper family conformance (MOR-1567)', 
     h.caps = {
       ...fixtureCaps(profile),
       capabilities: [...fixtureCaps(profile).capabilities, 'speech'],
+      dataModeCount: 1,
+      dataModeInputs: [0, 1, 2, 3, 4].map(value => ({ value, label: String(value) })),
     };
     h.sendCommand.mockClear();
   });
@@ -305,9 +307,9 @@ describe('IC-7300 fixture — remainder-sweeper family conformance (MOR-1567)', 
       readonly frames: Array<[string, Record<string, unknown>]>;
     }> = [
       { dataMode: 0, stateKey: 'dataOffModInput', frames: [] },
-      { dataMode: 1, stateKey: 'data1ModInput', frames: [['set_data1_mod_input', { source: 5 }]] },
-      { dataMode: 2, stateKey: 'data2ModInput', frames: [['set_data2_mod_input', { source: 5 }]] },
-      { dataMode: 3, stateKey: 'data3ModInput', frames: [['set_data3_mod_input', { source: 5 }]] },
+      { dataMode: 1, stateKey: 'data1ModInput', frames: [['set_data1_mod_input', { source: 4 }]] },
+      { dataMode: 2, stateKey: 'data2ModInput', frames: [] },
+      { dataMode: 3, stateKey: 'data3ModInput', frames: [] },
     ];
 
     for (const g of GROUPS) {
@@ -316,7 +318,7 @@ describe('IC-7300 fixture — remainder-sweeper family conformance (MOR-1567)', 
       it(`dataMode=${g.dataMode} (${g.stateKey}, observed=${observed}): ${outcome}`, () => {
         expect(h.state?.main).toBeTruthy();
         h.state!.main!.dataMode = g.dataMode;
-        const run = () => makeModeHandlers().onModInputChange(5);
+        const run = () => makeModeHandlers().onModInputChange(4);
         if (g.frames.length > 0) {
           expectFrames(run, g.frames);
         } else {

--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -1121,7 +1121,9 @@ describe('RF gain additive display observation', () => {
       delete indicator.sMeter.source;
       delete indicator.sMeter.domain;
     }
-    const strictJson = JSON.stringify(legacyView, (key, value) => ['display', 'activeFilterConfiguration', 'dataModeChoices'].includes(key) ? undefined : value);
+    const strictJson = JSON.stringify(legacyView, (key, value) => [
+      'display', 'activeFilterConfiguration', 'dataModeChoices', 'modInputSource', 'modInputChoices',
+    ].includes(key) ? undefined : value);
     const digest = createHash('sha256').update(strictJson).digest('hex');
     // MOR-2425/R40+R41: ONE digest for both freshness values. Read off this
     // test's own failure diff for stale=true, not computed by hand.
@@ -1160,6 +1162,42 @@ describe('MOR-2374 shared DATA and filter configuration', () => {
     s.fieldStatus = { ...s.fieldStatus, 'main.dataMode': fresh, 'sub.dataMode': fresh };
     return s;
   }
+  const ic7300Inputs = [
+    { value: 0, label: 'MIC' }, { value: 1, label: 'ACC' },
+    { value: 2, label: 'MIC+ACC' }, { value: 3, label: 'USB' },
+    { value: 4, label: 'MIC+USB' },
+  ];
+  const ic7610Inputs = [
+    { value: 0, label: 'MIC' }, { value: 1, label: 'ACC' },
+    { value: 3, label: 'USB' }, { value: 5, label: 'LAN' },
+    { value: 2, label: 'MIC+ACC' }, { value: 4, label: 'MIC+USB' },
+  ];
+  it.each([
+    [0, 'dataOffModInput', 3], [1, 'data1ModInput', 4],
+  ] as const)('projects IC-7300 DATA group %i from %s with its exact source domain', (dataMode, key, source) => {
+    const s = state(); s.main.dataMode = dataMode; s[key] = source; s.fieldStatus![key] = fresh;
+    const fp = toRadioViewModel(s, dataCaps({ dataModeCount: 1, dataModeInputs: ic7300Inputs }))!.filterPassband!;
+    expect(fp.modInputChoices).toEqual(ic7300Inputs);
+    expect(fp.modInputChoices!.map(choice => choice.label)).not.toContain('LAN');
+    expect(fp.modInputSource!.reading).toEqual({ status: 'known', value: source });
+  });
+  it('projects IC-7610 D3 and preserves the profile source order including LAN', () => {
+    const s = state(); s.main.dataMode = 3; s.data3ModInput = 5; s.fieldStatus!.data3ModInput = fresh;
+    const fp = toRadioViewModel(s, dataCaps({ dataModeInputs: ic7610Inputs }))!.filterPassband!;
+    expect(fp.modInputChoices).toEqual(ic7610Inputs);
+    expect(fp.modInputSource!.reading).toEqual({ status: 'known', value: 5 });
+  });
+  it('fails closed for absent domains, undeclared fields, and unobserved values', () => {
+    const s = state(); s.dataOffModInput = 0;
+    expect(toRadioViewModel(s, dataCaps())!.filterPassband!.modInputSource!.availability.structural).toBe(false);
+    s.fieldStatus!.dataOffModInput = { ...fresh, availability: 'undeclared', observed: false };
+    expect(toRadioViewModel(s, dataCaps({ dataModeInputs: ic7300Inputs }))!.filterPassband!
+      .modInputSource!.availability.structural).toBe(false);
+    s.fieldStatus!.dataOffModInput = { ...fresh, availability: 'missing', observed: false };
+    const unknown = toRadioViewModel(s, dataCaps({ dataModeInputs: ic7300Inputs }))!.filterPassband!.modInputSource!;
+    expect(unknown.availability).toEqual({ structural: true, operational: false });
+    expect(unknown.reading).toEqual({ status: 'unknown' });
+  });
   it.each([0, 1, 3])('offers exactly 0..%i with canonical labels', (count) => {
     const model = toRadioViewModel(state(), dataCaps({ dataModeCount: count,
       dataModeLabels: { '0': 'OFF label', '1': 'Digital', '2': '  ', '9': 'stray' } }))!;

--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -1189,7 +1189,7 @@ describe('MOR-2374 shared DATA and filter configuration', () => {
   });
   it('fails closed for absent domains, undeclared fields, and unobserved values', () => {
     const s = state(); s.dataOffModInput = 0;
-    expect(toRadioViewModel(s, dataCaps())!.filterPassband!.modInputSource!.availability.structural).toBe(false);
+    expect(toRadioViewModel(s, dataCaps())!.filterPassband!.modInputSource).toBeUndefined();
     s.fieldStatus!.dataOffModInput = { ...fresh, availability: 'undeclared', observed: false };
     expect(toRadioViewModel(s, dataCaps({ dataModeInputs: ic7300Inputs }))!.filterPassband!
       .modInputSource!.availability.structural).toBe(false);

--- a/frontend/src/lib/runtime/adapters/__tests__/rx-audio-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/rx-audio-adapter.test.ts
@@ -38,6 +38,8 @@ function caps(overrides: Partial<Capabilities> = {}): Capabilities {
     webrtc: { available: false, enabled: false },
     txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
     scopeSource: 'hardware', audioFftAvailable: false,
+    dataModeCount: 3,
+    dataModeInputs: [0, 1, 2, 3, 4, 5].map(value => ({ value, label: String(value) })),
     audioTxRequiredModInputSource: 5, ...overrides,
   } as Capabilities;
 }
@@ -94,6 +96,12 @@ describe('rxAudio group gate (MOR-1262 slice 3A, kill-test 4)', () => {
     const rxAudio = model(audioState(), routingOnly, SNAP).rxAudio!;
     expect(rxAudio.modInputSource.reading).toEqual({ status: 'known', value: 5 });
     expect(rxAudio.liveAudio).toEqual({ structural: false, operational: false });
+  });
+
+  it('hides MOD input when profile source metadata is absent', () => {
+    const rxAudio = model(audioState(), caps({ dataModeInputs: undefined }), SNAP).rxAudio!;
+    expect(rxAudio.modInputChoices).toEqual([]);
+    expect(rxAudio.modInputSource.availability).toEqual({ structural: false, operational: false });
   });
 
   it('emits no model at all when capabilities are absent', () => {

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -58,6 +58,7 @@ import { currentControlSessionEpoch } from '../commands/radio-intents';
 import type { ServerState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { DisplayObservation } from '../../../semantic/radio-view-model';
+import { modInputCommand, modInputStateKey, type ModInputStateKey } from '$lib/radio/mod-input';
 import { qualifyDisplayObservation, qualifyRadioDisplayObservation } from './display-observation';
 import {
   controlRangeFromCapsOrDefault, deriveIfShift, nbDepthRawToDisplay,
@@ -1065,7 +1066,8 @@ const ACK_CONFIRM_GRACE_MS = 3_000;
  * backstop above.
  */
 function latestPendingParam(
-  intentName: string, paramKey: string, receiver: 0 | 1, confirmedField: keyof ServerState['main'],
+  intentName: string, paramKey: string, receiver: 0 | 1 | null,
+  confirmedField: keyof ServerState['main'] | ModInputStateKey,
 ): unknown {
   let latest: {
     createdAt: number; value: unknown; status: string;
@@ -1074,7 +1076,7 @@ function latestPendingParam(
   } | null = null;
   for (const command of getCommandLifecycles()) {
     if (command.name !== intentName) continue;
-    if (command.params.receiver !== receiver) continue;
+    if (receiver !== null && command.params.receiver !== receiver) continue;
     // Supersession is durable for the older record even after the newer
     // terminal record's bounded presentation retention expires. Never let a
     // superseded lifecycle become the newest selectable pending command.
@@ -1101,7 +1103,8 @@ function latestPendingParam(
   // Grace backstop: bounds the no-answer case (NAK, or nothing at all).
   if (Date.now() - latest.updatedAt > ACK_CONFIRM_GRACE_MS) return undefined;
 
-  const fieldPath = `${receiver === 1 ? 'sub' : 'main'}.${String(confirmedField)}`;
+  const fieldPath = receiver === null
+    ? String(confirmedField) : `${receiver === 1 ? 'sub' : 'main'}.${String(confirmedField)}`;
   const boundary = latest.ackFieldObservationTimes?.[fieldPath];
   const observedAt = runtime.state?.fieldStatus?.[fieldPath]?.lastObservedMonotonic;
   if (typeof boundary === 'number' && Number.isFinite(boundary)
@@ -1115,7 +1118,10 @@ function latestPendingParam(
     && currentObservationSeq <= ackObservationSeq) {
     return latest.value;
   }
-  return confirmedReceiverState(receiver)?.[confirmedField] === latest.value ? undefined : latest.value;
+  const confirmed = receiver === null
+    ? runtime.state?.[confirmedField as ModInputStateKey]
+    : confirmedReceiverState(receiver)?.[confirmedField as keyof ServerState['main']];
+  return confirmed === latest.value ? undefined : latest.value;
 }
 
 /** Freshest unconfirmed `set_filter` target for `receiver`, or `null`.
@@ -1318,6 +1324,20 @@ export function getDataModeArmed(): ArmedFact<number> {
   const receiver = activeReceiverOrNull();
   if (receiver === null) return { armed: false, value: null };
   return armedFact<number>('set_data_mode', 'mode', receiver, 'dataMode');
+}
+
+/** Active DATA group's MOD-input source pending over the same lifecycle
+ * decision table, using its top-level readback rather than a receiver field. */
+export function getModInputArmed(): ArmedFact<number> {
+  const state = runtime.state;
+  const rx = state?.active === 'SUB' ? state.sub : state?.main;
+  const dataMode = rx?.dataMode;
+  if (!Number.isSafeInteger(dataMode) || (dataMode as number) < 0 || (dataMode as number) > 3) {
+    return { armed: false, value: null };
+  }
+  const key = modInputStateKey(dataMode as number);
+  const value = latestPendingParam(modInputCommand(dataMode as number), 'source', null, key);
+  return typeof value === 'number' ? { armed: true, value } : { armed: false, value: null };
 }
 
 /** Auto-notch armed fact (`set_auto_notch`). Notch mode is written as TWO

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -728,8 +728,10 @@ function deriveFilterPassband(
     },
     dataModeChoices,
     dataMode: txAuxField(hasDataModeCap, dataModeObserved, numOrUndef(dataRx?.dataMode)),
-    modInputChoices,
-    modInputSource: txAuxField(modInputStructural, modInputObserved, modInputValue),
+    ...(modInputChoices.length > 0 ? {
+      modInputChoices,
+      modInputSource: txAuxField(modInputStructural, modInputObserved, modInputValue),
+    } : {}),
   };
 }
 
@@ -1612,7 +1614,11 @@ function deriveRxAudio(
   // `toRxAudioProps`'s own gate: the radio's AF control, or the browser stream.
   const hasAfLevel = hasCap(caps, 'af_level') || hasLiveAudio;
   const hasDualRx = hasCap(caps, 'dual_rx');
-  const hasModInput = facts.modInputRoutingAvailable;
+  const modInputChoices = Array.isArray(caps?.dataModeInputs) ? caps.dataModeInputs : [];
+  const activeDataMode = state?.active === 'SUB' ? state.sub?.dataMode : state?.main?.dataMode;
+  const hasModInput = facts.modInputRoutingAvailable && modInputChoices.length > 0
+    && Number.isSafeInteger(activeDataMode) && (activeDataMode as number) >= 0
+    && (activeDataMode as number) <= (caps?.dataModeCount ?? -1);
   if (!hasAfLevel && !hasLiveAudio && !hasDualRx && !hasModInput) return undefined;
   // Byte-identical to `toRxAudioProps`'s monitor-mode derivation; parity across
   // the whole matrix is pinned in `__tests__/rx-audio-adapter.test.ts`.
@@ -1638,6 +1644,7 @@ function deriveRxAudio(
     routingFocus: txAuxField(hasDualRx, routing?.focus !== undefined, routing?.focus),
     routingSplit: txAuxField(hasDualRx, routing?.splitStereo !== undefined, routing?.splitStereo),
     modInputSource: txAuxField(hasModInput, source !== undefined, source),
+    modInputChoices,
     modInputReadiness: facts.modInputReadiness,
   };
 }

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -605,6 +605,18 @@ function deriveFilterPassband(
       const label = caps.dataModeLabels?.[String(value)];
       return { value, label: typeof label === 'string' && label.trim() ? label : null };
     }) : [];
+  const modInputChoices = Array.isArray(caps.dataModeInputs) ? caps.dataModeInputs : [];
+  const activeDataMode = isDataModeValue(dataValue) ? dataValue : null;
+  const modInputKey = activeDataMode === null ? null : modInputStateKey(activeDataMode);
+  const modInputStatus = modInputKey === null ? undefined : state?.fieldStatus?.[modInputKey];
+  const modInputStructural = hasDataModeCap && activeDataMode !== null
+    && typeof count === 'number' && activeDataMode <= count && modInputChoices.length > 0
+    && modInputStatus !== undefined
+    && modInputStatus.availability !== 'undeclared' && modInputStatus.availability !== 'unavailable';
+  const modInputValue = modInputKey === null ? undefined : numOrUndef(state?.[modInputKey]);
+  const modInputObserved = modInputStructural && modInputKey !== null
+    && strictFieldAvailable(state, modInputKey)
+    && modInputChoices.some(choice => choice.value === modInputValue);
   const pbtInnerObserved = topFieldAvailable(state, `${base}pbtInner`);
   const pbtOuterObserved = topFieldAvailable(state, `${base}pbtOuter`);
   const ifShiftRawObserved = topFieldAvailable(state, `${base}ifShift`);
@@ -716,6 +728,8 @@ function deriveFilterPassband(
     },
     dataModeChoices,
     dataMode: txAuxField(hasDataModeCap, dataModeObserved, numOrUndef(dataRx?.dataMode)),
+    modInputChoices,
+    modInputSource: txAuxField(modInputStructural, modInputObserved, modInputValue),
   };
 }
 

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
@@ -256,6 +256,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
       modes: ['USB', 'CW'],
       filters: ['FIL1', 'FIL2', 'FIL3'],
       dataModeCount: 3,
+      dataModeInputs: [0, 1, 2, 3, 4, 5].map(value => ({ value, label: String(value) })),
       preValues: [0, 1, 2],
       attValues: [0, 6, 12],
       agcModes: [1, 2, 3],

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -294,11 +294,17 @@ export function makeModeHandlers() {
       const receiver = knownActiveReceiver('dataMode');
       const dataMode = receiver === null ? null : getActiveReceiver()?.dataMode;
       const state = getRadioState();
+      const caps = getCapabilities();
       if (
         !state
+        || !caps
+        || !Array.isArray(caps.dataModeInputs)
+        || !caps.dataModeInputs.some(option => option.value === source)
         || !Number.isSafeInteger(dataMode)
         || (dataMode as number) < 0
         || (dataMode as number) > 3
+        || !Number.isSafeInteger(caps.dataModeCount)
+        || (dataMode as number) > (caps.dataModeCount as number)
         || !isFieldAvailable(state, modInputStateKey(dataMode as number))
       ) return;
       dispatchRadioIntent({ name: modInputCommand(dataMode as number), params: { source } });

--- a/frontend/src/lib/runtime/props/__tests__/panel-props.test.ts
+++ b/frontend/src/lib/runtime/props/__tests__/panel-props.test.ts
@@ -551,7 +551,12 @@ describe('AmberTelemetry props (MOR-483: drop dead TEMP tile)', () => {
 });
 
 describe('Mode panel MOD-input source (MOR-616)', () => {
-  const caps = { capabilities: ['data_mode'], dataModeCount: 3 } as any;
+  const choices = [
+    { value: 0, label: 'MIC' }, { value: 1, label: 'ACC' },
+    { value: 2, label: 'MIC+ACC' }, { value: 3, label: 'USB' },
+    { value: 4, label: 'MIC+USB' }, { value: 5, label: 'LAN' },
+  ];
+  const caps = { capabilities: ['data_mode'], dataModeCount: 3, dataModeInputs: choices } as any;
 
   function modInputState(overrides: Record<string, unknown> = {}) {
     return makeState({
@@ -573,6 +578,7 @@ describe('Mode panel MOD-input source (MOR-616)', () => {
     const props = toModeProps(modInputState(), caps);
     expect(props.modInputSource).toBe(0);
     expect(props.hasModInput).toBe(true);
+    expect(props.modInputChoices).toEqual(choices);
   });
 
   it('follows the active receiver into its DATA group (D1 on SUB)', () => {
@@ -585,6 +591,18 @@ describe('Mode panel MOD-input source (MOR-616)', () => {
   it('hides the control without the data_mode capability', () => {
     const props = toModeProps(modInputState(), { capabilities: [] } as any);
     expect(props.hasModInput).toBe(false);
+  });
+
+  it('hides the control when the profile does not declare a source domain', () => {
+    const props = toModeProps(modInputState(), { capabilities: ['data_mode'], dataModeCount: 1 } as any);
+    expect(props.hasModInput).toBe(false);
+    expect(props.modInputChoices).toEqual([]);
+  });
+
+  it('hides the control for a DATA group outside the profile count', () => {
+    const state = modInputState();
+    state.main.dataMode = 2;
+    expect(toModeProps(state, { ...caps, dataModeCount: 1 }).hasModInput).toBe(false);
   });
 
   it('hides the control while the active group is unread (missing)', () => {

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -555,6 +555,8 @@ export interface ModeProps {
   dataModeLabels: Record<string, string>;
   /** Active DATA group's MOD-input source (IC-7610 enum, MOR-616); null until read. */
   modInputSource: number | null;
+  /** Exact profile-declared MOD-input choices; empty when capability metadata is absent. */
+  modInputChoices: readonly { readonly value: number; readonly label: string }[];
   /** Show the MOD-input control: data_mode cap + the active group has been observed. */
   hasModInput: boolean;
 }
@@ -569,7 +571,12 @@ export function toModeProps(
   // `isFieldRead` as its availability compatibility gate. The helper rejects
   // the three explicit absence values while preserving the legacy no-entry
   // fallback; it does not establish observation evidence.
-  const modInputKey = modInputStateKey(rx?.dataMode ?? 0);
+  const dataMode = rx?.dataMode;
+  const validDataGroup = Number.isSafeInteger(dataMode) && (dataMode as number) >= 0
+    && (dataMode as number) <= (caps?.dataModeCount ?? -1);
+  const modInputKey = validDataGroup ? modInputStateKey(dataMode as number) : null;
+  const modInputChoices = caps?.dataModeInputs ?? [];
+  const modInputSource = modInputKey === null ? null : state?.[modInputKey] ?? null;
   return {
     // MOR-1409 A11: no fabricated USB stand-in for an unobserved mode.
     currentMode: rx?.mode ?? '---',
@@ -583,9 +590,12 @@ export function toModeProps(
     hasDataMode: hasCap(caps, 'data_mode'),
     dataModeCount: caps?.dataModeCount ?? 0,
     dataModeLabels: caps?.dataModeLabels ?? { '0': 'OFF', '1': 'D1', '2': 'D2', '3': 'D3' },
-    modInputSource: state?.[modInputKey] ?? null,
+    modInputSource: modInputChoices.some(option => option.value === modInputSource)
+      ? modInputSource : null,
+    modInputChoices,
     hasModInput:
-      hasCap(caps, 'data_mode') && state !== null && isFieldRead(state, modInputKey),
+      hasCap(caps, 'data_mode') && modInputChoices.length > 0 && modInputKey !== null
+      && state !== null && isFieldRead(state, modInputKey),
   };
 }
 

--- a/frontend/src/lib/types/__tests__/capabilities.control-domains.test.ts
+++ b/frontend/src/lib/types/__tests__/capabilities.control-domains.test.ts
@@ -65,6 +65,17 @@ function parse(control: Record<string, unknown>): ControlDomain {
   return result.controls?.test as ControlDomain;
 }
 describe('normalized control capability domains', () => {
+  it('validates optional per-profile MOD input choices and rejects malformed domains', () => {
+    const choices = [{ value: 0, label: 'MIC' }, { value: 3, label: 'USB' }];
+    expect(validateCapabilities({ ...baseCapabilities, dataModeInputs: choices }).dataModeInputs)
+      .toBe(choices);
+    expect(validateCapabilities(baseCapabilities)).toBe(baseCapabilities);
+    expect(() => validateCapabilities({ ...baseCapabilities,
+      dataModeInputs: [{ value: 0, label: 'MIC' }, { value: 0, label: 'USB' }] }))
+      .toThrow(/unique integer/);
+    expect(() => validateCapabilities({ ...baseCapabilities,
+      dataModeInputs: [{ value: 5, label: '' }] })).toThrow(/non-empty string/);
+  });
   it('consumes the loader-generated golden controls fixture without numeric coercion', () => {
     const payload = { ...baseCapabilities, controls: goldenControls };
     const parsed = validateCapabilities(payload);

--- a/frontend/src/lib/types/capabilities.ts
+++ b/frontend/src/lib/types/capabilities.ts
@@ -149,6 +149,11 @@ export interface TxBand {
   end: number;
 }
 
+export interface DataModeInput {
+  value: number;
+  label: string;
+}
+
 export interface Capabilities {
   [extension: string]: unknown;
   model: string;
@@ -181,6 +186,7 @@ export interface Capabilities {
   rfSqlControlModel?: 'separate' | 'combined';
   dataModeCount?: number;
   dataModeLabels?: Record<string, string>;
+  dataModeInputs?: DataModeInput[];
   keyboard?: KeyboardConfig | null;
   antennas?: number;      // Number of antenna ports
   hasRxAntenna?: boolean;
@@ -547,6 +553,26 @@ export function validateCapabilities(value: unknown): Capabilities {
   });
   requireStringArray(raw.modes, '$.modes');
   requireStringArray(raw.filters, '$.filters');
+  if ('dataModeInputs' in raw) {
+    if (!Array.isArray(raw.dataModeInputs) || raw.dataModeInputs.length > 6) {
+      invalid('$.dataModeInputs', 'an array of at most 6 source options');
+    }
+    const values = new Set<number>();
+    raw.dataModeInputs.forEach((value, index) => {
+      const path = `$.dataModeInputs[${index}]`;
+      const option = requireRecord(value, path);
+      if (Object.keys(option).length !== 2 || !('value' in option) || !('label' in option)) {
+        invalid(path, 'exactly value and label');
+      }
+      requireInteger(option.value, `${path}.value`);
+      if ((option.value as number) < 0 || (option.value as number) > 5 || values.has(option.value as number)) {
+        invalid(`${path}.value`, 'a unique integer from 0 to 5');
+      }
+      values.add(option.value as number);
+      requireString(option.label, `${path}.label`);
+      if (!(option.label as string).trim()) invalid(`${path}.label`, 'a non-empty string');
+    });
+  }
 
   const audioConfig = requireRecord(raw.audioConfig, '$.audioConfig');
   requireInteger(audioConfig.sampleRate, '$.audioConfig.sampleRate', true);

--- a/frontend/src/semantic/FilterInstrumentHost.svelte
+++ b/frontend/src/semantic/FilterInstrumentHost.svelte
@@ -16,10 +16,12 @@
     view: RadioViewModel | null;
     pendingFilter?: number | null;
     pendingDataMode?: number | null;
+    pendingModInput?: number | null;
     onModeChange?: (mode: string) => void;
     onFilterChange?: (filter: number) => void;
     onFilterShapeChange?: (shape: number) => void;
     onDataModeChange?: (mode: number) => void;
+    onModInputChange?: (source: number) => void;
     children: Snippet<[FilterInstrumentHandles]>;
   }
   type RendererSelection = { finiteAppearance?: undefined; rendererContext?: undefined } | {
@@ -29,8 +31,8 @@
   type Props = ExistingProps & RendererSelection;
 
   let {
-    view, pendingFilter = null, pendingDataMode = null,
-    onModeChange, onFilterChange, onFilterShapeChange, onDataModeChange,
+    view, pendingFilter = null, pendingDataMode = null, pendingModInput = null,
+    onModeChange, onFilterChange, onFilterShapeChange, onDataModeChange, onModInputChange,
     finiteAppearance, rendererContext, children,
   }: Props = $props();
 
@@ -38,6 +40,7 @@
   let filterPassband = $derived(view?.filterPassband);
   const pendingId = $props.id();
   const pendingDataModeId = `${pendingId}-data-mode`;
+  const pendingModInputId = `${pendingId}-mod-input`;
   const usable = (field: { availability: { structural: boolean; operational: boolean };
     reading: { status: string } } | undefined): boolean => field !== undefined
       && field.availability.structural && field.availability.operational
@@ -222,6 +225,28 @@
           {/each}
         </div>
         {#if pendingDataMode !== null}<span id={pendingDataModeId} class="sr-only">{t('core.modePanel.dataMode.pendingAnnouncement')}</span>{/if}
+        {#if filterPassband.modInputSource?.availability.structural}
+          <label class="standard-mod-input" data-testid="standard-mod-input"
+            data-disabled-reason={reason(filterPassband.modInputSource)}
+            data-mod-input-status={pendingModInput !== null ? 'pending' : usable(filterPassband.modInputSource) ? 'confirmed' : filterPassband.modInputSource.reading.status === 'known' ? 'retained' : 'unknown'}>
+            <span class="standard-section-label">{t('core.modePanel.modInputLabel')}</span>
+            {#key `${filterPassband.modInputSource.reading.status}:${filterPassband.modInputSource.reading.status === 'known' ? filterPassband.modInputSource.reading.value : ''}:${pendingModInput ?? ''}`}
+            <select data-testid="mod-input-select" aria-label={t('core.modePanel.modInputAria')}
+              aria-describedby={pendingModInput !== null ? pendingModInputId : undefined}
+              data-pending-value={pendingModInput === null ? undefined : pendingModInput}
+              disabled={!usable(filterPassband.modInputSource)}
+              onchange={(event) => onModInputChange?.(Number(event.currentTarget.value))}>
+              {#if filterPassband.modInputSource.reading.status !== 'known'}<option value="" disabled selected>—</option>{/if}
+              {#each filterPassband.modInputChoices ?? [] as choice (choice.value)}
+                <option value={choice.value}
+                  selected={filterPassband.modInputSource.reading.status === 'known'
+                    && filterPassband.modInputSource.reading.value === choice.value}>{choice.label}</option>
+              {/each}
+            </select>
+            {/key}
+            {#if pendingModInput !== null}<span id={pendingModInputId} class="sr-only">{t('core.modePanel.dataMode.pendingAnnouncement')}</span>{/if}
+          </label>
+        {/if}
       </div>
     {/if}
   {/if}
@@ -236,6 +261,8 @@
   .filter-choice:disabled { cursor: not-allowed; }
   .filter-choice[data-pending='true'] { font-style: italic; opacity: 0.75; }
   .standard-data-block { display: flex; flex-direction: column; gap: 0.5rem; }
+  .standard-mod-input { display: grid; grid-template-columns: 1fr minmax(0, 1fr); align-items: center; gap: 0.75rem; }
+  .standard-mod-input select { min-width: 0; }
   .standard-choice-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 4px; }
   .standard-choice-grid > span { min-width: 0; }
   .standard-choice-grid > span > :global(button) { width: 100%; min-width: 0; min-height: 36px; }

--- a/frontend/src/semantic/RxAudioInstrumentHost.svelte
+++ b/frontend/src/semantic/RxAudioInstrumentHost.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onDestroy, onMount, type Snippet } from 'svelte';
   import { t } from '$lib/i18n';
-  import { MOD_INPUT_SOURCES, modInputSourceLabel } from '$lib/radio/mod-input';
+  import { LAN_MOD_INPUT_SOURCE } from '$lib/radio/mod-input';
   import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
   import { ValueControl } from '../components-v2/controls/value-control';
   import {
@@ -83,6 +83,10 @@
   let lastAuthority: AfAuthority | null | undefined;
   let stop: (() => void) | null = null;
   let rx = $derived(presentation.rxAudio);
+  let modInputChoices = $derived(rx?.modInputChoices ?? []);
+  let modInputReadingValue = $derived(
+    rx?.modInputSource.reading.status === 'known' ? rx.modInputSource.reading.value : undefined,
+  );
   /** MOR-1279: the FACT, never a capability re-derivation. */
   let liveOffered = $derived(rx?.liveAudio.structural === true);
   /** MOR-1384 — the v2 `RxAudioPanel` link-lost readout, restored from the SAME
@@ -95,8 +99,8 @@
     liveOffered && rx?.monitorMode === 'live' && rx.liveAudio.operational === false,
   );
   let modInputRecognized = $derived(
-    rx?.modInputSource.reading.status === 'known'
-      && modInputSourceLabel(rx.modInputSource.reading.value) !== null,
+    modInputReadingValue !== undefined
+      && modInputChoices.some(option => option.value === modInputReadingValue),
   );
 
   const monitorBehavior = bindAbsoluteChoiceInstrument<MonitorMode>(() => ({
@@ -121,7 +125,7 @@
   }));
   const modInputBehavior = bindChoiceInstrument<number>(() => ({
     field: rx?.modInputSource,
-    choices: MOD_INPUT_SOURCES.map((option) => option.value),
+    choices: modInputChoices.map((option) => option.value),
     blocked: !modInputRecognized,
     invoke: (source) => onModInputChange?.(source),
   }));
@@ -130,7 +134,7 @@
   );
   function changeModInput(select: HTMLSelectElement): void {
     const value = select.value;
-    const source = MOD_INPUT_SOURCES.find((option) => String(option.value) === value);
+    const source = modInputChoices.find((option) => String(option.value) === value);
     select.value = modInputValue;
     if (source) modInputBehavior.invoke(source.value);
   }
@@ -174,14 +178,16 @@
   const modInputSeat = createChoiceRendererSeat<RxAudioFiniteChoiceValue>(() => ({
     context: rendererContext ?? null, label: 'MOD input',
     field: rx?.modInputSource, blocked: !modInputRecognized,
-    options: MOD_INPUT_SOURCES.map((option) => ({ value: option.value, label: option.label })),
+    options: modInputChoices.map((option) => ({ value: option.value, label: option.label })),
     invoke: (source) => onModInputChange?.(source as number),
   }));
   function setLanInput(): AvailabilityActionRendererInput {
     return {
       context: rendererContext ?? null, label: 'Set LAN',
-      availability: rx === undefined ? undefined : { structural: true, operational: true },
-      blocked: rx?.modInputReadiness.status !== 'mismatch',
+      availability: rx === undefined || !modInputChoices.some(option => option.value === LAN_MOD_INPUT_SOURCE)
+        ? undefined : { structural: true, operational: true },
+      blocked: rx?.modInputReadiness.status !== 'mismatch'
+        || !modInputChoices.some(option => option.value === LAN_MOD_INPUT_SOURCE),
       invoke: () => onSetModInputLan?.(),
     };
   }
@@ -404,13 +410,13 @@
             {#if modInputValue === ''}
               <option value="" disabled>{UNKNOWN_TEXT}</option>
             {/if}
-            {#each MOD_INPUT_SOURCES as option (option.value)}
+            {#each modInputChoices as option (option.value)}
               <option value={String(option.value)}>{option.label}</option>
             {/each}
           </select>
         </label>
         <span data-testid="rx-audio-mod-source">MOD: {rx.modInputSource.reading.status === 'known'
-          ? modInputSourceLabel(rx.modInputSource.reading.value) ?? UNKNOWN_TEXT
+          ? modInputChoices.find(option => option.value === modInputReadingValue)?.label ?? UNKNOWN_TEXT
           : UNKNOWN_TEXT}</span>
         <span data-testid="rx-audio-mod-readiness"
         >{READINESS_LABEL[rx.modInputReadiness.status]}</span>
@@ -420,7 +426,8 @@
 {/snippet}
 
 {#snippet setModInputLan()}
-  {#if rx?.modInputReadiness.status === 'mismatch'}
+  {#if rx?.modInputReadiness.status === 'mismatch'
+    && modInputChoices.some(option => option.value === LAN_MOD_INPUT_SOURCE)}
     {#if finiteAppearance}
       {#key rendererContext}{#key finiteAppearance.action}<ControlInstrumentRendererHost
         seat={setLanSeat} renderer={finiteAppearance.action}

--- a/frontend/src/semantic/__tests__/FilterInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/FilterInstrumentHost.isolated.test.ts
@@ -37,6 +37,28 @@ function reading(
 }
 
 describe('FilterInstrumentHost finite ownership', () => {
+  it('renders Standard MOD IN from confirmed truth while pending stays distinct', () => {
+    const onModInputChange = vi.fn();
+    const props = proxy({ view: base(), presentation: 'standard' as const,
+      pendingModInput: 3 as number | null, onModInputChange });
+    const component = mount(FilterInstrumentHostFixture, { target, props }); flushSync();
+    const select = target.querySelector<HTMLSelectElement>('[data-testid="mod-input-select"]')!;
+    expect([...select.options].map(option => option.text)).toEqual(['MIC', 'USB']);
+    expect(select.value).toBe('0');
+    expect(select.dataset.pendingValue).toBe('3');
+    expect(select.closest('[data-mod-input-status]')?.getAttribute('data-mod-input-status')).toBe('pending');
+    select.value = '3'; select.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(onModInputChange).toHaveBeenCalledExactlyOnceWith(3);
+    props.pendingModInput = null;
+    props.view = reading(base(), 'filterPassband', 'modInputSource', { status: 'unknown' }, false);
+    flushSync();
+    const unknown = target.querySelector<HTMLSelectElement>('[data-testid="mod-input-select"]')!;
+    expect(unknown.disabled).toBe(true);
+    expect(unknown.value).toBe('');
+    expect([...unknown.options].map(option => option.text)).toEqual(['—', 'MIC', 'USB']);
+    expect(unknown.closest('[data-mod-input-status]')?.getAttribute('data-mod-input-status')).toBe('unknown');
+    unmount(component);
+  });
   it('renders exact native choices in grouped and independent arrangements with pending separate from truth', () => {
     const onModeChange = vi.fn(), onFilterChange = vi.fn();
     const onFilterShapeChange = vi.fn(), onDataModeChange = vi.fn();

--- a/frontend/src/semantic/__tests__/RxAudioInstrumentHost.isolated.test.ts
+++ b/frontend/src/semantic/__tests__/RxAudioInstrumentHost.isolated.test.ts
@@ -370,6 +370,14 @@ describe('RxAudioInstrumentHost finite handles (RX-B/RX-C)', () => {
     expect(onModInputChange).toHaveBeenCalledTimes(MOD_INPUT_SOURCES.length);
   });
 
+  it('uses the declared source domain and does not offer LAN when it is unsupported', () => {
+    const choices = MOD_INPUT_SOURCES.filter(option => option.value !== 5);
+    renderFinite(withRx({ modInputChoices: choices, modInputReadiness: { status: 'mismatch', source: 0 } }));
+    expect(target.querySelector('[data-testid="external-MOD input-4"]')).not.toBeNull();
+    expect(target.querySelector('[data-testid="external-MOD input-5"]')).toBeNull();
+    expect(target.querySelector('[data-testid="external-Set LAN"]')).toBeNull();
+  });
+
   // The split seat's reading is the LABEL ('on'/'off') mapped from the raw
   // `routingSplit` boolean fact by `splitLabelOf`; these two rows are literal
   // (not derived via `SPLIT_CHOICES.find`) so a `splitLabelOf` that maps the

--- a/frontend/src/semantic/__tests__/fixtures/FilterInstrumentHostFixture.svelte
+++ b/frontend/src/semantic/__tests__/fixtures/FilterInstrumentHostFixture.svelte
@@ -8,16 +8,18 @@
 
   interface Props {
     view: RadioViewModel | null;
-    presentation?: 'grouped' | 'independent';
+    presentation?: 'grouped' | 'independent' | 'standard';
     renderSurface?: boolean;
     pendingFilter?: number | null;
     pendingDataMode?: number | null;
+    pendingModInput?: number | null;
     filterWidthFeedback?: Readonly<CommandScalarFeedback>;
     finiteAppearance?: FiniteControlAppearance<FilterFiniteChoiceValue>;
     rendererContext?: FiniteRendererContext | null;
     onModeChange?: (mode: string) => void;
     onFilterChange?: (filter: number) => void;
     onDataModeChange?: (mode: number) => void;
+    onModInputChange?: (source: number) => void;
     onFilterWidthChange?: (width: number) => void;
     onFilterShapeChange?: (shape: number) => void;
     onIfShiftChange?: (value: number) => void;
@@ -26,9 +28,9 @@
   }
   let {
     view, presentation = 'grouped', renderSurface = false,
-    pendingFilter = null, pendingDataMode = null, filterWidthFeedback,
+    pendingFilter = null, pendingDataMode = null, pendingModInput = null, filterWidthFeedback,
     finiteAppearance, rendererContext = null, onModeChange, onFilterChange,
-    onDataModeChange, onFilterWidthChange, onFilterShapeChange,
+    onDataModeChange, onModInputChange, onFilterWidthChange, onFilterShapeChange,
     onIfShiftChange, onPbtInnerChange, onPbtOuterChange,
   }: Props = $props();
   let selection = $derived(finiteAppearance === undefined ? {} : { finiteAppearance, rendererContext });
@@ -41,8 +43,8 @@
   <div data-slot="data-mode">{@render handles.dataMode()}</div>
 {/snippet}
 
-<FilterInstrumentHost {view} {pendingFilter} {pendingDataMode} {onModeChange} {onFilterChange}
-  {onFilterShapeChange} {onDataModeChange} {...selection}>
+<FilterInstrumentHost {view} {pendingFilter} {pendingDataMode} {pendingModInput} {onModeChange} {onFilterChange}
+  {onFilterShapeChange} {onDataModeChange} {onModInputChange} {...selection}>
   {#snippet children(handles: FilterInstrumentHandles)}
     {#if renderSurface && view !== null}
       <FilterSurface
@@ -53,7 +55,9 @@
     {:else}
       {#key presentation}
         <section data-testid={`${presentation}-filter-composition`}>
-          {#if presentation === 'grouped'}
+          {#if presentation === 'standard'}
+            {#if handles.standardDataMode}{@render handles.standardDataMode()}{/if}
+          {:else if presentation === 'grouped'}
             {@render handles.mode()}{@render handles.filter()}{@render handles.shape()}{@render handles.dataMode()}
           {:else}
             {@render independent(handles)}

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -302,6 +302,8 @@ export function withFilterPassband(fixture: RadioViewModel): RadioViewModel {
     pbtOuter: known(0),
     dataMode: known(0),
     dataModeChoices: [{ value: 0, label: 'OFF' }, { value: 1, label: 'D1' }],
+    modInputSource: known(0),
+    modInputChoices: [{ value: 0, label: 'MIC' }, { value: 3, label: 'USB' }],
   };
   return { ...fixture, filterPassband };
 }

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -247,6 +247,11 @@ export function withRxAudio(
     routingFocus: known('both'),
     routingSplit: known(false),
     modInputSource: known(readiness.status === 'ready' || readiness.status === 'mismatch' ? readiness.source : 5),
+    modInputChoices: [
+      { value: 0, label: 'MIC' }, { value: 1, label: 'ACC' },
+      { value: 2, label: 'MIC+ACC' }, { value: 3, label: 'USB' },
+      { value: 4, label: 'MIC+USB' }, { value: 5, label: 'LAN' },
+    ],
     modInputReadiness: readiness,
   };
   return { ...fixture, rxAudio };

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -300,6 +300,7 @@ export interface RxAudioViewModel {
   routingSplit: RxAudioField<boolean>;
   /** The active DATA group's MOD-input source enum (`$lib/radio/mod-input`). */
   modInputSource: RxAudioField<number>;
+  readonly modInputChoices?: readonly { readonly value: number; readonly label: string }[];
   modInputReadiness: ModInputReadiness;
 }
 
@@ -1717,7 +1718,7 @@ function validateRxAudio(value: unknown, path: string): RxAudioViewModel {
   const v = record(value, path);
   exactKeys(v, [
     'monitorMode', 'liveAudio', 'afLevel', 'routingFocus', 'routingSplit',
-    'modInputSource', 'modInputReadiness',
+    'modInputSource', 'modInputChoices', 'modInputReadiness',
   ], path);
   return {
     monitorMode: oneOf(v.monitorMode, MONITOR_MODES, `${path}.monitorMode`),
@@ -1728,6 +1729,9 @@ function validateRxAudio(value: unknown, path: string): RxAudioViewModel {
     ),
     routingSplit: validateTxAuxField(v.routingSplit, `${path}.routingSplit`, bool),
     modInputSource: validateTxAuxField(v.modInputSource, `${path}.modInputSource`, num),
+    ...(v.modInputChoices === undefined ? {} : {
+      modInputChoices: validateModInputChoices(v.modInputChoices, `${path}.modInputChoices`),
+    }),
     modInputReadiness: validateModInputReadiness(v.modInputReadiness, `${path}.modInputReadiness`),
   };
 }

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -426,6 +426,8 @@ export interface FilterPassbandViewModel {
   pbtOuter: DisplayObservedField<number>;
   dataMode: FilterPassbandField<number>;
   readonly dataModeChoices: readonly { readonly value: number; readonly label: string | null }[];
+  modInputSource?: FilterPassbandField<number>;
+  readonly modInputChoices?: readonly { readonly value: number; readonly label: string }[];
 }
 
 /**
@@ -1795,6 +1797,21 @@ function validateDataModeChoices(value: unknown, path: string): FilterPassbandVi
   });
 }
 
+function validateModInputChoices(value: unknown, path: string): NonNullable<FilterPassbandViewModel['modInputChoices']> {
+  if (!Array.isArray(value) || value.length > 6) invalid(path, 'MOD input choices in 0..5');
+  const seen = new Set<number>();
+  return value.map((item, i) => {
+    const choice = record(item, path + '[' + i + ']');
+    exactKeys(choice, ['value', 'label'], path);
+    const value = num(choice.value, `${path}[${i}].value`);
+    if (!Number.isSafeInteger(value) || value < 0 || value > 5 || seen.has(value)) {
+      invalid(`${path}[${i}].value`, 'a unique integer in 0..5');
+    }
+    seen.add(value);
+    return { value, label: nonBlank(choice.label, `${path}[${i}].label`) };
+  });
+}
+
 function validateModeFilter(value: unknown, path: string): ModeFilterViewModel {
   const v = record(value, path);
   exactKeys(v, [
@@ -1819,10 +1836,13 @@ function validateFilterPassband(value: unknown, path: string): FilterPassbandVie
     v,
     [
       'filterShape', 'filterShapeControlStructural', 'ifShift', 'ifShiftControlStructural',
-      'pbtInner', 'pbtOuter', 'dataMode', 'dataModeChoices',
+      'pbtInner', 'pbtOuter', 'dataMode', 'dataModeChoices', 'modInputSource', 'modInputChoices',
     ],
     path,
   );
+  const hasModInputSource = v.modInputSource !== undefined;
+  const hasModInputChoices = v.modInputChoices !== undefined;
+  if (hasModInputSource !== hasModInputChoices) invalid(path, 'MOD input source and choices together');
   return {
     filterShape: validateTxAuxField(v.filterShape, `${path}.filterShape`, num),
     filterShapeControlStructural: bool(v.filterShapeControlStructural, `${path}.filterShapeControlStructural`),
@@ -1832,6 +1852,10 @@ function validateFilterPassband(value: unknown, path: string): FilterPassbandVie
     pbtOuter: validateDisplayObservedField(v.pbtOuter, `${path}.pbtOuter`, num),
     dataModeChoices: validateDataModeChoices(v.dataModeChoices, `${path}.dataModeChoices`),
     dataMode: validateTxAuxField(v.dataMode, `${path}.dataMode`, num),
+    ...(hasModInputSource ? {
+      modInputChoices: validateModInputChoices(v.modInputChoices, `${path}.modInputChoices`),
+      modInputSource: validateTxAuxField(v.modInputSource, `${path}.modInputSource`, num),
+    } : {}),
   };
 }
 

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -393,6 +393,7 @@ class RadioProfile:
     rf_sql_control_model: str = "separate"
     data_mode_count: int = 0
     data_mode_labels: dict[str, str] | None = None
+    data_mode_inputs: tuple[tuple[int, str], ...] | None = None
     # When True, MAIN set_mode routes through CI-V 0x26 0x00 (set selected
     # receiver mode) instead of the bare 0x06. Data-driven: derived from the
     # profile declaring a ``set_selected_mode`` command (e.g. Xiegu X6200,

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -552,6 +552,7 @@ class RigConfig:
     max_watts: int | None = None
     data_mode_count: int = 0
     data_mode_labels: dict[str, str] | None = None
+    data_mode_inputs: tuple[tuple[int, str], ...] | None = None
     protocol_type: str = "civ"
     protocol_address: int | None = None
     protocol_baud: int | None = None
@@ -767,6 +768,7 @@ class RigConfig:
             rf_sql_control_model=self.rf_sql_control_model,
             data_mode_count=self.data_mode_count,
             data_mode_labels=self.data_mode_labels,
+            data_mode_inputs=self.data_mode_inputs,
             # isinstance, not membership: a declared-absent entry
             # (AbsentCommandSpec, MOR-2005 step 4a) is a dict key too, but
             # it means the opposite of "the radio has this command" — see
@@ -2431,12 +2433,47 @@ def load_rig(path: Path) -> RigConfig:
         data_mode_labels = (
             dict(data_mode_section["labels"]) if "labels" in data_mode_section else None
         )
+        raw_inputs = data_mode_section.get("inputs")
+        if raw_inputs is not None:
+            if not isinstance(raw_inputs, list) or not raw_inputs:
+                raise RigLoadError(
+                    f"{filename}: [data_mode].inputs must be a non-empty array"
+                )
+            parsed_inputs: list[tuple[int, str]] = []
+            for index, item in enumerate(raw_inputs):
+                if not isinstance(item, dict) or set(item) != {"value", "name"}:
+                    raise RigLoadError(
+                        f"{filename}: [data_mode].inputs[{index}] must contain value and name"
+                    )
+                value, name = item["value"], item["name"]
+                if (
+                    isinstance(value, bool)
+                    or not isinstance(value, int)
+                    or not 0 <= value <= 5
+                ):
+                    raise RigLoadError(
+                        f"{filename}: [data_mode].inputs[{index}].value must be an integer from 0 to 5"
+                    )
+                if not isinstance(name, str) or not name.strip():
+                    raise RigLoadError(
+                        f"{filename}: [data_mode].inputs[{index}].name must be non-empty"
+                    )
+                parsed_inputs.append((value, name))
+            if len({value for value, _ in parsed_inputs}) != len(parsed_inputs):
+                raise RigLoadError(
+                    f"{filename}: [data_mode].inputs values must be unique"
+                )
+            data_mode_inputs = tuple(parsed_inputs)
+        else:
+            data_mode_inputs = None
     elif has_data_mode_feature:
         data_mode_count = 1
         data_mode_labels = {"0": "OFF", "1": "DATA"}
+        data_mode_inputs = None
     else:
         data_mode_count = 0
         data_mode_labels = None
+        data_mode_inputs = None
 
     # Parse [controls] (optional)
     controls_raw = data.get("controls")
@@ -2684,6 +2721,7 @@ def load_rig(path: Path) -> RigConfig:
         rf_sql_control_model=rf_sql_control_model,
         data_mode_count=data_mode_count,
         data_mode_labels=data_mode_labels,
+        data_mode_inputs=data_mode_inputs,
         protocol_type=protocol_type,
         protocol_address=protocol_address,
         protocol_baud=protocol_baud,

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -3123,6 +3123,10 @@ class WebServer:
                     "hasRxAntenna": profile.antenna_has_rx_ant,
                     "dataModeCount": profile.data_mode_count,
                     "dataModeLabels": profile.data_mode_labels,
+                    "dataModeInputs": [
+                        {"value": value, "label": label}
+                        for value, label in (profile.data_mode_inputs or ())
+                    ],
                     "keyboard": _serialize_keyboard_config(profile),
                     **({"controls": profile.controls} if profile.controls else {}),
                     "txBands": [
@@ -3592,6 +3596,10 @@ class WebServer:
             "dataModeLabels": (
                 profile.data_mode_labels if profile.data_mode_labels else {}
             ),
+            "dataModeInputs": [
+                {"value": value, "label": label}
+                for value, label in (profile.data_mode_inputs or ())
+            ],
             "keyboard": _serialize_keyboard_config(profile),
             "scopeSource": (
                 "hardware"

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -6,6 +6,7 @@ TDD: these tests were written FIRST, then the implementation.
 from __future__ import annotations
 
 import json
+import re
 import textwrap
 import tomllib
 from decimal import Decimal
@@ -710,6 +711,54 @@ labels = { "1" = "FAST", "2" = "MID", "3" = "SLOW" }
     def test_ic7610_stays_separate_rf_sql_control_model(self):
         rig = load_rig(RIGS_DIR / "ic7610.toml")
         assert rig.rf_sql_control_model == "separate"
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            (
+                "ic7300.toml",
+                ((0, "MIC"), (1, "ACC"), (2, "MIC+ACC"), (3, "USB"), (4, "MIC+USB")),
+            ),
+            (
+                "ic7610.toml",
+                (
+                    (0, "MIC"),
+                    (1, "ACC"),
+                    (3, "USB"),
+                    (5, "LAN"),
+                    (2, "MIC+ACC"),
+                    (4, "MIC+USB"),
+                ),
+            ),
+        ],
+    )
+    def test_data_mode_inputs_reach_runtime_profile(self, name, expected):
+        rig = load_rig(RIGS_DIR / name)
+        assert rig.data_mode_inputs == expected
+        assert rig.to_profile().data_mode_inputs == expected
+
+    @pytest.mark.parametrize(
+        ("inputs", "message"),
+        [
+            (
+                '[{ value = 0, name = "MIC" }, { value = 0, name = "ACC" }]',
+                "inputs values must be unique",
+            ),
+            ("[]", "inputs must be a non-empty array"),
+        ],
+    )
+    def test_data_mode_inputs_reject_invalid_metadata(self, tmp_path, inputs, message):
+        text = re.sub(
+            r"inputs = \[.*?\]",
+            f"inputs = {inputs}",
+            TEMPLATE_PATH.read_text(),
+            count=1,
+            flags=re.DOTALL,
+        )
+        path = tmp_path / "invalid-input.toml"
+        path.write_text(text)
+        with pytest.raises(RigLoadError, match=message):
+            load_rig(path)
 
     @pytest.mark.parametrize(
         ("scheme", "receiver_count"),

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -2541,6 +2541,13 @@ async def test_capabilities_reports_combined_rf_sql_control_model_for_ic7300() -
     _, payload = _response_json(writer)
 
     assert payload["rfSqlControlModel"] == "combined"
+    assert payload["dataModeInputs"] == [
+        {"value": 0, "label": "MIC"},
+        {"value": 1, "label": "ACC"},
+        {"value": 2, "label": "MIC+ACC"},
+        {"value": 3, "label": "USB"},
+        {"value": 4, "label": "MIC+USB"},
+    ]
 
 
 @pytest.mark.asyncio
@@ -3939,6 +3946,14 @@ async def test_info_endpoint_returns_structured_capabilities() -> None:
     assert isinstance(caps["tags"], list)
     assert isinstance(caps["modes"], list)
     assert isinstance(caps["filters"], list)
+    assert caps["dataModeInputs"] == [
+        {"value": 0, "label": "MIC"},
+        {"value": 1, "label": "ACC"},
+        {"value": 3, "label": "USB"},
+        {"value": 5, "label": "LAN"},
+        {"value": 2, "label": "MIC+ACC"},
+        {"value": 4, "label": "MIC+USB"},
+    ]
 
     conn = data["connection"]
     assert conn["rigConnected"] is True


### PR DESCRIPTION
Guardrail exception: 34 code/test + 0 regenerated baselines = 34 files.

## Summary
- transport each radio profile’s authoritative MOD IN source domain through both capability response sites with strict, fail-closed validation
- restore MOD IN below DATA in the live Standard MODE panel, routed by the active confirmed DATA group while FILTER remains a separate sibling panel
- preserve confirmed truth during pending commands and show unknown readback disabled without fabricating MIC; omit unsupported radios and sources such as LAN on IC-7300

## Linear
- MOR-2451 (child of MOR-2425)

## Verification
- `npx svelte-check --tsconfig ./tsconfig.app.json` (0 errors, 0 warnings)
- scoped ESLint across all 15 changed frontend files
- `npx vitest run src/lib/types/__tests__/capabilities.control-domains.test.ts src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts src/lib/runtime/adapters/__tests__/mor1536-armed-adoption.isolated.test.ts src/semantic/__tests__/FilterInstrumentHost.isolated.test.ts src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts src/components-v2/wiring/__tests__/mod-input-wiring.isolated.test.ts` (462 passed)
- `.venv/bin/pytest -q tests/test_rig_loader.py tests/test_web_server_coverage.py tests/test_web_server.py::TestHttpEndpoints::test_capabilities_endpoint_json_fields` (564 passed, 1 skipped)
- scoped Ruff check and format check
- `npm run build`
- `git diff --check`
- correction-focused `npx vitest run` across 19 directly affected files (1066 passed)
- correction-focused compatibility and failed-CI reproductions also passed independently (289 and 315 tests)

## Acceptance handoff
- IC-7300 is limited to OFF/DATA and source values 0..4 (no LAN); IC-7610 covers OFF/D1/D2/D3 and source values 0..5; Yaesu/no-domain cases omit MOD IN
- tests cover group-specific routing, profile-domain rejection, confirmed versus pending, unknown/disabled state, callback wiring, malformed/empty metadata, and both server capability payloads
- this intentionally changes the production-root MODE panel pixels; Linux visual actuals should be reviewed before accepting any selected baseline delta
- owner-present radio and production lifecycle acceptance remain coordinator-owned

