### PR TITLE
fix(MOR-2462): keep Standard usable in short desktop windows

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -10,6 +10,7 @@
   import { hasAnyScope } from './lib/stores/capabilities.svelte';
   import { getLayoutMode } from './lib/stores/layout.svelte';
   import { readQaCockpitLayoutOverride } from './lib/stores/qa-cockpit-override';
+  import { isMobileViewport } from './lib/stores/viewport-classification';
   import { getAvailableThemes } from './components-v2/theme/theme-switcher';
   import { getDesignLanguage, listDesignLanguageIds } from './presentation/languages/contract';
   // Side-effect import: populates the design-language registry the lookup
@@ -69,11 +70,9 @@
   const qaCockpitLayoutOverride = readQaCockpitLayoutOverride();
   let windowWidth = $state(typeof window !== 'undefined' ? window.innerWidth : 1200);
   let windowHeight = $state(typeof window !== 'undefined' ? window.innerHeight : 800);
-  // Mobile = narrow portrait OR short landscape (touch device rotated)
-  let isMobile = $derived(
-    Math.min(windowWidth, windowHeight) < 640 ||
-    ('ontouchstart' in globalThis && Math.min(windowWidth, windowHeight) < 500)
-  );
+  let isMobile = $derived(isMobileViewport(
+    windowWidth, windowHeight, typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0,
+  ));
   let skinId = $derived<SkinId>(resolveSkinId({
     capabilities: runtime.caps,
     layoutPreference: qaCockpitLayoutOverride ?? getLayoutMode(),

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -1120,7 +1120,7 @@
   }
   .radio-layout.desktop-control-face.standard-face {
     grid-template-columns: 228px minmax(0, 1fr) 228px;
-    grid-template-rows: auto 28px auto minmax(0, 1fr) auto;
+    grid-template-rows: auto 28px auto minmax(min-content, 1fr) auto;
     gap: 5px;
   }
   .desktop-control-face > .receiver-deck,

--- a/frontend/src/lib/stores/__tests__/qa-cockpit-override.test.ts
+++ b/frontend/src/lib/stores/__tests__/qa-cockpit-override.test.ts
@@ -62,27 +62,26 @@ describe('readQaCockpitLayoutOverride (MOR-1257)', () => {
     });
   });
 
-  // MOR-1257 D2 (independent verification, F2 mitigation) — below the same
-  // 640px minimum dimension App.svelte uses to classify the viewport as
-  // mobile, `resolveSkinId`'s mobile short-circuit suppresses the override
-  // with no signal at all. This does not change that precedence (still an
-  // owner-escalated question, not decided here) — it only makes the no-op
-  // self-explaining.
   describe('mobile-suppression warning (MOR-1257 D2)', () => {
     let warnSpy: ReturnType<typeof vi.spyOn>;
     let originalWidth: number;
     let originalHeight: number;
+    let originalTouchPoints: PropertyDescriptor | undefined;
 
     beforeEach(() => {
       warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       originalWidth = window.innerWidth;
       originalHeight = window.innerHeight;
+      originalTouchPoints = Object.getOwnPropertyDescriptor(navigator, 'maxTouchPoints');
+      Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 0 });
     });
 
     afterEach(() => {
       warnSpy.mockRestore();
       Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalWidth });
       Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalHeight });
