### PR TITLE
feat(ui): split Standard left sidebar control panels

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -157,7 +157,7 @@
       draggable: true,
       onDragStart: owner.handleDragStart,
       style: owner.dragStyle(panelId),
-      title,
+      ...(title === undefined ? {} : { title }),
     };
   }
 

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -1047,6 +1047,11 @@
   .standard-bottom-dock > .content-right { display: contents; }
   .tx-aux-finite-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
   .dsp-finite-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+  .agc-finite-grid { display: block; width: 100%; }
+  .agc-finite-grid .dsp-finite-seat { display: contents; }
+  .agc-finite-grid :global([role='radiogroup']) {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(0, 1fr)); width: 100%;
+  }
   .rf-front-end-finite-grid { display: flex; flex-direction: column; gap: 0.5rem; min-width: 0; }
   .rf-front-end-finite-seat { display: contents; }
   /* The `.filter-finite-*` shape, not the siblings' wrap row: a wrap row let
@@ -1072,7 +1077,10 @@
   }
   .band-control-grid, .band-control-seat { display: contents; }
   .antenna-control-grid { display: flex; flex-direction: column; gap: 0.25rem; }
-  .antenna-fixed-port { display: flex; align-items: baseline; justify-content: space-between; gap: 0.5rem; }
+  .antenna-fixed-port {
+    display: flex; align-items: baseline; justify-content: space-between; gap: 0.5rem;
+    padding: 0.25rem 0.5rem;
+  }
   .antenna-control-seat { display: contents; }
   .antenna-blocked { margin: 0; padding-inline-start: 1.2em; }
   .antenna-blocked:empty { display: none; }

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -74,11 +74,66 @@
   let { skinId = 'desktop-v2', instruments }: { skinId?: SkinId; instruments: InstrumentComposition } = $props();
 
   const standardFaceAtMount = untrack(() => skinId === 'desktop-v2');
+  const STANDARD_PANEL_ID_REPLACEMENTS: Readonly<Record<string, readonly string[]>> = {
+    'semantic-rit-xit-scan': ['semantic-rit-xit', 'semantic-scan'],
+    'rit-xit': ['semantic-rit-xit'], scan: ['semantic-scan'], agc: ['semantic-agc'],
+  };
+  function migrateStandardPanelPreferences(): void {
+    if (!standardFaceAtMount || typeof localStorage === 'undefined') return;
+    const orderKeys = ['rigplane:panel-order', 'rigplane:right-panel-order'] as const;
+    const migratedIds = new Set<string>();
+    for (const key of orderKeys) {
+      try {
+        const raw = localStorage.getItem(key);
+        if (raw === null) continue;
+        const parsed: unknown = JSON.parse(raw);
+        if (!Array.isArray(parsed)) continue;
+        const seen = new Set<string>();
+        const migrated: string[] = [];
+        for (const entry of parsed) {
+          if (typeof entry !== 'string') continue;
+          const replacements = STANDARD_PANEL_ID_REPLACEMENTS[entry] ?? [entry];
+          for (const id of replacements) if (!seen.has(id)) {
+            seen.add(id); migrated.push(id); migratedIds.add(id);
+          }
+        }
+        localStorage.setItem(key, JSON.stringify(migrated));
+      } catch { /* retain unreadable preferences */ }
+    }
+    for (const key of orderKeys) {
+      try {
+        const knownKey = `${key}:known-defaults`;
+        const raw = localStorage.getItem(knownKey);
+        const parsed: unknown = raw === null ? [] : JSON.parse(raw);
+        const known = new Set(Array.isArray(parsed)
+          ? parsed.filter((entry): entry is string => typeof entry === 'string') : []);
+        for (const [legacy, replacements] of Object.entries(STANDARD_PANEL_ID_REPLACEMENTS)) {
+          if (known.delete(legacy)) replacements.forEach(id => known.add(id));
+        }
+        migratedIds.forEach(id => known.add(id));
+        localStorage.setItem(knownKey, JSON.stringify([...known]));
+      } catch { /* retain unreadable preferences */ }
+    }
+    try {
+      const raw = localStorage.getItem('rigplane:panel-collapsed');
+      if (raw === null) return;
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return;
+      const collapsed = parsed as Record<string, unknown>;
+      for (const [legacy, replacements] of Object.entries(STANDARD_PANEL_ID_REPLACEMENTS)) {
+        if (typeof collapsed[legacy] !== 'boolean') continue;
+        for (const id of replacements) if (!(id in collapsed)) collapsed[id] = collapsed[legacy];
+        delete collapsed[legacy];
+      }
+      localStorage.setItem('rigplane:panel-collapsed', JSON.stringify(collapsed));
+    } catch { /* retain unreadable preferences */ }
+  }
+  migrateStandardPanelPreferences();
   const standardLeftDrag: PanelDragOwner | null = standardFaceAtMount ? createDragReorder({
     storageKey: 'rigplane:panel-order',
     defaults: [
-      'semantic-rf-front-end', 'semantic-filter', 'semantic-band', 'semantic-antenna',
-      'semantic-rit-xit-scan', 'band',
+      'semantic-rf-front-end', 'semantic-filter', 'semantic-band', 'semantic-agc',
+      'semantic-rit-xit', 'semantic-antenna', 'semantic-scan', 'band',
     ],
     containerSelector: '.standard-panel-owner-left',
   }) : null;
@@ -96,12 +151,13 @@
     containerSelector: '.standard-bottom-dock',
   }) : null;
 
