### PR TITLE
feat(MOR-2461): resize the spectrum and waterfall split

### DIFF
--- a/frontend/fixtures/spectrum-witness.ts
+++ b/frontend/fixtures/spectrum-witness.ts
@@ -70,6 +70,10 @@ if (new URLSearchParams(location.search).has('legacyBaseline')) {
   document.head.append(style);
 }
 
+if (new URLSearchParams(location.search).has('portrait')) {
+  document.getElementById('app')!.style.height = '220px';
+}
+
 const BIN_COUNT = 256;
 /** The renderer saturates at 80 (`SPECTRUM_AMPLITUDE_MAX`); stay under it. */
 const BIN_BYTE_MAX = 80;

--- a/frontend/fixtures/spectrum-witness.ts
+++ b/frontend/fixtures/spectrum-witness.ts
@@ -15,15 +15,12 @@
  * tune-line/passband overlay. `binByte` is integer-only arithmetic over the
  * bin index — no `Math.random`, no `Date`, no transcendental function.
  *
- * WHAT IS NOT. This entry stubs nothing: the panel reaches the real
- * `frontend-runtime` singleton, so the toolbar's STEP readout still comes
- * from the live tuning store and `BandPlanOverlay`/`SpectrumToolbar` still
- * issue their band-plan fetches. Both are constant here rather than pinned by
- * construction — a fresh browsing context has no stored tuning step, and the
- * offline fixtures server has no `/api/v1/band-plan/*` handler, so those
- * routes resolve to its `text/html` dev-server fallback and the `.json()`
- * parse throws inside each call site's own `try`/`catch`, leaving its
- * defaults in place.
+ * WHAT IS NOT. Rendering and state projection stay production-real. The
+ * witness replaces only the panel's frequency and filter output callbacks
+ * with an in-page command log, so interaction tests can prove that separator
+ * gestures do not escape through either command seam. The toolbar's STEP
+ * readout still comes from the live tuning store and
+ * `BandPlanOverlay`/`SpectrumToolbar` still issue their band-plan fetches.
  *
  * The waterfall receives exactly one row: the panel pushes on a change of
  * `acceptedSequence`, and that never changes here. `WaterfallRenderer` draws
@@ -38,6 +35,40 @@ import '../src/app.css';
 import '../src/components-v2/theme/index';
 import SpectrumPanel from '../src/components/spectrum/SpectrumPanel.svelte';
 import type { ScopeDisplayProjection } from '../src/lib/runtime/adapters/scope-display-projection';
+import {
+  getFilterHandlers,
+  getVfoHandlers,
+} from '../src/lib/runtime/adapters/panel-adapters';
+
+type WitnessCommand = Readonly<{
+  kind: 'frequency' | 'filter';
+  args: readonly unknown[];
+}>;
+
+declare global {
+  interface Window {
+    __spectrumWitness: { commands: WitnessCommand[] };
+  }
+}
+
+const commands: WitnessCommand[] = [];
+window.__spectrumWitness = { commands };
+const vfoHandlers = getVfoHandlers();
+const filterHandlers = getFilterHandlers();
+vfoHandlers.onFreqChange = (...args) => commands.push({ kind: 'frequency', args });
+filterHandlers.onFilterWidthCommit = (...args) => commands.push({ kind: 'filter', args });
+
+if (new URLSearchParams(location.search).has('legacyBaseline')) {
+  const style = document.createElement('style');
+  style.textContent = `
+    .spectrum-split-region { display: contents !important; }
+    .spectrum-split-separator { display: none !important; }
+    .spectrum-with-scales { flex: 0 0 30% !important; border-bottom: 1px solid var(--panel-border) !important; }
+    .freq-axis { flex: 0 0 20px !important; border-bottom: 1px solid var(--panel-border) !important; }
+    .waterfall-area { flex: 1 1 70% !important; }
+  `;
+  document.head.append(style);
+}
 
 const BIN_COUNT = 256;
 /** The renderer saturates at 80 (`SPECTRUM_AMPLITUDE_MAX`); stay under it. */

--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -123,6 +123,117 @@
   let dxSpots = $state<DxSpot[]>([]);
   let spectrumArea = $state<HTMLDivElement | null>(null);
   let waterfallContent = $state<HTMLDivElement | null>(null);
