### PR TITLE
fix(ui): require deliberate slider wheel tuning (MOR-2460)

### DIFF
--- a/frontend/src/components-v2/controls/value-control/BipolarRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/BipolarRenderer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { wheelControl } from './wheel-control';
   import { onDestroy, untrack } from 'svelte';
   import type {
     ContinuousScalarRendererSeat,
@@ -65,7 +66,7 @@
   let activePointer: { id: number; token: number; target: HTMLElement } | null = null;
   const initialBinding = untrack(() => binding);
   let attachedBinding = initialBinding;
-  let lease: ContinuousScalarRendererLease = $state(initialBinding.attachRenderer());
+  let lease: ContinuousScalarRendererLease = $state.raw(initialBinding.attachRenderer());
 
   $effect(() => {
     if (binding === attachedBinding) return;
@@ -167,11 +168,6 @@
     activePointer = null;
   }
 
-  function handleWheel(e: WheelEvent) {
-    if (!view.editable) return;
-    e.preventDefault();
-    lease.wheel({ direction: e.deltaY > 0 ? -1 : 1, fine: e.shiftKey });
-  }
 
   function handleKeyDown(e: KeyboardEvent) {
     if (lease.key({ key: e.key, fine: e.shiftKey })) e.preventDefault();
@@ -219,7 +215,7 @@
     onpointermove={handlePointerMove}
     onpointerup={handlePointerUp}
     onpointercancel={handlePointerCancel}
-    onwheel={handleWheel}
+    use:wheelControl={{ view, lease }}
     onkeydown={handleKeyDown}
     ondblclick={handleDoubleClick}
   >

--- a/frontend/src/components-v2/controls/value-control/DiscreteRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/DiscreteRenderer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { wheelControl } from './wheel-control';
   import { onDestroy, untrack } from 'svelte';
   import type {
     ContinuousScalarRendererSeat,
@@ -77,7 +78,7 @@
   let activePointer: { id: number; token: number; target: HTMLElement } | null = null;
   const initialBinding = untrack(() => binding);
   let attachedBinding = initialBinding;
-  let lease: ContinuousScalarRendererLease = $state(initialBinding.attachRenderer());
+  let lease: ContinuousScalarRendererLease = $state.raw(initialBinding.attachRenderer());
 
   $effect(() => {
     if (binding === attachedBinding) return;
@@ -221,11 +222,6 @@
     activePointer = null;
   }
 
-  function handleWheel(e: WheelEvent) {
-    if (!view.editable) return;
-    e.preventDefault();
-    lease.wheel({ direction: e.deltaY > 0 ? -1 : 1, fine: e.shiftKey });
-  }
 
   function handleKeyDown(e: KeyboardEvent) {
     if (lease.key({ key: e.key, fine: e.shiftKey })) e.preventDefault();
@@ -277,7 +273,7 @@
     onpointermove={handlePointerMove}
     onpointerup={handlePointerUp}
     onpointercancel={handlePointerCancel}
-    onwheel={handleWheel}
+    use:wheelControl={{ view, lease }}
     onkeydown={handleKeyDown}
     ondblclick={handleDoubleClick}
   >

--- a/frontend/src/components-v2/controls/value-control/DualParamRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/DualParamRenderer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { wheelControl } from './wheel-control';
   import { onDestroy, untrack } from 'svelte';
   import type {
     ContinuousPairBinding,
@@ -45,7 +46,7 @@
   let activePointer: { id: number; token: number; target: HTMLElement } | null = null;
   const initialBinding = untrack(() => binding);
   let attachedBinding = initialBinding;
-  let lease: ContinuousPairRendererLease = initialBinding.attachRenderer();
+  let lease: ContinuousPairRendererLease = $state.raw(initialBinding.attachRenderer());
   let view = $state<ContinuousPairView | null>(null);
 
   function releaseActivePointer(): void {
@@ -157,11 +158,6 @@
     lease.cancelPointer(token);
   }
 
-  function handleWheel(e: WheelEvent) {
-    if (view === null || !view.editable) return;
-    e.preventDefault();
-    lease.wheel({ direction: e.deltaY > 0 ? -1 : 1, fine: e.shiftKey });
-  }
 
   function handleKeyDown(e: KeyboardEvent) {
     if (lease.key({ key: e.key, fine: e.shiftKey })) e.preventDefault();
@@ -224,7 +220,7 @@
     onpointermove={handlePointerMove}
     onpointerup={handlePointerUp}
     onpointercancel={handlePointerCancel}
-    onwheel={handleWheel}
+    use:wheelControl={{ view, lease }}
     onkeydown={handleKeyDown}
     ondblclick={handleDoubleClick}
   >

--- a/frontend/src/components-v2/controls/value-control/HBarRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/HBarRenderer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { wheelControl } from './wheel-control';
   import { onDestroy, untrack } from 'svelte';
   import type {
     ContinuousScalarRendererLease,
@@ -50,7 +51,7 @@
   } | null = null;
   const initialBinding = untrack(() => binding);
   let attachedBinding = initialBinding;
-  let lease: ContinuousScalarRendererLease = initialBinding.attachRenderer();
+  let lease: ContinuousScalarRendererLease = $state.raw(initialBinding.attachRenderer());
 
   function releaseActivePointer(): void {
     if (activePointer?.target.hasPointerCapture?.(activePointer.id)) {
@@ -194,11 +195,6 @@
     activePointer = null;
   }
 
-  function handleWheel(e: WheelEvent) {
-    if (view == null || !view.editable) return;
-    e.preventDefault();
-    lease.wheel({ direction: e.deltaY > 0 ? -1 : 1, fine: e.shiftKey });
-  }
 
   function handleKeyDown(e: KeyboardEvent) {
     if (lease.key({ key: e.key, fine: e.shiftKey })) e.preventDefault();
@@ -251,7 +247,7 @@
     onpointermove={handlePointerMove}
     onpointerup={handlePointerUp}
     onpointercancel={handlePointerCancel}
-    onwheel={handleWheel}
+    use:wheelControl={{ view, lease }}
     onkeydown={handleKeyDown}
     ondblclick={handleDoubleClick}
   >

--- a/frontend/src/components-v2/controls/value-control/KnobRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/KnobRenderer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { wheelControl } from './wheel-control';
   import { onDestroy, untrack } from 'svelte';
   import type {
     ContinuousScalarRendererSeat,
@@ -78,7 +79,7 @@
   } | null = null;
   const initialBinding = untrack(() => binding);
   let attachedBinding = initialBinding;
-  let lease: ContinuousScalarRendererLease = $state(initialBinding.attachRenderer());
+  let lease: ContinuousScalarRendererLease = $state.raw(initialBinding.attachRenderer());
 
   $effect(() => {
     if (binding === attachedBinding) return;
@@ -189,11 +190,6 @@
     activePointer = null;
   }
 
-  function handleWheel(e: WheelEvent) {
-    if (!view.editable) return;
-    e.preventDefault();
-    lease.wheel({ direction: e.deltaY > 0 ? -1 : 1, fine: e.shiftKey });
-  }
 
   function handleKeyDown(e: KeyboardEvent) {
     if (lease.key({ key: e.key, fine: e.shiftKey })) e.preventDefault();
@@ -232,7 +228,7 @@
     onpointermove={handlePointerMove}
     onpointerup={handlePointerUp}
     onpointercancel={handlePointerCancel}
-    onwheel={handleWheel}
+    use:wheelControl={{ view, lease }}
     onkeydown={handleKeyDown}
     ondblclick={handleDoubleClick}
   >

--- a/frontend/src/components-v2/controls/value-control/__tests__/DualParamRenderer.controlled.svelte.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/DualParamRenderer.controlled.svelte.test.ts
@@ -4,6 +4,8 @@ import DualParamRenderer from '../DualParamRenderer.svelte';
 import type { DualParamIssuedStatusPresentation } from '../dual-param-issued-status';
 import {
   createContinuousPair,
+  createLegacyContinuousPairPolicy,
+  createRenderedNativeRangeContinuousPairPolicy,
   nativeRangeContinuousPairPolicy,
   type CommandFeedbackContinuousPairInput,
   type ContinuousPairBinding,
@@ -86,6 +88,61 @@ function mountReactive(binding: ContinuousPairBinding) {
 function slider(target: HTMLElement): HTMLElement {
   return target.querySelector('[role="slider"]') as HTMLElement;
 }
+
+it('leaves unarmed RF/SQL wheel input available for page scrolling', () => {
+  const { binding, lease } = fakeBinding(1);
+  const { target } = mountReactive(binding);
+  const event = new WheelEvent('wheel', { deltaY: -1, bubbles: true, cancelable: true });
+  slider(target).dispatchEvent(event);
+  expect(event.defaultPrevented).toBe(false);
+  expect(lease.wheel).not.toHaveBeenCalled();
+});
+
+it.each(['legacy', 'native'] as const)('keeps %s RF/SQL geometry and authority through accelerated wheel input', (kind) => {
+  const requestRf = vi.fn();
+  const requestSql = vi.fn();
+  const source = $state({
+    evidence: 'reading' as const, ownerKey: 'receiver-a', enabled: true,
+    domain: { min: 0, max: 100, step: 2, defaultValue: null, fineStepDivisor: 10 },
+    rf: { reading: { status: 'known' as const, value: 100 }, availability: 'available' as const },
+    sql: { reading: { status: 'known' as const, value: 0 }, availability: 'available' as const },
+    requestRf, requestSql,
+  });
+  const binding = createContinuousPair(() => source, kind === 'legacy'
+    ? createLegacyContinuousPairPolicy({ keyboardDebounceMs: 50 })
+    : createRenderedNativeRangeContinuousPairPolicy());
+  const { target } = mountReactive(binding);
+  const control = slider(target);
+  control.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+  const wheel = (time: number, deltaY = -120) => {
+    const event = new WheelEvent('wheel', { deltaY, bubbles: true, cancelable: true });
+    Object.defineProperty(event, 'timeStamp', { value: time });
+    control.dispatchEvent(event);
+    flushSync();
+    return event;
+  };
+  wheel(1000);
+  if (kind === 'legacy') expect(requestSql).toHaveBeenCalledExactlyOnceWith(2);
+  else expect(requestSql).not.toHaveBeenCalled();
+  wheel(1010);
+  expect(requestSql).toHaveBeenLastCalledWith(kind === 'legacy' ? 18 : 26);
+  expect(requestRf).not.toHaveBeenCalled();
+  expect(binding.view.canonical).toEqual({ rf: 100, sql: 0 });
+  for (let time = 1020; time < 1200; time += 10) {
+    source.sql.reading.value = requestSql.mock.lastCall?.[0] ?? 0;
+    flushSync();
+    wheel(time);
+  }
+  expect(requestSql).toHaveBeenLastCalledWith(100);
+  expect(requestSql.mock.calls.every(([value]) => value >= 0 && value <= 100 && value % 2 === 0)).toBe(true);
+  source.ownerKey = 'receiver-b';
+  flushSync();
+  expect(control.dataset.wheelArmed).toBe('false');
+  requestSql.mockClear();
+  expect(wheel(1300).defaultPrevented).toBe(false);
+  expect(requestSql).not.toHaveBeenCalled();
+  binding.destroy();
+});
 
 function commandFeedback(
   control: string,
@@ -223,12 +280,12 @@ describe('binding-only DualParamRenderer', () => {
     }));
     control.dispatchEvent(new PointerEvent('pointercancel', { bubbles: true, pointerId: 2 }));
     expect(first.lease.cancelPointer).toHaveBeenCalledExactlyOnceWith(11);
+    control.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
     control.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: -1 }));
     control.dispatchEvent(new WheelEvent('wheel', {
       bubbles: true, cancelable: true, deltaY: 1, shiftKey: true,
     }));
-    expect(first.lease.wheel).toHaveBeenNthCalledWith(1, { direction: 1, fine: false });
-    expect(first.lease.wheel).toHaveBeenNthCalledWith(2, { direction: -1, fine: true });
+    expect(first.lease.wheel).toHaveBeenCalledExactlyOnceWith({ direction: 1, fine: false, steps: 1 });
     control.dispatchEvent(new KeyboardEvent('keydown', {
       bubbles: true, cancelable: true, key: 'ArrowRight', shiftKey: true,
     }));

--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
@@ -7,6 +7,7 @@ import DiscreteRenderer from '../DiscreteRenderer.svelte';
 import ExternalScalarRendererFixture from './ExternalScalarRendererFixture.svelte';
 import { professionalSkin } from '../skins';
 import type { Skin } from '../skin';
+import { wheelControl } from '../wheel-control';
 import {
   createBipolarContinuousScalarPolicy,
   createContinuousScalar,
@@ -81,6 +82,152 @@ const baseProps = {
   renderer: 'hbar' as const,
   debounceMs: 0,
 };
+
+describe('deliberate wheel interaction', () => {
+  it.each(['hbar', 'bipolar', 'discrete', 'knob', 'professional'])(
+    'requires activation and preserves native slow steps for %s', (appearance) => {
+      const onChange = vi.fn();
+      const { target } = mountReactive({ ...baseProps, value: 50, step: 1,
+        renderer: appearance === 'professional' ? 'knob' : appearance,
+        skin: appearance === 'professional' ? professionalSkin : undefined, onChange });
+      const control = slider(target);
+      const wheel = (options: WheelEventInit = {}) => {
+        const event = new WheelEvent('wheel', { deltaY: -1, bubbles: true, cancelable: true, ...options });
+        control.dispatchEvent(event);
+        flushSync();
+        return event;
+      };
+      expect(wheel().defaultPrevented).toBe(false);
+      expect(onChange).not.toHaveBeenCalled();
+      control.focus();
+      expect(wheel().defaultPrevented).toBe(false);
+      control.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      expect(control.dataset.wheelArmed).toBe('true');
+      expect(wheel().defaultPrevented).toBe(true);
+      expect(onChange).toHaveBeenCalledExactlyOnceWith(51);
+      for (const options of [{ deltaY: 0 }, { deltaY: 0, deltaX: 12 }, { ctrlKey: true }, { metaKey: true }, { shiftKey: true }]) {
+        expect(wheel(options).defaultPrevented).toBe(false);
+      }
+      expect(onChange).toHaveBeenCalledTimes(1);
+      control.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      expect(control.dataset.wheelArmed).toBe('false');
+      expect(wheel().defaultPrevented).toBe(false);
+      for (const exit of ['blur', 'pointerleave']) {
+        control.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+        expect(control.dataset.wheelArmed).toBe('true');
+        control.dispatchEvent(new Event(exit));
+        expect(control.dataset.wheelArmed).toBe('false');
+        expect(wheel().defaultPrevented).toBe(false);
+      }
+      control.setPointerCapture = vi.fn();
+      vi.spyOn(control.parentElement!, 'getBoundingClientRect')
+        .mockReturnValue({ left: 0, width: 100 } as DOMRect);
+      control.dispatchEvent(new PointerEvent('pointerdown', {
+        button: 0, isPrimary: true, pointerId: 1, clientX: 50, bubbles: true,
+      }));
+      flushSync();
+      expect(control.dataset.wheelArmed).toBe('true');
+      expect(wheel().defaultPrevented).toBe(true);
+    },
+  );
+
+  it('normalizes magnitude/time, caps bursts, resets on reversal and preserves scroll modifiers', () => {
+    const node = document.createElement('div');
+    node.tabIndex = 0;
+    document.body.appendChild(node);
+    roots.push(node);
+    let view = { editable: true, interactionEpoch: 0 };
+    const request = vi.fn();
+    const lease = { get view() { return view; }, wheel: request };
+    const action = wheelControl(node, { view, lease });
+    const arm = () => node.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    const wheel = (time: number, deltaY: number, deltaMode = 0, extra: WheelEventInit = {}) => {
+      const event = new WheelEvent('wheel', { deltaY, deltaMode, cancelable: true, ...extra });
+      Object.defineProperty(event, 'timeStamp', { value: time });
+      node.dispatchEvent(event);
+      return event;
+    };
+    arm();
+    wheel(1000, -120);
+    wheel(1010, -120);
+    wheel(1020, 120);
+    wheel(1400, -3, 1);
+    wheel(1410, -3, 1);
+    wheel(1800, -0.15, 2);
+    wheel(1810, -0.15, 2);
+    expect(request.mock.calls.map(([event]) => event.steps)).toEqual([1, 8, 1, 1, 8, 1, 8]);
+    request.mockClear();
+    wheel(2200, -24);
+    wheel(2208, -24);
+    wheel(2600, -24);
+    expect(request.mock.calls.map(([event]) => event.steps)).toEqual([1, 3, 1]);
+    for (const extra of [{ deltaX: 30 }, { shiftKey: true }, { ctrlKey: true }, { metaKey: true }]) {
+      expect(wheel(2700, -24, 0, extra).defaultPrevented).toBe(false);
+    }
+    expect(wheel(2700, 0).defaultPrevented).toBe(false);
+    expect(wheel(2700, -1, 3).defaultPrevented).toBe(false);
+    expect(request).toHaveBeenCalledTimes(3);
+    view = { editable: true, interactionEpoch: 1 };
+    expect(wheel(2800, -120).defaultPrevented).toBe(false);
+    expect(node.dataset.wheelArmed).toBe('false');
+    arm();
+    view = { editable: false, interactionEpoch: 1 };
+    action.update({ view, lease });
+    expect(node.dataset.wheelArmed).toBe('false');
+    expect(wheel(2900, -120).defaultPrevented).toBe(false);
+    view = { editable: true, interactionEpoch: 2 };
+    action.update({ view, lease });
+    node.dispatchEvent(new PointerEvent('pointerdown', { button: 0, isPrimary: true }));
+    expect(node.dataset.wheelArmed).toBe('true');
+    expect(node.style.outline).toContain('2px');
+    expect(wheel(3000, -120).defaultPrevented).toBe(true);
+    window.dispatchEvent(new Event('blur'));
+    expect(node.dataset.wheelArmed).toBe('false');
+    action.destroy();
+    expect(node.hasAttribute('data-wheel-armed')).toBe(false);
+    expect(wheel(3010, -120).defaultPrevented).toBe(false);
+    expect(request).toHaveBeenCalledTimes(4);
+  });
+
+  it.each(['hbar', 'bipolar', 'discrete', 'knob'])(
+    '%s clamps accelerated input on its native lattice without delaying callbacks or canonical ARIA', (renderer) => {
+      const onChange = vi.fn();
+      const { target, state } = mountReactive({ ...baseProps,
+        value: 3, min: -7, max: 13, step: 5, renderer, onChange });
+      const control = slider(target);
+      const arm = () => control.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      const wheel = (time: number, deltaY: number) => {
+        const event = new WheelEvent('wheel', { deltaY, bubbles: true, cancelable: true });
+        Object.defineProperty(event, 'timeStamp', { value: time });
+        control.dispatchEvent(event);
+        flushSync();
+        return event;
+      };
+      arm();
+      wheel(1000, -120);
+      expect(onChange).toHaveBeenLastCalledWith(8);
+      wheel(1010, -120);
+      expect(onChange).toHaveBeenLastCalledWith(13);
+      expect(control.getAttribute('aria-valuenow')).toBe('3');
+      wheel(1020, 120);
+      wheel(1030, 120);
+      expect(onChange).toHaveBeenLastCalledWith(-7);
+      expect(onChange.mock.calls.every(([value]) => (value + 7) % 5 === 0)).toBe(true);
+      state.disabled = true;
+      flushSync();
+      expect(control.dataset.wheelArmed).toBe('false');
+      expect(wheel(1100, -120).defaultPrevented).toBe(false);
+      state.disabled = false;
+      flushSync();
+      expect(wheel(1200, -120).defaultPrevented).toBe(false);
+      arm();
+      state.max = 18;
+      flushSync();
+      expect(control.dataset.wheelArmed).toBe('false');
+      expect(wheel(1300, -120).defaultPrevented).toBe(false);
+    },
+  );
+});
 
 const commandFeedback = (
   over: Partial<CommandScalarFeedback> = {},
@@ -951,6 +1098,7 @@ describe('ValueControl controlled Bipolar rendering', () => {
     });
     const control = slider(target);
 
+    control.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
     control.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true, cancelable: true }));
     flushSync();
     expect(onChange).toHaveBeenCalledExactlyOnceWith(5);
@@ -1097,6 +1245,7 @@ describe('ValueControl controlled Discrete rendering', () => {
     expect(control.getAttribute('aria-disabled')).toBe('true');
     expect(control.getAttribute('tabindex')).toBe('-1');
     control.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    control.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
     control.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true }));
     expect(onChange).not.toHaveBeenCalled();
   });
@@ -1255,6 +1404,7 @@ describe('ValueControl controlled Discrete rendering', () => {
     expect(onChange.mock.calls).toEqual([[8]]);
     expect(visibleValue(target)).toBe('4');
 
+    control.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
     control.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true, cancelable: true }));
     flushSync();
     expect(onChange).toHaveBeenLastCalledWith(5);
@@ -1422,6 +1572,7 @@ describe('ValueControl controlled Knob skins', () => {
       onChange,
     });
 
+    slider(target).dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
     slider(target).dispatchEvent(new WheelEvent('wheel', {
       deltaY: -1, bubbles: true, cancelable: true,
     }));
@@ -1430,11 +1581,12 @@ describe('ValueControl controlled Knob skins', () => {
     state.tickCount = 5;
     state.accentColor = '#ff0000';
     flushSync();
+    slider(target).dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
     slider(target).dispatchEvent(new WheelEvent('wheel', {
       deltaY: -1, bubbles: true, cancelable: true,
     }));
 
-    expect(onChange.mock.calls).toEqual([[80], [80]]);
+    expect(onChange.mock.calls).toEqual([[60], [60]]);
   });
 
   it.each([

--- a/frontend/src/components-v2/controls/value-control/skins/ProfessionalKnob.svelte
+++ b/frontend/src/components-v2/controls/value-control/skins/ProfessionalKnob.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { wheelControl } from '../wheel-control';
   import { onDestroy, untrack } from 'svelte';
   import '../value-control.css';
   import type {
@@ -26,7 +27,7 @@
   } | null = null;
   const initialBinding = untrack(() => binding);
   let attachedBinding = initialBinding;
-  let lease: ContinuousScalarRendererLease = $state(initialBinding.attachRenderer());
+  let lease: ContinuousScalarRendererLease = $state.raw(initialBinding.attachRenderer());
 
   $effect(() => {
     if (binding === attachedBinding) return;
@@ -112,11 +113,6 @@
     lease.cancelPointer(activePointer.token);
     activePointer = null;
   }
-  function onWheel(e: WheelEvent) {
-    if (!view.editable) return;
-    e.preventDefault();
-    lease.wheel({ direction: e.deltaY > 0 ? -1 : 1, fine: e.shiftKey });
-  }
   function onKey(e: KeyboardEvent) {
     if (lease.key({ key: e.key, fine: e.shiftKey })) e.preventDefault();
   }
@@ -137,7 +133,7 @@
     aria-describedby={renderPresentation.description !== null ? feedbackDescriptionId : undefined}
     data-command-phase={renderPresentation.attributes['data-command-phase'] ?? undefined}
     onpointerdown={onDown} onpointermove={onMove} onpointerup={onUp} onpointercancel={onCancel}
-    onwheel={onWheel} onkeydown={onKey} ondblclick={onDbl}>
+    use:wheelControl={{ view, lease }} onkeydown={onKey} ondblclick={onDbl}>
     <svg width={size} height={size} viewBox="0 0 {size} {size}" class="pro-svg">
       <defs>
         <radialGradient id="{uid}-b" cx="38%" cy="32%" r="68%"><stop offset="0%" stop-color="#3a4550"/><stop offset="50%" stop-color="#1c2428"/><stop offset="100%" stop-color="#0c1014"/></radialGradient>

--- a/frontend/src/components-v2/controls/value-control/wheel-control.ts
+++ b/frontend/src/components-v2/controls/value-control/wheel-control.ts
@@ -1,0 +1,96 @@
+import type { ScalarStepInput } from '../../../primitives/scalar/continuous-scalar.svelte';
+
+interface WheelView { readonly editable: boolean; readonly interactionEpoch?: number }
+interface WheelLease { readonly view: WheelView; wheel(event: ScalarStepInput): void }
+interface WheelControl { readonly view: WheelView | null | undefined; readonly lease: WheelLease }
+
+export function wheelControl(node: HTMLElement, initial: WheelControl) {
+  let options = initial;
+  let armed = false;
+  let epoch = initial.view?.interactionEpoch;
+  let lastTime = 0;
+  let lastDirection = 0;
+  const originalTitle = node.getAttribute('title');
+  const outline = node.style.outline;
+  const offset = node.style.outlineOffset;
+
+  function disarm() {
+    armed = false;
+    lastTime = 0;
+    lastDirection = 0;
+    node.dataset.wheelArmed = 'false';
+    node.style.outline = outline;
+    node.style.outlineOffset = offset;
+    node.title = [originalTitle, 'Click or press Enter to adjust with the wheel'].filter(Boolean).join(' · ');
+  }
+  function current() {
+    const view = options.lease.view;
+    if (!view.editable || view.interactionEpoch !== epoch) disarm();
+    epoch = view.interactionEpoch;
+    return view.editable;
+  }
+  function arm() {
+    if (!current()) return;
+    armed = true;
+    node.focus({ preventScroll: true });
+    node.dataset.wheelArmed = 'true';
+    node.style.outline = '2px solid var(--vc-accent, #00e5ff)';
+    node.style.outlineOffset = '2px';
+    node.title = 'Wheel adjustment active · Esc to finish';
+  }
+  function pointer(event: PointerEvent) {
+    if (event.button === 0 && event.isPrimary !== false) arm();
+  }
+  function key(event: KeyboardEvent) {
+    if (event.key === 'Escape') disarm();
+    else if ((event.key === 'Enter' || event.key === ' ') && !event.repeat) {
+      arm();
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  }
+  function wheel(event: WheelEvent) {
+    if (!current() || !armed || event.ctrlKey || event.metaKey || event.shiftKey
+      || !Number.isFinite(event.deltaY) || event.deltaY === 0
+      || Math.abs(event.deltaX) >= Math.abs(event.deltaY)) return;
+    const scale = event.deltaMode === 0 ? 1 : event.deltaMode === 1 ? 40 : event.deltaMode === 2 ? 800 : 0;
+    if (scale === 0) return;
+    const magnitude = Math.abs(event.deltaY) * scale;
+    const direction = event.deltaY > 0 ? -1 : 1;
+    const elapsed = event.timeStamp - lastTime;
+    const burst = lastDirection === direction && elapsed > 0 && elapsed < 160;
+    const steps = Math.min(8, Math.max(1, Math.floor(magnitude / 120),
+      burst ? Math.floor(magnitude / Math.max(8, elapsed)) : 1));
+    lastTime = event.timeStamp;
+    lastDirection = direction;
+    event.preventDefault();
+    options.lease.wheel({ direction, fine: false, steps });
+  }
+  disarm();
+  node.addEventListener('pointerdown', pointer, true);
+  node.addEventListener('keydown', key, true);
+  node.addEventListener('wheel', wheel, { passive: false });
+  node.addEventListener('blur', disarm);
+  node.addEventListener('pointerleave', disarm);
+  node.ownerDocument.defaultView?.addEventListener('blur', disarm);
+  return {
+    update(next: WheelControl) {
+      if (next.lease !== options.lease) disarm();
+      options = next;
+      if (!next.view?.editable || next.view.interactionEpoch !== epoch) disarm();
+      epoch = next.view?.interactionEpoch;
+    },
+    destroy() {
+      disarm();
+      node.removeEventListener('pointerdown', pointer, true);
+      node.removeEventListener('keydown', key, true);
+      node.removeEventListener('wheel', wheel);
+      node.removeEventListener('blur', disarm);
+      node.removeEventListener('pointerleave', disarm);
+      node.ownerDocument.defaultView?.removeEventListener('blur', disarm);
+      delete node.dataset.wheelArmed;
+      if (originalTitle === null) node.removeAttribute('title');
+      else node.title = originalTitle;
+    },
+  };
+}

--- a/frontend/src/components-v2/panels/FilterPanel.svelte
+++ b/frontend/src/components-v2/panels/FilterPanel.svelte
@@ -198,7 +198,15 @@
     name: 'filter-width-catalog',
     preview: 'confirmed',
     normalize: (value) => nearestWidthChoice(value),
-    wheel: (current, event) => adjacentWidthChoice(current, event.direction),
+    wheel: (current, event) => {
+      const steps = event.steps ?? 1;
+      if (!Number.isInteger(steps) || steps < 1 || steps > 8) return null;
+      let candidate: number | null = current;
+      for (let index = 0; index < steps && candidate !== null; index += 1) {
+        candidate = adjacentWidthChoice(candidate, event.direction);
+      }
+      return candidate;
+    },
     key: (current, event) => {
       if (event.key === 'Home') return validWidthCatalog() ? currentWidthTable[0] : null;
       if (event.key === 'End') return validWidthCatalog()

--- a/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
@@ -153,10 +153,14 @@ describe('CwPanel component rendering', () => {
   it('preserves immediate wheel requests for both controls', () => {
     const t = mountPanel({ cwPitch: 600, keySpeed: 12 });
     t.querySelector<HTMLElement>('[aria-label="CW Pitch"]')!
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    t.querySelector<HTMLElement>('[aria-label="CW Pitch"]')!
       .dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true, cancelable: true }));
     t.querySelector<HTMLElement>('[aria-label="Key Speed"]')!
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    t.querySelector<HTMLElement>('[aria-label="Key Speed"]')!
       .dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true, cancelable: true }));
-    expect(mockHandlers.onCwPitchChange).toHaveBeenCalledExactlyOnceWith(660);
+    expect(mockHandlers.onCwPitchChange).toHaveBeenCalledExactlyOnceWith(605);
     expect(mockHandlers.onKeySpeedChange).toHaveBeenCalledExactlyOnceWith(13);
   });
 

--- a/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
@@ -371,7 +371,7 @@ describe('Filter Width lifecycle presentation (MOR-1665)', () => {
     ['pointer-left', 1800], ['pointer-middle', 2100], ['pointer-right', 3000],
     ['ArrowRight', 3000], ['Home', 1800], ['End', 3000], ['Shift+ArrowRight', 3000],
     ['wheel', 3000], ['fine-wheel', 3000], ['reset', 1800],
-  ] as const)('%s requests only the actual nonuniform catalog choice %i', (gesture, expected) => {
+  ] as const)('%s preserves catalog choices and modified-wheel scrolling (choice %i)', (gesture, expected) => {
     setWidthFeedback({ confirmed: gesture === 'pointer-middle' ? 1800 : 2100 });
     const t = mountPanel({ filterConfig: {
       defaults: [2100, 2100, 2100], fixed: false,
@@ -385,6 +385,7 @@ describe('Filter Width lifecycle presentation (MOR-1665)', () => {
       const x = gesture === 'pointer-left' ? 0 : gesture === 'pointer-middle' ? 50 : 100;
       control.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: x, pointerId: 1 }));
     } else if (gesture.includes('wheel')) {
+      control.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
       control.dispatchEvent(new WheelEvent('wheel', {
         bubbles: true, cancelable: true, deltaY: -1, shiftKey: gesture === 'fine-wheel',
       }));
@@ -397,6 +398,10 @@ describe('Filter Width lifecycle presentation (MOR-1665)', () => {
     }
     vi.advanceTimersByTime(60);
 
+    if (gesture === 'fine-wheel') {
+      expect(mockHandlers.onFilterWidthChange).not.toHaveBeenCalled();
+      return;
+    }
     expect(mockHandlers.onFilterWidthChange).toHaveBeenCalledWith(expected);
     expect([1800, 2100, 3000]).toContain(mockHandlers.onFilterWidthChange.mock.calls.at(-1)?.[0]);
   });

--- a/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
@@ -406,6 +406,43 @@ describe('Filter Width lifecycle presentation (MOR-1665)', () => {
     expect([1800, 2100, 3000]).toContain(mockHandlers.onFilterWidthChange.mock.calls.at(-1)?.[0]);
   });
 
+  it.each([
+    [1800, -1, 1950, 2700, 3000],
+    [3000, 1, 2700, 1950, 1800],
+  ])('accelerates armed catalog wheel input from %i with one immediate final request',
+    (confirmed, direction, slow, accelerated, bound) => {
+      setWidthFeedback({ confirmed });
+      const t = mountPanel({ filterConfig: {
+        defaults: [confirmed, confirmed, confirmed], fixed: false,
+        minHz: 1800, maxHz: 3000, stepHz: 1, table: [1800, 1950, 2200, 2500, 2700, 3000],
+      } as typeof mockProps.filterConfig });
+      const control = t.querySelector<HTMLElement>('[role="slider"]')!;
+      const wheel = (time: number, deltaY: number, extra: WheelEventInit = {}) => {
+        const event = new WheelEvent('wheel', { deltaY, bubbles: true, cancelable: true, ...extra });
+        Object.defineProperty(event, 'timeStamp', { value: time });
+        control.dispatchEvent(event);
+        flushSync();
+        return event;
+      };
+      expect(wheel(500, direction * 120).defaultPrevented).toBe(false);
+      expect(mockHandlers.onFilterWidthChange).not.toHaveBeenCalled();
+      control.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      for (const extra of [{ shiftKey: true }, { ctrlKey: true }, { metaKey: true }]) {
+        expect(wheel(600, direction * 120, extra).defaultPrevented).toBe(false);
+      }
+      expect(mockHandlers.onFilterWidthChange).not.toHaveBeenCalled();
+      wheel(1000, direction * 120);
+      expect(mockHandlers.onFilterWidthChange.mock.calls).toEqual([[slow]]);
+      wheel(1030, direction * 120);
+      expect(mockHandlers.onFilterWidthChange.mock.calls).toEqual([[slow], [accelerated]]);
+      expect(control.getAttribute('aria-valuenow')).toBe(String(confirmed));
+      expect(t.querySelector('.vc-value')?.textContent).toBe(confirmed === 1800 ? '1.8kHz' : '3kHz');
+      wheel(1040, direction * 10000);
+      wheel(1050, -direction * 10000);
+      expect(mockHandlers.onFilterWidthChange.mock.calls).toEqual([[slow], [accelerated], [bound], [confirmed]]);
+    },
+  );
+
   it('invalidates a deferred choice when same-endpoint catalog content changes', () => {
     setWidthFeedback({ confirmed: 2100 });
     const t = mountPanel({ filterConfig: {

--- a/frontend/src/primitives/scalar/continuous-pair.svelte.ts
+++ b/frontend/src/primitives/scalar/continuous-pair.svelte.ts
@@ -120,6 +120,10 @@ export function createRenderedNativeRangeContinuousPairPolicy(): Readonly<Contin
     normalize: normalizeRenderedNativeAxis,
     wheel: (current, event, domain) => {
       const step = normalizedAxisStep(domain);
+      if (event.steps !== undefined) {
+        if (step === null || !Number.isInteger(event.steps) || event.steps < 1 || event.steps > 8) return null;
+        return normalizeRenderedNativeAxis(current + event.direction * step * event.steps, domain);
+      }
       return step === null || !Number.isFinite(current) ? null : handleKeyboardStep(
         current, event.direction > 0 ? 'ArrowRight' : 'ArrowLeft', step, 1, 0, 1, false,
       );
@@ -155,6 +159,15 @@ export function createLegacyContinuousPairPolicy(
     name: 'legacy-rf-sql-pair',
     preview: 'optimistic' as const,
     wheel: (current, event, domain) => {
+      if (event.steps !== undefined) {
+        if (!Number.isInteger(event.steps) || event.steps < 1 || event.steps > 8) return null;
+        let values = current;
+        for (let index = 0; index < event.steps; index++) {
+          values = dualParamStepAlongAxis(values.rf, values.sql, event.direction,
+            domain.step, domain.fineStepDivisor, domain.min, domain.max, false);
+        }
+        return values;
+      }
       const adaptive = Math.max(1, Math.ceil((domain.max - domain.min) / 255));
       const step = event.fine
         ? domain.step / domain.fineStepDivisor
@@ -207,6 +220,7 @@ interface PairCommandLaneView {
 export type ContinuousPairLaneView = Readonly<PairReadingLaneView | PairCommandLaneView>;
 
 export interface ContinuousPairView {
+  readonly interactionEpoch?: number;
   readonly evidence: ContinuousPairInput['evidence'];
   readonly domain: Readonly<ScalarDomain>;
   readonly domainValid: boolean;
@@ -558,6 +572,7 @@ export function createContinuousPair(
     return Object.freeze({
       evidence: input.evidence,
       domain: snapshotDomain(input.domain), domainValid: axis.domainValid,
+      interactionEpoch: axis.interactionEpoch,
       canonical: Object.freeze({ rf, sql }), position, axisDraft: axis.draft,
       draft, displayedPosition: axis.domainValid ? axis.displayed : null,
       editable: axis.editable, busy: input.evidence === 'command-feedback'

--- a/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
+++ b/frontend/src/primitives/scalar/continuous-scalar.svelte.ts
@@ -53,7 +53,7 @@ export interface ReadingScalarInput extends ContinuousScalarInputBase {
 export type ContinuousScalarInput = CommandFeedbackScalarInput | ReadingScalarInput;
 export type ScalarSource = 'native-input' | 'pointer' | 'wheel' | 'keyboard' | 'reset';
 export type ScalarDispatchMode = 'immediate' | Readonly<{ debounceMs: number }>;
-export interface ScalarStepInput { readonly direction: -1 | 1; readonly fine: boolean }
+export interface ScalarStepInput { readonly direction: -1 | 1; readonly fine: boolean; readonly steps?: number }
 export interface ScalarKeyInput { readonly key: string; readonly fine: boolean }
 export interface ScalarDispatchContext {
   readonly canonical: number;
@@ -79,6 +79,7 @@ export interface ContinuousScalarPolicy {
 }
 
 export interface ContinuousScalarViewBase {
+  readonly interactionEpoch?: number;
   readonly domain: Readonly<ScalarDomain>;
   readonly domainValid: boolean;
   readonly canonical: number | null;
@@ -177,6 +178,7 @@ export function createHBarContinuousScalarPolicy(
     preview: options.preview,
     normalize: (value, domain) => snap(value, domain, domain.step / domain.fineStepDivisor),
     wheel: (current, event, domain) => {
+      if (event.steps !== undefined) return nativeWheelStep(current, event, domain);
       const quantum = event.fine
         ? domain.step / domain.fineStepDivisor
         : domain.step * 4 * Math.max(1, Math.ceil((domain.max - domain.min) / 255));
@@ -216,6 +218,7 @@ export function createDiscreteContinuousScalarPolicy(
     normalize: (value, domain) => Number.isFinite(value)
       ? clamp(value, domain.min, domain.max) : null,
     wheel: (current, event, domain) => {
+      if (event.steps !== undefined) return nativeWheelStep(current, event, domain);
       const quantum = event.fine ? domain.step / domain.fineStepDivisor : domain.step;
       return snap(current + event.direction * quantum, domain, quantum);
     },
@@ -252,6 +255,7 @@ export function createKnobContinuousScalarPolicy(
     resolveKeyboardStep: () => undefined,
     normalize: (value, domain) => snap(value, domain, domain.step / domain.fineStepDivisor),
     wheel: (current, event, domain) => {
+      if (event.steps !== undefined) return nativeWheelStep(current, event, domain);
       const quantum = event.fine ? domain.step / domain.fineStepDivisor : domain.step * 4;
       return snap(current + event.direction * quantum, domain, quantum);
     },
@@ -326,6 +330,7 @@ export function createBipolarContinuousScalarPolicy(
     normalize: (value, domain) => Number.isFinite(value)
       ? clamp(value, domain.min, domain.max) : null,
     wheel: (current, event, domain) => {
+      if (event.steps !== undefined) return nativeWheelStep(current, event, domain);
       const stepsInRange = Math.max(1, (domain.max - domain.min) / domain.step);
       const multiplier = stepsInRange > 500 ? Math.round(stepsInRange / 240) : 1;
       const quantum = event.fine
@@ -357,6 +362,12 @@ export function createBipolarContinuousScalarPolicy(
     describeTarget: options.describeTarget ?? String,
   };
   return Object.freeze(policy);
+}
+
+function nativeWheelStep(current: number, event: ScalarStepInput, domain: ScalarDomain): number | null {
+  const steps = event.steps;
+  if (steps === undefined || !Number.isInteger(steps) || steps < 1 || steps > 8) return null;
+  return snap(current + event.direction * domain.step * steps, domain, domain.step);
 }
 
 function nativeLatticeCandidate(value: number, domain: ScalarDomain): boolean {
@@ -394,7 +405,7 @@ export function createRenderedNativeRangeContinuousScalarPolicy(): Readonly<Cont
     name: 'rendered-native-range',
     preview: 'optimistic',
     normalize: nativeRangePolicy.normalize,
-    wheel: (current, event, domain) => snap(
+    wheel: (current, event, domain) => event.steps !== undefined ? nativeWheelStep(current, event, domain) : snap(
       current + event.direction * domain.step, domain, domain.step,
     ),
     key: (current, event, domain) => handleKeyboardStep(
@@ -726,6 +737,7 @@ export function createContinuousScalar(
     const canonical = canonicalOf(input);
     const displayed = policy.preview === 'optimistic' && draft !== null ? draft : canonical;
     const common = {
+      interactionEpoch: invalidationGeneration,
       domain: snapshotDomain(input.domain),
       domainValid: validDomain(input.domain),
       canonical,


### PR DESCRIPTION
Guardrail exception: 14 code + 0 regenerated baselines = 14 files; coordinator-authorized because the complete wheel-safety invariant spans all six shipped renderers, shared scalar/pair policy, and the existing direct renderer and consumer regression tests.

Scrolling across a slider or knob currently changes its value and consumes page scrolling. All six built-in value-control renderers now require an explicit click or Enter/Space activation, display an armed outline, and disarm on focus loss, Escape, pointer exit, disabled/authority changes, or teardown.

Armed wheel input uses normalized pixel/line/page magnitude and event timing to select 1–8 native steps. The Filter Width catalog policy traverses bounded catalog entries and emits one final request per event, including nonuniform catalogs. Shift, Ctrl/Meta zoom, zero and horizontal wheel input remain available to the browser. Commands dispatch immediately; keyboard steps, drag/click paths, existing scalar preview/confirmation policies and the native RF/SQL axis remain intact. Optional step-count and interaction-epoch fields preserve existing typed callers. No runtime, transport, layout, or hardware/service changes.

No position animation was added: these renderers share optimistic and confirmed presentation policies, and interpolating their sole thumb could show an intermediate position without corresponding pending or confirmed evidence. Existing numeric/ARIA/status projection still follows those policies; additional visual smoothing is not claimed.

Linear: https://linear.app/morozsm/issue/MOR-2460

Validation on the local worktree:

- RED before implementation: five ValueControl appearance cases plus direct RF/SQL consumed unarmed wheel input (6 failing regression cases). Two catalog regressions also demonstrated that accelerated input incorrectly selected only the adjacent entry.
- GREEN: 389 tests passed across `ValueControl.controlled.svelte.test.ts`, `DualParamRenderer.controlled.svelte.test.ts`, `ValueControl.test.ts`, `continuous-scalar.test.ts`, `continuous-pair.test.ts`, `CwPanel.component.test.ts`, and `FilterPanel.isolated.test.ts`.
- Changed-path ESLint passed. `npm run check` passed with 0 Svelte errors/warnings and both TypeScript checks successful.
- `git diff --check` passed. No regenerated baselines. No local quick/full/visual suite, live radio/PTT/TUNE command, browser hardware test, or server restart was performed.

Required frontend/visual CI and independent exact-head review remain separate acceptance gates.