+      if (originalTouchPoints) Object.defineProperty(navigator, 'maxTouchPoints', originalTouchPoints);
+      else Reflect.deleteProperty(navigator, 'maxTouchPoints');
     });
 
     it('warns once when the param matches but the viewport is under 640px', () => {
@@ -93,7 +92,7 @@ describe('readQaCockpitLayoutOverride (MOR-1257)', () => {
 
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy.mock.calls[0][0]).toMatch(/dual-receiver-cockpit/);
-      expect(warnSpy.mock.calls[0][0]).toMatch(/640/);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/mobile/);
     });
 
     it('does not warn when the param matches and the viewport is desktop-sized', () => {
@@ -103,6 +102,21 @@ describe('readQaCockpitLayoutOverride (MOR-1257)', () => {
       expect(readQaCockpitLayoutOverride('?layout=dual-receiver-cockpit')).toBe('dual-receiver-cockpit');
 
       expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      [1136, 600, 0, false],
+      [1440, 450, 0, false],
+      [1024, 600, 5, false],
+      [844, 390, 5, true],
+      [844, 500, 5, false],
+      [639, 900, 0, true],
+    ])('classifies %ix%i with %i touch points consistently', (width, height, touchPoints, mobile) => {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: width });
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: height });
+      Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: touchPoints });
+      expect(readQaCockpitLayoutOverride('?layout=flagship-probe')).toBe('flagship-probe');
+      expect(warnSpy).toHaveBeenCalledTimes(mobile ? 1 : 0);
     });
 
     it('does not warn when the param is absent, regardless of viewport size', () => {

--- a/frontend/src/lib/stores/qa-cockpit-override.ts
+++ b/frontend/src/lib/stores/qa-cockpit-override.ts
@@ -18,37 +18,24 @@
  * several component-test suites already use for those two modules (e.g.
  * `src/__tests__/lazy-presentation.component.test.ts`) — a new named
  * export added to either would come back `undefined` under those mocks.
- *
- * Pure: reads only the given search string (or `window.location.search`
- * when none is given); touches no store and persists nothing. Safe to call
- * from tests.
- *
- * The param never overrides the mobile short-circuit in `resolveSkinId`
- * (`skins/registry.ts` checks `ctx.isMobile` first, unconditionally) —
- * that precedence is unchanged here. Below the same 640px minimum
- * dimension `App.svelte` uses to classify the viewport as mobile, the
- * param would otherwise be silently ignored with no signal, which reads
- * as "the param is broken" rather than "this viewport is mobile" — most
- * often on an ordinary narrow/short desktop window, not an actual phone.
- * `console.warn` makes that non-obvious no-op self-explaining.
  */
+import { isMobileViewport } from './viewport-classification';
+
 const QA_COCKPIT_QUERY_PARAM = 'layout';
 export type QaLayoutOverride = 'dual-receiver-cockpit' | 'flagship-probe';
 /** Exact match only: anything not in this list falls through to the normal
  *  preference, so a guessed `?layout=...` cannot reach a QA-only skin. */
 const QA_QUERY_VALUES: readonly QaLayoutOverride[] = ['dual-receiver-cockpit', 'flagship-probe'];
-const MOBILE_MIN_DIMENSION_PX = 640;
 
 export function readQaCockpitLayoutOverride(search?: string): QaLayoutOverride | null {
   const raw = search ?? (typeof window !== 'undefined' ? window.location.search : '');
   const value = new URLSearchParams(raw).get(QA_COCKPIT_QUERY_PARAM);
   const matched = QA_QUERY_VALUES.find((id) => id === value) ?? null;
   if (matched !== null && typeof window !== 'undefined'
-    && Math.min(window.innerWidth, window.innerHeight) < MOBILE_MIN_DIMENSION_PX) {
+    && isMobileViewport(window.innerWidth, window.innerHeight, navigator.maxTouchPoints > 0)) {
     console.warn(
-      `[rigplane] ?layout=${matched} is set, but the viewport is under `
-      + `${MOBILE_MIN_DIMENSION_PX}px — the mobile skin takes precedence and that skin will `
-      + 'not show. Widen the window to at least 640x640 to view it.',
+      `[rigplane] ?layout=${matched} is set, but the viewport is mobile — `
+      + 'the mobile skin takes precedence and that skin will not show.',
     );
   }
   return matched;

--- a/frontend/src/lib/stores/viewport-classification.ts
+++ b/frontend/src/lib/stores/viewport-classification.ts
@@ -1,0 +1,3 @@
+export function isMobileViewport(width: number, height: number, hasTouch: boolean): boolean {
+  return width < 640 || (hasTouch && height < 500);
+}

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -89,6 +89,7 @@ function fixture(known: boolean) {
 
 interface BootOptions {
   height?: number;
+  expectedMobile?: boolean;
   theme?: 'nord' | 'github-light';
   locale?: 'en-US' | 'ru-RU';
   extraCapabilities?: string[];
@@ -193,12 +194,44 @@ async function boot(page: Page, layout: string, width: number, known: boolean, l
   const qaLayout = options.qaLayout;
   await page.goto(`/?locale=${locale}${qaLayout ? `&layout=${qaLayout}` : ''}`, { waitUntil: 'networkidle' });
   const shell = qaLayout ? '[data-testid="flagship-geometry-probe"]'
-    : width <= 640 ? '.m-layout, .m-landscape'
+    : (options.expectedMobile ?? width < 640) ? '.m-layout, .m-landscape'
     : layout.startsWith('lcd') ? '.lcd-layout' : '.desktop-control-face';
   await expect(page.locator(shell).first()).toBeVisible();
   await page.evaluate(() => document.fonts.ready);
   return state;
 }
+
+test.describe('startup viewport classification', () => {
+  for (const width of [1024, 1136, 1280, 1440, 1920]) {
+    test(`Standard cold-boots on a ${width}×600 desktop viewport`, async ({ page }) => {
+      await boot(page, 'standard', width, true, 'studioline', false, undefined, { height: 600 });
+      await expect(page.locator('.desktop-control-face.standard-face')).toBeVisible();
+      await expect(page.locator('.m-layout, .m-landscape')).toHaveCount(0);
+      await page.setViewportSize({ width, height: 900 });
+      await page.setViewportSize({ width, height: 450 });
+      await expect(page.locator('.desktop-control-face.standard-face')).toBeVisible();
+      await expect(page.locator('.m-layout, .m-landscape')).toHaveCount(0);
+    });
+  }
+
+  test('touch phone keeps mobile portrait and landscape across cold entry and rotation', async ({ browser }) => {
+    const context = await browser.newContext({ hasTouch: true, isMobile: true });
+    const page = await context.newPage();
+    try {
+      await boot(page, 'standard', 390, true, 'studioline', false, undefined,
+        { height: 844, expectedMobile: true });
+      await expect(page.locator('.m-layout')).toBeVisible();
+      await page.setViewportSize({ width: 844, height: 390 });
+      await expect(page.locator('.m-landscape')).toBeVisible();
+      await page.reload();
+      await expect(page.locator('.m-landscape')).toBeVisible();
+      await page.setViewportSize({ width: 1024, height: 600 });
+      await expect(page.locator('.desktop-control-face.standard-face')).toBeVisible();
+    } finally {
+      await context.close();
+    }
+  });
+});
 
 async function focusWithoutActivation(page: Page, control: Locator) {
   // Focusing a disabled last button would leave focus on Unkey; re-focusing

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -231,6 +231,31 @@ test.describe('startup viewport classification', () => {
       await context.close();
     }
   });
+
+  for (const width of [1136, 1280, 1440]) for (const height of [600, 900]) {
+    test(`Standard keeps panorama above Station Meters in a ${width}×${height} viewport`, async ({ page }, info) => {
+      await boot(page, 'standard', width, true, 'studioline', false, 'topology-2-main-sub', { height });
+      const center = page.locator('.standard-face .desktop-controls-center');
+      const panorama = center.locator('.spectrum-frame');
+      const meters = page.locator('.standard-face [data-panel-id="semantic-meters"]');
+      const bounds = await Promise.all([center, panorama, meters].map(element =>
+        element.evaluate(node => node.getBoundingClientRect().toJSON())));
+      await writeFile(info.outputPath('layout-bounds.json'), JSON.stringify({ width, height, bounds }));
+      expect(bounds[0].bottom).toBeLessThanOrEqual(bounds[2].top);
+      expect(bounds[1].bottom).toBeLessThanOrEqual(bounds[2].top);
+      expect(bounds[1].height).toBeGreaterThanOrEqual(280);
+      await focusWithoutActivation(page, meters.locator('.panel-header'));
+      await expect(meters.locator('.panel-header')).toBeFocused();
+      await meters.scrollIntoViewIfNeeded();
+      const visibleBounds = await meters.evaluate(node => {
+        const box = node.getBoundingClientRect();
+        return { top: box.top, bottom: box.bottom - Number.parseFloat(getComputedStyle(node).borderBottomWidth) };
+      });
+      expect(visibleBounds.top).toBeGreaterThanOrEqual(0);
+      expect(visibleBounds.bottom).toBeLessThanOrEqual(height);
+      expect(await page.locator('.standard-face').evaluate(node => node.scrollWidth > node.clientWidth)).toBe(false);
+    });
+  }
 });
 
 async function focusWithoutActivation(page: Page, control: Locator) {

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -225,8 +225,22 @@ test.describe('startup viewport classification', () => {
       await expect(page.locator('.m-landscape')).toBeVisible();
       await page.reload();
       await expect(page.locator('.m-landscape')).toBeVisible();
-      await page.setViewportSize({ width: 1024, height: 600 });
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('wide touch viewport cold-boots Standard at 1024×600', async ({ browser }) => {
+    const context = await browser.newContext({
+      hasTouch: true, isMobile: true, viewport: { width: 1024, height: 600 },
+    });
+    const page = await context.newPage();
+    try {
+      await boot(page, 'standard', 1024, true, 'studioline', false, undefined, { height: 600 });
+      expect(await page.evaluate(() => ({ width: innerWidth, height: innerHeight, touch: navigator.maxTouchPoints > 0 })))
+        .toEqual({ width: 1024, height: 600, touch: true });
       await expect(page.locator('.desktop-control-face.standard-face')).toBeVisible();
+      await expect(page.locator('.m-layout, .m-landscape')).toHaveCount(0);
     } finally {
       await context.close();
     }


### PR DESCRIPTION
Wide desktop windows could select the mobile shell solely because their height fell below 640px. Once the Standard shell was reachable, its central grid row could shrink below the panorama's minimum height and overlap Station Meters. This fixes both parts of short-window desktop entry: viewport classification distinguishes narrow windows from short touch landscapes, and Standard preserves the central row's intrinsic minimum while allowing vertical scrolling. The QA layout warning uses the same viewport classification.

Validation: 85 focused unit tests passed, including registry precedence and QA warning coverage; restoring the old viewport formula failed four regression cases. Seven Chromium startup/rotation cases passed, covering desktop widths 1024, 1136, 1280, 1440 and 1920 at 600px height plus touch portrait/landscape and a separate wide-touch cold boot. Six real-page geometry cases passed at widths 1136/1280/1440 and heights 600/900, checking panorama/meter separation, focus access and scrolling. The old grid rule failed all three 600px cases; measured 900px bounds were unchanged. Build, type checks and scoped lint passed.

Tracks MOR-2462. Header visual fidelity is handled separately.