+  let splitRegion = $state<HTMLDivElement | null>(null);
+  let splitAxis = $state<HTMLDivElement | null>(null);
+  let splitSeparator = $state<HTMLDivElement | null>(null);
+  const SPLIT_STORAGE_KEY = 'rigplane-spectrum-split-ratio';
+  const DEFAULT_SPLIT_RATIO = 0.3;
+  const MIN_SPLIT_RATIO = 0.2;
+  const MAX_SPLIT_RATIO = 0.8;
+  const SPLIT_KEY_STEP = 0.05;
+  const SPLIT_AXIS_HEIGHT = 20;
+  const SPLIT_SEPARATOR_HEIGHT = 8;
+  const MIN_SPECTRUM_HEIGHT = 72;
+  const MIN_WATERFALL_HEIGHT = 96;
+
+  function normalizeSplitRatio(value: number): number {
+    return Math.max(MIN_SPLIT_RATIO, Math.min(MAX_SPLIT_RATIO, value));
+  }
+
+  function readSplitRatio(): number {
+    if (typeof localStorage === 'undefined') return DEFAULT_SPLIT_RATIO;
+    try {
+      const stored = localStorage.getItem(SPLIT_STORAGE_KEY);
+      if (stored === null || stored.trim() === '') return DEFAULT_SPLIT_RATIO;
+      const value = Number(stored);
+      return Number.isFinite(value) ? normalizeSplitRatio(value) : DEFAULT_SPLIT_RATIO;
+    } catch {
+      return DEFAULT_SPLIT_RATIO;
+    }
+  }
+
+  let splitRatio = $state(readSplitRatio());
+  let splitRows = $derived(
+    `minmax(${MIN_SPECTRUM_HEIGHT}px, ${splitRatio}fr) ${SPLIT_AXIS_HEIGHT}px ${SPLIT_SEPARATOR_HEIGHT}px minmax(${MIN_WATERFALL_HEIGHT}px, ${1 - splitRatio}fr)`,
+  );
+  type SplitCapture = Readonly<{ pointerId: number; target: HTMLElement }>;
+  let splitCapture = $state<SplitCapture | null>(null);
+
+  function setSplitRatio(value: number): void {
+    splitRatio = normalizeSplitRatio(value);
+    if (typeof localStorage === 'undefined') return;
+    try {
+      localStorage.setItem(SPLIT_STORAGE_KEY, String(splitRatio));
+    } catch {
+      // Storage availability must not disable the separator.
+    }
+  }
+
+  function updateSplitFromPointer(event: PointerEvent): void {
+    if (!splitRegion) return;
+    const regionRect = splitRegion.getBoundingClientRect();
+    const axisHeight = splitAxis?.getBoundingClientRect().height ?? SPLIT_AXIS_HEIGHT;
+    const separatorHeight = splitSeparator?.getBoundingClientRect().height
+      ?? SPLIT_SEPARATOR_HEIGHT;
+    const availableHeight = regionRect.height - axisHeight - separatorHeight;
+    if (!Number.isFinite(availableHeight) || availableHeight <= 0) return;
+    const spectrumHeight = event.clientY - regionRect.top - axisHeight - separatorHeight / 2;
+    setSplitRatio(spectrumHeight / availableHeight);
+  }
+
+  function handleSplitStart(event: PointerEvent): void {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const target = event.currentTarget as HTMLElement;
+    splitCapture = Object.freeze({ pointerId: event.pointerId, target });
+    target.setPointerCapture(event.pointerId);
+    updateSplitFromPointer(event);
+  }
+
+  function handleSplitMove(event: PointerEvent): void {
+    if (splitCapture?.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    event.stopPropagation();
+    updateSplitFromPointer(event);
+  }
+
+  function releaseSplitCapture(event: PointerEvent, update: boolean): void {
+    const capture = splitCapture;
+    if (!capture || capture.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    event.stopPropagation();
+    if (update) updateSplitFromPointer(event);
+    splitCapture = null;
+    try {
+      capture.target.releasePointerCapture(event.pointerId);
+    } catch {
+      // A browser may already have released capture during cancellation.
+    }
+  }
+
+  function handleSplitLostCapture(event: PointerEvent): void {
+    if (splitCapture?.pointerId !== event.pointerId) return;
+    event.stopPropagation();
+    splitCapture = null;
+  }
+
+  function handleSplitKeydown(event: KeyboardEvent): void {
+    let next: number;
+    if (event.key === 'ArrowUp') next = splitRatio - SPLIT_KEY_STEP;
+    else if (event.key === 'ArrowDown') next = splitRatio + SPLIT_KEY_STEP;
+    else if (event.key === 'Home') next = MIN_SPLIT_RATIO;
+    else if (event.key === 'End') next = MAX_SPLIT_RATIO;
+    else return;
+    event.preventDefault();
+    event.stopPropagation();
+    setSplitRatio(next);
+  }
+
+  function isolateSplitWheel(event: WheelEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+  }
   type SampleGeometry = Readonly<{
     frameMode: number;
     startFreq: number;
@@ -666,6 +777,7 @@
   {:else}
   <SpectrumToolbar bind:enableAvg bind:enablePeakHold bind:brtLevel bind:colorScheme bind:fullscreen bind:showBandPlan bind:hiddenLayers bind:showEiBi {scopeDemandOn} onScopeDemandChange={setScopeDemand} {hideSourceControls} {hideScopeControls} {hideAutoStepToggle} {scopeControls} />
   {/if}
+  <div class="spectrum-split-region" bind:this={splitRegion} style:grid-template-rows={splitRows}>
   <div class="spectrum-with-scales">
     <div class="db-scale">
       {#each audioFft ? [] : DB_TICKS as tick}
@@ -696,12 +808,32 @@
     </div>
   </div>
   {#if freqTicks.length > 0}
-    <div class="freq-axis">
+    <div class="freq-axis" bind:this={splitAxis}>
       {#each freqTicks as tick}
         <div class="tick" style="left: {tick.position}%">{tick.label}</div>
       {/each}
     </div>
   {/if}
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <div
+    class="spectrum-split-separator"
+    class:active={splitCapture !== null}
+    bind:this={splitSeparator}
+    role="separator"
+    aria-label="Resize spectrum and waterfall"
+    aria-orientation="horizontal"
+    aria-valuemin={Math.round(MIN_SPLIT_RATIO * 100)}
+    aria-valuemax={Math.round(MAX_SPLIT_RATIO * 100)}
+    aria-valuenow={Math.round(splitRatio * 100)}
+    tabindex="0"
+    onpointerdown={handleSplitStart}
+    onpointermove={handleSplitMove}
+    onpointerup={(event) => releaseSplitCapture(event, true)}
+    onpointercancel={(event) => releaseSplitCapture(event, false)}
+    onlostpointercapture={handleSplitLostCapture}
+    onkeydown={handleSplitKeydown}
+    onwheel={isolateSplitWheel}
+  ></div>
   <div class="waterfall-area">
     <div class="waterfall-scale"></div>
     <div class="waterfall-content" class:panning={dragging} class:draggable={canPan} bind:this={waterfallContent} onpointerdown={handleDragStart} role="presentation">
@@ -728,6 +860,7 @@
         <div class="tune-line" style="left:{tuneLinePct}%"></div>
       {/if}
     </div>
+  </div>
   </div>
 </div>
 
@@ -757,11 +890,17 @@
     border: none;
   }
 
+  .spectrum-split-region {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: grid;
+    overflow: hidden;
+  }
+
   .spectrum-with-scales {
-    flex: 0 0 30%;
+    grid-row: 1;
     min-height: 0;
     display: flex;
-    border-bottom: 1px solid var(--panel-border);
     overflow: hidden;
   }
 
@@ -799,10 +938,45 @@
   }
 
   .freq-axis {
-    flex: 0 0 20px;
+    grid-row: 2;
     position: relative;
     background: var(--panel);
-    border-bottom: 1px solid var(--panel-border);
+  }
+
+  .spectrum-split-separator {
+    grid-row: 3;
+    position: relative;
+    z-index: 20;
+    width: 100%;
+    min-height: 8px;
+    padding: 0;
+    border: 0;
+    background: linear-gradient(
+      to bottom,
+      transparent 3px,
+      var(--panel-border) 3px,
+      var(--panel-border) 5px,
+      transparent 5px
+    );
+    cursor: ns-resize;
+    touch-action: none;
+    user-select: none;
+  }
+
+  .spectrum-split-separator:hover,
+  .spectrum-split-separator.active {
+    background: linear-gradient(
+      to bottom,
+      transparent 2px,
+      var(--accent, var(--panel-border)) 2px,
+      var(--accent, var(--panel-border)) 6px,
+      transparent 6px
+    );
+  }
+
+  .spectrum-split-separator:focus-visible {
+    outline: 2px solid var(--accent, var(--panel-border));
+    outline-offset: -2px;
   }
 
   .freq-axis .tick {
@@ -824,7 +998,7 @@
   }
 
   .waterfall-area {
-    flex: 1 1 70%;
+    grid-row: 4;
     min-height: 0;
     position: relative;
     display: flex;

--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -124,8 +124,7 @@
   let spectrumArea = $state<HTMLDivElement | null>(null);
   let waterfallContent = $state<HTMLDivElement | null>(null);
   let splitRegion = $state<HTMLDivElement | null>(null);
-  let splitAxis = $state<HTMLDivElement | null>(null);
-  let splitSeparator = $state<HTMLDivElement | null>(null);
+  let splitRegionHeight = $state(0);
   const SPLIT_STORAGE_KEY = 'rigplane-spectrum-split-ratio';
   const DEFAULT_SPLIT_RATIO = 0.3;
   const MIN_SPLIT_RATIO = 0.2;
@@ -133,8 +132,8 @@
   const SPLIT_KEY_STEP = 0.05;
   const SPLIT_AXIS_HEIGHT = 20;
   const SPLIT_SEPARATOR_HEIGHT = 8;
-  const MIN_SPECTRUM_HEIGHT = 72;
-  const MIN_WATERFALL_HEIGHT = 96;
+  const MIN_SPECTRUM_HEIGHT = 64;
+  const MIN_WATERFALL_HEIGHT = 80;
 
   function normalizeSplitRatio(value: number): number {
     return Math.max(MIN_SPLIT_RATIO, Math.min(MAX_SPLIT_RATIO, value));
@@ -153,8 +152,32 @@
   }
 
   let splitRatio = $state(readSplitRatio());
+  type SplitBounds = Readonly<{ min: number; max: number }>;
+
+  function resolveSplitBounds(regionHeight: number): SplitBounds {
+    const paneHeight = regionHeight - SPLIT_AXIS_HEIGHT - SPLIT_SEPARATOR_HEIGHT;
+    if (!Number.isFinite(paneHeight) || paneHeight <= 0) {
+      return Object.freeze({ min: MIN_SPLIT_RATIO, max: MAX_SPLIT_RATIO });
+    }
+    const floorTotal = MIN_SPECTRUM_HEIGHT + MIN_WATERFALL_HEIGHT;
+    if (paneHeight < floorTotal) {
+      const compressed = MIN_SPECTRUM_HEIGHT / floorTotal;
+      return Object.freeze({ min: compressed, max: compressed });
+    }
+    return Object.freeze({
+      min: Math.max(MIN_SPLIT_RATIO, MIN_SPECTRUM_HEIGHT / paneHeight),
+      max: Math.min(MAX_SPLIT_RATIO, 1 - MIN_WATERFALL_HEIGHT / paneHeight),
+    });
+  }
+
+  function clampSplitRatio(value: number, bounds: SplitBounds): number {
+    return Math.max(bounds.min, Math.min(bounds.max, value));
+  }
+
+  let splitBounds = $derived(resolveSplitBounds(splitRegionHeight));
+  let renderedSplitRatio = $derived(clampSplitRatio(splitRatio, splitBounds));
   let splitRows = $derived(
-    `minmax(${MIN_SPECTRUM_HEIGHT}px, ${splitRatio}fr) ${SPLIT_AXIS_HEIGHT}px ${SPLIT_SEPARATOR_HEIGHT}px minmax(${MIN_WATERFALL_HEIGHT}px, ${1 - splitRatio}fr)`,
+    `${renderedSplitRatio}fr ${SPLIT_AXIS_HEIGHT}px ${SPLIT_SEPARATOR_HEIGHT}px ${1 - renderedSplitRatio}fr`,
   );
   type SplitCapture = Readonly<{ pointerId: number; target: HTMLElement }>;
   let splitCapture = $state<SplitCapture | null>(null);
@@ -172,13 +195,15 @@
   function updateSplitFromPointer(event: PointerEvent): void {
     if (!splitRegion) return;
     const regionRect = splitRegion.getBoundingClientRect();
-    const axisHeight = splitAxis?.getBoundingClientRect().height ?? SPLIT_AXIS_HEIGHT;
-    const separatorHeight = splitSeparator?.getBoundingClientRect().height
-      ?? SPLIT_SEPARATOR_HEIGHT;
-    const availableHeight = regionRect.height - axisHeight - separatorHeight;
+    splitRegionHeight = regionRect.height;
+    const availableHeight = regionRect.height - SPLIT_AXIS_HEIGHT - SPLIT_SEPARATOR_HEIGHT;
     if (!Number.isFinite(availableHeight) || availableHeight <= 0) return;
-    const spectrumHeight = event.clientY - regionRect.top - axisHeight - separatorHeight / 2;
-    setSplitRatio(spectrumHeight / availableHeight);
+    const spectrumHeight = event.clientY - regionRect.top
+      - SPLIT_AXIS_HEIGHT - SPLIT_SEPARATOR_HEIGHT / 2;
+    setSplitRatio(clampSplitRatio(
+      spectrumHeight / availableHeight,
+      resolveSplitBounds(regionRect.height),
+    ));
   }
 
   function handleSplitStart(event: PointerEvent): void {
@@ -219,15 +244,18 @@
   }
 
   function handleSplitKeydown(event: KeyboardEvent): void {
+    if (splitRegion) splitRegionHeight = splitRegion.getBoundingClientRect().height;
+    const bounds = resolveSplitBounds(splitRegionHeight);
+    const current = clampSplitRatio(splitRatio, bounds);
     let next: number;
-    if (event.key === 'ArrowUp') next = splitRatio - SPLIT_KEY_STEP;
-    else if (event.key === 'ArrowDown') next = splitRatio + SPLIT_KEY_STEP;
-    else if (event.key === 'Home') next = MIN_SPLIT_RATIO;
-    else if (event.key === 'End') next = MAX_SPLIT_RATIO;
+    if (event.key === 'ArrowUp') next = current - SPLIT_KEY_STEP;
+    else if (event.key === 'ArrowDown') next = current + SPLIT_KEY_STEP;
+    else if (event.key === 'Home') next = bounds.min;
+    else if (event.key === 'End') next = bounds.max;
     else return;
     event.preventDefault();
     event.stopPropagation();
-    setSplitRatio(next);
+    setSplitRatio(clampSplitRatio(next, bounds));
   }
 
   function isolateSplitWheel(event: WheelEvent): void {
@@ -777,7 +805,12 @@
   {:else}
   <SpectrumToolbar bind:enableAvg bind:enablePeakHold bind:brtLevel bind:colorScheme bind:fullscreen bind:showBandPlan bind:hiddenLayers bind:showEiBi {scopeDemandOn} onScopeDemandChange={setScopeDemand} {hideSourceControls} {hideScopeControls} {hideAutoStepToggle} {scopeControls} />
   {/if}
-  <div class="spectrum-split-region" bind:this={splitRegion} style:grid-template-rows={splitRows}>
+  <div
+    class="spectrum-split-region"
+    bind:this={splitRegion}
+    bind:clientHeight={splitRegionHeight}
+    style:grid-template-rows={splitRows}
+  >
   <div class="spectrum-with-scales">
     <div class="db-scale">
       {#each audioFft ? [] : DB_TICKS as tick}
@@ -808,7 +841,7 @@
     </div>
   </div>
   {#if freqTicks.length > 0}
-    <div class="freq-axis" bind:this={splitAxis}>
+    <div class="freq-axis">
       {#each freqTicks as tick}
         <div class="tick" style="left: {tick.position}%">{tick.label}</div>
       {/each}
@@ -818,13 +851,12 @@
   <div
     class="spectrum-split-separator"
     class:active={splitCapture !== null}
-    bind:this={splitSeparator}
     role="separator"
     aria-label="Resize spectrum and waterfall"
     aria-orientation="horizontal"
-    aria-valuemin={Math.round(MIN_SPLIT_RATIO * 100)}
-    aria-valuemax={Math.round(MAX_SPLIT_RATIO * 100)}
-    aria-valuenow={Math.round(splitRatio * 100)}
+    aria-valuemin={Math.round(splitBounds.min * 100)}
+    aria-valuemax={Math.round(splitBounds.max * 100)}
+    aria-valuenow={Math.round(renderedSplitRatio * 100)}
     tabindex="0"
     onpointerdown={handleSplitStart}
     onpointermove={handleSplitMove}

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -847,8 +847,7 @@ describe('SpectrumPanel spectrum/waterfall separator (MOR-2461)', () => {
     expect(separator.getAttribute('aria-valuemax')).toBe('80');
     expect(region.style.gridTemplateRows).toContain('0.3fr');
     expect(region.style.gridTemplateRows).toContain('0.7fr');
-    expect(region.style.gridTemplateRows).toContain('minmax(72px');
-    expect(region.style.gridTemplateRows).toContain('minmax(96px');
+    expect(region.style.gridTemplateRows).toContain('20px 8px');
   });
 
   it('restores a normalized persisted ratio without remounting either canvas', () => {
@@ -885,7 +884,7 @@ describe('SpectrumPanel spectrum/waterfall separator (MOR-2461)', () => {
     pointer(separator, 'pointermove', 71, 10, { clientY: -100 });
     expect(separator.getAttribute('aria-valuenow')).toBe('20');
     pointer(separator, 'pointermove', 71, 10, { clientY: 1000 });
-    expect(Number(separator.getAttribute('aria-valuenow'))).toBe(80);
+    expect(Number(separator.getAttribute('aria-valuenow'))).toBe(78);
 
     pointer(separator, 'pointerup', 71, 10, { clientY: 300 });
     expect(HTMLElement.prototype.releasePointerCapture).toHaveBeenCalledWith(71);
@@ -932,7 +931,7 @@ describe('SpectrumPanel spectrum/waterfall separator (MOR-2461)', () => {
     key('Home');
     expect(separator.getAttribute('aria-valuenow')).toBe('20');
     key('End');
-    expect(separator.getAttribute('aria-valuenow')).toBe('80');
+    expect(separator.getAttribute('aria-valuenow')).toBe('78');
 
     separator.dispatchEvent(new WheelEvent('wheel', {
       deltaY: -100, bubbles: true, cancelable: true,
@@ -940,7 +939,8 @@ describe('SpectrumPanel spectrum/waterfall separator (MOR-2461)', () => {
     expect(handlerHarness.vfo.onFreqChange).not.toHaveBeenCalled();
     expect(handlerHarness.filter.onFilterWidthCommit).not.toHaveBeenCalled();
     expect(mockRuntime.send).not.toHaveBeenCalled();
-    expect(Number(storageMap.get('rigplane-spectrum-split-ratio'))).toBe(0.8);
+    expect(Number(storageMap.get('rigplane-spectrum-split-ratio')))
+      .toBeCloseTo(1 - 80 / 372);
   });
 });
 

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -527,7 +527,7 @@ function rect(element: Element, left = 0, width = 200): void {
 
 function pointer(
   element: EventTarget,
-  type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel',
+  type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel' | 'lostpointercapture',
   pointerId: number,
   clientX: number,
   init: Partial<PointerEventInit> = {},
@@ -542,6 +542,16 @@ function pointer(
     ...init,
   }));
   flushSync();
+}
+
+function verticalRect(element: Element, top: number, height: number): void {
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    configurable: true,
+    value: vi.fn(() => ({
+      x: 0, y: top, left: 0, top, right: 800, bottom: top + height,
+      width: 800, height, toJSON: () => ({}),
+    })),
+  });
 }
 
 function prepareGeometry(target: HTMLElement, width = 200): {
@@ -568,6 +578,7 @@ function mountPanel(props: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   components = [];
+  storageMap.clear();
   txHarness = new ManagedAppTxHarness();
   appTxHostHarness.controller = txHarness.controller;
   runtimeHarness.state.capturedHardwareFrame = null;
@@ -810,6 +821,126 @@ describe('SpectrumPanel component', () => {
     expect(spectrumPanelSource).not.toContain('resolveFilterModeConfig');
     expect(spectrumPanelSource).not.toContain('tuneBy');
     expect(spectrumPanelSource).not.toContain('getDragInterval');
+  });
+});
+
+describe('SpectrumPanel spectrum/waterfall separator (MOR-2461)', () => {
+  function splitElements(target: HTMLElement) {
+    const region = target.querySelector<HTMLElement>('.spectrum-split-region')!;
+    const axis = target.querySelector<HTMLElement>('.freq-axis');
+    const separator = target.querySelector<HTMLElement>('[role="separator"]')!;
+    verticalRect(region, 0, 400);
+    if (axis) verticalRect(axis, 120, 20);
+    verticalRect(separator, 140, 8);
+    return { region, axis, separator };
+  }
+
+  it('renders a focusable horizontal separator and falls back safely for invalid storage', () => {
+    storageMap.set('rigplane-spectrum-split-ratio', 'not-a-ratio');
+    const target = mountPanel();
+    const { region, separator } = splitElements(target);
+
+    expect(separator.getAttribute('aria-orientation')).toBe('horizontal');
+    expect(separator.tabIndex).toBe(0);
+    expect(separator.getAttribute('aria-valuenow')).toBe('30');
+    expect(separator.getAttribute('aria-valuemin')).toBe('20');
+    expect(separator.getAttribute('aria-valuemax')).toBe('80');
+    expect(region.style.gridTemplateRows).toContain('0.3fr');
+    expect(region.style.gridTemplateRows).toContain('0.7fr');
+    expect(region.style.gridTemplateRows).toContain('minmax(72px');
+    expect(region.style.gridTemplateRows).toContain('minmax(96px');
+  });
+
+  it('restores a normalized persisted ratio without remounting either canvas', () => {
+    storageMap.set('rigplane-spectrum-split-ratio', '0.62');
+    const target = mountPanel();
+    const { region, separator } = splitElements(target);
+    const spectrumCanvas = target.querySelector('.spectrum-area canvas');
+    const waterfallCanvas = target.querySelector('.waterfall-content canvas');
+
+    expect(separator.getAttribute('aria-valuenow')).toBe('62');
+    expect(region.style.gridTemplateRows).toContain('0.62fr');
+    window.dispatchEvent(new Event('resize'));
+    target.querySelector<HTMLButtonElement>('[title="Toggle fullscreen"]')!.click();
+    flushSync();
+
+    expect(target.querySelector('.spectrum-panel')?.classList.contains('fullscreen')).toBe(true);
+    expect(separator.getAttribute('aria-valuenow')).toBe('62');
+    expect(region.style.gridTemplateRows).toContain('0.62fr');
+    expect(target.querySelector('.spectrum-area canvas')).toBe(spectrumCanvas);
+    expect(target.querySelector('.waterfall-content canvas')).toBe(waterfallCanvas);
+  });
+
+  it('captures pointer drag, clamps to practical minimum heights, and persists the ratio', () => {
+    const target = mountPanel();
+    const { separator } = splitElements(target);
+    const spectrumCanvas = target.querySelector('.spectrum-area canvas');
+    const waterfallCanvas = target.querySelector('.waterfall-content canvas');
+
+    pointer(separator, 'pointerdown', 71, 10, { clientY: 250 });
+    expect(HTMLElement.prototype.setPointerCapture).toHaveBeenCalledWith(71);
+    expect(Number(separator.getAttribute('aria-valuenow'))).toBe(61);
+    expect(Number(storageMap.get('rigplane-spectrum-split-ratio'))).toBeCloseTo(226 / 372);
+
+    pointer(separator, 'pointermove', 71, 10, { clientY: -100 });
+    expect(separator.getAttribute('aria-valuenow')).toBe('20');
+    pointer(separator, 'pointermove', 71, 10, { clientY: 1000 });
+    expect(Number(separator.getAttribute('aria-valuenow'))).toBe(80);
+
+    pointer(separator, 'pointerup', 71, 10, { clientY: 300 });
+    expect(HTMLElement.prototype.releasePointerCapture).toHaveBeenCalledWith(71);
+    const completed = separator.getAttribute('aria-valuenow');
+    pointer(separator, 'pointermove', 71, 10, { clientY: 100 });
+    expect(separator.getAttribute('aria-valuenow')).toBe(completed);
+    expect(target.querySelector('.spectrum-area canvas')).toBe(spectrumCanvas);
+    expect(target.querySelector('.waterfall-content canvas')).toBe(waterfallCanvas);
+  });
+
+  it('cleans up matching cancel and lost capture without emitting a radio command', () => {
+    const target = mountPanel();
+    const { separator } = splitElements(target);
+
+    pointer(separator, 'pointerdown', 72, 10, { clientY: 200 });
+    pointer(separator, 'pointercancel', 72, 10, { clientY: 200 });
+    const afterCancel = separator.getAttribute('aria-valuenow');
+    pointer(separator, 'pointermove', 72, 10, { clientY: 300 });
+    expect(separator.getAttribute('aria-valuenow')).toBe(afterCancel);
+
+    pointer(separator, 'pointerdown', 73, 10, { clientY: 220 });
+    pointer(separator, 'lostpointercapture', 73, 10, { clientY: 220 });
+    const afterLost = separator.getAttribute('aria-valuenow');
+    pointer(separator, 'pointermove', 73, 10, { clientY: 300 });
+    expect(separator.getAttribute('aria-valuenow')).toBe(afterLost);
+    expect(handlerHarness.vfo.onFreqChange).not.toHaveBeenCalled();
+    expect(handlerHarness.filter.onFilterWidthCommit).not.toHaveBeenCalled();
+    expect(mockRuntime.send).not.toHaveBeenCalled();
+  });
+
+  it('supports ArrowUp, ArrowDown, Home, and End while isolating wheel intent', () => {
+    storageMap.set('rigplane-spectrum-split-ratio', '0.5');
+    const target = mountPanel();
+    const { separator } = splitElements(target);
+    const key = (value: string) => {
+      separator.dispatchEvent(new KeyboardEvent('keydown', { key: value, bubbles: true }));
+      flushSync();
+    };
+
+    key('ArrowUp');
+    expect(separator.getAttribute('aria-valuenow')).toBe('45');
+    key('ArrowDown');
+    expect(separator.getAttribute('aria-valuenow')).toBe('50');
+    key('Home');
+    expect(separator.getAttribute('aria-valuenow')).toBe('20');
+    key('End');
+    expect(separator.getAttribute('aria-valuenow')).toBe('80');
+
+    separator.dispatchEvent(new WheelEvent('wheel', {
+      deltaY: -100, bubbles: true, cancelable: true,
+    }));
+    expect(handlerHarness.vfo.onFreqChange).not.toHaveBeenCalled();
+    expect(handlerHarness.filter.onFilterWidthCommit).not.toHaveBeenCalled();
+    expect(mockRuntime.send).not.toHaveBeenCalled();
+    expect(Number(storageMap.get('rigplane-spectrum-split-ratio'))).toBe(0.8);
   });
 });
 

--- a/frontend/tests/e2e/visual/spectrum-baselines.spec.ts
+++ b/frontend/tests/e2e/visual/spectrum-baselines.spec.ts
@@ -126,8 +126,8 @@ test('spectrum separator preserves geometry, ratio, canvas state, and command is
   expect(dragged.waterfall).toBeLessThan(initial.waterfall);
   expect(Math.abs(dragged.region - initial.region)).toBeLessThanOrEqual(1);
   expect(Math.abs(dragged.innerTotal - dragged.region)).toBeLessThanOrEqual(1);
-  expect(dragged.spectrum).toBeGreaterThanOrEqual(72);
-  expect(dragged.waterfall).toBeGreaterThanOrEqual(96);
+  expect(dragged.spectrum).toBeGreaterThanOrEqual(64);
+  expect(dragged.waterfall).toBeGreaterThanOrEqual(80);
   const persistedRatio = await page.evaluate(() =>
     Number(localStorage.getItem('rigplane-spectrum-split-ratio')),
   );
@@ -166,8 +166,8 @@ test('spectrum separator preserves geometry, ratio, canvas state, and command is
   const shrunk = await geometry();
   expect(shrunk.ariaRatio).toBeCloseTo(persistedRatio, 2);
   expect(shrunk.ratio).toBeCloseTo(persistedRatio, 2);
-  expect(shrunk.spectrum).toBeGreaterThanOrEqual(72);
-  expect(shrunk.waterfall).toBeGreaterThanOrEqual(96);
+  expect(shrunk.spectrum).toBeGreaterThanOrEqual(64);
+  expect(shrunk.waterfall).toBeGreaterThanOrEqual(80);
 
   await page.setViewportSize({ width: 1280, height: 900 });
   const grown = await geometry();
@@ -191,4 +191,91 @@ test('spectrum separator preserves geometry, ratio, canvas state, and command is
   const commands = await page.evaluate(() => window.__spectrumWitness.commands);
   expect(commands).toEqual([]);
   expect(requests).toHaveLength(initialRequestCount);
+});
+
+test('spectrum separator moves and reports rendered bounds in the 220px portrait slot', async ({ page }) => {
+  await page.setViewportSize(VIEWPORT);
+  await page.goto('/fixtures/spectrum-witness.html?portrait=1', { waitUntil: 'load' });
+  await page.waitForSelector('body[data-harness-ready="true"]');
+  const panel = page.locator('[data-waterfall]');
+  const separator = panel.locator('[role="separator"]');
+  const read = () => panel.evaluate((node) => {
+    const region = node.querySelector<HTMLElement>('.spectrum-split-region')!;
+    const spectrum = node.querySelector<HTMLElement>('.spectrum-with-scales')!;
+    const axis = node.querySelector<HTMLElement>('.freq-axis')!;
+    const split = node.querySelector<HTMLElement>('[role="separator"]')!;
+    const waterfall = node.querySelector<HTMLElement>('.waterfall-area')!;
+    const paneTotal = spectrum.offsetHeight + waterfall.offsetHeight;
+    return {
+      panel: node.getBoundingClientRect().height,
+      region: region.offsetHeight,
+      spectrum: spectrum.offsetHeight,
+      axis: axis.offsetHeight,
+      separator: split.offsetHeight,
+      waterfall: waterfall.offsetHeight,
+      innerTotal: spectrum.offsetHeight + axis.offsetHeight
+        + split.offsetHeight + waterfall.offsetHeight,
+      renderedRatio: spectrum.offsetHeight / paneTotal,
+      ariaRatio: Number(split.getAttribute('aria-valuenow')) / 100,
+      storedRatio: Number(localStorage.getItem('rigplane-spectrum-split-ratio')),
+    };
+  });
+  await panel.evaluate((node) => {
+    (window as typeof window & { __portraitCanvases?: Element[] }).__portraitCanvases = [
+      node.querySelector('.spectrum-area canvas')!,
+      node.querySelector('.waterfall-content canvas')!,
+    ];
+  });
+
+  const initial = await read();
+  expect(initial.panel).toBe(220);
+  expect(Math.abs(initial.innerTotal - initial.region)).toBeLessThanOrEqual(1);
+  expect(initial.spectrum).toBeGreaterThanOrEqual(64);
+  expect(initial.waterfall).toBeGreaterThanOrEqual(80);
+  expect(initial.ariaRatio).toBeCloseTo(initial.renderedRatio, 2);
+
+  const box = await separator.boundingBox();
+  await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2 + 12);
+  await page.mouse.up();
+  const pointerMoved = await read();
+  expect(pointerMoved.spectrum).toBeGreaterThan(initial.spectrum);
+  expect(pointerMoved.ariaRatio).toBeCloseTo(pointerMoved.renderedRatio, 2);
+  expect(pointerMoved.storedRatio).toBeCloseTo(pointerMoved.renderedRatio, 2);
+
+  await separator.press('Home');
+  const home = await read();
+  await separator.press('ArrowDown');
+  const keyboardMoved = await read();
+  expect(keyboardMoved.spectrum).toBeGreaterThan(home.spectrum);
+  expect(keyboardMoved.ariaRatio).toBeCloseTo(keyboardMoved.renderedRatio, 2);
+  expect(keyboardMoved.storedRatio).toBeCloseTo(keyboardMoved.renderedRatio, 2);
+
+  await panel.evaluate(() => {
+    document.getElementById('app')!.style.height = '150px';
+  });
+  await page.evaluate(() => new Promise<void>((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+  }));
+  const constrained = await read();
+  expect(Math.abs(constrained.innerTotal - constrained.region)).toBeLessThanOrEqual(1);
+  expect(constrained.renderedRatio).toBeCloseTo(64 / (64 + 80), 2);
+  expect(constrained.ariaRatio).toBeCloseTo(constrained.renderedRatio, 2);
+  await panel.evaluate(() => {
+    document.getElementById('app')!.style.height = '220px';
+  });
+  await page.evaluate(() => new Promise<void>((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+  }));
+  const restored = await read();
+  expect(restored.ariaRatio).toBeCloseTo(keyboardMoved.storedRatio, 2);
+  expect(restored.renderedRatio).toBeCloseTo(keyboardMoved.storedRatio, 2);
+  expect(await panel.evaluate((node) => {
+    const canvases = (window as typeof window & { __portraitCanvases?: Element[] })
+      .__portraitCanvases;
+    return canvases?.[0] === node.querySelector('.spectrum-area canvas')
+      && canvases?.[1] === node.querySelector('.waterfall-content canvas');
+  })).toBe(true);
+  expect(await page.evaluate(() => window.__spectrumWitness.commands)).toEqual([]);
 });

--- a/frontend/tests/e2e/visual/spectrum-baselines.spec.ts
+++ b/frontend/tests/e2e/visual/spectrum-baselines.spec.ts
@@ -12,6 +12,10 @@
  * `maxDiffPixelRatio` is a fraction of what is captured, so bounding the
  * region to the panel keeps the comparator's absolute pixel floor tied to
  * the panel rather than to the surrounding page.
+ *
+ * The screenshot keeps its renderer-only pre-separator layout through the
+ * fixture's `legacyBaseline` mode. The second test exercises the shipped
+ * separator layout and behavior without regenerating that PNG.
  */
 import { test, expect } from '@playwright/test';
 
@@ -19,7 +23,7 @@ const VIEWPORT = { width: 1280, height: 800 };
 
 test('spectrum-panel--managed-frame', async ({ page }) => {
   await page.setViewportSize(VIEWPORT);
-  await page.goto('/fixtures/spectrum-witness.html', { waitUntil: 'load' });
+  await page.goto('/fixtures/spectrum-witness.html?legacyBaseline=1', { waitUntil: 'load' });
   await page.waitForSelector('body[data-harness-ready="true"]');
   await page.evaluate(() => document.fonts.ready);
   const panel = page.locator('[data-waterfall]');
@@ -57,4 +61,134 @@ test('spectrum-panel--managed-frame', async ({ page }) => {
     animations: 'disabled',
     caret: 'hide',
   });
+});
+
+test('spectrum separator preserves geometry, ratio, canvas state, and command isolation', async ({ page }) => {
+  const requests: string[] = [];
+  page.on('request', (request) => requests.push(`${request.method()} ${request.url()}`));
+  await page.setViewportSize(VIEWPORT);
+  await page.goto('/fixtures/spectrum-witness.html', { waitUntil: 'load' });
+  await page.waitForSelector('body[data-harness-ready="true"]');
+  await page.evaluate(() => document.fonts.ready);
+  await page.waitForTimeout(100);
+
+  const panel = page.locator('[data-waterfall]');
+  const separator = panel.locator('[role="separator"]');
+  await expect(separator).toBeVisible();
+  const geometry = () => panel.evaluate((node) => {
+    const region = node.querySelector<HTMLElement>('.spectrum-split-region')!;
+    const spectrum = node.querySelector<HTMLElement>('.spectrum-with-scales')!;
+    const axis = node.querySelector<HTMLElement>('.freq-axis');
+    const split = node.querySelector<HTMLElement>('[role="separator"]')!;
+    const waterfall = node.querySelector<HTMLElement>('.waterfall-area')!;
+    const heights = {
+      region: region.getBoundingClientRect().height,
+      spectrum: spectrum.getBoundingClientRect().height,
+      axis: axis?.getBoundingClientRect().height ?? 0,
+      separator: split.getBoundingClientRect().height,
+      waterfall: waterfall.getBoundingClientRect().height,
+    };
+    return {
+      ...heights,
+      innerTotal: heights.spectrum + heights.axis + heights.separator + heights.waterfall,
+      ratio: heights.spectrum / (heights.spectrum + heights.waterfall),
+      ariaRatio: Number(split.getAttribute('aria-valuenow')) / 100,
+    };
+  });
+  await panel.evaluate((node) => {
+    const witness = window as typeof window & {
+      __spectrumCanvasNodes?: { spectrum: Element | null; waterfall: Element | null };
+    };
+    witness.__spectrumCanvasNodes = {
+      spectrum: node.querySelector('.spectrum-area canvas'),
+      waterfall: node.querySelector('.waterfall-content canvas'),
+    };
+  });
+
+  const initial = await geometry();
+  const initialRequestCount = requests.length;
+  const separatorBox = await separator.boundingBox();
+  expect(separatorBox).not.toBeNull();
+  await page.mouse.move(
+    separatorBox!.x + separatorBox!.width / 2,
+    separatorBox!.y + separatorBox!.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    separatorBox!.x + separatorBox!.width / 2,
+    separatorBox!.y + separatorBox!.height / 2 + 90,
+    { steps: 5 },
+  );
+  await page.mouse.up();
+
+  const dragged = await geometry();
+  expect(dragged.spectrum).toBeGreaterThan(initial.spectrum);
+  expect(dragged.waterfall).toBeLessThan(initial.waterfall);
+  expect(Math.abs(dragged.region - initial.region)).toBeLessThanOrEqual(1);
+  expect(Math.abs(dragged.innerTotal - dragged.region)).toBeLessThanOrEqual(1);
+  expect(dragged.spectrum).toBeGreaterThanOrEqual(72);
+  expect(dragged.waterfall).toBeGreaterThanOrEqual(96);
+  const persistedRatio = await page.evaluate(() =>
+    Number(localStorage.getItem('rigplane-spectrum-split-ratio')),
+  );
+  expect(persistedRatio).toBeCloseTo(dragged.ariaRatio, 2);
+
+  await separator.evaluate((node) => {
+    node.addEventListener('pointerdown', (event) => {
+      (window as typeof window & { __splitPointerId?: number }).__splitPointerId
+        = (event as PointerEvent).pointerId;
+    }, { once: true });
+  });
+  const cancelledBox = await separator.boundingBox();
+  await page.mouse.move(cancelledBox!.x + 10, cancelledBox!.y + cancelledBox!.height / 2);
+  await page.mouse.down();
+  const ratioAtCancel = (await geometry()).ariaRatio;
+  const pointerId = await page.evaluate(() =>
+    (window as typeof window & { __splitPointerId?: number }).__splitPointerId,
+  );
+  expect(pointerId).toBeDefined();
+  await separator.dispatchEvent('pointercancel', {
+    bubbles: true,
+    cancelable: true,
+    pointerId,
+    clientY: cancelledBox!.y + cancelledBox!.height / 2,
+  });
+  await page.mouse.move(cancelledBox!.x + 10, cancelledBox!.y + 60);
+  await page.mouse.up();
+  expect((await geometry()).ariaRatio).toBe(ratioAtCancel);
+
+  await page.evaluate(() => {
+    const app = document.getElementById('app')!;
+    app.style.width = '100vw';
+    app.style.height = '70vh';
+  });
+  await page.setViewportSize({ width: 900, height: 650 });
+  const shrunk = await geometry();
+  expect(shrunk.ariaRatio).toBeCloseTo(persistedRatio, 2);
+  expect(shrunk.ratio).toBeCloseTo(persistedRatio, 2);
+  expect(shrunk.spectrum).toBeGreaterThanOrEqual(72);
+  expect(shrunk.waterfall).toBeGreaterThanOrEqual(96);
+
+  await page.setViewportSize({ width: 1280, height: 900 });
+  const grown = await geometry();
+  expect(grown.ariaRatio).toBeCloseTo(persistedRatio, 2);
+  expect(grown.ratio).toBeCloseTo(persistedRatio, 2);
+  await panel.locator('[title="Toggle fullscreen"]').click();
+  await expect(panel).toHaveClass(/fullscreen/);
+  const fullscreen = await geometry();
+  expect(fullscreen.ariaRatio).toBeCloseTo(persistedRatio, 2);
+  expect(fullscreen.ratio).toBeCloseTo(persistedRatio, 2);
+
+  const canvasIdentity = await panel.evaluate((node) => {
+    const witness = window as typeof window & {
+      __spectrumCanvasNodes?: { spectrum: Element | null; waterfall: Element | null };
+    };
+    return witness.__spectrumCanvasNodes?.spectrum === node.querySelector('.spectrum-area canvas')
+      && witness.__spectrumCanvasNodes?.waterfall
+        === node.querySelector('.waterfall-content canvas');
+  });
+  expect(canvasIdentity).toBe(true);
+  const commands = await page.evaluate(() => window.__spectrumWitness.commands);
+  expect(commands).toEqual([]);
+  expect(requests).toHaveLength(initialRequestCount);
 });


### PR DESCRIPTION
## Summary

- add a persistent accessible separator between spectrum and waterfall
- clamp both panes to practical minimum heights while keeping the panorama height stable
- preserve mounted canvases and isolate divider input from tuning and filter commands
- cover pointer cancellation, keyboard control, persistence, resize/fullscreen restoration, and browser fixture behavior

Linear: https://linear.app/morozsm/issue/MOR-2461/resize-the-spectrum-and-waterfall-split-with-a-persistent-accessible

## Verification

- `npm test -- src/components/spectrum/__tests__/SpectrumPanel.component.test.ts` (126 passed)
- `npm run check` (0 errors, 0 warnings)
- focused ESLint on the changed SpectrumPanel source/test
- `npx playwright test -c ./playwright.visual.config.ts tests/e2e/visual/spectrum-baselines.spec.ts -g "spectrum separator preserves"` (1 passed)
- `git diff --check`

## Safety and scope

- no radio, PTT, TUNE, frequency, or filter commands were sent
- no server or hardware process was touched
- no wheel-intent behavior, TX layout/overlay files, desktop geometry test, or PNG baseline was changed
- MOR-2457 remains a separate known bar-meter timing flake


## Delivery size

This PR is one semantic unit despite crossing the 600-line soft threshold: the 4-file delta keeps the separator implementation, its component contract, and the isolated browser witness/regression together. Splitting the fixture proof from the interaction would leave either commit unable to establish the accepted geometry and command-isolation behavior.