-  function panelChrome(owner: PanelDragOwner, panelId: string): PanelChrome {
+  function panelChrome(owner: PanelDragOwner, panelId: string, title?: string): PanelChrome {
     return {
       panelId,
       draggable: true,
       onDragStart: owner.handleDragStart,
       style: owner.dragStyle(panelId),
+      title,
     };
   }
 
@@ -381,6 +437,11 @@
     <div class="dsp-finite-seat" data-field="nrActive">{@render dspInstruments.nrActive()}</div>
     <div class="dsp-finite-seat" data-field="nbActive">{@render dspInstruments.nbActive()}</div>
     <div class="dsp-finite-seat" data-field="notchMode">{@render dspInstruments.notchMode()}</div>
+  </div>
+{/snippet}
+
+{#snippet agcFiniteLayout(dspInstruments: DspFiniteHandles)}
+  <div class="dsp-finite-grid agc-finite-grid">
     <div class="dsp-finite-seat" data-field="agcMode">{@render dspInstruments.agcMode()}</div>
   </div>
 {/snippet}
@@ -456,19 +517,23 @@
   host hands both the id and the reason codes on `instruments.antennaLayout`.
 -->
 {#snippet antennaControlLayout()}
-  <div class="antenna-control-grid" data-testid="antenna-control-grid">
+  {#if runtime.caps?.antennas === 1}
+    <div class="antenna-fixed-port" data-testid="antenna-fixed-port">
+      <span>TX</span><output>ANT 1</output>
+    </div>
+  {:else}<div class="antenna-control-grid" data-testid="antenna-control-grid">
     <div class="antenna-control-seat" data-field="txPort">
       {@render instruments.antennaInstruments.txPort()}
     </div>
     <div class="antenna-control-seat" data-field="rxAnt">
       {@render instruments.antennaInstruments.rxAnt()}
     </div>
-  </div>
-  <ul class="antenna-blocked" id={instruments.antennaLayout.blockedId} data-testid="antenna-blocked">
+  </div>{/if}
+  {#if runtime.caps?.antennas !== 1}<ul class="antenna-blocked" id={instruments.antennaLayout.blockedId} data-testid="antenna-blocked">
     {#each instruments.antennaLayout.blocked as code (code)}
       <li data-reason={code}>{ANTENNA_BLOCKED_LABEL[code]}</li>
     {/each}
-  </ul>
+  </ul>{/if}
 {/snippet}
 
 {#snippet vfoOperationControls()}
@@ -509,9 +574,19 @@
       undefined, antennaControlLayout, panelChrome(owner, 'semantic-antenna'),
     )}
   {/if}
-  {#if owner.order.includes('semantic-rit-xit-scan')}
+  {#if owner.order.includes('semantic-agc')}
+    {@render instruments.dsp(
+      undefined, agcFiniteLayout, undefined, panelChrome(owner, 'semantic-agc', 'AGC'), 'agc',
+    )}
+  {/if}
+  {#if owner.order.includes('semantic-rit-xit')}
     {@render instruments.ritXitScan(
-      undefined, panelChrome(owner, 'semantic-rit-xit-scan'),
+      undefined, panelChrome(owner, 'semantic-rit-xit', 'RIT / XIT'), 'rit-xit',
+    )}
+  {/if}
+  {#if owner.order.includes('semantic-scan')}
+    {@render instruments.ritXitScan(
+      undefined, panelChrome(owner, 'semantic-scan', 'SCAN'), 'scan',
     )}
   {/if}
   {#if owner.order.includes('semantic-rx-tx')}
@@ -524,7 +599,7 @@
   {/if}
   {#if owner.order.includes('semantic-dsp')}
     {@render instruments.dsp(
-      undefined, dspFiniteLayout, dspScalarLayout, panelChrome(owner, 'semantic-dsp'),
+      undefined, dspFiniteLayout, dspScalarLayout, panelChrome(owner, 'semantic-dsp'), 'dsp',
     )}
   {/if}
   {#if owner.order.includes('semantic-cw')}
@@ -997,6 +1072,7 @@
   }
   .band-control-grid, .band-control-seat { display: contents; }
   .antenna-control-grid { display: flex; flex-direction: column; gap: 0.25rem; }
+  .antenna-fixed-port { display: flex; align-items: baseline; justify-content: space-between; gap: 0.5rem; }
   .antenna-control-seat { display: contents; }
   .antenna-blocked { margin: 0; padding-inline-start: 1.2em; }
   .antenna-blocked:empty { display: none; }

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -1977,7 +1977,8 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
     // The AGC half of the same family — the row that makes this a pairing.
     expect(t.querySelector('.left-sidebar [data-panel-id="agc"]')).toBeNull();
     expect(t.querySelector('[data-panel-id="desktop-agc"]')).toBeNull();
-    expect(t.querySelectorAll('[data-testid="dsp-surface"]').length).toBe(1);
+    expect(t.querySelectorAll('[data-testid="dsp-surface"][data-part="agc"]').length).toBe(1);
+    expect(t.querySelectorAll('[data-testid="dsp-surface"][data-part="dsp"]').length).toBe(1);
   });
 
   // SAFETY-CRITICAL (MOR-1310). After this, `CwKeyerSurface` is the SOLE
@@ -2001,7 +2002,8 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
     h.caps = S9_CAPS();
     const t = renderAll('desktop-v2');
     expect(t.querySelectorAll('[data-testid="rx-audio-surface"]').length).toBe(1);
-    expect(t.querySelectorAll('[data-testid="dsp-surface"]').length).toBe(1);
+    expect(t.querySelectorAll('[data-testid="dsp-surface"][data-part="agc"]').length).toBe(1);
+    expect(t.querySelectorAll('[data-testid="dsp-surface"][data-part="dsp"]').length).toBe(1);
     expect(t.querySelectorAll('[data-testid="cw-keyer-surface"]').length).toBe(1);
     for (const [, host, selector] of S9_RETIRED) {
       expect(t.querySelectorAll(selector).length, host).toBe(0);
@@ -2355,15 +2357,15 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
   // deck", which is the double-presentation defect this slice closes. Run
   // against the real resolved plan (see `renderWithPlan`), because that is the
   // read `zoneOwning()` makes.
-  it.each([['band', 'band-surface'], ['antenna', 'antenna-control-grid'],
-    ['rit-xit-scan', 'ritxit-scan-surface']])(
-    'mounts %s inside its own declared zone element', (zoneId, testid) => {
+  it.each([['band', 'band-surface', 1], ['antenna', 'antenna-control-grid', 1],
+    ['rit-xit-scan', 'ritxit-scan-surface', 2]])(
+    'mounts %s inside its own declared zone element', (zoneId, testid, count) => {
       const t = renderWithPlan('desktop-v2');
       const zone = t.querySelector(`[data-zone-id="${zoneId}"]`);
       expect(zone, `${zoneId} zone element`).not.toBeNull();
       expect(zone!.querySelector(`[data-testid="${testid}"]`)).not.toBeNull();
       // …and it is the ONLY instance — no second, bare mount alongside it.
-      expect(t.querySelectorAll(`[data-testid="${testid}"]`).length).toBe(1);
+      expect(t.querySelectorAll(`[data-testid="${testid}"]`).length).toBe(count);
     },
   );
 
@@ -2458,9 +2460,9 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
   // covers only some of the three zones, or a second mount path.
   it('presents band, antenna and ritXitScan exactly ONCE each on desktop-v2', () => {
     const t = renderAll('desktop-v2');
-    for (const testid of ['band-surface', 'antenna-control-grid', 'ritxit-scan-surface']) {
-      expect(t.querySelectorAll(`[data-testid="${testid}"]`).length, testid).toBe(1);
-    }
+    expect(t.querySelectorAll('[data-testid="band-surface"]')).toHaveLength(1);
+    expect(t.querySelectorAll('[data-testid="antenna-control-grid"]')).toHaveLength(1);
+    expect(t.querySelectorAll('[data-testid="ritxit-scan-surface"]')).toHaveLength(2);
     for (const selector of [
       '.left-sidebar [data-panel-id="rit-xit"]', '.left-sidebar [data-panel-id="scan"]',
       '[data-panel-id="desktop-rit"]', '.left-sidebar [data-panel-id="antenna"]',
@@ -2485,8 +2487,8 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
     enableAllServiceSurfaces();
     const t = renderAll('desktop-v2');
     for (const panelId of [
-      'semantic-rf-front-end', 'semantic-filter', 'semantic-band', 'semantic-antenna',
-      'semantic-rit-xit-scan', 'band',
+      'semantic-rf-front-end', 'semantic-filter', 'semantic-band', 'semantic-agc',
+      'semantic-rit-xit', 'semantic-antenna', 'semantic-scan', 'band',
     ]) {
       const renderedIds = [...t.querySelectorAll('[data-panel-id]')]
         .map((panel) => panel.getAttribute('data-panel-id'));
@@ -2505,6 +2507,32 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
     }
     expect(t.querySelector('.standard-bottom-dock [data-panel-id="semantic-meters"]'))
       .not.toBeNull();
+  });
+
+  it('migrates combined and legacy panel preferences without appending duplicates', () => {
+    localStorage.setItem('rigplane:panel-order', JSON.stringify([
+      'semantic-rf-front-end', 'semantic-rit-xit-scan', 'agc', 'band',
+    ]));
+    localStorage.setItem('rigplane:panel-collapsed', JSON.stringify({
+      'semantic-rit-xit-scan': true, agc: true,
+    }));
+    renderAll('desktop-v2');
+    expect(JSON.parse(localStorage.getItem('rigplane:panel-order')!)).toEqual([
+      'semantic-rf-front-end', 'semantic-rit-xit', 'semantic-scan', 'semantic-agc', 'band',
+      'semantic-filter', 'semantic-band', 'semantic-antenna',
+    ]);
+    expect(JSON.parse(localStorage.getItem('rigplane:panel-collapsed')!)).toMatchObject({
+      'semantic-rit-xit': true, 'semantic-scan': true, 'semantic-agc': true,
+    });
+  });
+
+  it('keeps a one-port antenna panel descriptive and non-interactive', () => {
+    h.caps = { ...h.caps!, antennas: 1, hasRxAntenna: false };
+    const t = renderAll('desktop-v2');
+    const fixed = t.querySelector('[data-testid="antenna-fixed-port"]');
+    expect(fixed?.textContent).toContain('TX');
+    expect(fixed?.textContent).toContain('ANT 1');
+    expect(fixed?.querySelectorAll('button, input')).toHaveLength(0);
   });
 
   it('restores capability-driven MODE hardware keys and keeps FILTER in a sibling panel', () => {

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -1383,9 +1383,19 @@ describe("the SDR face's zones are placed as five regions (MOR-2231, batch 5)", 
     ] as const) {
       for (const surface of surfaces) {
         const selector = `[data-testid="${surface}"]`;
-        expect(root.querySelectorAll(selector), surface).toHaveLength(1);
+        const splitCount = skinId === 'desktop-v2'
+          && (surface === 'ritxit-scan-surface' || surface === 'dsp-surface') ? 2 : 1;
+        expect(root.querySelectorAll(selector), surface).toHaveLength(splitCount);
         expect(root.querySelector(`.desktop-controls-${region} ${selector}`), surface).not.toBeNull();
       }
+    }
+    if (skinId === 'desktop-v2') {
+      expect(root.querySelector('.desktop-controls-left [data-testid="dsp-surface"][data-part="agc"]'))
+        .not.toBeNull();
+      expect(root.querySelector('.desktop-controls-left [data-testid="ritxit-scan-surface"] [data-testid="ritxit"]'))
+        .not.toBeNull();
+      expect(root.querySelector('.desktop-controls-left [data-testid="ritxit-scan-surface"] [data-testid="scan"]'))
+        .not.toBeNull();
     }
     expect(root.querySelectorAll(KEY_AUTHORITIES)).toHaveLength(1);
     expect(root.querySelector('.desktop-controls-right [data-testid="rx-tx-unkey"]')).not.toBeNull();

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -2203,14 +2203,14 @@
     remains the key/unkey authority (R9).
   -->
   {#snippet antennaSurface(controlLayout?: Snippet)}
-    {#if view?.antenna || (controlLayout && runtime.caps?.antennas === 1)}
-      {#if controlLayout}
+    {#if controlLayout}
+      {#if view?.antenna || runtime.caps?.antennas === 1}
         {@render controlLayout()}
-      {:else}
-        <AntennaSurface
-          {view} tx={txState} handles={antennaInstruments} layout={antennaLayout}
-        />
       {/if}
+    {:else if view?.antenna}
+      <AntennaSurface
+        {view} tx={txState} handles={antennaInstruments} layout={antennaLayout}
+      />
     {/if}
   {/snippet}
 

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -73,7 +73,7 @@
   import FrequencyEntryDialog from '../../semantic/FrequencyEntryDialog.svelte';
   import type { BandControlLayout } from '../../semantic/band-instruments';
   import DspSurface, {
-    type DspLevelField, type DspToggleField,
+    type DspLevelField, type DspSurfacePart, type DspToggleField,
   } from '../../semantic/DspSurface.svelte';
   import DspInstrumentHost from '../../semantic/DspInstrumentHost.svelte';
   import type { DspFiniteHandles, DspFiniteLayout } from '../../semantic/dsp-instruments';
@@ -101,7 +101,9 @@
   } from '../../semantic/RfFrontEndSurface.svelte';
   import RfFrontEndInstrumentHost from '../../semantic/RfFrontEndInstrumentHost.svelte';
   import type { RfFrontEndFiniteLayout } from '../../semantic/rf-front-end-instruments';
-  import RitXitScanSurface from '../../semantic/RitXitScanSurface.svelte';
+  import RitXitScanSurface, {
+    type RitXitScanSurfacePart,
+  } from '../../semantic/RitXitScanSurface.svelte';
   import RitXitScanInstrumentHost from '../../semantic/RitXitScanInstrumentHost.svelte';
   import RxAudioSurface from '../../semantic/RxAudioSurface.svelte';
   import RxAudioInstrumentHost from '../../semantic/RxAudioInstrumentHost.svelte';
@@ -621,6 +623,8 @@
    * with no capability check (see that surface's own file header). Same
    * "caps-echo display metadata" seam as `hasDualReceiver` below. */
   let scanCapable = $derived(hasCapability('scan'));
+  let scanTypeValues = $derived(runtime.caps?.scanTypeValues);
+  let scanResumeValues = $derived(runtime.caps?.scanResumeValues);
   /** MOR-1731: consume the shared validated tri-state boundary. `undefined`
    * keeps legacy servers compatible; `null` is the adapter's fail-closed
    * result for present-but-unusable metadata. */
@@ -2199,7 +2203,7 @@
     remains the key/unkey authority (R9).
   -->
   {#snippet antennaSurface(controlLayout?: Snippet)}
-    {#if view?.antenna}
+    {#if view?.antenna || (controlLayout && runtime.caps?.antennas === 1)}
       {#if controlLayout}
         {@render controlLayout()}
       {:else}
@@ -2235,11 +2239,13 @@
     props (`agcLabels` to the finite host, the two `nbLevel*` to the scalar
     host), never to this surface.
   -->
-  {#snippet dspSurface(finiteLayout?: DspFiniteLayout, scalarLayout?: DspScalarLayout)}
+  {#snippet dspSurface(
+    finiteLayout?: DspFiniteLayout, scalarLayout?: DspScalarLayout, part: DspSurfacePart = 'all',
+  )}
     {#if view?.dsp}
       <DspSurface
         {view} finiteHandles={dspInstruments} {finiteLayout}
-        scalarHandles={dspScalars} {scalarLayout}
+        scalarHandles={dspScalars} {scalarLayout} {part}
         onLevelChange={(field, value) => DSP_LEVEL_INTENT[field](value)}
       />
     {/if}
@@ -2312,10 +2318,10 @@
     `'ritXitScan'` becomes DECLARABLE with this slice, and `desktop-v2`
     declared it in MOR-1367 (S8); the cockpit still declares none.
   -->
-  {#snippet ritXitScanSurface()}
-    {#if view?.ritXit || view?.scan}
+  {#snippet ritXitScanSurface(part: RitXitScanSurfacePart = 'all')}
+    {#if (part !== 'scan' && view?.ritXit) || (part !== 'rit-xit' && view?.scan)}
       <RitXitScanSurface
-        {view} {ritDomain} {scanCapable}
+        {view} {ritDomain} {scanCapable} {scanTypeValues} {scanResumeValues} {part}
         handles={ritXitInstruments}
         onRitOffsetChange={ritXitIntents.onRitOffsetChange}
         onXitOffsetChange={ritXitIntents.onXitOffsetChange}
@@ -2326,6 +2332,7 @@
       />
     {/if}
   {/snippet}
+  {#snippet groupedRitXitScanSurface()}{@render ritXitScanSurface()}{/snippet}
 
   <!--
     MOR-1310 (vocabulary slice 9B) — SAFETY-CRITICAL. Same structural gate as
@@ -2531,9 +2538,9 @@
   {/snippet}
   {#snippet hostedDsp(
     allowBare = allowBareSurfaces, finiteLayout?: DspFiniteLayout,
-    scalarLayout?: DspScalarLayout, chrome?: PanelChrome,
+    scalarLayout?: DspScalarLayout, chrome?: PanelChrome, part: DspSurfacePart = 'all',
   )}
-    {#snippet body()}{@render dspSurface(finiteLayout, scalarLayout)}{/snippet}
+    {#snippet body()}{@render dspSurface(finiteLayout, scalarLayout, part)}{/snippet}
     {@render zoned('dsp', view?.dsp !== undefined, body, allowBare, chrome)}
   {/snippet}
   {#snippet hostedBand(
@@ -2546,12 +2553,19 @@
     allowBare = allowBareSurfaces, controlLayout?: Snippet, chrome?: PanelChrome,
   )}
     {#snippet body()}{@render antennaSurface(controlLayout)}{/snippet}
-    {@render zoned('antenna', view?.antenna !== undefined, body, allowBare, chrome)}
-  {/snippet}
-  {#snippet hostedRitXitScan(allowBare = allowBareSurfaces, chrome?: PanelChrome)}
     {@render zoned(
-      'ritXitScan', view?.ritXit !== undefined || view?.scan !== undefined,
-      ritXitScanSurface, allowBare, chrome,
+      'antenna', view?.antenna !== undefined || (controlLayout !== undefined && runtime.caps?.antennas === 1),
+      body, allowBare, chrome,
+    )}
+  {/snippet}
+  {#snippet hostedRitXitScan(
+    allowBare = allowBareSurfaces, chrome?: PanelChrome, part: RitXitScanSurfacePart = 'all',
+  )}
+    {#snippet body()}{@render ritXitScanSurface(part)}{/snippet}
+    {@render zoned(
+      'ritXitScan', (part !== 'scan' && view?.ritXit !== undefined)
+        || (part !== 'rit-xit' && view?.scan !== undefined),
+      body, allowBare, chrome,
     )}
   {/snippet}
   {#snippet hostedCwKeyer(
@@ -2670,7 +2684,7 @@
     {@render zoned('band', view?.band !== undefined, bandSurface, false)}
     {@render zoned('antenna', view?.antenna !== undefined, antennaSurface, false)}
     {@render zoned(
-      'ritXitScan', view?.ritXit !== undefined || view?.scan !== undefined, ritXitScanSurface, false,
+      'ritXitScan', view?.ritXit !== undefined || view?.scan !== undefined, groupedRitXitScanSurface, false,
     )}
     {@render zoned('cwKeyer', view?.cwKeyer !== undefined, cwKeyerSurface, false)}
     {@render zoned('scopeDisplay', view?.scopeDisplay !== undefined, scopeDisplaySurface)}
@@ -2689,7 +2703,7 @@
       {@render zoned('band', view?.band !== undefined, bandSurface, allowBareSurfaces)}
       {@render zoned('antenna', view?.antenna !== undefined, antennaSurface, allowBareSurfaces)}
       {@render zoned(
-        'ritXitScan', view?.ritXit !== undefined || view?.scan !== undefined, ritXitScanSurface,
+        'ritXitScan', view?.ritXit !== undefined || view?.scan !== undefined, groupedRitXitScanSurface,
         allowBareSurfaces,
       )}
       {#if regionExtras}{@render regionExtras('left')}{/if}
@@ -2771,7 +2785,7 @@
     {@render zoned('band', view?.band !== undefined, bandSurface, allowBareSurfaces)}
     {@render zoned('antenna', view?.antenna !== undefined, antennaSurface, allowBareSurfaces)}
     {@render zoned(
-      'ritXitScan', view?.ritXit !== undefined || view?.scan !== undefined, ritXitScanSurface,
+      'ritXitScan', view?.ritXit !== undefined || view?.scan !== undefined, groupedRitXitScanSurface,
       allowBareSurfaces,
     )}
     {@render zoned('cwKeyer', view?.cwKeyer !== undefined, cwKeyerSurface, allowBareSurfaces)}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -664,10 +664,12 @@ describe('persistent finite DSP composition and authority (MOR-2425)', () => {
     const staleStandardNr = retainedInvocations.get('NR')!;
 
     expect(seatFields('.dsp-finite-seat'))
-      .toEqual(['nrActive', 'nbActive', 'notchMode', 'agcMode']);
+      .toEqual(['agcMode', 'nrActive', 'nbActive', 'notchMode']);
     expect(seatFields('.dsp-scalar-seat')).toEqual(['nbLevel', 'nbWidth']);
     for (const label of external) expect(target.querySelectorAll(`[data-testid="external-${label}"]`)).toHaveLength(1);
-    expect(rangeFields()).toEqual(NATIVE_RANGE_FIELDS);
+    expect(rangeFields()).toEqual([
+      'agcTimeConstant', 'nrLevel', 'nbDepth', 'notchFreq', 'manualNotchWidth',
+    ]);
 
     (h.state as { main: Record<string, unknown> }).main.nr = false;
     props.skinId = 'sdr-test';

--- a/frontend/src/components-v2/wiring/instrument-composition.ts
+++ b/frontend/src/components-v2/wiring/instrument-composition.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../semantic/rf-front-end-instruments';
 import type { DspFiniteLayout } from '../../semantic/dsp-instruments';
 import type { DspScalarLayout } from '../../semantic/dsp-scalars';
+import type { DspSurfacePart } from '../../semantic/DspSurface.svelte';
 import type { VfoOperationHandles } from '../../semantic/VfoOperationSeatHost.svelte';
 import type { FilterFiniteLayout } from '../../semantic/filter-instruments';
 import type { BandControlLayout, BandInstrumentHandles } from '../../semantic/band-instruments';
@@ -19,11 +20,13 @@ import type {
   AntennaInstrumentHandles, AntennaInstrumentLayout,
 } from '../../semantic/AntennaInstrumentHost.svelte';
 import type { RitXitScanInstrumentHandles } from '../../semantic/RitXitScanInstrumentHost.svelte';
+import type { RitXitScanSurfacePart } from '../../semantic/RitXitScanSurface.svelte';
 
 export type InstrumentVfoAppearance = 'semantic' | 'sdr' | 'standard';
 
 export interface PanelChrome {
   readonly panelId: string;
+  readonly title?: string;
   readonly draggable: boolean;
   readonly onDragStart: (panelId: string, event: PointerEvent) => void;
   readonly style: string;
@@ -66,7 +69,7 @@ export interface InstrumentComposition {
   ]>;
   readonly dsp: Snippet<[
     allowBare?: boolean, finiteLayout?: DspFiniteLayout, scalarLayout?: DspScalarLayout,
-    chrome?: PanelChrome,
+    chrome?: PanelChrome, part?: DspSurfacePart,
   ]>;
   readonly band: Snippet<[
     allowBare?: boolean, controlLayout?: BandControlLayout, chrome?: PanelChrome,
@@ -77,7 +80,9 @@ export interface InstrumentComposition {
   ]>;
   readonly antennaInstruments: AntennaInstrumentHandles;
   readonly antennaLayout: AntennaInstrumentLayout;
-  readonly ritXitScan: Snippet<[allowBare?: boolean, chrome?: PanelChrome]>;
+  readonly ritXitScan: Snippet<[
+    allowBare?: boolean, chrome?: PanelChrome, part?: RitXitScanSurfacePart,
+  ]>;
   readonly ritXitInstruments: RitXitScanInstrumentHandles;
   readonly cwKeyerInstruments: CwKeyerInstrumentHandles;
   readonly cwKeyer: Snippet<[

--- a/frontend/src/lib/types/capabilities.ts
+++ b/frontend/src/lib/types/capabilities.ts
@@ -180,6 +180,8 @@ export interface Capabilities {
   preLabels?: Record<string, string>;  // Preamp labels (e.g. {"0":"OFF","1":"P1","2":"P2"})
   agcModes?: number[];    // AGC mode values (e.g. [1,2,3] = FAST/MID/SLOW)
   agcLabels?: Record<string, string>;  // AGC mode labels (e.g. {"1":"FAST","2":"MID","3":"SLOW"})
+  scanTypeValues?: number[];    // Profile-declared scan start types
+  scanResumeValues?: number[];  // Profile-declared scan resume modes
   /** RF/SQL control model (MOR-1447 leg 2): "separate" (default, two
    *  independent controls) or "combined" (Icom-style single RF/SQL knob).
    *  Absent on older servers — treat as "separate". */
@@ -456,6 +458,12 @@ export function validateCapabilities(value: unknown): Capabilities {
   requireInteger(raw.receivers, '$.receivers', true);
   if (Object.prototype.hasOwnProperty.call(raw, 'hasRxAntenna')) {
     requireBoolean(raw.hasRxAntenna, '$.hasRxAntenna');
+  }
+  for (const field of ['scanTypeValues', 'scanResumeValues'] as const) {
+    if (Object.prototype.hasOwnProperty.call(raw, field)) {
+      if (!Array.isArray(raw[field])) invalid(`$.${field}`, 'an array');
+      raw[field].forEach((entry, index) => requireInteger(entry, `$.${field}[${index}]`));
+    }
   }
 
   const txAudioFields = [

--- a/frontend/src/semantic/DspSurface.svelte
+++ b/frontend/src/semantic/DspSurface.svelte
@@ -55,6 +55,7 @@
     ['agcTimeConstant', 'AGC time', 0, 9, 1, formatAgcTime],
   ] as const;
   export type DspLevelField = (typeof DSP_LEVELS)[number][0] | 'nbLevel';
+  export type DspSurfacePart = 'all' | 'agc' | 'dsp';
   const [, , NR_FALLBACK_MIN, NR_FALLBACK_MAX, NR_FALLBACK_STEP] = DSP_LEVELS[0];
 
   /** Usable ⇔ the radio HAS it, it is readable NOW, and it has been observed. */
@@ -129,10 +130,11 @@
     finiteLayout?: DspFiniteLayout;
     scalarHandles?: DspScalarHandles;
     scalarLayout?: DspScalarLayout;
+    part?: DspSurfacePart;
     onLevelChange?: (field: DspLevelField, value: number) => void;
   }
   let {
-    view, finiteHandles, finiteLayout, scalarHandles, scalarLayout, onLevelChange,
+    view, finiteHandles, finiteLayout, scalarHandles, scalarLayout, part = 'all', onLevelChange,
   }: Props = $props();
 
   /** Absent group ⇒ this surface renders nothing (S0 optional-group doctrine). */
@@ -149,10 +151,12 @@
     }
     if (usable(dsp[field])) onLevelChange?.(field, value);
   }
+  const showsLevel = (field: DspLevelField): boolean =>
+    part === 'all' || (part === 'agc' ? field === 'agcTimeConstant' : field !== 'agcTimeConstant');
 </script>
 
 {#if dsp}
-  <section class="dsp-surface" data-testid="dsp-surface" aria-label="DSP controls">
+  <section class="dsp-surface" data-testid="dsp-surface" data-part={part} aria-label={part === 'agc' ? 'AGC controls' : 'DSP controls'}>
     {#if finiteLayout}
       {@render finiteLayout(finiteHandles)}
     {:else}
@@ -162,14 +166,14 @@
       </div>
     {/if}
 
-    {#if scalarHandles && scalarLayout}
+    {#if part !== 'agc' && scalarHandles && scalarLayout}
       {@render scalarLayout(scalarHandles)}
     {/if}
 
     {#each DSP_LEVELS as [field, label, min, max, step, format] (field)}
       {#if field === 'nbWidth'}
         {#if scalarHandles && !scalarLayout}{@render scalarHandles.nbWidth()}{/if}
-      {:else if dsp[field].availability.structural}
+      {:else if showsLevel(field) && dsp[field].availability.structural}
         {@const nr = field === 'nrLevel' ? nrPresentation(dsp) : null}
         <label
           class="dsp-level" data-testid={`dsp-${field}`} data-field={field}
@@ -187,11 +191,11 @@
       {/if}
     {/each}
 
-    {#if scalarHandles && !scalarLayout}{@render scalarHandles.nbLevel()}{/if}
+    {#if part !== 'agc' && scalarHandles && !scalarLayout}{@render scalarHandles.nbLevel()}{/if}
 
     {#if !finiteLayout}
-      {@render finiteHandles.notchMode()}
-      {@render finiteHandles.agcMode()}
+      {#if part !== 'agc'}{@render finiteHandles.notchMode()}{/if}
+      {#if part !== 'dsp'}{@render finiteHandles.agcMode()}{/if}
     {/if}
   </section>
 {/if}

--- a/frontend/src/semantic/RitXitScanSurface.svelte
+++ b/frontend/src/semantic/RitXitScanSurface.svelte
@@ -204,6 +204,8 @@
     selectedType = type;
     onScanStart?.(type);
   }
+  const resumeSelected = (value: number): boolean => sc?.scanResumeMode.reading.status === 'known'
+    && sc.scanResumeMode.reading.value === (value & 0x0f);
   function changeOffset(displayHz: number): void {
     if (!canAdjustOffset || !Number.isFinite(displayHz)) return;
     let raw = displayHz;
@@ -286,6 +288,7 @@
                 {#each availableScanTypes as [value, label] (value)}
                   <button
                     type="button" class="scan-choice" data-testid={`scan-type-0x${hex(value)}`}
+                    aria-pressed={effectiveSelectedType === value}
                     onclick={() => selectScanType(value)}
                   >{label}</button>
                 {/each}
@@ -317,6 +320,7 @@
                 {#each availableResumeModes as [value, label] (value)}
                   <button
                     type="button" class="scan-choice" data-testid={`scan-resume-0x${hex(value)}`}
+                    aria-pressed={resumeSelected(value)}
                     onclick={() => onResumeModeChange?.(value)}
                   >{label}</button>
                 {/each}
@@ -340,7 +344,7 @@
   .ritxit-scan-surface[data-part='rit-xit'] .row { flex-direction: column; align-items: stretch; }
   .ritxit-scan-surface[data-part='rit-xit'] .offset { width: 100%; }
   .ritxit-scan-surface[data-part='rit-xit'] .offset input { flex: 1; min-width: 0; }
-  .ritxit-scan-surface[data-part='rit-xit'] .ritxit-mode-row :global(button.v2-control-button[data-surface='hardware']) {
+  .ritxit-scan-surface[data-part='rit-xit'] .ritxit-mode-row :global(button) {
     width: 60px; min-width: 60px; flex: 0 0 60px;
   }
   .ritxit-scan-surface[data-part='scan'] .row {

--- a/frontend/src/semantic/RitXitScanSurface.svelte
+++ b/frontend/src/semantic/RitXitScanSurface.svelte
@@ -94,7 +94,7 @@
     [0xa5, '±100k'], [0xa6, '±500k'], [0xa7, '±1M'],
   ] as const;
   export const RESUME_MODES = [
-    [0xd0, 'OFF'], [0xd3, 'ON'],
+    [0xd0, 'OFF'], [0xd1, '5S'], [0xd2, '10S'], [0xd3, 'ON'],
   ] as const;
   export type RitXitScanSurfacePart = 'all' | 'rit-xit' | 'scan';
   const hex = (value: number): string => value.toString(16).padStart(2, '0');

--- a/frontend/src/semantic/RitXitScanSurface.svelte
+++ b/frontend/src/semantic/RitXitScanSurface.svelte
@@ -176,8 +176,10 @@
    *  file header). NOT an observed radio fact, so it needs no `usable()`
    *  gate: it is honest about what it is from the moment it exists. */
   let selectedType = $state(DEFAULT_SCAN_TYPE);
-  let availableScanTypes = $derived(SCAN_TYPES.filter(([value]) => scanTypeValues?.includes(value) ?? true));
-  let availableResumeModes = $derived(RESUME_MODES.filter(([value]) => scanResumeValues?.includes(value) ?? true));
+  let availableScanTypes = $derived(SCAN_TYPES.filter(([value]) =>
+    scanTypeValues === undefined ? part === 'all' : scanTypeValues.includes(value)));
+  let availableResumeModes = $derived(RESUME_MODES.filter(([value]) =>
+    scanResumeValues === undefined ? part === 'all' : scanResumeValues.includes(value)));
   let effectiveSelectedType = $derived(
     availableScanTypes.some(([value]) => value === selectedType)
       ? selectedType : (availableScanTypes[0]?.[0] ?? DEFAULT_SCAN_TYPE),
@@ -248,7 +250,8 @@
 {/snippet}
 
 {#if (part !== 'scan' && rx) || (part !== 'rit-xit' && sc)}
-  <section class="ritxit-scan-surface" data-testid="ritxit-scan-surface" aria-label="RIT, XIT and scan">
+  <section class="ritxit-scan-surface" data-testid="ritxit-scan-surface"
+    aria-label={part === 'rit-xit' ? 'RIT and XIT controls' : part === 'scan' ? 'Scan controls' : 'RIT, XIT and scan'}>
     {#if part !== 'scan' && rx}
       <div class="row" data-testid="ritxit" data-active-vfo-known={activeKnown}>
         {#if instrumentLayout}
@@ -269,13 +272,13 @@
       <div class="row" data-testid="scan">
         {#if sc.scanning.availability.structural}
           <span class="row-label">SCAN</span>
-          <span class="visually-hidden" data-testid="scan-status" data-observed={usable(sc.scanning)}>{textOf(sc.scanning)}</span>
+          {#if part === 'all'}<span data-testid="scan-status" data-observed={usable(sc.scanning)}>{textOf(sc.scanning)}</span>{/if}
           <button
             type="button" data-testid="scan-toggle" aria-pressed={pressedOf(sc.scanning)}
-            disabled={!scanToggle.available}
+            disabled={!scanToggle.available || (!scanningOn && availableScanTypes.length === 0)}
             onclick={() => scanToggle.invoke()}
           >{scanningOn ? 'STOP' : 'START'}</button>
-          {#if scanCapable}
+          {#if scanCapable && availableScanTypes.length > 0}
             <div class="scan-choice-group" data-testid="scan-type-group">
               <span class="row-label">TYPE</span>
               {#each availableScanTypes as [value, label] (value)}
@@ -297,12 +300,14 @@
             {/if}
           {/if}
         {/if}
-        {#if sc.scanType.availability.structural}
+        {#if part === 'all' && sc.scanType.availability.structural}
           <output data-testid="scan-type-value">{textOf(sc.scanType)}</output>
         {/if}
         {#if sc.scanResumeMode.availability.structural}
+          {#if part === 'all'}
           <output data-testid="scan-resume-value">{textOf(sc.scanResumeMode)}</output>
-          {#if scanCapable}
+          {/if}
+          {#if scanCapable && availableResumeModes.length > 0}
             <div class="scan-choice-group" data-testid="scan-resume-group">
               <span class="row-label">RESUME</span>
               {#each availableResumeModes as [value, label] (value)}
@@ -328,7 +333,6 @@
   .ritxit-mode-row output { margin-inline-start: auto; }
   .scan-choice-group { display: flex; flex-wrap: wrap; gap: 0.25rem; }
   .row-label { font: inherit; }
-  .visually-hidden { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
   [aria-pressed='true'] { font-weight: 700; }
   [data-observed='false'] { font-style: italic; }
   button:disabled, input:disabled { cursor: not-allowed; }

--- a/frontend/src/semantic/RitXitScanSurface.svelte
+++ b/frontend/src/semantic/RitXitScanSurface.svelte
@@ -250,7 +250,7 @@
 {/snippet}
 
 {#if (part !== 'scan' && rx) || (part !== 'rit-xit' && sc)}
-  <section class="ritxit-scan-surface" data-testid="ritxit-scan-surface"
+  <section class="ritxit-scan-surface" data-testid="ritxit-scan-surface" data-part={part}
     aria-label={part === 'rit-xit' ? 'RIT and XIT controls' : part === 'scan' ? 'Scan controls' : 'RIT, XIT and scan'}>
     {#if part !== 'scan' && rx}
       <div class="row" data-testid="ritxit" data-active-vfo-known={activeKnown}>
@@ -263,7 +263,8 @@
           <div class="ritxit-mode-row">
             {@render handles.xit()}<output data-testid="xit-offset-value">{signedOffset(rx.xitOffset)}</output>
           </div>
-          <div class="ritxit-offset-row">{@render offsetSlot()}{@render handles.clear()}</div>
+          <div class="ritxit-offset-row">{@render offsetSlot()}</div>
+          <div class="ritxit-clear-row">{@render handles.clear()}</div>
         {/if}
       </div>
     {/if}
@@ -281,12 +282,14 @@
           {#if scanCapable && availableScanTypes.length > 0}
             <div class="scan-choice-group" data-testid="scan-type-group">
               <span class="row-label">TYPE</span>
-              {#each availableScanTypes as [value, label] (value)}
-                <button
-                  type="button" class="scan-choice" data-testid={`scan-type-0x${hex(value)}`}
-                  onclick={() => selectScanType(value)}
-                >{label}</button>
-              {/each}
+              <div class="scan-choice-buttons scan-type-buttons">
+                {#each availableScanTypes as [value, label] (value)}
+                  <button
+                    type="button" class="scan-choice" data-testid={`scan-type-0x${hex(value)}`}
+                    onclick={() => selectScanType(value)}
+                  >{label}</button>
+                {/each}
+              </div>
             </div>
             {#if isDfSelected}
               <div class="scan-choice-group" data-testid="scan-span-group">
@@ -310,12 +313,14 @@
           {#if scanCapable && availableResumeModes.length > 0}
             <div class="scan-choice-group" data-testid="scan-resume-group">
               <span class="row-label">RESUME</span>
-              {#each availableResumeModes as [value, label] (value)}
-                <button
-                  type="button" class="scan-choice" data-testid={`scan-resume-0x${hex(value)}`}
-                  onclick={() => onResumeModeChange?.(value)}
-                >{label}</button>
-              {/each}
+              <div class="scan-choice-buttons scan-resume-buttons">
+                {#each availableResumeModes as [value, label] (value)}
+                  <button
+                    type="button" class="scan-choice" data-testid={`scan-resume-0x${hex(value)}`}
+                    onclick={() => onResumeModeChange?.(value)}
+                  >{label}</button>
+                {/each}
+              </div>
             </div>
           {/if}
         {/if}
@@ -331,7 +336,24 @@
   .offset { display: flex; align-items: baseline; gap: 0.5rem; }
   .ritxit-mode-row, .ritxit-offset-row { display: flex; align-items: center; gap: 0.5rem; width: 100%; }
   .ritxit-mode-row output { margin-inline-start: auto; }
+  .ritxit-clear-row { display: flex; justify-content: flex-end; width: 100%; }
+  .ritxit-scan-surface[data-part='rit-xit'] .row { flex-direction: column; align-items: stretch; }
+  .ritxit-scan-surface[data-part='rit-xit'] .offset { width: 100%; }
+  .ritxit-scan-surface[data-part='rit-xit'] .offset input { flex: 1; min-width: 0; }
+  .ritxit-scan-surface[data-part='rit-xit'] .ritxit-mode-row :global(.v2-control-button) { min-width: 60px; }
+  .ritxit-scan-surface[data-part='scan'] .row {
+    display: grid; grid-template-columns: 42px minmax(0, 1fr); align-items: center; width: 100%;
+  }
+  .ritxit-scan-surface[data-part='scan'] .row > button { width: 100%; }
   .scan-choice-group { display: flex; flex-wrap: wrap; gap: 0.25rem; }
+  .ritxit-scan-surface[data-part='scan'] .scan-choice-group {
+    grid-column: 1 / -1; display: grid; grid-template-columns: 42px minmax(0, 1fr);
+    align-items: center; gap: 0.25rem;
+  }
+  .scan-choice-buttons { display: grid; gap: 0.25rem; }
+  .scan-choice-buttons button { width: 100%; min-width: 0; }
+  .scan-type-buttons { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .scan-resume-buttons { grid-template-columns: repeat(auto-fit, minmax(0, 1fr)); }
   .row-label { font: inherit; }
   [aria-pressed='true'] { font-weight: 700; }
   [data-observed='false'] { font-style: italic; }

--- a/frontend/src/semantic/RitXitScanSurface.svelte
+++ b/frontend/src/semantic/RitXitScanSurface.svelte
@@ -340,7 +340,9 @@
   .ritxit-scan-surface[data-part='rit-xit'] .row { flex-direction: column; align-items: stretch; }
   .ritxit-scan-surface[data-part='rit-xit'] .offset { width: 100%; }
   .ritxit-scan-surface[data-part='rit-xit'] .offset input { flex: 1; min-width: 0; }
-  .ritxit-scan-surface[data-part='rit-xit'] .ritxit-mode-row :global(.v2-control-button) { min-width: 60px; }
+  .ritxit-scan-surface[data-part='rit-xit'] .ritxit-mode-row :global(button.v2-control-button[data-surface='hardware']) {
+    width: 60px; min-width: 60px; flex: 0 0 60px;
+  }
   .ritxit-scan-surface[data-part='scan'] .row {
     display: grid; grid-template-columns: 42px minmax(0, 1fr); align-items: center; width: 100%;
   }

--- a/frontend/src/semantic/RitXitScanSurface.svelte
+++ b/frontend/src/semantic/RitXitScanSurface.svelte
@@ -94,8 +94,9 @@
     [0xa5, '±100k'], [0xa6, '±500k'], [0xa7, '±1M'],
   ] as const;
   export const RESUME_MODES = [
-    [0xd0, 'OFF'], [0xd1, '5s'], [0xd2, '10s'], [0xd3, '15s'],
+    [0xd0, 'OFF'], [0xd3, 'ON'],
   ] as const;
+  export type RitXitScanSurfacePart = 'all' | 'rit-xit' | 'scan';
   const hex = (value: number): string => value.toString(16).padStart(2, '0');
 
   export const usable = (f: RitXitField<unknown> | ScanField<unknown>): boolean =>
@@ -103,6 +104,11 @@
   export const textOf = (f: RitXitField<unknown> | ScanField<unknown>): string =>
     f.reading.status === 'known' ? String(f.reading.value) : UNKNOWN_TEXT;
   const isOn = (f: RitXitField<boolean>): boolean => f.reading.status === 'known' && f.reading.value === true;
+  const signedOffset = (f: RitXitField<number>): string => {
+    if (f.reading.status !== 'known' || !Number.isFinite(f.reading.value)) return UNKNOWN_TEXT;
+    const value = f.reading.value;
+    return `${value > 0 ? '+' : ''}${value} Hz`;
+  };
 </script>
 
 <script lang="ts">
@@ -127,6 +133,9 @@
      *  (never merely disables) the TYPE/SPAN/RESUME button groups. Fails
      *  closed: absent controls until a caller proves the tag is present. */
     scanCapable?: boolean;
+    scanTypeValues?: readonly number[];
+    scanResumeValues?: readonly number[];
+    part?: RitXitScanSurfacePart;
     ritDomain?: ControlDomain | null;
     handles: RitXitScanInstrumentHandles;
     instrumentLayout?: RitXitScanInstrumentLayout;
@@ -134,6 +143,7 @@
   let {
     view, onRitOffsetChange, onXitOffsetChange,
     onScanStart, onScanStop, onDfSpanChange, onResumeModeChange, scanCapable = false,
+    scanTypeValues, scanResumeValues, part = 'all',
     ritDomain, handles, instrumentLayout,
   }: Props = $props();
 
@@ -166,16 +176,22 @@
    *  file header). NOT an observed radio fact, so it needs no `usable()`
    *  gate: it is honest about what it is from the moment it exists. */
   let selectedType = $state(DEFAULT_SCAN_TYPE);
+  let availableScanTypes = $derived(SCAN_TYPES.filter(([value]) => scanTypeValues?.includes(value) ?? true));
+  let availableResumeModes = $derived(RESUME_MODES.filter(([value]) => scanResumeValues?.includes(value) ?? true));
+  let effectiveSelectedType = $derived(
+    availableScanTypes.some(([value]) => value === selectedType)
+      ? selectedType : (availableScanTypes[0]?.[0] ?? DEFAULT_SCAN_TYPE),
+  );
   /** v2.11.1 `isDfSelected || (scanning && scanType === 0x03)`, verbatim —
    *  never reads `sc.scanType` to decide whether the SELECTION itself is
    *  ΔF, only whether an ALREADY-ACTIVE observed scan is. */
-  let isDfSelected = $derived(selectedType === 0x03 || (scanningOn
+  let isDfSelected = $derived(effectiveSelectedType === 0x03 || (scanningOn
     && sc?.scanType.reading.status === 'known' && sc.scanType.reading.value === 0x03));
 
   const scanToggle = bindToggleInstrument(() => ({
     field: sc?.scanning,
     invoke: (next) => {
-      if (next) onScanStart?.(selectedType);
+      if (next) onScanStart?.(effectiveSelectedType);
       else onScanStop?.();
     },
   }));
@@ -231,25 +247,29 @@
   </label>
 {/snippet}
 
-{#if rx || sc}
+{#if (part !== 'scan' && rx) || (part !== 'rit-xit' && sc)}
   <section class="ritxit-scan-surface" data-testid="ritxit-scan-surface" aria-label="RIT, XIT and scan">
-    {#if rx}
+    {#if part !== 'scan' && rx}
       <div class="row" data-testid="ritxit" data-active-vfo-known={activeKnown}>
         {#if instrumentLayout}
           {@render instrumentLayout(handles, offsetSlot)}
         {:else}
-          {@render handles.rit()}
-          {@render handles.xit()}
-          {@render offsetSlot()}
-          {@render handles.clear()}
+          <div class="ritxit-mode-row">
+            {@render handles.rit()}<output data-testid="rit-offset-value">{signedOffset(rx.ritOffset)}</output>
+          </div>
+          <div class="ritxit-mode-row">
+            {@render handles.xit()}<output data-testid="xit-offset-value">{signedOffset(rx.xitOffset)}</output>
+          </div>
+          <div class="ritxit-offset-row">{@render offsetSlot()}{@render handles.clear()}</div>
         {/if}
       </div>
     {/if}
 
-    {#if sc}
+    {#if part !== 'rit-xit' && sc}
       <div class="row" data-testid="scan">
         {#if sc.scanning.availability.structural}
-          <span data-testid="scan-status" data-observed={usable(sc.scanning)}>{textOf(sc.scanning)}</span>
+          <span class="row-label">SCAN</span>
+          <span class="visually-hidden" data-testid="scan-status" data-observed={usable(sc.scanning)}>{textOf(sc.scanning)}</span>
           <button
             type="button" data-testid="scan-toggle" aria-pressed={pressedOf(sc.scanning)}
             disabled={!scanToggle.available}
@@ -257,7 +277,8 @@
           >{scanningOn ? 'STOP' : 'START'}</button>
           {#if scanCapable}
             <div class="scan-choice-group" data-testid="scan-type-group">
-              {#each SCAN_TYPES as [value, label] (value)}
+              <span class="row-label">TYPE</span>
+              {#each availableScanTypes as [value, label] (value)}
                 <button
                   type="button" class="scan-choice" data-testid={`scan-type-0x${hex(value)}`}
                   onclick={() => selectScanType(value)}
@@ -283,7 +304,8 @@
           <output data-testid="scan-resume-value">{textOf(sc.scanResumeMode)}</output>
           {#if scanCapable}
             <div class="scan-choice-group" data-testid="scan-resume-group">
-              {#each RESUME_MODES as [value, label] (value)}
+              <span class="row-label">RESUME</span>
+              {#each availableResumeModes as [value, label] (value)}
                 <button
                   type="button" class="scan-choice" data-testid={`scan-resume-0x${hex(value)}`}
                   onclick={() => onResumeModeChange?.(value)}
@@ -302,7 +324,11 @@
   .ritxit-scan-surface { display: flex; flex-direction: column; gap: 0.25rem; }
   .row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin: 0; }
   .offset { display: flex; align-items: baseline; gap: 0.5rem; }
+  .ritxit-mode-row, .ritxit-offset-row { display: flex; align-items: center; gap: 0.5rem; width: 100%; }
+  .ritxit-mode-row output { margin-inline-start: auto; }
   .scan-choice-group { display: flex; flex-wrap: wrap; gap: 0.25rem; }
+  .row-label { font: inherit; }
+  .visually-hidden { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
   [aria-pressed='true'] { font-weight: 700; }
   [data-observed='false'] { font-style: italic; }
   button:disabled, input:disabled { cursor: not-allowed; }

--- a/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
@@ -577,6 +577,7 @@ describe('scan TYPE selection: six buttons restore v2.11.1, MOR-2425', () => {
     });
     expect([...target.querySelectorAll('[data-testid^="scan-type-0x"]')]
       .map((button) => button.textContent?.trim())).toEqual(['PROG', 'ΔF', 'SEL']);
+    expect(r.el('scan-type-0x01')?.getAttribute('aria-pressed')).toBe('true');
     expect(r.el('ritxit')).toBeNull();
     r.dispose();
   });
@@ -686,6 +687,7 @@ describe('scan RESUME mode: four explicit literal buttons, MOR-2425 (replacing t
     });
     expect([...target.querySelectorAll('[data-testid^="scan-resume-0x"]')]
       .map((button) => button.textContent?.trim())).toEqual(['OFF', 'ON']);
+    expect(r.el('scan-resume-0xd0')?.getAttribute('aria-pressed')).toBe('true');
     expect(r.el('scan-resume-0xd1')).toBeNull();
     expect(r.el('scan-resume-0xd2')).toBeNull();
     r.dispose();

--- a/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
@@ -98,6 +98,9 @@ type ScanHandlers = {
   onDfSpanChange?: (span: number) => void;
   onResumeModeChange?: (mode: number) => void;
   scanCapable?: boolean;
+  scanTypeValues?: readonly number[];
+  scanResumeValues?: readonly number[];
+  part?: 'all' | 'rit-xit' | 'scan';
 };
 function renderScan(view: RadioViewModel, handlers: ScanHandlers = {}) {
   const component = mount(RitXitScanSurface, {
@@ -568,6 +571,16 @@ describe('scan TYPE selection: six buttons restore v2.11.1, MOR-2425', () => {
     r.dispose();
   });
 
+  it('renders only labelled scan types declared by the profile', () => {
+    const r = renderScan(coldStart(), {
+      scanCapable: true, scanTypeValues: [0x01, 0x03, 0x13, 0x23], part: 'scan',
+    });
+    expect([...target.querySelectorAll('[data-testid^="scan-type-0x"]')]
+      .map((button) => button.textContent?.trim())).toEqual(['PROG', 'ΔF', 'SEL']);
+    expect(r.el('ritxit')).toBeNull();
+    r.dispose();
+  });
+
   it.each(scanTypeCases)(
     '$label ($hex) dispatches onScanStart with its own byte exactly once, from a cold start where scanType has never been reported',
     ({ value, hex }) => {
@@ -653,6 +666,17 @@ describe('scan RESUME mode: four explicit literal buttons, MOR-2425 (replacing t
   it('is hidden entirely — not merely disabled — while scanCapable is false', () => {
     const r = renderScan(coldStart(), { scanCapable: false });
     expect(r.el('scan-resume-group')).toBeNull();
+    r.dispose();
+  });
+
+  it('uses the profile domain and labels D3 by its wire meaning, ON', () => {
+    const r = renderScan(coldStart(), {
+      scanCapable: true, scanResumeValues: [0xd0, 0xd3], part: 'scan',
+    });
+    expect([...target.querySelectorAll('[data-testid^="scan-resume-0x"]')]
+      .map((button) => button.textContent?.trim())).toEqual(['OFF', 'ON']);
+    expect(r.el('scan-resume-0xd1')).toBeNull();
+    expect(r.el('scan-resume-0xd2')).toBeNull();
     r.dispose();
   });
 

--- a/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
@@ -581,6 +581,17 @@ describe('scan TYPE selection: six buttons restore v2.11.1, MOR-2425', () => {
     r.dispose();
   });
 
+  it('fails closed in the Standard scan part when an older server declares no domains', () => {
+    const r = renderScan(coldStart(), { scanCapable: true, part: 'scan' });
+    expect(r.el('scan-type-group')).toBeNull();
+    expect(r.el('scan-resume-group')).toBeNull();
+    expect(r.el('scan-toggle')?.hasAttribute('disabled')).toBe(true);
+    expect(r.el('scan-status')).toBeNull();
+    expect(r.el('scan-type-value')).toBeNull();
+    expect(r.el('scan-resume-value')).toBeNull();
+    r.dispose();
+  });
+
   it.each(scanTypeCases)(
     '$label ($hex) dispatches onScanStart with its own byte exactly once, from a cold start where scanType has never been reported',
     ({ value, hex }) => {

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -3118,6 +3118,16 @@ class WebServer:
                         list(profile.agc_modes) if profile.agc_modes else None
                     ),
                     "agcLabels": profile.agc_labels,
+                    "scanTypeValues": (
+                        list(profile.scan_type_values)
+                        if profile.scan_type_values is not None
+                        else []
+                    ),
+                    "scanResumeValues": (
+                        list(profile.scan_resume_values)
+                        if profile.scan_resume_values is not None
+                        else []
+                    ),
                     "rfSqlControlModel": profile.rf_sql_control_model,
                     "antennas": profile.antenna_tx_count,
                     "hasRxAntenna": profile.antenna_has_rx_ant,
@@ -3591,6 +3601,16 @@ class WebServer:
             "preLabels": profile.pre_labels if profile.pre_labels else {},
             "agcModes": list(profile.agc_modes) if profile.agc_modes else [],
             "agcLabels": profile.agc_labels if profile.agc_labels else {},
+            "scanTypeValues": (
+                list(profile.scan_type_values)
+                if profile.scan_type_values is not None
+                else []
+            ),
+            "scanResumeValues": (
+                list(profile.scan_resume_values)
+                if profile.scan_resume_values is not None
+                else []
+            ),
             "rfSqlControlModel": profile.rf_sql_control_model,
             "dataModeCount": profile.data_mode_count,
             "dataModeLabels": (

--- a/tests/test_web_api_contract.py
+++ b/tests/test_web_api_contract.py
@@ -75,6 +75,12 @@ scheme = "ab"
 tx_count = 2
 has_rx_ant = true
 
+[scan_types]
+values = [0x01, 0x03, 0x13, 0x23]
+
+[scan_resume]
+values = [0xD0, 0xD3]
+
 [controls.identity]
 mapping = "identity"
 raw_min = -2
@@ -175,6 +181,8 @@ async def test_control_domains_round_trip_through_both_capability_endpoints(
         assert controls == _golden_controls()
         assert capability_payload["antennas"] == 2
         assert capability_payload["hasRxAntenna"] is True
+        assert capability_payload["scanTypeValues"] == [0x01, 0x03, 0x13, 0x23]
+        assert capability_payload["scanResumeValues"] == [0xD0, 0xD3]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
MOR-2453: https://linear.app/morozsm/issue/MOR-2453

The Standard left sidebar now contains independent AGC, RIT/XIT, ANTENNA and SCAN panels. AGC mode and timing move out of the right-side DSP panel; RIT/XIT keeps its offset and CLEAR controls while SCAN has separate start/stop, type and resume rows. Existing saved panel order and collapse preferences migrate from the combined panel without duplicating controls. The established MODE button style is retained.

The panels reuse existing semantic hosts and intent handlers. A radio with one antenna shows a fixed, noninteractive ANT 1 readout. Additive capability fields expose the profile's scan type/resume domains through both existing API payloads, so the Standard SCAN panel offers only supported values. Resume 0xD3 is labelled ON rather than the old unsupported fixed-delay claim. No command execution or provider behavior changes.

Validation: 419 focused frontend tests, 25 web API contract tests, changed-component lint and production build. Final type checks and required CI are recorded in the checks. Browser review uses a read-only preview; its scan-domain fields are adapted from the candidate profile while the installed backend remains unchanged. Real capability serialization will be verified after guarded installation.
