### PR TITLE
fix(ui): finish panel drags outside original handle

### DIFF
--- a/frontend/src/lib/__tests__/DragReorderFixture.svelte
+++ b/frontend/src/lib/__tests__/DragReorderFixture.svelte
@@ -16,6 +16,7 @@
     defaults: ['gamma', 'delta'],
     containerSelector: '.test-drag-right',
   });
+  let handleGeneration = $state(0);
 </script>
 
 {#snippet dock(name: string, drag: typeof left)}
@@ -26,10 +27,12 @@
   >
     {#each drag.order as panelId (panelId)}
       <article data-panel-id={panelId} style={drag.dragStyle(panelId)}>
-        <button
-          data-drag-handle={panelId}
-          onpointerdown={(event) => drag.handleDragStart(panelId, event)}
-        >{panelId}</button>
+        {#key handleGeneration}
+          <button
+            data-drag-handle={panelId}
+            onpointerdown={(event) => drag.handleDragStart(panelId, event)}
+          >{panelId}</button>
+        {/key}
       </article>
     {/each}
   </section>
@@ -39,3 +42,4 @@
 {@render dock('bottom', bottom)}
 {@render dock('right', right)}
 <button data-reset-all onclick={() => left.resetAll()}>reset</button>
+<button data-replace-handles onclick={() => handleGeneration += 1}>replace handles</button>

--- a/frontend/src/lib/__tests__/drag-reorder.component.test.ts
+++ b/frontend/src/lib/__tests__/drag-reorder.component.test.ts
@@ -34,12 +34,15 @@ function handle(panelId: string): HTMLElement {
   return target.querySelector(`[data-drag-handle="${panelId}"]`)!;
 }
 
-function pointer(element: HTMLElement, type: string, clientX: number, clientY: number): void {
+function pointer(
+  element: EventTarget, type: string, clientX: number, clientY: number, buttons = 0,
+): void {
   element.dispatchEvent(new PointerEvent(type, {
     bubbles: true,
     pointerId: 1,
     clientX,
     clientY,
+    buttons,
   }));
   flushSync();
 }
@@ -97,6 +100,64 @@ afterEach(() => {
 });
 
 describe('three-zone panel drag', () => {
+  it('reorders upward on a window release and persists the result', () => {
+    render();
+    const beta = handle('beta');
+
+    pointer(beta, 'pointerdown', 10, 75, 1);
+    pointer(window, 'pointermove', 10, 20, 1);
+    pointer(window, 'pointerup', -20, -20);
+
+    expect(panelIds('left')).toEqual(['beta', 'alpha']);
+    expect(JSON.parse(localStorage.getItem(KEYS.left)!)).toEqual(['beta', 'alpha']);
+    expect(handle('beta').closest('[data-panel-id]')?.getAttribute('style')).not.toContain('opacity');
+  });
+
+  it('finishes from window after Svelte replaces the captured handle', () => {
+    render();
+    const beta = handle('beta');
+
+    pointer(beta, 'pointerdown', 10, 75, 1);
+    pointer(window, 'pointermove', 10, 20, 1);
+    target.querySelector<HTMLElement>('[data-replace-handles]')!.click();
+    flushSync();
+    expect(handle('beta')).not.toBe(beta);
+    pointer(beta, 'lostpointercapture', 10, 20, 1);
+    pointer(window, 'pointerup', 10, 20);
+
+    expect(panelIds('left')).toEqual(['beta', 'alpha']);
+    expect(JSON.parse(localStorage.getItem(KEYS.left)!)).toEqual(['beta', 'alpha']);
+  });
+
+  it('cancels without reordering and clears every drag preview', () => {
+    render();
+    const alpha = handle('alpha');
+
+    pointer(alpha, 'pointerdown', 10, 25, 1);
+    pointer(window, 'pointermove', 350, 75, 1);
+    expect(zone('right').dataset.dropTarget).toBe('true');
+    pointer(window, 'pointercancel', 350, 75);
+
+    expect(panelIds('left')).toEqual(['alpha', 'beta']);
+    expect(panelIds('right')).toEqual(['gamma', 'delta']);
+    expect(zone('right').dataset.dropTarget).toBe('false');
+    expect(handle('alpha').closest('[data-panel-id]')?.getAttribute('style')).not.toContain('opacity');
+  });
+
+  it('cleans up terminal lost capture without committing', () => {
+    render();
+    const alpha = handle('alpha');
+
+    pointer(alpha, 'pointerdown', 10, 25, 1);
+    pointer(window, 'pointermove', 350, 75, 1);
+    pointer(alpha, 'lostpointercapture', 350, 75, 0);
+
+    expect(panelIds('left')).toEqual(['alpha', 'beta']);
+    expect(panelIds('right')).toEqual(['gamma', 'delta']);
+    expect(zone('right').dataset.dropTarget).toBe('false');
+    expect(handle('alpha').closest('[data-panel-id]')?.getAttribute('style')).not.toContain('opacity');
+  });
+
   it('tracks left to bottom to right and transfers only to the active target', () => {
     render();
     const alpha = handle('alpha');

--- a/frontend/src/lib/drag-reorder.svelte.ts
+++ b/frontend/src/lib/drag-reorder.svelte.ts
@@ -128,6 +128,7 @@ export function createDragReorder(options: DragReorderOptions): DragInstance {
   let order = $state(loadPanelOrder(storageKey, defaults));
   let dragPanelId = $state<string | null>(null);
   let dropTargetIndex = $state<number>(-1);
+  let cancelActiveDrag: (() => void) | null = null;
 
   // Cross-sidebar state (set by peer during its drag)
   let _incomingDragId = $state<string | null>(null);
@@ -192,12 +193,12 @@ export function createDragReorder(options: DragReorderOptions): DragInstance {
 
   function handleDragStart(panelId: string, event: PointerEvent) {
     const handle = event.currentTarget as HTMLElement;
-    handle.setPointerCapture(event.pointerId);
-    dragPanelId = panelId;
-    dropTargetIndex = order.indexOf(panelId);
-
     const sidebar = handle.closest(containerSelector) as HTMLElement;
     if (!sidebar) return;
+    cancelActiveDrag?.();
+    const pointerId = event.pointerId;
+    dragPanelId = panelId;
+    dropTargetIndex = order.indexOf(panelId);
 
     // Cache own panel rects
     const rects = new Map<string, DOMRect>();
@@ -224,8 +225,10 @@ export function createDragReorder(options: DragReorderOptions): DragInstance {
     }
 
     let activePeer: (typeof peers)[number] | null = null;
+    let ended = false;
 
     function onMove(e: PointerEvent) {
+      if (e.pointerId !== pointerId || ended) return;
       const target = peers.find(({ rect }) =>
         e.clientX >= rect.left &&
         e.clientX <= rect.right &&
@@ -251,7 +254,23 @@ export function createDragReorder(options: DragReorderOptions): DragInstance {
       }
     }
 
-    function onUp() {
+    function cleanup() {
+      if (ended) return;
+      ended = true;
+      activePeer?.instance._setIncoming(null, -1);
+      activePeer = null;
+      dragPanelId = null;
+      dropTargetIndex = -1;
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onCancel);
+      window.removeEventListener('blur', onCancel);
+      handle.removeEventListener('lostpointercapture', onLostPointerCapture);
+      if (cancelActiveDrag === cleanup) cancelActiveDrag = null;
+    }
+
+    function onUp(e: PointerEvent) {
+      if (e.pointerId !== pointerId || ended) return;
       if (activePeer && dragPanelId) {
         const targetIdx = activePeer.instance._incomingDropIndex;
         activePeer.instance._acceptPanel(dragPanelId, targetIdx >= 0 ? targetIdx : 0);
@@ -260,18 +279,32 @@ export function createDragReorder(options: DragReorderOptions): DragInstance {
         const newOrder = reorderPanels(order, dragPanelId, dropTargetIndex);
         if (newOrder !== order) order = newOrder;
       }
-      activePeer?.instance._setIncoming(null, -1);
-      activePeer = null;
-      dragPanelId = null;
-      dropTargetIndex = -1;
-      handle.removeEventListener('pointermove', onMove);
-      handle.removeEventListener('pointerup', onUp);
-      handle.removeEventListener('pointercancel', onUp);
+      cleanup();
     }
 
-    handle.addEventListener('pointermove', onMove);
-    handle.addEventListener('pointerup', onUp);
-    handle.addEventListener('pointercancel', onUp);
+    function onCancel(e: Event) {
+      if (e instanceof PointerEvent && e.pointerId !== pointerId) return;
+      cleanup();
+    }
+
+    function onLostPointerCapture(e: PointerEvent) {
+      // A Svelte update may replace the original handle while the pointer is
+      // still down. Window listeners keep that drag alive; a capture loss with
+      // no pressed buttons is an end signal and must clear the preview.
+      if (e.pointerId === pointerId && e.buttons === 0) cleanup();
+    }
+
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onCancel);
+    window.addEventListener('blur', onCancel);
+    handle.addEventListener('lostpointercapture', onLostPointerCapture);
+    cancelActiveDrag = cleanup;
+    try {
+      handle.setPointerCapture(pointerId);
+    } catch {
+      // Global listeners still provide a complete drag lifecycle.
+    }
   }
 
   function reset() {
@@ -318,6 +351,7 @@ export function createDragReorder(options: DragReorderOptions): DragInstance {
   // In Svelte 5, $effect teardown runs on component unmount.
   $effect(() => {
     return () => {
+      cancelActiveDrag?.();
       const idx = _registry.indexOf(instance);
       if (idx >= 0) _registry.splice(idx, 1);
     };


### PR DESCRIPTION
Panel dragging could remain visually active after the original drag handle stopped receiving pointer events: the source panel stayed dimmed, the insertion marker remained visible, and the new order was not persisted. Move the active drag lifecycle to window listeners so release outside or after a Svelte handle replacement completes the reorder, while pointer cancellation, terminal capture loss, blur, restart, and unmount clear previews without committing.

Linear: [MOR-2454](https://linear.app/rigplane/issue/MOR-2454)

Validation: the base helper fails the exact handle-replacement regression (1 failed, 7 skipped), while the candidate's focused drag helper/component tests pass 24/24. Exact ESLint, Svelte/type check with 0 errors and 0 warnings, and frontend build also pass on the isolated Mac mini candidate checkout. The regression test deterministically replaces the captured handle, delivers release through `window`, and verifies the upward reorder and persisted order.
