### PR TITLE
fix(MOR-2462): restore Standard header hierarchy and stable geometry

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -10,6 +10,7 @@
   import { hasAnyScope } from './lib/stores/capabilities.svelte';
   import { getLayoutMode } from './lib/stores/layout.svelte';
   import { readQaCockpitLayoutOverride } from './lib/stores/qa-cockpit-override';
+  import { isMobileViewport } from './lib/stores/viewport-classification';
   import { getAvailableThemes } from './components-v2/theme/theme-switcher';
   import { getDesignLanguage, listDesignLanguageIds } from './presentation/languages/contract';
   // Side-effect import: populates the design-language registry the lookup
@@ -69,11 +70,9 @@
   const qaCockpitLayoutOverride = readQaCockpitLayoutOverride();
   let windowWidth = $state(typeof window !== 'undefined' ? window.innerWidth : 1200);
   let windowHeight = $state(typeof window !== 'undefined' ? window.innerHeight : 800);
-  // Mobile = narrow portrait OR short landscape (touch device rotated)
-  let isMobile = $derived(
-    Math.min(windowWidth, windowHeight) < 640 ||
-    ('ontouchstart' in globalThis && Math.min(windowWidth, windowHeight) < 500)
-  );
+  let isMobile = $derived(isMobileViewport(
+    windowWidth, windowHeight, typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0,
+  ));
   let skinId = $derived<SkinId>(resolveSkinId({
     capabilities: runtime.caps,
     layoutPreference: qaCockpitLayoutOverride ?? getLayoutMode(),

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -1120,7 +1120,7 @@
   }
   .radio-layout.desktop-control-face.standard-face {
     grid-template-columns: 228px minmax(0, 1fr) 228px;
-    grid-template-rows: auto 28px auto minmax(0, 1fr) auto;
+    grid-template-rows: auto 28px auto minmax(min-content, 1fr) auto;
     gap: 5px;
   }
   .desktop-control-face > .receiver-deck,

--- a/frontend/src/components-v2/vfo/VfoPanel.svelte
+++ b/frontend/src/components-v2/vfo/VfoPanel.svelte
@@ -366,10 +366,12 @@
   .tx-marker[data-rf-state='uncertain'] { color: var(--v2-accent-yellow, #ffca55); }
   .compact-header .slot-choice { font-size: 11px; line-height: 14px; margin-inline-start: 0; }
   .compact-header .slot-choice .vfo-role,
-  .compact-header .slot-choice .vfo-freq { font-size: inherit; }
+  .panel.compact-header .frequency-summary .slot-choice .vfo-freq {
+    font-size: 11px; line-height: 14px; letter-spacing: 0;
+  }
   @container (max-width: 540px) {
     .compact-header .display-row { gap: 6px; }
-    .compact-header .frequency-summary { min-width: 145px; }
+    .compact-header .frequency-summary { min-width: 125px; }
     .mode-filter-summary { gap: 3px; }
     .panel.compact-header .vfo-freq { font-size: 44px; }
     .passive-summary-reading { min-height: 24px; padding-inline: 4px; }

--- a/frontend/src/components-v2/vfo/VfoPanel.svelte
+++ b/frontend/src/components-v2/vfo/VfoPanel.svelte
@@ -235,11 +235,12 @@
           {#if onModeClick}
             <button type="button" class="mode-control" disabled={controlsDisabled}
               onclick={onModeClick} aria-label={`Change mode (current: ${mode ?? '—'})`}>{mode ?? '—'}</button>
-          {:else}<span class="mode-reading">{mode ?? '—'}</span>{/if}
-          <span>{filter ?? '—'}</span>
-          {#if bandText}<span>{bandText}</span>{/if}
+          {:else}<span class="mode-reading passive-summary-reading" data-summary-fact="mode">{mode ?? '—'}</span>{/if}
+          <span class="passive-summary-reading" data-summary-fact="filter">{filter ?? '—'}</span>
+          {#if bandText}<span class="band-reading" data-summary-fact="band">{bandText}</span>{/if}
           {#each badgeItems.filter((item) => item.label.startsWith('BW ')) as item}
-            <span data-indicator-fact="bw" data-state={item.state}>{item.label}</span>
+            <span class="passive-summary-reading" data-summary-fact="bandwidth"
+              data-indicator-fact="bw" data-state={item.state}>{item.label}</span>
           {/each}
           {@render slotChoiceControls()}
           </div>
@@ -323,32 +324,41 @@
 <style>
   .identity-row { display: contents; }
   .panel.compact-header {
-    grid-template-rows: 28px auto;
+    grid-template-rows: 30px auto;
     min-height: 100%;
     container-type: inline-size;
   }
   .compact-header .identity-row {
-    display: flex; align-items: center; min-width: 0; gap: 6px; padding: 0 8px;
+    display: flex; align-items: center; min-width: 0; gap: 10px; padding: 0 10px;
   }
   .compact-header .panel-header { width: auto; flex: 0 0 auto; padding: 0; min-height: 24px; }
   .compact-header .vfo-label { font-size: 12px; letter-spacing: 0.04em; }
-  .compact-header .panel-meter { margin-left: auto; flex: 1 1 240px; max-width: 310px; min-width: 0; padding: 0; height: 28px; }
+  .compact-header .panel-meter { margin-left: auto; flex: 1 1 250px; max-width: 350px; min-width: 0; padding: 0; height: 30px; }
   .compact-header .panel-meter:empty { display: none; }
-  .compact-header .panel-meter :global(svg) { width: 100%; height: 28px; }
-  .compact-header .panel-body { display: flex; flex-direction: column; gap: 3px; padding: 0 8px 3px; }
-  .compact-header .display-row { min-height: 44px; gap: 8px; flex-wrap: wrap; justify-content: flex-start; }
-  .panel.compact-header .vfo-freq { font-size: 44px; line-height: 1; letter-spacing: 0; inline-size: auto; white-space: nowrap; }
+  .compact-header .panel-meter :global(svg) { width: 100%; height: 30px; }
+  .compact-header .panel-body { display: flex; flex-direction: column; gap: 3px; padding: 1px 10px 3px; }
+  .compact-header .display-row { min-height: 50px; gap: 12px; flex-wrap: wrap; justify-content: flex-start; }
+  .panel.compact-header .vfo-freq { font-size: 48px; line-height: 1; letter-spacing: -0.015em; inline-size: auto; white-space: nowrap; }
   .compact-header .freq-row { flex: 0 0 auto; }
-  .frequency-summary { display: flex; flex-direction: column; justify-content: center; flex: 1 1 0; min-width: 150px; gap: 2px; font-size: 12px; font-variant-numeric: tabular-nums; color: var(--v2-text-secondary); }
-  .mode-filter-summary { display: flex; flex-wrap: wrap; align-items: center; gap: 4px 10px; }
+  .frequency-summary { display: flex; flex-direction: column; justify-content: center; flex: 1 1 0; min-width: 150px; gap: 4px; font-size: 12px; font-variant-numeric: tabular-nums; color: var(--v2-text-secondary); }
+  .mode-filter-summary { display: flex; flex-wrap: wrap; align-items: center; gap: 5px; }
   .mode-filter-summary > span { white-space: nowrap; }
-  .mode-reading { font-weight: 700; color: var(--v2-text-primary); }
-  .mode-control { font: inherit; color: var(--receiver-accent); background: var(--v2-bg-panel); border: 1px solid var(--receiver-control-border); border-radius: 3px; cursor: pointer; padding: 3px 6px; }
-  .compact-header .control-strip { display: flex; align-content: start; align-items: baseline; flex-wrap: wrap; gap: 3px 12px; min-height: 27px; overflow: visible; white-space: normal; font-size: 11px; }
+  .passive-summary-reading {
+    display: inline-flex; align-items: center; justify-content: center; min-height: 26px;
+    padding: 3px 8px; border: 1px solid var(--v2-border-panel);
+    border-radius: 3px; background: var(--v2-bg-panel); color: var(--v2-text-primary);
+    font-size: 12px; line-height: 1; box-sizing: border-box;
+  }
+  .mode-reading { font-weight: 700; color: var(--receiver-accent); border-color: var(--receiver-control-border); }
+  .band-reading { padding-inline: 3px; color: var(--v2-text-secondary); font-size: 12px; }
+  .mode-control { min-height: 28px; font: inherit; color: var(--receiver-accent); background: var(--v2-bg-panel); border: 1px solid var(--receiver-control-border); border-radius: 3px; cursor: pointer; padding: 3px 8px; }
+  .compact-header .control-strip { display: flex; align-content: start; align-items: stretch; flex-wrap: wrap; gap: 4px 0; min-height: 32px; overflow: visible; white-space: normal; font-size: 12px; }
   .tx-frequency { min-height: 12px; color: var(--v2-accent-orange, #ff9838); font-size: 11px; line-height: 12px; white-space: nowrap; }
   .tx-frequency[data-rf-state='transmitting'] { color: var(--v2-accent-red, #ff4040); }
   .tx-marker-slot { flex: 0 0 9ch; font-size: 11px; }
-  .indicator-group { display: flex; align-items: baseline; flex-wrap: wrap; gap: 3px 9px; font-size: 11px; line-height: 12px; }
+  .indicator-group { display: flex; align-items: center; flex-wrap: wrap; gap: 4px 10px; min-height: 28px; padding: 2px 12px; font-size: 12px; line-height: 16px; }
+  .indicator-group:first-child { padding-left: 0; }
+  .indicator-group + .indicator-group { border-left: 1px solid var(--v2-border-panel); }
   .group-label { color: var(--v2-accent-cyan); font-weight: 700; }
   .passive-reading { color: var(--v2-text-secondary); white-space: nowrap; }
   .tx-marker { flex: 0 0 9ch; color: var(--v2-accent-orange, #ff9838); font-size: 11px; white-space: nowrap; }
@@ -358,8 +368,11 @@
   .compact-header .slot-choice .vfo-role,
   .compact-header .slot-choice .vfo-freq { font-size: inherit; }
   @container (max-width: 540px) {
-    .compact-header .frequency-summary { flex-basis: 100%; }
-    .compact-header .display-row { row-gap: 0; }
+    .compact-header .display-row { gap: 6px; }
+    .compact-header .frequency-summary { min-width: 145px; }
+    .mode-filter-summary { gap: 3px; }
+    .panel.compact-header .vfo-freq { font-size: 44px; }
+    .passive-summary-reading { min-height: 24px; padding-inline: 4px; }
   }
 
   .panel {

--- a/frontend/src/components-v2/vfo/VfoPanel.svelte
+++ b/frontend/src/components-v2/vfo/VfoPanel.svelte
@@ -376,6 +376,9 @@
     .panel.compact-header .vfo-freq { font-size: 44px; }
     .passive-summary-reading { min-height: 24px; padding-inline: 4px; }
   }
+  @media (max-width: 1280px) {
+    .panel.compact-header .vfo-freq { font-size: 44px; }
+  }
 
   .panel {
     display: grid;

--- a/frontend/src/lib/stores/__tests__/qa-cockpit-override.test.ts
+++ b/frontend/src/lib/stores/__tests__/qa-cockpit-override.test.ts
@@ -62,27 +62,26 @@ describe('readQaCockpitLayoutOverride (MOR-1257)', () => {
     });
   });
 
-  // MOR-1257 D2 (independent verification, F2 mitigation) — below the same
-  // 640px minimum dimension App.svelte uses to classify the viewport as
-  // mobile, `resolveSkinId`'s mobile short-circuit suppresses the override
-  // with no signal at all. This does not change that precedence (still an
-  // owner-escalated question, not decided here) — it only makes the no-op
-  // self-explaining.
   describe('mobile-suppression warning (MOR-1257 D2)', () => {
     let warnSpy: ReturnType<typeof vi.spyOn>;
     let originalWidth: number;
     let originalHeight: number;
+    let originalTouchPoints: PropertyDescriptor | undefined;
 
     beforeEach(() => {
       warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       originalWidth = window.innerWidth;
       originalHeight = window.innerHeight;
+      originalTouchPoints = Object.getOwnPropertyDescriptor(navigator, 'maxTouchPoints');
+      Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 0 });
     });
 
     afterEach(() => {
       warnSpy.mockRestore();
       Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalWidth });
       Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalHeight });
+      if (originalTouchPoints) Object.defineProperty(navigator, 'maxTouchPoints', originalTouchPoints);
+      else Reflect.deleteProperty(navigator, 'maxTouchPoints');
     });
 
     it('warns once when the param matches but the viewport is under 640px', () => {
@@ -93,7 +92,7 @@ describe('readQaCockpitLayoutOverride (MOR-1257)', () => {
 
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy.mock.calls[0][0]).toMatch(/dual-receiver-cockpit/);
-      expect(warnSpy.mock.calls[0][0]).toMatch(/640/);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/mobile/);
     });
 
     it('does not warn when the param matches and the viewport is desktop-sized', () => {
@@ -103,6 +102,21 @@ describe('readQaCockpitLayoutOverride (MOR-1257)', () => {
       expect(readQaCockpitLayoutOverride('?layout=dual-receiver-cockpit')).toBe('dual-receiver-cockpit');
 
       expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      [1136, 600, 0, false],
+      [1440, 450, 0, false],
+      [1024, 600, 5, false],
+      [844, 390, 5, true],
+      [844, 500, 5, false],
+      [639, 900, 0, true],
+    ])('classifies %ix%i with %i touch points consistently', (width, height, touchPoints, mobile) => {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: width });
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: height });
+      Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: touchPoints });
+      expect(readQaCockpitLayoutOverride('?layout=flagship-probe')).toBe('flagship-probe');
+      expect(warnSpy).toHaveBeenCalledTimes(mobile ? 1 : 0);
     });
 
     it('does not warn when the param is absent, regardless of viewport size', () => {

--- a/frontend/src/lib/stores/qa-cockpit-override.ts
+++ b/frontend/src/lib/stores/qa-cockpit-override.ts
@@ -18,37 +18,24 @@
  * several component-test suites already use for those two modules (e.g.
  * `src/__tests__/lazy-presentation.component.test.ts`) — a new named
  * export added to either would come back `undefined` under those mocks.
- *
- * Pure: reads only the given search string (or `window.location.search`
- * when none is given); touches no store and persists nothing. Safe to call
- * from tests.
- *
- * The param never overrides the mobile short-circuit in `resolveSkinId`
- * (`skins/registry.ts` checks `ctx.isMobile` first, unconditionally) —
- * that precedence is unchanged here. Below the same 640px minimum
- * dimension `App.svelte` uses to classify the viewport as mobile, the
- * param would otherwise be silently ignored with no signal, which reads
- * as "the param is broken" rather than "this viewport is mobile" — most
- * often on an ordinary narrow/short desktop window, not an actual phone.
- * `console.warn` makes that non-obvious no-op self-explaining.
  */
+import { isMobileViewport } from './viewport-classification';
+
 const QA_COCKPIT_QUERY_PARAM = 'layout';
 export type QaLayoutOverride = 'dual-receiver-cockpit' | 'flagship-probe';
 /** Exact match only: anything not in this list falls through to the normal
  *  preference, so a guessed `?layout=...` cannot reach a QA-only skin. */
 const QA_QUERY_VALUES: readonly QaLayoutOverride[] = ['dual-receiver-cockpit', 'flagship-probe'];
-const MOBILE_MIN_DIMENSION_PX = 640;
 
 export function readQaCockpitLayoutOverride(search?: string): QaLayoutOverride | null {
   const raw = search ?? (typeof window !== 'undefined' ? window.location.search : '');
   const value = new URLSearchParams(raw).get(QA_COCKPIT_QUERY_PARAM);
   const matched = QA_QUERY_VALUES.find((id) => id === value) ?? null;
   if (matched !== null && typeof window !== 'undefined'
-    && Math.min(window.innerWidth, window.innerHeight) < MOBILE_MIN_DIMENSION_PX) {
+    && isMobileViewport(window.innerWidth, window.innerHeight, navigator.maxTouchPoints > 0)) {
     console.warn(
-      `[rigplane] ?layout=${matched} is set, but the viewport is under `
-      + `${MOBILE_MIN_DIMENSION_PX}px — the mobile skin takes precedence and that skin will `
-      + 'not show. Widen the window to at least 640x640 to view it.',
+      `[rigplane] ?layout=${matched} is set, but the viewport is mobile — `
+      + 'the mobile skin takes precedence and that skin will not show.',
     );
   }
   return matched;

--- a/frontend/src/lib/stores/viewport-classification.ts
+++ b/frontend/src/lib/stores/viewport-classification.ts
@@ -1,0 +1,3 @@
+export function isMobileViewport(width: number, height: number, hasTouch: boolean): boolean {
+  return width < 640 || (hasTouch && height < 500);
+}

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -1030,15 +1030,26 @@
   }
   [data-vfo-appearance='standard'] .bridge {
     flex: 0 0 170px;
-    padding: 4px;
-    gap: 4px;
+    padding: 6px;
+    gap: 5px;
     --vfo-ops-gap: 4px;
-    --vfo-ops-badge-padding-x: 3px;
-    --vfo-ops-badge-font-size: 10px;
+    --vfo-ops-badge-height: 28px;
+    --vfo-ops-badge-padding-x: 5px;
+    --vfo-ops-badge-font-size: 11px;
+    --btn-font-size: 12px;
+  }
+  [data-vfo-appearance='standard'] .bridge::before {
+    content: 'ACTIONS'; color: var(--v2-text-subdued, rgba(255,255,255,.55));
+    font-size: 10px; font-weight: 700; letter-spacing: .12em; line-height: 12px;
+  }
+  [data-vfo-appearance='standard'] .bridge :global(.fact-toggles) {
+    grid-template-columns: minmax(0, 1fr);
   }
   [data-vfo-appearance='standard'] .bridge :global(.vfo-ops) {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
+  [data-vfo-appearance='standard'] .bridge :global(.fact-toggle),
+  [data-vfo-appearance='standard'] .bridge :global(.vfo-op) { min-height: 28px; font-size: 12px; }
   .standard-radio-facts {
     display: flex; align-items: center; flex-wrap: wrap; gap: 4px 14px;
     min-height: 18px; padding: 0 8px; font-size: 11px; line-height: 16px;
@@ -1050,7 +1061,7 @@
   .radio-tx { margin-left: auto; min-width: 14ch; white-space: nowrap; }
   .standard-vfo-selectors { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 4px; }
   .standard-vfo-selectors .vfo-select {
-    min-width: 0; padding: 4px 3px; font-size: 11px; font-weight: 700;
+    min-width: 0; min-height: 28px; padding: 4px 3px; font-size: 11px; font-weight: 700;
   }
   .standard-vfo-selectors .vfo-select[data-active='true'] {
     border-color: var(--v2-accent-cyan, #00d4ff); color: var(--v2-accent-cyan, #00d4ff);
@@ -1097,6 +1108,7 @@
   }
   @media (max-width: 1050px) {
     .instrument-panel { flex-wrap: wrap; }
+    [data-vfo-appearance='standard'] .instrument-panel { min-height: 170px; }
     .receiver-instrument { flex-basis: calc(50% - 90px); }
     .bridge { flex-basis: 150px; }
     .receiver-instrument .vfo-freq { font-size: 26px; }

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -89,6 +89,7 @@ function fixture(known: boolean) {
 
 interface BootOptions {
   height?: number;
+  expectedMobile?: boolean;
   theme?: 'nord' | 'github-light';
   locale?: 'en-US' | 'ru-RU';
   extraCapabilities?: string[];
@@ -193,12 +194,44 @@ async function boot(page: Page, layout: string, width: number, known: boolean, l
   const qaLayout = options.qaLayout;
   await page.goto(`/?locale=${locale}${qaLayout ? `&layout=${qaLayout}` : ''}`, { waitUntil: 'networkidle' });
   const shell = qaLayout ? '[data-testid="flagship-geometry-probe"]'
-    : width <= 640 ? '.m-layout, .m-landscape'
+    : (options.expectedMobile ?? width < 640) ? '.m-layout, .m-landscape'
     : layout.startsWith('lcd') ? '.lcd-layout' : '.desktop-control-face';
   await expect(page.locator(shell).first()).toBeVisible();
   await page.evaluate(() => document.fonts.ready);
   return state;
 }
+
+test.describe('startup viewport classification', () => {
+  for (const width of [1024, 1136, 1280, 1440, 1920]) {
+    test(`Standard cold-boots on a ${width}×600 desktop viewport`, async ({ page }) => {
+      await boot(page, 'standard', width, true, 'studioline', false, undefined, { height: 600 });
+      await expect(page.locator('.desktop-control-face.standard-face')).toBeVisible();
+      await expect(page.locator('.m-layout, .m-landscape')).toHaveCount(0);
+      await page.setViewportSize({ width, height: 900 });
+      await page.setViewportSize({ width, height: 450 });
+      await expect(page.locator('.desktop-control-face.standard-face')).toBeVisible();
+      await expect(page.locator('.m-layout, .m-landscape')).toHaveCount(0);
+    });
+  }
+
+  test('touch phone keeps mobile portrait and landscape across cold entry and rotation', async ({ browser }) => {
+    const context = await browser.newContext({ hasTouch: true, isMobile: true });
+    const page = await context.newPage();
+    try {
+      await boot(page, 'standard', 390, true, 'studioline', false, undefined,
+        { height: 844, expectedMobile: true });
+      await expect(page.locator('.m-layout')).toBeVisible();
+      await page.setViewportSize({ width: 844, height: 390 });
+      await expect(page.locator('.m-landscape')).toBeVisible();
+      await page.reload();
+      await expect(page.locator('.m-landscape')).toBeVisible();
+      await page.setViewportSize({ width: 1024, height: 600 });
+      await expect(page.locator('.desktop-control-face.standard-face')).toBeVisible();
+    } finally {
+      await context.close();
+    }
+  });
+});
 
 async function focusWithoutActivation(page: Page, control: Locator) {
   // Focusing a disabled last button would leave focus on Unkey; re-focusing

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -231,6 +231,31 @@ test.describe('startup viewport classification', () => {
       await context.close();
     }
   });
+
+  for (const width of [1136, 1280, 1440]) for (const height of [600, 900]) {
+    test(`Standard keeps panorama above Station Meters in a ${width}×${height} viewport`, async ({ page }, info) => {
+      await boot(page, 'standard', width, true, 'studioline', false, 'topology-2-main-sub', { height });
+      const center = page.locator('.standard-face .desktop-controls-center');
+      const panorama = center.locator('.spectrum-frame');
+      const meters = page.locator('.standard-face [data-panel-id="semantic-meters"]');
+      const bounds = await Promise.all([center, panorama, meters].map(element =>
+        element.evaluate(node => node.getBoundingClientRect().toJSON())));
+      await writeFile(info.outputPath('layout-bounds.json'), JSON.stringify({ width, height, bounds }));
+      expect(bounds[0].bottom).toBeLessThanOrEqual(bounds[2].top);
+      expect(bounds[1].bottom).toBeLessThanOrEqual(bounds[2].top);
+      expect(bounds[1].height).toBeGreaterThanOrEqual(280);
+      await focusWithoutActivation(page, meters.locator('.panel-header'));
+      await expect(meters.locator('.panel-header')).toBeFocused();
+      await meters.scrollIntoViewIfNeeded();
+      const visibleBounds = await meters.evaluate(node => {
+        const box = node.getBoundingClientRect();
+        return { top: box.top, bottom: box.bottom - Number.parseFloat(getComputedStyle(node).borderBottomWidth) };
+      });
+      expect(visibleBounds.top).toBeGreaterThanOrEqual(0);
+      expect(visibleBounds.bottom).toBeLessThanOrEqual(height);
+      expect(await page.locator('.standard-face').evaluate(node => node.scrollWidth > node.clientWidth)).toBe(false);
+    });
+  }
 });
 
 async function focusWithoutActivation(page: Page, control: Locator) {

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -225,8 +225,22 @@ test.describe('startup viewport classification', () => {
       await expect(page.locator('.m-landscape')).toBeVisible();
       await page.reload();
       await expect(page.locator('.m-landscape')).toBeVisible();
-      await page.setViewportSize({ width: 1024, height: 600 });
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('wide touch viewport cold-boots Standard at 1024×600', async ({ browser }) => {
+    const context = await browser.newContext({
+      hasTouch: true, isMobile: true, viewport: { width: 1024, height: 600 },
+    });
+    const page = await context.newPage();
+    try {
+      await boot(page, 'standard', 1024, true, 'studioline', false, undefined, { height: 600 });
+      expect(await page.evaluate(() => ({ width: innerWidth, height: innerHeight, touch: navigator.maxTouchPoints > 0 })))
+        .toEqual({ width: 1024, height: 600, touch: true });
       await expect(page.locator('.desktop-control-face.standard-face')).toBeVisible();
+      await expect(page.locator('.m-layout, .m-landscape')).toHaveCount(0);
     } finally {
       await context.close();
     }

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -973,6 +973,18 @@ for (const width of [1024, 1440]) {
       expect(buttons.every(button => button.height >= 28 && button.fits)).toBe(true);
       expect(await measure()).toEqual(knownBounds);
     }
+    const longValues = structuredClone(initial);
+    Object.assign(longValues, { revision: 10, stateRevision: 10,
+      freshnessRevision: 10, observationSeq: 10 });
+    Object.assign(longValues.main, { activeSlot: 'A', freqHz: 999_999_999,
+      mode: 'RTTY-R', filter: 3, filterWidth: 9999 });
+    Object.assign(longValues.main.vfoA!, { freqHz: 999_999_999, mode: 'RTTY-R',
+      filterNum: 3 });
+    await page.evaluate(state => window.dispatchEvent(
+      new CustomEvent('geometry-state', { detail: state })), longValues);
+    await expect(page.locator('[data-standard-vfo-slot="A"] [data-vfo-freq]'))
+      .toContainText('999');
+    expect(await measure()).toEqual(knownBounds);
     expect(await page.evaluate(() => (window as unknown as { geometryCommands: { type: string }[] })
       .geometryCommands.filter(command => command.type === 'cmd'))).toEqual([]);
   });

--- a/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
+++ b/frontend/tests/e2e/i18n/desktop-geometry.spec.ts
@@ -540,7 +540,7 @@ test.describe('MOR-2424 Standard v2.11.1 outer grid', () => {
     }
   });
 
-  for (const width of [900, 1024, 1200, 1280, 1440, 1700, 1920] as const) {
+  for (const width of [900, 1024, 1136, 1200, 1280, 1440, 1700, 1920] as const) {
     test(`Standard ${width} compact absolute VFO pair keeps every bridge control`, async ({ page }, info) => {
       await boot(page, 'standard', width, true, 'studioline', false, undefined, {
         height: 1000, extraCapabilities: ALL_STRUCTURAL_ACTION_CAPS, absoluteVfoPair: true,
@@ -603,7 +603,24 @@ test.describe('MOR-2424 Standard v2.11.1 outer grid', () => {
       }
       const fonts = await cards.locator('.freq-row .freq').evaluateAll(elements =>
         elements.map(element => getComputedStyle(element).fontSize));
-      expect(fonts).toEqual(['44px', '44px']);
+      const expectedFont = width > 1280 ? '48px' : '44px';
+      expect(fonts).toEqual([expectedFont, expectedFont]);
+      const framedFacts = cards.locator('[data-summary-fact="mode"], [data-summary-fact="filter"], [data-summary-fact="bandwidth"]');
+      await expect(framedFacts).toHaveCount(5);
+      expect(await framedFacts.evaluateAll(elements => elements.map(element => {
+        const style = getComputedStyle(element);
+        const box = element.getBoundingClientRect();
+        return { fontSize: style.fontSize, borderStyle: style.borderStyle, height: box.height };
+      }))).toEqual(expect.arrayContaining([
+        expect.objectContaining({ fontSize: '12px', borderStyle: 'solid' }),
+      ]));
+      const bridgeButtons = page.locator('[data-instrument-bridge] button');
+      expect(await bridgeButtons.evaluateAll(elements => elements.map(element => {
+        const style = getComputedStyle(element);
+        return { height: element.getBoundingClientRect().height, fontSize: style.fontSize };
+      }))).toEqual(expect.arrayContaining([
+        expect.objectContaining({ height: 28, fontSize: '12px' }),
+      ]));
       await expect(cards.locator('[data-meter-space="reserved"]')).toHaveCount(0);
       await expect(cards.locator('.identity-row [data-testid="receiver-s-meter"]')).toHaveCount(1);
       expect(await page.evaluate(() => (window as unknown as { geometryCommands: { type: string }[] })
@@ -655,10 +672,11 @@ test.describe('MOR-2424 Standard v2.11.1 outer grid', () => {
       expectStandardReceiverIntegrity(geometry, bodyTop);
       for (const instrument of geometry.instruments) {
         expect.soft(instrument.meter?.width ?? 0, 'receiver meter is painted').toBeGreaterThan(0);
-        expect.soft(instrument.meter?.height ?? 0, 'inline receiver meter retains its readable height').toBe(28);
+        expect.soft(instrument.meter?.height ?? 0, 'inline receiver meter retains its readable height').toBe(30);
         expect.soft(instrument.primary?.width ?? 0, 'primary frequency glyphs are painted').toBeGreaterThan(0);
         expect.soft(instrument.primary?.height ?? 0, 'primary frequency glyphs are painted').toBeGreaterThan(0);
-        expect.soft(instrument.primary?.fontSize, 'primary frequency retains its 44px type').toBe(44);
+        expect.soft(instrument.primary?.fontSize, 'primary frequency retains readable type')
+          .toBe(width > 1280 ? 48 : 44);
         expect.soft(instrument.meter!.left).toBeGreaterThanOrEqual(instrument.instrument.left - 1);
         expect.soft(instrument.meter!.right).toBeLessThanOrEqual(instrument.instrument.right + 1);
         expect.soft(instrument.primary!.rect.left).toBeGreaterThanOrEqual(instrument.instrument.left - 1);


### PR DESCRIPTION
The delivered Standard header flattened MODE/FILTER/BW into small text, undersized the action buttons, and changed height for unknown or long VFO values. This restores framed demodulation readings beside dominant frequencies, separates RF and DSP readings, and gives central actions 28px targets. Passive readings remain passive; existing callbacks, receiver ownership and TX authority are preserved.

The correction also includes the independently reviewed short-desktop startup/layout fixes in PR #3460, pending its merge. MOR-2462 was reopened following the user's rejection. Native Safari at the user's unchanged 150% zoom now opens Standard and keeps panorama above Station Meters, using offline fixtures only.

Validation: 196 focused VFO tests, five focused geometry tests, type checks, build and scoped lint passed. Twelve state variants at each of 1024 and 1440 preserve header bounds across RX/TX, split, stale, unknown, long values, overlays and command receipts. Both radio profiles were captured at 1024/1280/1440/1920. Header heights are 217/200/186/186px versus original 218/233/233/233px: about 20% reduction on wide desktop, almost unchanged at 1024. The approximate one-third target is not met. Effective RX frequency under RIT remains unavailable without an authoritative ownership contract; the UI does not guess it.

Linux production screenshot baselines and required exact-head CI are pending. No connected-radio settings, physical PTT/TUNE or live service deployment were used.
