### PR TITLE
fix(MOR-1951): contain validation unkey transport failures

### DIFF
--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -613,11 +613,10 @@ def _manual_required_result(
 # TX actuation handlers (MOR-666) — reached ONLY after the full gate stack and
 # an explicit interactive confirm() YES. Each handler's teardown ATTEMPTS to
 # leave the radio un-keyed with power restored via a ``finally`` that contains
-# every ``Exception`` (MOR-1951: backend transport errors are plain
-# ``Exception`` subclasses outside ``_RESTORE_ERRORS`` and must not skip the
-# restore). An unkey that failed or could not be confirmed is recorded
-# (``unkeyed: False`` + ``unkey_error``) and FAILs the check — never a PASS on
-# uncertain teardown. ``BaseException`` cancellation still propagates.
+# every ordinary ``Exception``. An unkey that failed or could not be confirmed
+# is recorded (``unkeyed: False`` + ``unkey_error``) and FAILs the check —
+# never a PASS on uncertain teardown. ``BaseException`` cancellation still
+# propagates.
 #
 # MOR-1222: every PTT *assertion* below goes through the radio's managed TX
 # supervisor when it publishes one. A raw ``set_ptt`` here took no lease, so

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -611,8 +611,13 @@ def _manual_required_result(
 
 # ---------------------------------------------------------------------------
 # TX actuation handlers (MOR-666) — reached ONLY after the full gate stack and
-# an explicit interactive confirm() YES. Each guarantees the radio is left in a
-# safe (un-keyed, power-restored) state via a finally that never raises.
+# an explicit interactive confirm() YES. Each handler's teardown ATTEMPTS to
+# leave the radio un-keyed with power restored via a ``finally`` that contains
+# every ``Exception`` (MOR-1951: backend transport errors are plain
+# ``Exception`` subclasses outside ``_RESTORE_ERRORS`` and must not skip the
+# restore). An unkey that failed or could not be confirmed is recorded
+# (``unkeyed: False`` + ``unkey_error``) and FAILs the check — never a PASS on
+# uncertain teardown. ``BaseException`` cancellation still propagates.
 #
 # MOR-1222: every PTT *assertion* below goes through the radio's managed TX
 # supervisor when it publishes one. A raw ``set_ptt`` here took no lease, so
@@ -649,16 +654,22 @@ async def _release_validation_lease(
     supervisor to release a lease this owner never took is free (it answers
     ``STALE`` and touches no wire).
 
-    A refusal is recorded, never escalated. ``force_unkey`` exists for a rig an
-    *external* process left keyed (MOR-1182); reaching for it here would let
-    the validation harness adopt — and de-key — a live transmission belonging
-    to somebody else. This tool only ever releases keys it took itself.
+    A refusal — or any release-path ``Exception`` — is recorded, never
+    escalated. The OFF write rides the same wire as the key, so the release
+    can fail with the backend's own transport error (a plain ``Exception``
+    outside ``_RESTORE_ERRORS``, e.g. Yaesu ``CatTransportError``); raising it
+    past the caller's ``finally`` would skip the power restore (MOR-1951).
+    ``BaseException`` cancellation still propagates. ``force_unkey`` exists
+    for a rig an *external* process left keyed (MOR-1182); reaching for it
+    here would let the validation harness adopt — and de-key — a live
+    transmission belonging to somebody else. This tool only ever releases
+    keys it took itself.
     """
     try:
         transition = await asyncio.wait_for(
             managed.set_ptt(False), timeout=per_check_timeout
         )
-    except _RESTORE_ERRORS as exc:
+    except Exception as exc:
         evidence["unkey_error"] = str(exc)
         return False
     refusal = _tx_refusal(transition, "release")
@@ -686,11 +697,14 @@ async def _actuate_tx_ptt(
     read too; see ``ptt_state_source`` in the evidence) → unkey → restore
     power.
     The unkey AND power-restore run in a ``finally`` that ALWAYS executes and
-    never raises (contained by ``_RESTORE_ERRORS``, which includes ``OSError``),
-    so a mid-check exception/timeout/LAN drop can never leave the radio keyed or
-    at the wrong power. (A pre-existing gap in that same ``finally`` — a
-    Yaesu transport error from the unkey call itself escaping uncontained —
-    is filed separately as MOR-1951; not this row's fix.)
+    never raises: each leg catches ``Exception`` — backend-agnostic, because a
+    Yaesu ``CatTransportError`` from the unkey write itself is a plain
+    ``Exception`` outside ``_RESTORE_ERRORS`` and must not skip the power
+    restore (MOR-1951) — while ``BaseException`` cancellation still
+    propagates. A failed or unconfirmed unkey is recorded (``unkeyed: False``
+    + ``unkey_error``) and the check FAILs: the harness never reports a PASS
+    on teardown it could not confirm, nor claims the radio is unkeyed when the
+    wire write failed.
 
     MOR-1222: on a managed rig both the key and the unkey go through the
     supervisor under :data:`_VALIDATION_TX_OWNER`. A refused key is a FAIL, not
@@ -884,12 +898,18 @@ async def _actuate_tx_ptt(
             evidence["ptt_state_source"] = ptt_state_source
             keyed = ptt_state
             evidence["keyed"] = keyed
-    except _RESTORE_ERRORS as exc:
+    except Exception as exc:
+        # Backend-agnostic containment (MOR-1951): a plain-``Exception``
+        # transport failure must land in the evidence like every mapped error,
+        # so the ``finally`` teardown below is legible on the result instead of
+        # being discarded by the run-loop backstop. Cancellation
+        # (``BaseException``) still propagates.
         verify_error = str(exc)
         evidence["actuate_error"] = verify_error
     finally:
-        # ALWAYS unkey, no matter what — the radio must never be left keyed.
-        # Never gated on whether the key was believed to succeed.
+        # ALWAYS attempt the unkey, no matter what — never gated on whether
+        # the key was believed to succeed. A failed attempt is recorded
+        # (``unkeyed: False`` + ``unkey_error``), never reported as success.
         unkeyed = False
         if managed is not None:
             unkeyed = await _release_validation_lease(
@@ -899,7 +919,7 @@ async def _actuate_tx_ptt(
             try:
                 await asyncio.wait_for(set_ptt(False), timeout=per_check_timeout)
                 unkeyed = True
-            except _RESTORE_ERRORS as exc:
+            except Exception as exc:
                 evidence["unkey_error"] = str(exc)
         evidence["unkeyed"] = unkeyed
         # ALWAYS restore the original power if we lowered it.
@@ -914,7 +934,7 @@ async def _actuate_tx_ptt(
                 power_restored = rf is None
                 if rf is not None:
                     evidence["power_restore_error"] = rf.error
-            except _RESTORE_ERRORS as exc:
+            except Exception as exc:
                 evidence["power_restore_error"] = str(exc)
         evidence["power_restored"] = power_restored
 
@@ -938,12 +958,19 @@ async def _actuate_tx_ptt(
         )
     if keyed and bool(evidence.get("unkeyed")):
         return _base_result(entry, CheckStatus.PASS, evidence=evidence)
+    unkey_error = evidence.get("unkey_error")
+    if unkey_error:
+        # MOR-1951: a failed/unconfirmed unkey must be legible in the error
+        # itself, not only in evidence — the radio may still be keyed.
+        error = f"unkey failed; radio may still be keyed: {unkey_error}"
+    else:
+        error = "PTT did not key/unkey cleanly"
     return _base_result(
         entry,
         CheckStatus.FAIL,
         failure_domain=FailureDomain.COMMAND_EXECUTION,
         evidence=evidence,
-        error="PTT did not key/unkey cleanly",
+        error=error,
     )
 
 
@@ -1002,15 +1029,21 @@ async def _actuate_tuner_tune(
     _get_tuner_attr = getattr(radio, "get_tuner_status", None)
     if callable(_get_tuner_attr):
         get_tuner = cast(Callable[[], Awaitable[int]], _get_tuner_attr)
-        status, sf = await _guard(
-            get_tuner(),
-            entry,
-            per_check_timeout=per_check_timeout,
-        )
-        if sf is None:
-            evidence["tuner_status_readback"] = status
-        else:
-            evidence["tuner_status_read_error"] = sf.error
+        try:
+            status, sf = await _guard(
+                get_tuner(),
+                entry,
+                per_check_timeout=per_check_timeout,
+            )
+            if sf is None:
+                evidence["tuner_status_readback"] = status
+            else:
+                evidence["tuner_status_read_error"] = sf.error
+        except Exception as exc:
+            # Best-effort readback (MOR-1951): a backend transport error
+            # outside ``_guard``'s mapped family must be recorded as evidence,
+            # not discard the PASS the successful trigger earned.
+            evidence["tuner_status_read_error"] = str(exc)
     return _base_result(entry, CheckStatus.PASS, evidence=evidence)
 
 

--- a/tests/test_validation_hardware_tx.py
+++ b/tests/test_validation_hardware_tx.py
@@ -25,6 +25,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from rigplane.backends.yaesu_cat.transport import CatTransportError
 from rigplane.core.radio_protocol import Radio
 from rigplane.core.radio_state import RadioState
 from rigplane.core.tx_safety import (
@@ -99,11 +100,36 @@ class _RecordingSupervisor:
         return TxTransition(self._off, _IDLE_TX_SNAPSHOT)
 
 
+class _RaisingReleaseSupervisor(_RecordingSupervisor):
+    """A release whose OFF write dies on the backend wire (MOR-1951).
+
+    Raises ``exc`` instead of writing OFF — a plain ``Exception`` outside the
+    harness's ``_RESTORE_ERRORS`` tuple, the exact shape that used to escape
+    the teardown ``finally`` and skip the power restore. The key still
+    succeeds and mirrors PTT on, exactly as a real link failure mid-key-down.
+    """
+
+    def __init__(
+        self, log: list[tuple[str, object]], state: RadioState, *, exc: Exception
+    ) -> None:
+        super().__init__(log, state)
+        self._exc = exc
+
+    async def release_owner(
+        self, owner: TxOwner, *, reason: TxReleaseReason
+    ) -> TxTransition:
+        self.owners.append(owner)
+        self.reasons.append(reason)
+        self._log.append(("supervisor.release_owner", owner))
+        raise self._exc
+
+
 def _tx_radio(
     *,
     managed: bool,
     on: TxOutcome = TxOutcome.ACCEPTED,
     off: TxOutcome = TxOutcome.ACCEPTED,
+    release_exc: Exception | None = None,
 ):
     """Stateful fake rig plus the ordered log of everything it was asked to do.
 
@@ -150,7 +176,11 @@ def _tx_radio(
 
     supervisor: _RecordingSupervisor | None = None
     if managed:
-        supervisor = _RecordingSupervisor(log, state, on=on, off=off)
+        supervisor = (
+            _RaisingReleaseSupervisor(log, state, exc=release_exc)
+            if release_exc is not None
+            else _RecordingSupervisor(log, state, on=on, off=off)
+        )
         radio.managed_tx = supervisor
     return radio, supervisor, log, power
 
@@ -385,3 +415,50 @@ async def test_a_refused_release_is_recorded_and_never_escalated_to_force():
     assert TxOutcome.STALE.value in str(ptt.evidence["unkey_error"])
     assert ptt.status is CheckStatus.FAIL
     assert radio.set_ptt.await_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 4. Release that RAISES — backend transport error containment (MOR-1951).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_raising_release_is_contained_and_power_is_still_restored():
+    """The OFF write rides the same wire as the key, so the release can fail
+    with the backend's transport error (a plain ``Exception`` outside
+    ``_RESTORE_ERRORS``). That must not skip the power restore, must not fall
+    back to a raw PTT write, and must never read as a clean PASS."""
+    radio, supervisor, log, power = _tx_radio(
+        managed=True,
+        release_exc=CatTransportError("write OFF failed: link gone"),
+    )
+
+    checks = await _run(radio)
+
+    ptt = checks["tx.ptt"]
+    assert ptt.status is CheckStatus.FAIL
+    assert ptt.evidence["keyed"] is True
+    assert ptt.evidence["unkeyed"] is False
+    assert "link gone" in str(ptt.evidence["unkey_error"])
+    assert "may still be keyed" in str(ptt.error)
+
+    # Power was STILL restored after the failed release.
+    assert power["value"] == _START_POWER
+    assert ptt.evidence["power_restored"] is True
+
+    # Fail closed on the wire too: the key went through the supervisor and the
+    # failed release never fell back to a raw PTT write.
+    assert radio.set_ptt.await_count == 0
+    assert _names(log) == [
+        "radio.get_rf_power",
+        "radio.set_rf_power",  # -> minimum
+        "supervisor.request_on",
+        "supervisor.release_owner",
+        "radio.set_rf_power",  # -> restored, despite the raising release
+        "radio.set_tuner_status",
+        "radio.get_tuner_status",
+    ]
+    # The matrix continued: the next TX check still ran and passed.
+    assert checks["tuner.tune"].status is CheckStatus.PASS
+    assert supervisor is not None
+    assert supervisor.reasons == [TxReleaseReason.OPERATOR_RELEASE]

--- a/tests/validation/test_tx_actuate.py
+++ b/tests/validation/test_tx_actuate.py
@@ -10,11 +10,16 @@ never touch real hardware.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from rigplane.backends.yaesu_cat.transport import CatCommandRejected, CatTimeoutError
+from rigplane.backends.yaesu_cat.transport import (
+    CatCommandRejected,
+    CatTimeoutError,
+    CatTransportError,
+)
 from rigplane.core.radio_protocol import Radio
 from rigplane.core.radio_state import RadioState
 from rigplane.core.tx_observation import TxStateReading
@@ -542,3 +547,115 @@ async def test_tx_ptt_readback_falls_back_to_the_mirror_when_transmit_state_read
         ptt.evidence["ptt_read_unavailable"]
         == "radio does not implement TransmitStateReadable"
     )
+
+
+# ---------------------------------------------------------------------------
+# MOR-1951 — backend-agnostic teardown containment. ``CatTransportError`` is a
+# plain ``Exception`` outside ``_RESTORE_ERRORS``: raised by the OFF write
+# itself, it used to escape the teardown ``finally``, skip the power restore,
+# and die in the run-loop backstop, discarding the check's evidence. The
+# managed-path counterpart lives in tests/test_validation_hardware_tx.py.
+# ---------------------------------------------------------------------------
+
+
+async def test_unkey_transport_error_still_restores_power_and_fails_uncleanly():
+    """An OFF that dies on the wire must not skip the power restore, must be
+    legible in the evidence, and must never read as a clean PASS."""
+    radio, power = _tx_radio(start_power=200)
+    prompter, _ = _confirm_prompter(True)
+    state = radio.radio_state
+
+    async def _off_dies_on_wire(on: bool) -> None:
+        if on:
+            state.ptt = True
+            return
+        raise CatTransportError("write OFF failed: device not connected")
+
+    radio.set_ptt = AsyncMock(side_effect=_off_dies_on_wire)
+
+    levels = await _run(radio, safety=_FULL_SAFETY, tx_actuate=True, prompter=prompter)
+    ptt = _flatten(levels)["tx.ptt"]
+
+    assert ptt.status is CheckStatus.FAIL
+    assert ptt.evidence["keyed"] is True
+    assert ptt.evidence["unkeyed"] is False
+    assert "device not connected" in str(ptt.evidence["unkey_error"])
+    assert ptt.evidence["power_restored"] is True
+    assert power["value"] == 200  # restore ran despite the failed unkey
+    assert radio.set_rf_power.call_args_list[-1].args[0] == 200
+    # The verdict names the uncertain unkey instead of a generic failure.
+    assert "may still be keyed" in str(ptt.error)
+
+
+async def test_key_transport_error_keeps_teardown_evidence_on_the_result():
+    """A transport error from the KEY must land in the check's evidence (with
+    the ``finally`` teardown recorded), not die in the backstop that knows
+    nothing about it."""
+    radio, power = _tx_radio(start_power=200)
+    prompter, _ = _confirm_prompter(True)
+
+    async def _key_dies_on_wire(on: bool) -> None:
+        if on:
+            raise CatTransportError("write ON failed: device not connected")
+        radio.radio_state.ptt = False
+
+    radio.set_ptt = AsyncMock(side_effect=_key_dies_on_wire)
+
+    levels = await _run(radio, safety=_FULL_SAFETY, tx_actuate=True, prompter=prompter)
+    ptt = _flatten(levels)["tx.ptt"]
+
+    assert ptt.status is CheckStatus.FAIL
+    assert "tx actuation failed" in str(ptt.error)
+    assert "device not connected" in str(ptt.evidence["actuate_error"])
+    # The finally still ran and is reported: unkey attempted, power restored.
+    assert ptt.evidence["unkeyed"] is True
+    assert ptt.evidence["power_restored"] is True
+    assert power["value"] == 200
+    assert [c.args[0] for c in radio.set_ptt.call_args_list] == [True, False]
+
+
+async def test_cancellation_during_unkey_is_not_swallowed():
+    """``BaseException`` cancellation must still propagate out of the teardown:
+    the widened ``except Exception`` containment must not turn a cancelled run
+    into a fabricated result, and cancellation beats the best-effort restore."""
+    radio, power = _tx_radio(start_power=200)
+    prompter, _ = _confirm_prompter(True)
+    state = radio.radio_state
+
+    async def _cancel_on_off(on: bool) -> None:
+        if on:
+            state.ptt = True
+            return
+        raise asyncio.CancelledError()
+
+    radio.set_ptt = AsyncMock(side_effect=_cancel_on_off)
+
+    with pytest.raises(asyncio.CancelledError):
+        await _run(radio, safety=_FULL_SAFETY, tx_actuate=True, prompter=prompter)
+    # Cancellation beat the restore: nothing pretends the teardown finished.
+    assert power["value"] == 0
+    assert state.ptt is True
+
+
+async def test_tuner_readback_transport_error_keeps_the_triggered_pass():
+    """The tuner readback is best-effort and never the pass/fail driver: a
+    transport error from the read must be recorded as evidence, not discard
+    the PASS the successful trigger earned."""
+    radio, _ = _tx_radio(start_power=200)
+    prompter, _ = _confirm_prompter(True)
+
+    async def _read_dies_on_wire() -> int:
+        raise CatTransportError("read failed: device not connected")
+
+    radio.get_tuner_status = AsyncMock(side_effect=_read_dies_on_wire)
+
+    levels = await _run(radio, safety=_FULL_SAFETY, tx_actuate=True, prompter=prompter)
+    checks = _flatten(levels)
+
+    assert checks["tuner.tune"].status is CheckStatus.PASS
+    assert checks["tuner.tune"].evidence["tune_triggered"] is True
+    assert "device not connected" in str(
+        checks["tuner.tune"].evidence["tuner_status_read_error"]
+    )
+    # The earlier tx.ptt check and its evidence survived the same run.
+    assert checks["tx.ptt"].status is CheckStatus.PASS


### PR DESCRIPTION
A Yaesu CAT exception during validation unkey could escape teardown and skip restoration of the original RF power. Contain ordinary backend errors in the TX validation path, retain failure evidence, and attempt power restoration after an OFF failure. Task cancellation still propagates; this does not guarantee OFF reached the radio.

Also retain optional tuner readback errors as evidence after a successful trigger. No radio lifecycle, managed authority, or production Web behavior changes.

Linear: https://linear.app/morozsm/issue/MOR-1951

Validation on an isolated Mac mini checkout:
- New tests with base production: 4 expected failures, 27 passed.
- Fixed production: both affected test files, 31 passed.
- Scoped Ruff and format checks passed.
- No hardware actions or physical transmission tests.

Independent OpenCode GLM-5.3 exact-head review passed. Required comment correction applied. Current-head CI is checked separately before merge.
